### PR TITLE
Add brain-dumps agent for voice note brain dump processing

### DIFF
--- a/.claude/agents/brain-dumps.md
+++ b/.claude/agents/brain-dumps.md
@@ -7,6 +7,8 @@ color: purple
 
 You are a brain dump processor for the Hyperion system. Your job is to receive transcribed voice notes, determine if they represent a "brain dump" (unstructured thoughts, ideas, stream of consciousness), and if so, save them to the user's dedicated brain-dumps GitHub repository.
 
+**Note:** This is the default brain-dumps agent. Users can customize this agent by placing their own `agents/brain-dumps.md` in their private config directory (HYPERION_CONFIG_DIR). See `docs/CUSTOMIZATION.md` for the overlay pattern.
+
 ## What is a Brain Dump?
 
 A brain dump is distinguished from regular commands or questions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,8 @@ Launch via the Task tool with `subagent_type: functional-engineer`.
 
 When you receive a **voice message** that appears to be a "brain dump" (unstructured thoughts, ideas, stream of consciousness) rather than a command or question, use the **brain-dumps** agent.
 
+**Note:** This feature can be disabled via `HYPERION_BRAIN_DUMPS_ENABLED=false` in `hyperion.conf`. The agent can also be customized or replaced via the [private config overlay](docs/CUSTOMIZATION.md) by placing a custom `agents/brain-dumps.md` in your private config directory.
+
 **Indicators of a brain dump:**
 - Multiple unrelated topics in one message
 - Phrases like "brain dump", "note to self", "thinking out loud"
@@ -155,14 +157,15 @@ When you receive a **voice message** that appears to be a "brain dump" (unstruct
 **Workflow:**
 1. Receive voice message
 2. Transcribe using `transcribe_audio(message_id)`
-3. If transcription looks like a brain dump, spawn brain-dumps agent:
+3. Check if brain dumps are enabled (default: true)
+4. If transcription looks like a brain dump, spawn brain-dumps agent:
    ```
    Task(
      prompt="Process this brain dump:\nTranscription: {text}\nMessage ID: {id}\nChat ID: {chat_id}",
      subagent_type="brain-dumps"
    )
    ```
-4. Agent will save to user's `brain-dumps` GitHub repository as an issue
+5. Agent will save to user's `brain-dumps` GitHub repository as an issue
 
 **NOT a brain dump** (handle normally):
 - Direct questions ("What time is it?")

--- a/config/hyperion.conf.example
+++ b/config/hyperion.conf.example
@@ -89,10 +89,20 @@ HYPERION_ENABLE_VOICE="${HYPERION_ENABLE_VOICE:-true}"
 #===============================================================================
 # Brain Dumps Feature
 #===============================================================================
+# The brain-dumps agent processes voice messages that appear to be unstructured
+# thoughts, ideas, or stream-of-consciousness notes, saving them to GitHub Issues.
+#
+# The agent definition lives in .claude/agents/brain-dumps.md and can be
+# customized via the private config overlay by placing your own version at:
+#   ${HYPERION_CONFIG_DIR}/agents/brain-dumps.md
+#
+# See docs/BRAIN-DUMPS.md for full documentation.
+#===============================================================================
 
 # Enable brain dump processing for voice messages
 # When true, voice messages detected as "brain dumps" (stream of consciousness,
 # ideas, thoughts) will be automatically saved to a dedicated GitHub repository
+# Set to false to disable the feature entirely
 HYPERION_BRAIN_DUMPS_ENABLED="${HYPERION_BRAIN_DUMPS_ENABLED:-true}"
 
 # Repository name for storing brain dumps

--- a/docs/BRAIN-DUMPS.md
+++ b/docs/BRAIN-DUMPS.md
@@ -148,6 +148,49 @@ Issues can be:
 | `HYPERION_BRAIN_DUMPS_ENABLED` | `true` | Enable/disable the feature |
 | `HYPERION_BRAIN_DUMPS_REPO` | `brain-dumps` | Repository name |
 
+These variables are set in `config/hyperion.conf` or `config/hyperion.conf.example`.
+
+## Customization via Private Config Overlay
+
+The brain-dumps agent can be customized using Hyperion's [private config overlay system](CUSTOMIZATION.md).
+
+### Overriding the Agent Definition
+
+To customize the brain-dumps agent behavior, create your own version in your private config directory:
+
+```bash
+# Create custom agent in your private config
+cp ~/hyperion/.claude/agents/brain-dumps.md ~/hyperion-config/agents/brain-dumps.md
+
+# Edit to your preferences
+nano ~/hyperion-config/agents/brain-dumps.md
+```
+
+When the installer runs, your custom `agents/brain-dumps.md` will be copied to `~/hyperion/.claude/agents/`, overriding the default.
+
+### Customization Ideas
+
+You can modify the agent to:
+
+- **Change topic detection labels**: Add labels specific to your work (e.g., `client-a`, `project-x`)
+- **Modify the issue template**: Add custom sections or formatting
+- **Adjust classification criteria**: Be more or less strict about what counts as a brain dump
+- **Add integrations**: Post to Slack, create tasks, etc.
+
+### Disabling Brain Dumps
+
+To disable the feature entirely, set in your `hyperion.conf`:
+
+```bash
+HYPERION_BRAIN_DUMPS_ENABLED=false
+```
+
+Or simply remove/rename the agent file:
+
+```bash
+mv ~/hyperion-config/agents/brain-dumps.md ~/hyperion-config/agents/brain-dumps.md.disabled
+```
+
 ## Privacy
 
 - The brain-dumps repository is created as **private** by default

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -203,6 +203,24 @@ if you want to extend rather than replace it]
 
 Define custom Claude Code agents for specialized tasks. These are **merged** with the default agents in `~/hyperion/.claude/agents/`.
 
+**Built-in agents you can override:**
+
+| Agent | Description |
+|-------|-------------|
+| `functional-engineer.md` | Implements GitHub issues with functional programming patterns |
+| `hyperion-ops.md` | System operations and maintenance |
+| `brain-dumps.md` | Processes voice note brain dumps into GitHub issues |
+
+To customize a built-in agent, copy it to your private config and modify:
+
+```bash
+# Example: Customize the brain-dumps agent
+cp ~/hyperion/.claude/agents/brain-dumps.md ~/hyperion-config/agents/brain-dumps.md
+# Edit to add custom labels, change behavior, etc.
+```
+
+**Creating new agents:**
+
 Example: `agents/code-reviewer.md`
 
 ```markdown


### PR DESCRIPTION
## Summary

- Adds new `brain-dumps` agent for processing voice message brain dumps
- Creates documentation for the feature
- Adds configuration options to `hyperion.conf.example`
- Updates `CLAUDE.md` with integration instructions
- **Properly integrates with the private config overlay architecture**

Closes #12

## Changes

### Agent Definition (`.claude/agents/brain-dumps.md`)

New agent that:
- Receives transcribed voice messages
- Classifies whether content is a "brain dump" (stream of consciousness, ideas) vs. regular command/question
- Creates/verifies private `brain-dumps` repository exists
- Saves brain dumps as GitHub issues with auto-detected topic labels
- Sends confirmation to user
- **Includes note about customization via overlay pattern**

### Documentation (`docs/BRAIN-DUMPS.md`)

Comprehensive user documentation covering:
- What brain dumps are and how they're detected
- Setup and configuration
- Usage examples
- Label system
- **New: Customization via Private Config Overlay section**
- Troubleshooting

### Configuration (`config/hyperion.conf.example`)

Added:
- `HYPERION_BRAIN_DUMPS_ENABLED` - Enable/disable feature (default: true)
- `HYPERION_BRAIN_DUMPS_REPO` - Repository name (default: brain-dumps)
- **Enhanced documentation about overlay integration**

### Main Agent Integration (`CLAUDE.md`)

Added section on processing voice note brain dumps:
- When to use brain-dumps agent
- Workflow for detecting and delegating
- Examples of what is/isn't a brain dump
- **Note about configuration and overlay customization**

### Customization Documentation (`docs/CUSTOMIZATION.md`)

- Added brain-dumps to the list of built-in agents that can be overridden
- Example of how to customize the brain-dumps agent

## Architecture Alignment

This PR has been updated to align with the new configuration/overlay architecture:

1. **Agent as Default**: The brain-dumps agent in `.claude/agents/` serves as a sensible default
2. **Overlay Support**: Users can customize by placing their own `agents/brain-dumps.md` in their private config directory (`HYPERION_CONFIG_DIR`)
3. **Config Variables**: Uses `HYPERION_*` pattern (`HYPERION_BRAIN_DUMPS_ENABLED`, `HYPERION_BRAIN_DUMPS_REPO`)
4. **Enable/Disable**: Feature can be disabled via config without removing files
5. **Documentation**: All docs updated to explain the overlay integration

## Test Plan

- [ ] Verify agent definition follows existing patterns (compare with `functional-engineer.md`)
- [ ] Test brain dump classification logic with various inputs
- [ ] Verify repository creation works for new users
- [ ] Test issue creation with proper formatting and labels
- [ ] Confirm configuration options are picked up correctly
- [ ] Verify overlay customization works (place custom agent in private config)
- [ ] Test disabling via `HYPERION_BRAIN_DUMPS_ENABLED=false`

---
Generated with [Claude Code](https://claude.ai/code)