### PR TITLE
fix: extend CLAUDECODE guards to also unset CLAUDE_CODE_ENTRYPOINT

### DIFF
--- a/docker/worker-entrypoint.sh
+++ b/docker/worker-entrypoint.sh
@@ -38,7 +38,7 @@ fi
 # Run Claude
 #===============================================================================
 # Prevent "cannot launch inside another Claude Code session" error.
-unset CLAUDECODE
+unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
 
 start_time=$(date +%s)
 echo "Worker starting: job=$WORKER_JOB_NAME, max_turns=$WORKER_MAX_TURNS"

--- a/install.sh
+++ b/install.sh
@@ -884,7 +884,7 @@ export PATH="$HOME/.local/bin:$PATH"
 
 # Prevent "cannot launch inside another Claude Code session" error.
 # CLAUDECODE leaks when run-job.sh is manually tested from a Claude session.
-unset CLAUDECODE
+unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
 
 JOB_NAME="$1"
 

--- a/scheduled-tasks/run-job.sh
+++ b/scheduled-tasks/run-job.sh
@@ -9,7 +9,7 @@ export PATH="$HOME/.local/bin:$PATH"
 
 # Prevent "cannot launch inside another Claude Code session" error.
 # CLAUDECODE leaks when run-job.sh is manually tested from a Claude session.
-unset CLAUDECODE
+unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
 
 JOB_NAME="$1"
 

--- a/scripts/claude-persistent.sh
+++ b/scripts/claude-persistent.sh
@@ -27,6 +27,22 @@
 set -uo pipefail
 # Note: not using set -e because we handle exit codes explicitly
 
+# =============================================================================
+# CRITICAL: Sanitize Claude Code environment variables IMMEDIATELY at script
+# entry, before anything else runs. Claude Code sets CLAUDECODE=1 and
+# CLAUDE_CODE_ENTRYPOINT in its own process. These leak when:
+#   1. An SSH user runs Claude Code, which sets these in the shell
+#   2. That shell (or systemd) launches tmux, which inherits the vars
+#   3. The tmux server passes them to all new panes/windows
+#   4. claude binary inside tmux sees CLAUDECODE=1 and refuses to start
+#
+# This MUST happen at script top level (not inside a function) so the vars
+# are stripped from this process's environment before tmux inherits them.
+# The launch_claude() function also strips them from tmux's global env as
+# a second layer of defense.
+# =============================================================================
+unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
+
 WORKSPACE_DIR="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
 INSTALL_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
 MESSAGES_DIR="${LOBSTER_MESSAGES:-$HOME/messages}"

--- a/scripts/claude-wrapper.sh
+++ b/scripts/claude-wrapper.sh
@@ -19,7 +19,7 @@ export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"
 
 # Prevent "cannot launch inside another Claude Code session" error.
 # CLAUDECODE leaks when this script is run from an interactive Claude session.
-unset CLAUDECODE
+unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
 
 # Verify claude is available
 if ! command -v claude &>/dev/null; then

--- a/scripts/docker-worker.sh
+++ b/scripts/docker-worker.sh
@@ -66,7 +66,7 @@ CONTAINER_NAME="lobster-worker-${JOB_NAME}-$(date +%s)"
 
 # Prevent CLAUDECODE from leaking into Docker container via explicit -e flags
 # or docker's default environment passthrough.
-unset CLAUDECODE
+unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
 
 container_id=$(sudo docker run -d --rm \
     --name "$CONTAINER_NAME" \

--- a/scripts/health-check-v2.sh
+++ b/scripts/health-check-v2.sh
@@ -259,8 +259,9 @@ restart_lobster() {
     # Start new session
     log_info "Starting new Lobster session..."
     # Prevent CLAUDECODE leak into tmux server environment
-    unset CLAUDECODE
+    unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
     tmux -L "$TMUX_SOCKET" set-environment -gr CLAUDECODE 2>/dev/null || true
+    tmux -L "$TMUX_SOCKET" set-environment -gr CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
     tmux -L "$TMUX_SOCKET" new-session -d -s "$SESSION_NAME" -c "$HOME/lobster-workspace" \
         "$HOME/lobster/scripts/claude-wrapper.exp"
 

--- a/scripts/start-claude.sh
+++ b/scripts/start-claude.sh
@@ -44,7 +44,7 @@ LOBSTER_DEBUG="${LOBSTER_DEBUG:-false}"
 
 # Prevent "cannot launch inside another Claude Code session" error.
 # Clear before exec-ing into the actual launcher script.
-unset CLAUDECODE
+unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
 
 if [[ "$LOBSTER_DEBUG" == "true" ]]; then
     echo "[start-claude] LOBSTER_DEBUG=true — launching interactive REPL (claude-wrapper.exp)"

--- a/scripts/start-lobster.sh
+++ b/scripts/start-lobster.sh
@@ -45,8 +45,9 @@ info "Launcher:  $INSTALL_DIR/scripts/claude-persistent.sh"
 
 # Prevent "cannot launch inside another Claude Code session" error.
 # CLAUDECODE leaks into the tmux server when this script is run from a Claude session.
-unset CLAUDECODE
+unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
 tmux -L lobster set-environment -gr CLAUDECODE 2>/dev/null || true
+tmux -L lobster set-environment -gr CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
 
 # Create tmux session with persistent wrapper
 tmux -L lobster new-session -d -s "$SESSION_NAME" -c "$WORKSPACE" \

--- a/scripts/token-refresh.sh
+++ b/scripts/token-refresh.sh
@@ -141,7 +141,7 @@ print(d.get('claudeAiOauth', {}).get('expiresAt', 0))
 " 2>/dev/null)
 
     # Run auth status (unset CLAUDECODE to avoid nested session error)
-    env -u CLAUDECODE claude auth status > /dev/null 2>&1
+    env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT claude auth status > /dev/null 2>&1
 
     # Check if expiresAt changed (indicating successful refresh)
     local post_expires_at

--- a/services/lobster-claude.service.template
+++ b/services/lobster-claude.service.template
@@ -18,7 +18,7 @@ Environment=LOBSTER_USER_CONFIG={{USER_CONFIG_DIR}}
 EnvironmentFile=-{{INSTALL_DIR}}/config/config.env
 EnvironmentFile={{CONFIG_DIR}}/config.env
 EnvironmentFile=-{{CONFIG_DIR}}/global.env
-UnsetEnvironment=CLAUDECODE
+UnsetEnvironment=CLAUDECODE CLAUDE_CODE_ENTRYPOINT
 ExecStart=/usr/bin/tmux -L lobster new-session -d -s lobster -c {{WORKSPACE_DIR}} {{INSTALL_DIR}}/scripts/start-claude.sh
 ExecStop=/usr/bin/tmux -L lobster kill-session -t lobster
 RemainAfterExit=yes

--- a/setup.sh
+++ b/setup.sh
@@ -808,7 +808,7 @@ fi
 echo "🚀 Creating: $SESSION ($LAYOUT)"
 
 # Prevent CLAUDECODE leak into tmux server environment
-unset CLAUDECODE
+unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
 
 case "$LAYOUT" in
     dev)

--- a/tests/test_claudecode_guard.sh
+++ b/tests/test_claudecode_guard.sh
@@ -3,9 +3,9 @@
 # Test: CLAUDECODE Environment Variable Leak Prevention
 #
 # Verifies that every script which launches `claude` (or creates a tmux session
-# that will host claude) contains the `unset CLAUDECODE` guard.
+# that will host claude) contains the `unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT` guard.
 #
-# Also verifies that systemd service files include `UnsetEnvironment=CLAUDECODE`.
+# Also verifies that systemd service files include `UnsetEnvironment=CLAUDECODE CLAUDE_CODE_ENTRYPOINT`.
 #
 # This test is structural (grep-based) — it catches regressions at CI time
 # without needing to actually run Claude.
@@ -74,15 +74,20 @@ else
     for script in "${SCRIPTS_INVOKING_CLAUDE[@]}"; do
         rel="${script#$REPO_DIR/}"
 
-        # Special case: scripts that use `env -u CLAUDECODE claude` are already
-        # protected inline (e.g., token-refresh.sh). Accept that pattern too.
-        if grep -q 'env -u CLAUDECODE claude' "$script" 2>/dev/null; then
-            pass "$rel (uses env -u CLAUDECODE inline)"
+        # Special case: scripts that use `env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT claude`
+        # are already protected inline (e.g., token-refresh.sh). Accept that pattern too.
+        if grep -q 'env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT claude' "$script" 2>/dev/null; then
+            pass "$rel (uses env -u inline for both vars)"
             continue
         fi
 
         if grep -q 'unset CLAUDECODE' "$script" 2>/dev/null; then
-            pass "$rel"
+            # Also verify CLAUDE_CODE_ENTRYPOINT is unset
+            if grep -q 'CLAUDE_CODE_ENTRYPOINT' "$script" 2>/dev/null; then
+                pass "$rel (both CLAUDECODE and CLAUDE_CODE_ENTRYPOINT)"
+            else
+                fail "$rel — unsets CLAUDECODE but missing CLAUDE_CODE_ENTRYPOINT"
+            fi
         else
             fail "$rel — missing 'unset CLAUDECODE'"
         fi
@@ -181,7 +186,11 @@ else
     for svc in "${SERVICE_FILES[@]}"; do
         rel="${svc#$REPO_DIR/}"
         if grep -q 'UnsetEnvironment=CLAUDECODE' "$svc"; then
-            pass "$rel"
+            if grep -q 'CLAUDE_CODE_ENTRYPOINT' "$svc"; then
+                pass "$rel (both CLAUDECODE and CLAUDE_CODE_ENTRYPOINT)"
+            else
+                fail "$rel — has UnsetEnvironment=CLAUDECODE but missing CLAUDE_CODE_ENTRYPOINT"
+            fi
         else
             fail "$rel — missing 'UnsetEnvironment=CLAUDECODE'"
         fi
@@ -244,7 +253,7 @@ for script in "${SCRIPTS_INVOKING_CLAUDE[@]}"; do
     rel="${script#$REPO_DIR/}"
 
     # Skip scripts that use env -u inline
-    if grep -q 'env -u CLAUDECODE claude' "$script" 2>/dev/null; then
+    if grep -q 'env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT claude' "$script" 2>/dev/null; then
         pass "$rel (inline env -u, order N/A)"
         continue
     fi


### PR DESCRIPTION
## Summary

- Extends all `unset CLAUDECODE` guards across scripts, service templates, and docker entrypoints to also unset `CLAUDE_CODE_ENTRYPOINT`
- Prevents nested Claude Code session errors when `CLAUDE_CODE_ENTRYPOINT` leaks into child processes (tmux, subagents, docker workers)
- Updates `test_claudecode_guard.sh` to verify both variables are guarded, preventing future regressions

## What changed

Claude Code sets both `CLAUDECODE=1` **and** `CLAUDE_CODE_ENTRYPOINT` in its process environment. Previously only `CLAUDECODE` was being cleared. This caused intermittent "cannot launch inside another Claude Code session" errors from `CLAUDE_CODE_ENTRYPOINT` still being set.

Files updated:
- `scripts/claude-persistent.sh` — added early sanitization block with detailed comment explaining the leak chain
- `scripts/claude-wrapper.sh`, `start-claude.sh`, `start-lobster.sh`, `docker-worker.sh` — extended `unset` calls
- `scripts/health-check-v2.sh`, `scripts/start-lobster.sh` — also strip from tmux global environment
- `scripts/token-refresh.sh` — extended `env -u` inline guard
- `services/lobster-claude.service.template` — extended `UnsetEnvironment=` directive
- `docker/worker-entrypoint.sh`, `install.sh`, `scheduled-tasks/run-job.sh`, `setup.sh` — extended `unset` calls
- `tests/test_claudecode_guard.sh` — updated to verify both vars in all guards

## Test plan
- [ ] `tests/test_claudecode_guard.sh` passes with no failures
- [ ] Lobster can be restarted from within a Claude Code session without "nested session" errors
- [ ] Docker workers launch cleanly when `CLAUDE_CODE_ENTRYPOINT` is set in parent env

🤖 Generated with [Claude Code](https://claude.com/claude-code)