### PR TITLE
fix: coerce string message_ts to datetime in observe_message()

### DIFF
--- a/src/mcp/user_model/observation.py
+++ b/src/mcp/user_model/observation.py
@@ -236,6 +236,11 @@ def observe_message(
     - previous_topic: topic of previous message (for topic shift detection)
     - previous_message_ts: timestamp of previous message (for follow-up detection)
     """
+    if isinstance(message_ts, str):
+        try:
+            message_ts = datetime.fromisoformat(message_ts)
+        except (ValueError, TypeError):
+            message_ts = None
     ts = message_ts or datetime.utcnow()
     reply_length = len(message_text)
     signals = extract_signals(message_text, message_id, context, metadata)


### PR DESCRIPTION
## Summary

- `observe_message()` received ISO string timestamps from `_queue_observation()` but passed them directly to `extract_timing_signal()` which called `.hour`, raising `AttributeError`
- The bare `except Exception: return []` in the caller silently swallowed the error, so zero observations were written for every user message
- Fix adds `isinstance(message_ts, str)` coercion via `datetime.fromisoformat()` before the timestamp is first used, with a safe fallback to `None` (which then falls back to `datetime.utcnow()`)

## Key change

In `observe_message()` (line 239), before `ts = message_ts or datetime.utcnow()`:

```python
if isinstance(message_ts, str):
    try:
        message_ts = datetime.fromisoformat(message_ts)
    except (ValueError, TypeError):
        message_ts = None
```

## Test plan

- [ ] Confirm `observe_message()` no longer raises when called with an ISO string timestamp
- [ ] Confirm observations are written to the DB after the fix
- [ ] Confirm fallback to `datetime.utcnow()` when an unparseable string is passed

Closes #292

Generated with [Claude Code](https://claude.com/claude-code)