### PR TITLE
fix: log Telegram notify failures in on-compact.py to stderr

### DIFF
--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -19,6 +19,7 @@ check can suppress stale-inbox false-positives during the compaction pause.
 
 import json
 import os
+import sys
 import time
 import urllib.request
 from pathlib import Path
@@ -171,7 +172,8 @@ def _is_debug_mode(config: dict) -> bool:
 def _send_telegram_dev_notify(bot_token: str, chat_id: str) -> None:
     """
     Send DEV_TELEGRAM_MESSAGE to chat_id via the Telegram Bot API.
-    Silent on any failure — must never crash the hook.
+    Logs to stderr on failure so the cause is visible in Claude hook output.
+    Never raises — must not crash the hook.
     """
     try:
         url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
@@ -182,10 +184,25 @@ def _send_telegram_dev_notify(bot_token: str, chat_id: str) -> None:
             headers={"Content-Type": "application/json"},
             method="POST",
         )
-        with urllib.request.urlopen(req, timeout=5):
-            pass
-    except Exception:  # noqa: BLE001
-        pass
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            status = resp.status
+            if status != 200:
+                body = resp.read(500).decode("utf-8", errors="replace")
+                print(
+                    f"[on-compact] Telegram notify returned HTTP {status}: {body}",
+                    file=sys.stderr,
+                )
+    except urllib.request.HTTPError as e:  # noqa: BLE001
+        try:
+            body = e.read(500).decode("utf-8", errors="replace")
+        except Exception:
+            body = "(could not read body)"
+        print(
+            f"[on-compact] Telegram notify HTTP error {e.code}: {body}",
+            file=sys.stderr,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[on-compact] Telegram notify failed: {type(exc).__name__}: {exc}", file=sys.stderr)
 
 
 def maybe_send_dev_telegram_notify() -> None:


### PR DESCRIPTION
## Summary

- Compaction Telegram notifications were failing silently — `except Exception: pass` swallowed all errors
- Added stderr logging for HTTP errors, non-200 responses, and general exceptions so failures are visible in Claude hook output
- Handles `urllib.request.HTTPError` separately to capture and log the response body

Closes #331

## Root cause analysis

The `_send_telegram_dev_notify` function in `on-compact.py` had a bare `except Exception: pass` that hid all failures. The most likely causes are network timeout, bot token expiry, or Telegram API rate limiting. Now any failure will appear in the hook's stderr output, which Claude Code surfaces in the tool call result.

## Tests run

- [x] `python3 hooks/on-compact.py` (on main repo) — exits 0, writes compact-reminder to inbox as expected
- [ ] Live Telegram notification test — blocked: manual test would require running with valid token; stderr logging will make the failure visible on next compaction