### PR TITLE
fix: replace bash brace expansion with /bin/sh-compatible mkdir calls

### DIFF
--- a/tests/docker/Dockerfile.integration
+++ b/tests/docker/Dockerfile.integration
@@ -60,8 +60,12 @@ RUN cd /home/testuser/lobster && \
 # Initialize required files
 RUN echo '{"tasks": [], "next_id": 1}' > /home/testuser/messages/tasks.json && \
     mkdir -p /home/testuser/lobster/scheduled-tasks/tasks && \
-    mkdir -p /home/testuser/lobster-workspace/{data,scheduled-jobs/logs,projects} && \
-    mkdir -p /home/testuser/lobster-workspace/memory/{canonical/{people,projects},archive/digests} && \
+    mkdir -p /home/testuser/lobster-workspace/data && \
+    mkdir -p /home/testuser/lobster-workspace/scheduled-jobs/logs && \
+    mkdir -p /home/testuser/lobster-workspace/projects && \
+    mkdir -p /home/testuser/lobster-workspace/memory/canonical/people && \
+    mkdir -p /home/testuser/lobster-workspace/memory/canonical/projects && \
+    mkdir -p /home/testuser/lobster-workspace/memory/archive/digests && \
     echo '{"jobs": {}}' > /home/testuser/lobster-workspace/scheduled-jobs/jobs.json
 
 # Set working directory


### PR DESCRIPTION
## Summary

- `tests/docker/Dockerfile.integration` used brace expansion (`{a,b,c}`) in two `RUN` instructions
- Docker `RUN` runs under `/bin/sh` (dash) by default, which does not support bash brace expansion
- The image build was failing on both affected lines
- Replaced with explicit `mkdir -p` calls that are valid POSIX `/bin/sh` syntax

## Changes

**Before (broken — bash only):**
```dockerfile
mkdir -p /home/testuser/lobster-workspace/{data,scheduled-jobs/logs,projects}
mkdir -p /home/testuser/lobster-workspace/memory/{canonical/{people,projects},archive/digests}
```

**After (/bin/sh compatible):**
```dockerfile
mkdir -p /home/testuser/lobster-workspace/data && \
mkdir -p /home/testuser/lobster-workspace/scheduled-jobs/logs && \
mkdir -p /home/testuser/lobster-workspace/projects && \
mkdir -p /home/testuser/lobster-workspace/memory/canonical/people && \
mkdir -p /home/testuser/lobster-workspace/memory/canonical/projects && \
mkdir -p /home/testuser/lobster-workspace/memory/archive/digests
```

The resulting directory structure is identical — this is a pure syntax fix with no behavioral change.

## Test plan

- [ ] Verify `sh -c 'mkdir -p /tmp/test/data && mkdir -p /tmp/test/scheduled-jobs/logs && mkdir -p /tmp/test/projects'` runs without error under `/bin/sh`
- [ ] Run `docker build -f tests/docker/Dockerfile.integration -t lobster-test-integration .` and confirm it completes without error
- [ ] Run `docker run --rm lobster-test-integration` and confirm tests pass

Closes #272

Generated with [Claude Code](https://claude.com/claude-code)