### PR TITLE
fix: add lobster user to docker group during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -335,6 +335,13 @@ if [ "$(id -u)" = "0" ]; then
     else
         success "User 'lobster' already exists."
     fi
+    # Add lobster user to the docker group so bare `docker` works (no sudo needed)
+    if getent group docker &>/dev/null; then
+        usermod -aG docker lobster
+        success "Added 'lobster' to the docker group."
+    else
+        warn "docker group not found — skipping docker group membership (install Docker first)."
+    fi
     echo ""
     info "Next time, SSH directly as: lobster@$(hostname)"
     echo ""


### PR DESCRIPTION
## Summary

- During root-mode install, `install.sh` creates the `lobster` user but never added it to the `docker` group
- After this fix, `usermod -aG docker lobster` is called after user creation (guarded: skips if the `docker` group doesn't exist yet)
- Bare `docker` commands work after a session restart — no more `sudo docker` workaround needed

Closes #381

## Test plan

- [ ] Run install on a system with Docker already installed — verify "Added 'lobster' to the docker group" success message appears
- [ ] Run install on a system without Docker — verify warning is shown and install continues normally
- [ ] After install, verify `groups lobster` includes `docker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)