### PR TITLE
Suppress needrestart interactive prompts during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,12 @@
 
 set -euo pipefail
 
+# Suppress needrestart interactive prompts on Ubuntu/Debian
+# Without this, apt operations can hang waiting for user input
+# when libraries used by running services are upgraded.
+export DEBIAN_FRONTEND=noninteractive
+export NEEDRESTART_MODE=a
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary

- Set `DEBIAN_FRONTEND=noninteractive` and `NEEDRESTART_MODE=a` at the top of `install.sh`

## Problem

On Ubuntu 22.04+ and Debian 12+, the `needrestart` package (installed by default) prompts interactively during `apt-get install` when upgraded libraries are used by running services. This causes the installer to hang indefinitely when run unattended, via cloud-init, or piped through `curl | bash`.

## Fix

Export these two environment variables before any apt operations:
- `DEBIAN_FRONTEND=noninteractive` — standard apt prompt suppression
- `NEEDRESTART_MODE=a` — tells needrestart to automatically restart services without asking

## Test plan

- [x] `bash -n install.sh` passes
- Standard practice for automated Debian/Ubuntu installers