### PR TITLE
docs: add DEVELOPMENT.md with worktree conventions

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,98 @@
+# Lobster Development Guide
+
+This guide covers conventions for developing Lobster features using git worktrees, the standard workflow for all feature and fix branches.
+
+## Worktree Workflow
+
+All feature branch work happens in git worktrees placed at `~/lobster-workspace/projects/<branch-name>/`. The main repository at `~/lobster/` always stays on `main`.
+
+### Creating a worktree
+
+```bash
+cd ~/lobster
+git worktree add -b feature/my-feature ~/lobster-workspace/projects/my-feature main
+```
+
+Or, to check out an existing branch:
+
+```bash
+git worktree add ~/lobster-workspace/projects/my-feature feature/my-feature
+```
+
+Work inside the worktree directory. Commit and push from there. Open your editor pointing at the worktree path.
+
+### Removing a worktree after merge
+
+```bash
+cd ~/lobster
+git worktree remove ~/lobster-workspace/projects/my-feature
+git branch -d feature/my-feature
+```
+
+---
+
+## Convention 1: ~/lobster/ must stay on main
+
+**Never run `git checkout <branch>` inside `~/lobster/`.** The dispatcher process reads configuration, hooks, and agent definitions from `~/lobster/` at runtime. Switching branches there changes what the live system sees and can break the running dispatcher in unpredictable ways.
+
+All feature branch work uses worktrees at `~/lobster-workspace/projects/<branch>/`. This is not a preference — it is a system constraint.
+
+If you need to verify which branch `~/lobster/` is on:
+
+```bash
+git -C ~/lobster branch --show-current
+# Should always print: main
+```
+
+---
+
+## Convention 2: The cp-then-test pattern
+
+Hook scripts and agent definitions are referenced by **absolute path** in `~/.claude/settings.json`, which points into `~/lobster/hooks/` and `~/lobster/.claude/agents/`. A file that lives only in a worktree is **not** picked up at runtime — the live dispatcher never sees it.
+
+To test a new or modified hook or agent definition before merging:
+
+```bash
+# For hook scripts:
+cp ~/lobster-workspace/projects/<branch>/hooks/my-hook.py ~/lobster/hooks/my-hook.py
+
+# For agent definitions:
+cp ~/lobster-workspace/projects/<branch>/.claude/agents/my-agent.md ~/lobster/.claude/agents/my-agent.md
+```
+
+Test the live behavior. When you are satisfied:
+
+- Do **not** revert the copy manually — the file will be correct in `~/lobster/` once the PR lands on main.
+- If you need to abandon the test before merging, delete the copy from `~/lobster/hooks/` or `~/lobster/.claude/agents/`.
+
+This pattern lets you run real traffic against a change without touching the main branch checkout.
+
+---
+
+## Convention 3: Register-after-merge rule
+
+**Never update `~/.claude/settings.json` to register a hook before the hook file exists in `~/lobster/hooks/`** (i.e., before the PR is merged to main).
+
+If `settings.json` references a hook path that does not exist on disk, every Claude tool call fails with a hook error. This can completely paralyze the dispatcher — no tools work, no messages are processed.
+
+This is what caused the post-compact-enforcement incident.
+
+### Correct sequence for adding a new hook
+
+1. Develop the hook script in your worktree (`~/lobster-workspace/projects/<branch>/hooks/`)
+2. (Optional) Copy to `~/lobster/hooks/` for live testing using the cp-then-test pattern above
+3. Open a PR and get it reviewed
+4. Merge the PR — the file now exists in `~/lobster/hooks/` via main
+5. Only then: run `install.sh` to register the hook in `~/.claude/settings.json`, or rely on the idempotent registration block in `install.sh` if it already covers the hook
+
+### Why this order matters
+
+`install.sh` is designed to be idempotent and safe to re-run. It checks for existing entries before adding new ones. If your new hook is wired into `install.sh`, running it after merge is all you need. If you are registering manually, wait until after merge.
+
+---
+
+## Related documentation
+
+- `dispatcher.bootup.md` — runtime behavior and the worktree constraint from the dispatcher's perspective
+- `docs/engineering-lessons-learned.md` — recurring patterns to check during PR review
+- `CLAUDE.md` — full system architecture and key directories


### PR DESCRIPTION
## Summary

- Adds `docs/DEVELOPMENT.md` documenting three worktree development conventions that were either undocumented or only appeared in runtime-facing config files
- Covers the cp-then-test pattern, the register-after-merge rule, and the requirement that `~/lobster/` stays on main at all times

## Conventions documented

**Convention 1: `~/lobster/` must stay on main**
Never `git checkout <branch>` inside the live repo directory. All feature branch work uses worktrees at `~/lobster-workspace/projects/<branch>/`. Already in dispatcher.bootup.md but now also in developer-facing docs.

**Convention 2: cp-then-test pattern**
Hook scripts and agent definitions are resolved via absolute paths in `~/.claude/settings.json` pointing to `~/lobster/hooks/` and `~/lobster/.claude/agents/`. A file that only exists in a worktree is never picked up by the live dispatcher. The pattern: copy from worktree to live dir for testing, then let the merge make it permanent.

**Convention 3: Register-after-merge rule**
Never add a hook to `settings.json` before the hook file exists in `~/lobster/hooks/` (i.e., before the PR lands on main). A missing-file reference causes every Claude tool call to fail with a hook error, which can paralyze the dispatcher. Documents the correct 5-step sequence and explains why this order matters.

## Test plan

- [ ] Read `docs/DEVELOPMENT.md` in the worktree and verify all three conventions are clearly stated
- [ ] Verify links to related docs (`dispatcher.bootup.md`, `engineering-lessons-learned.md`, `CLAUDE.md`) are accurate
- [ ] Confirm no PII or secrets are included (pre-push hook passed)

Closes #236

Generated with [Claude Code](https://claude.com/claude-code)