### PR TITLE
Fix headless auth flow with token validation and setup-token

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -544,8 +544,16 @@ step "Checking existing Claude Code authentication..."
 
 EXISTING_OAUTH=false
 if claude auth status &>/dev/null 2>&1; then
-    success "Claude Code already authenticated via OAuth"
-    EXISTING_OAUTH=true
+    # auth status only checks if credentials exist, not if they're valid.
+    # Verify the token actually works by making a real API call.
+    info "Credentials found, verifying token is still valid..."
+    if claude --print -p "ping" --max-turns 1 &>/dev/null 2>&1; then
+        success "Claude Code authenticated via OAuth (token verified)"
+        EXISTING_OAUTH=true
+    else
+        warn "OAuth credentials exist but token is expired or invalid."
+        warn "You'll need to re-authenticate during the auth setup step."
+    fi
 elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
     success "ANTHROPIC_API_KEY found in environment"
 fi
@@ -1413,28 +1421,59 @@ if [ "$AUTH_METHOD" = "oauth" ] && [ "$EXISTING_OAUTH" != true ]; then
     echo ""
     info "Starting OAuth authentication..."
     echo ""
-    echo "Claude Code will generate an authentication URL."
-    echo -e "Open it in ${BOLD}any browser${NC} (phone, laptop, etc.) and sign in with your Anthropic account."
-    echo ""
-    read -p "Press Enter to continue..."
-    echo ""
 
-    # Run auth login interactively - it will display the URL
-    if claude auth login; then
-        # Verify the auth actually worked
-        if claude auth status &>/dev/null 2>&1; then
-            success "OAuth authentication successful!"
+    # Detect headless environment
+    IS_HEADLESS=false
+    if [ -z "${DISPLAY:-}" ] && [ -z "${WAYLAND_DISPLAY:-}" ] && ! command -v open &>/dev/null; then
+        IS_HEADLESS=true
+        echo -e "${YELLOW}Headless server detected (no display).${NC}"
+        echo ""
+        echo "For headless authentication, we recommend using 'claude setup-token'."
+        echo "It will display a URL — open it in any browser (phone, laptop, etc.),"
+        echo "authorize, then paste the code back here when prompted."
+        echo ""
+        echo -e "Alternatively, you can use an ${BOLD}API key${NC} instead (billed per-token)."
+        echo ""
+        echo "  1) Try setup-token (OAuth via URL + code paste)"
+        echo "  2) Use an API key instead"
+        echo ""
+        read -p "Choose [1/2]: " HEADLESS_CHOICE
+        if [ "$HEADLESS_CHOICE" = "2" ]; then
+            AUTH_METHOD="apikey_fallback"
+        fi
+    fi
+
+    if [ "$AUTH_METHOD" = "oauth" ]; then
+        echo ""
+        echo "Claude Code will generate an authentication URL."
+        echo -e "Open it in ${BOLD}any browser${NC} (phone, laptop, etc.) and sign in with your Anthropic account."
+        echo ""
+        read -p "Press Enter to continue..."
+        echo ""
+
+        # Use setup-token on headless, auth login otherwise
+        AUTH_CMD="claude auth login"
+        if [ "$IS_HEADLESS" = true ]; then
+            AUTH_CMD="claude setup-token"
+        fi
+
+        if $AUTH_CMD; then
+            # Verify the auth actually works (not just that credentials exist)
+            if claude --print -p "ping" --max-turns 1 &>/dev/null 2>&1; then
+                success "OAuth authentication successful (verified)!"
+            else
+                warn "Auth command completed but API verification failed."
+                warn "The token may have expired or the code exchange didn't complete."
+                echo ""
+                echo "Falling back to API key..."
+                AUTH_METHOD="apikey_fallback"
+            fi
         else
-            warn "Auth command completed but verification failed."
+            warn "OAuth authentication failed or was cancelled."
             echo ""
             echo "Falling back to API key..."
             AUTH_METHOD="apikey_fallback"
         fi
-    else
-        warn "OAuth authentication failed or was cancelled."
-        echo ""
-        echo "Falling back to API key..."
-        AUTH_METHOD="apikey_fallback"
     fi
 fi
 
@@ -1497,13 +1536,32 @@ if [ "$AUTH_METHOD" = "apikey" ] || [ "$AUTH_METHOD" = "apikey_fallback" ]; then
 fi
 
 # --- Select the Claude launcher ---
-# The persistent launcher (claude-persistent.sh) replaces the old polling
-# wrappers. It runs Claude in a persistent session with wait_for_messages()
-# and handles lifecycle (restart, hibernate, backoff) internally.
-info "Using persistent lifecycle launcher: claude-persistent.sh"
-CLAUDE_WRAPPER="$INSTALL_DIR/scripts/claude-persistent.sh"
-chmod +x "$CLAUDE_WRAPPER"
+# Choose the appropriate wrapper based on auth method and environment.
+# - claude-persistent.sh: Persistent interactive session (OAuth, has TTY)
+# - claude-wrapper.sh: Headless polling mode (API key, or no TTY)
+# - claude-wrapper.exp: Expect-based interactive (legacy, needs TTY + OAuth)
 
+if [ "$AUTH_METHOD" = "apikey" ] || [ "$AUTH_METHOD" = "apikey_fallback" ]; then
+    # API key mode: use headless polling wrapper (no interactive session needed)
+    info "API key auth: using headless polling launcher (claude-wrapper.sh)"
+    CLAUDE_WRAPPER="$INSTALL_DIR/scripts/claude-wrapper.sh"
+elif [ -z "${DISPLAY:-}" ] && [ -z "${WAYLAND_DISPLAY:-}" ] && ! command -v open &>/dev/null; then
+    # Headless server with OAuth: use persistent launcher if available,
+    # fall back to headless wrapper
+    if [ -f "$INSTALL_DIR/scripts/claude-persistent.sh" ]; then
+        info "Headless + OAuth: using persistent lifecycle launcher"
+        CLAUDE_WRAPPER="$INSTALL_DIR/scripts/claude-persistent.sh"
+    else
+        info "Headless + OAuth: using headless polling launcher (claude-wrapper.sh)"
+        CLAUDE_WRAPPER="$INSTALL_DIR/scripts/claude-wrapper.sh"
+    fi
+else
+    # Desktop/TTY environment with OAuth: use persistent launcher
+    info "Using persistent lifecycle launcher: claude-persistent.sh"
+    CLAUDE_WRAPPER="$INSTALL_DIR/scripts/claude-persistent.sh"
+fi
+
+chmod +x "$CLAUDE_WRAPPER"
 success "Claude wrapper: $CLAUDE_WRAPPER"
 
 #===============================================================================


### PR DESCRIPTION
## Summary

- **Verify OAuth tokens actually work**, not just exist. `claude auth status` only checks if credentials are present — it doesn't detect expired tokens. Now makes a real API call (`claude --print -p "ping"`) to confirm the token is valid.
- **Detect headless servers** and use `claude setup-token` (which has a code-paste prompt) instead of `claude auth login` (which hangs without a browser).
- **Offer clear API key fallback** when OAuth fails on headless — gives the user an explicit choice rather than silently failing.
- **Select appropriate wrapper** based on auth method: headless polling wrapper for API key, persistent launcher for OAuth.

## Test plan

- [ ] Run `install.sh` on a headless VPS with expired OAuth token — should detect and prompt for re-auth
- [ ] Run `install.sh` on a headless VPS with no existing auth — should offer setup-token vs API key choice
- [ ] Run `install.sh` on a desktop with valid OAuth — should skip re-auth (existing behavior)
- [ ] Verify API key fallback path writes key to config.env and selects headless wrapper

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)