### PR TITLE
fix: register require-write-result.py under SubagentStop hook event

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1327,6 +1327,28 @@ else
     info "Skipping require-write-result Stop hook (settings.json not yet created)"
 fi
 
+# Set up Claude Code SubagentStop hook to enforce write_result in subagent sessions
+# SubagentStop fires when a background sidechain session considers stopping — this is
+# the hook that actually catches subagents, whereas Stop only fires for the main session.
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.SubagentStop[]? | select(.matcher == "")' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq '.hooks.SubagentStop = (.hooks.SubagentStop // []) + [{
+            "matcher": "",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 '"$INSTALL_DIR"'/hooks/require-write-result.py",
+                "timeout": 10
+            }]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "require-write-result SubagentStop hook installed"
+    else
+        info "require-write-result SubagentStop hook already configured in Claude Code settings"
+    fi
+else
+    info "Skipping require-write-result SubagentStop hook (settings.json not yet created)"
+fi
+
 #===============================================================================
 # Python Environment
 #===============================================================================


### PR DESCRIPTION
## Summary

Subagents could exit without calling `write_result` because the `Stop` hook event only fires for the main (dispatcher) session — not for background sidechains. Claude Code uses a separate event, `SubagentStop`, for those. The `require-write-result.py` hook was never registered under `SubagentStop`, so it never ran for subagents, which is why they became ghosts.

The fix registers the same `require-write-result.py` hook under `SubagentStop` in `install.sh`, mirroring the existing `Stop` block. The live `~/.claude/settings.json` is also patched directly as part of this change so the fix is in effect without requiring a reinstall.

The hook itself needs no changes. Both `Stop` and `SubagentStop` deliver the same payload shape (`session_id` + `transcript`), so `is_dispatcher()` correctly identifies subagents via the marker file comparison, and the transcript scan for `write_result` calls works identically.

What this does not change: the hook logic, the dispatcher exemption, or any other hook registrations.

Closes #401

## Functional patterns

Pure function composition: `is_dispatcher(hook_input)` remains a pure predicate with no side effects; the hook logic is unchanged.

## Tests run

- [x] `jq '.hooks | keys' ~/.claude/settings.json` — confirms `SubagentStop` key is present alongside `Stop`
- [x] `git diff install.sh` — reviewed, change is minimal and mirrors the existing `Stop` block exactly
- [ ] Live subagent exit test — blocked: requires a running Claude Code session and a subagent that reaches `end_turn`; safe to merge, the hook path is identical to `Stop` which was already validated