### PR TITLE
refactor: rename write_result forward→sent_reply_to_user

### DIFF
--- a/.claude/agents/brain-dumps.md
+++ b/.claude/agents/brain-dumps.md
@@ -5,7 +5,7 @@ model: sonnet
 color: purple
 ---
 
-> **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `send_reply` then `write_result(forward=False)` when your task is complete.
+> **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `send_reply` then `write_result(sent_reply_to_user=True)` when your task is complete.
 
 You are a brain dump processor for the Lobster system with **staged processing** that leverages persistent user context. Your job is to receive transcribed voice notes, process them through multiple stages, and save enriched brain dumps to the user's GitHub repository.
 
@@ -668,11 +668,11 @@ mcp__lobster-inbox__write_result(
     text=f"Brain dump captured! Issue #{issue_number} created.",
     source=source,
     status="success",
-    forward=False,            # already delivered via send_reply above
+    sent_reply_to_user=True,  # already delivered via send_reply above
 )
 
 # On failure — e.g. issue creation failed (errors go via write_result alone,
-# dispatcher will add context before forwarding to user):
+# dispatcher will relay and add context):
 mcp__lobster-inbox__write_result(
     task_id="brain-dump-failed",
     chat_id=chat_id,
@@ -683,7 +683,7 @@ mcp__lobster-inbox__write_result(
     ),
     source=source,
     status="error",
-    # forward=True (default) — dispatcher will prepend error context
+    # sent_reply_to_user=False (default) — dispatcher will relay and prepend error context
 )
 ```
 

--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -5,7 +5,7 @@ model: opus
 color: orange
 ---
 
-> **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `send_reply` directly to deliver results, then call `write_result(forward=False)` when your task is complete.
+> **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `send_reply` directly to deliver results, then call `write_result(sent_reply_to_user=True)` when your task is complete.
 
 You are a senior software engineer with deep expertise in functional programming paradigms and modern development workflows. You have years of experience writing clean, composable, and testable code using functional patterns like pure functions, immutability, higher-order functions, and declarative data transformations.
 
@@ -253,7 +253,7 @@ gh api repos/<owner>/<repo>/issues/<number>   # raw API if gh subcommand insuffi
 
 ## Reporting Results Back to the User
 
-**Always deliver results in two steps: call `send_reply` directly first, then call `write_result` with `forward=False`.** This is crash-safe — the user gets the reply even if the dispatcher session has restarted.
+**Always deliver results in two steps: call `send_reply` directly first, then call `write_result` with `sent_reply_to_user=True`.** This is crash-safe — the user gets the reply even if the dispatcher session has restarted.
 
 ```python
 # On success — after PR is opened (or work is done):
@@ -275,7 +275,7 @@ mcp__lobster-inbox__write_result(
     text=f"Done! PR #{pr_number} open for issue #{issue_number}. {pr_url}",
     source=source,
     status="success",
-    forward=False,            # already delivered via send_reply above
+    sent_reply_to_user=True,  # already delivered via send_reply above
 )
 ```
 
@@ -292,7 +292,7 @@ mcp__lobster-inbox__write_result(
     ),
     source=source,
     status="error",
-    # forward=True (default) — dispatcher will prepend error context
+    # sent_reply_to_user=False (default) — dispatcher will relay and prepend error context
 )
 ```
 

--- a/.claude/agents/lobster-generalist.md
+++ b/.claude/agents/lobster-generalist.md
@@ -4,7 +4,7 @@ description: General-purpose Lobster subagent for background tasks that don't fi
 model: sonnet
 ---
 
-> **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `send_reply` then `write_result(forward=False)` when your task is complete.
+> **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `send_reply` then `write_result(sent_reply_to_user=True)` when your task is complete.
 
 You are a **background subagent** running inside the Lobster system.
 
@@ -13,7 +13,7 @@ You handle general research, investigation, and task execution that the main Lob
 
 ## Critical rules
 1. **You are a subagent** — do NOT call `wait_for_messages` or run a message loop
-2. **Always deliver results directly** via `send_reply`, then call `write_result(forward=False)` — see below
+2. **Always deliver results directly** via `send_reply`, then call `write_result(sent_reply_to_user=True)` — see below
 3. **One task, then done** — complete your assigned task and exit
 
 ## Delivering results (two steps, always)
@@ -33,7 +33,7 @@ mcp__lobster-inbox__write_result(
     task_id="<task_id from your prompt>",
     chat_id=<chat_id from your prompt>,
     text="<same text, or brief log summary>",
-    forward=False,  # you already sent via send_reply above
+    sent_reply_to_user=True,  # you already sent via send_reply above
 )
 ```
 

--- a/.claude/agents/lobster-ops.md
+++ b/.claude/agents/lobster-ops.md
@@ -5,7 +5,7 @@ tools: Read, Grep, Glob, Bash
 model: haiku
 ---
 
-> **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `send_reply` then `write_result(forward=False)` when your task is complete.
+> **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `send_reply` then `write_result(sent_reply_to_user=True)` when your task is complete.
 
 You are a Lobster operations specialist. Lobster is an always-on Claude Code message processor with Telegram integration.
 
@@ -93,7 +93,7 @@ mcp__lobster-inbox__write_result(
     task_id=task_id,   # from your prompt
     chat_id=chat_id,
     text="[same text or brief log summary]",
-    forward=False,     # already delivered via send_reply above
+    sent_reply_to_user=True,  # already delivered via send_reply above
 )
 ```
 

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -26,7 +26,7 @@ model: opus
 color: blue
 ---
 
-> **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `send_reply` then `write_result(forward=False)` when your task is complete.
+> **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `send_reply` then `write_result(sent_reply_to_user=True)` when your task is complete.
 
 You are a senior code reviewer. Your goal is to produce educational, thorough reviews that help the team understand what changed, why it matters, and what would break without the fix.
 
@@ -106,6 +106,6 @@ If `LINEAR_API_KEY` is not set in the environment, note that Linear context was 
 ## Constraints that are not obvious
 
 - **Use `gh` CLI for posting reviews** (not MCP tools). Example: `gh pr review 47 --repo SiderealPress/lobster --comment --body "..."`
-- **Deliver results in two steps:** call `send_reply(chat_id, text, source=source)` first (crash-safe), then call `write_result(..., forward=False)` so the dispatcher marks processed without re-sending. Pass `source` through from your input.
+- **Deliver results in two steps:** call `send_reply(chat_id, text, source=source)` first (crash-safe), then call `write_result(..., sent_reply_to_user=True)` so the dispatcher marks processed without re-sending. Pass `source` through from your input.
 - If no PR is linked to the issue, post a comment on the issue noting that and report back — don't silently fail.
 - If running in a context without a cloned repo, use `gh` and `curl` for all data access.

--- a/.claude/dispatcher.bootup.md
+++ b/.claude/dispatcher.bootup.md
@@ -67,7 +67,7 @@ When wait_for_messages() returns a subagent_result/subagent_error:
 1. mark_processing(message_id)
 2. # Note: write_result auto-unregisters the agent server-side — no manual unregister_agent call needed.
    # The tracker is updated atomically when write_result is called.
-3. ... forward or drop based on forward field as usual ...
+3. ... relay or drop based on sent_reply_to_user field as usual ...
 4. mark_processed(message_id)
 ```
 
@@ -140,11 +140,11 @@ Background subagents call `write_result(task_id, chat_id, text, ...)`, which dro
 
 **When `wait_for_messages` returns a message with `type: "subagent_result"`:**
 
-Check the `forward` field first:
+Check the `sent_reply_to_user` field first:
 
 ```
 1. mark_processing(message_id)
-2. if msg.get("forward") == False:
+2. if msg.get("sent_reply_to_user") == True:
        # Subagent already called send_reply — nothing to deliver
        mark_processed(message_id)
    else:
@@ -170,21 +170,21 @@ Check the `forward` field first:
 3. mark_processed(message_id)
 ```
 
-(Errors always forward — a subagent that fails may not have delivered anything to the user.)
+(Errors always relay — a subagent that fails may not have delivered anything to the user.)
 
 **Key fields on these messages:**
 - `task_id` — identifier for the originating task (for logging/debugging)
 - `chat_id` — where to deliver the reply
-- `text` — the reply text to forward
+- `text` — the reply text to relay
 - `source` — messaging platform (telegram, slack, etc.)
 - `status` — "success" or "error"
-- `forward` — boolean (default true). When false, the subagent already called `send_reply`; dispatcher just marks processed
+- `sent_reply_to_user` — boolean (default false). When true, the subagent already called `send_reply`; dispatcher just marks processed
 - `artifacts` — optional list of file paths the subagent produced
 - `thread_ts` — optional Slack thread timestamp
 
 ## Handling Subagent Notifications (`subagent_notification`)
 
-When `write_result` is called with `forward=False`, `inbox_server` writes a message of type `subagent_notification` instead of `subagent_result`. This is the canonical signal that the subagent already delivered its reply to the user via `send_reply`.
+When `write_result` is called with `sent_reply_to_user=True`, `inbox_server` writes a message of type `subagent_notification` instead of `subagent_result`. This is the canonical signal that the subagent already delivered its reply to the user via `send_reply`.
 
 **When `wait_for_messages` returns a message with `type: "subagent_notification"`:**
 
@@ -195,9 +195,9 @@ When `write_result` is called with `forward=False`, `inbox_server` writes a mess
    # Do NOT call send_reply — the user already received the message
 ```
 
-The distinct type enforces correct behavior structurally: the dispatcher's `subagent_result` branch (which calls `send_reply`) never fires for these messages. There is no risk of a duplicate reply even if the dispatcher ignores the `forward` field.
+The distinct type enforces correct behavior structurally: the dispatcher's `subagent_result` branch (which calls `send_reply`) never fires for these messages. There is no risk of a duplicate reply even if the dispatcher ignores the `sent_reply_to_user` field.
 
-**Why this matters:** Without a distinct type, the only safeguard against duplicate replies is the dispatcher reading and obeying the `forward: false` field. With `subagent_notification`, the message type itself routes correctly — the dispatcher gains situational awareness without any possibility of sending a duplicate.
+**Why this matters:** Without a distinct type, the only safeguard against duplicate replies is the dispatcher reading and obeying the `sent_reply_to_user: true` field. With `subagent_notification`, the message type itself routes correctly — the dispatcher gains situational awareness without any possibility of sending a duplicate.
 
 ---
 
@@ -462,7 +462,7 @@ Modes: `"active"` (default) | `"hibernate"`
 
 ## No redundant relay after subagent direct messages
 
-When a subagent calls `send_reply` directly AND calls `write_result` with `forward=False`, the user already received the message. The inbox server writes this as a `subagent_notification` (not `subagent_result`), which is the structural guarantee you never forward it.
+When a subagent calls `send_reply` directly AND calls `write_result` with `sent_reply_to_user=True`, the user already received the message. The inbox server writes this as a `subagent_notification` (not `subagent_result`), which is the structural guarantee you never relay it.
 
 **When `subagent_notification` arrives:**
 - `mark_processed` — nothing to deliver
@@ -473,12 +473,12 @@ When a subagent calls `send_reply` directly AND calls `write_result` with `forwa
 **Pattern to avoid:**
 1. You say "on it" (preview)
 2. Subagent sends detailed result via `send_reply`
-3. Subagent calls `write_result` with `forward=False`
+3. Subagent calls `write_result` with `sent_reply_to_user=True`
 4. You receive the `subagent_notification` and send another summary ← **don't do step 4**
 
 Correct pattern: preview once if needed → subagent sends result → you are silent.
 
-**Note on `forward=None`:** If a subagent passes `forward=None` (omits the argument), the server now treats it as `forward=False` — the message becomes a `subagent_notification` and the dispatcher will NOT forward it. Always pass `forward` explicitly. Subagents that want the dispatcher to relay their result must pass `forward=True` explicitly.
+**Note on omitting `sent_reply_to_user`:** If a subagent omits `sent_reply_to_user`, the server treats it as `False` — the message becomes a `subagent_result` and the dispatcher WILL relay it to the user. Always pass `sent_reply_to_user` explicitly. Subagents that already called `send_reply` must pass `sent_reply_to_user=True` explicitly.
 
 ## Skill System: Dispatcher Behavior
 

--- a/.claude/subagent.bootup.md
+++ b/.claude/subagent.bootup.md
@@ -14,7 +14,7 @@ Users communicate through a chat interface (Telegram or Slack), typically on mob
 When your task is complete:
 
 1. **Call `send_reply(chat_id, text)` directly** to deliver the result to the user immediately. This ensures the user gets their reply even if the dispatcher session has crashed or restarted.
-2. **Then call `write_result(..., forward=False)`** so the dispatcher marks the message processed without re-delivering it.
+2. **Then call `write_result(..., sent_reply_to_user=True)`** so the dispatcher marks the message processed without re-delivering it.
 
 This two-step pattern is crash-safe: the user gets the reply from you regardless of dispatcher state.
 
@@ -43,18 +43,18 @@ These files are private and not in the git repo. They extend and override the de
 
 You MUST both deliver results to the user directly AND call `write_result` at the end of every task. Never silently complete and return.
 
-**CRITICAL: `forward` must always be explicit — never omit it:**
-- The server default for `forward` is `False`. If you omit `forward`, the dispatcher will NOT relay your result to the user.
-- **If you called `send_reply` directly:** pass `forward=False`. The dispatcher will otherwise forward the result a second time, producing duplicate messages. No exceptions.
-- **If you did NOT call `send_reply` and want the dispatcher to relay your result:** pass `forward=True` explicitly. Omitting it is NOT safe — it will silently drop delivery.
-- Both `True` and `False` are valid. Omitting `forward` is never correct.
+**CRITICAL: `sent_reply_to_user` must always be explicit — never omit it:**
+- The server default for `sent_reply_to_user` is `False`. If you omit it, the dispatcher WILL relay your result to the user.
+- **If you called `send_reply` directly:** pass `sent_reply_to_user=True`. The dispatcher will otherwise relay the result a second time, producing duplicate messages. No exceptions.
+- **If you did NOT call `send_reply` and want the dispatcher to relay your result:** pass `sent_reply_to_user=False` explicitly (or omit it — False is the default).
+- Both `True` and `False` are valid. Passing `True` when you haven't called `send_reply` will silently drop delivery — the dispatcher will not relay.
 
 **Required at end of every subagent task — two steps:**
 
 ```python
 # Step 1: Deliver directly to the user (crash-safe delivery)
 # Pass task_id to enable server-side auto-dedup: the inbox server will
-# automatically suppress forward=True in write_result for this task_id.
+# automatically set sent_reply_to_user=True in write_result for this task_id.
 mcp__lobster-inbox__send_reply(
     chat_id=<user's chat_id — get this from your task prompt>,
     text="<your result or report>",
@@ -68,23 +68,23 @@ mcp__lobster-inbox__write_result(
     chat_id=<user's chat_id>,
     text="<same result text, or a brief log summary>",
     source="telegram",
-    forward=False,  # REQUIRED — you already sent via send_reply above
+    sent_reply_to_user=True,  # REQUIRED — you already sent via send_reply above
 )
 ```
 
-**CRITICAL: If you called `send_reply` directly at any point, you MUST pass `forward=False` to `write_result`:**
+**CRITICAL: If you called `send_reply` directly at any point, you MUST pass `sent_reply_to_user=True` to `write_result`:**
 
 ```python
 mcp__lobster-inbox__write_result(
-    task_id=..., chat_id=..., text=..., forward=False
+    task_id=..., chat_id=..., text=..., sent_reply_to_user=True
 )
 ```
 
-Failing to pass `forward=False` causes duplicate messages — the dispatcher will forward your `write_result` on top of the `send_reply` you already sent.
+Failing to pass `sent_reply_to_user=True` causes duplicate messages — the dispatcher will relay your `write_result` on top of the `send_reply` you already sent.
 
-**Why two steps?** If the dispatcher session crashes or restarts between when you finish and when it checks the inbox, the user still received the reply — because you sent it directly. The `forward=False` flag tells the dispatcher "this was already delivered; just mark it done."
+**Why two steps?** If the dispatcher session crashes or restarts between when you finish and when it checks the inbox, the user still received the reply — because you sent it directly. The `sent_reply_to_user=True` flag tells the dispatcher "this was already delivered; just mark it done."
 
-**Server-side safety net:** If you pass `task_id` to `send_reply`, the inbox server automatically sets `forward=False` in `write_result` for that `task_id` — even if you forget. This is a belt-and-suspenders guard, not a substitute for passing `forward=False` explicitly.
+**Server-side safety net:** If you pass `task_id` to `send_reply`, the inbox server automatically sets `sent_reply_to_user=True` in `write_result` for that `task_id` — even if you forget. This is a belt-and-suspenders guard, not a substitute for passing `sent_reply_to_user=True` explicitly.
 
 **If you were not given a `chat_id`:** do not call `send_reply` or `write_result` — your results will be returned directly to the caller.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ User context files are private and not committed to git. They contain user-speci
 ## Available Tools (MCP)
 
 ### Messaging Tools
-- `send_reply(chat_id, text, source?, thread_ts?, buttons?, message_id?, task_id?)` - Send a reply to a user. **Pass `message_id` to atomically mark the message as processed** (combines send_reply + mark_processed in one call). **Pass `task_id` (subagents only) to auto-suppress duplicate forwarding: if write_result is later called with the same task_id, forward is automatically set to False.** Supports inline keyboard buttons (Telegram) and thread replies (Slack).
+- `send_reply(chat_id, text, source?, thread_ts?, buttons?, message_id?, task_id?)` - Send a reply to a user. **Pass `message_id` to atomically mark the message as processed** (combines send_reply + mark_processed in one call). **Pass `task_id` (subagents only) to auto-suppress duplicate delivery: if write_result is later called with the same task_id, sent_reply_to_user is automatically set to True.** Supports inline keyboard buttons (Telegram) and thread replies (Slack).
 - `check_inbox(source?, limit?)` - Non-blocking inbox check
 - `list_sources()` - List available channels
 - `get_stats()` - Inbox statistics

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ The lobster-inbox MCP server provides:
 - `get_stats()` - Inbox statistics
 
 ### Subagent Result Bus
-- `write_result(task_id, chat_id, text, forward?, status?)` - Return a result from a background subagent. Pass `forward=False` if already called `send_reply` directly.
+- `write_result(task_id, chat_id, text, sent_reply_to_user?, status?)` - Return a result from a background subagent. Pass `sent_reply_to_user=True` if already called `send_reply` directly.
 - `write_observation(chat_id, text, category, task_id?)` - Write a side-channel observation (user_context, system_context, system_error)
 
 ### Agent Session Tracking (SQLite)

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -389,9 +389,9 @@ def _track_reply(chat_id: Any) -> None:
             _recent_replies = dict(sorted_items[:_REPLY_TRACK_MAX])
 
 # Direct-send deduplication — tracks recent send_reply calls by (chat_id, text_hash).
-# When write_result is called with forward=True, we check whether an identical message
-# was already delivered directly to the same chat within the dedup window.  If so,
-# forward is silently overridden to False to prevent the dispatcher from sending a
+# When write_result is called with sent_reply_to_user=False, we check whether an identical
+# message was already delivered directly to the same chat within the dedup window.  If so,
+# sent_reply_to_user is silently overridden to True to prevent the dispatcher from sending a
 # duplicate to the user.
 #
 # State is stored as small files in SENT_REPLIES_DIR rather than an in-memory dict so
@@ -438,7 +438,7 @@ def _was_sent_directly(chat_id: Any, text: str) -> bool:
 
 # Task-ID-based dedup registry — primary dedup mechanism for send_reply + write_result.
 # When send_reply is called with a task_id, we record (task_id, chat_id) here.
-# When write_result arrives with the same task_id, forward is auto-set to False.
+# When write_result arrives with the same task_id, sent_reply_to_user is auto-set to True.
 # This is more reliable than text-hash dedup because it works even when send_reply
 # and write_result carry different texts (e.g. full reply vs short summary).
 #
@@ -455,7 +455,7 @@ def _task_replied_key(task_id: str, chat_id: Any) -> str:
 
 
 def _record_task_replied(task_id: str, chat_id: Any) -> None:
-    """Record that send_reply was called with this task_id so write_result can suppress forward."""
+    """Record that send_reply was called with this task_id so write_result can suppress relay."""
     try:
         key = _task_replied_key(task_id, chat_id)
         marker = TASK_REPLIED_DIR / key
@@ -950,8 +950,8 @@ async def list_tools() -> list[Tool]:
                         "description": (
                             "Subagent task identifier. When provided, the server records that this task has "
                             "already delivered a reply directly. If write_result is later called with the same "
-                            "task_id, forward is automatically set to False — preventing duplicate messages "
-                            "even if the subagent forgets to pass forward=False."
+                            "task_id, sent_reply_to_user is automatically set to True — preventing duplicate messages "
+                            "even if the subagent forgets to pass sent_reply_to_user=True."
                         ),
                     },
                 },
@@ -1368,9 +1368,9 @@ async def list_tools() -> list[Tool]:
             description=(
                 "Write a result from a background subagent back to the main message queue. "
                 "Subagents should call send_reply directly first (crash-safe delivery), then call "
-                "this with forward=False so the dispatcher marks the message processed without "
-                "re-sending. On failure, call this with status='error' (no prior send_reply) so "
-                "the main thread can notify the user gracefully."
+                "this with sent_reply_to_user=True so the dispatcher marks the message processed "
+                "without re-sending. On failure, call this with status='error' (no prior send_reply) "
+                "so the main thread can notify the user gracefully."
             ),
             inputSchema={
                 "type": "object",
@@ -1410,14 +1410,14 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "Slack thread timestamp. If provided, the reply will be sent as a thread reply.",
                     },
-                    "forward": {
+                    "sent_reply_to_user": {
                         "type": "boolean",
                         "description": (
-                            "Whether the dispatcher should forward this result to the user. "
-                            "Default false. Set to True if you want the dispatcher to relay this "
-                            "result as a message to the user. Most subagents should use False and "
-                            "call send_reply directly, or set True only when the dispatcher should "
-                            "relay a short verdict."
+                            "Whether the subagent already called send_reply to deliver the result. "
+                            "Default false. Set to True if you already called send_reply — the "
+                            "dispatcher will mark processed without relaying. Set to False (or omit) "
+                            "if you did NOT call send_reply and want the dispatcher to relay this "
+                            "result to the user."
                         ),
                         "default": False,
                     },
@@ -2854,11 +2854,11 @@ async def handle_send_reply(args: dict) -> list[TextContent]:
     # Track reply for mark_processed guard
     _track_reply(chat_id)
 
-    # Record direct send for write_result deduplication (suppress duplicate forwards)
+    # Record direct send for write_result deduplication (suppress duplicate relays)
     _record_direct_send(chat_id, text)
 
     # Task-ID-based dedup (primary): if task_id provided, record so write_result can
-    # auto-suppress forward even when texts differ (e.g. full reply vs short summary).
+    # auto-set sent_reply_to_user=True even when texts differ (e.g. full reply vs short summary).
     task_id_param = args.get("task_id", "").strip() if args.get("task_id") else ""
     if task_id_param:
         _record_task_replied(task_id_param, chat_id)
@@ -4376,7 +4376,16 @@ async def handle_write_result(args: dict) -> list[TextContent]:
     status = args.get("status", "success")
     artifacts = args.get("artifacts") or []
     thread_ts = args.get("thread_ts")
-    forward = args.get("forward", False)
+    # Accept new name (sent_reply_to_user) with backward-compat alias (forward).
+    # Semantics: sent_reply_to_user=True means subagent already called send_reply →
+    # dispatcher should NOT relay. This is the inverse of the old `forward` field.
+    if "sent_reply_to_user" in args:
+        sent_reply_to_user = bool(args["sent_reply_to_user"])
+    elif "forward" in args:
+        # Legacy callers: forward=True meant "dispatcher relays" → sent_reply_to_user=False
+        sent_reply_to_user = not bool(args["forward"])
+    else:
+        sent_reply_to_user = False  # default: dispatcher should relay
 
     if not task_id:
         return [TextContent(type="text", text="Error: task_id is required")]
@@ -4385,35 +4394,35 @@ async def handle_write_result(args: dict) -> list[TextContent]:
     if not text:
         return [TextContent(type="text", text="Error: text is required")]
 
-    # Server-side deduplication: suppress duplicate forwards when the subagent already
-    # delivered a reply directly via send_reply.
+    # Server-side deduplication: promote sent_reply_to_user to True when the subagent
+    # already delivered a reply directly via send_reply, preventing duplicates.
     #
     # Primary path — task_id registry: if send_reply was called with this task_id, the
     # (task_id, chat_id) pair is recorded in TASK_REPLIED_DIR.  This works even when
     # send_reply and write_result carry different texts (e.g. full reply vs short summary).
-    if forward and _was_task_replied(task_id, chat_id):
+    if not sent_reply_to_user and _was_task_replied(task_id, chat_id):
         log.info(
-            f"write_result dedup (task_id): suppressing forward for task {task_id!r} — "
+            f"write_result dedup (task_id): suppressing relay for task {task_id!r} — "
             f"send_reply was already called with task_id={task_id!r} for chat {chat_id}"
         )
-        forward = False
+        sent_reply_to_user = True
 
     # Secondary path — text-hash fallback: catches cases where task_id was not passed
     # to send_reply but the texts happen to match.
-    if forward and _was_sent_directly(chat_id, text):
+    if not sent_reply_to_user and _was_sent_directly(chat_id, text):
         log.info(
-            f"write_result dedup (text-hash): suppressing forward for task {task_id!r} — "
+            f"write_result dedup (text-hash): suppressing relay for task {task_id!r} — "
             f"identical message already sent directly to chat {chat_id}"
         )
-        forward = False
+        sent_reply_to_user = True
 
     if status not in ("success", "error"):
         status = "success"
 
-    # When forward=False the subagent already called send_reply directly.
+    # When sent_reply_to_user=True the subagent already called send_reply directly.
     # Use a distinct message type so the dispatcher knows to read for situational
     # awareness and mark_processed without calling send_reply — no duplicate risk.
-    if not forward:
+    if sent_reply_to_user:
         msg_type = "subagent_notification"
     else:
         msg_type = "subagent_result" if status == "success" else "subagent_error"
@@ -4432,7 +4441,7 @@ async def handle_write_result(args: dict) -> list[TextContent]:
         "text": text,
         "task_id": task_id,
         "status": status,
-        "forward": bool(forward),
+        "sent_reply_to_user": bool(sent_reply_to_user),
         "timestamp": now.isoformat(),
     }
     if artifacts:
@@ -4461,7 +4470,7 @@ async def handle_write_result(args: dict) -> list[TextContent]:
 
     log.info(f"Subagent result queued in inbox: task_id={task_id} status={status} chat_id={chat_id}")
     if msg_type == "subagent_notification":
-        delivery_note = "Subagent handled delivery directly via send_reply — dispatcher will mark processed without forwarding."
+        delivery_note = "Subagent already sent reply via send_reply — dispatcher will mark processed without relaying."
     else:
         delivery_note = f"The main thread will deliver it to chat {chat_id}."
     return [TextContent(
@@ -6143,7 +6152,7 @@ def _enqueue_reconciler_notification(session: dict, outcome: str) -> None:
         "task_id": agent_id,
         "agent_id": agent_id,
         "status": status,
-        "forward": True,
+        "sent_reply_to_user": False,  # reconciler hasn't sent anything directly
         "timestamp": now.isoformat(),
     }
 

--- a/tests/unit/test_mcp_server/test_message_tools.py
+++ b/tests/unit/test_mcp_server/test_message_tools.py
@@ -886,7 +886,7 @@ class TestGetStats:
 
 
 class TestWriteResultDeduplication:
-    """Tests for server-side dedup: write_result should not forward when send_reply
+    """Tests for server-side dedup: write_result should not relay when send_reply
     was already called with the same text to the same chat."""
 
     @pytest.fixture(autouse=True)
@@ -908,8 +908,8 @@ class TestWriteResultDeduplication:
         sent.mkdir(exist_ok=True)
         return inbox, outbox, sent
 
-    def test_forward_suppressed_after_send_reply(self, dirs):
-        """write_result with forward=True is overridden to False when an identical
+    def test_sent_reply_promoted_after_send_reply(self, dirs):
+        """write_result with sent_reply_to_user=False is promoted to True when an identical
         message was already delivered via send_reply to the same chat."""
         inbox, outbox, sent = dirs
 
@@ -932,29 +932,28 @@ class TestWriteResultDeduplication:
                 "source": "telegram",
             }))
 
-            # Then calls write_result with forward=True (the buggy pattern)
+            # Then calls write_result omitting sent_reply_to_user (buggy pattern — would relay duplicate)
             result = asyncio.run(handle_write_result({
                 "task_id": "issue-42",
                 "chat_id": 111,
                 "text": text,
                 "source": "telegram",
-                "forward": True,
+                # sent_reply_to_user omitted — server should detect dedup and set True
             }))
 
             assert len(result) == 1
             assert "Result queued" in result[0].text
 
-            # Read the written message and verify forward was overridden to False
+            # Verify sent_reply_to_user was promoted to True by server-side dedup
             inbox_files = list(inbox.glob("*.json"))
             assert len(inbox_files) == 1
             msg = json.loads(inbox_files[0].read_text())
-            assert msg["forward"] is False, (
-                "forward should be overridden to False when send_reply was already called"
+            assert msg["sent_reply_to_user"] is True, (
+                "sent_reply_to_user should be promoted to True when send_reply was already called"
             )
 
-    def test_forward_not_suppressed_for_different_text(self, dirs):
-        """write_result forward is NOT suppressed when the text differs from
-        what was sent via send_reply."""
+    def test_relay_not_suppressed_for_different_text(self, dirs):
+        """write_result is NOT suppressed when the text differs from what was sent via send_reply."""
         inbox, outbox, sent = dirs
 
         with patch.multiple(
@@ -974,24 +973,24 @@ class TestWriteResultDeduplication:
                 "source": "telegram",
             }))
 
-            # write_result with different text
+            # write_result with different text and sent_reply_to_user=False
             asyncio.run(handle_write_result({
                 "task_id": "issue-99",
                 "chat_id": 222,
                 "text": "Final result: all done.",
                 "source": "telegram",
-                "forward": True,
+                "sent_reply_to_user": False,
             }))
 
             inbox_files = list(inbox.glob("*.json"))
             assert len(inbox_files) == 1
             msg = json.loads(inbox_files[0].read_text())
-            assert msg["forward"] is True, (
-                "forward should remain True when texts differ"
+            assert msg["sent_reply_to_user"] is False, (
+                "sent_reply_to_user should remain False when texts differ"
             )
 
-    def test_forward_not_suppressed_for_different_chat(self, dirs):
-        """write_result forward is NOT suppressed when the chat_id differs."""
+    def test_relay_not_suppressed_for_different_chat(self, dirs):
+        """write_result is NOT suppressed when the chat_id differs."""
         inbox, outbox, sent = dirs
 
         with patch.multiple(
@@ -1013,24 +1012,24 @@ class TestWriteResultDeduplication:
                 "source": "telegram",
             }))
 
-            # write_result to a different chat 444
+            # write_result to a different chat 444 with sent_reply_to_user=False
             asyncio.run(handle_write_result({
                 "task_id": "issue-77",
                 "chat_id": 444,
                 "text": text,
                 "source": "telegram",
-                "forward": True,
+                "sent_reply_to_user": False,
             }))
 
             inbox_files = list(inbox.glob("*.json"))
             assert len(inbox_files) == 1
             msg = json.loads(inbox_files[0].read_text())
-            assert msg["forward"] is True, (
-                "forward should remain True when chat_id differs"
+            assert msg["sent_reply_to_user"] is False, (
+                "sent_reply_to_user should remain False when chat_id differs"
             )
 
-    def test_explicit_forward_false_still_false(self, dirs):
-        """write_result with explicit forward=False is preserved regardless."""
+    def test_explicit_sent_reply_true(self, dirs):
+        """write_result with explicit sent_reply_to_user=True produces subagent_notification."""
         inbox, outbox, sent = dirs
 
         with patch.multiple(
@@ -1046,12 +1045,69 @@ class TestWriteResultDeduplication:
             asyncio.run(handle_write_result({
                 "task_id": "issue-55",
                 "chat_id": 555,
-                "text": "No forward needed.",
+                "text": "Already delivered directly.",
                 "source": "telegram",
-                "forward": False,
+                "sent_reply_to_user": True,
             }))
 
             inbox_files = list(inbox.glob("*.json"))
             assert len(inbox_files) == 1
             msg = json.loads(inbox_files[0].read_text())
-            assert msg["forward"] is False
+            assert msg["sent_reply_to_user"] is True
+            assert msg["type"] == "subagent_notification"
+
+    def test_legacy_forward_false_compat(self, dirs):
+        """Legacy callers using forward=False are treated as sent_reply_to_user=True (inverse semantics)."""
+        inbox, outbox, sent = dirs
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox,
+            OUTBOX_DIR=outbox,
+            SENT_DIR=sent,
+            SENT_REPLIES_DIR=self._sent_replies_dir,
+        ):
+            import asyncio
+            from src.mcp.inbox_server import handle_write_result
+
+            asyncio.run(handle_write_result({
+                "task_id": "issue-legacy",
+                "chat_id": 666,
+                "text": "Legacy forward=False call.",
+                "source": "telegram",
+                "forward": False,  # old API: forward=False meant "don't relay" → sent_reply_to_user=True
+            }))
+
+            inbox_files = list(inbox.glob("*.json"))
+            assert len(inbox_files) == 1
+            msg = json.loads(inbox_files[0].read_text())
+            assert msg["sent_reply_to_user"] is True
+            assert msg["type"] == "subagent_notification"
+
+    def test_legacy_forward_true_compat(self, dirs):
+        """Legacy callers using forward=True are treated as sent_reply_to_user=False (inverse semantics)."""
+        inbox, outbox, sent = dirs
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox,
+            OUTBOX_DIR=outbox,
+            SENT_DIR=sent,
+            SENT_REPLIES_DIR=self._sent_replies_dir,
+        ):
+            import asyncio
+            from src.mcp.inbox_server import handle_write_result
+
+            asyncio.run(handle_write_result({
+                "task_id": "issue-legacy-fwd",
+                "chat_id": 777,
+                "text": "Legacy forward=True call.",
+                "source": "telegram",
+                "forward": True,  # old API: forward=True meant "relay" → sent_reply_to_user=False
+            }))
+
+            inbox_files = list(inbox.glob("*.json"))
+            assert len(inbox_files) == 1
+            msg = json.loads(inbox_files[0].read_text())
+            assert msg["sent_reply_to_user"] is False
+            assert msg["type"] == "subagent_result"


### PR DESCRIPTION
## Problem

`write_result(forward=False)` means "I already replied, don't relay" — but the double negative requires careful reading. A subagent that called `send_reply` directly should pass a parameter that reads naturally as "yes, I already replied," not one that says "no, don't forward."

## What this changes

Renames the `forward` field on `write_result` to `sent_reply_to_user`, with inverted semantics:

| Old | New | Meaning |
|-----|-----|---------|
| `forward=False` | `sent_reply_to_user=True` | I called `send_reply` — dispatcher just marks processed |
| `forward=True` | `sent_reply_to_user=False` | I did NOT reply — dispatcher should relay |
| omitted (default `False`) | omitted (default `False`) | dispatcher relays (unchanged) |

Backward compatibility is preserved: the old `forward` field is accepted as a legacy alias with automatically inverted semantics. New callers use `sent_reply_to_user` exclusively.

The rename touches: `inbox_server.py` (handler, tool schema, message envelope, reconciler notification), dispatcher and subagent bootup docs, all agent system prompts, CLAUDE.md, README.md, and the deduplication test suite (which also gains two new legacy-compat tests).

Closes #362

## Functional patterns

Pure function dispatch — the `handle_write_result` handler reads `sent_reply_to_user` (or translates from legacy `forward`) and produces an immutable message envelope. The translation logic is a simple conditional at the top of the function, with no shared mutable state.

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_message_tools.py -v` — 33 passed, 6 failed. The 6 failures are pre-existing failures in `TestSendReply`, `TestAutoThreading`, and `TestMarkProcessed` unrelated to this rename (they fail on `main` as well). All `TestWriteResultDeduplication` tests pass, including two new legacy-compat tests.

**Blocked items needing attention before merge:** none