### PR TITLE
fix: extract transcription text from whisper timestamp lines

### DIFF
--- a/src/transcription/worker.py
+++ b/src/transcription/worker.py
@@ -21,6 +21,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import shutil
 import signal
 import sys
@@ -228,8 +229,20 @@ async def run_whisper_cpp(audio_path: Path, timeout_s: int = TRANSCRIPTION_TIMEO
         return False, f"whisper.cpp exited {proc.returncode}: {error_msg}"
 
     raw = stdout.decode().strip()
-    # Strip any residual timestamp lines (start with "[")
-    lines = [ln for ln in raw.split("\n") if not ln.strip().startswith("[")]
+    # whisper-cli emits lines in the form:
+    #   [HH:MM:SS.mmm --> HH:MM:SS.mmm]   transcription text here
+    # The transcription text lives on the same line as the timestamp bracket,
+    # so we must extract the text after "]" rather than discard the whole line.
+    # Lines that contain no timestamp (e.g. blank lines) are included as-is.
+    _TIMESTAMP_RE = re.compile(r"^\[[\d:.,\s\-–>]+\]\s*")
+    lines = []
+    for ln in raw.split("\n"):
+        stripped = ln.strip()
+        if not stripped:
+            continue
+        text = _TIMESTAMP_RE.sub("", stripped).strip()
+        if text:
+            lines.append(text)
     transcription = " ".join(lines).strip()
     return True, transcription
 


### PR DESCRIPTION
## What broke and why

Every voice message has been landing in dead-letter since transcription was deployed. The failure reason logged is "whisper returned empty transcription" — not an ffmpeg error, which pointed away from the OGG→WAV conversion and toward the text extraction step.

The root cause: `whisper-cli` embeds transcription text on the same line as its timestamp bracket:

```
[00:00:00.000 --> 00:00:06.520]   remember when you were going to have a haiku agent
[00:00:06.520 --> 00:00:12.520]   look through our last many hours of history
```

The previous post-processing filtered out every line starting with `[`, treating all of them as "residual timestamp lines to strip." This discarded all transcription content, leaving an empty string. An empty result triggers the retry path; after 3 retries the message is dead-lettered.

The OGG→WAV conversion via ffmpeg was working correctly throughout — the issue was entirely in the output parsing step.

## The fix

Switch from a filter (discard lines matching `[`) to an extractor (strip the timestamp prefix regex and keep the text). The regex `^\[[\d:.,\s\-–>]+\]\s*` matches the full `[HH:MM:SS.mmm --> HH:MM:SS.mmm]` prefix and removes it, leaving the transcription words.

The approach is a pure transformation: each input line maps to either nothing (blank) or the text portion after the timestamp — no mutable state, no side effects on the conversion or retry logic.

## Tests run

- [x] `python3 -c "..."` simulating the fixed `run_whisper_cpp` against `/tmp/test_audio.wav` — returned full transcription on first attempt
- [x] Full `transcribe_pending_file` pipeline against `/home/lobster/messages/audio/1773613067905_7759.ogg` (the specific file named in the issue) — succeeded in ~11s, correct text produced
- [x] Audited all 4 dead-letter voice messages — all failed with the same empty-transcription reason, all have audio files intact and are retryable once this fix is deployed

## Dead-letter retry

4 messages are ready to retry: IDs 6329, 7300, 7616, 7759. All OGG files exist. Moving them back to `pending-transcription/` after deployment will reprocess them.

Closes #411