### PR TITLE
fix: harden require-write-result Stop hook to actually block subagent exit

### DIFF
--- a/hooks/require-write-result.py
+++ b/hooks/require-write-result.py
@@ -34,14 +34,14 @@ def main():
     if "mcp__lobster-inbox__write_result" in tool_calls:
         sys.exit(0)
 
-    # Subagent finished without calling write_result — inject reminder
+    # Subagent finished without calling write_result — block exit
     print(
         "STOP: You must call mcp__lobster-inbox__write_result before finishing. "
         "The dispatcher is waiting for your result. "
         "If the task failed, report the failure — but you must call write_result. "
         "Call it now with your findings, then you may exit."
     )
-    sys.exit(0)  # Exit 0 so the message is injected (not a hard block)
+    sys.exit(2)  # Exit 2 to hard-block the session from terminating
 
 
 if __name__ == "__main__":

--- a/install.sh
+++ b/install.sh
@@ -1259,6 +1259,27 @@ else
     info "Skipping on-compact hook (settings.json not yet created)"
 fi
 
+# Set up Claude Code Stop hook to enforce write_result in subagent sessions
+chmod +x "$INSTALL_DIR/hooks/require-write-result.py" || true
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.Stop[]? | select(.matcher == "")' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq '.hooks.Stop = (.hooks.Stop // []) + [{
+            "matcher": "",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 '"$INSTALL_DIR"'/hooks/require-write-result.py",
+                "timeout": 10
+            }]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "require-write-result Stop hook installed"
+    else
+        info "require-write-result Stop hook already configured in Claude Code settings"
+    fi
+else
+    info "Skipping require-write-result Stop hook (settings.json not yet created)"
+fi
+
 #===============================================================================
 # Python Environment
 #===============================================================================


### PR DESCRIPTION
## What this PR does

This PR hardens the `require-write-result` Stop hook so that subagents that forget to call `write_result` are **hard-blocked from exiting** — not just shown an advisory message they can ignore.

The change is one integer: `sys.exit(0)` → `sys.exit(2)`. The second change adds Stop hook registration to `install.sh` so the hook survives reinstalls.

Closes #337

---

## Background: Lobster's Subagent Contract

Lobster subagents are Claude Code sessions launched as background agents. They are spawned by the dispatcher, do some work, and then exit. The system depends on them signaling completion via a single MCP call:

```
mcp__lobster-inbox__write_result(task_id, chat_id, text, forward, source)
```

This call does two things simultaneously:
1. **Delivers the result** — either to the dispatcher (for forwarding to the user) or directly to the user (if the subagent already called `send_reply`)
2. **Auto-unregisters the agent** from the pending-agents tracker

Without it, the agent disappears silently. The dispatcher has no idea whether the agent succeeded, failed, or is still running. Ghost agents accumulate in the tracker.

---

## The Two MCP Calls and What They Signal

| MCP call | Who calls it | What it means |
|---|---|---|
| `mcp__lobster-inbox__write_result` | Subagents (mandatory) | "I am done. Here is my result." |
| `mcp__lobster-inbox__wait_for_messages` | Dispatcher only | "I am the main loop, blocking for the next message." |

The presence of `wait_for_messages` in a transcript is the definitive signal that the session is the dispatcher, not a subagent. The dispatcher must never be blocked.

---

## The `forward` Flag: How Results Are Routed

`write_result` takes a `forward` parameter that controls whether the dispatcher sends a reply to the user on the subagent's behalf:

| `forward` value | Result type stored | What the dispatcher does |
|---|---|---|
| `True` (default) | `subagent_result` | Dispatcher forwards `text` to the user via `send_reply` |
| `False` | `subagent_notification` | Subagent already called `send_reply` directly; dispatcher just marks processed |
| (not called at all) | nothing | Subagent went silent — ghost agent, no output, no cleanup |

The `forward=False` pattern is used when a subagent is sending multiple replies during its work (e.g., streaming updates). It calls `send_reply` directly, then calls `write_result(forward=False)` at the end to signal completion without triggering a duplicate message.

---

## Stop Hook Exit Codes

Claude Code Stop hooks receive the session transcript on stdin and can either allow or block termination:

| Exit code | Behavior |
|---|---|
| `0` | Advisory — hook output is shown to the model as context, but exit proceeds |
| `2` | Hard block — Claude Code **will not let the session terminate**; model must act |
| Other non-zero | Also blocks (but `2` is the canonical code per Claude Code docs) |

The previous version used `sys.exit(0)` in the failure branch, which printed a message but allowed the session to exit anyway. The message was advisory — and ignored. This PR changes it to `sys.exit(2)`, which forces the model to call `write_result` before it can exit.

---

## Hook Detection Logic

The hook scans the session transcript for MCP tool calls and applies this decision tree:

```
┌─────────────────────────────────────────────────────────┐
│            require-write-result Stop hook               │
│                                                         │
│  Parse transcript from stdin                            │
│           │                                             │
│           ▼                                             │
│  Extract all tool_use call names                        │
│           │                                             │
│           ▼                                             │
│  wait_for_messages in calls?                            │
│       YES ──────────────────────► exit 0 (dispatcher,  │
│       │                                  never block)   │
│       NO                                                │
│       │                                                 │
│       ▼                                                 │
│  write_result in calls?                                 │
│       YES ──────────────────────► exit 0 (compliant    │
│       │                                  subagent)      │
│       NO                                                │
│       │                                                 │
│       ▼                                                 │
│  Non-compliant subagent                                 │
│  Print: STOP — call write_result                        │
│  exit 2 ────────────────────────► HARD BLOCK            │
│                         (model cannot exit until fixed) │
└─────────────────────────────────────────────────────────┘
```

---

## Three Session Outcomes After This Hook

| Session type | Transcript contains | Hook action | Exit allowed? |
|---|---|---|---|
| Dispatcher | `wait_for_messages` | exit 0 | Yes |
| Compliant subagent | `write_result` | exit 0 | Yes |
| Non-compliant subagent | Neither | exit 2 + print reminder | No — must call `write_result` first |
| Unreadable transcript | (parse error) | exit 0 | Yes (fail-open) |

---

## What Was NOT Changed

- **Detection logic** — transcript scanning for `mcp__lobster-inbox__write_result` and `mcp__lobster-inbox__wait_for_messages` is unchanged and was already correct
- **Dispatcher exclusion** — sessions that called `wait_for_messages` still exit freely
- **Error fallback** — if stdin can't be parsed as JSON, the hook exits 0 (fail-open, no unexpected blocks)
- **The MCP server** — no changes to `inbox_server.py` or the `write_result` protocol itself
- **The hook message text** — the STOP message printed to the model is unchanged

---

## Files Changed

- `hooks/require-write-result.py`: `sys.exit(0)` → `sys.exit(2)` in the non-compliant branch (one line)
- `install.sh`: Add Stop hook registration block (matches the existing pattern for `link-checker`, `require-subagent-type`, and `on-compact` hooks)

---

## Tests

- [x] Manual trace of all four branches (dispatcher / compliant subagent / non-compliant subagent / parse error) — logic verified correct
- [x] `uv run python3 hooks/require-write-result.py <<< '{}'` — exits 2 correctly (empty transcript has no `wait_for_messages` and no `write_result`)
- [ ] Live subagent session test — blocked by environment; requires a running subagent session to trigger the Stop hook. Safe to merge: the logic change is a single integer and all branches are covered by static analysis.