### PR TITLE
fix: pass reply_parameters to send_photo so photo replies are threaded

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -1117,11 +1117,13 @@ class OutboxHandler(FileSystemEventHandler):
             if reply_type == 'photo' and photo_url and chat_id and bot_app:
                 try:
                     caption_html = md_to_html(caption) if caption else None
+                    photo_reply_params = ReplyParameters(message_id=int(reply_to_id)) if reply_to_id else None
                     await bot_app.bot.send_photo(
                         chat_id=chat_id,
                         photo=photo_url,
                         caption=caption_html,
                         parse_mode="HTML" if caption_html else None,
+                        reply_parameters=photo_reply_params,
                     )
                     log.info(f"Sent photo to {chat_id}: {photo_url[:80]}...")
                     os.remove(filepath)


### PR DESCRIPTION
## Summary

Closes #344

- \`send_photo\` in \`lobster_bot.py\` already extracted \`reply_to_id\` from the outbox JSON (line 1114) but never used it — the \`reply_parameters\` kwarg was simply absent from the Telegram Bot API call.
- Text replies via \`send_message\` already threaded correctly using the same \`reply_to_id\` value and \`ReplyParameters\`.
- This change adds two lines: build \`photo_reply_params\` from \`reply_to_id\` (or \`None\` if absent), then pass it as \`reply_parameters=photo_reply_params\` to \`send_photo\`.
- The fallback text path (when \`send_photo\` fails) is left without threading — that path is already a degraded fallback, and adding threading there is a separate concern.

## Key pattern

Matches the existing text-reply pattern exactly:

\`\`\`python
# text (existing):
reply_params = ReplyParameters(message_id=int(reply_to_id)) if reply_to_id else None
await bot_app.bot.send_message(..., reply_parameters=reply_params)

# photo (this PR):
photo_reply_params = ReplyParameters(message_id=int(reply_to_id)) if reply_to_id else None
await bot_app.bot.send_photo(..., reply_parameters=photo_reply_params)
\`\`\`

## Tests run

- [x] \`git diff origin/main\` — single-hunk diff, 2 lines added, no unintended changes
- [ ] Live Telegram photo reply test — blocked: requires production bot restart and a skill that sends photos (e.g. image-generation); no behavior change when \`reply_to_id\` is absent, so safe to merge. The new parameter is only applied when \`reply_to_id\` is present in the outbox JSON.

**Blocked items needing attention before merge:** none — the change is additive and backward-compatible.