### PR TITLE
feat: shared session_role utility for dispatcher/subagent hook discrimination

### DIFF
--- a/hooks/post-compact-gate.py
+++ b/hooks/post-compact-gate.py
@@ -7,7 +7,7 @@ main loop before doing anything else.
 The sentinel file ~/messages/config/compact-pending is written by
 on-compact.py when a compaction occurs. This hook passes when:
   1. No sentinel file exists (normal operation), OR
-  2. Not the dispatcher session (see is_dispatcher_session()), OR
+  2. Not the dispatcher session (see session_role.is_dispatcher()), OR
   3. The sentinel is older than SENTINEL_TTL_SECONDS (stale / post-hibernation), OR
   4. The tool being called IS wait_for_messages (let it through, delete sentinel).
 
@@ -17,27 +17,21 @@ finds a stale sentinel and the gate passes immediately. No deadlock.
 
 ## Dispatcher vs subagent detection
 
-LOBSTER_MAIN_SESSION=1 is set by claude-persistent.sh and is inherited by
-subagents spawned via the Task tool. A bare env-var check would incorrectly
-activate the gate for subagents too.
+Detection is delegated to session_role.is_dispatcher(), which uses a layered
+strategy:
 
-The fix: walk the process tree upward from the current process. If we encounter
-a parent 'claude' process before reaching a tmux pane PID, this process is a
-subagent (child of the dispatcher Claude). If the first non-hook ancestor is
-the dispatcher Claude directly under a tmux pane, we are the dispatcher.
+1. Marker file (primary): At dispatcher startup, write-dispatcher-session-id.py
+   (a SessionStart hook) writes the session ID to
+   ~/messages/config/dispatcher-session-id. This hook reads that file and
+   compares it to the session_id in the hook JSON input. Match → dispatcher.
 
-Concretely: a subagent's hook process ancestry looks like:
-  hook.py → claude (subagent) → claude (dispatcher) → tmux pane → ...
+2. Process-tree fallback (secondary): If the marker file is absent or
+   unreadable, walk the process tree upward. Two consecutive claude-like
+   ancestors before reaching a tmux pane PID → subagent. One or fewer →
+   dispatcher. See _is_dispatcher_by_process_tree() below.
 
-The dispatcher's hook process ancestry looks like:
-  hook.py → claude (dispatcher) → tmux pane → ...
-
-We detect the subagent case by finding two consecutive claude-like processes
-in the ancestor chain before reaching a tmux pane PID. If we see only one
-claude-like process before the tmux pane, we are the dispatcher.
-
-Falls back to the env-var-only check when tmux is unavailable or the process
-tree walk fails — maintaining prior behaviour (slightly imprecise but safe).
+3. Env-var-only fallback: If tmux is unavailable, fall back to
+   LOBSTER_MAIN_SESSION=1 alone.
 
 ## Settings.json configuration
 
@@ -65,6 +59,9 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+
+# Make hooks/ importable regardless of cwd.
+sys.path.insert(0, str(Path(__file__).parent))
 
 SENTINEL_FILE = Path(os.path.expanduser("~/messages/config/compact-pending"))
 SENTINEL_TTL_SECONDS = 600  # 10 minutes — treats stale sentinel as harmless
@@ -153,8 +150,10 @@ def _is_claude_process(name: str) -> bool:
     return "claude" in name.lower()
 
 
-def is_dispatcher_session() -> bool:
+def _is_dispatcher_by_process_tree() -> bool:
     """Return True only when this hook is running inside the dispatcher Claude.
+
+    Process-tree fallback used when the session_role marker file is absent.
 
     Strategy:
       1. Must have LOBSTER_MAIN_SESSION=1 (env var set by claude-persistent.sh).
@@ -196,6 +195,40 @@ def is_dispatcher_session() -> bool:
     return True
 
 
+def is_dispatcher_session(hook_input: dict) -> bool:
+    """Return True when this hook is running inside the dispatcher Claude.
+
+    Uses session_role.is_dispatcher() (marker-file + transcript) as the primary
+    check. Falls back to the process-tree walk when neither signal is available
+    (e.g. marker file not yet written on first boot, no transcript in PreToolUse).
+    """
+    # Primary: marker file + transcript (via session_role).
+    # session_role returns False by default when no signal is found; we need to
+    # distinguish "definitely subagent" from "no signal" to know when to apply
+    # the process-tree fallback. We probe the marker file directly here.
+    from session_role import (
+        _check_marker_file,
+        get_session_id,
+        _transcript_has_dispatcher_tool,
+        DISPATCHER_SESSION_FILE,
+    )
+
+    session_id = get_session_id(hook_input)
+    marker_result = _check_marker_file(session_id)
+
+    if marker_result is not None:
+        # Marker file exists and gave a definitive answer.
+        return marker_result
+
+    # Transcript fallback (Stop hooks only — transcript absent in PreToolUse).
+    transcript = hook_input.get("transcript")
+    if transcript is not None:
+        return _transcript_has_dispatcher_tool(transcript)
+
+    # No session_role signal available — fall back to process-tree.
+    return _is_dispatcher_by_process_tree()
+
+
 def sentinel_is_fresh() -> bool:
     """Return True if the sentinel exists and is recent enough to enforce."""
     if not SENTINEL_FILE.exists():
@@ -214,7 +247,7 @@ def main() -> None:
         sys.exit(0)
 
     # Only enforce for the main dispatcher session.
-    if not is_dispatcher_session():
+    if not is_dispatcher_session(data):
         sys.exit(0)
 
     tool_name = data.get("tool_name", "")

--- a/hooks/require-write-result.py
+++ b/hooks/require-write-result.py
@@ -2,9 +2,17 @@
 """
 Stop hook: ensure subagents call write_result before exiting.
 Injects a reminder if write_result was not called during the session.
+
+Dispatcher sessions (detected via session_role.is_dispatcher()) are exempt —
+the dispatcher never calls write_result, so the check only applies to subagents.
 """
 import json
 import sys
+from pathlib import Path
+
+# Import shared session role utility.
+sys.path.insert(0, str(Path(__file__).parent))
+from session_role import is_dispatcher
 
 
 def main():
@@ -13,8 +21,12 @@ def main():
     except Exception:
         sys.exit(0)  # If we can't read transcript, don't block
 
-    # Check if this is a subagent session (not the dispatcher)
-    # Dispatchers call wait_for_messages; subagents don't
+    # Dispatcher sessions are exempt — skip the write_result check.
+    # session_role.is_dispatcher() uses the marker file as primary signal and
+    # the transcript (which is present in Stop hooks) as fallback.
+    if is_dispatcher(data):
+        sys.exit(0)
+
     transcript = data.get("transcript", [])
 
     tool_calls = []
@@ -25,10 +37,6 @@ def main():
                 for item in content:
                     if isinstance(item, dict) and item.get("type") == "tool_use":
                         tool_calls.append(item.get("name", ""))
-
-    # If this session called wait_for_messages, it's the dispatcher — skip
-    if "mcp__lobster-inbox__wait_for_messages" in tool_calls:
-        sys.exit(0)
 
     # If this session called write_result, we're good
     if "mcp__lobster-inbox__write_result" in tool_calls:

--- a/hooks/session_role.py
+++ b/hooks/session_role.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Shared utility: dispatcher vs subagent session discrimination.
+
+Provides a single `is_dispatcher(hook_input)` predicate that all hooks can
+import to determine whether the current Claude Code session is the Lobster
+dispatcher or a background subagent.
+
+## Detection strategy (layered)
+
+1. **Marker file (primary)**: At dispatcher startup the session ID is written to
+   `~/messages/config/dispatcher-session-id`. This hook reads that file and
+   compares to the `session_id` field in the hook JSON input.
+   Match → dispatcher.  Mismatch or file absent → try fallback.
+
+2. **Transcript fallback (secondary)**: Scan the `transcript` field (present in
+   Stop hooks; absent in PreToolUse hooks) for tool_use blocks containing the
+   dispatcher-only tool `wait_for_messages` or `check_inbox`.
+   Found → dispatcher.  Not found → subagent.
+
+3. **Default**: If neither signal is available (e.g. a PreToolUse hook with no
+   marker file), return False (treat as subagent = safe/conservative).
+
+## Writing the marker file
+
+Call `write_dispatcher_session_id(session_id)` at dispatcher startup.
+Typically invoked from a `SessionStart` hook or from the dispatcher bootup
+script via a small wrapper.
+"""
+
+import json
+import os
+from pathlib import Path
+
+DISPATCHER_SESSION_FILE = Path(
+    os.path.expanduser("~/messages/config/dispatcher-session-id")
+)
+
+# Tools that only the dispatcher calls — used as transcript fallback signal.
+DISPATCHER_ONLY_TOOLS = {
+    "mcp__lobster-inbox__wait_for_messages",
+    "mcp__lobster-inbox__check_inbox",
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_session_id(hook_input: dict) -> str | None:
+    """Return the session_id from hook JSON input, or None if absent."""
+    return hook_input.get("session_id") or None
+
+
+def is_dispatcher(hook_input: dict) -> bool:
+    """Return True if the current session is the Lobster dispatcher.
+
+    Checks marker file first; falls back to transcript scan if the marker file
+    is absent or unreadable.  Returns False (subagent) when no signal is found.
+    """
+    session_id = get_session_id(hook_input)
+
+    # --- Primary: marker file ---
+    marker_result = _check_marker_file(session_id)
+    if marker_result is not None:
+        return marker_result
+
+    # --- Secondary: transcript scan ---
+    transcript = hook_input.get("transcript")
+    if transcript is not None:
+        return _transcript_has_dispatcher_tool(transcript)
+
+    # --- Default: no signal → treat as subagent (conservative) ---
+    return False
+
+
+def write_dispatcher_session_id(session_id: str) -> None:
+    """Write session_id to the dispatcher marker file.
+
+    Should be called once at dispatcher startup (e.g. from a SessionStart hook
+    or a thin wrapper script).  Atomic write via a .tmp rename so concurrent
+    readers never see a partial file.
+
+    Silent on any failure — must never crash the caller.
+    """
+    try:
+        DISPATCHER_SESSION_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = DISPATCHER_SESSION_FILE.with_suffix(".tmp")
+        tmp_path.write_text(session_id.strip())
+        tmp_path.replace(DISPATCHER_SESSION_FILE)  # atomic on Linux
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_dispatcher_session_id() -> str | None:
+    """Return the stored dispatcher session ID, or None on any failure."""
+    try:
+        if not DISPATCHER_SESSION_FILE.exists():
+            return None
+        value = DISPATCHER_SESSION_FILE.read_text().strip()
+        return value or None
+    except OSError:
+        return None
+
+
+def _check_marker_file(session_id: str | None) -> bool | None:
+    """Compare session_id against the marker file.
+
+    Returns:
+        True   — session_id matches the stored dispatcher ID.
+        False  — marker file exists and session_id does NOT match (→ subagent).
+        None   — marker file absent or unreadable; caller should try fallback.
+    """
+    stored = _read_dispatcher_session_id()
+    if stored is None:
+        return None  # No marker file — can't decide; use fallback.
+    if session_id is None:
+        return None  # Session ID not in hook input — can't decide; use fallback.
+    return session_id == stored
+
+
+def _transcript_has_dispatcher_tool(transcript: list) -> bool:
+    """Return True if any tool_use block in transcript calls a dispatcher-only tool."""
+    for msg in transcript:
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content", [])
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") == "tool_use" and item.get("name") in DISPATCHER_ONLY_TOOLS:
+                return True
+    return False

--- a/hooks/write-dispatcher-session-id.py
+++ b/hooks/write-dispatcher-session-id.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+SessionStart hook: write the dispatcher session ID to the marker file.
+
+Fires on SessionStart (non-compact) for the main Lobster dispatcher session.
+Writes the current session_id to ~/messages/config/dispatcher-session-id so
+that other hooks can quickly identify whether they are running inside the
+dispatcher or a background subagent.
+
+Only writes when LOBSTER_MAIN_SESSION=1 is set — the env var established by
+claude-persistent.sh to mark the dispatcher process. Subagents inherit this
+var but are detected later via the marker file comparison in session_role.py.
+
+## settings.json configuration
+
+Add this to ~/.claude/settings.json under "hooks" → "SessionStart":
+
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 $HOME/lobster/hooks/write-dispatcher-session-id.py",
+          "timeout": 5
+        }
+      ]
+    }
+
+The empty-string matcher fires on every SessionStart event (both fresh starts
+and compact events). The compact variant is already handled by on-compact.py
+via a "compact" matcher — the two hooks can coexist safely.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Inline the write logic to avoid import path complexity in hook context.
+DISPATCHER_SESSION_FILE = Path(
+    os.path.expanduser("~/messages/config/dispatcher-session-id")
+)
+
+
+def _write_session_id(session_id: str) -> None:
+    """Atomically write session_id to the dispatcher marker file."""
+    try:
+        DISPATCHER_SESSION_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = DISPATCHER_SESSION_FILE.with_suffix(".tmp")
+        tmp_path.write_text(session_id.strip())
+        tmp_path.replace(DISPATCHER_SESSION_FILE)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def main() -> None:
+    # Only write for the main dispatcher process.
+    if os.environ.get("LOBSTER_MAIN_SESSION", "") != "1":
+        sys.exit(0)
+
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    session_id = data.get("session_id", "").strip()
+    if not session_id:
+        sys.exit(0)
+
+    _write_session_id(session_id)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/install.sh
+++ b/install.sh
@@ -1263,6 +1263,28 @@ else
     info "Skipping post-compact-gate hook (settings.json not yet created)"
 fi
 
+# Set up Claude Code SessionStart hook to write the dispatcher session ID
+# This enables hooks to reliably distinguish dispatcher from subagent sessions.
+chmod +x "$INSTALL_DIR/hooks/write-dispatcher-session-id.py" || true
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.SessionStart[]? | select(.hooks[]?.command | contains("write-dispatcher-session-id"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq '.hooks.SessionStart = (.hooks.SessionStart // []) + [{
+            "matcher": "",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 '"$INSTALL_DIR"'/hooks/write-dispatcher-session-id.py",
+                "timeout": 5
+            }]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "write-dispatcher-session-id hook installed"
+    else
+        info "write-dispatcher-session-id hook already configured in Claude Code settings"
+    fi
+else
+    info "Skipping write-dispatcher-session-id hook (settings.json not yet created)"
+fi
+
 # Set up Claude Code SessionStart hook to set compact flag on context compaction
 chmod +x "$INSTALL_DIR/hooks/on-compact.py" || true
 if [ -f "$CLAUDE_SETTINGS" ]; then


### PR DESCRIPTION
## Summary

Hooks like `post-compact-gate.py` and `require-write-result.py` previously had no reliable way to distinguish the dispatcher from background subagents. The process-tree walk in `post-compact-gate.py` is tmux-dependent and unavailable in environments without tmux. The transcript scan in `require-write-result.py` is correct but inline, duplicated, and unavailable in `PreToolUse` hooks (which don't receive a transcript).

This PR introduces a shared, importable `session_role` module with a layered detection strategy: marker file first (fast, O(1)), transcript scan as fallback (for Stop hooks before the marker file is written), process-tree walk as last resort (preserved for backward compatibility in `post-compact-gate.py`).

## What changed

**`hooks/session_role.py`** (new) — shared utility module:
- `is_dispatcher(hook_input)` — the single predicate all hooks import
- `get_session_id(hook_input)` — extracts `session_id` from hook JSON
- `write_dispatcher_session_id(session_id)` — atomic write to `~/messages/config/dispatcher-session-id`
- Internal helpers: `_check_marker_file`, `_transcript_has_dispatcher_tool`

**`hooks/write-dispatcher-session-id.py`** (new) — `SessionStart` hook:
- Fires on every session start (empty matcher)
- Writes `session_id` to `~/messages/config/dispatcher-session-id` when `LOBSTER_MAIN_SESSION=1`
- Keeps the marker file current after restarts and hibernation cycles

**`hooks/post-compact-gate.py`** (updated):
- `is_dispatcher_session(hook_input)` now uses the marker file as primary signal
- Falls back to transcript scan (for Stop-style contexts), then process-tree walk
- Process-tree logic preserved as `_is_dispatcher_by_process_tree()` for backward compatibility

**`hooks/require-write-result.py`** (updated):
- Replaces the inline `wait_for_messages` transcript scan with `session_role.is_dispatcher(data)`
- Cleaner: the shared utility handles both marker-file and transcript signals

**`install.sh`** (updated):
- Registers `write-dispatcher-session-id.py` as a `SessionStart` hook with empty matcher
- Idempotent check guards against double-registration

## Functional patterns used

- Pure functions with explicit inputs and no shared mutable state (`is_dispatcher`, `_check_marker_file`)
- Layered fallback via function composition (marker → transcript → process-tree)
- Atomic file writes via `.tmp` + `replace()` to avoid partial reads in concurrent hooks
- Conservative default (returns `False` / treats as subagent) when no signal is available

## What is NOT changed

- The process-tree walk logic in `post-compact-gate.py` is preserved unchanged as a fallback — no behaviour change for deployments that haven't written the marker file yet (e.g. first boot after this update)
- `on-compact.py` is untouched
- `~/lobster/` stays on `main` throughout; all work done in worktree

## Tests run

- [x] `python3 -m py_compile hooks/session_role.py hooks/write-dispatcher-session-id.py hooks/post-compact-gate.py hooks/require-write-result.py` — all four files compile cleanly, no errors
- [x] Manual unit test of `session_role.py` (5 scenarios: no marker/no transcript, marker match, marker mismatch, transcript dispatcher, transcript subagent) — all passed
- [x] Manual integration test of `require-write-result.py` (3 scenarios: dispatcher exits 0, subagent with write_result exits 0, subagent without write_result exits 2) — all passed
- [ ] Live dispatcher test — requires a running dispatcher session with `LOBSTER_MAIN_SESSION=1` and a real `SessionStart` event; cannot be simulated in this environment without restarting the dispatcher, which would break the MCP pipe

**Blocked items needing attention before merge:** none — the process-tree fallback ensures backward compatibility on first boot.