### PR TITLE
fix: scheduled jobs deliver results via send_reply + write_result(forward=False)

### DIFF
--- a/scheduled-tasks/run-job.sh
+++ b/scheduled-tasks/run-job.sh
@@ -48,15 +48,18 @@ START_ISO=$(date -Iseconds)
 echo "[$START_ISO] Starting job: $JOB_NAME" | tee "$LOG_FILE"
 
 # Run Claude with the task
-# The task instructions tell Claude to call write_task_output with results
+# The task instructions tell Claude to deliver results via send_reply + write_result
 claude -p "$TASK_CONTENT
 
 ---
 
 IMPORTANT: You are running as a scheduled task. When you complete your task:
-1. Call write_task_output() with your results summary
-2. Keep output concise - the main Lobster instance will review this later
-3. Exit after writing output - do not start a loop" \
+1. Call send_reply(chat_id=8305714125, text=<your digest>, source=\"telegram\") to deliver results directly to the user
+2. Call write_result(task_id=\"scheduled-job-$JOB_NAME\", chat_id=8305714125, text=<same text>, forward=False) to notify the dispatcher that the job completed
+3. Keep output concise - the user is on mobile
+4. Exit after writing output - do not start a loop
+
+Both calls are required. send_reply delivers the digest immediately to Telegram; write_result(forward=False) signals the dispatcher that the job is done without double-sending." \
     --dangerously-skip-permissions \
     --max-turns 15 \
     2>&1 | tee -a "$LOG_FILE"


### PR DESCRIPTION
## Problem

Scheduled jobs (linear-digest and others) were completing silently. The `run-job.sh` injected footer — which appears at the end of every job's prompt and overrides anything the task file says — told Claude to call only `write_task_output`. That tool archives to `~/messages/task-outputs/`, visible only via `check_task_outputs`. The dispatcher inbox received nothing, so the user had to manually ask "what did the digest find?" instead of getting proactive notification.

## Fix

The injected footer now instructs jobs to follow the crash-safe subagent pattern used everywhere else in Lobster:

1. `send_reply(chat_id=8305714125, text=..., source="telegram")` — delivers the digest immediately to Telegram
2. `write_result(task_id=..., chat_id=8305714125, text=..., forward=False)` — signals the dispatcher the job is done, without double-sending

Because `run-job.sh`'s footer is authoritative for all scheduled jobs (it overrides per-job task files at runtime), this single change fixes every current and future scheduled job simultaneously.

The `linear-digest.md` task file in `~/lobster-workspace/scheduled-jobs/tasks/` (outside the repo) was also updated directly for consistency.

## What is not changed

- Job scheduling, crontab, and job registry logic are untouched
- No task logic is modified

## Why forward=False (not forward=True)

PR #377 used `write_result(forward=True)`, which was rejected. The correct pattern: `send_reply` delivers the message directly (crash-safe), then `write_result(forward=False)` signals completion to the dispatcher without re-delivering. This is identical to how all other subagents report results.

## Functional patterns used

Pure boundary isolation: the injected footer acts as a declarative contract at the system boundary. Individual task files are free of infrastructure concerns; the footer enforces the output protocol universally.

## Tests run

- [x] `git diff` reviewed — footer replaces `write_task_output` with `send_reply + write_result(forward=False)`; change is clear and mechanical
- [ ] Live scheduled job execution — blocked: requires waiting for cron tick or manually invoking `run-job.sh linear-digest` in an environment with MCP tools. Recommend triggering manually after merge.

**Blocked items needing attention before merge:** Live execution test not run. Low regression risk — additive replacement of one tool call with two well-understood ones.

Closes #371