### PR TITLE
fix: prevent health check restart loop and lock FD leak

### DIFF
--- a/scripts/claude-persistent.sh
+++ b/scripts/claude-persistent.sh
@@ -194,6 +194,12 @@ launch_claude() {
     # Any persistent state lives in canonical memory files, not conversation history.
     local claude_exit_code=0
     log "Starting fresh session (attempt $attempt)..."
+
+    # Transition to active BEFORE the blocking claude call.
+    # The "starting" state above covers env cleanup and preflight.
+    # Once we hand off to claude, we're active.
+    write_state "active" "claude running, attempt=$attempt"
+
     claude --dangerously-skip-permissions \
         --model sonnet \
         --max-turns 150 \

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -517,7 +517,7 @@ check_dashboard_server() {
     fi
 
     log_warn "Dashboard server not running on port 9100 - restarting"
-    nohup $dashboard_cmd >> "$WORKSPACE_DIR/logs/dashboard-server.log" 2>&1 &
+    nohup $dashboard_cmd >> "$WORKSPACE_DIR/logs/dashboard-server.log" 2>&1 200>&- &
     log_info "Dashboard server restarted (PID $!)"
     return 0
 }


### PR DESCRIPTION
## Summary

Two bugs in the health check / persistent session system caused constant Telegram health alerts and unnecessary restarts:

### Bug 1: State never transitions to "active" (`claude-persistent.sh`)

`launch_claude()` writes `mode="starting"` at the top (line 159), then blocks on the `claude` command. **Nothing ever wrote `mode="active"`**, so the state stayed `"starting"` for the entire Claude session. The health check sees this as a stale transient state (>120s), goes RED, restarts `lobster-claude`, which resets to `"starting"` again — infinite restart-alert loop.

**Fix:** `write_state "active"` immediately before the blocking `claude` command. The "starting" phase now only covers the brief env cleanup (CLAUDECODE leak prevention), then transitions to "active" before handing off to Claude.

### Bug 2: Dashboard server inherits flock FD (`health-check-v3.sh`)

`check_dashboard_server()` launches the dashboard with `nohup ... &`. The child process **inherits file descriptor 200** (the exclusive flock from `acquire_lock()`). Since the dashboard is long-lived, it holds the lock forever. Every subsequent cron health check tries `flock -n 200`, fails, and silently exits — **disabling all health monitoring**.

**Fix:** Close FD 200 before forking: `200>&-`

## Test plan

- [x] `bash -n` syntax check on both scripts
- [x] State file transitions to `mode=active` after restart
- [x] Health check runs twice in succession (lock not blocked)
- [x] Dashboard server does not hold FD 200 (`/proc/<pid>/fd/200` absent)
- [x] Full state machine trace — no path leaves state stuck at "starting"
- [x] No other backgrounded commands in health check that could leak FD 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)