### PR TITLE
fix: block Bash bypass of no-auto-memory hook

### DIFF
--- a/hooks/no-auto-memory.py
+++ b/hooks/no-auto-memory.py
@@ -2,12 +2,48 @@
 """
 Block writes to Claude Code's auto-memory directory.
 
-Persistent state belongs in CLAUDE.md or canonical memory files, not .claude/memory/.
+Persistent state belongs in CLAUDE.md or Lobster's MCP memory system,
+not Claude Code's .claude/memory/ auto-memory.
 Based on sayhar/claude-bicycle hooks/no-auto-memory.py
 """
 
 import json
+import re
 import sys
+
+DENY_REASON = (
+    "Don't use Claude Code auto-memory. "
+    "Use Lobster's MCP memory system instead "
+    "(memory_store, memory_search, memory_recent)."
+)
+
+# Bash commands that write/create files or directories
+_BASH_WRITE_PATTERN = re.compile(
+    r"\b(mkdir|touch|cp|mv|tee|install|echo\s.*>|printf\s.*>|cat\s.*>|>\.*)\b"
+)
+
+
+def is_memory_file_path(file_path: str) -> bool:
+    """Return True if file_path targets Claude Code's auto-memory directory."""
+    return "/.claude/" in file_path and "/memory/" in file_path
+
+
+def is_bash_memory_write(command: str) -> bool:
+    """
+    Return True if a Bash command would create or write to Claude Code's
+    auto-memory directories.
+
+    We look for commands that:
+    - Reference both '.claude' and 'memory' in the path, AND
+    - Are write/create operations (mkdir, touch, cp, mv, tee, redirects, etc.)
+
+    Read-only commands (ls, cat reading, grep, etc.) are allowed through.
+    """
+    if ".claude" not in command or "memory" not in command:
+        return False
+
+    # Only block if the command looks like a write/create operation
+    return bool(_BASH_WRITE_PATTERN.search(command))
 
 
 def main():
@@ -16,19 +52,27 @@ def main():
     except json.JSONDecodeError:
         sys.exit(0)
 
-    file_path = data.get("tool_input", {}).get("file_path", "")
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {})
 
-    if "/.claude/" not in file_path or "/memory/" not in file_path:
+    should_deny = False
+
+    if tool_name == "Bash":
+        command = tool_input.get("command", "")
+        should_deny = is_bash_memory_write(command)
+    else:
+        # Write, Edit, and any other file-path based tools
+        file_path = tool_input.get("file_path", "")
+        should_deny = is_memory_file_path(file_path)
+
+    if not should_deny:
         sys.exit(0)
 
     print(json.dumps({
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "permissionDecision": "deny",
-            "permissionDecisionReason": (
-                "Don't use auto-memory. Instead update CLAUDE.md or "
-                "canonical memory files (memory/priorities.md, etc.)."
-            ),
+            "permissionDecisionReason": DENY_REASON,
         }
     }))
     sys.exit(0)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The previous hook only checked `file_path` for `Write`/`Edit` tool calls, leaving a bypass: Claude could run `mkdir -p ~/.claude/projects/.../memory/` or similar Bash commands to create auto-memory directories undetected.
- Updated `hooks/no-auto-memory.py` to also handle `Bash` tool calls by checking the `command` field for patterns that write/create into `.claude/.../memory/` paths.
- Updated the deny message to direct to Lobster's MCP memory system (`memory_store`, `memory_search`, `memory_recent`) instead of generic CLAUDE.md guidance.

## Changes

**`hooks/no-auto-memory.py`**
- Added `is_bash_memory_write(command)` — blocks Bash commands that reference `.claude` + `memory` AND use a write/create operation (`mkdir`, `touch`, `cp`, `mv`, `tee`, output redirects, etc.). Read-only commands (`ls`, `grep`, `cat` reading) are left unblocked.
- Added `is_memory_file_path(file_path)` helper (same logic as before, extracted).
- Main logic now branches on `tool_name`: Bash path checks `command`, all other tools check `file_path`.
- Updated deny reason: _"Don't use Claude Code auto-memory. Use Lobster's MCP memory system instead (memory_store, memory_search, memory_recent)."_

## Local settings.json change required

`/home/lobster/.claude/settings.json` is not tracked in this repo, but the hook matcher needs to be updated to also fire on Bash calls. Change the matcher for this hook from:

```json
"matcher": "Write|Edit"
```

to:

```json
"matcher": "Write|Edit|Bash"
```

## Test plan

- [ ] Verify `Write`/`Edit` to a `.claude/.../memory/` path is still denied
- [ ] Verify `Bash` command `mkdir -p ~/.claude/projects/x/memory/` is denied
- [ ] Verify `Bash` command `ls ~/.claude/projects/x/memory/` is allowed through (read-only)
- [ ] Verify `Bash` command unrelated to `.claude`/`memory` is unaffected
- [ ] Update `settings.json` matcher to `"Write|Edit|Bash"` on the deployed host

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)