### PR TITLE
Add remote auth docs and post-update checklist

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -91,8 +91,22 @@ This is what caused the post-compact-enforcement incident.
 
 ---
 
+## Post-Update Checklist (VPS)
+
+After pulling updates on the VPS (`git pull` + `uv pip install -e .`):
+
+1. **Fix file permissions**: `chmod +x scripts/claude-persistent.sh scripts/claude-wrapper.sh`
+   - `git pull` can change file modes (755→644), which silently breaks the tmux launch
+2. **Verify auth**: Test that Claude can authenticate — see `docs/REMOTE-AUTH.md`
+3. **Restart services**: `systemctl restart lobster-claude && lobster restart`
+4. **Verify startup**: `tail -f /home/lobster/lobster-workspace/logs/claude-persistent.log`
+   - Should see `"Starting fresh session (attempt 1)..."` without immediate exit
+
+---
+
 ## Related documentation
 
 - `dispatcher.bootup.md` — runtime behavior and the worktree constraint from the dispatcher's perspective
 - `docs/engineering-lessons-learned.md` — recurring patterns to check during PR review
+- `docs/REMOTE-AUTH.md` — headless OAuth re-authentication for the VPS
 - `CLAUDE.md` — full system architecture and key directories

--- a/docs/REMOTE-AUTH.md
+++ b/docs/REMOTE-AUTH.md
@@ -1,0 +1,174 @@
+# Remote / Headless Authentication
+
+Claude Code uses OAuth tokens that expire periodically. On a headless VPS there is
+no browser to complete the re-authentication flow. If the token expires unnoticed,
+the Claude session crash-loops silently — in one incident, 22,551 restart attempts
+over several weeks went undetected.
+
+This document covers how to re-authenticate and how to detect expired tokens.
+
+---
+
+## Method 1: `claude setup-token` (preferred)
+
+1. SSH to the VPS:
+
+   ```bash
+   ssh root@162.55.60.42
+   ```
+
+2. Run `setup-token` as the lobster user:
+
+   ```bash
+   sudo -u lobster bash -c '
+     export HOME=/home/lobster
+     export PATH=/home/lobster/.local/bin:/usr/local/bin:/usr/bin:/bin
+     claude setup-token
+   '
+   ```
+
+3. The CLI displays an OAuth URL. Copy it and open in **any** browser (your laptop, phone, etc.).
+
+4. Authorize in the browser. You will be redirected to a callback page.
+
+5. The CLI polls `platform.claude.com` automatically using the `state` parameter. Wait up to 30 seconds — it should pick up the code and write credentials.
+
+6. Verify credentials were written:
+
+   ```bash
+   cat /home/lobster/.claude/.credentials.json | python3 -c '
+     import json, sys, datetime
+     d = json.load(sys.stdin)
+     oauth = d.get("claudeAiOauth", {})
+     if oauth.get("accessToken"):
+         exp = datetime.datetime.fromtimestamp(oauth["expiresAt"] / 1000)
+         print(f"OK — token expires {exp}")
+     else:
+         print("MISSING — no token found")
+   '
+   ```
+
+7. Restart the Claude session:
+
+   ```bash
+   systemctl restart lobster-claude
+   ```
+
+---
+
+## Method 2: Transfer credentials from local machine (fallback)
+
+If `setup-token` polling does not pick up the code (network issues, timeout, etc.),
+transfer OAuth credentials from a machine where Claude Code is already authenticated.
+
+1. **On your Mac** — extract credentials from Keychain:
+
+   ```bash
+   security find-generic-password -s "Claude Code-credentials" -w > /tmp/creds.json
+   ```
+
+2. **Transfer to VPS**:
+
+   ```bash
+   scp /tmp/creds.json root@162.55.60.42:/home/lobster/.claude/.credentials.json
+   ```
+
+3. **Fix ownership and permissions**:
+
+   ```bash
+   ssh root@162.55.60.42 "chown lobster:lobster /home/lobster/.claude/.credentials.json && chmod 600 /home/lobster/.claude/.credentials.json"
+   ```
+
+4. **Clean up locally**:
+
+   ```bash
+   rm /tmp/creds.json
+   ```
+
+5. **Restart**:
+
+   ```bash
+   ssh root@162.55.60.42 "systemctl restart lobster-claude"
+   ```
+
+---
+
+## ANTHROPIC_API_KEY conflict
+
+If `ANTHROPIC_API_KEY` is set in the environment, Claude Code uses it **instead of**
+OAuth — even when valid OAuth credentials exist. The `config.env` file sets this
+variable for other Lobster services (MCP server, scheduled tasks).
+
+`claude-persistent.sh` unsets `ANTHROPIC_API_KEY` before launching Claude so OAuth
+is used. If you see "API usage limits" or "Invalid API key" errors in
+`claude-session.log` but the credentials file looks valid, check whether the env
+var is leaking through.
+
+---
+
+## Detecting expired auth
+
+Signs that authentication has expired:
+
+- **Session log**: `tail /home/lobster/lobster-workspace/logs/claude-session.log` shows
+  repeated `"authentication_error"` or `"OAuth token has expired"` messages.
+- **Persistent log**: `tail /home/lobster/lobster-workspace/logs/claude-persistent.log`
+  shows rapid `"Claude exited with code 1"` entries every 5–50 seconds.
+- **Tmux session dead**: `lobster status` shows `lobster-claude` as "running" (systemd
+  thinks it is alive because `RemainAfterExit=yes`) but the tmux session is gone:
+  ```bash
+  sudo -u lobster tmux -L lobster list-sessions
+  # "no server running" = Claude is not running
+  ```
+- **No Telegram responses**: The bot accepts messages but Claude never processes them.
+
+### Check token expiry directly
+
+```bash
+python3 -c '
+  import json, datetime
+  d = json.load(open("/home/lobster/.claude/.credentials.json"))
+  exp = d["claudeAiOauth"]["expiresAt"] / 1000
+  print("Expires:", datetime.datetime.fromtimestamp(exp))
+  print("Status:", "EXPIRED" if exp < datetime.datetime.now().timestamp() else "VALID")
+'
+```
+
+---
+
+## Post-auth checklist
+
+1. **Verify credentials exist**:
+
+   ```bash
+   cat /home/lobster/.claude/.credentials.json | python3 -c '
+     import json, sys
+     d = json.load(sys.stdin)
+     print("OK" if d.get("claudeAiOauth", {}).get("accessToken") else "MISSING")
+   '
+   ```
+
+2. **Test Claude directly**:
+
+   ```bash
+   sudo -u lobster bash -c '
+     export HOME=/home/lobster
+     export PATH=/home/lobster/.local/bin:/usr/local/bin:/usr/bin:/bin
+     claude -p "hi" --max-turns 1 2>&1
+   '
+   ```
+
+3. **Restart the service**:
+
+   ```bash
+   systemctl restart lobster-claude
+   ```
+
+4. **Verify startup** (wait 15–20 seconds for Claude to initialize):
+
+   ```bash
+   tail -5 /home/lobster/lobster-workspace/logs/claude-persistent.log
+   ```
+
+   You should see `"Starting fresh session (attempt 1)..."` without an immediate
+   `"Claude exited with code 1"` on the next line.


### PR DESCRIPTION
## Summary
- New `docs/REMOTE-AUTH.md`: complete guide for re-authenticating Claude Code on the headless VPS (two methods: `setup-token` and credential transfer), detecting expired tokens, and the `ANTHROPIC_API_KEY` override gotcha
- Added post-update checklist to `docs/DEVELOPMENT.md` (file permissions, auth verification, service restart)

## Context
On 2026-03-14, we discovered Claude had been crash-looping for weeks due to an expired OAuth token — 22,551 restart attempts with zero notification. This doc ensures the procedure is documented for future sessions.

Refs #276

## Test plan
- [ ] Verify `docs/REMOTE-AUTH.md` renders correctly on GitHub
- [ ] Verify commands in the doc work on the VPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)