### PR TITLE
fix: correct emoji escaping and curl URL-encoding in health alert

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -141,17 +141,13 @@ send_telegram_alert() {
         return 1
     fi
 
-    local full_message="\U0001F6A8 *Lobster Health Alert*
-
-${message}
-
-_$(date '+%Y-%m-%d %H:%M:%S %Z')_"
+    local full_message=$'🚨 *Lobster Health Alert*\n\n'"${message}"$'\n\n_'"$(date '+%Y-%m-%d %H:%M:%S %Z')"$'_'
 
     curl -s -X POST \
         "https://api.telegram.org/bot${bot_token}/sendMessage" \
-        -d chat_id="$chat_id" \
-        -d text="$full_message" \
-        -d parse_mode="Markdown" \
+        --data-urlencode "chat_id=${chat_id}" \
+        --data-urlencode "text=${full_message}" \
+        --data-urlencode "parse_mode=Markdown" \
         --max-time 10 \
         > /dev/null 2>&1
 


### PR DESCRIPTION
## Summary

- **Bug**: `\U0001F6A8` inside a regular bash double-quoted string is NOT a Unicode escape — bash does not interpret `\U` sequences. The literal text `\U0001F6A8` was being sent to Telegram instead of the 🚨 emoji.
- **Fix**: Changed to ANSI-C quoting (`$'🚨 ...\n\n'`) so the emoji and `\n` newlines are expanded correctly by the shell.
- **Secondary fix**: Switched `curl -d` to `curl --data-urlencode` so that Markdown characters (`*`, `_`) and multi-line message bodies are properly URL-encoded, preventing potential Telegram parse errors.

## Root cause

```bash
# Before (broken): \U0001F6A8 is sent literally as a string
local full_message="\U0001F6A8 *Lobster Health Alert*..."

# After (fixed): emoji expands correctly, newlines expand correctly
local full_message=$'🚨 *Lobster Health Alert*\n\n'"${message}"$'\n\n_..._'
```

## Test plan

- [ ] Send a test alert by temporarily lowering thresholds and verify 🚨 appears correctly in Telegram
- [ ] Verify the Markdown formatting (`*bold*`, `_italic_`) renders correctly (not raw asterisks/underscores)
- [ ] Confirm no regression: healthy state produces no spurious alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)