### PR TITLE
Remove lobster-observability as install-time dependency

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1062,16 +1062,6 @@ pip install --quiet mcp python-telegram-bot watchdog python-dotenv slack-bolt ps
 success "Core Python packages installed"
 
 #-------------------------------------------------------------------------------
-# lobster-observability
-#-------------------------------------------------------------------------------
-info "Installing lobster-observability..."
-if pip install --quiet "git+https://github.com/SiderealPress/lobster-observability.git"; then
-    success "lobster-observability installed"
-else
-    warn "lobster-observability install failed. Observability server will be unavailable."
-fi
-
-#-------------------------------------------------------------------------------
 # fastembed
 #-------------------------------------------------------------------------------
 info "Installing fastembed..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "uvicorn>=0.29.0",
     "sqlite-vec>=0.1.1",
     "fastembed>=0.3.0",
-    "lobster-observability @ git+https://github.com/SiderealPress/lobster-observability.git",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Removes `lobster-observability` from `pyproject.toml` dependencies
- Removes the `pip install lobster-observability` block from `install.sh`

## What was removed

**`pyproject.toml`** — deleted one line:
```
"lobster-observability @ git+https://github.com/SiderealPress/lobster-observability.git",
```

**`install.sh`** — deleted the install block (lines 1064–1072):
```bash
#-------------------------------------------------------------------------------
# lobster-observability
#-------------------------------------------------------------------------------
info "Installing lobster-observability..."
if pip install --quiet "git+https://github.com/SiderealPress/lobster-observability.git"; then
    success "lobster-observability installed"
else
    warn "lobster-observability install failed. Observability server will be unavailable."
fi
```

## What was intentionally left alone

- `services/lobster-observability.service` and `.service.template` — service definitions are fine to live here; hyperlobster installs the binary
- `install.sh` service generation block (generates the `.service` file from the template) — runtime config, not package install
- `install.sh` service installation block (copies `.service` to `/etc/systemd/system/`) — runtime deployment
- `scripts/start-lobster.sh` references — starts the server at runtime, not an install-time dependency

## Rationale

`lobster-observability` is a separate package that hyperlobster handles at deploy time. Lobster itself should not own that install step. This was introduced by PR #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)