### PR TITLE
fix: add subagent guard to self-check scripts

### DIFF
--- a/scripts/periodic-self-check.sh
+++ b/scripts/periodic-self-check.sh
@@ -14,6 +14,7 @@
 #   2. Only fires if there isn't already a self-check in the inbox (no spam)
 #   3. Rate-limited: won't inject if last self-check was < 2 minutes ago
 #   4. Max inbox depth: won't inject if inbox already has 20+ messages (backpressure)
+#   5. Only fires if subagents are running (more than 1 Claude process)
 #===============================================================================
 
 set -e
@@ -48,6 +49,12 @@ fi
 # Guard 4: Backpressure — don't add to an already-deep inbox
 INBOX_COUNT=$(find "$INBOX_DIR" -maxdepth 1 -name "*.json" 2>/dev/null | wc -l)
 if [ "$INBOX_COUNT" -ge "$MAX_INBOX_DEPTH" ]; then
+    exit 0
+fi
+
+# Guard 5: No subagents running — skip if only the main Claude process exists
+CLAUDE_COUNT=$(pgrep -c -f "claude" 2>/dev/null || echo "0")
+if [ "$CLAUDE_COUNT" -le 1 ]; then
     exit 0
 fi
 

--- a/scripts/self-check-reminder.sh
+++ b/scripts/self-check-reminder.sh
@@ -24,6 +24,13 @@ set -e
 # Use environment variable or default
 INBOX_DIR="${LOBSTER_MESSAGES:-$HOME/messages}/inbox"
 
+# Guard: No subagents running — skip if only the main Claude process exists
+CLAUDE_COUNT=$(pgrep -c -f "claude" 2>/dev/null || echo "0")
+if [ "$CLAUDE_COUNT" -le 1 ]; then
+    echo "No subagents running, skipping self-check"
+    exit 0
+fi
+
 # Ensure inbox directory exists
 mkdir -p "$INBOX_DIR"
 


### PR DESCRIPTION
## Summary
- Adds a "subagent running" guard to both self-check scripts (`periodic-self-check.sh` and `self-check-reminder.sh`)
- If only the main Claude process is running (no subagents), the self-check is skipped
- This allows `wait_for_messages` idle timeout to expire, enabling hibernation

## Problem
Self-checks were firing even when no subagents were running, preventing the idle timeout from ever expiring and blocking hibernation.

## Test plan
- [ ] Verify `pgrep -c -f "claude"` correctly counts Claude processes
- [ ] Verify self-checks stop when no subagents are active
- [ ] Verify self-checks still fire when a subagent is running
- [ ] End-to-end hibernation test: idle timeout expires → hibernate → wake on message

🤖 Generated with [Claude Code](https://claude.com/claude-code)