### PR TITLE
Implement smart model tiering to reduce token costs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,6 +286,27 @@ When you receive a **voice message** that appears to be a "brain dump" (unstruct
 
 See `docs/BRAIN-DUMPS.md` for full documentation.
 
+## Model Selection for Subagents
+
+Lobster uses a tiered model strategy to balance cost and quality. Each subagent has an explicit model assigned in its `.md` frontmatter. When delegating work, the dispatcher does not need to specify a model -- the agent definition handles it.
+
+**Model tiers:**
+
+| Tier | Model | Use For | Cost |
+|------|-------|---------|------|
+| **High** | `opus` | Complex coding, architecture, debugging | 1x (baseline) |
+| **Standard** | `sonnet` | Planning, research, execution, synthesis | 0.6x |
+| **Light** | `haiku` | Verification, plan-checking, integration checks | 0.2x |
+
+**Agent model assignments:**
+
+- **Opus**: `functional-engineer`, `gsd-debugger` -- tasks requiring deep reasoning
+- **Sonnet**: `gsd-executor`, `gsd-planner`, `gsd-phase-researcher`, `gsd-codebase-mapper`, `gsd-research-synthesizer`, `gsd-roadmapper`, `gsd-project-researcher` -- structured work
+- **Haiku**: `gsd-verifier`, `gsd-plan-checker`, `gsd-integration-checker` -- pass/fail evaluation
+- **Inherit (Sonnet)**: `general-purpose` -- inherits from `CLAUDE_CODE_SUBAGENT_MODEL` env var
+
+**When to override:** If a task normally handled by a Sonnet agent requires unusually deep reasoning (e.g., a complex multi-system execution plan), consider using `functional-engineer` (Opus) instead.
+
 ## Behavior Guidelines
 
 1. **Never exit** - Always call `wait_for_messages` after processing

--- a/scripts/agent-status.sh
+++ b/scripts/agent-status.sh
@@ -11,12 +11,22 @@
 #   # Returns: "Agents: abc123 (52 turns, last activity 30s ago), def456 (49 turns, stale 2h)"
 #   # Returns: "" (empty string) if no agents found
 #
+#   completed=$(scan_completed_tasks)
+#   # Returns: JSON-like summary of completed tasks not yet reported
+#   # Returns: "" (empty string) if no newly completed tasks
+#
 # Environment:
 #   AGENT_TASKS_DIR - Override the agent output directory (for testing)
 #===============================================================================
 
 # Staleness threshold: 15 minutes in seconds
 AGENT_STALE_THRESHOLD=900
+
+# Completion threshold: task file unchanged for this long = likely done
+AGENT_COMPLETION_THRESHOLD=120
+
+# State directory for tracking reported completions
+AGENT_STATE_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}/.state"
 
 # Maximum agents to show in summary (keep messages concise)
 AGENT_MAX_DISPLAY=5
@@ -117,6 +127,103 @@ scan_agent_status() {
     if [ "$remaining" -gt 0 ]; then
         result+=", +${remaining} more"
     fi
+
+    echo "$result"
+}
+
+# Scan for completed tasks that haven't been reported yet.
+# A task is "completed" when:
+#   1. Its output file hasn't been modified for AGENT_COMPLETION_THRESHOLD seconds
+#   2. It hasn't been previously reported (tracked via .state/reported-tasks)
+#
+# Returns a structured completion summary or empty string if nothing new.
+scan_completed_tasks() {
+    local tasks_dir="${AGENT_TASKS_DIR:-/tmp/claude-1000/-home-admin-lobster-workspace/tasks}"
+    local reported_file="$AGENT_STATE_DIR/reported-tasks"
+
+    mkdir -p "$AGENT_STATE_DIR"
+    touch "$reported_file" 2>/dev/null
+
+    if [ ! -d "$tasks_dir" ]; then
+        return 0
+    fi
+
+    local output_files=()
+    while IFS= read -r -d '' f; do
+        output_files+=("$f")
+    done < <(find "$tasks_dir" -maxdepth 1 -name "*.output" -print0 2>/dev/null)
+
+    if [ ${#output_files[@]} -eq 0 ]; then
+        return 0
+    fi
+
+    local now
+    now=$(date +%s)
+    local completed=()
+
+    for filepath in "${output_files[@]}"; do
+        local basename_f
+        basename_f=$(basename "$filepath" .output)
+
+        # Skip if already reported
+        if grep -q "^${basename_f}$" "$reported_file" 2>/dev/null; then
+            continue
+        fi
+
+        # Check staleness (file not modified recently = task done)
+        local file_mtime
+        file_mtime=$(stat -c %Y "$filepath" 2>/dev/null || echo "$now")
+        local age=$(( now - file_mtime ))
+
+        if [ "$age" -lt "$AGENT_COMPLETION_THRESHOLD" ]; then
+            continue
+        fi
+
+        # Extract the last assistant message text for a brief summary
+        local last_msg
+        last_msg=$(grep '"type":"assistant"' "$filepath" 2>/dev/null | tail -1 | \
+            python3 -c "
+import json, sys
+try:
+    line = sys.stdin.readline()
+    d = json.loads(line)
+    msg = d.get('message', {})
+    content = msg.get('content', [])
+    texts = [c.get('text', '') for c in content if c.get('type') == 'text']
+    result = ' '.join(texts).strip()
+    # Truncate to 200 chars for concise reporting
+    if len(result) > 200:
+        result = result[:197] + '...'
+    print(result)
+except Exception:
+    print('')
+" 2>/dev/null)
+
+        local turns
+        turns=$(grep -c '"type":"assistant"' "$filepath" 2>/dev/null) || turns=0
+
+        local duration
+        duration=$(_format_duration "$age")
+
+        # Mark as reported
+        echo "$basename_f" >> "$reported_file"
+
+        completed+=("Task ${basename_f} completed (${turns} turns, ${duration} ago): ${last_msg}")
+    done
+
+    if [ ${#completed[@]} -eq 0 ]; then
+        return 0
+    fi
+
+    # Build structured result
+    local result=""
+    for entry in "${completed[@]}"; do
+        if [ -z "$result" ]; then
+            result="$entry"
+        else
+            result="$result | $entry"
+        fi
+    done
 
     echo "$result"
 }

--- a/scripts/claude-persistent.sh
+++ b/scripts/claude-persistent.sh
@@ -41,6 +41,23 @@ mkdir -p "$MESSAGES_DIR/config" "$LOG_DIR"
 export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
 
 #===============================================================================
+# Model Tiering Configuration
+#
+# The dispatcher runs on Sonnet for cost efficiency (~40% cheaper than Opus).
+# Subagents that don't specify an explicit model in their .md frontmatter
+# will inherit Sonnet via CLAUDE_CODE_SUBAGENT_MODEL.
+# Agents needing Opus (functional-engineer, gsd-debugger) override explicitly.
+#
+# To revert dispatcher to Opus: remove --model sonnet from launch_claude()
+# To revert subagents to Opus: unset CLAUDE_CODE_SUBAGENT_MODEL
+#===============================================================================
+export CLAUDE_CODE_SUBAGENT_MODEL=sonnet
+
+# Trigger context compaction at 80% capacity instead of default 95%.
+# Keeps peak context size lower, reducing token costs per turn.
+export CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=80
+
+#===============================================================================
 # Logging
 #===============================================================================
 log() {
@@ -144,17 +161,22 @@ launch_claude() {
     local claude_exit_code=0
     if [[ "$attempt" -eq 1 ]]; then
         # First attempt: try to continue the most recent session
+        # --model sonnet: Dispatcher uses Sonnet for cost efficiency (~40% cheaper).
+        # Sonnet handles message routing, tool invocation, and reply composition well.
+        # To revert to Opus: remove the --model sonnet flag below.
         log "Trying to continue most recent session..."
         claude --dangerously-skip-permissions \
+            --model sonnet \
             --continue \
-            --max-turns 200 \
+            --max-turns 150 \
             -p "$init_prompt" \
             2>&1 | tee -a "$LOG_DIR/claude-session.log" || claude_exit_code=$?
     else
         # Subsequent attempts after failure: start fresh
         log "Starting fresh session (previous attempt failed)..."
         claude --dangerously-skip-permissions \
-            --max-turns 200 \
+            --model sonnet \
+            --max-turns 150 \
             -p "$init_prompt" \
             2>&1 | tee -a "$LOG_DIR/claude-session.log" || claude_exit_code=$?
     fi

--- a/scripts/periodic-self-check.sh
+++ b/scripts/periodic-self-check.sh
@@ -72,18 +72,31 @@ fi
 # Guard 5: Subagent check — only self-check when subagents are running
 # If claude count is <= 1, only the main session exists (no subagents to check on)
 CLAUDE_COUNT=$(pgrep -c -f "claude" 2>/dev/null || echo "0")
-if [ "$CLAUDE_COUNT" -le 1 ]; then
-    exit 0
-fi
 
-# All guards passed — build self-check message with agent status
+# Source agent status scanner for both status and completion detection
 AGENT_STATUS_SCRIPT="${LOBSTER_INSTALL_DIR:-$HOME/lobster}/scripts/agent-status.sh"
 source "$AGENT_STATUS_SCRIPT"
-AGENT_SUMMARY=$(scan_agent_status)
 
-SELF_CHECK_TEXT="status? (Self-check)"
-if [ -n "$AGENT_SUMMARY" ]; then
-    SELF_CHECK_TEXT="status? (Self-check) | ${AGENT_SUMMARY}"
+# Check for completed tasks first (works even if subagents already exited)
+COMPLETED_TASKS=$(scan_completed_tasks)
+
+if [ -n "$COMPLETED_TASKS" ]; then
+    # Completed task found — inject structured completion message.
+    # This replaces the generic "status?" prompt with actionable info,
+    # so the dispatcher can relay results directly without LLM reasoning
+    # about what to check.
+    SELF_CHECK_TEXT="[Task Completed] ${COMPLETED_TASKS}"
+else
+    # No completed tasks — only inject status check if subagents are still running
+    if [ "$CLAUDE_COUNT" -le 1 ]; then
+        exit 0
+    fi
+
+    AGENT_SUMMARY=$(scan_agent_status)
+    SELF_CHECK_TEXT="status? (Self-check)"
+    if [ -n "$AGENT_SUMMARY" ]; then
+        SELF_CHECK_TEXT="status? (Self-check) | ${AGENT_SUMMARY}"
+    fi
 fi
 
 TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%S.%6N)


### PR DESCRIPTION
## Summary

Implements the four-phase model tiering plan from #77 to reduce token costs by routing tasks to cheaper models where appropriate.

- **Phase 1 (Subagent model config):** Add `model` fields to all agent `.md` files — Opus for complex coding/debugging, Sonnet for structured work, Haiku for pass/fail verification. Set `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` as default fallback.
- **Phase 2 (Dispatcher downgrade):** Run main dispatcher on Sonnet via `--model sonnet` flag (~40% cheaper than Opus for message routing).
- **Phase 3 (Self-check optimization):** Add `scan_completed_tasks()` to `agent-status.sh` for detecting finished background tasks. Modify `periodic-self-check.sh` to inject structured `[Task Completed]` messages instead of generic "status?" prompts, reducing unnecessary LLM reasoning turns.
- **Phase 4 (Context optimization):** Set `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=80` (compact at 80% vs default 95%), reduce `--max-turns` from 200 to 150.
- **Documentation:** Add "Model Selection for Subagents" section to `CLAUDE.md`.

## Files Changed

| File | Change |
|------|--------|
| `CLAUDE.md` | Added model tiering documentation section |
| `scripts/claude-persistent.sh` | Added env vars, `--model sonnet`, reduced `--max-turns` |
| `scripts/agent-status.sh` | Added `scan_completed_tasks()` function |
| `scripts/periodic-self-check.sh` | Structured completion messages, smarter self-check logic |

## Agent Model Assignments

| Tier | Agents |
|------|--------|
| **Opus** | `functional-engineer`, `gsd-debugger` |
| **Sonnet** | `gsd-executor`, `gsd-planner`, `gsd-phase-researcher`, `gsd-codebase-mapper`, `gsd-research-synthesizer`, `gsd-roadmapper`, `gsd-project-researcher`, `brain-dumps` |
| **Haiku** | `gsd-verifier`, `gsd-plan-checker`, `gsd-integration-checker`, `lobster-ops` |

## Rollback

To revert any individual phase:
- **Dispatcher model:** Remove `--model sonnet` from `claude-persistent.sh`
- **Subagent default:** Unset `CLAUDE_CODE_SUBAGENT_MODEL`
- **Compaction:** Unset `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`
- **Max turns:** Change `--max-turns 150` back to `--max-turns 200`

Closes #77