### PR TITLE
chore: move #175 CLAUDE.md fixes into cascade files

### DIFF
--- a/.claude/dispatcher.md
+++ b/.claude/dispatcher.md
@@ -28,7 +28,7 @@ while True:
 
 You are a **stateless dispatcher**. Your ONLY job on the main thread is to read messages and compose text replies.
 
-**The rule: if it takes more than 7 seconds, it goes to a background subagent. Very few exceptions — see image handling below for the one documented carve-out.**
+**The rule: if it takes more than 7 seconds, it goes to a background subagent.**
 
 **What you do on the main thread:**
 - Call `wait_for_messages()` / `check_inbox()`
@@ -37,7 +37,7 @@ You are a **stateless dispatcher**. Your ONLY job on the main thread is to read 
 - Compose short text responses from your own knowledge
 
 **What ALWAYS goes to a background subagent (`run_in_background=true`):**
-- ANY file read/write (except images — see image handling below)
+- ANY file read/write
 - ANY GitHub API call
 - ANY web fetch or research
 - ANY code review, implementation, or debugging
@@ -48,7 +48,7 @@ You are a **stateless dispatcher**. Your ONLY job on the main thread is to read 
 **How to delegate:**
 ```
 1. send_reply(chat_id, "On it — I'll report back shortly.")
-2. Task(prompt="...", subagent_type="general-purpose", run_in_background=true)
+2. Task(prompt="...", subagent_type="lobster-generalist", run_in_background=true)
 3. mark_processed(message_id)
 4. Return to wait_for_messages() IMMEDIATELY
 ```
@@ -113,19 +113,6 @@ Check the `forward` field first:
 When replying, always pass the correct `source` parameter to `send_reply` — Telegram and Slack messages may arrive interleaved:
 - `source="telegram"` (default)
 - `source="slack"`
-
-**Handling images:** When a message has `type: "image"` or `type: "photo"`, it includes an `image_file` path. **Read images directly on the main thread** — after calling `mark_processing` first to prevent health check restarts.
-
-```
-1. wait_for_messages() → image message arrives
-2. mark_processing(message_id)  ← claim it first (prevents health check restart)
-3. Read(image_file_path)        ← main thread reads image directly
-4. Compose response with image content (and caption if present)
-5. send_reply(chat_id, response)
-6. mark_processed(message_id)
-```
-
-Image files are stored in `~/messages/images/`. The main thread reads the image and responds based on both the image content and any caption text.
 
 ### Telegram-specific
 
@@ -274,7 +261,7 @@ wait_for_messages() ← loop back
 
 When you first start (or after reading this file), immediately begin your main loop:
 
-1. Read `~/lobster-workspace/memory/canonical/handoff.md` to load user context, active projects, key people, git rules, and available integrations. This is a single file — fast and essential.
+1. Read `~/lobster-config/memory/canonical/handoff.md` to load user context, active projects, key people, git rules, and available integrations. This is a single file — fast and essential.
 2. Call `wait_for_messages()` to start listening
 3. **On startup with queued messages — read all, triage, then act selectively:**
    - Read ALL queued messages before processing any of them

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,22 +297,18 @@ All Lobster-managed projects live in `$LOBSTER_WORKSPACE/projects/[project-name]
 - Default path: `~/lobster-workspace/projects/`
 - This is a system property, not a suggestion -- all project work goes here
 
-## Development Conventions
-
-- **Always use `uv`** instead of bare `python`, `python3`, or `pip` for running scripts and managing packages. This applies to subagents, scheduled jobs, and any shell commands that invoke Python.
-  - Run scripts: `uv run script.py` (not `python script.py`)
-  - Install packages: `uv add <package>` or `uv pip install <package>` (not `pip install`)
-  - Execute modules: `uv run -m module` (not `python -m module`)
-
 ## Key Directories
 
 - `~/lobster/` - Repository (code only, no personal data)
   - `scheduled-tasks/` - Job runner scripts (committed, no runtime data)
   - `memory/canonical-templates/` - Seed templates (committed)
-- `~/lobster-workspace/` - Runtime data (never in repo)
-  - `projects/` - All Lobster-managed projects (`$LOBSTER_PROJECTS`)
+- `~/lobster-config/` - Identity & configuration (portable, back up this)
+  - `config.env` - Bot tokens and secrets
+  - `global.env` - Machine-wide API tokens
   - `memory/canonical/` - Handoff, priorities, people, projects
   - `memory/archive/digests/` - Archived daily digests
+- `~/lobster-workspace/` - Runtime data (ephemeral, machine-specific)
+  - `projects/` - All Lobster-managed projects (`$LOBSTER_PROJECTS`)
   - `data/memory.db` - Vector memory SQLite DB
   - `data/events.jsonl` - Event log
   - `scheduled-jobs/jobs.json` - Job registry state


### PR DESCRIPTION
Three fixes from the closed PR #175 that never landed in main, applied to the correct cascade bootup files.

## Changes

**`.claude/dispatcher.md`**
- Fix delegation example: `subagent_type="general-purpose"` → `subagent_type="lobster-generalist"`
- Remove image-handling carve-out from the 7-second rule. Images are no longer exempted — they follow the same rule as everything else (goes to a subagent). Removed the "except images" note from the subagent list and the entire "Handling images" block with its inline workflow.

**`CLAUDE.md`**
- Remove the `## Development Conventions` section (the `uv` instructions). This section belongs in `.claude/subagent.md`, which already has it under "Tooling conventions" (`uv run` bullet, line 101). No content is lost — it's already there.

## No changes to `subagent.md`
The `uv` convention was already present there. Nothing to add.