### PR TITLE
docs: clarify self-check reminder behavior for three states

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,13 @@ echo "$HOME/hyperion/scripts/self-check-reminder.sh" | at now + 3 minutes
 **Guidelines:**
 - **Default timing:** 3 minutes (typical subagent work)
 - **Max timing:** 10 minutes (don't schedule too far out)
-- **Silent behavior:** Only respond to user if there's actual news to report
+
+**Self-check behavior** (three states):
+1. **Completed** - Report completion with details to the user
+2. **Still working** - Send brief progress update (e.g., "Still working on X...")
+3. **Nothing running** - Silent (mark processed, no reply needed)
+
+The key insight: users want to know work is ongoing. A brief "still working" update is better than silence.
 
 **Workflow:**
 1. User requests substantial work


### PR DESCRIPTION
## Summary

- Updates the Self-Check Reminders section in CLAUDE.md to clarify behavior for three distinct states
- Replaces vague "Silent behavior: Only respond to user if there's actual news to report" with explicit guidance

**New behavior documentation:**

1. **Completed** - Report completion with details to the user
2. **Still working** - Send brief progress update (e.g., "Still working on X...")
3. **Nothing running** - Silent (mark processed, no reply needed)

The key change is that "still working" should trigger a brief update rather than silence, so users know work is ongoing.

## Test plan

- [ ] Review the updated Self-Check Reminders section in CLAUDE.md
- [ ] Verify the three states are clearly documented
- [ ] Confirm the guidance matches expected Hyperion behavior

---
Generated with [Claude Code](https://claude.ai/code)