### PR TITLE
feat: Telegram reply threading (rebased on current main, closes #252)

### DIFF
--- a/.claude/dispatcher.bootup.md
+++ b/.claude/dispatcher.bootup.md
@@ -150,7 +150,8 @@ Check the `forward` field first:
            chat_id=msg["chat_id"],
            text=msg["text"],
            source=msg.get("source", "telegram"),
-           thread_ts=msg.get("thread_ts")   # pass through if present
+           thread_ts=msg.get("thread_ts"),            # Slack thread
+           reply_to_message_id=msg.get("telegram_message_id")  # Telegram threading
        )
        mark_processed(message_id)
 ```
@@ -327,6 +328,13 @@ Message example:
 
 Additional message fields:
 - `thread_ts` — Reply in a thread by passing this as the `thread_ts` parameter to `send_reply` (use the `slack_ts` or `thread_ts` from the original message)
+
+### Telegram-specific
+
+**Chat IDs** are integers.
+
+Additional message fields:
+- `telegram_message_id` — The Telegram message ID of the incoming message. Pass this as `reply_to_message_id` to `send_reply` to visually thread your reply under the user's message. **Always pass this** — it makes Lobster feel responsive and conversational.
 - `is_dm` — Indicates if the message is a direct message
 - `channel_name` — Human-readable channel name
 

--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -29,7 +29,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Optional
 
-from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, ReplyParameters
 from telegram.ext import Application, CommandHandler, MessageHandler, CallbackQueryHandler, filters, ContextTypes
 
 
@@ -714,6 +714,7 @@ async def handle_photo_message(update: Update, context: ContextTypes.DEFAULT_TYP
             "source": "telegram",
             "type": "photo",
             "chat_id": message.chat_id,
+            "telegram_message_id": message.message_id,
             "user_id": user.id,
             "username": user.username,
             "user_name": user.first_name,
@@ -798,6 +799,7 @@ async def handle_document_message(update: Update, context: ContextTypes.DEFAULT_
             "source": "telegram",
             "type": "document",
             "chat_id": message.chat_id,
+            "telegram_message_id": message.message_id,
             "user_id": user.id,
             "username": user.username,
             "user_name": user.first_name,
@@ -872,6 +874,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "id": msg_id,
         "source": "telegram",
         "chat_id": message.chat_id,
+        "telegram_message_id": message.message_id,
         "user_id": user.id,
         "username": user.username,
         "user_name": user.first_name,
@@ -944,6 +947,7 @@ async def handle_audio_message(
             "source": "telegram",
             "type": msg_type,
             "chat_id": message.chat_id,
+            "telegram_message_id": message.message_id,
             "user_id": user.id,
             "username": user.username,
             "user_name": user.first_name,
@@ -1107,6 +1111,7 @@ class OutboxHandler(FileSystemEventHandler):
             reply_type = reply.get('type', 'text')
             photo_url = reply.get('photo_url', '')
             caption = reply.get('caption', '')
+            reply_to_id = reply.get('reply_to_message_id')
 
             # Handle photo messages (from image-generation skill or other sources)
             if reply_type == 'photo' and photo_url and chat_id and bot_app:
@@ -1139,17 +1144,21 @@ class OutboxHandler(FileSystemEventHandler):
 
             if chat_id and text and bot_app:
                 reply_markup = build_inline_keyboard(buttons) if buttons else None
+                reply_params = ReplyParameters(message_id=int(reply_to_id)) if reply_to_id else None
                 send_items = _prepare_send_items(text)
                 n = len(send_items)
                 for i, (md_chunk, html_chunk) in enumerate(send_items):
                     # Only attach inline keyboard to the final chunk
                     chunk_markup = reply_markup if i == n - 1 else None
+                    # Only thread the first chunk; subsequent chunks are continuations
+                    chunk_reply_params = reply_params if i == 0 else None
                     try:
                         await bot_app.bot.send_message(
                             chat_id=chat_id,
                             text=html_chunk,
                             parse_mode="HTML",
-                            reply_markup=chunk_markup
+                            reply_markup=chunk_markup,
+                            reply_parameters=chunk_reply_params,
                         )
                     except Exception as exc:
                         # Fallback to plain text if HTML parsing fails.
@@ -1165,7 +1174,8 @@ class OutboxHandler(FileSystemEventHandler):
                         await bot_app.bot.send_message(
                             chat_id=chat_id,
                             text=plain,
-                            reply_markup=chunk_markup
+                            reply_markup=chunk_markup,
+                            reply_parameters=chunk_reply_params,
                         )
                 if n > 1:
                     log.info(f"Sent reply to {chat_id} in {n} chunks: {text[:50]}...")

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -805,6 +805,10 @@ async def list_tools() -> list[Tool]:
                             }
                         }
                     },
+                    "reply_to_message_id": {
+                        "type": "integer",
+                        "description": "Telegram message ID to reply to. If provided, the bot sends the reply as a threaded reply to that specific message (Telegram only). Pass the telegram_message_id from the incoming message.",
+                    },
                     "message_id": {
                         "type": "string",
                         "description": "If provided, atomically marks this message as processed after sending the reply. Combines send_reply + mark_processed into one call.",
@@ -2325,6 +2329,9 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
         else:
             output += f"**[{source}]** from **{user}**\n"
         output += f"Chat ID: `{chat_id}` | Message ID: `{msg_id}`\n"
+        tg_msg_id = msg.get("telegram_message_id")
+        if tg_msg_id:
+            output += f"Telegram Message ID: `{tg_msg_id}` (pass as reply_to_message_id to send_reply to thread your reply)\n"
         output += f"Time: {ts}\n"
         # dispatcher_hint: flag messages with file attachments so dispatcher knows to use a subagent
         _has_file = msg_type in ("voice", "photo", "document") or bool(
@@ -2409,6 +2416,11 @@ async def handle_send_reply(args: dict) -> list[TextContent]:
     # Include thread_ts if provided (Slack only)
     if thread_ts and source == "slack":
         reply_data["thread_ts"] = thread_ts
+
+    # Include reply_to_message_id if provided (Telegram only)
+    reply_to_msg_id = args.get("reply_to_message_id")
+    if reply_to_msg_id and source == "telegram":
+        reply_data["reply_to_message_id"] = int(reply_to_msg_id)
 
     # Route bisque replies to the bisque-outbox so the relay server picks them up.
     # All other sources go to the standard outbox for the bot process.


### PR DESCRIPTION
## Summary

Closes #252. Supersedes #254 (which had a merge conflict due to photo handling being added to main separately).

This is a clean rebase of the threading feature on current main (7c8820e), applying only the threading-specific changes:

- **`src/bot/lobster_bot.py`**: Add `telegram_message_id: message.message_id` to all 4 incoming message handlers (text, photo, document, audio/voice). Add `ReplyParameters` import. Read `reply_to_message_id` from outbox JSON and pass as `ReplyParameters` to `send_message`. Only thread the first chunk of multi-chunk messages — subsequent chunks are plain continuations.
- **`src/mcp/inbox_server.py`**: Surface `telegram_message_id` in check_inbox display with a hint to pass it as `reply_to_message_id`. Add `reply_to_message_id` to `send_reply` inputSchema. Pass `reply_to_message_id` through to outbox JSON in `handle_send_reply` (Telegram only, no-op for other sources).
- **`.claude/dispatcher.bootup.md`**: Document `telegram_message_id` field and instruct dispatcher to always pass it as `reply_to_message_id` to `send_reply`. Add Telegram-specific section mirroring Slack-specific section.

### Why this supersedes #254

PR #254 was based on an older commit that didn't include the send_photo support added later. This causes a merge conflict. Rather than resolving that conflict, this PR applies only the threading-specific diffs to the current main, resulting in a clean, conflict-free implementation.

## Test plan

- [ ] Send a Telegram message to Lobster
- [ ] Confirm `telegram_message_id` appears in the check_inbox output
- [ ] Call `send_reply` with `reply_to_message_id` set to that value
- [ ] Verify the bot's outgoing message in Telegram shows "Replied to" UI
- [ ] Verify multi-chunk messages only thread the first chunk
- [ ] Verify existing photo/audio/document messages still work correctly

## Breaking changes

None. `reply_to_message_id` is optional everywhere — all existing callers continue to work without modification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)