### PR TITLE
fix: correct gh project item-edit invocation in functional-engineer agent

### DIFF
--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -125,11 +125,22 @@ git branch -d feature/issue-42-my-feature
 2. Use `gh` CLI to update the project item status on "Main Board":
 
 ```bash
-# Find the project item ID for an issue
-gh project item-list "Main Board" --owner <owner> --format json | jq '.items[] | select(.content.number == <issue-number>)'
+# Step 1: List projects to get the project number and node ID
+gh project list --owner <owner> --format json
 
-# Update status (common status option IDs vary per project - query first if needed)
-gh project item-edit --project "Main Board" --owner <owner> --id <item-id> --field-id Status --text "In Progress"
+# Step 2: Discover field IDs and single-select option IDs (node IDs like PVTF_..., PVTSSF_...)
+gh project field-list <PROJECT_NUMBER> --owner <owner> --format json
+
+# Step 3: Find the item ID for an issue/PR
+gh project item-list <PROJECT_NUMBER> --owner <owner> --format json | jq '.items[] | select(.content.number == <issue-number>)'
+
+# Step 4: Update a single-select field (e.g. Status) — note: --field-id takes a node ID,
+#          not a name; --single-select-option-id takes the option's node ID, not its label
+gh project item-edit \
+  --project-id <PROJECT_NODE_ID> \
+  --id <ITEM_NODE_ID> \
+  --field-id <FIELD_NODE_ID> \
+  --single-select-option-id <OPTION_NODE_ID>
 ```
 
 **Workflow integration:**


### PR DESCRIPTION
## Summary

Fixes a bug in the `Project Status Management` section of the functional-engineer agent prompt where `gh project item-edit` was called with incorrect flags.

**What was broken:**
```bash
gh project item-edit --project "Main Board" --owner <owner> --id <item-id> --field-id Status --text "In Progress"
```

Two correctness bugs:
- `--field-id` accepts a GraphQL node ID (e.g. `PVTF_...`), not a human-readable field name like `"Status"`. Passing a name causes the command to error.
- `--text` is for free-text project fields. Status is a single-select field, which requires `--single-select-option-id <OPTION_NODE_ID>`.

**What this PR does:**

Replaces the broken one-liner with a correct 4-step pattern:
1. `gh project list` — discover project number and node ID
2. `gh project field-list` — discover field node IDs and single-select option node IDs
3. `gh project item-list` — find the item ID for a specific issue/PR
4. `gh project item-edit` — update using correct `--project-id`, `--field-id`, and `--single-select-option-id` flags

## Notes

- PR #248 is also open touching this file (refactoring the prompt). This PR targets a **separate bug fix** on a separate branch to avoid conflict.
- The worktree instructions (already on `main`) are preserved unchanged.

## Test plan

- [ ] Verify the changed `gh project item-edit` command uses correct flags
- [ ] Confirm PR #248 can still merge cleanly after this is merged (no conflict — different line range)

Closes #258