### PR TITLE
Fix: remove 4096-char truncation from validate_send_reply_args

### DIFF
--- a/src/mcp/reliability.py
+++ b/src/mcp/reliability.py
@@ -119,9 +119,12 @@ def validate_send_reply_args(args: dict) -> dict:
     # text: required, non-empty, reasonable length
     if not text or not text.strip():
         raise ValidationError("text is required and cannot be empty")
-    if len(text) > 4096:
-        # Telegram max message length is 4096 chars
-        text = text[:4093] + "..."
+    # Sanity cap only — do NOT truncate at Telegram's per-message limit here.
+    # The bot's _prepare_send_items() pipeline handles splitting long messages
+    # into multiple chunks before they reach the Telegram API. Truncating here
+    # silently drops content for messages between 4096 and ~12000 chars.
+    if len(text) > 100_000:
+        text = text[:99_997] + "..."
 
     # source: must be a known source
     valid_sources = {"telegram", "slack", "sms", "signal", "whatsapp", "bisque"}

--- a/tests/unit/test_reliability.py
+++ b/tests/unit/test_reliability.py
@@ -144,11 +144,22 @@ class TestValidateSendReplyArgs:
         with pytest.raises(ValidationError, match="Invalid source"):
             validate_send_reply_args({"chat_id": 123, "text": "Hi", "source": "carrier_pigeon"})
 
-    def test_truncates_long_text(self):
-        """Text longer than 4096 chars is truncated."""
+    def test_does_not_truncate_below_sanity_cap(self):
+        """Text longer than 4096 chars is NOT truncated — chunking handles it.
+
+        The 4096-char Telegram limit applies per API call, but the bot's
+        _prepare_send_items() pipeline splits long messages into multiple
+        chunks before sending. Truncating here would silently drop content.
+        """
         long_text = "x" * 5000
         result = validate_send_reply_args({"chat_id": 123, "text": long_text})
-        assert len(result["text"]) == 4096
+        assert len(result["text"]) == 5000
+
+    def test_truncates_at_sanity_cap(self):
+        """Text exceeding the 100,000-char sanity cap is truncated."""
+        huge_text = "x" * 110_000
+        result = validate_send_reply_args({"chat_id": 123, "text": huge_text})
+        assert len(result["text"]) == 100_000
         assert result["text"].endswith("...")
 
     def test_float_chat_id_converted(self):


### PR DESCRIPTION
## Summary

- Removes the 4096-character hard truncation from `validate_send_reply_args` in `src/mcp/reliability.py`
- Replaces it with a 100,000-char sanity cap to guard against truly runaway inputs
- The bot's `_prepare_send_items()` two-pass chunking pipeline already handles splitting long messages correctly — the validation layer was silently dropping content before it ever reached the chunker

## Root Cause

`validate_send_reply_args` was treating 4096 as the maximum allowed message length. While 4096 is Telegram's per-message API limit, Lobster's bot layer handles splitting via `_prepare_send_items()`. Any message between ~4097 and ~12000 chars was silently truncated with `...` instead of being split into two or three clean chunks.

## Changes

- `src/mcp/reliability.py`: Replace `> 4096` truncation with `> 100_000` sanity cap; improve comment to explain why
- `tests/unit/test_reliability.py`: Replace `test_truncates_long_text` with two tests:
  - `test_does_not_truncate_below_sanity_cap` — 5000-char message passes through intact
  - `test_truncates_at_sanity_cap` — 110,000-char message is truncated at 100,000

## Testing

All 33 unit tests pass.

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)