### PR TITLE
fix: add OOM monitor cron setup to install.sh with LOBSTER_DEBUG=true

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1163,6 +1163,21 @@ CONSOLIDATION_MARKER="# LOBSTER-NIGHTLY-CONSOLIDATION"
 success "Nightly consolidation configured (runs at 03:00 nightly)"
 
 #===============================================================================
+# OOM Kill Monitor
+#===============================================================================
+
+step "Setting up OOM kill monitor..."
+
+chmod +x "$INSTALL_DIR/scripts/oom-monitor.py" || true
+
+# Add OOM monitor to crontab (runs every 10 minutes, debug-gated via LOBSTER_DEBUG=true)
+OOM_MARKER="# LOBSTER-OOM"
+(crontab -l 2>/dev/null | grep -v "$OOM_MARKER" | grep -v "oom-monitor" || true; \
+ echo "*/10 * * * * LOBSTER_DEBUG=true uv run \$HOME/lobster/scripts/oom-monitor.py --since-minutes 10 $OOM_MARKER") | crontab -
+
+success "OOM kill monitor configured (runs every 10 minutes, active only when LOBSTER_DEBUG=true)"
+
+#===============================================================================
 # Self-Check Reminder System
 #===============================================================================
 


### PR DESCRIPTION
## Summary

- PR #408 added `scripts/oom-monitor.py` with a `LOBSTER_DEBUG=true` guard, but did not add the corresponding cron setup block to `install.sh`
- Fresh installs would never schedule the OOM monitor — the cron entry only exists on systems where it was manually added
- This PR adds the missing install section between Nightly Consolidation and Self-Check Reminder, matching the pattern of all other cron entries in the file
- The cron command is correctly prefixed with `LOBSTER_DEBUG=true` so the debug gate in the script is always respected

## What changed

`install.sh` — new section "OOM Kill Monitor" added at line ~1165:
- `chmod +x` the script
- idempotent crontab update (removes old entry first, then appends)
- cron line: `*/10 * * * * LOBSTER_DEBUG=true uv run $HOME/lobster/scripts/oom-monitor.py --since-minutes 10 # LOBSTER-OOM`

## Live fix already applied

The live crontab on the running system was already updated directly (system change, no PR needed for that). This PR ensures fresh installs and re-installs also get the entry.

## Test plan

- [ ] Run `bash install.sh` on a fresh system and verify `crontab -l` contains the OOM monitor entry with `LOBSTER_DEBUG=true`
- [ ] Run `bash install.sh` a second time (idempotency check) — confirm only one OOM monitor entry appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)