### PR TITLE
docs: enforce forward=False when send_reply is called directly

### DIFF
--- a/.claude/subagent.bootup.md
+++ b/.claude/subagent.bootup.md
@@ -63,6 +63,16 @@ mcp__lobster-inbox__write_result(
 )
 ```
 
+**CRITICAL: If you called `send_reply` directly at any point, you MUST pass `forward=False` to `write_result`:**
+
+```python
+mcp__lobster-inbox__write_result(
+    task_id=..., chat_id=..., text=..., forward=False
+)
+```
+
+Failing to pass `forward=False` causes duplicate messages — the dispatcher will forward your `write_result` on top of the `send_reply` you already sent.
+
 **Why two steps?** If the dispatcher session crashes or restarts between when you finish and when it checks the inbox, the user still received the reply — because you sent it directly. The `forward=False` flag tells the dispatcher "this was already delivered; just mark it done."
 
 **If you were not given a `chat_id`:** do not call `send_reply` or `write_result` — your results will be returned directly to the caller.


### PR DESCRIPTION
## Summary

- Adds a prominent `CRITICAL` warning block to `.claude/subagent.bootup.md` immediately after the two-step send_reply/write_result pattern
- The warning explicitly states the consequence of omitting `forward=False`: duplicate messages delivered to the user
- Previously `forward=False` was only visible as a code comment (`# REQUIRED — you already sent via send_reply above`), making it easy to overlook

Closes #304

## What changed

The new block appears directly after the two-step code pattern:

```
**CRITICAL: If you called `send_reply` directly at any point, you MUST pass `forward=False` to `write_result`:**
...
Failing to pass `forward=False` causes duplicate messages — the dispatcher will forward your `write_result` on top of the `send_reply` you already sent.
```

## Tests run

- [x] Manual diff review — 10-line addition, no regressions, correct placement in the doc
- [ ] Runtime behavior test — not applicable; this is a documentation/context file change with no executable code

**Blocked items needing attention before merge:** none