### PR TITLE
fix: read images on main thread instead of delegating to subagent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ while True:
 
 You are a **stateless dispatcher**. Your ONLY job on the main thread is to read messages and compose text replies.
 
-**The rule: if it takes more than 7 seconds, it goes to a background subagent. No exceptions.**
+**The rule: if it takes more than 7 seconds, it goes to a background subagent. Very few exceptions — see image handling below for the one documented carve-out.**
 
 **What you do on the main thread:**
 - Call `wait_for_messages()` / `check_inbox()`


### PR DESCRIPTION
## Summary

- **Image handling moved to main thread.** Previously, when an image message arrived, Lobster would acknowledge it and spawn a background subagent to read the image and compose a reply. Images are now read directly on the main thread after `mark_processing` is called.
- **`mark_processing` called first.** The new flow calls `mark_processing` before reading the image, which prevents the health check from treating the message as stale and restarting mid-read.
- **Subagent list updated.** The "What ALWAYS goes to a background subagent" list now carves out images with a note pointing to the image handling section.
- **Development Conventions section added.** Documents the `uv`-first policy: always use `uv run`, `uv add`, etc. instead of bare `python`/`pip` when running scripts or managing packages.

## Behavior change

**Before:**
```
1. Image message arrives
2. send_reply("Got it, looking at that...")  ← ack
3. Spawn subagent with image_file path
4. Subagent reads image, calls write_result()
5. Main loop delivers reply via subagent_result message
```

**After:**
```
1. Image message arrives
2. mark_processing(message_id)  ← claim it first
3. Read(image_file_path)        ← main thread reads image directly
4. Compose response
5. send_reply(chat_id, response)
6. mark_processed(message_id)
```

## Rationale

Image reads via the `Read` tool are nearly instantaneous — the file is already on disk. The subagent round-trip added latency and complexity with no real benefit. Calling `mark_processing` first is sufficient to satisfy the health check's safety requirement.

## Test plan

- [ ] Send an image (with and without caption) via Telegram — Lobster should respond in-line without a "Got it, looking at that..." pre-ack
- [ ] Confirm `mark_processing` is called before the `Read` tool in the main loop
- [ ] Confirm no subagent is spawned for image messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)