### PR TITLE
Layer 4: macOS integration (launchd, CLI, installer)

### DIFF
--- a/macos/README.md
+++ b/macos/README.md
@@ -1,0 +1,316 @@
+# Lobster Local Sync -- macOS Integration
+
+Continuously backs up your local git working trees (including uncommitted and untracked files) to `lobster-sync` branches on GitHub, with zero disruption to your workflow.
+
+## How It Works
+
+```
+┌──────────────────────────────────────────────────────┐
+│                     Your Mac                          │
+│                                                       │
+│  lobster-sync daemon (launchd)                       │
+│  ├── Every 5 min (configurable):                     │
+│  │   ├── For each registered repo:                   │
+│  │   │   ├── git write-tree (temp index)             │
+│  │   │   ├── git commit-tree (no branch switch)      │
+│  │   │   └── git push origin lobster-sync --force    │
+│  │   └── Log results                                 │
+│  └── Runs continuously via launchd KeepAlive         │
+│                                                       │
+│  lobster-sync CLI                                    │
+│  ├── add/remove repos                                │
+│  ├── check status                                    │
+│  ├── trigger immediate sync                          │
+│  └── start/stop service                              │
+└──────────────────────────────────────────────────────┘
+```
+
+The sync uses git plumbing commands (`write-tree`, `commit-tree`, `update-ref`) with a temporary index file. Your working directory, staged changes, and current branch are never touched.
+
+## Prerequisites
+
+- **macOS** (launchd-based service management)
+- **git** (included with Xcode Command Line Tools)
+- **jq** (for JSON config handling): `brew install jq`
+- A **GitHub personal access token** with `repo` scope
+
+## Quick Start
+
+```bash
+# Clone the Lobster repo (if you haven't already)
+git clone https://github.com/SiderealPress/Lobster.git
+cd Lobster
+
+# Run the installer
+./macos/install-lobster-local.sh
+
+# Register repos for sync
+lobster-sync add ~/projects/my-app
+lobster-sync add ~/projects/another-project
+
+# Check everything is working
+lobster-sync status
+```
+
+## Installation
+
+The installer (`install-lobster-local.sh`) performs these steps:
+
+1. Creates `~/.lobster/` directory structure (`bin/`, `logs/`, `config/`)
+2. Copies sync scripts to `~/.lobster/bin/`
+3. Generates default `sync-config.json`
+4. Installs launchd plist to `~/Library/LaunchAgents/`
+5. Walks you through GitHub token setup (with Keychain option)
+6. Optionally configures Claude Code MCP settings
+
+The installer is **idempotent** -- running it again updates scripts and the plist while preserving your config and registered repos.
+
+### Options
+
+```bash
+./macos/install-lobster-local.sh              # Interactive install
+./macos/install-lobster-local.sh --no-start   # Install without starting service
+```
+
+## CLI Reference
+
+### `lobster-sync add <path>`
+
+Register a git repository for continuous sync.
+
+```bash
+lobster-sync add ~/projects/my-app
+lobster-sync add ~/projects/govscan
+```
+
+The repo is added to `~/.lobster/sync-config.json`. If the repo was previously removed, it is re-enabled.
+
+### `lobster-sync remove <path>`
+
+Unregister a repository. The repo itself and its sync branch are not deleted.
+
+```bash
+lobster-sync remove ~/projects/old-project
+```
+
+### `lobster-sync status`
+
+Show the sync status for all registered repos and the daemon service.
+
+```bash
+$ lobster-sync status
+--- Service ---
+  launchd:  loaded
+  daemon:   running (PID 12345)
+  interval: 300s
+
+--- Repos ---
+  my-app               ~/projects/my-app              last sync: 2m ago     ok
+  govscan              ~/projects/govscan              last sync: 2m ago     ok
+  old-project          ~/projects/old-project          last sync: 15m ago    stale
+```
+
+Status indicators:
+- **ok** (green) -- synced within 2x the interval
+- **stale** (yellow) -- last sync was longer ago than expected
+- **never synced** -- no sync branch exists yet
+- **disabled** -- repo is registered but disabled
+- **missing** -- repo path no longer exists
+
+### `lobster-sync now`
+
+Trigger an immediate sync of all registered repos (runs one cycle and exits).
+
+```bash
+lobster-sync now
+```
+
+### `lobster-sync log`
+
+Tail the sync daemon log.
+
+```bash
+lobster-sync log
+```
+
+Press `Ctrl-C` to stop tailing.
+
+### `lobster-sync start`
+
+Load the launchd service (starts the daemon).
+
+```bash
+lobster-sync start
+```
+
+### `lobster-sync stop`
+
+Unload the launchd service (stops the daemon).
+
+```bash
+lobster-sync stop
+```
+
+## Configuration
+
+### `~/.lobster/sync-config.json`
+
+```json
+{
+  "sync_interval_seconds": 300,
+  "sync_branch": "lobster-sync",
+  "repos": [
+    {
+      "path": "/Users/drew/projects/my-app",
+      "remote": "origin",
+      "enabled": true
+    }
+  ]
+}
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `sync_interval_seconds` | `300` | Seconds between sync cycles |
+| `sync_branch` | `lobster-sync` | Branch name for sync commits |
+| `repos[].path` | -- | Absolute path to the git repo |
+| `repos[].remote` | `origin` | Git remote to push to |
+| `repos[].enabled` | `true` | Set to `false` to skip this repo |
+
+You can edit this file directly or use the CLI (`add`/`remove`) to manage repos.
+
+### Per-Repo Exclusions
+
+Create a `.lobster-sync-exclude` file in any repo to exclude files from sync (uses `.gitignore` syntax):
+
+```gitignore
+# .lobster-sync-exclude
+node_modules/
+.env.local
+build/
+*.sqlite
+```
+
+## GitHub Token Setup
+
+The sync daemon needs a GitHub token with `repo` scope to push sync branches.
+
+### macOS Keychain (Recommended)
+
+The installer offers to store the token in macOS Keychain. This is the most secure option -- the token is encrypted at rest and never stored in a plaintext file.
+
+**Manual Keychain setup:**
+
+```bash
+# Store token
+security add-generic-password \
+  -s lobster-sync \
+  -a github-token \
+  -w "ghp_your_token_here"
+
+# Verify it works
+security find-generic-password \
+  -s lobster-sync \
+  -a github-token \
+  -w
+```
+
+### Fallback: `.env` File
+
+If Keychain is not used, the token is read from `~/.lobster/.env`:
+
+```bash
+GITHUB_TOKEN=ghp_your_token_here
+```
+
+The CLI checks Keychain first, then falls back to the `.env` file.
+
+## Logs
+
+| File | Description |
+|------|-------------|
+| `~/.lobster/logs/sync.log` | Daemon log (sync cycle results) |
+| `~/.lobster/logs/sync-stdout.log` | launchd stdout capture |
+| `~/.lobster/logs/sync-stderr.log` | launchd stderr capture |
+
+## Uninstalling
+
+```bash
+./macos/uninstall-lobster-local.sh           # Interactive
+./macos/uninstall-lobster-local.sh --full    # Remove everything
+```
+
+The uninstaller:
+1. Stops and unloads the launchd service
+2. Removes the plist from `~/Library/LaunchAgents/`
+3. Removes the CLI symlink from `/usr/local/bin/`
+4. Optionally removes the Keychain entry
+5. Optionally removes `~/.lobster/` (config, logs, scripts)
+
+**Not removed:** Git repositories, sync branches (local or remote). To clean those up:
+
+```bash
+# In each repo:
+git branch -D lobster-sync
+git push origin --delete lobster-sync
+```
+
+## Troubleshooting
+
+### Service is loaded but daemon is not running
+
+Check the launchd stderr log for errors:
+
+```bash
+cat ~/.lobster/logs/sync-stderr.log
+```
+
+Common causes:
+- Missing `jq` (install with `brew install jq`)
+- Missing config file (run `lobster-sync add <path>` to create one)
+- Script not found (re-run the installer)
+
+### Sync completes but push fails
+
+Check that your GitHub token is valid:
+
+```bash
+# Test token
+curl -s -H "Authorization: token $(security find-generic-password -s lobster-sync -a github-token -w)" \
+  https://api.github.com/user | jq .login
+```
+
+### "No changes detected" on every cycle
+
+This is normal if you haven't made any changes since the last sync. The daemon uses tree-hash comparison and only creates a new commit when the working tree differs.
+
+### launchd restarts the daemon repeatedly
+
+The plist has `ThrottleInterval` set to 10 seconds. If the daemon crashes immediately on start, check the stderr log. Common causes:
+- Config parse error (validate JSON: `jq . ~/.lobster/sync-config.json`)
+- Permission issues on `~/.lobster/`
+
+### PATH issues (git not found)
+
+The plist includes `/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin` in PATH. If git is installed elsewhere, edit the plist:
+
+```bash
+# Edit the installed plist
+vi ~/Library/LaunchAgents/com.lobster.sync.plist
+# Reload
+launchctl unload ~/Library/LaunchAgents/com.lobster.sync.plist
+launchctl load ~/Library/LaunchAgents/com.lobster.sync.plist
+```
+
+## Architecture
+
+This is **Layer 4** of the Lobster sync system. It wraps the core sync scripts from Layer 1:
+
+- `lobster-sync-daemon.sh` -- Daemon loop that syncs all registered repos on interval
+- `lobster-sync-repo.sh` -- Syncs a single repo using git plumbing (write-tree/commit-tree)
+
+Layer 4 adds:
+- **launchd integration** -- Runs the daemon as a macOS service (auto-start, keep-alive, log routing)
+- **CLI wrapper** -- Manages repos, service, and logs from a single command
+- **Installer/uninstaller** -- Sets up the directory structure, scripts, and config
+- **Keychain integration** -- Secure token storage using macOS Keychain

--- a/macos/com.lobster.sync.plist
+++ b/macos/com.lobster.sync.plist
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.lobster.sync.plist - launchd service for the lobster-sync daemon
+
+  This is a TEMPLATE. The installer (install-lobster-local.sh) replaces
+  __USER_HOME__ with the actual home directory at install time.
+
+  launchd does not expand ~ or $HOME in plist files, so absolute paths
+  are required. The installer handles this substitution.
+
+  Manual install (if not using the installer):
+    sed "s|__USER_HOME__|$HOME|g" com.lobster.sync.plist \
+      > ~/Library/LaunchAgents/com.lobster.sync.plist
+    launchctl load ~/Library/LaunchAgents/com.lobster.sync.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.lobster.sync</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__USER_HOME__/.lobster/bin/lobster-sync-daemon.sh</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>__USER_HOME__/.lobster/logs/sync-stdout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__USER_HOME__/.lobster/logs/sync-stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+
+        <key>LOBSTER_SYNC_CONFIG</key>
+        <string>__USER_HOME__/.lobster/sync-config.json</string>
+
+        <key>LOBSTER_SYNC_HOME</key>
+        <string>__USER_HOME__/.lobster</string>
+
+        <key>HOME</key>
+        <string>__USER_HOME__</string>
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>__USER_HOME__/.lobster</string>
+
+    <!-- Throttle restarts: wait 10 seconds between respawns -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <!-- Nice level: run at low priority to avoid impacting foreground work -->
+    <key>Nice</key>
+    <integer>5</integer>
+</dict>
+</plist>

--- a/macos/install-lobster-local.sh
+++ b/macos/install-lobster-local.sh
@@ -1,0 +1,438 @@
+#!/bin/bash
+#===============================================================================
+# install-lobster-local.sh -- Install Lobster local sync on macOS
+#
+# Creates the ~/.lobster directory structure, copies scripts, generates default
+# configuration, installs the launchd plist, and optionally sets up macOS
+# Keychain for GitHub token storage.
+#
+# This script is idempotent: safe to run multiple times. Existing config
+# files are preserved; scripts and plist are always updated.
+#
+# Usage:
+#   ./install-lobster-local.sh              Interactive install
+#   ./install-lobster-local.sh --no-start   Install without starting the service
+#   ./install-lobster-local.sh --help       Show help
+#===============================================================================
+
+set -euo pipefail
+
+#-------------------------------------------------------------------------------
+# Constants
+#-------------------------------------------------------------------------------
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+readonly LOBSTER_DIR="$HOME/.lobster"
+readonly BIN_DIR="$LOBSTER_DIR/bin"
+readonly LOG_DIR="$LOBSTER_DIR/logs"
+readonly CONFIG_DIR="$LOBSTER_DIR/config"
+readonly CONFIG_FILE="$LOBSTER_DIR/sync-config.json"
+readonly ENV_FILE="$LOBSTER_DIR/.env"
+readonly PLIST_LABEL="com.lobster.sync"
+readonly PLIST_TEMPLATE="$SCRIPT_DIR/com.lobster.sync.plist"
+readonly PLIST_DEST="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
+readonly KEYCHAIN_SERVICE="lobster-sync"
+readonly KEYCHAIN_ACCOUNT="github-token"
+readonly CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+
+# Control flags
+AUTO_START=true
+
+#-------------------------------------------------------------------------------
+# Terminal colors (only when stdout is a terminal)
+#-------------------------------------------------------------------------------
+
+if [[ -t 1 ]]; then
+    readonly C_GREEN=$'\033[32m'
+    readonly C_RED=$'\033[31m'
+    readonly C_YELLOW=$'\033[33m'
+    readonly C_DIM=$'\033[2m'
+    readonly C_BOLD=$'\033[1m'
+    readonly C_RESET=$'\033[0m'
+else
+    readonly C_GREEN="" C_RED="" C_YELLOW="" C_DIM="" C_BOLD="" C_RESET=""
+fi
+
+#-------------------------------------------------------------------------------
+# Helper functions
+#-------------------------------------------------------------------------------
+
+info() {
+    printf '  %s-->%s %s\n' "$C_BOLD" "$C_RESET" "$*"
+}
+
+success() {
+    printf '  %s[ok]%s %s\n' "$C_GREEN" "$C_RESET" "$*"
+}
+
+warn() {
+    printf '  %s[!!]%s %s\n' "$C_YELLOW" "$C_RESET" "$*" >&2
+}
+
+die() {
+    printf '  %s[FAIL]%s %s\n' "$C_RED" "$C_RESET" "$*" >&2
+    exit 1
+}
+
+# Ask a yes/no question, default to the given value.
+# Returns 0 for yes, 1 for no.
+ask_yn() {
+    local prompt="$1" default="${2:-y}"
+    local yn_hint="[Y/n]"
+    [[ "$default" == "n" ]] && yn_hint="[y/N]"
+
+    if [[ ! -t 0 ]]; then
+        # Non-interactive: use default
+        [[ "$default" == "y" ]]
+        return $?
+    fi
+
+    local reply
+    printf '  %s%s%s %s ' "$C_BOLD" "$prompt" "$C_RESET" "$yn_hint"
+    read -r reply
+    reply="${reply:-$default}"
+    [[ "$reply" =~ ^[Yy] ]]
+}
+
+#-------------------------------------------------------------------------------
+# Step 1: Create directory structure
+#-------------------------------------------------------------------------------
+
+step_directories() {
+    printf '\n%s[1/6] Directory structure%s\n' "$C_BOLD" "$C_RESET"
+
+    local dirs=("$LOBSTER_DIR" "$BIN_DIR" "$LOG_DIR" "$CONFIG_DIR")
+    for dir in "${dirs[@]}"; do
+        if [[ -d "$dir" ]]; then
+            success "$dir (exists)"
+        else
+            mkdir -p "$dir"
+            success "$dir (created)"
+        fi
+    done
+}
+
+#-------------------------------------------------------------------------------
+# Step 2: Copy scripts
+#-------------------------------------------------------------------------------
+
+step_scripts() {
+    printf '\n%s[2/6] Install scripts%s\n' "$C_BOLD" "$C_RESET"
+
+    # Copy daemon and repo sync scripts
+    local daemon_src="$REPO_ROOT/scripts/lobster-sync-daemon.sh"
+    local repo_src="$REPO_ROOT/scripts/lobster-sync-repo.sh"
+    local cli_src="$SCRIPT_DIR/lobster-sync"
+
+    [[ -f "$daemon_src" ]] || die "Daemon script not found: $daemon_src"
+    [[ -f "$repo_src" ]]   || die "Repo sync script not found: $repo_src"
+    [[ -f "$cli_src" ]]    || die "CLI wrapper not found: $cli_src"
+
+    cp "$daemon_src" "$BIN_DIR/lobster-sync-daemon.sh"
+    chmod +x "$BIN_DIR/lobster-sync-daemon.sh"
+    success "lobster-sync-daemon.sh -> $BIN_DIR/"
+
+    cp "$repo_src" "$BIN_DIR/lobster-sync-repo.sh"
+    chmod +x "$BIN_DIR/lobster-sync-repo.sh"
+    success "lobster-sync-repo.sh -> $BIN_DIR/"
+
+    cp "$cli_src" "$BIN_DIR/lobster-sync"
+    chmod +x "$BIN_DIR/lobster-sync"
+    success "lobster-sync -> $BIN_DIR/"
+
+    # Symlink CLI to /usr/local/bin if possible
+    local symlink_target="/usr/local/bin/lobster-sync"
+    if [[ -w "/usr/local/bin" ]] || [[ -w "$(dirname "$symlink_target")" ]]; then
+        ln -sf "$BIN_DIR/lobster-sync" "$symlink_target"
+        success "Symlinked lobster-sync to $symlink_target"
+    elif [[ -L "$symlink_target" ]] || [[ -f "$symlink_target" ]]; then
+        info "lobster-sync already in PATH at $symlink_target"
+    else
+        warn "Cannot write to /usr/local/bin. Add $BIN_DIR to your PATH:"
+        warn "  echo 'export PATH=\"$BIN_DIR:\$PATH\"' >> ~/.zshrc"
+    fi
+}
+
+#-------------------------------------------------------------------------------
+# Step 3: Generate default config
+#-------------------------------------------------------------------------------
+
+step_config() {
+    printf '\n%s[3/6] Configuration%s\n' "$C_BOLD" "$C_RESET"
+
+    if [[ -f "$CONFIG_FILE" ]]; then
+        success "sync-config.json (exists, preserved)"
+    else
+        cat > "$CONFIG_FILE" <<'CONFIG'
+{
+  "sync_interval_seconds": 300,
+  "sync_branch": "lobster-sync",
+  "repos": []
+}
+CONFIG
+        success "sync-config.json (created with defaults)"
+        info "Add repos with: lobster-sync add ~/projects/my-repo"
+    fi
+}
+
+#-------------------------------------------------------------------------------
+# Step 4: Install launchd plist
+#-------------------------------------------------------------------------------
+
+step_plist() {
+    printf '\n%s[4/6] launchd service%s\n' "$C_BOLD" "$C_RESET"
+
+    [[ -f "$PLIST_TEMPLATE" ]] || die "Plist template not found: $PLIST_TEMPLATE"
+
+    # Ensure LaunchAgents directory exists
+    mkdir -p "$HOME/Library/LaunchAgents"
+
+    # Unload existing service if loaded (so we can update the plist)
+    if launchctl list "$PLIST_LABEL" > /dev/null 2>&1; then
+        launchctl unload "$PLIST_DEST" 2>/dev/null || true
+        info "Unloaded existing service for update"
+    fi
+
+    # Generate plist by replacing placeholders with actual home directory
+    sed "s|__USER_HOME__|$HOME|g" "$PLIST_TEMPLATE" > "$PLIST_DEST"
+    success "Installed plist to $PLIST_DEST"
+}
+
+#-------------------------------------------------------------------------------
+# Step 5: Keychain setup (optional)
+#-------------------------------------------------------------------------------
+
+step_keychain() {
+    printf '\n%s[5/6] GitHub token%s\n' "$C_BOLD" "$C_RESET"
+
+    # Check if token already exists in Keychain
+    local existing_token
+    existing_token="$(security find-generic-password \
+        -s "$KEYCHAIN_SERVICE" \
+        -a "$KEYCHAIN_ACCOUNT" \
+        -w 2>/dev/null)" && {
+        success "GitHub token found in Keychain"
+        return
+    }
+
+    # Check if token exists in .env file
+    if [[ -f "$ENV_FILE" ]] && grep -qE '^GITHUB_TOKEN=.+' "$ENV_FILE" 2>/dev/null; then
+        success "GitHub token found in $ENV_FILE"
+        if ask_yn "Move token to macOS Keychain (more secure)?" "y"; then
+            local token
+            token="$(grep -E '^GITHUB_TOKEN=' "$ENV_FILE" | head -1)"
+            token="${token#GITHUB_TOKEN=}"
+            if [[ -n "$token" ]]; then
+                security add-generic-password \
+                    -s "$KEYCHAIN_SERVICE" \
+                    -a "$KEYCHAIN_ACCOUNT" \
+                    -w "$token" \
+                    -U 2>/dev/null && {
+                    success "Token stored in Keychain"
+                    # Comment out the plaintext token in .env
+                    sed -i '' 's/^GITHUB_TOKEN=/#GITHUB_TOKEN=/' "$ENV_FILE" 2>/dev/null || true
+                    info "Commented out plaintext token in $ENV_FILE"
+                    return
+                }
+            fi
+        fi
+        return
+    fi
+
+    # No token found anywhere -- walk the user through setup
+    info "No GitHub token found."
+    info "A token with 'repo' scope is needed to push sync branches."
+    info ""
+    info "Create one at: https://github.com/settings/tokens/new"
+    info "Required scope: repo"
+    info ""
+
+    if ! ask_yn "Set up GitHub token now?" "y"; then
+        warn "Skipping token setup. Sync will work locally but cannot push."
+        warn "Run this installer again or add manually:"
+        warn "  security add-generic-password -s $KEYCHAIN_SERVICE -a $KEYCHAIN_ACCOUNT -w <token>"
+        return
+    fi
+
+    if [[ ! -t 0 ]]; then
+        warn "Non-interactive mode: cannot read token. Set it manually."
+        return
+    fi
+
+    printf '  %sGitHub token:%s ' "$C_BOLD" "$C_RESET"
+    local token
+    read -rs token
+    printf '\n'
+
+    if [[ -z "$token" ]]; then
+        warn "Empty token, skipping."
+        return
+    fi
+
+    if ask_yn "Store in macOS Keychain (recommended)?" "y"; then
+        security add-generic-password \
+            -s "$KEYCHAIN_SERVICE" \
+            -a "$KEYCHAIN_ACCOUNT" \
+            -w "$token" \
+            -U 2>/dev/null && {
+            success "Token stored in Keychain"
+            return
+        }
+        warn "Keychain storage failed. Falling back to .env file."
+    fi
+
+    # Fall back to .env file
+    printf 'GITHUB_TOKEN=%s\n' "$token" >> "$ENV_FILE"
+    chmod 600 "$ENV_FILE"
+    success "Token saved to $ENV_FILE"
+}
+
+#-------------------------------------------------------------------------------
+# Step 6: Claude Code settings (optional)
+#-------------------------------------------------------------------------------
+
+step_claude_settings() {
+    printf '\n%s[6/6] Claude Code settings (optional)%s\n' "$C_BOLD" "$C_RESET"
+
+    if ! ask_yn "Configure Claude Code MCP settings for the local bridge?" "n"; then
+        info "Skipped. You can configure this later."
+        return
+    fi
+
+    if [[ ! -f "$CLAUDE_SETTINGS" ]]; then
+        mkdir -p "$(dirname "$CLAUDE_SETTINGS")"
+        printf '{}\n' > "$CLAUDE_SETTINGS"
+        info "Created $CLAUDE_SETTINGS"
+    fi
+
+    # Check if jq is available for JSON manipulation
+    if ! command -v jq > /dev/null 2>&1; then
+        warn "jq not found. Please manually configure $CLAUDE_SETTINGS"
+        return
+    fi
+
+    # Add lobster-bridge MCP server config if not already present
+    local has_lobster
+    has_lobster="$(jq -r '.mcpServers["lobster-bridge"] // empty' "$CLAUDE_SETTINGS" 2>/dev/null)" || true
+    if [[ -n "$has_lobster" ]]; then
+        success "lobster-bridge already configured in Claude settings"
+        return
+    fi
+
+    local tmp
+    tmp="$(jq '. + {"mcpServers": (.mcpServers // {} | . + {"lobster-bridge": {"type": "stdio", "command": "'"$BIN_DIR"'/lobster-bridge", "args": []}})}' "$CLAUDE_SETTINGS")"
+    printf '%s\n' "$tmp" > "$CLAUDE_SETTINGS"
+    success "Added lobster-bridge to Claude Code settings"
+    info "Note: The bridge script (Layer 3) must also be installed for this to work."
+}
+
+#-------------------------------------------------------------------------------
+# Post-install: optionally start the service
+#-------------------------------------------------------------------------------
+
+step_start() {
+    printf '\n'
+    if $AUTO_START && ask_yn "Start the sync service now?" "y"; then
+        launchctl load "$PLIST_DEST"
+        success "Service started"
+        info "Check status with: lobster-sync status"
+    else
+        info "Service installed but not started."
+        info "Start with: lobster-sync start"
+    fi
+}
+
+#-------------------------------------------------------------------------------
+# Summary
+#-------------------------------------------------------------------------------
+
+print_summary() {
+    printf '\n%s========================================%s\n' "$C_BOLD" "$C_RESET"
+    printf '%s  Lobster Sync installed successfully!%s\n' "$C_GREEN" "$C_RESET"
+    printf '%s========================================%s\n' "$C_BOLD" "$C_RESET"
+    printf '\n'
+    printf '  Home:     %s\n' "$LOBSTER_DIR"
+    printf '  Config:   %s\n' "$CONFIG_FILE"
+    printf '  Logs:     %s\n' "$LOG_DIR"
+    printf '  Service:  %s\n' "$PLIST_DEST"
+    printf '\n'
+    printf '  Next steps:\n'
+    printf '    1. Add repos:  lobster-sync add ~/projects/my-repo\n'
+    printf '    2. Check:      lobster-sync status\n'
+    printf '    3. View logs:  lobster-sync log\n'
+    printf '\n'
+}
+
+#-------------------------------------------------------------------------------
+# Prerequisite checks
+#-------------------------------------------------------------------------------
+
+check_prerequisites() {
+    printf '%s[0/6] Prerequisites%s\n' "$C_BOLD" "$C_RESET"
+
+    # Must be macOS
+    [[ "$(uname)" == "Darwin" ]] || die "This installer is for macOS only."
+    success "macOS detected"
+
+    # git must be available
+    command -v git > /dev/null 2>&1 || die "git is required but not found."
+    success "git found: $(git --version | head -1)"
+
+    # jq must be available
+    if command -v jq > /dev/null 2>&1; then
+        success "jq found: $(jq --version)"
+    else
+        die "jq is required. Install with: brew install jq"
+    fi
+
+    # Source scripts must exist
+    [[ -f "$REPO_ROOT/scripts/lobster-sync-daemon.sh" ]] || \
+        die "Source scripts not found. Run from the Lobster repo: macos/install-lobster-local.sh"
+    success "Source scripts found in $REPO_ROOT/scripts/"
+}
+
+#-------------------------------------------------------------------------------
+# Parse arguments
+#-------------------------------------------------------------------------------
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --no-start)  AUTO_START=false; shift ;;
+            --help|-h)
+                printf 'Usage: %s [--no-start] [--help]\n' "$(basename "$0")"
+                printf '\nInstalls Lobster local sync on macOS.\n'
+                printf '\nOptions:\n'
+                printf '  --no-start   Install without starting the service\n'
+                printf '  --help       Show this help message\n'
+                exit 0
+                ;;
+            *)
+                die "Unknown option: $1"
+                ;;
+        esac
+    done
+}
+
+#-------------------------------------------------------------------------------
+# Main
+#-------------------------------------------------------------------------------
+
+main() {
+    parse_args "$@"
+
+    printf '\n%s=== Lobster Local Sync Installer ===%s\n\n' "$C_BOLD" "$C_RESET"
+
+    check_prerequisites
+    step_directories
+    step_scripts
+    step_config
+    step_plist
+    step_keychain
+    step_claude_settings
+    step_start
+    print_summary
+}
+
+main "$@"

--- a/macos/lobster-sync
+++ b/macos/lobster-sync
@@ -1,0 +1,491 @@
+#!/bin/bash
+#===============================================================================
+# lobster-sync -- CLI wrapper for the lobster-sync daemon
+#
+# Manages the lobster-sync-daemon.sh service on macOS: register and unregister
+# repos, check sync status, trigger immediate syncs, tail logs, and
+# start/stop the launchd service.
+#
+# Usage:
+#   lobster-sync add <path>        Register a repo for continuous sync
+#   lobster-sync remove <path>     Unregister a repo
+#   lobster-sync status            Show sync status for all registered repos
+#   lobster-sync now               Trigger immediate sync of all repos
+#   lobster-sync log               Tail the sync log
+#   lobster-sync start             Load the launchd service
+#   lobster-sync stop              Unload the launchd service
+#   lobster-sync help              Show this help message
+#
+# Configuration: ~/.lobster/sync-config.json
+# Logs:          ~/.lobster/logs/sync.log
+#===============================================================================
+
+set -euo pipefail
+
+#-------------------------------------------------------------------------------
+# Constants
+#-------------------------------------------------------------------------------
+
+readonly LOBSTER_DIR="${LOBSTER_SYNC_HOME:-$HOME/.lobster}"
+readonly CONFIG_FILE="${LOBSTER_SYNC_CONFIG:-$LOBSTER_DIR/sync-config.json}"
+readonly LOG_FILE="$LOBSTER_DIR/logs/sync.log"
+readonly PID_FILE="$LOBSTER_DIR/sync.pid"
+readonly PLIST_LABEL="com.lobster.sync"
+readonly PLIST_PATH="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
+readonly DAEMON_SCRIPT="$LOBSTER_DIR/bin/lobster-sync-daemon.sh"
+readonly KEYCHAIN_SERVICE="lobster-sync"
+readonly KEYCHAIN_ACCOUNT="github-token"
+readonly ENV_FILE="$LOBSTER_DIR/.env"
+
+#-------------------------------------------------------------------------------
+# Terminal colors (only when stdout is a terminal)
+#-------------------------------------------------------------------------------
+
+if [[ -t 1 ]]; then
+    readonly C_GREEN=$'\033[32m'
+    readonly C_RED=$'\033[31m'
+    readonly C_YELLOW=$'\033[33m'
+    readonly C_DIM=$'\033[2m'
+    readonly C_BOLD=$'\033[1m'
+    readonly C_RESET=$'\033[0m'
+else
+    readonly C_GREEN="" C_RED="" C_YELLOW="" C_DIM="" C_BOLD="" C_RESET=""
+fi
+
+#-------------------------------------------------------------------------------
+# Pure helper functions (no side effects)
+#-------------------------------------------------------------------------------
+
+die() {
+    printf '%s%s%s\n' "$C_RED" "$*" "$C_RESET" >&2
+    exit 1
+}
+
+info() {
+    printf '%s%s%s\n' "$C_DIM" "$*" "$C_RESET"
+}
+
+success() {
+    printf '%s%s%s\n' "$C_GREEN" "$*" "$C_RESET"
+}
+
+warn() {
+    printf '%s%s%s\n' "$C_YELLOW" "$*" "$C_RESET" >&2
+}
+
+# Resolve a path to its absolute form, handling ~ and relative paths.
+# Pure function of its argument (reads filesystem but no writes).
+resolve_path() {
+    local raw="$1"
+    # Expand leading ~ manually (not expanded inside quotes)
+    raw="${raw/#\~/$HOME}"
+    # Use cd + pwd to resolve symlinks and relative components
+    if [[ -d "$raw" ]]; then
+        (cd "$raw" && pwd)
+    else
+        echo "$raw"
+    fi
+}
+
+# Read the GitHub token, preferring Keychain, falling back to .env file.
+# Returns empty string if neither source has a token.
+read_github_token() {
+    # Try macOS Keychain first
+    local token
+    token="$(security find-generic-password \
+        -s "$KEYCHAIN_SERVICE" \
+        -a "$KEYCHAIN_ACCOUNT" \
+        -w 2>/dev/null)" && {
+        echo "$token"
+        return
+    }
+    # Fall back to .env file
+    if [[ -f "$ENV_FILE" ]]; then
+        local line
+        line="$(grep -E '^GITHUB_TOKEN=' "$ENV_FILE" 2>/dev/null | head -1)" || true
+        echo "${line#GITHUB_TOKEN=}"
+        return
+    fi
+    echo ""
+}
+
+# Check whether jq is available (needed for config manipulation).
+require_jq() {
+    command -v jq > /dev/null 2>&1 || die "jq is required but not found. Install with: brew install jq"
+}
+
+# Read a field from the config file with a default value.
+config_field() {
+    local field="$1" default="$2"
+    if [[ -f "$CONFIG_FILE" ]]; then
+        local value
+        value="$(jq -r "$field // empty" "$CONFIG_FILE" 2>/dev/null)"
+        echo "${value:-$default}"
+    else
+        echo "$default"
+    fi
+}
+
+# Return the list of repo entries as "path|remote|enabled" lines.
+config_repo_entries() {
+    [[ -f "$CONFIG_FILE" ]] || return
+    jq -r '.repos[]? | "\(.path)|\(.remote // "origin")|\(if .enabled == false then "false" else "true" end)"' \
+        "$CONFIG_FILE" 2>/dev/null
+}
+
+# Check if the daemon process is running (via PID file).
+is_daemon_running() {
+    [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null
+}
+
+# Check if the launchd service is loaded.
+is_service_loaded() {
+    launchctl list "$PLIST_LABEL" > /dev/null 2>&1
+}
+
+# Format a duration in seconds as a human-friendly string.
+format_duration() {
+    local seconds="$1"
+    if [[ "$seconds" -lt 60 ]]; then
+        echo "${seconds}s ago"
+    elif [[ "$seconds" -lt 3600 ]]; then
+        echo "$(( seconds / 60 ))m ago"
+    elif [[ "$seconds" -lt 86400 ]]; then
+        echo "$(( seconds / 3600 ))h ago"
+    else
+        echo "$(( seconds / 86400 ))d ago"
+    fi
+}
+
+# Get the timestamp of the last sync commit on a repo's sync branch.
+# Returns empty string if no sync branch exists.
+last_sync_time() {
+    local repo_path="$1"
+    local sync_branch
+    sync_branch="$(config_field '.sync_branch' 'lobster-sync')"
+
+    if [[ ! -d "$repo_path/.git" ]]; then
+        echo ""
+        return
+    fi
+
+    git -C "$repo_path" log -1 --format='%ct' "refs/heads/$sync_branch" 2>/dev/null || echo ""
+}
+
+# Get the basename of a repo path for display.
+repo_name() {
+    basename "$1"
+}
+
+#-------------------------------------------------------------------------------
+# Subcommand: add <path>
+#-------------------------------------------------------------------------------
+
+cmd_add() {
+    local raw_path="${1:-}"
+    [[ -z "$raw_path" ]] && die "Usage: lobster-sync add <path>"
+    require_jq
+
+    local abs_path
+    abs_path="$(resolve_path "$raw_path")"
+
+    # Validate it is a git repo
+    [[ -d "$abs_path" ]] || die "Directory does not exist: $abs_path"
+    git -C "$abs_path" rev-parse --git-dir > /dev/null 2>&1 || \
+        die "Not a git repository: $abs_path"
+
+    # Ensure config file exists
+    if [[ ! -f "$CONFIG_FILE" ]]; then
+        printf '{"sync_interval_seconds": 300, "sync_branch": "lobster-sync", "repos": []}\n' > "$CONFIG_FILE"
+        info "Created config: $CONFIG_FILE"
+    fi
+
+    # Check if repo is already registered
+    local existing
+    existing="$(jq -r --arg p "$abs_path" '.repos[] | select(.path == $p) | .path' "$CONFIG_FILE" 2>/dev/null)" || true
+    if [[ -n "$existing" ]]; then
+        # Re-enable if disabled
+        local tmp
+        tmp="$(jq --arg p "$abs_path" '(.repos[] | select(.path == $p)).enabled = true' "$CONFIG_FILE")"
+        printf '%s\n' "$tmp" > "$CONFIG_FILE"
+        success "Re-enabled: $abs_path"
+        return
+    fi
+
+    # Add new repo entry
+    local tmp
+    tmp="$(jq --arg p "$abs_path" '.repos += [{"path": $p, "remote": "origin", "enabled": true}]' "$CONFIG_FILE")"
+    printf '%s\n' "$tmp" > "$CONFIG_FILE"
+    success "Added: $abs_path"
+
+    # Export GITHUB_TOKEN if available so the daemon can push
+    local token
+    token="$(read_github_token)"
+    if [[ -z "$token" ]]; then
+        warn "No GitHub token found. Run: lobster-sync add-token"
+        warn "Or set GITHUB_TOKEN in $ENV_FILE"
+    fi
+}
+
+#-------------------------------------------------------------------------------
+# Subcommand: remove <path>
+#-------------------------------------------------------------------------------
+
+cmd_remove() {
+    local raw_path="${1:-}"
+    [[ -z "$raw_path" ]] && die "Usage: lobster-sync remove <path>"
+    require_jq
+
+    local abs_path
+    abs_path="$(resolve_path "$raw_path")"
+
+    [[ -f "$CONFIG_FILE" ]] || die "Config not found: $CONFIG_FILE"
+
+    # Check the repo is registered
+    local existing
+    existing="$(jq -r --arg p "$abs_path" '.repos[] | select(.path == $p) | .path' "$CONFIG_FILE" 2>/dev/null)" || true
+    [[ -z "$existing" ]] && die "Repo not registered: $abs_path"
+
+    # Remove from config
+    local tmp
+    tmp="$(jq --arg p "$abs_path" '.repos = [.repos[] | select(.path != $p)]' "$CONFIG_FILE")"
+    printf '%s\n' "$tmp" > "$CONFIG_FILE"
+    success "Removed: $abs_path"
+}
+
+#-------------------------------------------------------------------------------
+# Subcommand: status
+#-------------------------------------------------------------------------------
+
+cmd_status() {
+    require_jq
+
+    # Service status
+    printf '%s--- Service ---%s\n' "$C_BOLD" "$C_RESET"
+    if is_service_loaded; then
+        printf '  launchd:  %sloaded%s\n' "$C_GREEN" "$C_RESET"
+    else
+        printf '  launchd:  %snot loaded%s\n' "$C_RED" "$C_RESET"
+    fi
+
+    if is_daemon_running; then
+        local pid
+        pid="$(cat "$PID_FILE")"
+        printf '  daemon:   %srunning%s (PID %s)\n' "$C_GREEN" "$C_RESET" "$pid"
+    else
+        printf '  daemon:   %sstopped%s\n' "$C_RED" "$C_RESET"
+    fi
+
+    local interval
+    interval="$(config_field '.sync_interval_seconds' '300')"
+    printf '  interval: %ss\n' "$interval"
+    printf '\n'
+
+    # Repo status
+    printf '%s--- Repos ---%s\n' "$C_BOLD" "$C_RESET"
+
+    if [[ ! -f "$CONFIG_FILE" ]]; then
+        warn "  No config file found. Run: lobster-sync add <path>"
+        return
+    fi
+
+    local has_repos=false
+    while IFS='|' read -r repo_path remote enabled; do
+        [[ -z "$repo_path" ]] && continue
+        has_repos=true
+
+        local name status_icon last_sync duration_str
+
+        name="$(repo_name "$repo_path")"
+
+        if [[ "$enabled" != "true" ]]; then
+            status_icon="${C_DIM}disabled${C_RESET}"
+            duration_str="-"
+        elif [[ ! -d "$repo_path" ]]; then
+            status_icon="${C_RED}missing${C_RESET}"
+            duration_str="-"
+        else
+            last_sync="$(last_sync_time "$repo_path")"
+            if [[ -n "$last_sync" ]]; then
+                local now
+                now="$(date +%s)"
+                local diff=$(( now - last_sync ))
+                duration_str="$(format_duration "$diff")"
+                # Green if synced within 2x interval, yellow otherwise
+                if [[ "$diff" -lt $(( interval * 2 )) ]]; then
+                    status_icon="${C_GREEN}ok${C_RESET}"
+                else
+                    status_icon="${C_YELLOW}stale${C_RESET}"
+                fi
+            else
+                status_icon="${C_DIM}never synced${C_RESET}"
+                duration_str="-"
+            fi
+        fi
+
+        printf '  %-20s %-40s last sync: %-12s %s\n' \
+            "$name" "$repo_path" "$duration_str" "$status_icon"
+    done <<< "$(config_repo_entries)"
+
+    if ! $has_repos; then
+        info "  No repos registered. Run: lobster-sync add <path>"
+    fi
+}
+
+#-------------------------------------------------------------------------------
+# Subcommand: now
+#-------------------------------------------------------------------------------
+
+cmd_now() {
+    [[ -x "$DAEMON_SCRIPT" ]] || die "Daemon script not found: $DAEMON_SCRIPT"
+    [[ -f "$CONFIG_FILE" ]] || die "Config not found: $CONFIG_FILE"
+
+    # Export GITHUB_TOKEN from Keychain / .env if available
+    local token
+    token="$(read_github_token)"
+    if [[ -n "$token" ]]; then
+        export GITHUB_TOKEN="$token"
+    fi
+
+    info "Running sync cycle..."
+    "$DAEMON_SCRIPT" --once
+    success "Sync complete."
+}
+
+#-------------------------------------------------------------------------------
+# Subcommand: log
+#-------------------------------------------------------------------------------
+
+cmd_log() {
+    local log_target="$LOG_FILE"
+    # Also check stdout/stderr logs from launchd
+    local stdout_log="$LOBSTER_DIR/logs/sync-stdout.log"
+    local stderr_log="$LOBSTER_DIR/logs/sync-stderr.log"
+
+    if [[ -f "$log_target" ]]; then
+        tail -f "$log_target"
+    elif [[ -f "$stderr_log" ]]; then
+        info "Main log not found, tailing stderr log..."
+        tail -f "$stderr_log"
+    else
+        die "No log files found in $LOBSTER_DIR/logs/"
+    fi
+}
+
+#-------------------------------------------------------------------------------
+# Subcommand: start
+#-------------------------------------------------------------------------------
+
+cmd_start() {
+    [[ -f "$PLIST_PATH" ]] || die "Plist not installed: $PLIST_PATH\nRun the installer first: macos/install-lobster-local.sh"
+
+    if is_service_loaded; then
+        warn "Service is already loaded."
+        if is_daemon_running; then
+            info "Daemon is running (PID: $(cat "$PID_FILE"))."
+        fi
+        return
+    fi
+
+    info "Loading launchd service..."
+    launchctl load "$PLIST_PATH"
+    success "Service started."
+
+    # Give it a moment to spin up
+    sleep 1
+    if is_daemon_running; then
+        info "Daemon running (PID: $(cat "$PID_FILE"))."
+    elif is_service_loaded; then
+        info "Service loaded. Daemon starting up..."
+    fi
+}
+
+#-------------------------------------------------------------------------------
+# Subcommand: stop
+#-------------------------------------------------------------------------------
+
+cmd_stop() {
+    if ! is_service_loaded; then
+        warn "Service is not loaded."
+        # Clean up stale PID file if present
+        if [[ -f "$PID_FILE" ]]; then
+            rm -f "$PID_FILE"
+            info "Removed stale PID file."
+        fi
+        return
+    fi
+
+    info "Unloading launchd service..."
+    launchctl unload "$PLIST_PATH"
+
+    # Wait briefly for daemon to stop
+    local i=0
+    while is_daemon_running && [[ $i -lt 5 ]]; do
+        sleep 1
+        i=$((i + 1))
+    done
+
+    if is_daemon_running; then
+        warn "Daemon still running after unload. Force stopping..."
+        local pid
+        pid="$(cat "$PID_FILE")"
+        kill "$pid" 2>/dev/null || true
+        sleep 1
+        kill -9 "$pid" 2>/dev/null || true
+        rm -f "$PID_FILE"
+    fi
+
+    success "Service stopped."
+}
+
+#-------------------------------------------------------------------------------
+# Subcommand: help
+#-------------------------------------------------------------------------------
+
+cmd_help() {
+    cat <<'USAGE'
+lobster-sync -- Manage the Lobster continuous sync daemon
+
+Usage:
+  lobster-sync add <path>        Register a git repo for continuous sync
+  lobster-sync remove <path>     Unregister a repo
+  lobster-sync status            Show sync status for all registered repos
+  lobster-sync now               Trigger immediate sync of all repos
+  lobster-sync log               Tail the sync log
+  lobster-sync start             Load the launchd service
+  lobster-sync stop              Unload the launchd service
+  lobster-sync help              Show this help message
+
+Configuration:
+  ~/.lobster/sync-config.json    Repo list and sync settings
+  ~/.lobster/.env                GitHub token (fallback if not in Keychain)
+
+Logs:
+  ~/.lobster/logs/sync.log       Daemon log (from lobster-sync-daemon.sh)
+  ~/.lobster/logs/sync-stdout.log  launchd stdout capture
+  ~/.lobster/logs/sync-stderr.log  launchd stderr capture
+
+Examples:
+  lobster-sync add ~/projects/my-app
+  lobster-sync status
+  lobster-sync now
+  lobster-sync log
+USAGE
+}
+
+#-------------------------------------------------------------------------------
+# Entry point: dispatch subcommand
+#-------------------------------------------------------------------------------
+
+case "${1:-}" in
+    add)      shift; cmd_add "$@" ;;
+    remove)   shift; cmd_remove "$@" ;;
+    status)   cmd_status ;;
+    now)      cmd_now ;;
+    log)      cmd_log ;;
+    start)    cmd_start ;;
+    stop)     cmd_stop ;;
+    help|-h|--help)  cmd_help ;;
+    "")       cmd_help; exit 1 ;;
+    *)        die "Unknown command: $1 (try: lobster-sync help)" ;;
+esac

--- a/macos/uninstall-lobster-local.sh
+++ b/macos/uninstall-lobster-local.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+#===============================================================================
+# uninstall-lobster-local.sh -- Remove Lobster local sync from macOS
+#
+# Unloads the launchd service, removes the plist, and optionally removes the
+# ~/.lobster directory. Does NOT remove git repos or sync branches.
+#
+# Usage:
+#   ./uninstall-lobster-local.sh           Interactive uninstall
+#   ./uninstall-lobster-local.sh --full    Remove everything including ~/.lobster
+#   ./uninstall-lobster-local.sh --help    Show help
+#===============================================================================
+
+set -euo pipefail
+
+#-------------------------------------------------------------------------------
+# Constants
+#-------------------------------------------------------------------------------
+
+readonly LOBSTER_DIR="$HOME/.lobster"
+readonly PLIST_LABEL="com.lobster.sync"
+readonly PLIST_PATH="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
+readonly BIN_DIR="$LOBSTER_DIR/bin"
+readonly SYMLINK_PATH="/usr/local/bin/lobster-sync"
+readonly KEYCHAIN_SERVICE="lobster-sync"
+readonly KEYCHAIN_ACCOUNT="github-token"
+
+# Control flags
+FULL_REMOVE=false
+
+#-------------------------------------------------------------------------------
+# Terminal colors (only when stdout is a terminal)
+#-------------------------------------------------------------------------------
+
+if [[ -t 1 ]]; then
+    readonly C_GREEN=$'\033[32m'
+    readonly C_RED=$'\033[31m'
+    readonly C_YELLOW=$'\033[33m'
+    readonly C_DIM=$'\033[2m'
+    readonly C_BOLD=$'\033[1m'
+    readonly C_RESET=$'\033[0m'
+else
+    readonly C_GREEN="" C_RED="" C_YELLOW="" C_DIM="" C_BOLD="" C_RESET=""
+fi
+
+#-------------------------------------------------------------------------------
+# Helper functions
+#-------------------------------------------------------------------------------
+
+info() {
+    printf '  %s-->%s %s\n' "$C_BOLD" "$C_RESET" "$*"
+}
+
+success() {
+    printf '  %s[ok]%s %s\n' "$C_GREEN" "$C_RESET" "$*"
+}
+
+warn() {
+    printf '  %s[!!]%s %s\n' "$C_YELLOW" "$C_RESET" "$*" >&2
+}
+
+ask_yn() {
+    local prompt="$1" default="${2:-n}"
+    local yn_hint="[y/N]"
+    [[ "$default" == "y" ]] && yn_hint="[Y/n]"
+
+    if [[ ! -t 0 ]]; then
+        [[ "$default" == "y" ]]
+        return $?
+    fi
+
+    local reply
+    printf '  %s%s%s %s ' "$C_BOLD" "$prompt" "$C_RESET" "$yn_hint"
+    read -r reply
+    reply="${reply:-$default}"
+    [[ "$reply" =~ ^[Yy] ]]
+}
+
+#-------------------------------------------------------------------------------
+# Step 1: Stop and unload the launchd service
+#-------------------------------------------------------------------------------
+
+step_service() {
+    printf '\n%s[1/4] launchd service%s\n' "$C_BOLD" "$C_RESET"
+
+    if launchctl list "$PLIST_LABEL" > /dev/null 2>&1; then
+        launchctl unload "$PLIST_PATH" 2>/dev/null || true
+        success "Service unloaded"
+    else
+        info "Service was not loaded"
+    fi
+
+    # Remove plist file
+    if [[ -f "$PLIST_PATH" ]]; then
+        rm -f "$PLIST_PATH"
+        success "Removed $PLIST_PATH"
+    else
+        info "Plist not found (already removed)"
+    fi
+
+    # Clean up PID file
+    local pid_file="$LOBSTER_DIR/sync.pid"
+    if [[ -f "$pid_file" ]]; then
+        local pid
+        pid="$(cat "$pid_file")"
+        if kill -0 "$pid" 2>/dev/null; then
+            info "Stopping daemon process (PID: $pid)..."
+            kill "$pid" 2>/dev/null || true
+            sleep 2
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+        rm -f "$pid_file"
+        success "Removed PID file"
+    fi
+}
+
+#-------------------------------------------------------------------------------
+# Step 2: Remove symlinks
+#-------------------------------------------------------------------------------
+
+step_symlinks() {
+    printf '\n%s[2/4] CLI symlinks%s\n' "$C_BOLD" "$C_RESET"
+
+    if [[ -L "$SYMLINK_PATH" ]]; then
+        rm -f "$SYMLINK_PATH"
+        success "Removed $SYMLINK_PATH"
+    elif [[ -f "$SYMLINK_PATH" ]]; then
+        warn "$SYMLINK_PATH exists but is not a symlink. Leaving it."
+    else
+        info "No symlink at $SYMLINK_PATH"
+    fi
+}
+
+#-------------------------------------------------------------------------------
+# Step 3: Optionally remove Keychain entry
+#-------------------------------------------------------------------------------
+
+step_keychain() {
+    printf '\n%s[3/4] Keychain%s\n' "$C_BOLD" "$C_RESET"
+
+    # Check if Keychain entry exists
+    if security find-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" > /dev/null 2>&1; then
+        if ask_yn "Remove GitHub token from Keychain?" "n"; then
+            security delete-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" 2>/dev/null || true
+            success "Removed Keychain entry"
+        else
+            info "Keychain entry preserved"
+        fi
+    else
+        info "No Keychain entry found"
+    fi
+}
+
+#-------------------------------------------------------------------------------
+# Step 4: Optionally remove ~/.lobster directory
+#-------------------------------------------------------------------------------
+
+step_directory() {
+    printf '\n%s[4/4] Data directory%s\n' "$C_BOLD" "$C_RESET"
+
+    if [[ ! -d "$LOBSTER_DIR" ]]; then
+        info "$LOBSTER_DIR does not exist"
+        return
+    fi
+
+    if $FULL_REMOVE || ask_yn "Remove $LOBSTER_DIR? (config, logs, scripts will be deleted)" "n"; then
+        rm -rf "$LOBSTER_DIR"
+        success "Removed $LOBSTER_DIR"
+    else
+        info "$LOBSTER_DIR preserved"
+        info "You can remove it later with: rm -rf $LOBSTER_DIR"
+    fi
+}
+
+#-------------------------------------------------------------------------------
+# Summary
+#-------------------------------------------------------------------------------
+
+print_summary() {
+    printf '\n%s========================================%s\n' "$C_BOLD" "$C_RESET"
+    printf '%s  Lobster Sync uninstalled%s\n' "$C_GREEN" "$C_RESET"
+    printf '%s========================================%s\n' "$C_BOLD" "$C_RESET"
+    printf '\n'
+    printf '  Note: Git repos and lobster-sync branches were NOT removed.\n'
+    printf '  To remove sync branches from a repo:\n'
+    printf '    git branch -D lobster-sync\n'
+    printf '    git push origin --delete lobster-sync\n'
+    printf '\n'
+}
+
+#-------------------------------------------------------------------------------
+# Parse arguments
+#-------------------------------------------------------------------------------
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --full)  FULL_REMOVE=true; shift ;;
+            --help|-h)
+                printf 'Usage: %s [--full] [--help]\n' "$(basename "$0")"
+                printf '\nUninstalls Lobster local sync from macOS.\n'
+                printf '\nOptions:\n'
+                printf '  --full    Remove everything including ~/.lobster directory\n'
+                printf '  --help    Show this help message\n'
+                printf '\nDoes NOT remove:\n'
+                printf '  - Git repositories\n'
+                printf '  - lobster-sync branches in repos\n'
+                printf '  - Remote sync branches on GitHub\n'
+                exit 0
+                ;;
+            *)
+                printf 'Unknown option: %s\n' "$1" >&2
+                exit 1
+                ;;
+        esac
+    done
+}
+
+#-------------------------------------------------------------------------------
+# Main
+#-------------------------------------------------------------------------------
+
+main() {
+    parse_args "$@"
+
+    printf '\n%s=== Lobster Sync Uninstaller ===%s\n' "$C_BOLD" "$C_RESET"
+
+    step_service
+    step_symlinks
+    step_keychain
+    step_directory
+    print_summary
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds comprehensive macOS support for the lobster-sync daemon (Layer 1), making it seamless to install, manage, and run on macOS.

Closes #38 | Parent epic: #30

### What's included

- **`macos/com.lobster.sync.plist`** -- launchd service template with `KeepAlive`, `RunAtLoad`, proper `PATH` (including `/opt/homebrew/bin`), and `LOBSTER_SYNC_CONFIG` env var. Uses `__USER_HOME__` placeholders that the installer substitutes at install time (launchd does not expand `~`).

- **`macos/lobster-sync`** -- CLI wrapper with 7 subcommands:
  - `add <path>` / `remove <path>` -- register/unregister repos (validates git repo, uses jq for config manipulation)
  - `status` -- shows service state + per-repo sync freshness with colored output (ok/stale/never synced/disabled/missing)
  - `now` -- triggers immediate sync cycle (exports Keychain token, invokes `--once`)
  - `log` -- tails the daemon log
  - `start` / `stop` -- loads/unloads the launchd service

- **`macos/install-lobster-local.sh`** -- Idempotent 6-step installer:
  1. Creates `~/.lobster/{bin,logs,config}/`
  2. Copies daemon, repo sync, and CLI scripts to `~/.lobster/bin/`
  3. Generates default `sync-config.json` (preserves existing)
  4. Installs plist to `~/Library/LaunchAgents/` (unloads first if updating)
  5. Interactive Keychain setup (detects existing token in Keychain or `.env`, offers migration)
  6. Optional Claude Code MCP settings configuration

- **`macos/uninstall-lobster-local.sh`** -- Clean 4-step uninstaller:
  1. Unloads launchd service, kills daemon, removes plist
  2. Removes `/usr/local/bin/lobster-sync` symlink
  3. Optionally removes Keychain entry
  4. Optionally removes `~/.lobster/` (never touches git repos or sync branches)

- **`macos/README.md`** -- Full documentation: architecture diagram, prerequisites, quick start, CLI reference, config schema, Keychain setup, troubleshooting guide

### Key design decisions

- **Plist uses placeholder substitution** rather than hardcoded paths, so the template works for any user
- **Keychain-first token strategy** with `.env` fallback -- the CLI reads from Keychain at runtime, never stores tokens in plaintext by default
- **Functional structure** -- pure helper functions for path resolution, config reading, duration formatting; side effects isolated to subcommand handlers
- **Idempotent installer** -- safe to re-run; preserves config, updates scripts and plist
- **Color output** with terminal detection (`[[ -t 1 ]]`) -- degrades gracefully in pipes and CI

### Testing notes

- Scripts use `set -euo pipefail` throughout
- Installer validates prerequisites (macOS, git, jq, source scripts) before proceeding
- Non-interactive mode (piped stdin) uses sensible defaults
- All file operations check existence before acting