### PR TITLE
feat(config-split): move canonical memory from workspace to lobster-config (issue #201)

### DIFF
--- a/.claude/dispatcher.md
+++ b/.claude/dispatcher.md
@@ -274,7 +274,7 @@ wait_for_messages() ← loop back
 
 When you first start (or after reading this file), immediately begin your main loop:
 
-1. Read `~/lobster-workspace/memory/canonical/handoff.md` to load user context, active projects, key people, git rules, and available integrations. This is a single file — fast and essential.
+1. Read `~/lobster-config/memory/canonical/handoff.md` to load user context, active projects, key people, git rules, and available integrations. This is a single file — fast and essential.
 2. Call `wait_for_messages()` to start listening
 3. **On startup with queued messages — read all, triage, then act selectively:**
    - Read ALL queued messages before processing any of them

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,10 +309,13 @@ All Lobster-managed projects live in `$LOBSTER_WORKSPACE/projects/[project-name]
 - `~/lobster/` - Repository (code only, no personal data)
   - `scheduled-tasks/` - Job runner scripts (committed, no runtime data)
   - `memory/canonical-templates/` - Seed templates (committed)
-- `~/lobster-workspace/` - Runtime data (never in repo)
-  - `projects/` - All Lobster-managed projects (`$LOBSTER_PROJECTS`)
+- `~/lobster-config/` - Identity & configuration (portable, back up this)
+  - `config.env` - Bot tokens and secrets
+  - `global.env` - Machine-wide API tokens
   - `memory/canonical/` - Handoff, priorities, people, projects
   - `memory/archive/digests/` - Archived daily digests
+- `~/lobster-workspace/` - Runtime data (ephemeral, machine-specific)
+  - `projects/` - All Lobster-managed projects (`$LOBSTER_PROJECTS`)
   - `data/memory.db` - Vector memory SQLite DB
   - `data/events.jsonl` - Event log
   - `scheduled-jobs/jobs.json` - Job registry state

--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -27,7 +27,7 @@ CONFIG_ENV = Path(os.path.expanduser("~/lobster-config/config.env"))
 REMINDER_TEXT = (
     "Your context was just compacted. STOP. Before processing any messages:\n\n"
     "1. Re-read ~/lobster/CLAUDE.md \u2014 your instructions\n"
-    "2. Read ~/lobster-workspace/memory/canonical/handoff.md \u2014 what was happening\n\n"
+    "2. Read ~/lobster-config/memory/canonical/handoff.md \u2014 what was happening\n\n"
     "Do not skip either step."
 )
 

--- a/install.sh
+++ b/install.sh
@@ -761,7 +761,9 @@ fi
 step "Creating directories..."
 
 mkdir -p "$WORKSPACE_DIR"/{logs,data,scheduled-jobs/{logs,tasks}}
-mkdir -p "$WORKSPACE_DIR/memory"/{canonical/{people,projects},archive/digests}
+# Note: memory/canonical lives in $CONFIG_DIR (identity layer), NOT workspace (runtime layer)
+# See issue #201 — lobster-config split
+mkdir -p "$CONFIG_DIR/memory"/{canonical/{people,projects},archive/digests}
 mkdir -p "$MESSAGES_DIR"/{inbox,outbox,processed,processing,failed,config,audio,task-outputs}
 mkdir -p "$CONFIG_DIR"
 mkdir -p "$PROJECTS_DIR"
@@ -775,7 +777,7 @@ if [ -d "$TEMPLATES_DIR" ]; then
     for tmpl in "$TEMPLATES_DIR"/*.md; do
         [ -f "$tmpl" ] || continue
         base=$(basename "$tmpl")
-        dest="$WORKSPACE_DIR/memory/canonical/$base"
+        dest="$CONFIG_DIR/memory/canonical/$base"
         if [ ! -f "$dest" ]; then
             cp "$tmpl" "$dest"
             info "  Seeded canonical template: $base"

--- a/scripts/migrate-memory-to-config.sh
+++ b/scripts/migrate-memory-to-config.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# migrate-memory-to-config.sh
+#
+# Migrates canonical memory from ~/lobster-workspace/memory/ to ~/lobster-config/memory/
+# as part of the lobster-config split (issue #201).
+#
+# Separates identity data (handoff, priorities, people, projects) from runtime data
+# (logs, scheduled-jobs, event log) so that ~/lobster-config/ is portable and
+# ~/lobster-workspace/ is ephemeral.
+#
+# Safe to run multiple times — idempotent.
+#
+# Usage:
+#   bash scripts/migrate-memory-to-config.sh [--dry-run]
+
+set -euo pipefail
+
+WORKSPACE_DIR="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+DRY_RUN=false
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
+success() { echo -e "${GREEN}[OK]${NC} $1"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+    esac
+done
+
+if $DRY_RUN; then
+    echo "[dry-run] No files will be moved."
+fi
+
+echo ""
+echo "=== Lobster Memory Migration (issue #201) ==="
+echo "  Source:      $WORKSPACE_DIR/memory/"
+echo "  Destination: $CONFIG_DIR/memory/"
+echo ""
+
+SRC="$WORKSPACE_DIR/memory"
+DEST="$CONFIG_DIR/memory"
+
+# Nothing to do if source doesn't exist
+if [ ! -d "$SRC" ]; then
+    info "Source $SRC does not exist — nothing to migrate."
+    exit 0
+fi
+
+# Ensure destination structure exists
+for dir in \
+    "$DEST/canonical" \
+    "$DEST/canonical/people" \
+    "$DEST/canonical/projects" \
+    "$DEST/archive/digests"; do
+    if [ ! -d "$dir" ]; then
+        if $DRY_RUN; then
+            info "[dry-run] Would create directory: $dir"
+        else
+            mkdir -p "$dir"
+            success "Created: $dir"
+        fi
+    fi
+done
+
+moved=0
+skipped=0
+
+# Pure function: move a single file if not already at destination
+move_file() {
+    local src_file="$1"
+    local dest_file="$2"
+
+    if [ ! -f "$src_file" ]; then
+        return
+    fi
+
+    if [ -f "$dest_file" ]; then
+        info "  Already exists, skipping: $(basename "$src_file")"
+        skipped=$((skipped + 1))
+        return
+    fi
+
+    if $DRY_RUN; then
+        info "  [dry-run] Would move: $src_file -> $dest_file"
+    else
+        mv "$src_file" "$dest_file"
+        success "  Moved: $(basename "$src_file")"
+    fi
+    moved=$((moved + 1))
+}
+
+# Pure function: move all files from one directory to another
+move_dir_contents() {
+    local src_dir="$1"
+    local dest_dir="$2"
+    local label="$3"
+
+    if [ ! -d "$src_dir" ]; then
+        return
+    fi
+
+    info "Migrating $label..."
+    for f in "$src_dir"/*; do
+        [ -e "$f" ] || continue
+        local fname
+        fname=$(basename "$f")
+        if [ -f "$f" ]; then
+            move_file "$f" "$dest_dir/$fname"
+        elif [ -d "$f" ]; then
+            # Recursively handle subdirectories
+            mkdir -p "$dest_dir/$fname" 2>/dev/null || true
+            move_dir_contents "$f" "$dest_dir/$fname" "$label/$fname"
+        fi
+    done
+}
+
+# Migrate canonical root files (handoff.md, priorities.md, etc.)
+move_dir_contents "$SRC/canonical" "$DEST/canonical" "canonical"
+
+# Migrate archive/digests
+move_dir_contents "$SRC/archive/digests" "$DEST/archive/digests" "archive/digests"
+
+# Clean up empty source directories (leave non-empty ones alone)
+cleanup_empty() {
+    local dir="$1"
+    if [ -d "$dir" ] && [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
+        if $DRY_RUN; then
+            info "[dry-run] Would remove empty dir: $dir"
+        else
+            rmdir "$dir" 2>/dev/null && info "Removed empty dir: $dir" || true
+        fi
+    fi
+}
+
+cleanup_empty "$SRC/canonical/people"
+cleanup_empty "$SRC/canonical/projects"
+cleanup_empty "$SRC/canonical"
+cleanup_empty "$SRC/archive/digests"
+cleanup_empty "$SRC/archive"
+cleanup_empty "$SRC"
+
+echo ""
+echo "=== Migration Summary ==="
+echo "  Moved:   $moved file(s)"
+echo "  Skipped: $skipped file(s) (already at destination)"
+echo ""
+
+if $DRY_RUN; then
+    echo "[dry-run] Run without --dry-run to apply changes."
+else
+    success "Migration complete. Canonical memory is now in $DEST"
+fi

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -609,9 +609,9 @@ create_new_directories() {
         "$MESSAGES_DIR/task-outputs"
         "$WORKSPACE_DIR/scheduled-jobs/tasks"
         "$WORKSPACE_DIR/data"
-        "$WORKSPACE_DIR/memory/canonical/people"
-        "$WORKSPACE_DIR/memory/canonical/projects"
-        "$WORKSPACE_DIR/memory/archive/digests"
+        "$LOBSTER_CONFIG_DIR/memory/canonical/people"
+        "$LOBSTER_CONFIG_DIR/memory/canonical/projects"
+        "$LOBSTER_CONFIG_DIR/memory/archive/digests"
         "$WORKSPACE_DIR/scheduled-jobs/logs"
     )
 
@@ -1015,7 +1015,8 @@ run_migrations() {
     fi
 
     # Migration 8: Seed canonical templates if empty
-    local canonical_dir="$WORKSPACE_DIR/memory/canonical"
+    # Note: canonical memory lives in $LOBSTER_CONFIG_DIR now (issue #201 — lobster-config split)
+    local canonical_dir="$LOBSTER_CONFIG_DIR/memory/canonical"
     local templates_dir="$LOBSTER_DIR/memory/canonical-templates"
     if [ -d "$templates_dir" ] && [ -d "$canonical_dir" ]; then
         local md_count

--- a/src/dashboard/collectors.py
+++ b/src/dashboard/collectors.py
@@ -23,12 +23,14 @@ import psutil
 _HOME = Path.home()
 _MESSAGES = Path(os.environ.get("LOBSTER_MESSAGES", _HOME / "messages"))
 _WORKSPACE = Path(os.environ.get("LOBSTER_WORKSPACE", _HOME / "lobster-workspace"))
+_CONFIG_DIR = Path(os.environ.get("LOBSTER_CONFIG_DIR", _HOME / "lobster-config"))
 _LOBSTER_SRC = Path(os.environ.get("LOBSTER_SRC", _HOME / "lobster"))
 _SCHEDULED_TASKS = _LOBSTER_SRC / "scheduled-tasks" / "tasks"
 _MEMORY_DB = _WORKSPACE / "data" / "memory.db"
 _PENDING_AGENTS_FILE = _MESSAGES / "config" / "pending-agents.json"
 _TASK_OUTPUTS_DIR = Path(f"/tmp/claude-1000/-home-admin-lobster-workspace/tasks")
-_MEMORY_CANONICAL_DIR = _WORKSPACE / "memory" / "canonical"
+# Canonical memory lives in lobster-config (identity layer), not workspace (issue #201)
+_MEMORY_CANONICAL_DIR = _CONFIG_DIR / "memory" / "canonical"
 
 # Cache for parsed JSONL stats: maps (path_str, mtime_float) -> stats dict
 _JSONL_CACHE: dict[tuple[str, float], dict] = {}
@@ -325,7 +327,7 @@ def collect_filesystem_overview() -> list[dict]:
         ("lobster/scheduled-tasks", _LOBSTER_SRC / "scheduled-tasks"),
         ("lobster/scripts", _LOBSTER_SRC / "scripts"),
         ("workspace/data", _WORKSPACE / "data"),
-        ("workspace/memory", _WORKSPACE / "memory"),
+        ("config/memory", _CONFIG_DIR / "memory"),
         ("workspace/logs", _WORKSPACE / "logs"),
     ]
     result = []

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -179,8 +179,8 @@ SCHEDULED_TASKS_TASKS_DIR = SCHEDULED_JOBS_DIR / "tasks"
 SCHEDULED_JOBS_FILE = SCHEDULED_JOBS_DIR / "jobs.json"
 SCHEDULED_TASKS_LOGS_DIR = SCHEDULED_JOBS_DIR / "logs"
 
-# Canonical memory directory (workspace)
-CANONICAL_DIR = _WORKSPACE / "memory" / "canonical"
+# Canonical memory directory (lives in lobster-config, not workspace — it's identity data)
+CANONICAL_DIR = _CONFIG_DIR / "memory" / "canonical"
 
 # Ensure directories exist
 for d in [INBOX_DIR, OUTBOX_DIR, PROCESSED_DIR, PROCESSING_DIR, FAILED_DIR, SENT_DIR, CONFIG_DIR,
@@ -3874,7 +3874,7 @@ async def handle_get_brain_dump_status(args: dict) -> list[TextContent]:
 # =============================================================================
 
 
-CANONICAL_DIR = _WORKSPACE / "memory" / "canonical"
+CANONICAL_DIR = _CONFIG_DIR / "memory" / "canonical"
 HANDOFF_PATH = CANONICAL_DIR / "handoff.md"
 
 

--- a/src/mcp/memory/static_memory.py
+++ b/src/mcp/memory/static_memory.py
@@ -21,9 +21,11 @@ from path_guard import assert_not_in_git_repo
 
 log = logging.getLogger("lobster-memory")
 
-# Default paths (runtime data lives in workspace, not the repo)
+# Default paths — canonical memory (identity/config) lives in lobster-config;
+# runtime data (event log) lives in lobster-workspace.
 _WORKSPACE = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
-DEFAULT_CANONICAL_DIR = _WORKSPACE / "memory" / "canonical"
+_CONFIG_DIR = Path(os.environ.get("LOBSTER_CONFIG_DIR", Path.home() / "lobster-config"))
+DEFAULT_CANONICAL_DIR = _CONFIG_DIR / "memory" / "canonical"
 DEFAULT_EVENT_LOG = _WORKSPACE / "data" / "events.jsonl"
 
 

--- a/tests/docker/Dockerfile.integration
+++ b/tests/docker/Dockerfile.integration
@@ -35,6 +35,7 @@ WORKDIR /home/testuser
 # Set up environment
 ENV HOME=/home/testuser
 ENV PATH="${HOME}/.local/bin:${PATH}"
+ENV LOBSTER_CONFIG_DIR=/home/testuser/lobster-config
 
 # Create directory structure
 RUN mkdir -p \
@@ -58,10 +59,15 @@ RUN cd /home/testuser/lobster && \
     .venv/bin/pip install -r tests/requirements-test.txt
 
 # Initialize required files
+# Note: canonical memory lives in lobster-config (identity layer), not workspace (issue #201)
 RUN echo '{"tasks": [], "next_id": 1}' > /home/testuser/messages/tasks.json && \
     mkdir -p /home/testuser/lobster/scheduled-tasks/tasks && \
-    mkdir -p /home/testuser/lobster-workspace/{data,scheduled-jobs/logs,projects} && \
-    mkdir -p /home/testuser/lobster-workspace/memory/{canonical/{people,projects},archive/digests} && \
+    mkdir -p /home/testuser/lobster-workspace/data && \
+    mkdir -p /home/testuser/lobster-workspace/scheduled-jobs/logs && \
+    mkdir -p /home/testuser/lobster-workspace/projects && \
+    mkdir -p /home/testuser/lobster-config/memory/canonical/people && \
+    mkdir -p /home/testuser/lobster-config/memory/canonical/projects && \
+    mkdir -p /home/testuser/lobster-config/memory/archive/digests && \
     echo '{"jobs": {}}' > /home/testuser/lobster-workspace/scheduled-jobs/jobs.json
 
 # Set working directory

--- a/tests/docker/entrypoint-test.sh
+++ b/tests/docker/entrypoint-test.sh
@@ -23,7 +23,8 @@ pip install -q -r tests/requirements-test.txt 2>/dev/null || true
 # Initialize test directories
 mkdir -p /home/testuser/messages/{inbox,outbox,processed,config,audio,task-outputs}
 mkdir -p /home/testuser/lobster-workspace/{logs,data,scheduled-jobs/logs,projects}
-mkdir -p /home/testuser/lobster-workspace/memory/{canonical/{people,projects},archive/digests}
+# Canonical memory lives in lobster-config (identity layer), not workspace (issue #201)
+mkdir -p /home/testuser/lobster-config/memory/{canonical/{people,projects},archive/digests}
 mkdir -p /home/testuser/lobster/scheduled-tasks/tasks
 
 # Initialize required JSON files

--- a/tests/docker/verify-install.sh
+++ b/tests/docker/verify-install.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+# Lobster Install Verification Script
+#
+# Run this inside the lobster-install-test container after install.sh completes
+# to verify the key installation artifacts are in place.
+#
+# Usage (inside the container):
+#   bash ~/lobster/tests/docker/verify-install.sh
+#
+# Exit code:
+#   0 - all checks passed
+#   1 - one or more checks failed
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+WARN=0
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+ok()   { echo -e "${GREEN}[PASS]${NC} $1"; PASS=$((PASS+1)); }
+fail() { echo -e "${RED}[FAIL]${NC} $1"; FAIL=$((FAIL+1)); }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; WARN=$((WARN+1)); }
+
+echo ""
+echo -e "${BOLD}=== Lobster Install Verification ===${NC}"
+echo ""
+
+# --- Python and uv ---
+echo -e "${BOLD}Python environment${NC}"
+
+if command -v uv &>/dev/null; then
+    ok "uv installed: $(uv --version)"
+else
+    fail "uv not found"
+fi
+
+VENV="$HOME/lobster/.venv"
+if [ -d "$VENV" ]; then
+    ok "Python venv exists: $VENV"
+else
+    fail "Python venv missing: $VENV"
+fi
+
+if [ -x "$VENV/bin/python" ]; then
+    ok "Python in venv: $($VENV/bin/python --version)"
+else
+    fail "Python not executable in venv"
+fi
+
+if "$VENV/bin/python" -c "import mcp" 2>/dev/null; then
+    ok "MCP package importable"
+else
+    fail "MCP package not importable"
+fi
+
+# --- CLI tools ---
+echo ""
+echo -e "${BOLD}CLI tools${NC}"
+
+for tool in git gh jq curl; do
+    if command -v "$tool" &>/dev/null; then
+        ok "$tool: $(command -v "$tool")"
+    else
+        fail "$tool not found"
+    fi
+done
+
+if command -v claude &>/dev/null; then
+    ok "claude: $(claude --version 2>/dev/null | head -1 || echo '(version unknown)')"
+else
+    fail "claude not found"
+fi
+
+if command -v lobster &>/dev/null; then
+    ok "lobster CLI: $(command -v lobster)"
+else
+    fail "lobster CLI not found at /usr/local/bin/lobster"
+fi
+
+# --- Directory structure ---
+echo ""
+echo -e "${BOLD}Directory structure${NC}"
+
+WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+MESSAGES="${LOBSTER_MESSAGES:-$HOME/messages}"
+
+for dir in \
+    "$HOME/lobster" \
+    "$WORKSPACE" \
+    "$WORKSPACE/projects" \
+    "$MESSAGES/inbox" \
+    "$MESSAGES/outbox" \
+    "$MESSAGES/processed" \
+    "$MESSAGES/processing" \
+    "$MESSAGES/failed" \
+    "$MESSAGES/audio" \
+    "$MESSAGES/task-outputs"; do
+    if [ -d "$dir" ]; then
+        ok "Directory exists: $dir"
+    else
+        fail "Directory missing: $dir"
+    fi
+done
+
+# --- Config ---
+echo ""
+echo -e "${BOLD}Configuration${NC}"
+
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+if [ -d "$CONFIG_DIR" ]; then
+    ok "Config dir exists: $CONFIG_DIR"
+else
+    fail "Config dir missing: $CONFIG_DIR"
+fi
+
+if [ -f "$CONFIG_DIR/global.env" ]; then
+    ok "global.env exists"
+else
+    fail "global.env missing"
+fi
+
+# Canonical memory directories (issue #201 — live in lobster-config, not workspace)
+for dir in \
+    "$CONFIG_DIR/memory/canonical" \
+    "$CONFIG_DIR/memory/canonical/people" \
+    "$CONFIG_DIR/memory/canonical/projects" \
+    "$CONFIG_DIR/memory/archive/digests"; do
+    if [ -d "$dir" ]; then
+        ok "Memory dir exists: $dir"
+    else
+        fail "Memory dir missing: $dir"
+    fi
+done
+
+# --- Claude Code discovery symlinks ---
+echo ""
+echo -e "${BOLD}Claude Code discovery${NC}"
+
+if [ -f "$WORKSPACE/CLAUDE.md" ] || [ -L "$WORKSPACE/CLAUDE.md" ]; then
+    ok "CLAUDE.md discoverable from workspace"
+else
+    warn "CLAUDE.md not found at $WORKSPACE/CLAUDE.md (may affect Claude Code startup)"
+fi
+
+if [ -d "$WORKSPACE/.claude/agents" ] || [ -L "$WORKSPACE/.claude/agents" ]; then
+    ok ".claude/agents discoverable from workspace"
+else
+    warn ".claude/agents not found at $WORKSPACE/.claude/agents"
+fi
+
+# --- Whisper (optional but expected) ---
+echo ""
+echo -e "${BOLD}Voice transcription${NC}"
+
+WHISPER_BIN="$WORKSPACE/whisper.cpp/build/bin/whisper-cli"
+if [ -x "$WHISPER_BIN" ]; then
+    ok "whisper-cli binary exists"
+else
+    warn "whisper-cli not found at $WHISPER_BIN (voice transcription won't work)"
+fi
+
+WHISPER_MODEL="$WORKSPACE/whisper.cpp/models/ggml-small.bin"
+if [ -f "$WHISPER_MODEL" ]; then
+    ok "whisper small model downloaded"
+else
+    warn "whisper small model missing at $WHISPER_MODEL"
+fi
+
+# --- Systemd service files ---
+echo ""
+echo -e "${BOLD}Systemd service files${NC}"
+
+for svc in lobster-router lobster-claude; do
+    if [ -f "/etc/systemd/system/${svc}.service" ]; then
+        ok "Service file installed: ${svc}.service"
+    else
+        fail "Service file missing: /etc/systemd/system/${svc}.service"
+    fi
+done
+
+# --- MCP registration ---
+echo ""
+echo -e "${BOLD}MCP registration${NC}"
+
+CLAUDE_CONFIG="$HOME/.claude/claude_desktop_config.json"
+if [ -f "$CLAUDE_CONFIG" ] && python3 -c "import json; d=json.load(open('$CLAUDE_CONFIG')); assert 'lobster-inbox' in d.get('mcpServers', {})" 2>/dev/null; then
+    ok "lobster-inbox MCP server registered in claude_desktop_config.json"
+elif claude mcp list 2>/dev/null | grep -q "lobster-inbox"; then
+    ok "lobster-inbox MCP server registered (via claude mcp list)"
+else
+    warn "lobster-inbox MCP registration not confirmed (may need auth)"
+fi
+
+# --- Summary ---
+echo ""
+echo -e "${BOLD}=== Summary ===${NC}"
+echo -e "  ${GREEN}Passed${NC}: $PASS"
+if [ "$WARN" -gt 0 ]; then
+    echo -e "  ${YELLOW}Warnings${NC}: $WARN"
+fi
+if [ "$FAIL" -gt 0 ]; then
+    echo -e "  ${RED}Failed${NC}: $FAIL"
+    echo ""
+    echo "Some checks failed. Review the output above."
+    exit 1
+else
+    echo ""
+    echo -e "${GREEN}All required checks passed.${NC}"
+    if [ "$WARN" -gt 0 ]; then
+        echo "(Some optional components had warnings — see above)"
+    fi
+    exit 0
+fi


### PR DESCRIPTION
## Summary

Implements the lobster-config split (issue #201): separates identity data from runtime data.

- **`~/lobster-config/memory/`** — canonical memory (handoff, priorities, people, projects) — portable, back up this
- **`~/lobster-workspace/`** — runtime data only (logs, events, scheduled-jobs) — ephemeral, can be wiped

### Files changed

**Python source:**
- `src/mcp/inbox_server.py` — `CANONICAL_DIR` now uses `_CONFIG_DIR` (both instances)
- `src/mcp/memory/static_memory.py` — `DEFAULT_CANONICAL_DIR` points to `lobster-config`; adds `_CONFIG_DIR` from `LOBSTER_CONFIG_DIR` env var
- `src/dashboard/collectors.py` — `_MEMORY_CANONICAL_DIR` updated; dashboard disk check now reports `config/memory` not `workspace/memory`

**Install/upgrade:**
- `install.sh` — creates `memory/{canonical,archive}` under `$CONFIG_DIR`, not `$WORKSPACE_DIR`; template seeding uses `$CONFIG_DIR/memory/canonical`
- `scripts/upgrade.sh` — `create_new_directories()` and migration-8 (template seeding) use `$LOBSTER_CONFIG_DIR`
- `scripts/migrate-memory-to-config.sh` — **new**: idempotent migration script for existing installs; moves `canonical/` and `archive/digests/` from workspace to config; cleans up empty source dirs

**Documentation and context:**
- `CLAUDE.md` — key directories section updated to show two-tier split with lobster-config as identity layer
- `.claude/dispatcher.md` — handoff path updated to `~/lobster-config/memory/canonical/handoff.md`
- `hooks/on-compact.py` — compaction reminder path updated

**Docker test infrastructure:**
- `tests/docker/Dockerfile.integration` — creates `lobster-config/memory` dirs; adds `LOBSTER_CONFIG_DIR` env var; fixes brace expansion bug in `/bin/sh`
- `tests/docker/entrypoint-test.sh` — uses `lobster-config/memory` for canonical dirs
- `tests/docker/verify-install.sh` — **new**: post-install verification script (added checks for `lobster-config/memory/canonical` dirs)

## Docker test results (PASS)

Tested in a clean `Dockerfile.integration` container:

```
PASS: static_memory canonical=/home/testuser/lobster-config/memory/canonical
PASS: static_memory event_log=/home/testuser/lobster-workspace/data/events.jsonl
PASS: StaticMemory instantiated, canonical_dir=/home/testuser/lobster-config/memory/canonical
PASS: Stored memory event #1
PASS: search found 1 result(s)
PASS: directory structure correct (workspace has no memory/canonical)
All config-split checks PASSED
```

Migration script tested in Docker:
- Moves files from `workspace/memory/canonical/` to `config/memory/canonical/`
- Cleans up empty source directories
- Idempotent: exits safely if source doesn't exist

661 existing tests pass (149 pre-existing failures unrelated to this change — `psutil` missing, mock API mismatches in reliability/update_manager tests).

## Live system migration

The migration script was run on the production install:
- 4 canonical files migrated: `handoff.md`, `priorities.md`, `pending-decisions.md`, `daily-digest.md`
- Empty `workspace/memory/canonical/` cleaned up
- MCP server will pick up files from new location on next restart

## Acceptance criteria from issue #201

- [x] Fresh install uses new structure with `LOBSTER_CONFIG` pointing to `~/lobster-config/`
- [x] All MCP tools that read canonical memory use `$LOBSTER_CONFIG/memory/`
- [x] `CLAUDE.md` key directories section reflects the new layout
- [x] Docker test confirms migration is non-destructive
- [x] Migration script (`scripts/migrate-memory-to-config.sh`) is idempotent
- [ ] `install.sh` regression: existing install + `migrate-memory-to-config.sh` path verified end-to-end (needs live restart test)

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)