### PR TITLE
fix: add nightly-consolidation.sh to crontab setup in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1049,6 +1049,21 @@ DAILY_MARKER="# LOBSTER-DAILY-HEALTH"
 success "Daily dependency health check configured (runs at 06:00 daily)"
 
 #===============================================================================
+# Nightly Consolidation
+#===============================================================================
+
+step "Setting up nightly consolidation..."
+
+chmod +x "$INSTALL_DIR/scripts/nightly-consolidation.sh" || true
+
+# Add nightly consolidation to crontab (runs at 03:00 every night)
+CONSOLIDATION_MARKER="# LOBSTER-NIGHTLY-CONSOLIDATION"
+({ crontab -l 2>/dev/null | grep -v "$CONSOLIDATION_MARKER" | grep -v "nightly-consolidation" || true; }; \
+ echo "0 3 * * * $INSTALL_DIR/scripts/nightly-consolidation.sh $CONSOLIDATION_MARKER") | crontab -
+
+success "Nightly consolidation configured (runs at 03:00 nightly)"
+
+#===============================================================================
 # Self-Check Reminder System
 #===============================================================================
 


### PR DESCRIPTION
## Summary

- `scripts/nightly-consolidation.sh` existed but was never registered in `install.sh`, so fresh installs never got the nightly consolidation cron job
- Adds a new "Nightly Consolidation" section to `install.sh` following the same idiomatic pattern used for existing cron entries (health check, daily health check, self-check)
- Schedule: `0 3 * * *` (3am nightly — matching the schedule documented in the script's own header comment)
- Uses marker `# LOBSTER-NIGHTLY-CONSOLIDATION` for idempotent installs (re-running install.sh won't duplicate the entry)
- Makes the script executable with `chmod +x` before registering it

## What the script does

`scripts/nightly-consolidation.sh` injects a consolidation task message into Lobster's inbox each night, prompting Claude to synthesize the day's events into canonical memory files (handoff, priorities, projects, people). It includes a dedup guard so it won't queue duplicate messages if already pending.

## Test plan

- [ ] Run `install.sh` on a fresh VM and verify `crontab -l` includes the `0 3 * * *` nightly-consolidation entry
- [ ] Run `install.sh` a second time and confirm the entry is not duplicated (idempotent via marker)
- [ ] Confirm the script is executable after install: `ls -la ~/lobster/scripts/nightly-consolidation.sh`