### PR TITLE
fix: scheduled jobs now call write_result so dispatcher receives notifications

### DIFF
--- a/scheduled-tasks/run-job.sh
+++ b/scheduled-tasks/run-job.sh
@@ -48,15 +48,18 @@ START_ISO=$(date -Iseconds)
 echo "[$START_ISO] Starting job: $JOB_NAME" | tee "$LOG_FILE"
 
 # Run Claude with the task
-# The task instructions tell Claude to call write_task_output with results
+# The task instructions tell Claude to call write_task_output AND write_result with results
 claude -p "$TASK_CONTENT
 
 ---
 
 IMPORTANT: You are running as a scheduled task. When you complete your task:
-1. Call write_task_output() with your results summary
-2. Keep output concise - the main Lobster instance will review this later
-3. Exit after writing output - do not start a loop" \
+1. Call write_task_output() with your results summary (job_name: \"$JOB_NAME\", output: ..., status: \"success\" or \"failed\")
+2. Call write_result() to notify the dispatcher (task_id: \"scheduled-job-$JOB_NAME\", chat_id: 8305714125, text: ..., forward: True)
+3. Keep output concise - the main Lobster instance will review this
+4. Exit after writing output - do not start a loop
+
+Both calls are required: write_task_output archives the output for check_task_outputs; write_result delivers the result to the dispatcher inbox so the user is notified automatically." \
     --dangerously-skip-permissions \
     --max-turns 15 \
     2>&1 | tee -a "$LOG_FILE"


### PR DESCRIPTION
## Problem

Scheduled jobs (linear-digest and others) were silently completing without the dispatcher ever knowing. They called `write_task_output`, which archives to `~/messages/task-outputs/` — only visible via `check_task_outputs`. The dispatcher inbox received nothing, so the user had to manually ask "what did the digest job find?" instead of getting proactive notification.

The root cause was in `run-job.sh`: it injects a footer into every job's prompt at runtime that explicitly told Claude to call only `write_task_output`. Since this footer appears at the end of the prompt, it overrode whatever the individual task file said.

## Fix

`run-job.sh`'s injected footer now instructs jobs to call both tools:

1. `write_task_output` — unchanged, still archives to `~/messages/task-outputs/` for `check_task_outputs`
2. `write_result` with `forward=True` — routes through the dispatcher inbox, producing a `subagent_result` the user receives automatically

Because `run-job.sh` is authoritative for all scheduled jobs (its footer overrides per-job task files), this single change fixes every current and future scheduled job simultaneously.

The user-space `linear-digest.md` task file was also patched directly in `~/lobster-workspace/scheduled-jobs/tasks/` (outside the repo — not in this diff) so its Output section is consistent. The committed `nightly-github-backup.md` has a matching fix pending in the working tree, blocked by the pre-commit hook (`scheduled-tasks/tasks/` is listed as a blocked pattern, a pre-existing inconsistency since that file predates the hook).

## What is not changed

- `write_task_output` is still called — backward compatible with anything that uses `check_task_outputs`
- Job scheduling, crontab, and job registry logic are untouched
- The fix applies only to the injected footer in `run-job.sh`; no task logic is modified

## Functional patterns used

Pure composition: the `run-job.sh` change is additive — it appends a second required call without altering the first. The injected footer acts as a declarative contract that all jobs satisfy at the boundary, keeping individual task files free of infrastructure concerns.

## Tests run

- [ ] Live scheduled job execution — blocked: requires waiting for the next 6-hour cron tick or manually invoking `run-job.sh linear-digest` in an environment with MCP tools available. The injected footer change is straightforward string addition; the risk of regression is low.
- [x] `git diff` reviewed — the footer change is additive only; `write_task_output` call is preserved exactly

**Blocked items needing attention before merge:** The live execution test cannot be run in this environment. Recommend manually triggering `run-job.sh linear-digest` after merge to confirm `write_result` fires correctly.

Closes #371