### PR TITLE
feat: send Telegram dev notification on context compaction

### DIFF
--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -18,8 +18,6 @@ import json
 import os
 import time
 import urllib.request
-import urllib.error
-import urllib.parse
 from pathlib import Path
 
 


### PR DESCRIPTION
## Summary

- Adds `maybe_send_dev_telegram_notify()` to `hooks/on-compact.py`, called after the existing inbox write
- Reads `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALLOWED_USERS` from `~/lobster-config/config.env`; takes the first entry in `TELEGRAM_ALLOWED_USERS` as the owner chat ID
- Checks `LOBSTER_DEBUG=true` in both the process environment and `config.env` — only fires when that flag is set
- Sends `⚠️ [DEV] Context compacted. Re-orienting from CLAUDE.md + handoff.` via the Telegram Bot API using `urllib.request` (stdlib only, no extra dependencies)
- Fully silent on failure — any network error, missing config, or API error is swallowed so the hook never crashes

## Test plan

- [ ] Set `LOBSTER_DEBUG=true` in `config.env` and trigger a compaction — confirm Telegram message arrives
- [ ] Unset / set `LOBSTER_DEBUG=false` — confirm no Telegram message is sent
- [ ] Remove `TELEGRAM_BOT_TOKEN` from config — confirm hook completes silently with no crash
- [ ] Confirm existing inbox-write behavior is unchanged in all cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)