### PR TITLE
fix: route debug observations directly to Telegram in handle_write_observation

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -4366,18 +4366,19 @@ OBSERVATION_CATEGORIES = frozenset({"user_context", "system_context", "system_er
 
 
 async def handle_write_observation(args: dict) -> list[TextContent]:
-    """Write a subagent observation into the inbox for the dispatcher to route.
+    """Write a subagent observation, routing it server-side based on LOBSTER_DEBUG.
 
     Observations are separate from primary results — they surface things the
-    subagent noticed in passing (user context, system state, errors). The
-    dispatcher routes each observation based on its category:
+    subagent noticed in passing (user context, system state, errors). Routing:
 
-      user_context   → forward to user + act if actionable
-      system_context → store to memory silently (no user message)
-      system_error   → write to observations.log (no user message)
+      user_context   → always written to inbox for dispatcher to forward + act
+      system_context → bypasses inbox when LOBSTER_DEBUG=true (direct Telegram push)
+      system_error   → bypasses inbox when LOBSTER_DEBUG=true (direct Telegram push)
 
-    When LOBSTER_DEBUG=true, all categories are also forwarded to the user
-    with a label like "📎 [Observation: system_context]".
+    When LOBSTER_DEBUG=false (production), system_context and system_error still
+    go through the inbox so the dispatcher can store/log them. In debug mode the
+    inbox round-trip is skipped entirely to ensure observations reach the user
+    regardless of dispatcher routing behavior.
     """
     chat_id = args.get("chat_id")
     text = args.get("text", "").strip()
@@ -4392,6 +4393,25 @@ async def handle_write_observation(args: dict) -> list[TextContent]:
     if category not in OBSERVATION_CATEGORIES:
         valid = ", ".join(sorted(OBSERVATION_CATEGORIES))
         return [TextContent(type="text", text=f"Error: category must be one of: {valid}")]
+
+    # When LOBSTER_DEBUG=true, system_context and system_error observations bypass
+    # the dispatcher inbox and go directly to Telegram. Previously these categories
+    # went through the inbox but the dispatcher silently memory_store'd them instead
+    # of forwarding — so they never appeared in Telegram. Direct delivery fixes this
+    # without relying on dispatcher LLM routing behavior.
+    _resolve_debug_config()
+    if _DEBUG_MODE and category in ("system_context", "system_error"):
+        task_suffix = f" [task={task_id}]" if task_id else ""
+        _emit_debug_observation(f"{text}{task_suffix}", category=category)
+        log.info(
+            f"Subagent observation sent directly to Telegram (debug mode): "
+            f"category={category} chat_id={chat_id}"
+            + (f" task_id={task_id}" if task_id else "")
+        )
+        return [TextContent(
+            type="text",
+            text=f"Observation delivered directly to Telegram (debug mode, category={category}).",
+        )]
 
     now = datetime.now(timezone.utc)
     ts_ms = int(now.timestamp() * 1000)
@@ -4411,6 +4431,12 @@ async def handle_write_observation(args: dict) -> list[TextContent]:
 
     inbox_file = INBOX_DIR / f"{message_id}.json"
     atomic_write_json(inbox_file, message)
+
+    # When LOBSTER_DEBUG=true and category is user_context, also emit a direct
+    # Telegram push so the user sees it immediately alongside the inbox copy.
+    if _DEBUG_MODE and category == "user_context":
+        task_suffix = f" [task={task_id}]" if task_id else ""
+        _emit_debug_observation(f"{text}{task_suffix}", category=category)
 
     log.info(
         f"Subagent observation queued in inbox: category={category} chat_id={chat_id}"

--- a/tests/unit/test_mcp_server/test_write_observation.py
+++ b/tests/unit/test_mcp_server/test_write_observation.py
@@ -34,9 +34,13 @@ class TestHandleWriteObservation:
     def _run(self, args: dict, inbox_dir: Path) -> list:
         # Import inside the patch block, matching the pattern used throughout
         # the existing MCP server test suite.
+        # Always mock _DEBUG_MODE=False/_DEBUG_RESOLVED=True so tests that
+        # expect inbox writes are not affected by the host LOBSTER_DEBUG setting.
         with patch.multiple(
             "src.mcp.inbox_server",
             INBOX_DIR=inbox_dir,
+            _DEBUG_MODE=False,
+            _DEBUG_RESOLVED=True,
         ):
             from src.mcp.inbox_server import handle_write_observation
             return asyncio.run(handle_write_observation(args))
@@ -350,3 +354,144 @@ class TestHandleWriteObservation:
         assert "Observation queued" in result[0].text
         files = list(inbox_dir.glob("*.json"))
         assert len(files) == 1
+
+    # ------------------------------------------------------------------
+    # Debug mode: automatic routing (LOBSTER_DEBUG=true)
+    # ------------------------------------------------------------------
+
+    def test_system_context_bypasses_inbox_in_debug_mode(self, inbox_dir: Path):
+        """system_context observations bypass the inbox when LOBSTER_DEBUG=true."""
+        emitted: list[dict] = []
+
+        def fake_emit(text: str, category: str = "system_context") -> None:
+            emitted.append({"text": text, "category": category})
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox_dir,
+            _DEBUG_MODE=True,
+            _DEBUG_RESOLVED=True,
+            _emit_debug_observation=fake_emit,
+        ):
+            from src.mcp.inbox_server import handle_write_observation
+            result = asyncio.run(handle_write_observation({
+                "chat_id": 123,
+                "text": "Config drift detected.",
+                "category": "system_context",
+            }))
+
+        # No inbox file — bypassed entirely
+        assert list(inbox_dir.glob("*.json")) == []
+        # Direct Telegram delivery
+        assert len(emitted) == 1
+        assert emitted[0]["category"] == "system_context"
+        assert "Config drift detected." in emitted[0]["text"]
+        assert "debug mode" in result[0].text
+
+    def test_system_error_bypasses_inbox_in_debug_mode(self, inbox_dir: Path):
+        """system_error observations bypass the inbox when LOBSTER_DEBUG=true."""
+        emitted: list[dict] = []
+
+        def fake_emit(text: str, category: str = "system_context") -> None:
+            emitted.append({"text": text, "category": category})
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox_dir,
+            _DEBUG_MODE=True,
+            _DEBUG_RESOLVED=True,
+            _emit_debug_observation=fake_emit,
+        ):
+            from src.mcp.inbox_server import handle_write_observation
+            result = asyncio.run(handle_write_observation({
+                "chat_id": 123,
+                "text": "API call failed.",
+                "category": "system_error",
+            }))
+
+        assert list(inbox_dir.glob("*.json")) == []
+        assert len(emitted) == 1
+        assert emitted[0]["category"] == "system_error"
+        assert "debug mode" in result[0].text
+
+    def test_user_context_still_queues_inbox_in_debug_mode(self, inbox_dir: Path):
+        """user_context observations always write to inbox even when LOBSTER_DEBUG=true."""
+        emitted: list[dict] = []
+
+        def fake_emit(text: str, category: str = "system_context") -> None:
+            emitted.append({"text": text, "category": category})
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox_dir,
+            _DEBUG_MODE=True,
+            _DEBUG_RESOLVED=True,
+            _emit_debug_observation=fake_emit,
+        ):
+            from src.mcp.inbox_server import handle_write_observation
+            result = asyncio.run(handle_write_observation({
+                "chat_id": 123,
+                "text": "User prefers dark mode.",
+                "category": "user_context",
+            }))
+
+        # Inbox file written (dispatcher needs to act on user_context)
+        files = list(inbox_dir.glob("*.json"))
+        assert len(files) == 1
+        # Also emitted directly so user sees it in debug mode
+        assert len(emitted) == 1
+        assert emitted[0]["category"] == "user_context"
+        assert "Observation queued" in result[0].text
+
+    def test_system_context_goes_to_inbox_in_non_debug_mode(self, inbox_dir: Path):
+        """system_context observations write to inbox when LOBSTER_DEBUG=false."""
+        emitted: list[dict] = []
+
+        def fake_emit(text: str, category: str = "system_context") -> None:
+            emitted.append({"text": text, "category": category})
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox_dir,
+            _DEBUG_MODE=False,
+            _DEBUG_RESOLVED=True,
+            _emit_debug_observation=fake_emit,
+        ):
+            from src.mcp.inbox_server import handle_write_observation
+            result = asyncio.run(handle_write_observation({
+                "chat_id": 123,
+                "text": "Config state normal.",
+                "category": "system_context",
+            }))
+
+        # Goes to inbox — dispatcher handles it
+        files = list(inbox_dir.glob("*.json"))
+        assert len(files) == 1
+        # No direct Telegram delivery
+        assert emitted == []
+        assert "Observation queued" in result[0].text
+
+    def test_debug_bypass_includes_task_id_in_emitted_text(self, inbox_dir: Path):
+        """When bypassing inbox in debug mode, task_id is appended to the emitted text."""
+        emitted: list[dict] = []
+
+        def fake_emit(text: str, category: str = "system_context") -> None:
+            emitted.append({"text": text, "category": category})
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox_dir,
+            _DEBUG_MODE=True,
+            _DEBUG_RESOLVED=True,
+            _emit_debug_observation=fake_emit,
+        ):
+            from src.mcp.inbox_server import handle_write_observation
+            asyncio.run(handle_write_observation({
+                "chat_id": 123,
+                "text": "Something happened.",
+                "category": "system_context",
+                "task_id": "task-42",
+            }))
+
+        assert len(emitted) == 1
+        assert "task-42" in emitted[0]["text"]


### PR DESCRIPTION
## Problem

PR #334 fixed `_emit_debug_observation` (the internal worker path) but missed `handle_write_observation` — the MCP tool subagents actually call. When a subagent calls `write_observation` with `category=system_context` or `system_error`, the message still went through the dispatcher inbox, where the dispatcher silently memory_store'd it. The fix in #334 was structurally incomplete.

## Fix

`handle_write_observation` now checks `_DEBUG_MODE` server-side:

- `system_context` / `system_error` + `LOBSTER_DEBUG=true` → calls `_emit_debug_observation` directly, **no inbox write**
- `user_context` + `LOBSTER_DEBUG=true` → writes to inbox (dispatcher must act) **and** emits direct push
- All categories + `LOBSTER_DEBUG=false` → unchanged inbox behavior

The routing is now structural/server-side, not dependent on dispatcher LLM behavior.

## Tests

5 new tests covering:
- system_context bypasses inbox in debug mode
- system_error bypasses inbox in debug mode
- user_context still writes inbox in debug mode (+ direct push)
- system_context goes to inbox in non-debug mode
- task_id is included in emitted text when bypassing inbox

Also fixes the shared `_run()` test helper to mock `_DEBUG_MODE=False` so tests that expect inbox writes aren't broken by the host's `LOBSTER_DEBUG` setting.

Pre-existing failures: `test_observation_type_default_is_preference` and `test_observation_type_explicit_value_forwarded` — these test user model dispatch behavior not yet implemented in `handle_write_observation` and were already failing before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)