### PR TITLE
fix: fall back to git clone when no release exists; persist ~/.local/bin to PATH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -531,6 +531,17 @@ if [ "$CLAUDE_INSTALLED" = false ]; then
     # Add to PATH for current session
     export PATH="$HOME/.local/bin:$PATH"
 
+    # Persist ~/.local/bin to PATH in shell config files
+    PATH_LINE="export PATH=\"\$HOME/.local/bin:\$PATH\""
+    for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+        if [ -f "$rc" ] && ! grep -q '\.local/bin' "$rc"; then
+            echo "" >> "$rc"
+            echo "# Added by Lobster installer" >> "$rc"
+            echo "$PATH_LINE" >> "$rc"
+            info "Added ~/.local/bin to PATH in $rc"
+        fi
+    done
+
     if command -v claude &>/dev/null; then
         success "Claude Code installed"
     else
@@ -597,17 +608,12 @@ else
         info "Existing tarball install found (v$(cat "$INSTALL_DIR/VERSION")). Updating..."
     fi
 
-    # Fetch latest release from GitHub API
-    RELEASE_JSON=$(curl -fsSL "$GITHUB_API/releases/latest" 2>/dev/null) || {
-        error "Failed to fetch latest release from GitHub"
-        error "Check your internet connection and try again"
-        exit 1
-    }
+    # Fetch latest release from GitHub API; fall back to git clone on any error
+    RELEASE_JSON=$(curl -fsSL "$GITHUB_API/releases/latest" 2>/dev/null) || true
+    LATEST_TAG=$(echo "$RELEASE_JSON" | jq -r '.tag_name // empty' 2>/dev/null || true)
 
-    LATEST_TAG=$(echo "$RELEASE_JSON" | jq -r '.tag_name // empty')
     if [ -z "$LATEST_TAG" ]; then
-        error "Could not parse release tag. Falling back to git clone..."
-        INSTALL_MODE="git"
+        info "No release found, falling back to git clone..."
         git clone --quiet --branch "$REPO_BRANCH" "$REPO_URL" "$INSTALL_DIR"
         cd "$INSTALL_DIR"
         success "Repository ready at $INSTALL_DIR (git fallback)"


### PR DESCRIPTION
## Summary

- **Bug 1 (release fallback):** Non-dev installs no longer exit with a fatal error when `https://api.github.com/repos/SiderealPress/lobster/releases/latest` returns a 404 (no releases published yet). Previously the installer used `curl -f ... || { error...; exit 1 }`, which aborted on any HTTP error. Now both the curl failure and an empty `tag_name` in the response trigger an automatic fallback to `git clone` with an informational message: "No release found, falling back to git clone...".

- **Bug 2 (PATH persistence):** After the Claude Code installer (`curl -fsSL https://claude.ai/install.sh | bash`) runs, `~/.local/bin` is now persisted to `~/.bashrc` (and `~/.zshrc` if it exists) so it is on PATH in future shell sessions. The file is only updated if it does not already contain a `.local/bin` entry, preventing duplicate entries on re-runs.

## Changes

Only `install.sh` is modified. No refactoring — minimal targeted fixes to the two identified bugs.

## Test plan

- [x] `bash -n install.sh` passes (syntax check)
- [ ] Fresh VM install (no releases): installer falls back to git clone instead of exiting with an error
- [ ] Fresh VM install: after Claude Code install, `~/.bashrc` contains `~/.local/bin` in PATH
- [ ] Re-running installer does not duplicate the PATH entry in `~/.bashrc`
- [ ] Existing dev mode install (`--dev`) unaffected by Bug 1 fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)