### PR TITLE
Layer 3: lobster-bridge convenience tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !.env.example
 !config.env.example
 !mcp-http-auth.env.example
+!bridge-local.example.env
 config.env
 
 # Python

--- a/config/bridge-local.example.env
+++ b/config/bridge-local.example.env
@@ -1,0 +1,26 @@
+# Lobster Bridge — Local MCP Server Configuration
+#
+# Copy this file and set LOBSTER_CANONICAL_DIR to point at your local clone
+# of the canonical memory directory.
+#
+# Usage:
+#   cp bridge-local.example.env bridge-local.env
+#   # Edit bridge-local.env to set your path
+#   source bridge-local.env && python src/mcp/lobster_bridge_local.py
+#
+# Or configure directly in Claude Code's ~/.claude/settings.json:
+#   {
+#     "mcpServers": {
+#       "lobster-bridge": {
+#         "command": "python",
+#         "args": ["/path/to/src/mcp/lobster_bridge_local.py"],
+#         "env": {
+#           "LOBSTER_CANONICAL_DIR": "/Users/you/projects/lobster/memory/canonical"
+#         }
+#       }
+#     }
+#   }
+
+# Absolute path to the canonical memory directory.
+# This is typically memory/canonical/ inside your Lobster repo clone.
+LOBSTER_CANONICAL_DIR=/Users/you/projects/lobster/memory/canonical

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -910,6 +910,45 @@ async def list_tools() -> list[Tool]:
                 "required": ["confirm"],
             },
         ),
+        # Convenience Tools (canonical memory readers)
+        Tool(
+            name="get_priorities",
+            description="Fetch Lobster's current priority stack. Returns the canonical priorities.md file, updated nightly by the consolidation process. Shows what Lobster considers most important right now, ranked and annotated.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+            },
+        ),
+        Tool(
+            name="get_project_context",
+            description="Fetch status and context for a specific project. Returns project status, recent decisions, pending items, and blockers from the canonical project file.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "project": {
+                        "type": "string",
+                        "description": "Project name (e.g., 'lobster', 'govscan', 'transformers')",
+                    },
+                },
+                "required": ["project"],
+            },
+        ),
+        Tool(
+            name="get_daily_digest",
+            description="Fetch the latest daily digest. Summarizes recent activity: key conversations, task progress, decisions made, and items needing follow-up.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+            },
+        ),
+        Tool(
+            name="list_projects",
+            description="List all projects tracked in Lobster's canonical memory. Returns project names for use with get_project_context().",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+            },
+        ),
         # Google Calendar Tools (dynamically loaded from calendar_integration.py)
         *[
             Tool(
@@ -1024,6 +1063,15 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[TextConte
         return await handle_get_upgrade_plan(arguments)
     elif name == "execute_update":
         return await handle_execute_update(arguments)
+    # Convenience Tools (canonical memory readers)
+    elif name == "get_priorities":
+        return await handle_get_priorities(arguments)
+    elif name == "get_project_context":
+        return await handle_get_project_context(arguments)
+    elif name == "get_daily_digest":
+        return await handle_get_daily_digest(arguments)
+    elif name == "list_projects":
+        return await handle_list_projects(arguments)
     # Google Calendar Tools
     elif name in CALENDAR_HANDLERS:
         handler = CALENDAR_HANDLERS[name]
@@ -2870,7 +2918,8 @@ async def handle_get_brain_dump_status(args: dict) -> list[TextContent]:
 # =============================================================================
 
 
-HANDOFF_PATH = Path.home() / "lobster" / "memory" / "canonical" / "handoff.md"
+CANONICAL_DIR = Path.home() / "lobster" / "memory" / "canonical"
+HANDOFF_PATH = CANONICAL_DIR / "handoff.md"
 
 
 async def handle_memory_store(arguments: dict[str, Any]) -> list[TextContent]:
@@ -3090,6 +3139,92 @@ async def handle_execute_update(arguments: dict[str, Any]) -> list[TextContent]:
     except Exception as e:
         log.error(f"execute_update failed: {e}", exc_info=True)
         return [TextContent(type="text", text=f"Error executing update: {e}")]
+
+
+# =============================================================================
+# Convenience Tools — Canonical Memory Readers
+# =============================================================================
+
+
+def _read_canonical_file(relative_path: str, missing_message: str) -> str:
+    """Pure helper: read a file under CANONICAL_DIR or return a fallback message."""
+    path = CANONICAL_DIR / relative_path
+    if path.exists():
+        return path.read_text()
+    return missing_message
+
+
+def _list_project_names() -> list[dict]:
+    """Pure helper: list project markdown files under CANONICAL_DIR/projects/."""
+    projects_dir = CANONICAL_DIR / "projects"
+    if not projects_dir.exists():
+        return []
+    return [
+        {"name": f.stem, "path": str(f)}
+        for f in sorted(projects_dir.glob("*.md"))
+    ]
+
+
+async def handle_get_priorities(arguments: dict[str, Any]) -> list[TextContent]:
+    """Return the canonical priorities.md content."""
+    try:
+        content = _read_canonical_file(
+            "priorities.md",
+            "No priorities file found. Nightly consolidation has not run yet.",
+        )
+        return [TextContent(type="text", text=content)]
+    except Exception as e:
+        log.error(f"get_priorities failed: {e}", exc_info=True)
+        return [TextContent(type="text", text=f"Error reading priorities: {e}")]
+
+
+async def handle_get_project_context(arguments: dict[str, Any]) -> list[TextContent]:
+    """Return a specific project's canonical markdown content."""
+    project = arguments.get("project", "")
+    if not project:
+        return [TextContent(type="text", text="Error: project name is required.")]
+
+    # Sanitize: reject path traversal attempts
+    if "/" in project or "\\" in project or ".." in project:
+        return [TextContent(type="text", text="Error: invalid project name.")]
+
+    try:
+        path = CANONICAL_DIR / "projects" / f"{project}.md"
+        if path.exists():
+            return [TextContent(type="text", text=path.read_text())]
+        available = [f.stem for f in (CANONICAL_DIR / "projects").glob("*.md")] if (CANONICAL_DIR / "projects").exists() else []
+        return [TextContent(
+            type="text",
+            text=f"No project file for '{project}'. Available: {', '.join(available) or 'none'}",
+        )]
+    except Exception as e:
+        log.error(f"get_project_context failed: {e}", exc_info=True)
+        return [TextContent(type="text", text=f"Error reading project context: {e}")]
+
+
+async def handle_get_daily_digest(arguments: dict[str, Any]) -> list[TextContent]:
+    """Return the canonical daily-digest.md content."""
+    try:
+        content = _read_canonical_file(
+            "daily-digest.md",
+            "No daily digest found. Nightly consolidation has not run yet.",
+        )
+        return [TextContent(type="text", text=content)]
+    except Exception as e:
+        log.error(f"get_daily_digest failed: {e}", exc_info=True)
+        return [TextContent(type="text", text=f"Error reading daily digest: {e}")]
+
+
+async def handle_list_projects(arguments: dict[str, Any]) -> list[TextContent]:
+    """List all project files in canonical memory."""
+    try:
+        projects = _list_project_names()
+        if not projects:
+            return [TextContent(type="text", text="No project files found in canonical memory.")]
+        return [TextContent(type="text", text=json.dumps(projects, indent=2))]
+    except Exception as e:
+        log.error(f"list_projects failed: {e}", exc_info=True)
+        return [TextContent(type="text", text=f"Error listing projects: {e}")]
 
 
 async def main():

--- a/src/mcp/inbox_server_http.py
+++ b/src/mcp/inbox_server_http.py
@@ -88,6 +88,11 @@ READONLY_TOOLS = frozenset({
     # Self-update reading
     "check_updates",
     "get_upgrade_plan",
+    # Convenience tools (canonical memory readers)
+    "get_priorities",
+    "get_project_context",
+    "get_daily_digest",
+    "list_projects",
     # Utilities (read-only)
     "fetch_page",
     "transcribe_audio",

--- a/src/mcp/lobster_bridge_local.py
+++ b/src/mcp/lobster_bridge_local.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Lobster Bridge — Local MCP Server (Read-Only)
+
+A standalone MCP server that reads canonical memory files from a local
+directory (e.g., a git clone of the Lobster repo). Provides the same
+convenience tool interface as the VPS bridge, but works entirely offline
+with no network dependency.
+
+Configuration:
+    LOBSTER_CANONICAL_DIR — Path to the canonical memory directory
+                            (e.g., /Users/drew/projects/lobster/memory/canonical)
+
+Usage:
+    LOBSTER_CANONICAL_DIR=/path/to/canonical python lobster_bridge_local.py
+
+Claude Code config (~/.claude/settings.json):
+    {
+      "mcpServers": {
+        "lobster-bridge": {
+          "command": "python",
+          "args": ["/path/to/lobster_bridge_local.py"],
+          "env": {
+            "LOBSTER_CANONICAL_DIR": "/path/to/memory/canonical"
+          }
+        }
+      }
+    }
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import Tool, TextContent
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_raw_dir = os.environ.get("LOBSTER_CANONICAL_DIR", "")
+CANONICAL_DIR = Path(_raw_dir) if _raw_dir else Path(".")
+
+
+def _validate_config() -> None:
+    """Validate CANONICAL_DIR at startup. Called from main(), not at import time."""
+    if not _raw_dir or not CANONICAL_DIR.is_absolute():
+        print(
+            "Error: LOBSTER_CANONICAL_DIR must be set to an absolute path.\n"
+            "Example: LOBSTER_CANONICAL_DIR=/Users/drew/projects/lobster/memory/canonical",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# Pure helpers — shared logic with no side effects beyond file reads
+# ---------------------------------------------------------------------------
+
+
+def _read_canonical_file(canonical_dir: Path, relative_path: str, missing_message: str) -> str:
+    """Read a file under canonical_dir or return a fallback message."""
+    path = canonical_dir / relative_path
+    if path.exists():
+        return path.read_text()
+    return missing_message
+
+
+def _list_project_names(canonical_dir: Path) -> list[dict]:
+    """List project markdown files under canonical_dir/projects/."""
+    projects_dir = canonical_dir / "projects"
+    if not projects_dir.exists():
+        return []
+    return [
+        {"name": f.stem, "path": str(f)}
+        for f in sorted(projects_dir.glob("*.md"))
+    ]
+
+
+def _get_project_context(canonical_dir: Path, project: str) -> str:
+    """Read a project file or return available projects as a fallback."""
+    if "/" in project or "\\" in project or ".." in project:
+        return "Error: invalid project name."
+
+    path = canonical_dir / "projects" / f"{project}.md"
+    if path.exists():
+        return path.read_text()
+
+    available = (
+        [f.stem for f in (canonical_dir / "projects").glob("*.md")]
+        if (canonical_dir / "projects").exists()
+        else []
+    )
+    return f"No project file for '{project}'. Available: {', '.join(available) or 'none'}"
+
+
+# ---------------------------------------------------------------------------
+# MCP Server
+# ---------------------------------------------------------------------------
+
+server = Server("lobster-bridge-local")
+
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    """List available convenience tools."""
+    return [
+        Tool(
+            name="get_priorities",
+            description="Fetch Lobster's current priority stack. Returns the canonical priorities.md file, updated nightly by the consolidation process.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+            },
+        ),
+        Tool(
+            name="get_project_context",
+            description="Fetch status and context for a specific project. Returns project status, recent decisions, pending items, and blockers.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "project": {
+                        "type": "string",
+                        "description": "Project name (e.g., 'lobster', 'govscan', 'transformers')",
+                    },
+                },
+                "required": ["project"],
+            },
+        ),
+        Tool(
+            name="get_daily_digest",
+            description="Fetch the latest daily digest. Summarizes recent activity: key conversations, task progress, decisions made, and items needing follow-up.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+            },
+        ),
+        Tool(
+            name="list_projects",
+            description="List all projects tracked in Lobster's canonical memory. Returns project names for use with get_project_context().",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+            },
+        ),
+        Tool(
+            name="get_handoff",
+            description="Read the current handoff document. Contains identity, architecture, current state, and pending items.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+            },
+        ),
+    ]
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    """Dispatch tool calls to pure reader functions."""
+    dispatch = {
+        "get_priorities": lambda args: _read_canonical_file(
+            CANONICAL_DIR,
+            "priorities.md",
+            "No priorities file found. Nightly consolidation has not run yet.",
+        ),
+        "get_daily_digest": lambda args: _read_canonical_file(
+            CANONICAL_DIR,
+            "daily-digest.md",
+            "No daily digest found. Nightly consolidation has not run yet.",
+        ),
+        "get_handoff": lambda args: _read_canonical_file(
+            CANONICAL_DIR,
+            "handoff.md",
+            "No handoff document found.",
+        ),
+        "get_project_context": lambda args: _get_project_context(
+            CANONICAL_DIR,
+            args.get("project", ""),
+        ),
+        "list_projects": lambda args: json.dumps(_list_project_names(CANONICAL_DIR), indent=2)
+        if _list_project_names(CANONICAL_DIR)
+        else "No project files found in canonical memory.",
+    }
+
+    handler = dispatch.get(name)
+    if handler is None:
+        return [TextContent(type="text", text=f"Unknown tool: {name}")]
+
+    try:
+        result = handler(arguments)
+        return [TextContent(type="text", text=result)]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error in {name}: {e}")]
+
+
+async def main():
+    """Run the local MCP server over stdio."""
+    _validate_config()
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_bridge_tools.py
+++ b/tests/test_bridge_tools.py
@@ -1,0 +1,394 @@
+"""
+Tests for Layer 3 convenience tools (canonical memory readers).
+
+Covers:
+- get_priorities / get_daily_digest / get_handoff (file readers)
+- get_project_context (file reader with project selection)
+- list_projects (directory listing)
+- Graceful fallback when files do not exist
+- Path traversal rejection in get_project_context
+- Pure helper functions (_read_canonical_file, _list_project_names)
+- Local bridge server tool dispatch
+- HTTP bridge READONLY_TOOLS allowlist inclusion
+"""
+
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — ensure src/mcp is importable
+# ---------------------------------------------------------------------------
+
+SRC_MCP_DIR = Path(__file__).resolve().parent.parent / "src" / "mcp"
+sys.path.insert(0, str(SRC_MCP_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def canonical_dir(tmp_path: Path) -> Path:
+    """Create a temporary canonical directory with sample files."""
+    canonical = tmp_path / "canonical"
+    canonical.mkdir()
+    (canonical / "projects").mkdir()
+
+    (canonical / "priorities.md").write_text("# Priorities\n\n1. Ship Layer 3\n")
+    (canonical / "daily-digest.md").write_text("# Daily Digest\n\nAll quiet.\n")
+    (canonical / "handoff.md").write_text("# Handoff\n\nLobster is running.\n")
+    (canonical / "projects" / "lobster.md").write_text("# Lobster\n\nStatus: active\n")
+    (canonical / "projects" / "transformers.md").write_text("# Transformers\n\nStatus: planning\n")
+
+    return canonical
+
+
+@pytest.fixture
+def empty_canonical_dir(tmp_path: Path) -> Path:
+    """Create an empty canonical directory (no files at all)."""
+    canonical = tmp_path / "canonical-empty"
+    canonical.mkdir()
+    return canonical
+
+
+# ===========================================================================
+# Tests for pure helpers in inbox_server.py
+# ===========================================================================
+
+
+class TestReadCanonicalFile:
+    """Tests for _read_canonical_file."""
+
+    def test_returns_file_content_when_exists(self, canonical_dir: Path):
+        from inbox_server import _read_canonical_file
+
+        with patch("inbox_server.CANONICAL_DIR", canonical_dir):
+            result = _read_canonical_file("priorities.md", "fallback")
+        assert result == "# Priorities\n\n1. Ship Layer 3\n"
+
+    def test_returns_fallback_when_missing(self, empty_canonical_dir: Path):
+        from inbox_server import _read_canonical_file
+
+        with patch("inbox_server.CANONICAL_DIR", empty_canonical_dir):
+            result = _read_canonical_file("priorities.md", "No file found.")
+        assert result == "No file found."
+
+
+class TestListProjectNames:
+    """Tests for _list_project_names."""
+
+    def test_returns_sorted_project_list(self, canonical_dir: Path):
+        from inbox_server import _list_project_names
+
+        with patch("inbox_server.CANONICAL_DIR", canonical_dir):
+            result = _list_project_names()
+        names = [p["name"] for p in result]
+        assert names == ["lobster", "transformers"]
+
+    def test_returns_empty_list_when_no_projects_dir(self, empty_canonical_dir: Path):
+        from inbox_server import _list_project_names
+
+        with patch("inbox_server.CANONICAL_DIR", empty_canonical_dir):
+            result = _list_project_names()
+        assert result == []
+
+
+# ===========================================================================
+# Tests for VPS handler functions (inbox_server.py)
+# ===========================================================================
+
+
+class TestHandleGetPriorities:
+    """Tests for handle_get_priorities."""
+
+    @pytest.mark.asyncio
+    async def test_returns_priorities_content(self, canonical_dir: Path):
+        from inbox_server import handle_get_priorities
+
+        with patch("inbox_server.CANONICAL_DIR", canonical_dir):
+            result = await handle_get_priorities({})
+        assert len(result) == 1
+        assert "Ship Layer 3" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_returns_fallback_when_missing(self, empty_canonical_dir: Path):
+        from inbox_server import handle_get_priorities
+
+        with patch("inbox_server.CANONICAL_DIR", empty_canonical_dir):
+            result = await handle_get_priorities({})
+        assert "No priorities file found" in result[0].text
+
+
+class TestHandleGetDailyDigest:
+    """Tests for handle_get_daily_digest."""
+
+    @pytest.mark.asyncio
+    async def test_returns_digest_content(self, canonical_dir: Path):
+        from inbox_server import handle_get_daily_digest
+
+        with patch("inbox_server.CANONICAL_DIR", canonical_dir):
+            result = await handle_get_daily_digest({})
+        assert "All quiet" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_returns_fallback_when_missing(self, empty_canonical_dir: Path):
+        from inbox_server import handle_get_daily_digest
+
+        with patch("inbox_server.CANONICAL_DIR", empty_canonical_dir):
+            result = await handle_get_daily_digest({})
+        assert "No daily digest found" in result[0].text
+
+
+class TestHandleGetProjectContext:
+    """Tests for handle_get_project_context."""
+
+    @pytest.mark.asyncio
+    async def test_returns_project_content(self, canonical_dir: Path):
+        from inbox_server import handle_get_project_context
+
+        with patch("inbox_server.CANONICAL_DIR", canonical_dir):
+            result = await handle_get_project_context({"project": "lobster"})
+        assert "Status: active" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_returns_available_projects_on_miss(self, canonical_dir: Path):
+        from inbox_server import handle_get_project_context
+
+        with patch("inbox_server.CANONICAL_DIR", canonical_dir):
+            result = await handle_get_project_context({"project": "govscan"})
+        assert "No project file for 'govscan'" in result[0].text
+        assert "lobster" in result[0].text
+        assert "transformers" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_rejects_path_traversal_slash(self, canonical_dir: Path):
+        from inbox_server import handle_get_project_context
+
+        with patch("inbox_server.CANONICAL_DIR", canonical_dir):
+            result = await handle_get_project_context({"project": "../etc/passwd"})
+        assert "invalid project name" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_rejects_path_traversal_dotdot(self, canonical_dir: Path):
+        from inbox_server import handle_get_project_context
+
+        with patch("inbox_server.CANONICAL_DIR", canonical_dir):
+            result = await handle_get_project_context({"project": "..\\secrets"})
+        assert "invalid project name" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_project_name(self, canonical_dir: Path):
+        from inbox_server import handle_get_project_context
+
+        with patch("inbox_server.CANONICAL_DIR", canonical_dir):
+            result = await handle_get_project_context({})
+        assert "project name is required" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_returns_none_available_when_no_projects_dir(self, empty_canonical_dir: Path):
+        from inbox_server import handle_get_project_context
+
+        with patch("inbox_server.CANONICAL_DIR", empty_canonical_dir):
+            result = await handle_get_project_context({"project": "lobster"})
+        assert "Available: none" in result[0].text
+
+
+class TestHandleListProjects:
+    """Tests for handle_list_projects."""
+
+    @pytest.mark.asyncio
+    async def test_returns_project_list_json(self, canonical_dir: Path):
+        from inbox_server import handle_list_projects
+
+        with patch("inbox_server.CANONICAL_DIR", canonical_dir):
+            result = await handle_list_projects({})
+        parsed = json.loads(result[0].text)
+        names = [p["name"] for p in parsed]
+        assert "lobster" in names
+        assert "transformers" in names
+
+    @pytest.mark.asyncio
+    async def test_returns_message_when_empty(self, empty_canonical_dir: Path):
+        from inbox_server import handle_list_projects
+
+        with patch("inbox_server.CANONICAL_DIR", empty_canonical_dir):
+            result = await handle_list_projects({})
+        assert "No project files found" in result[0].text
+
+
+# ===========================================================================
+# Tests for HTTP bridge allowlist
+# ===========================================================================
+
+
+class TestHttpBridgeAllowlist:
+    """Verify convenience tools are in the READONLY_TOOLS set."""
+
+    def test_convenience_tools_in_readonly_set(self):
+        # inbox_server_http calls sys.exit(1) if MCP_HTTP_TOKEN is not set;
+        # supply a dummy token so the module can be imported.
+        import os
+        os.environ.setdefault("MCP_HTTP_TOKEN", "test-token-for-import")
+        from inbox_server_http import READONLY_TOOLS
+
+        expected = {"get_priorities", "get_project_context", "get_daily_digest", "list_projects"}
+        assert expected.issubset(READONLY_TOOLS)
+
+
+# ===========================================================================
+# Tests for local bridge pure helpers
+# ===========================================================================
+
+
+class TestLocalBridgeHelpers:
+    """Tests for pure functions in lobster_bridge_local.py."""
+
+    def test_read_canonical_file_returns_content(self, canonical_dir: Path):
+        from lobster_bridge_local import _read_canonical_file
+
+        result = _read_canonical_file(canonical_dir, "priorities.md", "fallback")
+        assert result == "# Priorities\n\n1. Ship Layer 3\n"
+
+    def test_read_canonical_file_returns_fallback(self, empty_canonical_dir: Path):
+        from lobster_bridge_local import _read_canonical_file
+
+        result = _read_canonical_file(empty_canonical_dir, "priorities.md", "fallback")
+        assert result == "fallback"
+
+    def test_list_project_names_returns_sorted(self, canonical_dir: Path):
+        from lobster_bridge_local import _list_project_names
+
+        result = _list_project_names(canonical_dir)
+        names = [p["name"] for p in result]
+        assert names == ["lobster", "transformers"]
+
+    def test_list_project_names_empty(self, empty_canonical_dir: Path):
+        from lobster_bridge_local import _list_project_names
+
+        result = _list_project_names(empty_canonical_dir)
+        assert result == []
+
+    def test_get_project_context_returns_content(self, canonical_dir: Path):
+        from lobster_bridge_local import _get_project_context
+
+        result = _get_project_context(canonical_dir, "lobster")
+        assert "Status: active" in result
+
+    def test_get_project_context_returns_available_on_miss(self, canonical_dir: Path):
+        from lobster_bridge_local import _get_project_context
+
+        result = _get_project_context(canonical_dir, "govscan")
+        assert "No project file for 'govscan'" in result
+        assert "lobster" in result
+
+    def test_get_project_context_rejects_traversal(self, canonical_dir: Path):
+        from lobster_bridge_local import _get_project_context
+
+        result = _get_project_context(canonical_dir, "../etc/passwd")
+        assert "invalid project name" in result
+
+
+# ===========================================================================
+# Tests for local bridge tool dispatch
+# ===========================================================================
+
+
+class TestLocalBridgeDispatch:
+    """Tests for the local bridge call_tool dispatch."""
+
+    @pytest.mark.asyncio
+    async def test_get_priorities(self, canonical_dir: Path):
+        from lobster_bridge_local import call_tool
+
+        with patch("lobster_bridge_local.CANONICAL_DIR", canonical_dir):
+            result = await call_tool("get_priorities", {})
+        assert "Ship Layer 3" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_get_daily_digest(self, canonical_dir: Path):
+        from lobster_bridge_local import call_tool
+
+        with patch("lobster_bridge_local.CANONICAL_DIR", canonical_dir):
+            result = await call_tool("get_daily_digest", {})
+        assert "All quiet" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_get_handoff(self, canonical_dir: Path):
+        from lobster_bridge_local import call_tool
+
+        with patch("lobster_bridge_local.CANONICAL_DIR", canonical_dir):
+            result = await call_tool("get_handoff", {})
+        assert "Lobster is running" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_get_project_context(self, canonical_dir: Path):
+        from lobster_bridge_local import call_tool
+
+        with patch("lobster_bridge_local.CANONICAL_DIR", canonical_dir):
+            result = await call_tool("get_project_context", {"project": "transformers"})
+        assert "Status: planning" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_list_projects(self, canonical_dir: Path):
+        from lobster_bridge_local import call_tool
+
+        with patch("lobster_bridge_local.CANONICAL_DIR", canonical_dir):
+            result = await call_tool("list_projects", {})
+        parsed = json.loads(result[0].text)
+        names = [p["name"] for p in parsed]
+        assert names == ["lobster", "transformers"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool(self, canonical_dir: Path):
+        from lobster_bridge_local import call_tool
+
+        with patch("lobster_bridge_local.CANONICAL_DIR", canonical_dir):
+            result = await call_tool("nonexistent_tool", {})
+        assert "Unknown tool" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_list_projects_empty(self, empty_canonical_dir: Path):
+        from lobster_bridge_local import call_tool
+
+        with patch("lobster_bridge_local.CANONICAL_DIR", empty_canonical_dir):
+            result = await call_tool("list_projects", {})
+        assert "No project files found" in result[0].text
+
+
+# ===========================================================================
+# Tests for local bridge list_tools
+# ===========================================================================
+
+
+class TestLocalBridgeListTools:
+    """Tests for the local bridge list_tools."""
+
+    @pytest.mark.asyncio
+    async def test_lists_all_five_tools(self):
+        from lobster_bridge_local import list_tools
+
+        tools = await list_tools()
+        tool_names = {t.name for t in tools}
+        assert tool_names == {
+            "get_priorities",
+            "get_project_context",
+            "get_daily_digest",
+            "list_projects",
+            "get_handoff",
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_project_context_requires_project(self):
+        from lobster_bridge_local import list_tools
+
+        tools = await list_tools()
+        ctx_tool = next(t for t in tools if t.name == "get_project_context")
+        assert "project" in ctx_tool.inputSchema.get("required", [])


### PR DESCRIPTION
## Summary

Implements [Layer 3: lobster-bridge Convenience Tools](https://github.com/SiderealPress/Lobster/issues/37) -- four read-only tools that surface canonical memory files through both the VPS HTTP bridge and a standalone local MCP server.

### Changes

- **`src/mcp/inbox_server.py`** -- Added `CANONICAL_DIR` constant (replacing inline path in `HANDOFF_PATH`), four tool definitions in `list_tools()`, dispatch entries in `_dispatch_tool()`, and four handler functions with pure helper extractors (`_read_canonical_file`, `_list_project_names`). Path traversal protection on `get_project_context`.
- **`src/mcp/inbox_server_http.py`** -- Added `get_priorities`, `get_project_context`, `get_daily_digest`, `list_projects` to the `READONLY_TOOLS` allowlist so they are automatically available through the HTTP bridge.
- **`src/mcp/lobster_bridge_local.py`** (new) -- Standalone MCP server for MacBook that reads from `LOBSTER_CANONICAL_DIR` env var. Same tool interface as VPS. Works fully offline. Config validation deferred to `main()` so the module is importable for testing.
- **`config/bridge-local.example.env`** (new) -- Example config with Claude Code `settings.json` snippet.
- **`tests/test_bridge_tools.py`** (new) -- 33 tests covering VPS handlers, local bridge dispatch, pure helpers, HTTP allowlist, edge cases (missing files, empty projects dir, path traversal, empty project name).
- **`.gitignore`** -- Added `!bridge-local.example.env` exception.

### Functional patterns used

- Pure helper functions (`_read_canonical_file`, `_list_project_names`, `_get_project_context`) separated from side-effectful handler wrappers
- Dispatch table in local bridge `call_tool` using a dictionary of lambdas
- Immutable data flow: read file -> return string, no mutation

### Testing

All 33 tests pass:
```
tests/test_bridge_tools.py  33 passed in 0.83s
```

Test coverage:
- Pure helpers (2 functions x 2 cases each)
- VPS handlers (4 tools: happy path + missing file fallback)
- Project context edge cases (path traversal slash, backslash, dotdot; empty name; missing projects dir)
- HTTP bridge allowlist membership
- Local bridge helpers (7 cases)
- Local bridge dispatch (7 cases including unknown tool)
- Local bridge tool listing and schema validation

Closes #37