### PR TITLE
Fix inotify watcher missing messages from atomic rename writes

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -1170,6 +1170,9 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
         def on_created(self, event):
             if not event.is_directory and event.src_path.endswith('.json'):
                 message_arrived.set()
+        def on_moved(self, event):
+            if not event.is_directory and event.dest_path.endswith('.json'):
+                message_arrived.set()
 
     observer = Observer()
     observer.schedule(InboxHandler(), str(INBOX_DIR), recursive=False)


### PR DESCRIPTION
## Summary

- Fix critical bug where `wait_for_messages` blocks for the full 300s timeout because inotify never detects messages written via `atomic_write_json()` (which uses `tempfile` + `os.rename()`)
- Add `on_moved` handler to `InboxHandler` so rename-based file arrivals trigger the event, matching the existing `on_created` handler

## Root Cause

`atomic_write_json()` in `lobster_bot.py` writes messages using `tempfile.mkstemp()` followed by `os.rename()`. On Linux, `rename()` generates an `IN_MOVED_TO` inotify event, **not** `IN_CREATE`. The `InboxHandler` in `inbox_server.py` only handled `on_created`, so messages arriving via rename were invisible to the watcher.

## Log Evidence (5-minute delay)

```
19:34:06 — wait_for_messages starts inotify watcher
19:34:22 — "Yo" message written to inbox via atomic rename
19:39:06 — wait_for_messages times out after 300s (inotify never fired)
19:39:09 — next call finally discovers the 5-minute-old message
```

## Fix

Add `on_moved` handler to `InboxHandler`, checking `event.dest_path` (the rename destination) for `.json` files:

```python
def on_moved(self, event):
    if not event.is_directory and event.dest_path.endswith('.json'):
        message_arrived.set()
```

## Test plan

- [ ] Deploy updated `inbox_server.py` and send a Telegram message
- [ ] Verify message is detected within seconds (not 300s)
- [ ] Confirm `on_created` still works for any non-atomic writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)