### PR TITLE
Fix Claude auth flow: TTY wrapping + token persistence

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1494,7 +1494,7 @@ if [ "$AUTH_METHOD" = "oauth" ] && [ "$EXISTING_OAUTH" != true ]; then
                 if [ -f "$CONFIG_FILE" ]; then
                     echo "" >> "$CONFIG_FILE"
                     echo "# OAuth token from claude setup-token (long-lived)" >> "$CONFIG_FILE"
-                    echo "CLAUDE_CODE_OAUTH_TOKEN=$CAPTURED_TOKEN" >> "$CONFIG_FILE"
+                    echo "export CLAUDE_CODE_OAUTH_TOKEN=$CAPTURED_TOKEN" >> "$CONFIG_FILE"
                 fi
 
                 success "OAuth token captured and saved to config.env!"
@@ -1513,7 +1513,7 @@ if [ "$AUTH_METHOD" = "oauth" ] && [ "$EXISTING_OAUTH" != true ]; then
                     if [ -f "$CONFIG_FILE" ]; then
                         echo "" >> "$CONFIG_FILE"
                         echo "# OAuth token from claude setup-token (long-lived, manually pasted)" >> "$CONFIG_FILE"
-                        echo "CLAUDE_CODE_OAUTH_TOKEN=$CAPTURED_TOKEN" >> "$CONFIG_FILE"
+                        echo "export CLAUDE_CODE_OAUTH_TOKEN=$CAPTURED_TOKEN" >> "$CONFIG_FILE"
                     fi
                     success "OAuth token saved to config.env!"
                 else


### PR DESCRIPTION
## Summary

Fixes two root-cause bugs in the Claude authentication flow in `install.sh` that caused silent auth failures on headless servers:

- **Problem 1 — No pseudo-TTY:** Both `claude setup-token` and `claude auth login` use Ink (React-for-CLI) which requires raw mode on stdin. Inside a bash script, stdin doesn't support raw mode, causing the interactive auth flow to fail. **Fix:** Wrap both commands with `script -qc` to provide a pseudo-TTY.

- **Problem 2 — `setup-token` doesn't persist credentials:** `claude setup-token` does NOT save credentials to `~/.claude/.credentials.json` by design ([anthropics/claude-code#19274](https://github.com/anthropics/claude-code/issues/19274)). It only outputs an OAuth token to stdout. The install script assumed it saved to disk. **Fix:** Capture the token from output, strip ANSI codes, extract the `sk-ant-oat01-...` token, and persist it to `config.env` as `CLAUDE_CODE_OAUTH_TOKEN`. Includes a manual-paste fallback if automatic extraction fails.

### Changes
- Headless path (`setup-token`): Run via `script -qc` with output capture to temp file, extract token, save to config.env, manual-paste fallback
- Non-headless path (`auth login`): Wrap with `script -qc` for TTY (auth login saves credentials itself)
- API-key fallback retry path: Also wrap `claude auth login` with `script -qc`

### Supersedes
- PR #98 (closed) — only addressed TTY issue, not token persistence
- PR #99 — addressed symptoms with retry loops but not root causes. Should be closed.

## Test plan

- [x] `bash -n install.sh` — syntax validation passes
- [x] `script -qc "claude setup-token"` starts without raw mode error on Hetzner server (77.42.79.44)
- [x] `script -qc` command available on both Ubuntu (Hetzner) and Amazon Linux (EC2)
- [ ] Full headless OAuth flow: run install.sh on headless server, complete OAuth in browser, verify token is captured and saved to config.env
- [ ] Full non-headless OAuth flow: run install.sh with display available, verify auth login works through `script -qc`
- [ ] Fallback path: cancel setup-token, verify manual paste prompt appears, paste valid token, verify it's saved
- [ ] API key fallback: choose API key path, verify it still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)