### PR TITLE
Add self-check reminder feature for background agent status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,33 @@ Review results from scheduled jobs:
 - `check_task_outputs(since?, limit?, job_name?)` - Read recent job outputs
 - `write_task_output(job_name, output, status?)` - Write job output (used by job instances)
 
+### Self-Check Reminders
+
+Schedule a one-off reminder to check on background work (subagent status, deferred tasks).
+
+**Use case:** After spawning a subagent for substantial work, schedule a self-check to follow up:
+
+```bash
+echo "$HOME/hyperion/scripts/self-check-reminder.sh" | at now + 3 minutes
+```
+
+**Guidelines:**
+- **Default timing:** 3 minutes (typical subagent work)
+- **Max timing:** 10 minutes (don't schedule too far out)
+- **Silent behavior:** Only respond to user if there's actual news to report
+
+**Workflow:**
+1. User requests substantial work
+2. Acknowledge and spawn subagent
+3. Schedule self-check: `Bash: echo "$HOME/hyperion/scripts/self-check-reminder.sh" | at now + 3 minutes`
+4. Return to `wait_for_messages()` immediately
+5. When self-check fires, check subagent status and report to user if complete
+
+**When NOT to use:**
+- Quick tasks (< 30 seconds) - handle directly
+- Tasks where user explicitly said "no rush" or "whenever"
+- Already have a pending self-check for same work
+
 ### GitHub Integration (MCP)
 Access GitHub repos, issues, PRs, and projects:
 - **Issues**: Create, read, update, close issues; add comments and labels

--- a/install.sh
+++ b/install.sh
@@ -326,6 +326,7 @@ PACKAGES=(
     python3-pip
     python3-venv
     cron
+    at
     expect
     tmux
 )
@@ -564,6 +565,10 @@ chmod +x "$INSTALL_DIR/scheduled-tasks/sync-crontab.sh"
 sudo systemctl enable cron 2>/dev/null || true
 sudo systemctl start cron 2>/dev/null || true
 
+# Enable atd service (for self-check reminders via 'at' command)
+sudo systemctl enable atd 2>/dev/null || true
+sudo systemctl start atd 2>/dev/null || true
+
 success "Scheduled tasks infrastructure ready"
 
 #===============================================================================
@@ -572,8 +577,9 @@ success "Scheduled tasks infrastructure ready"
 
 step "Setting up health monitoring..."
 
-# Make health check executable
+# Make scripts executable
 chmod +x "$INSTALL_DIR/scripts/health-check.sh"
+chmod +x "$INSTALL_DIR/scripts/self-check-reminder.sh"
 
 # Add health check to crontab (runs every 5 minutes)
 HEALTH_MARKER="# HYPERION-HEALTH"

--- a/scripts/self-check-reminder.sh
+++ b/scripts/self-check-reminder.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#===============================================================================
+# Self-Check Reminder Script
+#
+# Injects a self-check message into the Hyperion inbox. This allows the main
+# Claude session to schedule a one-off reminder to check on background agent
+# status or other deferred tasks.
+#
+# Usage:
+#   Direct:  ./self-check-reminder.sh
+#   Via at:  echo "$HOME/hyperion/scripts/self-check-reminder.sh" | at now + 3 minutes
+#
+# The injected message appears as a system message with the text "status? (Self-check)"
+# which prompts Hyperion to check on any pending subagent work.
+#
+# Behavior:
+#   - Silent: Only respond to user if there's actual news to report
+#   - Default timing: 3 minutes (when scheduling via at)
+#   - Max timing: 10 minutes (don't schedule too far out)
+#===============================================================================
+
+set -e
+
+# Use environment variable or default
+INBOX_DIR="${HYPERION_MESSAGES:-$HOME/messages}/inbox"
+
+# Ensure inbox directory exists
+mkdir -p "$INBOX_DIR"
+
+# Generate unique message ID using epoch milliseconds
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%S.%6N)
+EPOCH_MS=$(date +%s%3N)
+MSG_ID="${EPOCH_MS}_self"
+
+# Create the self-check message
+cat > "${INBOX_DIR}/${MSG_ID}.json" << EOF
+{
+  "id": "${MSG_ID}",
+  "source": "system",
+  "chat_id": 0,
+  "user_id": 0,
+  "username": "hyperion-system",
+  "user_name": "Self-Check",
+  "text": "status? (Self-check)",
+  "timestamp": "${TIMESTAMP}"
+}
+EOF
+
+echo "Self-check reminder injected: ${MSG_ID}"


### PR DESCRIPTION
## Summary

- Adds `scripts/self-check-reminder.sh` that injects a system message into the inbox to trigger a status check on background subagent work
- Documents the self-check workflow in `CLAUDE.md` with usage guidelines (3 min default, 10 min max, silent behavior)
- Adds `at` package to `install.sh` dependencies and enables/starts the `atd` service during installation

## Use Case

When the main Hyperion session spawns a subagent for substantial work (code review, feature implementation, etc.), it can now schedule a self-check reminder to follow up:

```bash
echo "$HOME/hyperion/scripts/self-check-reminder.sh" | at now + 3 minutes
```

This allows Hyperion to:
1. Acknowledge the user's request immediately
2. Spawn the subagent
3. Schedule a reminder to check on progress
4. Return to the message loop without blocking
5. Report back to the user when the work completes

## Test plan

- [ ] Verify `at` package installs correctly during `install.sh`
- [ ] Verify `atd` service starts and is enabled
- [ ] Test `self-check-reminder.sh` creates valid JSON in inbox
- [ ] Test scheduling via `at now + 1 minute` triggers the reminder
- [ ] Verify Hyperion processes the self-check message correctly

---
Generated with [Claude Code](https://claude.com/claude-code)