### PR TITLE
fix: strengthen post-compaction re-orientation message

### DIFF
--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -19,8 +19,10 @@ from pathlib import Path
 INBOX_DIR = Path(os.path.expanduser("~/messages/inbox"))
 
 REMINDER_TEXT = (
-    "Your context was just compacted. Re-read CLAUDE.md \u2014 it will guide you "
-    "to the handoff, memory, and all other bootup context you need to re-orient."
+    "Your context was just compacted. STOP. Before processing any messages:\n\n"
+    "1. Re-read ~/lobster/CLAUDE.md \u2014 your instructions\n"
+    "2. Read ~/lobster-workspace/memory/canonical/handoff.md \u2014 what was happening\n\n"
+    "Do not skip either step."
 )
 
 


### PR DESCRIPTION
## Summary

- Replaces the vague post-compaction reminder with a more directive, step-by-step message
- Explicitly names both required files (`~/lobster/CLAUDE.md` and `~/lobster-workspace/memory/canonical/handoff.md`) with absolute paths
- Uses imperative language ("STOP", "Do not skip either step") to reduce the chance of Lobster skipping re-orientation after a context compaction

## Test plan

- [ ] Trigger a context compaction and verify the new reminder text appears in the inbox
- [ ] Confirm the message causes Lobster to read both CLAUDE.md and handoff.md before processing further messages