### PR TITLE
fix: post-merge cleanup — brain dump flow, subagent inbox labels, image text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,8 +339,8 @@ When you receive a **voice message** that appears to be a "brain dump" (unstruct
 - Ideas/reflections rather than questions or requests
 
 **Workflow:**
-1. Receive voice message
-2. Transcribe using `transcribe_audio(message_id)`
+1. Receive voice message (already transcribed — `msg["transcription"]` is populated by the worker)
+2. Read transcription from `msg["transcription"]` or `msg["text"]`
 3. Check if brain dumps are enabled (default: true)
 4. If transcription looks like a brain dump, spawn brain-dumps agent:
    ```
@@ -499,7 +499,7 @@ Apply mental recency decay when reading history: the most recent messages carry 
 2. **Be concise** - Users are on mobile
 3. **Be helpful** - Answer directly and completely
 4. **Maintain context** - You remember all previous conversations
-5. **Handle voice messages** - Use `transcribe_audio` for voice messages
+5. **Handle voice messages** - Voice messages arrive pre-transcribed; read from `msg["transcription"]`
 6. **Steel-man before reassuring** - When the user expresses doubt, fear, or
    negativity, state the strongest honest version of what's wrong FIRST — with
    specific, verified facts — before offering any counterevidence.

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -1883,6 +1883,11 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
         elif msg_type == "document":
             file_name = msg.get("file_name", "file")
             output += f"**[{source}]** 📎 from **{user}** ({file_name})\n"
+        elif msg_type in ("subagent_result", "subagent_error"):
+            status_icon = "✅" if msg_type == "subagent_result" else "❌"
+            label = "RESULT" if msg_type == "subagent_result" else "ERROR"
+            task_id = msg.get("task_id", "?")
+            output += f"{status_icon} **[SUBAGENT {label}]** for task `{task_id}`\n"
         else:
             output += f"**[{source}]** from **{user}**\n"
         output += f"Chat ID: `{chat_id}` | Message ID: `{msg_id}`\n"
@@ -1892,12 +1897,12 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
             image_files = msg.get("image_files")
             image_file = msg.get("image_file")
             if image_files:
-                output += f"**Image files** (read each to view):\n"
+                output += f"**Image files**:\n"
                 for img_path in image_files:
                     output += f"  - `{img_path}`\n"
                 output += "\n"
             elif image_file:
-                output += f"**Image file** (read to view): `{image_file}`\n\n"
+                output += f"**Image file**: `{image_file}`\n\n"
         # Surface file path for document messages so Claude can read them
         if msg_type == "document":
             doc_file_path = msg.get("file_path")


### PR DESCRIPTION
## Summary

Three small post-merge fixes addressing stale documentation and fragile behavior in `check_inbox`.

- **Issue 1 (CLAUDE.md — Medium):** The "Processing Voice Note Brain Dumps" workflow still told Claude to call `transcribe_audio(message_id)` in step 2. After PR #159, voice messages arrive already transcribed — the worker populates `msg["transcription"]` and `msg["text"]` before the message lands in inbox. Updated the workflow to read from `msg["transcription"]` / `msg["text"]` directly. Also updated Behavior Guidelines item 5 which had the same stale reference.

- **Issue 2 (inbox_server.py — Medium):** `subagent_result` and `subagent_error` messages fell into the generic `else` branch in `handle_check_inbox`, displaying as `[TELEGRAM] from Unknown`. Added an explicit `elif msg_type in ("subagent_result", "subagent_error")` case that renders a clear status icon (✅/❌) and the `task_id`, making these messages unambiguous in the inbox view.

- **Issue 3 (inbox_server.py — Low):** Image labels in `check_inbox` output included `(read to view)` and `(read each to view)` parentheticals that could nudge Claude toward reading images on the main thread. Removed the parentheticals — the labels now read `**Image file**:` and `**Image files**:`.

## Test plan

- [ ] Verify `check_inbox` with a `subagent_result` message shows `✅ [SUBAGENT RESULT] for task ...` header
- [ ] Verify `check_inbox` with a `subagent_error` message shows `❌ [SUBAGENT ERROR] for task ...` header
- [ ] Verify photo messages still show `**Image file**: /path/to/img` (no parenthetical)
- [ ] Confirm brain dump voice message processing works end-to-end without calling `transcribe_audio`

🤖 Generated with [Claude Code](https://claude.com/claude-code)