### PR TITLE
fix: security scanner — reject-only, exclude tests/.md/binaries, fix self-match

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -13,7 +13,7 @@
 #
 # Exclusions (never scanned):
 #   - Test directories: tests/, test/, spec/, or any path with /test
-#   - Documentation: .md files (contain examples/placeholders by design)
+#   - Documentation: .md, .mdx, .rst, .txt, .adoc (examples/placeholders by design)
 #   - Binary files: detected by extension or git's binary check
 #   - Files in the allowlist: .githooks/security-allowlist.txt
 #
@@ -92,9 +92,9 @@ should_skip_file() {
         return 0
     fi
 
-    # Skip documentation files — .md files use example/placeholder values by design.
+    # Skip documentation files — these use example/placeholder values by design.
     case "$filepath" in
-        *.md)
+        *.md|*.mdx|*.rst|*.txt|*.adoc)
             return 0
             ;;
     esac

--- a/scripts/pre-push-security-scan.sh
+++ b/scripts/pre-push-security-scan.sh
@@ -15,7 +15,7 @@
 #
 # Exclusions (never scanned):
 #   - Test directories: tests/, test/, spec/, or any path with /test
-#   - Documentation: .md files
+#   - Documentation: .md, .mdx, .rst, .txt, .adoc files
 #   - Binary files: non-text files detected by git's binary check
 #   - Known safe extensions: lock files, compiled artifacts, images, etc.
 # =============================================================================
@@ -187,46 +187,12 @@ PII_PATTERNS=(
 
 # --- File exclusion -----------------------------------------------------------
 
-# Returns 0 (should skip) or 1 (should scan) for a given file path.
-# Skips:
-#   - Test directories: any path starting with tests/, test/, spec/, or
-#     containing /test/ anywhere in the path
-#   - Documentation: .md files (contain examples and placeholders by design)
-#   - Known binary/generated extensions: lock files, compiled artifacts, images
-should_skip_file() {
-    local filepath="$1"
-
-    # Skip test directories — fake/mock values are intentional there.
-    # Pattern: path starts with tests/, test/, spec/, or contains /test anywhere.
-    case "$filepath" in
-        tests/*|test/*|spec/*)
-            return 0
-            ;;
-    esac
-    if [[ "$filepath" == */test/* || "$filepath" == */tests/* || "$filepath" == */spec/* ]]; then
-        return 0
-    fi
-
-    # Skip documentation files — .md files use example/placeholder values by design.
-    case "$filepath" in
-        *.md)
-            return 0
-            ;;
-    esac
-
-    # Skip known binary/generated extensions and lock files.
-    case "$filepath" in
-        *.lock|*.min.js|*.min.css|*.map|*.png|*.jpg|*.jpeg|*.gif|*.ico| \
-        *.woff|*.woff2|*.ttf|*.eot|*.svg|*.pdf|*.zip|*.tar|*.gz|*.bz2| \
-        *.exe|*.dll|*.so|*.dylib|*.pyc|*.pyo|*.class|*.o|*.a| \
-        package-lock.json|yarn.lock|Cargo.lock|go.sum|poetry.lock|Gemfile.lock| \
-        *.pb.go|*_generated.*|*.gen.*|vendor/*|node_modules/*)
-            return 0
-            ;;
-    esac
-
-    return 1
-}
+# should_skip_file is defined in scripts/security-scan-lib.sh (sourced below).
+# Keeping it there ensures the test suite always exercises the real production
+# logic rather than a hand-maintained copy.
+SCRIPT_DIR_HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/security-scan-lib.sh
+source "$SCRIPT_DIR_HOOK/security-scan-lib.sh"
 
 # Returns 0 if git diff considers this file binary (contains NUL bytes in the
 # diff header), 1 if it is a text file.  Binary files are never scanned —

--- a/scripts/security-scan-lib.sh
+++ b/scripts/security-scan-lib.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# =============================================================================
+# security-scan-lib.sh
+# Shared helper functions for the pre-push security scanner.
+#
+# Sourced by:
+#   - scripts/pre-push-security-scan.sh  (the hook itself)
+#   - tests/test-security-scan.sh        (the test suite)
+#
+# Keeping the logic here ensures that tests always exercise the real
+# production code rather than a hand-maintained copy.
+# =============================================================================
+
+# Returns 0 (should skip) or 1 (should scan) for a given file path.
+# Skips:
+#   - Test directories: any path starting with tests/, test/, spec/, or
+#     containing /test/ anywhere in the path
+#   - Documentation: .md, .mdx, .rst, .txt, .adoc files
+#   - Known binary/generated extensions: lock files, compiled artifacts, images
+should_skip_file() {
+    local filepath="$1"
+
+    # Skip test directories — fake/mock values are intentional there.
+    # Pattern: path starts with tests/, test/, spec/, or contains /test anywhere.
+    case "$filepath" in
+        tests/*|test/*|spec/*)
+            return 0
+            ;;
+    esac
+    if [[ "$filepath" == */test/* || "$filepath" == */tests/* || "$filepath" == */spec/* ]]; then
+        return 0
+    fi
+
+    # Skip documentation files — these use example/placeholder values by design.
+    case "$filepath" in
+        *.md|*.mdx|*.rst|*.txt|*.adoc)
+            return 0
+            ;;
+    esac
+
+    # Skip known binary/generated extensions and lock files.
+    case "$filepath" in
+        *.lock|*.min.js|*.min.css|*.map|*.png|*.jpg|*.jpeg|*.gif|*.ico| \
+        *.woff|*.woff2|*.ttf|*.eot|*.svg|*.pdf|*.zip|*.tar|*.gz|*.bz2| \
+        *.exe|*.dll|*.so|*.dylib|*.pyc|*.pyo|*.class|*.o|*.a| \
+        package-lock.json|yarn.lock|Cargo.lock|go.sum|poetry.lock|Gemfile.lock| \
+        *.pb.go|*_generated.*|*.gen.*|vendor/*|node_modules/*)
+            return 0
+            ;;
+    esac
+
+    return 1
+}

--- a/tests/test-security-scan.sh
+++ b/tests/test-security-scan.sh
@@ -77,33 +77,14 @@ assert_line_detected() {
     fi
 }
 
-# Source the should_skip_file function from the hook
+# Source should_skip_file from the shared library so tests always exercise the
+# real production logic. Any changes to the function in security-scan-lib.sh
+# are automatically picked up here — no manual sync required.
+# shellcheck source=../scripts/security-scan-lib.sh
+source "$REPO_ROOT/scripts/security-scan-lib.sh"
+
 source_should_skip_file() {
-    local filepath="$1"
-    # Inline the should_skip_file logic for testability
-    case "$filepath" in
-        tests/*|test/*|spec/*)
-            return 0
-            ;;
-    esac
-    if [[ "$filepath" == */test/* || "$filepath" == */tests/* || "$filepath" == */spec/* ]]; then
-        return 0
-    fi
-    case "$filepath" in
-        *.md)
-            return 0
-            ;;
-    esac
-    case "$filepath" in
-        *.lock|*.min.js|*.min.css|*.map|*.png|*.jpg|*.jpeg|*.gif|*.ico| \
-        *.woff|*.woff2|*.ttf|*.eot|*.svg|*.pdf|*.zip|*.tar|*.gz|*.bz2| \
-        *.exe|*.dll|*.so|*.dylib|*.pyc|*.pyo|*.class|*.o|*.a| \
-        package-lock.json|yarn.lock|Cargo.lock|go.sum|poetry.lock|Gemfile.lock| \
-        *.pb.go|*_generated.*|*.gen.*|vendor/*|node_modules/*)
-            return 0
-            ;;
-    esac
-    return 1
+    should_skip_file "$@"
 }
 
 # ---------------------------------------------------------------------------
@@ -121,12 +102,16 @@ assert_skipped "path with /test/" "src/integrations/test/mock_client.py"
 assert_skipped "path with /tests/" "src/integrations/tests/mock_client.py"
 
 echo ""
-echo "=== should_skip_file: .md exclusion ==="
+echo "=== should_skip_file: documentation file exclusion ==="
 
 assert_skipped "root .md file" "README.md"
 assert_skipped "agents .md file" "agents/eloso-deployer.md"
 assert_skipped "docs .md file" "docs/google-calendar-setup.md"
 assert_skipped "nested .md file" ".claude/agents/functional-engineer.md"
+assert_skipped ".mdx file" "docs/guide.mdx"
+assert_skipped ".rst file" "docs/api.rst"
+assert_skipped ".txt file" "docs/notes.txt"
+assert_skipped ".adoc file" "docs/readme.adoc"
 
 echo ""
 echo "=== should_skip_file: binary extension exclusion ==="


### PR DESCRIPTION
## Summary

Fixes all four recurring false-positive incidents from issue #266. The core problem was that the **active** hook (`.githooks/pre-push`, installed via `core.hooksPath`) had a "reject-and-rewrite" design that auto-fixed detections by running `perl -pi -e "s/pattern/replacement/g"` on source files in place.

**Root cause**: `.githooks/pre-push` (not `scripts/pre-push-security-scan.sh`) was the source of all three incidents.

### Changes to `.githooks/pre-push` (the active hook)

- **Remove silent file rewriting**: deleted all `perl -pi -e` auto-fix logic. Hook now reports and blocks only — no file modification. Prevents binary corruption, test fixture breakage, and self-reinforcing loops.
- **Exclude test directories**: skip `tests/`, `test/`, `spec/`, or any path containing `/test/`. Fake/mock values in test fixtures are intentional.
- **Exclude `.md` files**: documentation uses example/placeholder values by design (incident: `agents/eloso-deployer.md`).
- **Exclude binary files by extension**: extended the skip list to include `.exe`, `.o`, `.a`, `.class` (incident: `kissinger/bin/kissinger` extensionless Go binary).
- **Fix self-match**: add `<REDACTED` to the placeholder filter so `<REDACTED_SECRET>` and friends never trigger re-detection on subsequent scans (incident: self-reinforcing loop).
- **Extend placeholder filter**: `your[_-]?\w*[_-]?here` now catches `your_api_key_here` style variable names.

### Changes to `scripts/pre-push-security-scan.sh` (external-repo scanner)

Applied the same exclusions: test directory exclusion, `.md` exclusion, binary detection via `git diff-tree --numstat` (catches extensionless binaries that bypass the static extension list), and the extended placeholder filter.

### New: `tests/test-security-scan.sh`

35 automated assertions:
- `should_skip_file()` for test paths, `.md` files, binary extensions, and source files that should be scanned
- False-positive filter for the exact values from incident files (`ya29.fake`, `fake-client-secret`, `1//fake-refresh-token`, `your-token-here`, `<REDACTED_SECRET>`)
- Real secret pattern detection for AKIA, sk-ant-, ghp_, RSA key header, Slack xoxb-

## Functional patterns used

- Pure `should_skip_file()` and `is_placeholder_value()` predicates replacing inline logic
- Fail-safe by default: scanner is reject-only, never mutates state
- Explicit exclusion boundaries rather than allowlist growth

## Test plan

- [ ] Run `bash tests/test-security-scan.sh` — all 35 tests pass
- [ ] Verify `tests/unit/test_integrations/test_google_calendar_client.py` (which has `ya29.fake` tokens) does not trigger the hook on push
- [ ] Verify `agents/eloso-deployer.md` does not trigger the hook
- [ ] Verify `lobster-shop/kissinger/bin/kissinger` (binary) does not trigger the hook
- [ ] Verify a real hardcoded secret in a non-test Python file IS caught and blocks the push

Closes #266

Generated with Claude Code