### PR TITLE
fix: remove -nt flag from whisper.cpp to prevent segment collapse (#298)

### DIFF
--- a/src/transcription/worker.py
+++ b/src/transcription/worker.py
@@ -191,7 +191,11 @@ async def run_whisper_cpp(audio_path: Path, timeout_s: int = TRANSCRIPTION_TIMEO
         "-m", str(WHISPER_MODEL_PATH),
         "-f", str(audio_path),
         "-l", "en",
-        "-nt",          # no timestamps in output
+        # NOTE: do NOT pass -nt / --no-timestamps here.
+        # With that flag, whisper.cpp collapses all segments and only emits the
+        # last one, silently truncating long audio.  We let whisper output the
+        # default "[HH:MM:SS.mmm --> HH:MM:SS.mmm]  text" format; the
+        # post-processing below strips timestamp lines to produce clean text.
         "--no-prints",  # suppress progress noise
     ]
 


### PR DESCRIPTION
## Summary

- Removes the \`-nt\` / \`--no-timestamps\` flag from the \`run_whisper_cpp\` invocation in \`src/transcription/worker.py\`
- This flag causes whisper.cpp to collapse all audio segments and emit only the last one, silently truncating long voice messages
- The existing post-processing already strips timestamp lines, so the final transcription remains clean plain text — no other changes needed

## Root Cause

When \`-nt\` is passed, whisper.cpp does not accumulate segments — each segment overwrites the previous output, so only the tail is captured on stdout. Removing the flag lets whisper use its default \`[HH:MM:SS.mmm --> HH:MM:SS.mmm]  text\` format, which the worker already strips in post-processing.

## Test Results

Tested against the 45-second OGG file \`1773501940135_5873.ogg\`:

**Before (with \`-nt\`):** \`Art Presentation is\`

**After (without \`-nt\`):** \`Alright, I'm also here with Lionel Hagenbotham and I want you to do something similar...\` (full 45-second transcription)

## Functional Patterns

Minimal, pure change — removes a flag that produces incorrect behaviour. No new state, no side effects introduced.

Closes #298