### PR TITLE
feat: subagent result relay via message queue (#148)

### DIFF
--- a/.claude/agents/brain-dumps.md
+++ b/.claude/agents/brain-dumps.md
@@ -644,12 +644,45 @@ This allows the brain-dumps agent to reliably process dumps without variance in 
 
 ---
 
+## Reporting Results Back to the User
+
+**Never call `send_reply` directly.** When the brain dump is fully processed, use `write_result` to relay the outcome back to the main thread, which will deliver it to the user:
+
+```python
+# On success — after all stages complete and the GitHub issue is created:
+write_result(
+    task_id=f"brain-dump-{issue_number}",
+    chat_id=chat_id,          # from the Task prompt
+    text=(
+        f"Brain dump captured! Issue #{issue_number} created.\n\n"
+        f"{context_summary}"  # e.g. "Matched: ProjectX · Mike (hiking buddy)"
+    ),
+    source=source,            # from the Task prompt, default "telegram"
+    status="success",
+)
+
+# On failure — e.g. issue creation failed:
+write_result(
+    task_id="brain-dump-failed",
+    chat_id=chat_id,
+    text=(
+        "I couldn't save your brain dump to GitHub. "
+        "Here's the transcription so nothing is lost:\n\n"
+        f"{transcription}"
+    ),
+    source=source,
+    status="error",
+)
+```
+
+The `chat_id` and `source` values are passed in the Task prompt from the main thread.
+
 ## Error Handling
 
 - **Context files missing**: Skip context matching, proceed with basic processing
-- **Repo creation fails**: Notify user, suggest manual creation
-- **Issue creation fails**: Notify user, include transcription in message (don't lose content)
-- **Context matching fails**: Log warning, continue without context enrichment
+- **Repo creation fails**: Call `write_result` with `status="error"`, include transcription in text
+- **Issue creation fails**: Call `write_result` with `status="error"`, include transcription so content is not lost
+- **Context matching fails**: Log warning, continue without context enrichment, still call `write_result` on completion
 
 ---
 

--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -136,6 +136,39 @@ gh project item-edit --project "Main Board" --owner <owner> --id <item-id> --fie
 - Add comments only for non-obvious business logic or complex algorithms
 - Ensure your code is testable by keeping functions pure and dependencies injectable
 
+## Reporting Results Back to the User
+
+**Never call `send_reply` directly.** When work is complete (or has failed), use `write_result` to relay the outcome back through the main message queue. The main thread will deliver it to the user.
+
+```python
+# On success — after PR is opened (or work is done):
+write_result(
+    task_id=f"issue-{issue_number}",
+    chat_id=chat_id,          # passed in the Task prompt
+    text=(
+        f"Done! PR #{pr_number} is open for issue #{issue_number}.\n"
+        f"{pr_url}"
+    ),
+    source=source,            # passed in the Task prompt, default "telegram"
+    status="success",
+)
+
+# On failure — e.g. implementation blocked, tests failing:
+write_result(
+    task_id=f"issue-{issue_number}-failed",
+    chat_id=chat_id,
+    text=(
+        f"Issue #{issue_number}: I ran into a blocker.\n\n"
+        f"{error_description}\n\n"
+        "I've left a comment on the issue with details."
+    ),
+    source=source,
+    status="error",
+)
+```
+
+The `chat_id` and `source` values must be included in the Task prompt by the dispatcher.
+
 ## Communication Style
 
 - Keep issue comments concise but informative

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,44 @@ You are a **stateless dispatcher**. Your ONLY job on the main thread is to read 
 - The health check may restart you mid-task
 - You are disposable — you can be killed and restarted at any moment with zero impact, because you are stateless. All real work lives in subagents.
 
+### Handling Subagent Results (`subagent_result` / `subagent_error`)
+
+Background subagents **must not call `send_reply` directly**. Instead they call `write_result(task_id, chat_id, text, ...)`, which drops a message of type `subagent_result` (or `subagent_error`) into the inbox. The main thread picks it up and delivers it.
+
+**When `wait_for_messages` returns a message with `type: "subagent_result"`:**
+
+```
+1. mark_processing(message_id)
+2. send_reply(
+       chat_id=msg["chat_id"],
+       text=msg["text"],
+       source=msg.get("source", "telegram"),
+       thread_ts=msg.get("thread_ts")   # pass through if present
+   )
+3. mark_processed(message_id)
+```
+
+**When type is `subagent_error`:**
+
+```
+1. mark_processing(message_id)
+2. send_reply(
+       chat_id=msg["chat_id"],
+       text=f"Sorry, something went wrong with that task:\n\n{msg['text']}",
+       source=msg.get("source", "telegram")
+   )
+3. mark_processed(message_id)
+```
+
+**Key fields on these messages:**
+- `task_id` — identifier for the originating task (for logging/debugging)
+- `chat_id` — where to deliver the reply
+- `text` — the reply text to forward
+- `source` — messaging platform (telegram, slack, etc.)
+- `status` — "success" or "error"
+- `artifacts` — optional list of file paths the subagent produced
+- `thread_ts` — optional Slack thread timestamp
+
 ## System Architecture
 
 ```
@@ -342,7 +380,7 @@ Calendar commands work in two modes. Check auth status first (no network call ne
 ```python
 import sys; sys.path.insert(0, "/home/admin/lobster/src")
 from integrations.google_calendar.token_store import load_token
-is_authenticated = load_token("1234567890") is not None
+is_authenticated = load_token("<REDACTED_PHONE>") is not None
 ```
 
 ### Unauthenticated mode (default)
@@ -368,14 +406,14 @@ Delegate to a background subagent — API calls exceed the 7-second rule.
 **Reading events** ("what's on my calendar", "what do I have this week/today"):
 ```python
 from integrations.google_calendar.client import get_upcoming_events
-events = get_upcoming_events(user_id="1234567890", days=7)
+events = get_upcoming_events(user_id="<REDACTED_PHONE>", days=7)
 # Returns List[CalendarEvent] or [] on failure — always falls back gracefully
 ```
 
 **Creating events** ("add X to my calendar", "schedule X for [time]"):
 ```python
 from integrations.google_calendar.client import create_event
-event = create_event(user_id="1234567890", title="...", start=start, end=end)
+event = create_event(user_id="<REDACTED_PHONE>", title="...", start=start, end=end)
 # Returns CalendarEvent with .url, or None on failure
 # On failure, fall back to gcal_add_link_md()
 ```

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -944,6 +944,58 @@ async def list_tools() -> list[Tool]:
                 "required": ["job_name", "output"],
             },
         ),
+        # Subagent Result Relay
+        Tool(
+            name="write_result",
+            description=(
+                "Write a result from a background subagent back to the main message queue. "
+                "The main thread will pick this up during its normal wait_for_messages loop, "
+                "send the text to the user, and mark it processed. "
+                "Use this instead of send_reply — subagents must not call send_reply directly. "
+                "On failure, call this with status='error' so the main thread can notify the user gracefully."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "task_id": {
+                        "type": "string",
+                        "description": "Identifier for the task that produced this result (e.g. 'brain-dump-42', 'pr-review-7'). Used for deduplication and logging.",
+                    },
+                    "chat_id": {
+                        "oneOf": [
+                            {"type": "integer"},
+                            {"type": "string"},
+                        ],
+                        "description": "The chat/channel ID to deliver the result to. Pass the same chat_id received in the original message.",
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "The result text to deliver to the user.",
+                    },
+                    "source": {
+                        "type": "string",
+                        "description": "The messaging source to reply via (telegram, slack, etc.). Default: telegram.",
+                        "default": "telegram",
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "Result status: 'success' (default) or 'error'. Use 'error' when the subagent failed so the main thread can signal failure to the user.",
+                        "default": "success",
+                        "enum": ["success", "error"],
+                    },
+                    "artifacts": {
+                        "type": "array",
+                        "description": "Optional list of file paths produced by the subagent that the main thread may reference or include in its reply.",
+                        "items": {"type": "string"},
+                    },
+                    "thread_ts": {
+                        "type": "string",
+                        "description": "Slack thread timestamp. If provided, the reply will be sent as a thread reply.",
+                    },
+                },
+                "required": ["task_id", "chat_id", "text"],
+            },
+        ),
         # Brain Dump Triage Tools
         Tool(
             name="triage_brain_dump",
@@ -1569,6 +1621,8 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[TextConte
         return await handle_check_task_outputs(arguments)
     elif name == "write_task_output":
         return await handle_write_task_output(arguments)
+    elif name == "write_result":
+        return await handle_write_result(arguments)
     # Brain Dump Triage Tools
     elif name == "triage_brain_dump":
         return await handle_triage_brain_dump(arguments)
@@ -3342,6 +3396,69 @@ async def handle_write_task_output(args: dict) -> list[TextContent]:
         json.dump(output_data, f, indent=2)
 
     return [TextContent(type="text", text=f"Output recorded for job '{job_name}'")]
+
+
+# =============================================================================
+# Subagent Result Relay Handler
+# =============================================================================
+
+async def handle_write_result(args: dict) -> list[TextContent]:
+    """Write a subagent result into the inbox so the main thread can relay it to the user.
+
+    The message written has type 'subagent_result' (or 'subagent_error' on failure).
+    The main thread's wait_for_messages / check_inbox loop will pick it up, call
+    send_reply to deliver the text to the user, and mark it processed — keeping the
+    main thread as the single point of user communication.
+    """
+    task_id = args.get("task_id", "").strip()
+    chat_id = args.get("chat_id")
+    text = args.get("text", "").strip()
+    source = args.get("source", "telegram").strip() or "telegram"
+    status = args.get("status", "success")
+    artifacts = args.get("artifacts") or []
+    thread_ts = args.get("thread_ts")
+
+    if not task_id:
+        return [TextContent(type="text", text="Error: task_id is required")]
+    if chat_id is None:
+        return [TextContent(type="text", text="Error: chat_id is required")]
+    if not text:
+        return [TextContent(type="text", text="Error: text is required")]
+
+    if status not in ("success", "error"):
+        status = "success"
+
+    msg_type = "subagent_result" if status == "success" else "subagent_error"
+
+    now = datetime.now(timezone.utc)
+    # Use millisecond timestamp + task_id fragment for a unique, sortable filename
+    ts_ms = int(now.timestamp() * 1000)
+    safe_task_id = "".join(c if c.isalnum() or c in "-_" else "_" for c in task_id)[:40]
+    message_id = f"{ts_ms}_{safe_task_id}"
+
+    message = {
+        "id": message_id,
+        "type": msg_type,
+        "source": source,
+        "chat_id": chat_id,
+        "text": text,
+        "task_id": task_id,
+        "status": status,
+        "timestamp": now.isoformat(),
+    }
+    if artifacts:
+        message["artifacts"] = artifacts
+    if thread_ts:
+        message["thread_ts"] = thread_ts
+
+    inbox_file = INBOX_DIR / f"{message_id}.json"
+    atomic_write_json(inbox_file, message)
+
+    log.info(f"Subagent result queued in inbox: task_id={task_id} status={status} chat_id={chat_id}")
+    return [TextContent(
+        type="text",
+        text=f"Result queued in inbox as {msg_type} (id={message_id}). The main thread will deliver it to chat {chat_id}.",
+    )]
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Adds `write_result(task_id, chat_id, text, source?, status?, artifacts?, thread_ts?)` MCP tool so subagents can relay results through the main inbox queue instead of calling `send_reply` directly
- Subagents write a `subagent_result` or `subagent_error` message to `~/messages/inbox/`; the main thread's `wait_for_messages` loop picks it up, calls `send_reply`, and marks it processed
- Keeps the main thread as the single point of user communication and ensures subagent failures surface as visible error messages rather than silent drops

## Changes

| File | What changed |
|------|-------------|
| `src/mcp/inbox_server.py` | New `write_result` Tool definition + `handle_write_result` handler |
| `CLAUDE.md` | Documents `subagent_result` / `subagent_error` handling in the main loop |
| `.claude/agents/brain-dumps.md` | Replaces `send_reply` guidance with `write_result` pattern |
| `.claude/agents/functional-engineer.md` | Replaces `send_reply` guidance with `write_result` pattern |

## Tool signature

```python
write_result(
    task_id: str,           # e.g. "brain-dump-42" — for deduplication/logging
    chat_id: int | str,     # same chat_id as the original message
    text: str,              # reply text to deliver
    source: str = "telegram",
    status: "success" | "error" = "success",
    artifacts: list[str] = [],   # optional file paths
    thread_ts: str = None,       # Slack thread reply support
)
```

## Test plan

- [ ] Confirm `write_result` appears in `list_tools()` output from the MCP server
- [ ] Call `write_result` from a subagent context; verify a `subagent_result` JSON file appears in `~/messages/inbox/`
- [ ] Confirm main thread `wait_for_messages` picks it up and calls `send_reply` with the correct `chat_id` and `text`
- [ ] Call with `status="error"`; confirm main thread wraps the text in an error message before sending
- [ ] Confirm existing `send_reply`-based flows are unaffected

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)