### PR TITLE
fix: SubagentStop hook marks agent completed in DB synchronously

### DIFF
--- a/hooks/require-write-result.py
+++ b/hooks/require-write-result.py
@@ -5,6 +5,10 @@ Injects a reminder if write_result was not called during the session.
 
 Dispatcher sessions (detected via session_role.is_dispatcher()) are exempt —
 the dispatcher never calls write_result, so the check only applies to subagents.
+
+When write_result was called, this hook also marks the session completed in
+agent_sessions.db synchronously — without relying on the unreliable server-side
+auto-unregister path in inbox_server.py.
 """
 import json
 import sys
@@ -12,7 +16,28 @@ from pathlib import Path
 
 # Import shared session role utility.
 sys.path.insert(0, str(Path(__file__).parent))
-from session_role import is_dispatcher
+from session_role import is_dispatcher, get_session_id
+
+
+def _mark_session_completed(session_id: str) -> None:
+    """Mark the agent session completed in agent_sessions.db.
+
+    Best-effort: any failure is silently swallowed so the hook always exits 0.
+    Uses session_store.session_end() which matches on id OR task_id and is
+    idempotent — safe to call even if inbox_server already updated the row.
+    """
+    try:
+        hooks_dir = Path(__file__).parent
+        repo_src = hooks_dir.parent / "src"
+        sys.path.insert(0, str(repo_src))
+        from agents.session_store import session_end  # noqa: PLC0415
+        session_end(
+            id_or_task_id=session_id,
+            status="completed",
+            result_summary="Completed via SubagentStop hook",
+        )
+    except Exception:
+        pass  # DB update is best-effort; never block exit
 
 
 def main():
@@ -38,8 +63,11 @@ def main():
                     if isinstance(item, dict) and item.get("type") == "tool_use":
                         tool_calls.append(item.get("name", ""))
 
-    # If this session called write_result, we're good
+    # If this session called write_result, mark it completed in the DB and allow exit.
     if "mcp__lobster-inbox__write_result" in tool_calls:
+        session_id = get_session_id(data)
+        if session_id:
+            _mark_session_completed(session_id)
         sys.exit(0)
 
     # Subagent finished without calling write_result — block exit


### PR DESCRIPTION
## Problem

After a subagent calls \`write_result\` and exits cleanly, its row in \`agent_sessions.db\` can remain \`status='running'\` indefinitely. The DB update is supposed to happen server-side in \`inbox_server.py\` when \`write_result\` is called, but that path is unreliable — race conditions, restarts, or edge cases in task_id matching can all cause it to be skipped.

The SubagentStop hook already knows write_result was called (it checks the transcript). It just wasn't doing anything with that information beyond exiting 0.

## Fix

In the success branch of \`require-write-result.py\` (write_result found in transcript), before exiting 0, extract \`session_id\` from the hook JSON input and call \`session_store.session_end()\` to mark the row \`completed\`.

This is a synchronous write that happens in the same process as the hook — no IPC, no server dependency. The \`session_end()\` function matches on either \`id\` or \`task_id\` (covering both registration conventions) and its \`WHERE status='running'\` guard makes double-calls (hook + server) a safe no-op.

The DB update is wrapped in \`try/except\` so any failure (missing DB, import error, schema mismatch) is silently ignored and never blocks the exit.

## Functional patterns

Pure helper function (\`_mark_session_completed\`) with a single side effect, isolated from the main control flow. The guard \`if session_id:\` keeps the success path unconditional — no session ID means no DB write, hook still exits 0.

## Tests run

- [x] \`echo '{"session_id":"test-session-123","transcript":[...write_result...]}' | python3 hooks/require-write-result.py\` — exit 0, DB row transitions to \`status='completed'\`
- [x] Same but without write_result in transcript — exit 2, STOP message printed
- [x] \`session_end()\` idempotency: second call on an already-completed row is a no-op (result_summary not overwritten)
- [x] Syntax check via \`ast.parse()\` — clean

Closes #417