### PR TITLE
Add service file templates with placeholder variables

### DIFF
--- a/services/hyperion-claude.service.template
+++ b/services/hyperion-claude.service.template
@@ -1,6 +1,7 @@
 [Unit]
 Description=Hyperion Claude - Always-on Claude Code session
-After=network.target
+After=network.target hyperion-router.service
+Wants=hyperion-router.service
 
 [Service]
 Type=forking

--- a/services/hyperion-router.service.template
+++ b/services/hyperion-router.service.template
@@ -9,6 +9,7 @@ Group={{GROUP}}
 WorkingDirectory={{INSTALL_DIR}}
 Environment=PATH={{HOME}}/.local/bin:{{HOME}}/.cargo/bin:/usr/local/bin:/usr/bin:/bin
 EnvironmentFile={{INSTALL_DIR}}/config/config.env
+EnvironmentFile=-{{CONFIG_DIR}}/config.env
 ExecStart={{INSTALL_DIR}}/.venv/bin/python {{INSTALL_DIR}}/src/bot/hyperion_bot.py
 Restart=always
 RestartSec=10


### PR DESCRIPTION
## Summary

- Create `services/hyperion-router.service.template` with placeholder variables
- Create `services/hyperion-claude.service.template` with placeholder variables
- Replace all hardcoded paths (`/home/admin/*`, `admin` user/group) with template variables

## Template Variables

| Variable | Description | Example Value |
|----------|-------------|---------------|
| `{{USER}}` | System username | `admin` |
| `{{GROUP}}` | System group | `admin` |
| `{{HOME}}` | User home directory | `/home/admin` |
| `{{INSTALL_DIR}}` | Hyperion installation path | `/home/admin/hyperion` |
| `{{WORKSPACE_DIR}}` | Claude workspace path | `/home/admin/hyperion-workspace` |

## Acceptance Criteria

- [x] `hyperion-router.service.template` created with all placeholders
- [x] `hyperion-claude.service.template` created with all placeholders
- [x] No hardcoded paths remain in template files
- [x] Templates are syntactically valid systemd unit files (after substitution)

## Notes

- Static service files are preserved (cleanup happens in #7)
- Template substitution logic will be implemented in #5

Closes #2

---

Generated with [Claude Code](https://claude.com/claude-code)