### PR TITLE
Fix transcribe_audio not finding messages in processing/ directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -831,6 +831,86 @@ else
 fi
 
 #===============================================================================
+# Voice Transcription (Optional - whisper.cpp + ffmpeg)
+#===============================================================================
+
+step "Voice Transcription (Optional)..."
+
+echo ""
+echo -e "${BOLD}Voice Message Transcription Setup${NC}"
+echo ""
+echo "Lobster can transcribe voice messages locally using whisper.cpp."
+echo "This requires ~500MB of disk space for the model."
+echo ""
+read -p "Set up voice transcription? [y/N] " -n 1 -r
+echo
+
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    # Install ffmpeg
+    if ! command -v ffmpeg &> /dev/null; then
+        step "Installing ffmpeg..."
+        if command -v apt-get &> /dev/null; then
+            sudo apt-get install -y ffmpeg
+        elif command -v dnf &> /dev/null; then
+            sudo dnf install -y ffmpeg
+        elif command -v yum &> /dev/null; then
+            sudo yum install -y ffmpeg
+        else
+            warn "Could not install ffmpeg automatically. Please install it manually."
+        fi
+    else
+        success "ffmpeg already installed"
+    fi
+
+    # Build whisper.cpp
+    WHISPER_DIR="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}/whisper.cpp"
+    if [ ! -f "$WHISPER_DIR/build/bin/whisper-cli" ]; then
+        step "Building whisper.cpp..."
+        if ! command -v cmake &> /dev/null; then
+            if command -v apt-get &> /dev/null; then
+                sudo apt-get install -y cmake build-essential
+            elif command -v dnf &> /dev/null; then
+                sudo dnf install -y cmake gcc-c++ make
+            fi
+        fi
+        mkdir -p "$(dirname "$WHISPER_DIR")"
+        if [ ! -d "$WHISPER_DIR" ]; then
+            git clone https://github.com/ggerganov/whisper.cpp.git "$WHISPER_DIR"
+        fi
+        cd "$WHISPER_DIR"
+        cmake -B build
+        cmake --build build -j$(nproc)
+        cd - > /dev/null
+        if [ -f "$WHISPER_DIR/build/bin/whisper-cli" ]; then
+            success "whisper.cpp built successfully"
+        else
+            warn "whisper.cpp build failed. You can build it manually later - see README.md"
+        fi
+    else
+        success "whisper.cpp already built"
+    fi
+
+    # Download model
+    if [ ! -f "$WHISPER_DIR/models/ggml-small.bin" ]; then
+        step "Downloading whisper small model (~465MB)..."
+        if [ -f "$WHISPER_DIR/models/download-ggml-model.sh" ]; then
+            bash "$WHISPER_DIR/models/download-ggml-model.sh" small
+            if [ -f "$WHISPER_DIR/models/ggml-small.bin" ]; then
+                success "Whisper model downloaded"
+            else
+                warn "Model download failed. You can download it manually later - see README.md"
+            fi
+        else
+            warn "Model download script not found. You can download it manually later - see README.md"
+        fi
+    else
+        success "Whisper model already downloaded"
+    fi
+else
+    info "Skipped voice transcription. You can set it up later - see README.md"
+fi
+
+#===============================================================================
 # Authentication Method (OAuth-first)
 #===============================================================================
 

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -1848,6 +1848,22 @@ async def handle_transcribe_audio(args: dict) -> list[TextContent]:
             continue
 
     if not msg_file:
+        # Also check processing directory (messages claimed via mark_processing)
+        for f in PROCESSING_DIR.glob("*.json"):
+            if message_id in f.name:
+                msg_file = f
+                break
+            try:
+                with open(f) as fp:
+                    data = json.load(fp)
+                    if data.get("id") == message_id:
+                        msg_file = f
+                        msg_data = data
+                        break
+            except:
+                continue
+
+    if not msg_file:
         # Also check processed directory
         for f in PROCESSED_DIR.glob("*.json"):
             if message_id in f.name:


### PR DESCRIPTION
## Summary

- **Bug fix**: `handle_transcribe_audio` now searches `PROCESSING_DIR` in addition to `INBOX_DIR` and `PROCESSED_DIR`. Previously, when `mark_processing` moved a message to `processing/` before `transcribe_audio` was called, the transcription would fail with "Message not found".
- **Installer improvement**: Added optional whisper.cpp + ffmpeg installation step to `install.sh`. Users are prompted during install and can set up voice transcription dependencies automatically (clone, build whisper.cpp, download model, install ffmpeg).

## Test plan

- [ ] Verify that `transcribe_audio` succeeds when the message file is in `processing/`
- [ ] Verify that `transcribe_audio` still works for messages in `inbox/` and `processed/`
- [ ] Run `install.sh` and verify the voice transcription prompt appears and works when accepted
- [ ] Run `install.sh` and verify skipping voice transcription still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)