### PR TITLE
fix: replace hardcoded /home/lobster paths with portable references

### DIFF
--- a/config/config.env.example
+++ b/config/config.env.example
@@ -73,3 +73,8 @@ OPENAI_API_KEY=your_openai_api_key_here
 # Google Calendar token bridge (for myownlobster.ai hosted instances)
 # LOBSTER_INTERNAL_SECRET=<shared secret matching myownlobster Vercel env var>
 # See ~/messages/config/calendar-config.json for oauth_backend configuration
+
+# Google Workspace CLI (gws) — optional, for Gmail/Workspace integration
+# $HOME is expanded at shell source time, so this works for any username.
+# GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE=$HOME/.config/gws/credentials.json
+# GOOGLE_WORKSPACE_CLI_KEYRING_BACKEND=file

--- a/hooks/post-compact-gate.py
+++ b/hooks/post-compact-gate.py
@@ -24,11 +24,13 @@ Add this to ~/.claude/settings.json under "hooks" → "PreToolUse":
       "hooks": [
         {
           "type": "command",
-          "command": "python3 /home/lobster/lobster/hooks/post-compact-gate.py",
+          "command": "python3 $HOME/lobster/hooks/post-compact-gate.py",
           "timeout": 5
         }
       ]
     }
+
+Note: $HOME is expanded by the shell at runtime, so this works for any username.
 
 The empty string matcher fires on every tool call.
 """

--- a/install.sh
+++ b/install.sh
@@ -324,11 +324,12 @@ if [ "$(id -u)" = "0" ]; then
         chmod 0440 /etc/sudoers.d/lobster
         # Copy SSH authorized_keys so user can SSH in directly next time
         if [ -f /root/.ssh/authorized_keys ]; then
-            mkdir -p /home/lobster/.ssh
-            cp /root/.ssh/authorized_keys /home/lobster/.ssh/authorized_keys
-            chown -R lobster:lobster /home/lobster/.ssh
-            chmod 700 /home/lobster/.ssh
-            chmod 600 /home/lobster/.ssh/authorized_keys
+            LOBSTER_HOME=$(getent passwd lobster | cut -d: -f6)
+            mkdir -p "$LOBSTER_HOME/.ssh"
+            cp /root/.ssh/authorized_keys "$LOBSTER_HOME/.ssh/authorized_keys"
+            chown -R lobster:lobster "$LOBSTER_HOME/.ssh"
+            chmod 700 "$LOBSTER_HOME/.ssh"
+            chmod 600 "$LOBSTER_HOME/.ssh/authorized_keys"
         fi
         success "User 'lobster' created."
     else


### PR DESCRIPTION
## Summary

An audit found 3 places where \`/home/lobster\` was hardcoded, assuming the system username is always \`lobster\`. This PR replaces them with portable alternatives.

- **hooks/post-compact-gate.py** (docstring example): Changed \`"command": "python3 /home/lobster/lobster/hooks/post-compact-gate.py"\` to use \`\$HOME\`, which the shell expands at runtime. Added a note clarifying this.
- **install.sh** (SSH setup block): Replaced 4 lines using \`/home/lobster/.ssh\` with a \`LOBSTER_HOME=\$(getent passwd lobster | cut -d: -f6)\` lookup so the actual home directory is resolved from the system's passwd database rather than assumed.
- **config/config.env.example** (template): Added a commented GWS (Google Workspace CLI) section using \`\$HOME/.config/gws/credentials.json\` so any future installs copying this template get a portable path rather than a hardcoded one.

## Test plan

- [ ] Verify \`install.sh\` SSH block works correctly on a fresh Ubuntu VM where the lobster user's home is the default (\`/home/lobster\`) — should behave identically
- [ ] Verify \`install.sh\` SSH block works on a system where the lobster user has a non-default home directory
- [ ] Confirm \`hooks/post-compact-gate.py\` docstring example renders correctly in docs/editors
- [ ] Confirm \`config/config.env.example\` can be sourced by bash with \`\$HOME\` expanding correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)