### PR TITLE
Install and configure GitHub CLI (gh) in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -387,11 +387,20 @@ step "Installing system dependencies..."
 if [ "$PKG_MANAGER" = "apt" ]; then
     sudo apt-get update -qq
 
+    # Install GitHub CLI (gh) repository if not already present
+    if ! dpkg -s gh &>/dev/null; then
+        info "Adding GitHub CLI apt repository..."
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+        sudo apt-get update -qq
+    fi
+
     PACKAGES=(
         curl
         wget
         git
         jq
+        gh
         python3
         python3-pip
         python3-venv
@@ -422,6 +431,7 @@ else
         wget
         git
         jq
+        gh
         python3
         python3-pip
         cronie
@@ -1308,6 +1318,37 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     fi
 else
     info "Skipped GitHub integration. You can set it up later - see README.md"
+fi
+
+#===============================================================================
+# GitHub CLI Authentication
+#===============================================================================
+
+step "Checking GitHub CLI authentication..."
+
+if gh auth status &>/dev/null 2>&1; then
+    success "GitHub CLI already authenticated"
+elif [ -n "${GITHUB_PAT:-}" ]; then
+    info "Authenticating gh with GITHUB_PAT from environment..."
+    echo "$GITHUB_PAT" | gh auth login --with-token 2>/dev/null && \
+        success "GitHub CLI authenticated via PAT" || \
+        warn "GitHub CLI auth via PAT failed. Authenticate later with: gh auth login"
+else
+    echo ""
+    echo "GitHub CLI (gh) is not authenticated."
+    echo "This is needed for creating PRs, managing issues, etc."
+    echo ""
+    read -p "Authenticate GitHub CLI now? [y/N] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        if gh auth login; then
+            success "GitHub CLI authenticated"
+        else
+            warn "GitHub CLI auth failed. Authenticate later with: gh auth login"
+        fi
+    else
+        info "Skipped. Authenticate later with: gh auth login"
+    fi
 fi
 
 #===============================================================================


### PR DESCRIPTION
## Summary

- Add `gh` (GitHub CLI) to system dependencies and offer authentication during install

## Motivation

Lobster frequently needs to interact with GitHub — creating PRs, managing issues, browsing repos. The `gh` CLI is the standard tool for this, and having it installed and authenticated out of the box saves manual setup.

## Changes

### Package installation
- Add GitHub CLI apt repository on Ubuntu/Debian (official `cli.github.com/packages`)
- Add `gh` to the apt `PACKAGES` array
- Add `gh` to the dnf `DNF_PACKAGES` array

### Authentication step (new section after GitHub MCP setup)
- If `gh auth status` already passes, skip
- If `GITHUB_PAT` is in the environment, auto-authenticate via `gh auth login --with-token`
- Otherwise, offer interactive `gh auth login`
- All paths degrade gracefully (warn + skip, never block)

## Test plan

- [x] `bash -n install.sh` passes
- `gh` appears in both apt and dnf package lists
- Auth section handles all three cases: already authed, PAT available, interactive prompt