### PR TITLE
feat: wire tracker.py into MCP layer with register_agent/unregister_agent tools

### DIFF
--- a/.claude/dispatcher.bootup.md
+++ b/.claude/dispatcher.bootup.md
@@ -46,10 +46,36 @@ You are a **stateless dispatcher**. Your ONLY job on the main thread is to read 
 **How to delegate:**
 ```
 1. send_reply(chat_id, "On it — I'll report back shortly.")
-2. Task(prompt="...", subagent_type="general-purpose", run_in_background=true)
-3. mark_processed(message_id)
-4. Return to wait_for_messages() IMMEDIATELY
+2. task_result = Task(prompt="...", subagent_type="general-purpose", run_in_background=true)
+3. agent_id = extract agentId from task_result text (look for "agentId: <id>")
+4. register_agent(agent_id=agent_id, description="Brief what/why + chat_id", chat_id=chat_id)
+5. mark_processed(message_id)
+6. Return to wait_for_messages() IMMEDIATELY
 ```
+
+**Closing the loop when write_result arrives:**
+```
+When wait_for_messages() returns a subagent_result/subagent_error:
+1. mark_processing(message_id)
+2. agent_id = msg.get("task_id")   # subagents pass task_id = agent_id by convention
+3. unregister_agent(agent_id=agent_id)   # remove from pending tracker
+4. ... forward or drop based on forward field as usual ...
+5. mark_processed(message_id)
+```
+
+**Agent tracking — why it matters:**
+
+`register_agent` / `unregister_agent` write to `~/messages/config/pending-agents.json` via `tracker.py`. This JSON file is the single source of truth for in-flight agents. It survives dispatcher restarts and context compactions, so you can always answer "what agents are running?" even after a crash. Without it, any compaction leaves a blind spot where you cannot distinguish agents that completed silently from agents that are still running.
+
+**Extracting the agentId from a Task result:**
+
+The Task tool returns text containing "agentId: <uuid>". Parse it with a simple search:
+```python
+import re
+match = re.search(r'agentId[:\s]+([a-f0-9\-]{8,})', task_result or "", re.IGNORECASE)
+agent_id = match.group(1) if match else f"agent-{int(time.time())}"
+```
+If the pattern does not match, fall back to a synthetic timestamp-based ID — the record is still useful for human review even without the real agent UUID.
 
 **Why this matters:**
 - If you spend even 60 seconds on a task, new messages pile up unanswered

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -49,6 +49,9 @@ from reliability import (
 # Self-update system
 from update_manager import UpdateManager
 
+# Pending agent tracker
+from agents.tracker import add_pending_agent as _add_pending_agent, remove_pending_agent as _remove_pending_agent
+
 # Skill management system
 from skill_manager import (
     list_available_skills as _list_available_skills,
@@ -1148,6 +1151,64 @@ async def list_tools() -> list[Tool]:
                 "required": ["chat_id", "text", "category"],
             },
         ),
+        # Pending Agent Tracker Tools
+        Tool(
+            name="register_agent",
+            description=(
+                "Record a newly-spawned background agent in the pending-agents tracker. "
+                "Call this immediately after spawning a Task, passing the agent_id extracted "
+                "from the Task tool result text and a human-readable description of what the "
+                "agent is doing. This creates a durable record that survives dispatcher restarts "
+                "and compactions, so in-flight agents are never silently lost."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "string",
+                        "description": (
+                            "Unique identifier for the agent task. Extract from the Task tool "
+                            "result text (looks like 'agentId: abc123...'). If the ID cannot be "
+                            "parsed, use a synthetic ID derived from task context."
+                        ),
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": (
+                            "Human-readable summary of what the agent is doing. Include enough "
+                            "context so Lobster can relay results correctly after a restart "
+                            "(e.g. 'Implement feature X on issue #42 for chat 1234567890')."
+                        ),
+                    },
+                    "chat_id": {
+                        "oneOf": [
+                            {"type": "integer"},
+                            {"type": "string"},
+                        ],
+                        "description": "Telegram/Slack chat_id to notify when the agent completes.",
+                    },
+                },
+                "required": ["agent_id", "description", "chat_id"],
+            },
+        ),
+        Tool(
+            name="unregister_agent",
+            description=(
+                "Remove a completed or failed agent from the pending-agents tracker. "
+                "Call this when a write_result arrives from a background agent to mark it done. "
+                "Idempotent: removing a non-existent ID is a no-op."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "string",
+                        "description": "The agent_id that was passed to register_agent when the task was spawned.",
+                    },
+                },
+                "required": ["agent_id"],
+            },
+        ),
         # Brain Dump Triage Tools
         Tool(
             name="triage_brain_dump",
@@ -1777,6 +1838,11 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[TextConte
         return await handle_write_result(arguments)
     elif name == "write_observation":
         return await handle_write_observation(arguments)
+    # Pending Agent Tracker Tools
+    elif name == "register_agent":
+        return await handle_register_agent(arguments)
+    elif name == "unregister_agent":
+        return await handle_unregister_agent(arguments)
     # Brain Dump Triage Tools
     elif name == "triage_brain_dump":
         return await handle_triage_brain_dump(arguments)
@@ -3730,6 +3796,71 @@ async def handle_write_observation(args: dict) -> list[TextContent]:
     return [TextContent(
         type="text",
         text=f"Observation queued (id={message_id}, category={category}). The dispatcher will route it.",
+    )]
+
+
+# =============================================================================
+# Pending Agent Tracker Handlers
+# =============================================================================
+
+
+async def handle_register_agent(args: dict) -> list[TextContent]:
+    """Record a newly-spawned background agent in the pending-agents tracker.
+
+    Delegates to tracker.add_pending_agent(), which atomically writes to
+    ~/messages/config/pending-agents.json under a file lock. Records survive
+    dispatcher restarts and context compactions.
+    """
+    agent_id = args.get("agent_id", "").strip()
+    description = args.get("description", "").strip()
+    chat_id = args.get("chat_id")
+
+    if not agent_id:
+        return [TextContent(type="text", text="Error: agent_id is required")]
+    if not description:
+        return [TextContent(type="text", text="Error: description is required")]
+    if chat_id is None:
+        return [TextContent(type="text", text="Error: chat_id is required")]
+
+    # Normalise chat_id to int when possible (tracker stores it as int)
+    try:
+        chat_id_int = int(chat_id)
+    except (TypeError, ValueError):
+        chat_id_int = chat_id  # type: ignore[assignment]
+
+    try:
+        _add_pending_agent(agent_id=agent_id, description=description, chat_id=chat_id_int)
+    except Exception as exc:
+        log.error(f"register_agent failed: {exc}", exc_info=True)
+        return [TextContent(type="text", text=f"Error recording agent: {exc}")]
+
+    log.info(f"Registered pending agent: agent_id={agent_id!r} chat_id={chat_id_int}")
+    return [TextContent(
+        type="text",
+        text=f"Agent registered: {agent_id!r} — {description}",
+    )]
+
+
+async def handle_unregister_agent(args: dict) -> list[TextContent]:
+    """Remove a completed or failed agent from the pending-agents tracker.
+
+    Idempotent: removing an agent_id that does not exist is a no-op.
+    """
+    agent_id = args.get("agent_id", "").strip()
+
+    if not agent_id:
+        return [TextContent(type="text", text="Error: agent_id is required")]
+
+    try:
+        _remove_pending_agent(agent_id=agent_id)
+    except Exception as exc:
+        log.error(f"unregister_agent failed: {exc}", exc_info=True)
+        return [TextContent(type="text", text=f"Error removing agent: {exc}")]
+
+    log.info(f"Unregistered pending agent: agent_id={agent_id!r}")
+    return [TextContent(
+        type="text",
+        text=f"Agent unregistered: {agent_id!r}",
     )]
 
 


### PR DESCRIPTION
## Summary

`tracker.py` has been fully implemented but was never imported or called anywhere. This PR wires it up end-to-end via two new MCP tools and documents the usage pattern in the dispatcher.

- **`register_agent(agent_id, description, chat_id)`** — new MCP tool that calls `tracker.add_pending_agent()`. The dispatcher calls this immediately after `Task()` to durably record the in-flight agent in `~/messages/config/pending-agents.json`.
- **`unregister_agent(agent_id)`** — new MCP tool that calls `tracker.remove_pending_agent()`. The dispatcher calls this when a `subagent_result` or `subagent_error` arrives to close the lifecycle record.
- **`dispatcher.bootup.md`** — updated to document the full delegate-and-track pattern, including how to extract the `agentId` from the Task tool result text and the reciprocal unregister step when `write_result` lands.

## Key design choices

- The MCP layer wraps the tracker's pure-functional API (atomic writes, file locking, immutable records) so the dispatcher never touches the file directly.
- Import is via `from agents.tracker import ...` — safe because `_SRC_DIR` (`src/`) is already on `sys.path` in `inbox_server.py`.
- `chat_id` is coerced to `int` when possible, matching the tracker's expected type.
- Both handlers are idempotent on the happy path: `register_agent` deduplicates by ID, `unregister_agent` is a no-op if the ID is absent.

## Testing approach

- Python syntax check passes (`ast.parse`).
- Dispatching logic follows the identical pattern to every other handler in `_dispatch_tool`.
- The underlying tracker functions are pure and have their own atomic-write guarantees (temp-file rename + `fcntl.flock`).

Closes #299
Relates to #295