### PR TITLE
Increase wait_for_messages timeout from 5min to 20hrs

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -180,8 +180,8 @@ async def list_tools() -> list[Tool]:
                 "properties": {
                     "timeout": {
                         "type": "integer",
-                        "description": "Maximum seconds to wait. Default 300 (5 minutes). After timeout, returns with a prompt to call again.",
-                        "default": 300,
+                        "description": "Maximum seconds to wait. Default 72000 (20 hours). After timeout, returns with a prompt to call again.",
+                        "default": 72000,
                     },
                 },
             },
@@ -1146,7 +1146,7 @@ def _recover_retryable_messages():
 
 async def handle_wait_for_messages(args: dict) -> list[TextContent]:
     """Block until new messages arrive in inbox, or return immediately if messages exist."""
-    timeout = args.get("timeout", 300)
+    timeout = args.get("timeout", 72000)
 
     # Touch heartbeat at start - signals Claude is alive and waiting for messages
     touch_heartbeat()


### PR DESCRIPTION
## Summary
- Changes `wait_for_messages` default timeout from 300s (5 minutes) to 72000s (20 hours)
- The underlying mechanism is inotify (zero-cost blocking) — the short timeout was causing unnecessary token waste from idle wake-up cycles every 5 minutes
- Claude Code's `MCP_TOOL_TIMEOUT` defaults to ~27.7 hours (`1e8` ms), so there's no upstream constraint preventing this

## Why 20 hours?
- Long enough that idle sessions don't burn tokens on pointless re-invocations
- Short enough to naturally recycle the session roughly once a day (context hygiene)
- Heartbeats still fire every 60 seconds during the wait (health check compatibility)

## Test plan
- [ ] Verify inotify still wakes Claude immediately when a message arrives (no regression)
- [ ] Verify health-check-v3.sh still works (it monitors inbox staleness, not wait duration)
- [ ] Confirm no token consumption during extended idle wait
- [ ] Unit tests pass (note: require Python 3.10+ which wasn't available on test machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)