### PR TITLE
Fix memory system import fallback broken by missing psutil

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -682,7 +682,7 @@ fi
 
 source .venv/bin/activate
 pip install --quiet --upgrade pip
-pip install --quiet mcp python-telegram-bot watchdog python-dotenv slack-bolt
+pip install --quiet mcp python-telegram-bot watchdog python-dotenv slack-bolt psutil
 deactivate
 
 success "Python environment ready"

--- a/src/mcp/memory/__init__.py
+++ b/src/mcp/memory/__init__.py
@@ -18,7 +18,10 @@ Static files are always the source of truth; the vector DB is an acceleration la
 import logging
 
 from .provider import MemoryProvider, MemoryEvent
-from .vector_memory import VectorMemory
+try:
+    from .vector_memory import VectorMemory
+except ImportError:
+    VectorMemory = None
 from .static_memory import StaticMemory
 
 log = logging.getLogger("lobster-memory")
@@ -42,13 +45,15 @@ def create_memory_provider(use_vector: bool = True) -> MemoryProvider:
     Returns:
         A MemoryProvider instance (VectorMemory or StaticMemory).
     """
-    if use_vector:
+    if use_vector and VectorMemory is not None:
         try:
             provider = VectorMemory()
             log.info("Memory provider: VectorMemory (SQLite + sqlite-vec + FTS5)")
             return provider
         except Exception as e:
             log.warning(f"VectorMemory unavailable ({e}), falling back to StaticMemory")
+    elif use_vector and VectorMemory is None:
+        log.warning("VectorMemory not importable (missing dependencies), falling back to StaticMemory")
     provider = StaticMemory()
     log.info("Memory provider: StaticMemory (grep over canonical files)")
     return provider


### PR DESCRIPTION
## Summary

- **Root cause**: The `VectorMemory` import in `memory/__init__.py` was unconditional. When `psutil` (an unlisted dependency used by `vector_memory.py`) was missing, the entire memory module failed to import, preventing the `StaticMemory` fallback from ever running and disabling memory completely.
- Wrap `VectorMemory` import in `try/except ImportError` so the module loads even when optional dependencies are missing
- Guard `create_memory_provider()` against `VectorMemory` being `None` with a clear warning log
- Add `psutil` to the pip install line in `install.sh`

## Test plan

- [ ] Verify memory system starts with StaticMemory fallback when psutil/sqlite-vec/fastembed are not installed
- [ ] Verify VectorMemory is used when all dependencies are present
- [ ] Run `install.sh` on a fresh venv and confirm psutil gets installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)