### PR TITLE
Add mosh to installed packages in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -407,6 +407,7 @@ if [ "$PKG_MANAGER" = "apt" ]; then
         fd-find
         bat
         fzf
+        mosh
     )
 
     for pkg in "${PACKAGES[@]}"; do
@@ -431,6 +432,7 @@ else
         gcc-c++
         cmake
         make
+        mosh
     )
 
     for pkg in "${DNF_PACKAGES[@]}"; do


### PR DESCRIPTION
## Summary

- Add `mosh` to both apt (Ubuntu/Debian) and dnf (Amazon Linux/Fedora) package lists in `install.sh`

Mosh provides a more resilient remote terminal than SSH alone — it handles roaming, intermittent connectivity, and high-latency links gracefully. Useful for managing Lobster instances over unstable connections.

## Changes

Two lines added: `mosh` appended to the `PACKAGES` array (apt) and the `DNF_PACKAGES` array (dnf).

## Test plan

- [x] `bash -n install.sh` passes