### PR TITLE
fix: convert any non-WAV audio to WAV before whisper transcription

### DIFF
--- a/src/transcription/worker.py
+++ b/src/transcription/worker.py
@@ -289,11 +289,11 @@ async def transcribe_pending_file(pending_file: Path) -> None:
     timeout_s = compute_timeout(audio_duration)
     log.info(f"  Audio duration: {audio_duration:.0f}s → timeout: {timeout_s}s")
 
-    # OGG → WAV conversion (once; reuse on retries).
+    # Audio → WAV conversion for any non-WAV format (once; reuse on retries).
     # convert_ogg_to_wav writes atomically (temp-then-rename), so any existing
     # file at wav_path is guaranteed to be a complete, valid conversion.
     wav_path: Path | None = None
-    if audio_path.suffix.lower() in (".ogg", ".oga", ".opus"):
+    if audio_path.suffix.lower() not in (".wav",):
         wav_path = audio_path.with_suffix(".wav")
         if not wav_path.exists():
             ok = await convert_ogg_to_wav(audio_path, wav_path, timeout_s=timeout_s)
@@ -301,7 +301,7 @@ async def transcribe_pending_file(pending_file: Path) -> None:
                 # ffmpeg failure is generally permanent (bad file or binary missing)
                 move_to_dead_letter(
                     pending_file, msg_data,
-                    "ffmpeg OGG→WAV conversion failed"
+                    f"ffmpeg audio→WAV conversion failed ({audio_path.suffix})"
                 )
                 return
     transcribe_path = wav_path if wav_path else audio_path


### PR DESCRIPTION
## Summary

- Changes the format-conversion guard from an allowlist of OGG variants (`.ogg`, `.oga`, `.opus`) to a denylist of WAV — so **any** non-WAV audio file (e.g. `.m4a` from Telegram audio attachments) is converted via ffmpeg before being handed to whisper.cpp.
- Updates the dead-letter error message to include the actual file suffix, making failures easier to diagnose.
- Updates the inline comment to be format-agnostic.

**Root cause:** Telegram sends audio file attachments (non-voice messages) as `.m4a`. The old guard only converted OGG-family files, so `.m4a` files were passed raw to whisper, which can't decode them and would fail.

**Note:** The helper function `convert_ogg_to_wav` is now a slight misnomer — it accepts any ffmpeg-supported input, not just OGG. Renaming it is left as a follow-up to keep this fix minimal.

## Test plan

- [ ] Send a `.m4a` audio attachment via Telegram and confirm it is transcribed successfully.
- [ ] Confirm existing OGG/OPUS voice notes still transcribe correctly (regression check).
- [ ] Confirm a corrupt/unsupported file still lands in dead-letter with the updated error message showing the suffix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)