### PR TITLE
fix: add whisper.cpp to Docker integration test image

### DIFF
--- a/tests/docker/Dockerfile.integration
+++ b/tests/docker/Dockerfile.integration
@@ -22,6 +22,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     cron \
     ffmpeg \
+    build-essential \
+    cmake \
     && rm -rf /var/lib/apt/lists/*
 
 # Create test user
@@ -46,6 +48,22 @@ RUN mkdir -p \
     /home/testuser/messages/config \
     /home/testuser/messages/audio \
     /home/testuser/messages/task-outputs
+
+# Build whisper.cpp from source and download the small model.
+# Paths mirror production: ~/lobster-workspace/whisper.cpp/build/bin/whisper-cli
+#                          ~/lobster-workspace/whisper.cpp/models/ggml-small.bin
+RUN git clone --depth 1 https://github.com/ggml-org/whisper.cpp.git \
+        /home/testuser/lobster-workspace/whisper.cpp && \
+    cmake -B /home/testuser/lobster-workspace/whisper.cpp/build \
+          -S /home/testuser/lobster-workspace/whisper.cpp \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DWHISPER_BUILD_TESTS=OFF \
+          -DWHISPER_BUILD_EXAMPLES=OFF && \
+    cmake --build /home/testuser/lobster-workspace/whisper.cpp/build \
+          --config Release -j$(nproc) --target whisper-cli && \
+    curl -L --retry 3 \
+        "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin" \
+        -o /home/testuser/lobster-workspace/whisper.cpp/models/ggml-small.bin
 
 # Copy source code
 COPY --chown=testuser:testuser . /home/testuser/lobster


### PR DESCRIPTION
## Summary

The integration test image had `ffmpeg` installed but no `whisper-cli` binary or model file, so any test that exercises `transcribe_audio` would fail with "whisper not installed" rather than testing real behaviour. Transcription regressions were invisible in CI.

This PR adds a whisper.cpp build step to `Dockerfile.integration` so the binary and model are present at the same paths the production system uses:
- `~/lobster-workspace/whisper.cpp/build/bin/whisper-cli`
- `~/lobster-workspace/whisper.cpp/models/ggml-small.bin`

Changes are confined to `Dockerfile.integration`. `Dockerfile.test` (the install smoke-test image) is out of scope — it does not run transcription tests.

## Approach

- `build-essential` and `cmake` are added to the apt layer (single `RUN` to keep layer count low)
- whisper.cpp is cloned at depth 1 and built with shared libs off and test/example targets disabled to minimise build time
- `ggml-small.bin` is downloaded from HuggingFace with `--retry 3` to tolerate transient network failures
- The build runs as `testuser` so all paths resolve correctly under `/home/testuser/lobster-workspace/`

## Functional patterns

Pure declarative Dockerfile instructions; no imperative shell logic beyond the cmake invocations whisper.cpp itself requires.

## Tests run

- [ ] `docker build -f tests/docker/Dockerfile.integration -t lobster-test-integration .` — skipped: Docker not available in this environment; build correctness reviewed by inspection against the cmake flags whisper.cpp documents

Closes #384