### PR TITLE
Fix daily-health-check.sh PATH to include /usr/local/bin

### DIFF
--- a/scripts/daily-health-check.sh
+++ b/scripts/daily-health-check.sh
@@ -21,7 +21,7 @@ TIMESTAMP=$(date -Iseconds)
 mkdir -p "$(dirname "$LOG_FILE")" "$INBOX_DIR"
 
 # Ensure PATH includes common tool locations
-export PATH="$HOME/.local/bin:$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node/" 2>/dev/null | sort -V | tail -1)/bin:$PATH"
+export PATH="$HOME/.local/bin:/usr/local/bin:$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node/" 2>/dev/null | sort -V | tail -1)/bin:$PATH"
 
 FAILURES=()
 


### PR DESCRIPTION
## Summary
- Adds `/usr/local/bin` to the PATH in `daily-health-check.sh`
- The cron-provided PATH doesn't include `/usr/local/bin`, so `rg`, `fd`, `bat`, `fzf` (all installed there) were falsely reported as missing every day at 06:00
- This false alarm deposited a message in the inbox, which then triggered the health check restart loop (stale inbox → restart → message still there → restart again)

## Test plan
- [ ] Verify `bash -n scripts/daily-health-check.sh` passes
- [ ] Run `scripts/daily-health-check.sh` manually and confirm no failures for rg/fd/bat/fzf
- [ ] Confirm tomorrow's 06:00 cron run is silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)