### PR TITLE
Add forward field to write_result to suppress dispatcher re-delivery

### DIFF
--- a/.claude/dispatcher.md
+++ b/.claude/dispatcher.md
@@ -61,19 +61,25 @@ You are a **stateless dispatcher**. Your ONLY job on the main thread is to read 
 
 ## Handling Subagent Results (`subagent_result` / `subagent_error`)
 
-Background subagents **must not call `send_reply` directly**. Instead they call `write_result(task_id, chat_id, text, ...)`, which drops a message of type `subagent_result` (or `subagent_error`) into the inbox. The main thread picks it up and delivers it.
+Background subagents call `write_result(task_id, chat_id, text, ...)`, which drops a message of type `subagent_result` (or `subagent_error`) into the inbox. The main thread picks it up.
 
 **When `wait_for_messages` returns a message with `type: "subagent_result"`:**
 
+Check the `forward` field first:
+
 ```
 1. mark_processing(message_id)
-2. send_reply(
-       chat_id=msg["chat_id"],
-       text=msg["text"],
-       source=msg.get("source", "telegram"),
-       thread_ts=msg.get("thread_ts")   # pass through if present
-   )
-3. mark_processed(message_id)
+2. if msg.get("forward") == False:
+       # Subagent already called send_reply — nothing to deliver
+       mark_processed(message_id)
+   else:
+       send_reply(
+           chat_id=msg["chat_id"],
+           text=msg["text"],
+           source=msg.get("source", "telegram"),
+           thread_ts=msg.get("thread_ts")   # pass through if present
+       )
+       mark_processed(message_id)
 ```
 
 **When type is `subagent_error`:**
@@ -88,12 +94,15 @@ Background subagents **must not call `send_reply` directly**. Instead they call 
 3. mark_processed(message_id)
 ```
 
+(Errors always forward — a subagent that fails may not have delivered anything to the user.)
+
 **Key fields on these messages:**
 - `task_id` — identifier for the originating task (for logging/debugging)
 - `chat_id` — where to deliver the reply
 - `text` — the reply text to forward
 - `source` — messaging platform (telegram, slack, etc.)
 - `status` — "success" or "error"
+- `forward` — boolean (default true). When false, the subagent already called `send_reply`; dispatcher just marks processed
 - `artifacts` — optional list of file paths the subagent produced
 - `thread_ts` — optional Slack thread timestamp
 

--- a/.claude/subagent.md
+++ b/.claude/subagent.md
@@ -2,6 +2,19 @@
 
 This file contains everything specific to running as a Lobster subagent. Read this if you were spawned to do a specific task (research, code review, GitHub operations, implementation, etc.) and have a defined `task_id` and `chat_id` in your prompt.
 
+## Lobster System Primer
+
+Lobster is an always-on AI assistant that processes messages from Telegram and Slack. The system has two layers:
+
+- **Dispatcher (main loop):** Receives incoming messages via `wait_for_messages`, sends quick acknowledgments, and spawns background subagents for any work taking more than ~7 seconds.
+- **Subagents (you):** Handle specific tasks — research, code review, GitHub ops, implementation — then report back.
+
+Users communicate through a chat interface (Telegram or Slack), typically on mobile. Keep replies concise and mobile-friendly. The GitHub repo is `SiderealPress/lobster`.
+
+When your task is complete, call `mcp__lobster-inbox__write_result(task_id=..., chat_id=..., text=...)` to send results back through the queue. The dispatcher picks this up and forwards the text to the user. If you have already called `send_reply` yourself, pass `forward=False` to prevent double-delivery. Do NOT call `wait_for_messages` — that is only for the main loop.
+
+---
+
 **After reading this file**, also check for and read user context files if they exist:
 - `~/lobster-workspace/.claude/user.md` — applies to all roles
 - `~/lobster-workspace/.claude/subagent.md` — subagent-specific user overrides
@@ -31,6 +44,23 @@ mcp__lobster-inbox__write_result(
     source="telegram"  # or "slack" if appropriate
 )
 ```
+
+**Using `forward=False` to suppress re-delivery:**
+
+If your subagent has already called `send_reply` directly to deliver a result to the user, pass `forward=False` to `write_result`. This tells the dispatcher to mark the message processed silently without sending anything — avoiding a duplicate delivery.
+
+```python
+# Subagent called send_reply, then signals dispatcher to skip forwarding:
+mcp__lobster-inbox__write_result(
+    task_id="<descriptive-task-id>",
+    chat_id=<user's chat_id>,
+    text="<summary of what was delivered — for logging>",
+    source="telegram",
+    forward=False,  # dispatcher will not re-send this to the user
+)
+```
+
+Default is `forward=True` (dispatcher forwards the result text to the user as normal).
 
 If you were not given a `chat_id` in your prompt, do not call write_result — your results will be returned directly to the caller.
 

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -996,6 +996,16 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "Slack thread timestamp. If provided, the reply will be sent as a thread reply.",
                     },
+                    "forward": {
+                        "type": "boolean",
+                        "description": (
+                            "Whether the dispatcher should forward this result to the user. "
+                            "Default true. Set to false when the subagent has already called "
+                            "send_reply directly — the dispatcher will mark the message processed "
+                            "silently without re-sending to the user."
+                        ),
+                        "default": True,
+                    },
                 },
                 "required": ["task_id", "chat_id", "text"],
             },
@@ -3437,6 +3447,7 @@ async def handle_write_result(args: dict) -> list[TextContent]:
     status = args.get("status", "success")
     artifacts = args.get("artifacts") or []
     thread_ts = args.get("thread_ts")
+    forward = args.get("forward", True)
 
     if not task_id:
         return [TextContent(type="text", text="Error: task_id is required")]
@@ -3464,6 +3475,7 @@ async def handle_write_result(args: dict) -> list[TextContent]:
         "text": text,
         "task_id": task_id,
         "status": status,
+        "forward": bool(forward),
         "timestamp": now.isoformat(),
     }
     if artifacts:


### PR DESCRIPTION
## Summary

- **`src/mcp/inbox_server.py`**: Add optional `forward` boolean param (default `True`) to the `write_result` tool. The param is written into the queued `subagent_result` message JSON as `"forward": bool(forward)`.
- **`.claude/dispatcher.md`**: Update subagent result handling — if `msg.get("forward") == False`, dispatcher marks processed silently without calling `send_reply`. Errors always forward regardless.
- **`.claude/subagent.md`**: Document the `forward=False` pattern with a code example in both the primer paragraph and the Subagent Rules section.

## Motivation

Reduces context token burn. Subagents that call `send_reply` directly (e.g. this agent, which called `send_reply` in its task prompt) previously had the dispatcher re-forward the result text anyway. With `forward=False`, the subagent controls whether the dispatcher re-delivers, avoiding duplicate messages.

## Behavior

| Scenario | Dispatcher action |
|----------|------------------|
| `write_result(..., forward=True)` (default) | Calls `send_reply` with `msg["text"]` |
| `write_result(..., forward=False)` | Marks processed silently — no `send_reply` |
| `subagent_error` (any `forward` value) | Always calls `send_reply` with error message |

## Test plan

- [ ] Verify that a subagent calling `write_result(forward=True)` still gets delivered by dispatcher (backward-compatible default)
- [ ] Verify that a subagent calling `write_result(forward=False)` results in the dispatcher marking processed without sending a reply
- [ ] Verify `subagent_error` messages always forward to the user regardless of `forward` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)