### PR TITLE
docs: enforce all file reads to background subagents, no exceptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,7 @@ Calendar commands work in two modes. Check auth status first (no network call ne
 ```python
 import sys; sys.path.insert(0, "/home/admin/lobster/src")
 from integrations.google_calendar.token_store import load_token
-is_authenticated = load_token("1234567890") is not None
+is_authenticated = load_token("<REDACTED_PHONE>") is not None
 ```
 
 ### Unauthenticated mode (default)
@@ -384,14 +384,14 @@ Delegate to a background subagent — API calls exceed the 7-second rule.
 **Reading events** ("what's on my calendar", "what do I have this week/today"):
 ```python
 from integrations.google_calendar.client import get_upcoming_events
-events = get_upcoming_events(user_id="1234567890", days=7)
+events = get_upcoming_events(user_id="<REDACTED_PHONE>", days=7)
 # Returns List[CalendarEvent] or [] on failure — always falls back gracefully
 ```
 
 **Creating events** ("add X to my calendar", "schedule X for [time]"):
 ```python
 from integrations.google_calendar.client import create_event
-event = create_event(user_id="1234567890", title="...", start=start, end=end)
+event = create_event(user_id="<REDACTED_PHONE>", title="...", start=start, end=end)
 # Returns CalendarEvent with .url, or None on failure
 # On failure, fall back to gcal_add_link_md()
 ```


### PR DESCRIPTION
## Summary

- Strengthens the 7-Second Rule by explicitly enumerating all file types (PDFs, images, documents, text files, audio) that MUST go to background subagents — no exceptions
- Adds a post-incident callout explaining the real-world consequence: a PDF read on the main thread caused a 4.5-minute freeze, health-check restart, and message retry loop
- Rewrites the **Handling Images** section to use the subagent delegation pattern instead of reading images directly on the main thread (which contradicted the 7-second rule)

## Motivation

An incident where PDF processing blocked the main thread for 4.5 minutes revealed that the existing wording ("ANY file read/write (including images)") was too easy to rationalize around. This PR makes the rule unambiguous with concrete examples, explicit types, and a documented incident as rationale.

## Changes

**7-Second Rule — subagent list:**
- Expanded the single file read bullet into a structured list with explicit types: images, PDFs/documents, text files, audio files
- Added blockquote callout explaining the incident and the "no exceptions" rationale

**Handling Images section:**
- Rewrote from "read the image on the main thread" to "delegate to a subagent" pattern
- Added CRITICAL warning at the top of the section
- Provided concrete subagent delegation code template

## Test plan

- [ ] Read through the updated 7-Second Rule section and confirm file type bullets are clear and unambiguous
- [ ] Read through the updated Handling Images section and confirm it now matches the dispatcher pattern
- [ ] Verify no on-thread file reads remain in CLAUDE.md instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)