### PR TITLE
Fix Python version check to use integer comparison

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -362,7 +362,9 @@ if ! command -v python3 &>/dev/null; then
     NEED_PYTHON=true
 else
     PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-    if [[ $(echo "$PYTHON_VERSION < 3.9" | bc -l 2>/dev/null || echo "0") == "1" ]]; then
+    PYTHON_MAJOR=$(echo "$PYTHON_VERSION" | cut -d. -f1)
+    PYTHON_MINOR=$(echo "$PYTHON_VERSION" | cut -d. -f2)
+    if [ "$PYTHON_MAJOR" -lt 3 ] || { [ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -lt 9 ]; }; then
         warn "Python $PYTHON_VERSION found, but 3.9+ recommended"
     else
         success "Python $PYTHON_VERSION found"


### PR DESCRIPTION
## Summary

- Replace `bc -l` floating-point comparison with integer major/minor comparison for Python version detection

## Problem

The current check `echo "$PYTHON_VERSION < 3.9" | bc -l` has two issues:

1. **`bc` may not be installed** — on minimal VMs (especially Amazon Linux), `bc` is not in the default package set. The `|| echo "0"` fallback silently treats any Python version as acceptable.
2. **Lexicographic edge case** — while `bc` handles 3.10 correctly, the pattern is fragile and depends on an external tool for what should be simple integer arithmetic.

## Fix

Use `cut` to extract major and minor version components, then compare with shell integer operators (`-lt`, `-eq`). This works on every POSIX system with no external dependencies.

## Test plan

- [x] `bash -n install.sh` passes
- Tested logic: Python 3.8 triggers warning, Python 3.9+ passes, Python 3.10+ passes