### PR TITLE
Fix: maintenance mode flag prevents health check restart loop

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -43,6 +43,7 @@ MESSAGES_DIR="${LOBSTER_MESSAGES:-$HOME/messages}"
 WORKSPACE_DIR="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
 
 INBOX_DIR="$MESSAGES_DIR/inbox"
+MAINTENANCE_FLAG="$MESSAGES_DIR/config/lobster-maintenance"
 LOBSTER_STATE_FILE="${LOBSTER_STATE_FILE_OVERRIDE:-$MESSAGES_DIR/config/lobster-state.json}"
 STALE_THRESHOLD_SECONDS=180          # 3 minutes - RED if any message older (watchdog handles soft recovery at 90s)
 YELLOW_THRESHOLD_SECONDS=120         # 2 minutes - YELLOW warning
@@ -634,6 +635,13 @@ Status: Restarted successfully"
 #===============================================================================
 main() {
     acquire_lock
+
+    # Maintenance mode: lobster stop sets this flag to prevent auto-restart
+    if [[ -f "$MAINTENANCE_FLAG" ]]; then
+        log_info "=== Maintenance mode active, skipping all checks ==="
+        exit 0
+    fi
+
     log_info "=== Health check v3 starting ==="
 
     local level="GREEN"

--- a/src/cli
+++ b/src/cli
@@ -32,9 +32,11 @@ CYAN='\033[0;36m'
 NC='\033[0m'
 
 # Directories
-INBOX_DIR="$HOME/messages/inbox"
-OUTBOX_DIR="$HOME/messages/outbox"
-PROCESSED_DIR="$HOME/messages/processed"
+MESSAGES_DIR="${LOBSTER_MESSAGES:-$HOME/messages}"
+INBOX_DIR="$MESSAGES_DIR/inbox"
+OUTBOX_DIR="$MESSAGES_DIR/outbox"
+PROCESSED_DIR="$MESSAGES_DIR/processed"
+MAINTENANCE_FLAG="$MESSAGES_DIR/config/lobster-maintenance"
 
 # Services
 SERVICES=("lobster-router" "lobster-claude")
@@ -72,6 +74,12 @@ count_files() {
 cmd_start() {
     print_header "Starting Lobster"
 
+    # Clear maintenance mode flag if present
+    if [[ -f "$MAINTENANCE_FLAG" ]]; then
+        rm -f "$MAINTENANCE_FLAG"
+        echo -e "Maintenance mode cleared"
+    fi
+
     for service in "${SERVICES[@]}"; do
         echo -n "Starting $service... "
         if sudo systemctl start "$service" 2>/dev/null; then
@@ -97,6 +105,11 @@ cmd_stop() {
             echo -e "${YELLOW}not running${NC}"
         fi
     done
+
+    # Set maintenance flag so health check doesn't restart services
+    mkdir -p "$(dirname "$MAINTENANCE_FLAG")"
+    echo "stopped_at=$(date -Iseconds) stopped_by=$(whoami)" > "$MAINTENANCE_FLAG"
+    echo -e "${GREEN}Maintenance mode enabled${NC} (health check will not restart services)"
 }
 
 cmd_restart() {
@@ -108,6 +121,11 @@ cmd_restart() {
 
 cmd_status() {
     print_header "Lobster Status"
+
+    if [[ -f "$MAINTENANCE_FLAG" ]]; then
+        echo ""
+        echo -e "${YELLOW}⚠ MAINTENANCE MODE - health check auto-restart disabled${NC}"
+    fi
 
     echo ""
     echo -e "${CYAN}Services:${NC}"


### PR DESCRIPTION
Duplicate of #118. Closing.