### PR TITLE
fix: enforce write_result for all subagents via CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,32 @@ Background subagents **must not call `send_reply` directly**. Instead they call 
 - `artifacts` — optional list of file paths the subagent produced
 - `thread_ts` — optional Slack thread timestamp
 
+## Subagent Rules
+
+> **If you are a spawned subagent** (not the Lobster main loop), this section applies to you.
+
+You MUST call `write_result` at the end of every task to relay your results through the inbox queue. Never silently complete and return — always send your output via `write_result` so the main loop can deliver it to the user.
+
+**Required at end of every subagent task:**
+```python
+mcp__lobster-inbox__write_result(
+    task_id="<descriptive-task-id>",
+    chat_id=<user's chat_id — get this from your task prompt>,
+    text="<your result or report>",
+    source="telegram"  # or "slack" if appropriate
+)
+```
+
+If you were not given a `chat_id` in your prompt, do not call write_result — your results will be returned directly to the caller.
+
+**You are the Lobster main loop (orchestrator) if:**
+- You are calling `wait_for_messages` in a loop
+- Your first action was to read CLAUDE.md and begin the main loop
+
+**You are a subagent if:**
+- You were spawned to do a specific task (research, code review, GitHub operations, etc.)
+- You have a defined task_id and chat_id in your prompt
+
 ## System Architecture
 
 ```


### PR DESCRIPTION
## Summary

- Adds a new `## Subagent Rules` section to `CLAUDE.md`, inserted between the main loop section and `## System Architecture`
- Clearly identifies whether a Claude instance is the main loop (orchestrator) or a spawned subagent
- Makes `write_result` a mandatory requirement for all subagents that have a `chat_id`, ensuring results always flow back through the inbox queue to the user

## Why

Subagents were completing work silently without calling `write_result`, meaning the main loop never received their output and users never got a reply. By embedding this rule directly in `CLAUDE.md`, every subagent that reads the file inherits the requirement automatically — no per-agent configuration needed.

## Test plan

- [ ] Review the new section appears correctly between "Handling Subagent Results" and "System Architecture"
- [ ] Verify existing content is unchanged
- [ ] Confirm `write_result` call signature example matches the actual MCP tool signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)