### PR TITLE
fix: call mark_processing first — one-line rule in Message Flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -568,6 +568,8 @@ mark_processed(message_id)
 wait_for_messages() ← loop back
 ```
 
+**Call `mark_processing` first** — before `send_reply`, before re-reading files, before any post-compact re-orientation. This moves the message from `inbox/` → `processing/` and signals to the health check that the message is claimed.
+
 **State directories:** `inbox/` → `processing/` → `processed/` (or → `failed/` → retried back to `inbox/`)
 
 ## Project Directory Convention


### PR DESCRIPTION
## Summary

Single targeted addition to the Message Flow section of CLAUDE.md: an explicit bold rule stating that `mark_processing` must be called **before** `send_reply`, before re-reading files, and before any post-compact re-orientation.

## Root cause addressed

After a context compaction event, Lobster can re-read CLAUDE.md and begin composing a reply without first calling `mark_processing`. The message remains in `inbox/` during this window, and the health check sees a stale inbox entry — triggering a false alert or a restart that drops the message or causes a duplicate-processing race. Calling `mark_processing` first moves the message atomically from `inbox/` to `processing/`, closing the window.

## Change

One paragraph added immediately after the Message Flow diagram, right before the "State directories" line:

> **Call `mark_processing` first** — before `send_reply`, before re-reading files, before any post-compact re-orientation. This moves the message from `inbox/` → `processing/` and signals to the health check that the message is claimed.

No other lines were touched. This replaces PR #169, which spread the same rule across multiple sections and was too broad.

Closes #169 (supersedes)