### PR TITLE
fix: skip inbox write when write_result forward=False

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -3917,12 +3917,25 @@ async def handle_write_result(args: dict) -> list[TextContent]:
     if not text:
         return [TextContent(type="text", text="Error: text is required")]
 
+    # If forward=False, the subagent already called send_reply directly and delivery
+    # is complete.  Do not write anything to the inbox — the dispatcher must never
+    # see this result so it cannot accidentally send a duplicate reply.
+    if not forward:
+        log.info(
+            f"write_result: forward=False for task {task_id!r}, skipping inbox write — "
+            f"subagent already delivered directly to chat {chat_id}"
+        )
+        return [TextContent(
+            type="text",
+            text=f"Result acknowledged (forward=False). Subagent delivery already complete for task {task_id!r}.",
+        )]
+
     # Server-side deduplication: if the subagent already called send_reply with the
     # same text to the same chat, suppress the forwarded duplicate regardless of the
     # forward flag passed by the caller.  This prevents the common mistake where a
     # subagent calls send_reply AND write_result without forward=False, causing the
     # dispatcher to deliver the message a second time.
-    if forward and _was_sent_directly(chat_id, text):
+    if _was_sent_directly(chat_id, text):
         log.info(
             f"write_result dedup: suppressing forward for task {task_id!r} — "
             f"identical message already sent directly to chat {chat_id}"


### PR DESCRIPTION
## Summary

- When `write_result(forward=False)` is called, the handler now returns immediately without writing any message to the inbox
- The dispatcher never sees the result, so duplicate delivery to the user is structurally impossible
- The existing text-hash dedup path (PR #307) is preserved for the `forward=True` case where a subagent mistakenly calls `send_reply` without setting `forward=False`

## Root cause

PR #307 added server-side dedup via `~/messages/sent-replies/{hash}` marker files, but the `subagent_result` message was still written to the inbox with `forward=False` in its payload. The dispatcher received it and had to decide at read-time whether to forward — a fragile two-step that could race or be missed. The cleaner fix is to never write to the inbox at all when the subagent has already handled delivery.

## Change

`/home/lobster/lobster/src/mcp/inbox_server.py` — `handle_write_result`:

Added an early-return guard immediately after argument validation:

```python
if not forward:
    log.info(...)
    return [TextContent(type="text", text="Result acknowledged (forward=False). ...")]
```

The remaining dedup check (`_was_sent_directly`) is kept for the `forward=True` path as a safety net.

## Tests run

- [ ] Unit tests — skipped: no unit test suite exists in this repository
- [ ] Live integration test — blocked: requires a running Lobster instance and a live Telegram session; safe to merge as the change is a pure early-return with no side effects on the `forward=True` path

**Blocked items needing attention before merge:** none — the change is isolated and the logic is straightforward.

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)