### PR TITLE
feat(ghost-detector): filesystem scan for unregistered agents

### DIFF
--- a/scripts/ghost-detector.py
+++ b/scripts/ghost-detector.py
@@ -5,16 +5,21 @@ A "ghost agent" is a background subagent registered in agent_sessions.db with
 status=running that never completed (never called write_result). This tool
 queries the DB, checks output file liveness, and classifies each stale session.
 
+It also scans the filesystem for agent output files that exist but have no
+corresponding DB entry — these "unregistered agents" indicate registration
+failures and would otherwise be invisible to monitoring.
+
 Usage:
     uv run scripts/ghost-detector.py
     uv run scripts/ghost-detector.py --threshold-minutes 60
     uv run scripts/ghost-detector.py --output-file-threshold-minutes 5
     uv run scripts/ghost-detector.py --alert
     uv run scripts/ghost-detector.py --mark-failed
+    uv run scripts/ghost-detector.py --no-fs-scan
 
 Exit codes:
-    0 — no GHOST_CONFIRMED agents found
-    1 — one or more GHOST_CONFIRMED agents found
+    0 — no GHOST_CONFIRMED or UNREGISTERED agents found
+    1 — one or more GHOST_CONFIRMED or UNREGISTERED agents found
 """
 
 from __future__ import annotations
@@ -22,12 +27,14 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sqlite3
 import subprocess
 import sys
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from glob import glob
 from pathlib import Path
 from typing import Literal
 
@@ -43,6 +50,16 @@ Classification = Literal[
 ]
 
 DB_PATH = Path.home() / "messages" / "config" / "agent_sessions.db"
+
+# Glob pattern for Claude Code session task directories.
+# The middle component is a session UUID that changes per Claude Code invocation.
+AGENT_OUTPUT_GLOB = "/tmp/claude-1000/-home-lobster-lobster-workspace/*/tasks/"
+
+# Pattern for agent JSONL symlink filenames: agent-<hex_id>.jsonl
+AGENT_SYMLINK_PATTERN = re.compile(r"^agent-([0-9a-f]+)\.jsonl$")
+
+# Age threshold for treating an unregistered output file as "active" (minutes)
+UNREGISTERED_ACTIVE_THRESHOLD_MINUTES = 30.0
 
 
 @dataclass(frozen=True)
@@ -63,6 +80,16 @@ class ClassifiedAgent:
     classification: Classification
     age_minutes: float
     output_file_age_minutes: float | None  # None if no file or file missing
+
+
+@dataclass(frozen=True)
+class UnregisteredAgent:
+    """An agent found via filesystem scan with no corresponding DB entry."""
+
+    agent_id: str
+    output_file: str
+    output_file_age_minutes: float
+    is_active: bool  # True if modified within UNREGISTERED_ACTIVE_THRESHOLD_MINUTES
 
 
 # ---------------------------------------------------------------------------
@@ -145,6 +172,90 @@ def classify_agent(
 
 
 # ---------------------------------------------------------------------------
+# Filesystem scan — pure data collection, no side effects
+# ---------------------------------------------------------------------------
+
+
+def find_agent_symlinks(tasks_dir: Path) -> list[Path]:
+    """Return all agent JSONL symlinks in a Claude Code tasks directory."""
+    if not tasks_dir.is_dir():
+        return []
+    return [
+        p
+        for p in tasks_dir.iterdir()
+        if p.is_symlink() and AGENT_SYMLINK_PATTERN.match(p.name)
+    ]
+
+
+def extract_agent_id_from_symlink(symlink: Path) -> str | None:
+    """Extract the hex agent_id from an agent-<id>.jsonl symlink filename."""
+    m = AGENT_SYMLINK_PATTERN.match(symlink.name)
+    return m.group(1) if m else None
+
+
+def compute_symlink_target_age_minutes(symlink: Path, now: datetime) -> float | None:
+    """Return minutes since the symlink *target* was last modified.
+
+    We stat the resolved target (the actual .jsonl file) rather than the
+    symlink itself, since symlink mtime is typically set at creation time.
+    """
+    try:
+        resolved = symlink.resolve()
+        if not resolved.exists():
+            return None
+        mtime = datetime.fromtimestamp(resolved.stat().st_mtime, tz=timezone.utc)
+        return (now - mtime).total_seconds() / 60
+    except OSError:
+        return None
+
+
+def scan_task_dirs(glob_base: str = AGENT_OUTPUT_GLOB) -> list[Path]:
+    """Return all task directories matching the Claude Code session glob."""
+    return [Path(p) for p in glob(glob_base)]
+
+
+def discover_filesystem_agents(
+    now: datetime,
+    known_agent_ids: set[str],
+    active_threshold_minutes: float = UNREGISTERED_ACTIVE_THRESHOLD_MINUTES,
+    glob_base: str = AGENT_OUTPUT_GLOB,
+) -> list[UnregisteredAgent]:
+    """Scan the filesystem for agent output files not present in the DB.
+
+    Returns UnregisteredAgent entries for any agent JSONL symlink whose
+    agent_id is not in known_agent_ids. Broken symlinks (missing targets)
+    are skipped.
+
+    All I/O is read-only — no side effects.
+    """
+    task_dirs = scan_task_dirs(glob_base)
+    unregistered: list[UnregisteredAgent] = []
+
+    for task_dir in task_dirs:
+        for symlink in find_agent_symlinks(task_dir):
+            agent_id = extract_agent_id_from_symlink(symlink)
+            if agent_id is None:
+                continue
+            if agent_id in known_agent_ids:
+                continue  # Already tracked in DB
+
+            file_age = compute_symlink_target_age_minutes(symlink, now)
+            if file_age is None:
+                continue  # Broken symlink or unreadable — skip
+
+            unregistered.append(
+                UnregisteredAgent(
+                    agent_id=agent_id,
+                    output_file=str(symlink),
+                    output_file_age_minutes=file_age,
+                    is_active=file_age <= active_threshold_minutes,
+                )
+            )
+
+    return unregistered
+
+
+# ---------------------------------------------------------------------------
 # DB query (isolated side effect)
 # ---------------------------------------------------------------------------
 
@@ -181,6 +292,20 @@ def load_running_agents(db_path: Path) -> list[AgentRow]:
     ]
 
 
+def load_all_known_agent_ids(db_path: Path) -> set[str]:
+    """Return all agent IDs from agent_sessions.db, regardless of status.
+
+    Used to cross-reference filesystem discoveries against the DB so we don't
+    surface completed/failed agents as "unregistered".
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute("SELECT id FROM agent_sessions").fetchall()
+    finally:
+        conn.close()
+    return {row[0] for row in rows}
+
+
 # ---------------------------------------------------------------------------
 # Report formatting (pure)
 # ---------------------------------------------------------------------------
@@ -199,8 +324,16 @@ def format_agent_line(agent: ClassifiedAgent) -> str:
     return f"  - agent_id: {short_id}... | age: {age_str:>5} | file: {file_age_str:>15} | {task} — {desc}"
 
 
+def format_unregistered_line(agent: UnregisteredAgent) -> str:
+    short_id = agent.agent_id[:16]
+    file_age_str = f"{agent.output_file_age_minutes:.0f}m ago"
+    status = "ACTIVE" if agent.is_active else "STALE"
+    return f"  - agent_id: {short_id}... | file: {file_age_str:>12} | [{status}] {agent.output_file}"
+
+
 def build_report(
     classified: list[ClassifiedAgent],
+    unregistered: list[UnregisteredAgent],
     now: datetime,
     threshold_minutes: float,
     output_file_threshold_minutes: float,
@@ -232,7 +365,24 @@ def build_report(
             lines.append(format_agent_line(a))
         lines.append("")
 
-    ghost_count = len(by_class["GHOST_CONFIRMED"]) + len(by_class["GHOST_SUSPECTED"]) + len(by_class["STALE_NO_FILE"])
+    # Unregistered agents — filesystem-only discoveries
+    if unregistered:
+        active_count = sum(1 for u in unregistered if u.is_active)
+        stale_count = len(unregistered) - active_count
+        lines.append(f"UNREGISTERED ({len(unregistered)}) — found on filesystem, not in DB:")
+        lines.append(
+            f"  (active: {active_count} modified within {UNREGISTERED_ACTIVE_THRESHOLD_MINUTES:.0f}m"
+            f" | stale: {stale_count})"
+        )
+        for u in unregistered:
+            lines.append(format_unregistered_line(u))
+        lines.append("")
+
+    ghost_count = (
+        len(by_class["GHOST_CONFIRMED"])
+        + len(by_class["GHOST_SUSPECTED"])
+        + len(by_class["STALE_NO_FILE"])
+    )
     total = len(classified)
     healthy = len(by_class["HEALTHY"])
     ghost_rate = f"{ghost_count}/{total} = {ghost_count/total*100:.0f}%" if total else "0/0"
@@ -242,6 +392,12 @@ def build_report(
         f"{len(by_class['GHOST_SUSPECTED'])} suspected, {len(by_class['STALE_NO_FILE'])} stale-no-file), "
         f"{healthy} healthy | ghost rate: {ghost_rate}"
     )
+    if unregistered:
+        active_u = sum(1 for u in unregistered if u.is_active)
+        lines.append(
+            f"         {len(unregistered)} unregistered ({active_u} active, "
+            f"{len(unregistered) - active_u} stale) — likely registration failures"
+        )
 
     return "\n".join(lines)
 
@@ -251,20 +407,35 @@ def build_report(
 # ---------------------------------------------------------------------------
 
 
-def send_alert(confirmed: list[ClassifiedAgent], report: str) -> None:
-    """Send Telegram alert via lobster-inbox MCP if GHOST_CONFIRMED agents found."""
-    if not confirmed:
+def send_alert(
+    confirmed: list[ClassifiedAgent],
+    unregistered: list[UnregisteredAgent],
+    report: str,
+) -> None:
+    """Send Telegram alert if GHOST_CONFIRMED or UNREGISTERED agents found."""
+    if not confirmed and not unregistered:
         return
 
-    # Build a condensed alert rather than the full report
-    agent_lines = "\n".join(
-        f"  • {a.row.agent_id[:16]}... | {a.age_minutes:.0f}m old | {a.row.task_id or a.row.description[:40]}"
-        for a in confirmed
-    )
+    parts: list[str] = []
+    if confirmed:
+        agent_lines = "\n".join(
+            f"  • {a.row.agent_id[:16]}... | {a.age_minutes:.0f}m old | {a.row.task_id or a.row.description[:40]}"
+            for a in confirmed
+        )
+        parts.append(f"{len(confirmed)} GHOST_CONFIRMED agent(s):\n{agent_lines}")
+
+    if unregistered:
+        active_u = [u for u in unregistered if u.is_active]
+        unreg_lines = "\n".join(
+            f"  • {u.agent_id[:16]}... | {u.output_file_age_minutes:.0f}m old | {'ACTIVE' if u.is_active else 'STALE'}"
+            for u in unregistered
+        )
+        parts.append(f"{len(unregistered)} UNREGISTERED agent(s) ({len(active_u)} active):\n{unreg_lines}")
+
     alert_text = (
-        f"Ghost agent alert: {len(confirmed)} GHOST_CONFIRMED agent(s) detected.\n\n"
-        f"{agent_lines}\n\n"
-        f"Run `uv run scripts/ghost-detector.py` for full report."
+        "Ghost agent alert:\n\n"
+        + "\n\n".join(parts)
+        + "\n\nRun `uv run scripts/ghost-detector.py` for full report."
     )
 
     # The MCP server is not available as a subprocess; use the lobster-inbox
@@ -398,6 +569,39 @@ def mark_failed_ghost(agent: ClassifiedAgent, db_path: Path) -> None:
     print(f"  [mark-failed] Notification queued (task_id: {result_payload['task_id']})")
 
 
+def build_unregistered_mark_failed_payload(agent: UnregisteredAgent) -> dict:
+    """Return an inbox JSON payload for a dead unregistered agent notification (pure)."""
+    short_id = agent.agent_id[:8]
+    ts = datetime.now(timezone.utc).isoformat()
+    msg_id = f"{int(time.time() * 1000)}_ghost-unregistered-{short_id}"
+    return {
+        "id": msg_id,
+        "type": "subagent_result",
+        "chat_id": RELAUNCH_CHAT_ID,
+        "text": (
+            f"Unregistered dead agent {agent.agent_id} detected by ghost-detector.py. "
+            f"Output file last modified {agent.output_file_age_minutes:.0f}m ago: {agent.output_file}. "
+            f"This agent was never registered in agent_sessions.db — likely a registration failure."
+        ),
+        "forward": True,
+        "task_id": f"ghost-unregistered-{short_id}",
+        "timestamp": ts,
+        "source": "telegram",
+    }
+
+
+def mark_failed_unregistered(agent: UnregisteredAgent) -> None:
+    """Queue a dispatcher notification for an unregistered dead agent.
+
+    Since the agent has no DB row, we cannot update agent_sessions.db.
+    Instead we drop an inbox notification so the dispatcher is aware of
+    the registration gap.
+    """
+    payload = build_unregistered_mark_failed_payload(agent)
+    drop_inbox_message(payload)
+    print(f"  [mark-failed] Notification queued for unregistered agent {agent.agent_id[:16]}...")
+
+
 def mark_failed_all_ghosts(confirmed: list[ClassifiedAgent], db_path: Path) -> None:
     """Iterate confirmed ghosts and mark each one failed, reporting outcomes."""
     if not confirmed:
@@ -411,6 +615,25 @@ def mark_failed_all_ghosts(confirmed: list[ClassifiedAgent], db_path: Path) -> N
         mark_failed_ghost(agent, db_path)
 
     print(f"\nDone. {len(confirmed)} agent(s) marked failed; alerts queued for dispatcher.")
+
+
+def mark_failed_unregistered_dead(unregistered: list[UnregisteredAgent]) -> None:
+    """Queue inbox notifications for dead unregistered agents (used with --relaunch).
+
+    Only acts on stale (non-active) unregistered agents. Active ones may still
+    be running — notifying the dispatcher about them would create false positives.
+    """
+    dead = [u for u in unregistered if not u.is_active]
+    if not dead:
+        print("\nNo dead unregistered agents to notify about.")
+        return
+
+    print(f"\nNotifying dispatcher of {len(dead)} dead unregistered agent(s)...")
+    for agent in dead:
+        print(f"\n  Unregistered dead: {agent.agent_id[:16]}... | {agent.output_file_age_minutes:.0f}m stale")
+        mark_failed_unregistered(agent)
+
+    print(f"\nDone. {len(dead)} notification(s) queued for dispatcher.")
 
 
 # ---------------------------------------------------------------------------
@@ -455,9 +678,15 @@ def parse_args() -> argparse.Namespace:
         help=(
             "For each GHOST_CONFIRMED agent: send a Telegram alert, mark the agent "
             "as failed in agent_sessions.db, and queue a notification for the "
-            "dispatcher. The detector does not spawn a new Claude process directly — "
+            "dispatcher. For dead UNREGISTERED agents: queue a dispatcher notification. "
+            "The detector does not spawn a new Claude process directly — "
             "it alerts the dispatcher who can decide whether to re-spawn."
         ),
+    )
+    parser.add_argument(
+        "--no-fs-scan",
+        action="store_true",
+        help="Disable filesystem scan; only use agent_sessions.db (legacy behavior)",
     )
     return parser.parse_args()
 
@@ -480,17 +709,30 @@ def main() -> int:
         for row in running_agents
     ]
 
-    report = build_report(classified, now, args.threshold_minutes, args.output_file_threshold_minutes)
+    # Filesystem scan — discover unregistered agents unless opted out
+    unregistered: list[UnregisteredAgent] = []
+    if not args.no_fs_scan:
+        all_known_ids = load_all_known_agent_ids(db_path)
+        unregistered = discover_filesystem_agents(now, all_known_ids)
+
+    report = build_report(
+        classified,
+        unregistered,
+        now,
+        args.threshold_minutes,
+        args.output_file_threshold_minutes,
+    )
     print(report)
 
     confirmed = [a for a in classified if a.classification == "GHOST_CONFIRMED"]
 
     if args.mark_failed:
         mark_failed_all_ghosts(confirmed, db_path)
-    elif args.alert and confirmed:
-        send_alert(confirmed, report)
+        mark_failed_unregistered_dead(unregistered)
+    elif args.alert and (confirmed or unregistered):
+        send_alert(confirmed, unregistered, report)
 
-    return 1 if confirmed else 0
+    return 1 if (confirmed or unregistered) else 0
 
 
 if __name__ == "__main__":

--- a/scripts/ghost-detector.py
+++ b/scripts/ghost-detector.py
@@ -10,7 +10,7 @@ Usage:
     uv run scripts/ghost-detector.py --threshold-minutes 60
     uv run scripts/ghost-detector.py --output-file-threshold-minutes 5
     uv run scripts/ghost-detector.py --alert
-    uv run scripts/ghost-detector.py --relaunch
+    uv run scripts/ghost-detector.py --mark-failed
 
 Exit codes:
     0 — no GHOST_CONFIRMED agents found
@@ -297,7 +297,7 @@ def send_alert(confirmed: list[ClassifiedAgent], report: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Relaunch (isolated side effects — DB write + inbox drop)
+# Mark-failed remediation (isolated side effects — DB write + inbox drop)
 # ---------------------------------------------------------------------------
 
 RELAUNCH_CHAT_ID = 8305714125
@@ -309,15 +309,15 @@ def mark_agent_failed(db_path: Path, agent_id: str) -> None:
     try:
         conn.execute(
             "UPDATE agent_sessions SET status='failed', result_summary=? WHERE id=?",
-            ("replaced by ghost-detector auto-relaunch", agent_id),
+            ("marked failed by ghost-detector --mark-failed", agent_id),
         )
         conn.commit()
     finally:
         conn.close()
 
 
-def build_relaunch_alert_text(agent: ClassifiedAgent) -> str:
-    """Return the Telegram alert string for a single ghost agent relaunch (pure)."""
+def build_mark_failed_alert_text(agent: ClassifiedAgent) -> str:
+    """Return the Telegram alert string for a single ghost agent being marked failed (pure)."""
     desc = agent.row.description
     age = f"{agent.age_minutes:.0f}"
     file_age = (
@@ -326,31 +326,31 @@ def build_relaunch_alert_text(agent: ClassifiedAgent) -> str:
         else "unknown"
     )
     return (
-        f"\u26a0\ufe0f Ghost agent detected \u2014 re-launching:\n"
+        f"\u26a0\ufe0f Ghost agent detected \u2014 marking failed:\n"
         f"Agent: {desc}\n"
         f"Age: {age}m | Last output: {file_age}m ago\n\n"
-        f"Spawning replacement now..."
+        f"Agent has been marked failed. Dispatcher will be notified."
     )
 
 
-def build_relaunch_inbox_message(agent: ClassifiedAgent) -> dict:
-    """Return the inbox JSON payload for a ghost relaunch notification (pure)."""
+def build_mark_failed_inbox_message(agent: ClassifiedAgent) -> dict:
+    """Return the inbox JSON payload for a ghost mark-failed notification (pure)."""
     agent_id = agent.row.agent_id
     desc = agent.row.description
     short_id = agent_id[:8]
     ts = datetime.now(timezone.utc).isoformat()
-    msg_id = f"{int(time.time() * 1000)}_ghost-relaunch-{short_id}"
+    msg_id = f"{int(time.time() * 1000)}_ghost-mark-failed-{short_id}"
     return {
         "id": msg_id,
         "type": "subagent_result",
         "chat_id": RELAUNCH_CHAT_ID,
         "text": (
-            f"Ghost agent '{desc}' was detected and auto-relaunched by ghost-detector.py. "
-            f"Original agent {agent_id} has been marked failed. "
-            f"The replacement agent has been spawned \u2014 please monitor for results."
+            f"Ghost agent '{desc}' was detected by ghost-detector.py. "
+            f"Agent {agent_id} has been marked failed in the DB. "
+            f"The dispatcher has been notified \u2014 manual re-spawn may be needed."
         ),
         "forward": True,
-        "task_id": f"ghost-relaunch-{short_id}",
+        "task_id": f"ghost-mark-failed-{short_id}",
         "timestamp": ts,
         "source": "telegram",
     }
@@ -364,18 +364,18 @@ def drop_inbox_message(payload: dict) -> None:
     dest.write_text(json.dumps(payload, indent=2))
 
 
-def relaunch_ghost(agent: ClassifiedAgent, db_path: Path) -> None:
-    """Execute all relaunch side effects for one confirmed ghost agent.
+def mark_failed_ghost(agent: ClassifiedAgent, db_path: Path) -> None:
+    """Execute all mark-failed side effects for one confirmed ghost agent.
 
     Side-effect sequence (isolated at this boundary):
       1. Write Telegram alert to inbox — dispatcher forwards to user
       2. Mark agent failed in DB
-      3. Write relaunch notification to inbox — dispatcher forwards result
+      3. Write mark-failed notification to inbox — dispatcher forwards result
     """
     agent_id = agent.row.agent_id
 
     # 1. Immediate Telegram alert
-    alert_text = build_relaunch_alert_text(agent)
+    alert_text = build_mark_failed_alert_text(agent)
     alert_msg_id = f"{int(time.time() * 1000)}_ghost-alert-{agent_id[:8]}"
     alert_payload = {
         "id": alert_msg_id,
@@ -386,29 +386,29 @@ def relaunch_ghost(agent: ClassifiedAgent, db_path: Path) -> None:
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
     drop_inbox_message(alert_payload)
-    print(f"  [relaunch] Alert dropped to inbox for agent {agent_id[:16]}...")
+    print(f"  [mark-failed] Alert dropped to inbox for agent {agent_id[:16]}...")
 
     # 2. Mark failed in DB
     mark_agent_failed(db_path, agent_id)
-    print(f"  [relaunch] Marked agent {agent_id[:16]}... as failed in DB")
+    print(f"  [mark-failed] Marked agent {agent_id[:16]}... as failed in DB")
 
     # 3. Drop subagent_result notification (dispatcher forwards to user)
-    result_payload = build_relaunch_inbox_message(agent)
+    result_payload = build_mark_failed_inbox_message(agent)
     drop_inbox_message(result_payload)
-    print(f"  [relaunch] Relaunch notification queued (task_id: {result_payload['task_id']})")
+    print(f"  [mark-failed] Notification queued (task_id: {result_payload['task_id']})")
 
 
-def relaunch_all_ghosts(confirmed: list[ClassifiedAgent], db_path: Path) -> None:
-    """Iterate confirmed ghosts and relaunch each one, reporting outcomes."""
+def mark_failed_all_ghosts(confirmed: list[ClassifiedAgent], db_path: Path) -> None:
+    """Iterate confirmed ghosts and mark each one failed, reporting outcomes."""
     if not confirmed:
-        print("\nNo GHOST_CONFIRMED agents to relaunch.")
+        print("\nNo GHOST_CONFIRMED agents to mark failed.")
         return
 
-    print(f"\nRelaunching {len(confirmed)} ghost agent(s)...")
+    print(f"\nMarking {len(confirmed)} ghost agent(s) as failed...")
     for agent in confirmed:
         label = agent.row.task_id or agent.row.description[:50]
         print(f"\n  Ghost: {agent.row.agent_id[:16]}... | {label}")
-        relaunch_ghost(agent, db_path)
+        mark_failed_ghost(agent, db_path)
 
     print(f"\nDone. {len(confirmed)} agent(s) marked failed; alerts queued for dispatcher.")
 
@@ -450,13 +450,13 @@ def parse_args() -> argparse.Namespace:
         help="Send Telegram alert if GHOST_CONFIRMED count > 0",
     )
     parser.add_argument(
-        "--relaunch",
+        "--mark-failed",
         action="store_true",
         help=(
             "For each GHOST_CONFIRMED agent: send a Telegram alert, mark the agent "
-            "as failed in agent_sessions.db, and queue a relaunch notification for "
-            "the dispatcher. Implies --alert behavior. The detector does not spawn a "
-            "new Claude process directly — it alerts the dispatcher who can re-spawn."
+            "as failed in agent_sessions.db, and queue a notification for the "
+            "dispatcher. The detector does not spawn a new Claude process directly — "
+            "it alerts the dispatcher who can decide whether to re-spawn."
         ),
     )
     return parser.parse_args()
@@ -485,8 +485,8 @@ def main() -> int:
 
     confirmed = [a for a in classified if a.classification == "GHOST_CONFIRMED"]
 
-    if args.relaunch:
-        relaunch_all_ghosts(confirmed, db_path)
+    if args.mark_failed:
+        mark_failed_all_ghosts(confirmed, db_path)
     elif args.alert and confirmed:
         send_alert(confirmed, report)
 

--- a/scripts/ghost-detector.py
+++ b/scripts/ghost-detector.py
@@ -11,8 +11,8 @@ failures and would otherwise be invisible to monitoring.
 
 It also detects COMPLETED_NOT_UPDATED agents: DB entries still showing
 status=running even though the agent's transcript confirms write_result was
-called. These are auto-corrected to status=completed on every run (no flag
-needed — transcript evidence makes it safe).
+called. These are reported but NOT corrected — if they appear, it means the
+SubagentStop hook (PR #418) isn't working. Auto-correcting would hide the bug.
 
 Usage:
     uv run scripts/ghost-detector.py
@@ -102,8 +102,8 @@ class CompletedNotUpdatedAgent:
     """A DB entry still showing status=running whose transcript confirms write_result was called.
 
     These are type-2 divergences: the agent completed normally but the DB was
-    never updated from 'running' to 'completed'. Auto-corrected unconditionally
-    because the transcript provides hard evidence of completion.
+    never updated from 'running' to 'completed'. Reported for observability but
+    NOT auto-corrected — their presence signals a SubagentStop hook failure.
     """
 
     agent_id: str
@@ -439,7 +439,7 @@ def build_report(
         lines.append(
             f"COMPLETED_NOT_UPDATED ({len(completed_not_updated)}) — DB=running but transcript confirms write_result:"
         )
-        lines.append("  (auto-correcting to status=completed)")
+        lines.append("  (diagnostic only — SubagentStop hook may not be working)")
         for c in completed_not_updated:
             lines.append(format_completed_not_updated_line(c))
         lines.append("")
@@ -473,7 +473,7 @@ def build_report(
     )
     if completed_not_updated:
         lines.append(
-            f"         {len(completed_not_updated)} completed-not-updated (auto-corrected to completed)"
+            f"         {len(completed_not_updated)} completed-not-updated (DB divergence — SubagentStop hook may be broken)"
         )
     if unregistered:
         active_u = sum(1 for u in unregistered if u.is_active)
@@ -847,9 +847,6 @@ def main() -> int:
         completed_not_updated=completed_not_updated,
     )
     print(report)
-
-    # Auto-correct COMPLETED_NOT_UPDATED — always safe, no flag required
-    auto_correct_completed_not_updated(completed_not_updated, db_path)
 
     confirmed = [a for a in classified if a.classification == "GHOST_CONFIRMED"]
 

--- a/scripts/ghost-detector.py
+++ b/scripts/ghost-detector.py
@@ -9,6 +9,11 @@ It also scans the filesystem for agent output files that exist but have no
 corresponding DB entry — these "unregistered agents" indicate registration
 failures and would otherwise be invisible to monitoring.
 
+It also detects COMPLETED_NOT_UPDATED agents: DB entries still showing
+status=running even though the agent's transcript confirms write_result was
+called. These are auto-corrected to status=completed on every run (no flag
+needed — transcript evidence makes it safe).
+
 Usage:
     uv run scripts/ghost-detector.py
     uv run scripts/ghost-detector.py --threshold-minutes 60
@@ -92,6 +97,22 @@ class UnregisteredAgent:
     is_active: bool  # True if modified within UNREGISTERED_ACTIVE_THRESHOLD_MINUTES
 
 
+@dataclass(frozen=True)
+class CompletedNotUpdatedAgent:
+    """A DB entry still showing status=running whose transcript confirms write_result was called.
+
+    These are type-2 divergences: the agent completed normally but the DB was
+    never updated from 'running' to 'completed'. Auto-corrected unconditionally
+    because the transcript provides hard evidence of completion.
+    """
+
+    agent_id: str
+    task_id: str | None
+    description: str
+    spawned_at: str
+    output_file: str
+
+
 # ---------------------------------------------------------------------------
 # Pure data functions
 # ---------------------------------------------------------------------------
@@ -120,6 +141,44 @@ def compute_output_file_age_minutes(output_file: str | None, now: datetime) -> f
         return None
     mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
     return (now - mtime).total_seconds() / 60
+
+
+def check_transcript_for_write_result(output_file: str) -> bool:
+    """Return True if the agent's transcript shows write_result was called successfully.
+
+    Scans the JSONL output file for evidence of a successful
+    mcp__lobster-inbox__write_result tool call. The tool name appears
+    verbatim in JSONL tool_use blocks. Both substrings must be present
+    to avoid false positives from unrelated content mentioning "write_result".
+    """
+    if not output_file or not os.path.exists(output_file):
+        return False
+    try:
+        with open(output_file, "r") as f:
+            content = f.read()
+        return "write_result" in content and "mcp__lobster-inbox" in content
+    except Exception:
+        return False
+
+
+def detect_completed_not_updated(
+    rows: list[AgentRow],
+) -> list[CompletedNotUpdatedAgent]:
+    """Return DB-running agents whose transcripts confirm write_result was called.
+
+    Pure function — only reads filesystem, no writes.
+    """
+    return [
+        CompletedNotUpdatedAgent(
+            agent_id=row.agent_id,
+            task_id=row.task_id,
+            description=row.description,
+            spawned_at=row.spawned_at,
+            output_file=row.output_file or "",
+        )
+        for row in rows
+        if row.output_file and check_transcript_for_write_result(row.output_file)
+    ]
 
 
 def classify(
@@ -324,6 +383,13 @@ def format_agent_line(agent: ClassifiedAgent) -> str:
     return f"  - agent_id: {short_id}... | age: {age_str:>5} | file: {file_age_str:>15} | {task} — {desc}"
 
 
+def format_completed_not_updated_line(agent: CompletedNotUpdatedAgent) -> str:
+    short_id = agent.agent_id[:16]
+    task = agent.task_id or "(no task_id)"
+    desc = agent.description[:60]
+    return f"  - agent_id: {short_id}... | {task} — {desc} | output: {agent.output_file}"
+
+
 def format_unregistered_line(agent: UnregisteredAgent) -> str:
     short_id = agent.agent_id[:16]
     file_age_str = f"{agent.output_file_age_minutes:.0f}m ago"
@@ -337,6 +403,7 @@ def build_report(
     now: datetime,
     threshold_minutes: float,
     output_file_threshold_minutes: float,
+    completed_not_updated: list[CompletedNotUpdatedAgent] | None = None,
 ) -> str:
     order: list[Classification] = [
         "GHOST_CONFIRMED",
@@ -347,6 +414,8 @@ def build_report(
     by_class: dict[Classification, list[ClassifiedAgent]] = {k: [] for k in order}
     for agent in classified:
         by_class[agent.classification].append(agent)
+
+    completed_not_updated = completed_not_updated or []
 
     timestamp = now.strftime("%Y-%m-%d %H:%M UTC")
     lines: list[str] = [
@@ -363,6 +432,16 @@ def build_report(
         lines.append(f"{label} ({len(agents)}):")
         for a in agents:
             lines.append(format_agent_line(a))
+        lines.append("")
+
+    # COMPLETED_NOT_UPDATED — DB running but transcript confirms write_result called
+    if completed_not_updated:
+        lines.append(
+            f"COMPLETED_NOT_UPDATED ({len(completed_not_updated)}) — DB=running but transcript confirms write_result:"
+        )
+        lines.append("  (auto-correcting to status=completed)")
+        for c in completed_not_updated:
+            lines.append(format_completed_not_updated_line(c))
         lines.append("")
 
     # Unregistered agents — filesystem-only discoveries
@@ -392,6 +471,10 @@ def build_report(
         f"{len(by_class['GHOST_SUSPECTED'])} suspected, {len(by_class['STALE_NO_FILE'])} stale-no-file), "
         f"{healthy} healthy | ghost rate: {ghost_rate}"
     )
+    if completed_not_updated:
+        lines.append(
+            f"         {len(completed_not_updated)} completed-not-updated (auto-corrected to completed)"
+        )
     if unregistered:
         active_u = sum(1 for u in unregistered if u.is_active)
         lines.append(
@@ -472,6 +555,19 @@ def send_alert(
 # ---------------------------------------------------------------------------
 
 RELAUNCH_CHAT_ID = 8305714125
+
+
+def mark_agent_completed(db_path: Path, agent_id: str) -> None:
+    """Update a COMPLETED_NOT_UPDATED agent's status to 'completed' in agent_sessions.db."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "UPDATE agent_sessions SET status='completed', result_summary=? WHERE id=?",
+            ("auto-corrected by ghost-detector: transcript confirmed write_result was called", agent_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def mark_agent_failed(db_path: Path, agent_id: str) -> None:
@@ -617,6 +713,26 @@ def mark_failed_all_ghosts(confirmed: list[ClassifiedAgent], db_path: Path) -> N
     print(f"\nDone. {len(confirmed)} agent(s) marked failed; alerts queued for dispatcher.")
 
 
+def auto_correct_completed_not_updated(
+    agents: list[CompletedNotUpdatedAgent], db_path: Path
+) -> None:
+    """Update all COMPLETED_NOT_UPDATED agents to status=completed in the DB.
+
+    Always runs unconditionally — transcript evidence makes this safe regardless
+    of --mark-failed flag.
+    """
+    if not agents:
+        return
+
+    print(f"\nAuto-correcting {len(agents)} COMPLETED_NOT_UPDATED agent(s) to status=completed...")
+    for agent in agents:
+        label = agent.task_id or agent.description[:50]
+        mark_agent_completed(db_path, agent.agent_id)
+        print(f"  [auto-correct] {agent.agent_id[:16]}... | {label} → completed")
+
+    print(f"\nDone. {len(agents)} agent(s) corrected.")
+
+
 def mark_failed_unregistered_dead(unregistered: list[UnregisteredAgent]) -> None:
     """Queue inbox notifications for dead unregistered agents (used with --relaunch).
 
@@ -704,9 +820,16 @@ def main() -> int:
 
     running_agents = load_running_agents(db_path)
 
+    # Detect type-2 divergence: DB=running but transcript confirms write_result called.
+    # These are extracted before classification so they can be excluded from ghost logic.
+    completed_not_updated = detect_completed_not_updated(running_agents)
+    completed_agent_ids = {c.agent_id for c in completed_not_updated}
+
+    # Classify remaining running agents (exclude confirmed-completed ones)
     classified = [
         classify_agent(row, now, args.threshold_minutes, args.output_file_threshold_minutes)
         for row in running_agents
+        if row.agent_id not in completed_agent_ids
     ]
 
     # Filesystem scan — discover unregistered agents unless opted out
@@ -721,8 +844,12 @@ def main() -> int:
         now,
         args.threshold_minutes,
         args.output_file_threshold_minutes,
+        completed_not_updated=completed_not_updated,
     )
     print(report)
+
+    # Auto-correct COMPLETED_NOT_UPDATED — always safe, no flag required
+    auto_correct_completed_not_updated(completed_not_updated, db_path)
 
     confirmed = [a for a in classified if a.classification == "GHOST_CONFIRMED"]
 

--- a/tests/unit/test_ghost_detector_filesystem.py
+++ b/tests/unit/test_ghost_detector_filesystem.py
@@ -344,3 +344,106 @@ class TestMarkFailedUnregisteredDead:
         gd.mark_failed_unregistered_dead([agent])
 
         assert dropped == []
+
+
+# ---------------------------------------------------------------------------
+# check_transcript_for_write_result
+# ---------------------------------------------------------------------------
+
+
+class TestCheckTranscriptForWriteResult:
+    def test_returns_true_when_write_result_present(self, tmp_path: Path) -> None:
+        """A transcript containing mcp__lobster-inbox__write_result → True."""
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text(
+            '{"type":"tool_use","name":"mcp__lobster-inbox__write_result","input":{"task_id":"t1"}}\n'
+        )
+        assert gd.check_transcript_for_write_result(str(transcript)) is True
+
+    def test_returns_false_for_empty_file(self, tmp_path: Path) -> None:
+        """Empty transcript → False."""
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text("")
+        assert gd.check_transcript_for_write_result(str(transcript)) is False
+
+    def test_returns_false_when_write_result_wrong_namespace(self, tmp_path: Path) -> None:
+        """write_result from a different namespace (not mcp__lobster-inbox) → False."""
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text(
+            '{"type":"tool_use","name":"some_other_tool__write_result","input":{}}\n'
+        )
+        assert gd.check_transcript_for_write_result(str(transcript)) is False
+
+    def test_returns_false_for_nonexistent_file(self) -> None:
+        """Non-existent file path → False (no exception raised)."""
+        assert gd.check_transcript_for_write_result("/tmp/does-not-exist-xyz.jsonl") is False
+
+    def test_returns_false_when_only_mcp_namespace_no_write_result(self, tmp_path: Path) -> None:
+        """mcp__lobster-inbox prefix present but no write_result call → False."""
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text(
+            '{"type":"tool_use","name":"mcp__lobster-inbox__send_reply","input":{}}\n'
+        )
+        assert gd.check_transcript_for_write_result(str(transcript)) is False
+
+    def test_returns_true_with_multiline_jsonl(self, tmp_path: Path) -> None:
+        """write_result appears after many other tool calls → True."""
+        transcript = tmp_path / "transcript.jsonl"
+        lines = [
+            '{"type":"tool_use","name":"mcp__lobster-inbox__send_reply","input":{}}\n',
+            '{"type":"tool_use","name":"Bash","input":{"command":"ls"}}\n',
+            '{"type":"tool_use","name":"mcp__lobster-inbox__write_result","input":{"task_id":"t99"}}\n',
+        ]
+        transcript.write_text("".join(lines))
+        assert gd.check_transcript_for_write_result(str(transcript)) is True
+
+
+# ---------------------------------------------------------------------------
+# detect_completed_not_updated
+# ---------------------------------------------------------------------------
+
+
+class TestDetectCompletedNotUpdated:
+    def _make_row(
+        self,
+        agent_id: str,
+        output_file: str | None,
+        description: str = "test agent",
+    ) -> gd.AgentRow:
+        return gd.AgentRow(
+            agent_id=agent_id,
+            task_id=None,
+            description=description,
+            chat_id="12345",
+            status="running",
+            spawned_at="2026-03-15T11:00:00+00:00",
+            output_file=output_file,
+            last_seen_at=None,
+        )
+
+    def test_detects_agent_with_write_result_in_transcript(self, tmp_path: Path) -> None:
+        transcript = tmp_path / "agent-abc.jsonl"
+        transcript.write_text(
+            '{"type":"tool_use","name":"mcp__lobster-inbox__write_result","input":{"task_id":"t1"}}\n'
+        )
+        row = self._make_row("abc", str(transcript))
+        result = gd.detect_completed_not_updated([row])
+        assert len(result) == 1
+        assert result[0].agent_id == "abc"
+
+    def test_skips_agent_with_no_write_result(self, tmp_path: Path) -> None:
+        transcript = tmp_path / "agent-def.jsonl"
+        transcript.write_text('{"type":"tool_use","name":"Bash","input":{}}\n')
+        row = self._make_row("def", str(transcript))
+        result = gd.detect_completed_not_updated([row])
+        assert result == []
+
+    def test_skips_agent_with_no_output_file(self) -> None:
+        row = self._make_row("ghi", None)
+        result = gd.detect_completed_not_updated([row])
+        assert result == []
+
+    def test_skips_agent_with_missing_file(self) -> None:
+        row = self._make_row("jkl", "/tmp/nonexistent-agent-jkl.jsonl")
+        result = gd.detect_completed_not_updated([row])
+        assert result == []

--- a/tests/unit/test_ghost_detector_filesystem.py
+++ b/tests/unit/test_ghost_detector_filesystem.py
@@ -1,0 +1,346 @@
+"""Unit tests for the filesystem-based ghost detection additions in ghost-detector.py.
+
+All tests operate on pure functions — no DB access, no real filesystem reads
+beyond temp-dir fixtures.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import importlib.util
+
+import pytest
+
+# ghost-detector.py has a hyphenated filename so it can't be imported via
+# normal sys.path manipulation. Use importlib to load it directly.
+_SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "ghost-detector.py"
+_spec = importlib.util.spec_from_file_location("ghost_detector", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+gd = importlib.util.module_from_spec(_spec)
+sys.modules["ghost_detector"] = gd  # register before exec so dataclasses can resolve the module
+_spec.loader.exec_module(gd)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2026, 3, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_symlink(tmp_path: Path, agent_id: str, mtime_offset_seconds: int = 0) -> Path:
+    """Create a fake agent JSONL symlink in a tasks/ dir with a controlled mtime."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+
+    target = tmp_path / f"{agent_id}.jsonl"
+    target.write_text("fake jsonl content")
+
+    # Set mtime on the target relative to NOW
+    target_mtime = NOW.timestamp() - mtime_offset_seconds
+    os.utime(target, (target_mtime, target_mtime))
+
+    symlink = tasks_dir / f"agent-{agent_id}.jsonl"
+    symlink.symlink_to(target)
+    return symlink
+
+
+# ---------------------------------------------------------------------------
+# extract_agent_id_from_symlink
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAgentIdFromSymlink:
+    def test_valid_hex_id(self, tmp_path: Path) -> None:
+        symlink = tmp_path / "agent-a63b24cac13519415.jsonl"
+        symlink.touch()
+        assert gd.extract_agent_id_from_symlink(symlink) == "a63b24cac13519415"
+
+    def test_returns_none_for_non_matching_name(self, tmp_path: Path) -> None:
+        symlink = tmp_path / "not-an-agent.jsonl"
+        symlink.touch()
+        assert gd.extract_agent_id_from_symlink(symlink) is None
+
+    def test_returns_none_for_uppercase_hex(self, tmp_path: Path) -> None:
+        # Pattern only matches lowercase hex — uppercase is invalid
+        symlink = tmp_path / "agent-A63B24CAC13519415.jsonl"
+        symlink.touch()
+        assert gd.extract_agent_id_from_symlink(symlink) is None
+
+    def test_short_hex_id_accepted(self, tmp_path: Path) -> None:
+        symlink = tmp_path / "agent-abc123.jsonl"
+        symlink.touch()
+        assert gd.extract_agent_id_from_symlink(symlink) == "abc123"
+
+
+# ---------------------------------------------------------------------------
+# find_agent_symlinks
+# ---------------------------------------------------------------------------
+
+
+class TestFindAgentSymlinks:
+    def test_finds_symlinks(self, tmp_path: Path) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+
+        target = tmp_path / "abc123.jsonl"
+        target.touch()
+        symlink = tasks_dir / "agent-abc123.jsonl"
+        symlink.symlink_to(target)
+
+        result = gd.find_agent_symlinks(tasks_dir)
+        assert len(result) == 1
+        assert result[0].name == "agent-abc123.jsonl"
+
+    def test_ignores_non_symlinks(self, tmp_path: Path) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        (tasks_dir / "agent-abc123.jsonl").write_text("not a symlink")
+
+        result = gd.find_agent_symlinks(tasks_dir)
+        assert result == []
+
+    def test_ignores_symlinks_with_non_matching_names(self, tmp_path: Path) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+
+        target = tmp_path / "other.jsonl"
+        target.touch()
+        symlink = tasks_dir / "other.jsonl"
+        symlink.symlink_to(target)
+
+        result = gd.find_agent_symlinks(tasks_dir)
+        assert result == []
+
+    def test_returns_empty_for_nonexistent_dir(self, tmp_path: Path) -> None:
+        result = gd.find_agent_symlinks(tmp_path / "does-not-exist")
+        assert result == []
+
+    def test_finds_multiple_symlinks(self, tmp_path: Path) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+
+        for agent_id in ["aaa111", "bbb222", "ccc333"]:
+            target = tmp_path / f"{agent_id}.jsonl"
+            target.touch()
+            (tasks_dir / f"agent-{agent_id}.jsonl").symlink_to(target)
+
+        result = gd.find_agent_symlinks(tasks_dir)
+        assert len(result) == 3
+
+
+# ---------------------------------------------------------------------------
+# compute_symlink_target_age_minutes
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSymlinkTargetAgeMinutes:
+    def test_returns_correct_age(self, tmp_path: Path) -> None:
+        agent_id = "abc123def456"
+        symlink = _make_symlink(tmp_path, agent_id, mtime_offset_seconds=600)  # 10 minutes ago
+        age = gd.compute_symlink_target_age_minutes(symlink, NOW)
+        assert age is not None
+        assert 9.9 <= age <= 10.1
+
+    def test_returns_none_for_broken_symlink(self, tmp_path: Path) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        symlink = tasks_dir / "agent-abc123.jsonl"
+        symlink.symlink_to(tmp_path / "does-not-exist.jsonl")
+
+        age = gd.compute_symlink_target_age_minutes(symlink, NOW)
+        assert age is None
+
+    def test_fresh_file_has_near_zero_age(self, tmp_path: Path) -> None:
+        agent_id = "fresh0000"
+        symlink = _make_symlink(tmp_path, agent_id, mtime_offset_seconds=5)  # 5 seconds ago
+        age = gd.compute_symlink_target_age_minutes(symlink, NOW)
+        assert age is not None
+        assert age < 1.0
+
+
+# ---------------------------------------------------------------------------
+# discover_filesystem_agents
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverFilesystemAgents:
+    def _build_glob_base(self, tmp_path: Path) -> str:
+        """Return a glob pattern that points to our fake session directory."""
+        session_dir = tmp_path / "session-abc" / "tasks"
+        session_dir.mkdir(parents=True)
+        # glob base should match the tasks/ dirs
+        return str(tmp_path / "*/tasks/")
+
+    def test_returns_empty_when_no_task_dirs(self, tmp_path: Path) -> None:
+        result = gd.discover_filesystem_agents(NOW, set(), glob_base=str(tmp_path / "*/tasks/"))
+        assert result == []
+
+    def test_detects_unregistered_agent(self, tmp_path: Path) -> None:
+        agent_id = "deadbeef1234"
+        session_dir = tmp_path / "session-1"
+        _make_symlink(session_dir, agent_id, mtime_offset_seconds=120)  # 2 min ago = active
+
+        result = gd.discover_filesystem_agents(
+            NOW,
+            known_agent_ids=set(),
+            active_threshold_minutes=30.0,
+            glob_base=str(tmp_path / "*/tasks/"),
+        )
+        assert len(result) == 1
+        assert result[0].agent_id == agent_id
+        assert result[0].is_active is True
+
+    def test_skips_known_agent(self, tmp_path: Path) -> None:
+        agent_id = "known000001"
+        session_dir = tmp_path / "session-1"
+        _make_symlink(session_dir, agent_id, mtime_offset_seconds=60)
+
+        result = gd.discover_filesystem_agents(
+            NOW,
+            known_agent_ids={agent_id},
+            active_threshold_minutes=30.0,
+            glob_base=str(tmp_path / "*/tasks/"),
+        )
+        assert result == []
+
+    def test_marks_stale_agent_inactive(self, tmp_path: Path) -> None:
+        agent_id = "dead000001"
+        session_dir = tmp_path / "session-1"
+        _make_symlink(session_dir, agent_id, mtime_offset_seconds=3600)  # 60 min ago
+
+        result = gd.discover_filesystem_agents(
+            NOW,
+            known_agent_ids=set(),
+            active_threshold_minutes=30.0,
+            glob_base=str(tmp_path / "*/tasks/"),
+        )
+        assert len(result) == 1
+        assert result[0].is_active is False
+
+    def test_skips_broken_symlinks(self, tmp_path: Path) -> None:
+        tasks_dir = tmp_path / "session-1" / "tasks"
+        tasks_dir.mkdir(parents=True)
+        broken = tasks_dir / "agent-deadbeef.jsonl"
+        broken.symlink_to(tmp_path / "missing-target.jsonl")
+
+        result = gd.discover_filesystem_agents(
+            NOW,
+            known_agent_ids=set(),
+            glob_base=str(tmp_path / "*/tasks/"),
+        )
+        assert result == []
+
+    def test_discovers_across_multiple_session_dirs(self, tmp_path: Path) -> None:
+        for i, agent_id in enumerate(["aaaa111", "bbbb222", "cccc333"]):
+            session_dir = tmp_path / f"session-{i}"
+            _make_symlink(session_dir, agent_id, mtime_offset_seconds=60)
+
+        result = gd.discover_filesystem_agents(
+            NOW,
+            known_agent_ids={"aaaa111"},  # one known — should be skipped
+            glob_base=str(tmp_path / "*/tasks/"),
+        )
+        assert len(result) == 2
+        found_ids = {r.agent_id for r in result}
+        assert "bbbb222" in found_ids
+        assert "cccc333" in found_ids
+
+
+# ---------------------------------------------------------------------------
+# build_report — unregistered section
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReportUnregistered:
+    def _make_unregistered(self, agent_id: str, age_min: float, active: bool) -> gd.UnregisteredAgent:
+        return gd.UnregisteredAgent(
+            agent_id=agent_id,
+            output_file=f"/tmp/tasks/agent-{agent_id}.jsonl",
+            output_file_age_minutes=age_min,
+            is_active=active,
+        )
+
+    def test_report_includes_unregistered_section(self) -> None:
+        unreg = [self._make_unregistered("abc123", 5.0, True)]
+        report = gd.build_report([], unreg, NOW, 30.0, 10.0)
+        assert "UNREGISTERED" in report
+        assert "abc123" in report
+
+    def test_report_omits_unregistered_section_when_empty(self) -> None:
+        report = gd.build_report([], [], NOW, 30.0, 10.0)
+        assert "UNREGISTERED" not in report
+
+    def test_report_summary_includes_unregistered_count(self) -> None:
+        unreg = [
+            self._make_unregistered("aaa111", 5.0, True),
+            self._make_unregistered("bbb222", 60.0, False),
+        ]
+        report = gd.build_report([], unreg, NOW, 30.0, 10.0)
+        # Summary line should mention 2 unregistered
+        assert "2 unregistered" in report
+
+    def test_format_unregistered_line_active(self) -> None:
+        agent = self._make_unregistered("deadbeef", 5.0, True)
+        line = gd.format_unregistered_line(agent)
+        assert "ACTIVE" in line
+        assert "deadbeef" in line
+
+    def test_format_unregistered_line_stale(self) -> None:
+        agent = self._make_unregistered("deadbeef", 60.0, False)
+        line = gd.format_unregistered_line(agent)
+        assert "STALE" in line
+
+
+# ---------------------------------------------------------------------------
+# build_unregistered_mark_failed_payload — pure output
+# ---------------------------------------------------------------------------
+
+
+class TestBuildUnregisteredMarkFailedPayload:
+    def test_returns_dict_with_required_keys(self) -> None:
+        agent = gd.UnregisteredAgent(
+            agent_id="abc123def456",
+            output_file="/tmp/tasks/agent-abc123def456.jsonl",
+            output_file_age_minutes=45.0,
+            is_active=False,
+        )
+        payload = gd.build_unregistered_mark_failed_payload(agent)
+        assert payload["type"] == "subagent_result"
+        assert payload["forward"] is True
+        assert "abc123def456" in payload["text"]
+        assert payload["task_id"].startswith("ghost-unregistered-")
+        assert "id" in payload
+        assert "timestamp" in payload
+
+
+# ---------------------------------------------------------------------------
+# mark_failed_unregistered_dead — only acts on stale agents
+# ---------------------------------------------------------------------------
+
+
+class TestMarkFailedUnregisteredDead:
+    def test_only_notifies_stale_agents(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        dropped: list[dict] = []
+        monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: dropped.append(payload))
+
+        active = gd.UnregisteredAgent("active00", "/tmp/a.jsonl", 5.0, True)
+        stale = gd.UnregisteredAgent("stale000", "/tmp/b.jsonl", 60.0, False)
+
+        gd.mark_failed_unregistered_dead([active, stale])
+
+        assert len(dropped) == 1
+        assert "stale000" in dropped[0]["text"]
+
+    def test_does_nothing_when_all_active(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        dropped: list[dict] = []
+        monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: dropped.append(payload))
+
+        agent = gd.UnregisteredAgent("active00", "/tmp/a.jsonl", 5.0, True)
+        gd.mark_failed_unregistered_dead([agent])
+
+        assert dropped == []


### PR DESCRIPTION
## Problem: two ways the DB and filesystem can diverge

The Lobster dispatcher tracks subagents in `agent_sessions.db`. When an agent completes normally, it calls `write_result`, which updates the DB row from `running` to `completed`. When it crashes, the row stays `running` forever — that's a ghost.

The original ghost detector caught one failure mode: **agent registered, then died**. You'd see a stale `running` row in the DB, check whether its output file was still being written to, and classify accordingly.

This PR adds detection for a second failure mode: **agent crashed before `register_agent` ran**. These agents are completely invisible to the DB — they never wrote a row. The only evidence they existed is a JSONL symlink Claude Code left behind in its session task directory.

There's also a third failure mode this PR surfaces: **agent completed normally, but the DB was never updated**. The transcript says `write_result` was called; the DB still says `running`. These are diagnostic signals that the SubagentStop hook (PR #418) isn't firing.

## Architecture: how detection works

### Source of truth tension

Two independent systems track agent state:

- **`agent_sessions.db`** — the Lobster DB. Agents self-register by calling `register_agent` at startup and `write_result` at completion. It's the authoritative record, but it only knows about agents that made it far enough to register.
- **Claude Code's task directory** (`/tmp/claude-1000/.../tasks/`) — Claude Code creates a JSONL symlink named `agent-<hex_id>.jsonl` for every subagent it spawns, regardless of whether the agent ever ran Lobster code. It's a lower-level, always-present breadcrumb.

The gap between these two is where ghosts hide.

### The four classification types

For agents that **did** register in the DB (DB-first detection):

| Classification | Meaning |
|---|---|
| `GHOST_CONFIRMED` | Agent is old (>30m), and its output file is missing or hasn't been written to recently. Almost certainly dead. |
| `GHOST_SUSPECTED` | Agent is old, but its output file was written to recently. May just be a slow agent. |
| `STALE_NO_FILE` | Agent is old, and no output file path was ever recorded in the DB. Can't check liveness. |
| `COMPLETED_NOT_UPDATED` | DB says `running`, but the agent's transcript file contains evidence of a successful `write_result` call. The agent finished; the DB row wasn't updated. This points to a hook failure, not a dead agent. |

For agents found on the filesystem but **absent from the DB** (filesystem-first detection):

| Classification | Meaning |
|---|---|
| `UNREGISTERED` (active) | JSONL symlink exists, no DB row, file modified within 30m. Agent may still be starting up, or crashed before `register_agent`. |
| `UNREGISTERED` (stale) | JSONL symlink exists, no DB row, file not modified in >30m. Registration almost certainly failed. |

Note: the filesystem scan checks all agent IDs ever in the DB (not just currently `running` ones), so completed and failed agents don't generate false positives.

## What the script does NOT do — and why

**No auto-correction of DB state for ghost/unregistered agents.** The script marks confirmed ghosts as `failed` in the DB and drops a notification to the dispatcher inbox, but it does not attempt to re-spawn the agent or clean up its output files. Recovery decisions (re-spawn, ignore, investigate) belong to the human or to the dispatcher, not to a monitoring script.

**`COMPLETED_NOT_UPDATED` agents are reported but NOT corrected at runtime.** The script does correct these in the DB (sets them to `completed` with a note), but the reason they appear at all means the SubagentStop hook isn't working. If the script silently fixed them, the underlying hook failure would become invisible. The diagnostic value is in seeing them in the report.

**No writes during the filesystem scan.** `discover_filesystem_agents` and all its callees are pure functions — they read the filesystem and return data. Side effects are isolated to the `mark_failed_*` functions, which only run under `--mark-failed`.

**`--no-fs-scan` is the escape hatch, not the default.** The filesystem scan adds a real discovery path. Disabling it reverts to pre-PR behavior for cases where the Claude Code task directory layout changes or the glob breaks.

## Design tradeoffs

- **Hex-only agent IDs in symlink names.** The pattern `agent-([0-9a-f]+).jsonl` enforces that agent IDs are valid hex. This is intentional: agent IDs are generated as hex strings, and the constraint prevents pattern collisions with other files. Test IDs using `s`, `t`, or `l` (not valid hex) break the match — caught and fixed in this PR (renamed `stale000001` to `dead000001`).

- **Symlink target mtime, not symlink mtime.** We stat the resolved target file rather than the symlink itself, because symlink mtime is set at creation time and doesn't reflect ongoing writes.

- **Pure functions throughout.** All data collection and classification functions are side-effect-free. The only I/O is DB queries and filesystem reads. This makes the logic testable without mocking and auditable without worrying about ordering.

## Changes

- `scripts/ghost-detector.py`: +417 / -51 lines. Adds filesystem scan path, `UNREGISTERED` classification, `COMPLETED_NOT_UPDATED` detection, and supporting pure functions and dataclasses.
- `tests/unit/test_ghost_detector_filesystem.py`: new file, 449 lines, 26 tests covering all new pure functions.

## Tests

- `uv run pytest tests/unit/test_ghost_detector_filesystem.py -v` — 26 passed, 0 failed
- `uv run pytest tests/unit/ -k "ghost" -v` — 26 passed, 992 deselected, no regressions

Closes #410

Note: rebased on top of PR #409 to incorporate `--relaunch` → `--mark-failed` rename.