### PR TITLE
fix: guard on-compact.py with is_dispatcher() to prevent subagent noise

### DIFF
--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -15,6 +15,10 @@ that a compaction occurred.
 
 State: always writes compacted_at to lobster-state.json so that the health
 check can suppress stale-inbox false-positives during the compaction pause.
+
+Dispatcher-only: exits immediately for subagent sessions (detected via
+session_role.is_dispatcher()). Subagent compactions must not write compact-
+reminders or the sentinel — those signals are only meaningful to the dispatcher.
 """
 
 import json
@@ -23,6 +27,10 @@ import sys
 import time
 import urllib.request
 from pathlib import Path
+
+# Import shared session role utility.
+sys.path.insert(0, str(Path(__file__).parent))
+from session_role import is_dispatcher
 
 
 INBOX_DIR = Path(os.path.expanduser("~/messages/inbox"))
@@ -228,6 +236,17 @@ def maybe_send_dev_telegram_notify() -> None:
 
 
 def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        data = {}
+
+    # Only act for the dispatcher session. Subagent compactions must not
+    # inject compact-reminders into the shared inbox or write the sentinel,
+    # because those signals are only meaningful to the dispatcher.
+    if not is_dispatcher(data):
+        sys.exit(0)
+
     # Always record compaction timestamp first — before any early returns.
     # This ensures the health check can suppress false-positive restarts even
     # if a compact-reminder is already pending.


### PR DESCRIPTION
## Summary

- `on-compact.py` (SessionStart hook) was firing for subagent sessions as well as the dispatcher
- When a subagent's context compacts, it would inject a spurious `compact-reminder` into the shared inbox and touch the `compact-pending` sentinel
- This could cause the dispatcher to mis-orient on its next `wait_for_messages()` and cause `post-compact-gate.py` to block legitimate tool calls
- Fix: add `session_role.is_dispatcher()` guard at the top of `main()` — subagent compaction events now exit immediately without touching the inbox, sentinel, or state file

## Depends on

PR #390 (`feature/hook-session-discrimination`) for `session_role.py` — this PR should be merged after #390.

## Hook audit findings (gap this PR addresses)

PR #390 updated `post-compact-gate.py` and `require-write-result.py` to use `session_role.is_dispatcher()`. This PR closes the remaining gap: `on-compact.py`.

Hooks assessed for dispatcher-only applicability:

| Hook | Should be dispatcher-only? | Has is_dispatcher() guard? | Status |
|------|---------------------------|---------------------------|--------|
| `on-compact.py` | YES — compact-reminder and sentinel are only meaningful to the dispatcher | NO (before this PR) | Fixed here |
| `post-compact-gate.py` | YES — gate only applies to dispatcher loop | YES (PR #390) | Done |
| `require-write-result.py` | YES — dispatcher never calls write_result | YES (PR #390) | Done |
| `require-subagent-type.py` | NO — correct for both roles (subagents should also use typed subagents if they spawn agents) | n/a | No change needed |
| `no-auto-memory.py` | NO — applies to both roles equally | n/a | No change needed |
| `link-checker.py` | NO — both dispatcher and subagents send replies | n/a | No change needed |
| `restore-exec-bit.py` | NO — both roles edit files | n/a | No change needed |

## Test plan

- [ ] Verify `on-compact.py` exits 0 without side effects when run without `LOBSTER_MAIN_SESSION=1` (simulates subagent)
- [ ] Verify `on-compact.py` still writes compact-reminder and sentinel when run as dispatcher (marker file matches session_id)
- [ ] Confirm no spurious compact-reminders appear in inbox after a subagent session compacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)