### PR TITLE
feat: add swap file setup to installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -509,12 +509,25 @@ setup_swap() {
 
     step "Setting up ${swap_size_mb}MB swap file at $swapfile..."
 
-    # Create the file: fallocate is instant; dd is the universal fallback
-    if command -v fallocate &>/dev/null; then
+    # Create the file.
+    # fallocate is instant but fails on BTRFS (BTRFS doesn't support preallocation
+    # for swap files). Detect BTRFS on the target filesystem and fall back to dd.
+    # Also fall back to dd if fallocate is not installed.
+    # dd status=progress requires GNU coreutils >= 8.24 and is omitted for
+    # portability across older Ubuntu LTS and Amazon Linux releases.
+    local use_dd=0
+    if ! command -v fallocate &>/dev/null; then
+        use_dd=1
+        info "fallocate not available — using dd (this may take a moment)..."
+    elif stat -f -c %T "$(dirname "$swapfile")" 2>/dev/null | grep -qi btrfs; then
+        use_dd=1
+        info "BTRFS filesystem detected — fallocate unsupported for swap, using dd (this may take a moment)..."
+    fi
+
+    if [ "$use_dd" -eq 0 ]; then
         sudo fallocate -l "${swap_size_mb}M" "$swapfile"
     else
-        info "fallocate not available — using dd (this may take a moment)..."
-        sudo dd if=/dev/zero of="$swapfile" bs=1M count="$swap_size_mb" status=progress
+        sudo dd if=/dev/zero of="$swapfile" bs=1M count="$swap_size_mb"
     fi
 
     # Secure permissions (world-readable swap is a security risk)


### PR DESCRIPTION
## Problem

Lobster runs as an always-on Claude Code session. The current installer
leaves systems with no swap configured. On a 7.5 GB RAM server — the
reference deployment — this means any OOM event kills the Claude process
outright. Large context windows and concurrent subagents make this a
realistic failure mode, not a theoretical one.

## What this does

Adds a `setup_swap` function that runs immediately after system package
installation. The function:

- Is fully idempotent: checks `swapon --show` and exits early if any swap
  is already active (existing swap partitions, other swapfiles, etc.)
- Creates a 4 GB swapfile at `/swapfile` using `fallocate` (instant), with
  a `dd` fallback for systems where `fallocate` is unavailable
- Sets file permissions to 600 before formatting — world-readable swap
  leaks process memory to any local user
- Formats with `mkswap` and activates with `swapon`
- Adds `/swapfile none swap sw 0 0` to `/etc/fstab` if not already present
- Writes `vm.swappiness=10` to `/etc/sysctl.d/99-lobster-swap.conf` and
  applies it immediately via `sysctl -p`; swappiness 10 avoids aggressive
  paging while still providing an OOM buffer
- Resolves `swapon` and `mkswap` via `/sbin` and `/usr/sbin` fallbacks,
  since installer sessions often run with a restricted PATH that omits
  these sbin paths

## Functional patterns

Pure function with a single side-effect boundary: all swap commands run
inside `setup_swap`, which is called exactly once. Early-return guard at
the top keeps the happy path readable.

## Scope

This change only affects `install.sh`. No service files, Python code, or
MCP server configuration are touched. The swap size (4 GB) is hardcoded
as a named local variable (`swap_size_mb`) for easy future adjustment.

## Tests run

- [x] Live system test — ran `setup_swap` logic manually on the target
  server (7.5 GB RAM, Ubuntu, `/sbin/swapon`). Result: 4 GB swap active,
  `/etc/fstab` updated, `vm.swappiness=10` applied. `free -h` confirms
  `Swap: 4.0Gi`.
- [x] Idempotency — re-ran after swap was active; function exited at the
  `swapon --show` guard with "Swap already configured — skipping".
- [ ] Full installer run from scratch — not run end-to-end; doing so would
  require a fresh VM. The swap section is isolated from the rest of the
  installer and does not affect other steps.

**Blocked items needing attention before merge:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)