### PR TITLE
feat: add user-context cascade for private bootup files

### DIFF
--- a/.claude/dispatcher.md
+++ b/.claude/dispatcher.md
@@ -2,6 +2,12 @@
 
 This file contains everything specific to running as the Lobster main loop dispatcher. Read this if you are the dispatcher (i.e. you are calling `wait_for_messages` in a loop).
 
+**After reading this file**, also check for and read user context files if they exist:
+- `~/lobster-workspace/.claude/user.md` — applies to all roles
+- `~/lobster-workspace/.claude/dispatcher.md` — dispatcher-specific user overrides
+
+These files are private and not in the git repo. They extend and override the defaults here.
+
 ## Your Main Loop
 
 You operate in an infinite loop. This is your core behavior:

--- a/.claude/subagent.md
+++ b/.claude/subagent.md
@@ -2,6 +2,12 @@
 
 This file contains everything specific to running as a Lobster subagent. Read this if you were spawned to do a specific task (research, code review, GitHub operations, implementation, etc.) and have a defined `task_id` and `chat_id` in your prompt.
 
+**After reading this file**, also check for and read user context files if they exist:
+- `~/lobster-workspace/.claude/user.md` — applies to all roles
+- `~/lobster-workspace/.claude/subagent.md` — subagent-specific user overrides
+
+These files are private and not in the git repo. They extend and override the defaults here.
+
 ## Identity: Are You a Subagent?
 
 **You are a subagent if:**
@@ -50,3 +56,16 @@ Lobster uses a tiered model strategy to balance cost and quality. Each subagent 
 **When to override:** If a task normally handled by a Sonnet agent requires unusually deep reasoning (e.g., a complex multi-system execution plan), consider using `functional-engineer` (Opus) instead.
 
 **For general background tasks** with no specific agent type, use `subagent_type='lobster-generalist'` rather than omitting `subagent_type` or using an untyped Agent call. The `lobster-generalist` agent is the correct default for open-ended background work that doesn't map to a more specialized agent.
+
+## Tooling conventions
+
+- **GitHub operations:** Use `gh` CLI (via Bash tool) for all GitHub operations — posting PR reviews, merging PRs, creating issues, etc. Do NOT use `mcp__github__*` MCP tools in agent code.
+  - Post a PR review: `gh pr review <number> --comment --body "..." --repo SiderealPress/lobster`
+  - Merge a PR: `gh pr merge <number> --squash --repo SiderealPress/lobster`
+  - Create an issue: `gh issue create --title "..." --body "..." --repo SiderealPress/lobster`
+
+- **Default repo:** `SiderealPress/lobster` (owner=SiderealPress, repo=lobster). If no repo is specified in your task, use this.
+
+- **Linear API:** Access Linear via REST API. The `LINEAR_API_KEY` environment variable is set. GraphQL endpoint: `https://api.linear.app/graphql`. Use `curl -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json"`.
+
+- **Python:** Always use `uv run` not `python` or `python3`.

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,8 @@ config/camofox-browser/
 # Planning artifacts
 PLAN-*.md
 .planning/
+
+# Private user context overlay (lives in ~/lobster-workspace/.claude/, not here)
+# Listed here as a safety net in case someone clones into the wrong place
+.claude/user.md
+.claude/user/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,16 @@ You are **Lobster**, an always-on AI assistant that never exits. You run in a pe
 
 This file provides shared context. Depending on your role, read the appropriate supplement:
 
+**System context** (always read):
 - **If you are the dispatcher (main loop):** read `.claude/dispatcher.md` — it covers the main loop pseudocode, the 7-second rule, the dispatcher pattern, handling subagent results, message source handling (Telegram/Slack), self-check reminders, message flow diagram, startup behavior, and hibernation.
 - **If you are a subagent:** read `.claude/subagent.md` — it covers the `write_result` requirement, identity rules, and the model selection table.
+
+**User context** (read after system files, if the files exist):
+- Both roles: `~/lobster-workspace/.claude/user.md`
+- Dispatcher: `~/lobster-workspace/.claude/dispatcher.md`
+- Subagent: `~/lobster-workspace/.claude/subagent.md`
+
+User context files are private and not committed to git. They contain user-specific preferences, decisions, and constraints that extend the system defaults. When the user says "remember X" and it belongs to a specific scope, write it to the appropriate user file.
 
 ## System Architecture
 


### PR DESCRIPTION
## Summary

- Adds a private user-context overlay directory at `~/lobster-workspace/.claude/` that is never committed to git
- Both dispatcher and subagents are instructed to read `user.md` (shared) and their role-specific file (`dispatcher.md` / `subagent.md`) after the system context files
- Updates `CLAUDE.md` Role-Specific Context section to document the two-layer load order
- Adds `.gitignore` entries to prevent accidental commits of user context files
- Creates initial empty user context files locally (`user.md` pre-populated with established conventions)

## Load order

1. System files (in repo `.claude/`): `dispatcher.md` or `subagent.md`
2. User files (private, `~/lobster-workspace/.claude/`): `user.md` then role-specific file

## Test plan

- [ ] Verify dispatcher picks up instructions from `~/lobster-workspace/.claude/user.md` on next boot
- [ ] Verify subagent picks up instructions from the same file
- [ ] Confirm `~/lobster-workspace/.claude/` is not tracked by git
- [ ] Confirm user context files survive a `git pull` / repo update

🤖 Generated with [Claude Code](https://claude.com/claude-code)