### PR TITLE
Add transport-level HTTP mock to test_write_observation (Fix #2, #353)

### DIFF
--- a/tests/unit/test_mcp_server/conftest.py
+++ b/tests/unit/test_mcp_server/conftest.py
@@ -1,0 +1,37 @@
+"""
+Shared fixtures for test_mcp_server unit tests.
+
+Transport-level HTTP mock
+-------------------------
+`handle_write_observation` calls `_emit_debug_observation` → `_send_telegram_direct`
+which fires a real urllib HTTP request when LOBSTER_DEBUG=true is set on the host.
+The `block_outbound_http` fixture patches urllib.request.urlopen at the transport
+level so no real network call can escape this test suite, regardless of how debug
+mode flags are set in any individual test.
+
+The fixture is auto-used (session-scoped) so every test in this package is covered
+without requiring per-test opt-in.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def block_outbound_http():
+    """Patch urllib.request.urlopen to prevent any real HTTP calls from tests.
+
+    Targets the exact import used by _send_telegram_direct inside inbox_server.py:
+      import urllib.request as _urllib_request
+      ...
+      with _urllib_request.urlopen(req, timeout=5):
+
+    Patching `urllib.request.urlopen` intercepts that call at the transport layer
+    regardless of which debug-mode flags individual tests set.
+    """
+    mock_response = MagicMock()
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        yield


### PR DESCRIPTION
## Problem

When \`LOBSTER_DEBUG=true\` is set on the host running the test suite, \`handle_write_observation\` calls that don't suppress debug mode reach \`_emit_debug_observation\` → \`_send_telegram_direct\` → \`urllib.request.urlopen\`, firing real HTTP POST requests to the Telegram Bot API. This is what caused the spam burst described in issue #353: the test suite ran against a live system and every test fixture string appeared as a real queued observation.

The root is that several tests in \`test_write_observation.py\` patch \`_user_model\` (for user model dispatch assertions) but do not patch \`_DEBUG_MODE=False\`. The existing \`_run()\` helper guards against this, but the user-model tests bypass \`_run()\` and patch directly.

## Fix

Add \`tests/unit/test_mcp_server/conftest.py\` with a session-scoped, autouse fixture that patches \`urllib.request.urlopen\` — the exact transport symbol used inside \`_send_telegram_direct\` — with a no-op mock. This is a pure test infrastructure change: no business logic is touched, no routing behavior is altered.

The patch targets the transport layer rather than the application layer (\`_emit_debug_observation\` or \`_DEBUG_MODE\`) so it acts as a hard backstop regardless of how any individual test configures debug mode. Even if a future test intentionally enables \`_DEBUG_MODE=True\` to test routing behavior, the mock ensures no real HTTP escapes.

## What is not changed

- \`inbox_server.py\` is untouched — Fix #1 (dual delivery) is explicitly out of scope for this PR
- No test assertions are changed; the 2 pre-existing failures (\`test_observation_type_default_is_preference\`, \`test_observation_type_explicit_value_forwarded\`) were already failing on \`main\` and are unchanged by this PR

## Functional patterns

Pure fixture composition: the conftest provides a session-scoped no-op transport stub that individual tests can optionally override. No shared state, no side effects.

## Tests run

- [x] \`LOBSTER_DEBUG=true uv run pytest tests/unit/test_mcp_server/test_write_observation.py -v\` — 15 passed, 2 pre-existing failures (same count as on \`main\` without the patch). Confirmed no new failures introduced.
- [x] \`uv run pytest tests/unit/test_mcp_server/ -v\` — 196 passed, 10 failed. All 10 failures are pre-existing on \`main\`; this PR introduces none.

Relates to #353