### PR TITLE
Add systemd service for MCP HTTP bridge

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1019,6 +1019,14 @@ if [ -f "$SLACK_ROUTER_TEMPLATE" ]; then
         "$INSTALL_DIR/services/lobster-slack-router.service"
 fi
 
+# Generate MCP HTTP bridge service if template exists
+MCP_TEMPLATE="$INSTALL_DIR/services/lobster-mcp.service.template"
+if [ -f "$MCP_TEMPLATE" ]; then
+    generate_from_template \
+        "$MCP_TEMPLATE" \
+        "$INSTALL_DIR/services/lobster-mcp.service"
+fi
+
 #===============================================================================
 # Install Services
 #===============================================================================
@@ -1032,6 +1040,12 @@ sudo cp "$INSTALL_DIR/services/lobster-claude.service" /etc/systemd/system/
 if [ -f "$INSTALL_DIR/services/lobster-slack-router.service" ]; then
     sudo cp "$INSTALL_DIR/services/lobster-slack-router.service" /etc/systemd/system/
     info "Slack router service installed (enable manually with: sudo systemctl enable lobster-slack-router)"
+fi
+
+# Install MCP HTTP bridge service if generated
+if [ -f "$INSTALL_DIR/services/lobster-mcp.service" ]; then
+    sudo cp "$INSTALL_DIR/services/lobster-mcp.service" /etc/systemd/system/
+    info "MCP HTTP bridge service installed (enable manually with: sudo systemctl enable lobster-mcp)"
 fi
 
 sudo systemctl daemon-reload

--- a/services/lobster-mcp.service.template
+++ b/services/lobster-mcp.service.template
@@ -1,0 +1,24 @@
+[Unit]
+Description=Lobster MCP HTTP Server
+After=network.target
+
+[Service]
+Type=simple
+User={{USER}}
+Group={{GROUP}}
+WorkingDirectory={{INSTALL_DIR}}
+EnvironmentFile={{INSTALL_DIR}}/config/config.env
+EnvironmentFile=-{{CONFIG_DIR}}/config.env
+ExecStart={{INSTALL_DIR}}/.venv/bin/python {{INSTALL_DIR}}/src/mcp/inbox_server_http.py
+Restart=always
+RestartSec=10
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=lobster-mcp
+
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Adds `services/lobster-mcp.service.template` for the MCP HTTP bridge (`inbox_server_http.py`)
- Updates `install.sh` to generate and install the MCP service file during setup

## Context
During a production VPS reboot, the MCP HTTP bridge was the only Lobster component that didn't automatically recover — because it had no systemd service and was previously started manually. The router and Claude session both came back via their existing systemd units, but the MCP bridge stayed down until manually restarted.

The template follows the same pattern as the existing Slack router service (optional, conditional on template existence).

Ref: welfvh/lobster-vps#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)