### PR TITLE
Enforce actual test execution before PR merge

### DIFF
--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -92,14 +92,15 @@ git branch -d feature/issue-42-my-feature
 - Write a comprehensive PR description including:
   - Summary of changes
   - Key functional patterns used
-  - **"Tests run" section** — not a test plan, not aspirational steps. Record only what you actually executed. Use the PR template format:
+  - **"Tests run" section** — not a test plan, not aspirational steps. Record only what you actually executed. Each checked item must show the exact command AND a brief outcome. Each unchecked item must explain why it was skipped or blocked. No abstract category labels. Use the PR template format:
     ```
     ## Tests run
-    - [x] Unit tests: `uv run pytest tests/unit/` — all pass
-    - [x] Lint: `uv run ruff check .` — clean
-    - [ ] Integration tests — skipped (no live Telegram token available)
+    - [x] `uv run pytest tests/unit/` — 42 passed, 0 failed
+    - [x] `uv run ruff check . && uv run mypy .` — clean, no errors
+    - [ ] `docker compose -f tests/docker/docker-compose.test.yml up install-test` — skipped: Docker not available in this environment
+    - [ ] Live Telegram test — blocked: requires production restart (safe to merge, no behavior change)
 
-    Blocked items needing attention before merge: none
+    **Blocked items needing attention before merge:** none
     ```
   - If any tests could not be run (missing Docker, live token, specific env), you **must**:
     1. Leave them unchecked in the PR with a note: "Couldn't run: [reason] — needs [X] before merge"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,17 +5,16 @@
 
 ## Tests run
 
-Fill this in before opening the PR. Check each item when actually executed. Leave unchecked if not applicable or blocked, and note the reason below.
+Fill this in before opening the PR. Each checked item must show the exact command and a brief outcome. Each unchecked item must explain why it was skipped or blocked. No abstract category labels — just commands and results.
 
-- [ ] Unit tests: `uv run pytest tests/unit/` —
-- [ ] Lint / type check: `uv run ruff check . && uv run mypy .` —
-- [ ] Docker install test: service starts and responds correctly —
-- [ ] Integration tests —
-- [ ] Manual smoke test —
+- [x] `uv run pytest tests/unit/` — 42 passed, 0 failed
+- [x] `uv run ruff check . && uv run mypy .` — clean, no errors
+- [ ] `docker compose -f tests/docker/docker-compose.test.yml up install-test` — skipped: Docker not available in this environment
+- [ ] Live Telegram test — blocked: requires production restart (safe to merge, no behavior change)
 
 **Blocked items needing attention before merge:** none
 
-> If you couldn't run something, write: "Couldn't run: [reason] — needs [X] before merge"
+> If you couldn't run something, write the exact command and: "Couldn't run: [reason] — needs [X] before merge"
 > and flag it in `write_result` so the dispatcher can relay to the user.
 
 ## Functional patterns used


### PR DESCRIPTION
## Summary

- Add `.github/pull_request_template.md` with a "Tests run" section that records what was actually executed, not what should be run in the future
- Strengthen `.claude/agents/functional-engineer.md` to require running tests before opening a PR and to specify how to handle tests that cannot be run

## Tests run

- [x] Manual review of both files against the requirements in #267
- [ ] Automated tests — not applicable (documentation/config changes only)

Blocked items needing attention before merge: none

## Functional patterns used

N/A — documentation and configuration changes only.

## Breaking changes / migration notes

The PR template changes the expected format for all future PRs. Existing open PRs are not affected. Engineers should fill in the "Tests run" section with actual outcomes going forward.

Closes #267