### PR TITLE
fix: auto-split long Telegram messages at 4096-char limit

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -58,6 +58,50 @@ LOBSTER_STATE_FILE = _MESSAGES / "config" / "lobster-state.json"
 _REPO_DIR = Path(os.environ.get("LOBSTER_INSTALL_DIR", Path.home() / "lobster"))
 CLAUDE_WAKE_SCRIPT = _REPO_DIR / "scripts" / "start-lobster.sh"
 
+# Telegram message length limit (API max is 4096, we use 4000 for safety margin)
+TELEGRAM_MAX_LENGTH = 4000
+
+
+def split_message(text: str, max_length: int = TELEGRAM_MAX_LENGTH) -> list[str]:
+    """Split a message into chunks that fit within Telegram's character limit.
+
+    Splitting strategy (in priority order):
+    1. Paragraph boundaries (double newline)
+    2. Single newline boundaries
+    3. Hard split at max_length
+    """
+    if len(text) <= max_length:
+        return [text]
+
+    chunks = []
+    remaining = text
+
+    while remaining:
+        if len(remaining) <= max_length:
+            chunks.append(remaining)
+            break
+
+        # Try splitting at paragraph boundary (double newline)
+        split_pos = remaining.rfind("\n\n", 0, max_length)
+        if split_pos > 0:
+            chunks.append(remaining[:split_pos])
+            remaining = remaining[split_pos + 2:]  # skip the double newline
+            continue
+
+        # Try splitting at single newline
+        split_pos = remaining.rfind("\n", 0, max_length)
+        if split_pos > 0:
+            chunks.append(remaining[:split_pos])
+            remaining = remaining[split_pos + 1:]  # skip the newline
+            continue
+
+        # Hard split at max_length
+        chunks.append(remaining[:max_length])
+        remaining = remaining[max_length:]
+
+    return chunks
+
+
 # Ensure directories exist
 INBOX_DIR.mkdir(parents=True, exist_ok=True)
 OUTBOX_DIR.mkdir(parents=True, exist_ok=True)
@@ -312,21 +356,28 @@ class OutboxHandler(FileSystemEventHandler):
 
             if chat_id and text and bot_app:
                 reply_markup = build_inline_keyboard(buttons) if buttons else None
-                try:
-                    await bot_app.bot.send_message(
-                        chat_id=chat_id,
-                        text=text,
-                        parse_mode="Markdown",
-                        reply_markup=reply_markup
-                    )
-                except Exception:
-                    # Fallback to plain text if Markdown parsing fails
-                    await bot_app.bot.send_message(
-                        chat_id=chat_id,
-                        text=text,
-                        reply_markup=reply_markup
-                    )
-                log.info(f"Sent reply to {chat_id}: {text[:50]}...")
+                chunks = split_message(text)
+                for i, chunk in enumerate(chunks):
+                    # Only attach buttons to the last chunk
+                    chunk_markup = reply_markup if (i == len(chunks) - 1) else None
+                    try:
+                        await bot_app.bot.send_message(
+                            chat_id=chat_id,
+                            text=chunk,
+                            parse_mode="Markdown",
+                            reply_markup=chunk_markup
+                        )
+                    except Exception:
+                        # Fallback to plain text if Markdown parsing fails
+                        await bot_app.bot.send_message(
+                            chat_id=chat_id,
+                            text=chunk,
+                            reply_markup=chunk_markup
+                        )
+                if len(chunks) > 1:
+                    log.info(f"Sent reply to {chat_id} in {len(chunks)} chunks: {text[:50]}...")
+                else:
+                    log.info(f"Sent reply to {chat_id}: {text[:50]}...")
                 os.remove(filepath)
             else:
                 log.warning(f"Skipping reply {filepath}: missing chat_id={chat_id}, text={bool(text)}, bot={bool(bot_app)}")

--- a/tests/unit/test_bot/test_outbox_watcher.py
+++ b/tests/unit/test_bot/test_outbox_watcher.py
@@ -68,7 +68,8 @@ class TestOutboxHandler:
             await handler.process_reply(str(reply_file))
 
             mock_bot_app.bot.send_message.assert_called_once_with(
-                chat_id=123456, text="Hello from Lobster!"
+                chat_id=123456, text="Hello from Lobster!",
+                parse_mode="Markdown", reply_markup=None
             )
 
             assert not reply_file.exists()
@@ -194,3 +195,153 @@ class TestOutboxHandler:
         with patch("asyncio.run_coroutine_threadsafe") as mock_run:
             handler.on_created(event)
             mock_run.assert_not_called()
+
+
+class TestSplitMessage:
+    """Tests for the split_message function."""
+
+    @pytest.fixture
+    def bot_module(self):
+        return get_bot_module()
+
+    def test_short_message_no_split(self, bot_module):
+        """Messages under the limit are returned as-is."""
+        result = bot_module.split_message("Hello world")
+        assert result == ["Hello world"]
+
+    def test_exactly_at_limit(self, bot_module):
+        """Message exactly at limit is not split."""
+        text = "a" * 4000
+        result = bot_module.split_message(text)
+        assert result == [text]
+
+    def test_split_at_paragraph_boundary(self, bot_module):
+        """Prefers splitting at paragraph boundaries (double newline)."""
+        para1 = "a" * 3000
+        para2 = "b" * 3000
+        text = para1 + "\n\n" + para2
+        result = bot_module.split_message(text)
+        assert len(result) == 2
+        assert result[0] == para1
+        assert result[1] == para2
+
+    def test_split_at_single_newline(self, bot_module):
+        """Falls back to single newline when no paragraph boundary fits."""
+        line = "x" * 200
+        # 21 lines of 200 chars each, joined by newlines = ~4200 chars
+        text = "\n".join([line] * 21)
+        result = bot_module.split_message(text)
+        assert len(result) >= 2
+        for chunk in result:
+            assert len(chunk) <= 4000
+
+    def test_hard_split(self, bot_module):
+        """Falls back to hard split when no newlines present."""
+        text = "a" * 8500
+        result = bot_module.split_message(text)
+        assert len(result) == 3  # 4000 + 4000 + 500
+        assert result[0] == "a" * 4000
+        assert result[1] == "a" * 4000
+        assert result[2] == "a" * 500
+
+    def test_custom_max_length(self, bot_module):
+        """Supports custom max_length parameter."""
+        text = "a" * 100
+        result = bot_module.split_message(text, max_length=30)
+        assert len(result) == 4  # 30 + 30 + 30 + 10
+
+    def test_empty_string(self, bot_module):
+        """Empty string returns single empty chunk."""
+        result = bot_module.split_message("")
+        assert result == [""]
+
+    def test_multi_paragraph_split(self, bot_module):
+        """Handles multiple paragraphs requiring several splits."""
+        paras = ["paragraph " + str(i) + " " + "x" * 1500 for i in range(5)]
+        text = "\n\n".join(paras)
+        result = bot_module.split_message(text)
+        assert len(result) >= 3
+        for chunk in result:
+            assert len(chunk) <= 4000
+
+
+class TestLongMessageSending:
+    """Tests that process_reply splits long messages into multiple sends."""
+
+    @pytest.fixture
+    def mock_bot_app(self):
+        app = MagicMock()
+        app.bot.send_message = AsyncMock()
+        return app
+
+    @pytest.fixture
+    def bot_module(self):
+        return get_bot_module()
+
+    @pytest.mark.asyncio
+    async def test_long_message_split_into_chunks(self, temp_messages_dir, mock_bot_app, bot_module):
+        """Long messages should result in multiple send_message calls."""
+        outbox = temp_messages_dir / "outbox"
+
+        long_text = ("First paragraph. " + "a" * 3000 + "\n\n"
+                     + "Second paragraph. " + "b" * 3000)
+        reply = {
+            "chat_id": 123456,
+            "text": long_text,
+            "source": "telegram",
+        }
+        reply_file = outbox / "reply_long.json"
+        reply_file.write_text(json.dumps(reply))
+
+        handler = bot_module.OutboxHandler()
+
+        original_bot_app = bot_module.bot_app
+        bot_module.bot_app = mock_bot_app
+
+        loop = asyncio.new_event_loop()
+        bot_module.main_loop = loop
+
+        try:
+            await handler.process_reply(str(reply_file))
+
+            assert mock_bot_app.bot.send_message.call_count == 2
+            assert not reply_file.exists()
+        finally:
+            bot_module.bot_app = original_bot_app
+            loop.close()
+
+    @pytest.mark.asyncio
+    async def test_buttons_only_on_last_chunk(self, temp_messages_dir, mock_bot_app, bot_module):
+        """Inline keyboard buttons should only be attached to the last chunk."""
+        outbox = temp_messages_dir / "outbox"
+
+        long_text = "a" * 5000
+        reply = {
+            "chat_id": 123456,
+            "text": long_text,
+            "source": "telegram",
+            "buttons": [["Yes", "No"]],
+        }
+        reply_file = outbox / "reply_buttons.json"
+        reply_file.write_text(json.dumps(reply))
+
+        handler = bot_module.OutboxHandler()
+
+        original_bot_app = bot_module.bot_app
+        bot_module.bot_app = mock_bot_app
+
+        loop = asyncio.new_event_loop()
+        bot_module.main_loop = loop
+
+        try:
+            await handler.process_reply(str(reply_file))
+
+            calls = mock_bot_app.bot.send_message.call_args_list
+            assert len(calls) == 2
+            # First chunk: no reply_markup
+            assert calls[0].kwargs.get("reply_markup") is None
+            # Last chunk: has reply_markup
+            assert calls[1].kwargs.get("reply_markup") is not None
+        finally:
+            bot_module.bot_app = original_bot_app
+            loop.close()


### PR DESCRIPTION
## Summary
- Adds `split_message()` function to `lobster_bot.py` that breaks messages exceeding Telegram's 4096-char limit into multiple chunks
- Splitting prefers paragraph boundaries (double newline), falls back to single newline, then hard-splits at 4000 chars
- Inline keyboard buttons are only attached to the final chunk
- Includes 8 unit tests for `split_message()` and 2 integration tests for multi-chunk sending

## Test plan
- [x] `split_message` unit tests pass (8/8 green)
- [x] `py_compile` passes for both changed files
- [x] No new test failures introduced (pre-existing pytest-asyncio config issue affects async tests equally before and after)
- [ ] Manual test: send a reply > 4096 chars via Telegram and verify it arrives as multiple messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)