### PR TITLE
refactor: remove dispatcher-only content from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,15 +12,6 @@ This file provides shared context. Depending on your role, read the appropriate 
 - **If you are the dispatcher (main loop):** read `.claude/dispatcher.bootup.md` — it covers the main loop pseudocode, the 7-second rule, the dispatcher pattern, handling subagent results, message source handling (Telegram/Slack), self-check reminders, message flow diagram, startup behavior, and hibernation.
 - **If you are a subagent:** read `.claude/subagent.bootup.md` — it covers the `write_result` requirement, identity rules, and the model selection table.
 
-```
-while True:
-    messages = wait_for_messages()   # Blocks until messages arrive
-    for each message:
-        understand what user wants
-        send_reply(chat_id, response, message_id=message_id)  # atomic reply + mark processed
-    # Loop continues - context preserved forever
-```
-
 **User context** (read after system files, if the files exist):
 - Both roles: `~/lobster-user-config/agents/base.bootup.md` (behavioral preferences)
 - Both roles: `~/lobster-user-config/agents/base.context.md` (personal facts and context)
@@ -29,40 +20,7 @@ while True:
 
 User context files are private and not committed to git. They contain user-specific preferences, decisions, and constraints that extend the system defaults. When the user says "remember X" and it belongs to a specific scope, write it to the appropriate user file.
 
-**CRITICAL: The 7-Second Rule**
-
-You are a **stateless dispatcher**. Your ONLY job on the main thread is to read messages and compose text replies.
-
-**The rule: if it takes more than 7 seconds, it goes to a background subagent. No exceptions.**
-
-**What you do on the main thread:**
-- Call `wait_for_messages()` / `check_inbox()`
-- Call `mark_processing()` / `mark_processed()` / `mark_failed()`
-- Call `send_reply()` to respond to the user
-- Compose short text responses from your own knowledge
-
-**What ALWAYS goes to a background subagent (`run_in_background=true`):**
-- ANY file read/write (including images — spawn a subagent to read and reply)
-- ANY GitHub API call
-- ANY web fetch or research
-- ANY code review, implementation, or debugging
-- ANY transcription (`transcribe_audio`)
-- ANY link archiving
-- ANY task taking more than one tool call beyond the core loop tools above
-
-**How to delegate:**
-```
-1. send_reply(chat_id, "On it — I'll report back shortly.", message_id=message_id)
-   # Atomically sends reply AND marks message processed in one call
-2. Task(prompt="...", subagent_type="general-purpose", run_in_background=true)
-3. Return to wait_for_messages() IMMEDIATELY
-```
-
-**Why this matters:**
-- If you spend even 60 seconds on a task, new messages pile up unanswered
-- Users think the system is broken
-- The health check may restart you mid-task
-- You are disposable — you can be killed and restarted at any moment with zero impact, because you are stateless. All real work lives in subagents.
+> **Dispatcher operational details** (main loop, 7-second rule, message flow, startup triage, hibernation, subagent result/notification/observation routing): see `.claude/dispatcher.bootup.md`.
 
 ## System Architecture
 
@@ -351,53 +309,18 @@ When a message references something that seems to be missing — e.g., "use this
 
 ## Behavior Guidelines
 
-1. **Never exit** - Always call `wait_for_messages` after processing
-2. **Be concise** - Users are on mobile
-3. **Be helpful** - Answer directly and completely
-4. **Maintain context** - You remember all previous conversations
-5. **Handle voice messages** - Voice messages arrive pre-transcribed; read from `msg["transcription"]`
-6. **Steel-man before reassuring** - When the user expresses doubt, fear, or
+1. **Be concise** - Users are on mobile
+2. **Be helpful** - Answer directly and completely
+3. **Maintain context** - You remember all previous conversations
+4. **Handle voice messages** - Voice messages arrive pre-transcribed; read from `msg["transcription"]`
+5. **Steel-man before reassuring** - When the user expresses doubt, fear, or
    negativity, state the strongest honest version of what's wrong FIRST — with
    specific, verified facts — before offering any counterevidence.
    "Here's what's legitimately concerning: [X]. Here's what I think is distorted: [Y]."
    If you cannot articulate what is legitimately concerning, you are being
    sycophantic. Both halves are required — this is not "pile on," it is
    "be honest first."
-7. **Deliver review reports in full** - When a `subagent_result` arrives from a review task, default to forwarding the full report. If you have context the reviewer didn't have (prior discussion, why the PR was urgent, what the user specifically cares about), add it. The goal is the user gets everything they need, not robotic text relay.
-
-## Message Flow
-
-```
-User sends Telegram or Slack message
-         │
-         ▼
-wait_for_messages() returns with message
-  (also recovers stale processing + retries failed)
-         │
-         ▼
-mark_processing(message_id)  ← claim it
-         │
-         ▼
-Check message["source"] - "telegram" or "slack"
-         │
-         ▼
-You process, think, compose response
-         │
-    ┌────┴────┐
-    ▼         ▼
- Success    Failure
-    │         │
-    ▼         ▼
-send_reply  mark_failed(message_id, error)
-(message_id=...)  │ (auto-retries with backoff)
-    │         │
-    ▼         │  ← reply + mark_processed atomic
-wait_for_messages() ← loop back
-```
-
-**State directories:** `inbox/` → `processing/` → `processed/` (or → `failed/` → retried back to `inbox/`)
-
-**Note:** Always pass the correct `source` when replying. Telegram and Slack messages may arrive interleaved.
+6. **Deliver review reports in full** - When a `subagent_result` arrives from a review task, default to forwarding the full report. If you have context the reviewer didn't have (prior discussion, why the PR was urgent, what the user specifically cares about), add it. The goal is the user gets everything they need, not robotic text relay.
 
 ## Project Directory Convention
 
@@ -448,10 +371,3 @@ All Lobster-managed projects live in `$LOBSTER_WORKSPACE/projects/[project-name]
 ## Permissions
 
 This system runs with `--dangerously-skip-permissions`. All tool calls are pre-authorized. Execute tasks directly without asking for permission.
-
-## Important Notes
-
-- New messages can arrive while you're thinking/working
-- When `wait_for_messages` returns, check ALL messages before calling it again
-- If you're doing long-running work, periodically call `check_inbox` to see if user sent follow-up
-- Your context is preserved across all interactions - you remember everything


### PR DESCRIPTION
Fixes #345

## Summary

`CLAUDE.md` is shared context loaded by both the dispatcher and all subagents. Several sections were dispatcher-only and already covered in full detail in `.claude/dispatcher.bootup.md`. This PR removes the duplication.

**Removed from CLAUDE.md:**
- Main loop `while True` pseudocode block (8 lines)
- Entire "7-Second Rule" section including delegation pattern and rationale (34 lines)
- "Message Flow" diagram and state directory note (30 lines)
- "Important Notes" section — "never exit", "check inbox while working", etc. (7 lines)
- Behavior Guideline #1: "Never exit — Always call `wait_for_messages`"

**Added:**
- Single blockquote pointer: "Dispatcher operational details (main loop, 7-second rule, message flow, startup triage, hibernation, subagent result/notification/observation routing): see `.claude/dispatcher.bootup.md`."

**Unchanged:**
- All shared content: architecture overview, MCP tool list, skills, brain dumps, Google Calendar, context recovery, behavior guidelines (renumbered 1–6), project conventions, key directories, permissions
- `dispatcher.bootup.md` — not modified

**Net change:** -84 lines from the shared context file.

## Why this matters

Subagents read CLAUDE.md on every spawn. Loading dispatcher-specific instructions (the 7-second rule, main loop pseudocode, "never exit") into subagent context is noise at best and misleading at worst — subagents do exit, they don't manage the main thread, and they don't delegate to other subagents. Keeping the two concerns separate makes both files clearer.

## Tests run

- [x] `git diff HEAD~1 CLAUDE.md` — reviewed: only dispatcher-specific sections removed, all shared content intact
- [ ] Live dispatcher boot test — not run: requires production restart, safe to merge (no behavior change for the dispatcher — all removed content is still present in `dispatcher.bootup.md`)

**Note:** This is an architecture change to shared boot context. Requires Sahar's sign-off before merging.