### PR TITLE
fix: add missing type field at all message ingestion sites

### DIFF
--- a/scripts/check-agent-outputs.sh
+++ b/scripts/check-agent-outputs.sh
@@ -108,6 +108,7 @@ while IFS= read -r agent_id; do
 {
   "id": "${MSG_ID}",
   "source": "system",
+  "type": "system",
   "chat_id": 0,
   "user_id": 0,
   "username": "lobster-system",

--- a/scripts/periodic-self-check.sh
+++ b/scripts/periodic-self-check.sh
@@ -127,6 +127,7 @@ out_path, msg_id, timestamp, text = sys.argv[1], sys.argv[2], sys.argv[3], sys.a
 msg = {
     "id": msg_id,
     "source": "system",
+    "type": "self_check",
     "chat_id": 0,
     "user_id": 0,
     "username": "lobster-system",

--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -878,6 +878,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     msg_data = {
         "id": msg_id,
         "source": "telegram",
+        "type": "text",
         "chat_id": message.chat_id,
         "telegram_message_id": message.message_id,
         "user_id": user.id,

--- a/src/bot/slack_router.py
+++ b/src/bot/slack_router.py
@@ -239,6 +239,7 @@ def handle_message_events(body, say, logger):
     msg_data = {
         "id": msg_id,
         "source": "slack",
+        "type": "text",
         "chat_id": channel_id,
         "user_id": user_id,
         "username": username,


### PR DESCRIPTION
## Problem

77% of all processed messages were classified as `unknown` by routing stats and analytics — making message-type filtering and dashboards unreliable. The root cause was not in the stats reporter, but in the message writers: four ingestion sites wrote inbox JSON without a `"type"` field, so any reader that does `msg.get("type", "unknown")` would fall through to the default.

From sampling 4,690 processed messages: 3,611 (77%) had no `"type"` key at all. Of those, 2,337 were self-check messages from the periodic cron script, and 1,253 were plain Telegram text messages.

## What changed

Four one-line additions, one at each ingestion site that was missing the field:

- `src/bot/lobster_bot.py` — Telegram text messages (`handle_message`): `"type": "text"`
- `src/bot/slack_router.py` — Slack text messages (`handle_message_events`): `"type": "text"`
- `scripts/periodic-self-check.sh` — periodic self-check cron messages: `"type": "self_check"`
- `scripts/check-agent-outputs.sh` — agent relay notifications: `"type": "system"`

Message types that already had the field (`photo`, `document`, `voice`, `audio`, `callback`, `subagent_result`, `subagent_error`, `subagent_observation`) are untouched. No logic changes, no schema changes — only missing fields added.

The existing processed archive (~3,600 unknown-typed messages) is not retroactively migrated; that is lower priority and can be addressed separately if needed. All new messages going forward will be correctly typed.

## Tests run

- [x] Manual diff review of all 4 changed files — each adds exactly one key-value pair to the correct dict literal
- [x] `git diff` verified: 4 files, 4 insertions, 0 deletions
- [ ] Live Telegram/Slack integration test — requires running bot; no behavior change to routing, only field presence added

Closes #394