### PR TITLE
feat: inject debug.sys.bootup.md via SessionStart hook when LOBSTER_DEBUG=true

### DIFF
--- a/hooks/inject-debug-bootup.py
+++ b/hooks/inject-debug-bootup.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+SessionStart hook: inject debug.sys.bootup.md when LOBSTER_DEBUG=true.
+
+Fires on every SessionStart event. If the LOBSTER_DEBUG environment variable
+is set to 'true' (case-insensitive), reads
+~/lobster/.claude/debug.sys.bootup.md and prints its contents to stdout.
+
+Claude Code SessionStart hooks can inject content into the agent's initial
+context by printing to stdout. This causes the content to appear as a system
+message at the start of the session.
+
+If LOBSTER_DEBUG is not set or is not 'true', the hook exits silently with
+exit code 0.
+
+Also checks ~/lobster-config/config.env as a fallback for the LOBSTER_DEBUG
+setting, so developers can set it in config.env instead of the shell
+environment.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+
+CONFIG_ENV = Path(os.path.expanduser("~/lobster-config/config.env"))
+DEBUG_BOOTUP_FILE = Path(os.path.expanduser("~/lobster/.claude/debug.sys.bootup.md"))
+
+
+def _parse_config_env() -> dict:
+    """Parse key=value pairs from config.env, ignoring comments and blank lines."""
+    config: dict = {}
+    if not CONFIG_ENV.exists():
+        return config
+    try:
+        for line in CONFIG_ENV.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            value = value.strip().strip('"').strip("'")
+            config[key.strip()] = value
+    except OSError:
+        pass
+    return config
+
+
+def _is_debug_mode() -> bool:
+    """Return True if LOBSTER_DEBUG is 'true' in the environment or config.env.
+
+    The environment variable takes priority over config.env: if LOBSTER_DEBUG
+    is present in the environment (regardless of value), it overrides whatever
+    is set in config.env.
+    """
+    raw_env = os.environ.get("LOBSTER_DEBUG")
+    if raw_env is not None:
+        # Env var is explicitly set — use it exclusively (don't fall back to config.env).
+        return raw_env.strip().lower() == "true"
+    # Env var absent — check config.env as fallback.
+    config = _parse_config_env()
+    config_val = config.get("LOBSTER_DEBUG", "").strip().lower()
+    return config_val == "true"
+
+
+def main() -> None:
+    if not _is_debug_mode():
+        sys.exit(0)
+
+    if not DEBUG_BOOTUP_FILE.exists():
+        # File missing — exit silently rather than crashing the session.
+        print(
+            f"[inject-debug-bootup] WARNING: LOBSTER_DEBUG=true but "
+            f"{DEBUG_BOOTUP_FILE} not found; skipping injection.",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+
+    try:
+        content = DEBUG_BOOTUP_FILE.read_text()
+    except OSError as exc:
+        print(
+            f"[inject-debug-bootup] WARNING: could not read {DEBUG_BOOTUP_FILE}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+
+    # Print to stdout — Claude Code injects stdout from SessionStart hooks
+    # into the agent's initial context as a system message.
+    print(content)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/install.sh
+++ b/install.sh
@@ -1408,6 +1408,27 @@ else
     info "Skipping on-compact hook (settings.json not yet created)"
 fi
 
+# Set up Claude Code SessionStart hook to inject debug.sys.bootup.md when LOBSTER_DEBUG=true
+chmod +x "$INSTALL_DIR/hooks/inject-debug-bootup.py" || true
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.SessionStart[]? | select(.hooks[]?.command | contains("inject-debug-bootup"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq '.hooks.SessionStart = (.hooks.SessionStart // []) + [{
+            "matcher": "",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 '"$INSTALL_DIR"'/hooks/inject-debug-bootup.py",
+                "timeout": 5
+            }]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "inject-debug-bootup hook installed"
+    else
+        info "inject-debug-bootup hook already configured in Claude Code settings"
+    fi
+else
+    info "Skipping inject-debug-bootup hook (settings.json not yet created)"
+fi
+
 # Set up Claude Code Stop hook to enforce write_result in subagent sessions
 chmod +x "$INSTALL_DIR/hooks/require-write-result.py" || true
 if [ -f "$CLAUDE_SETTINGS" ]; then

--- a/tests/unit/test_hooks/test_inject_debug_bootup.py
+++ b/tests/unit/test_hooks/test_inject_debug_bootup.py
@@ -1,0 +1,202 @@
+"""
+Unit tests for hooks/inject-debug-bootup.py
+
+Tests cover:
+- Hook exits silently when LOBSTER_DEBUG is not set
+- Hook exits silently when LOBSTER_DEBUG is set to a non-true value
+- Hook injects file content to stdout when LOBSTER_DEBUG=true (env var)
+- Hook injects file content to stdout when LOBSTER_DEBUG=true (config.env)
+- Hook handles case-insensitive LOBSTER_DEBUG values (TRUE, True)
+- Hook exits silently (with stderr warning) when the bootup file is missing
+- Hook exits silently (with stderr warning) when the bootup file is unreadable
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _load_hook(monkeypatch, tmp_path):
+    """
+    Load hooks/inject-debug-bootup.py as a module, with CONFIG_ENV and
+    DEBUG_BOOTUP_FILE patched to temp-dir paths so tests are hermetic.
+
+    Returns the loaded module object.
+    """
+    hook_path = Path(__file__).parents[3] / "hooks" / "inject-debug-bootup.py"
+    spec = importlib.util.spec_from_file_location("inject_debug_bootup", hook_path)
+    mod = importlib.util.module_from_spec(spec)
+    # Load into a fresh namespace each time
+    spec.loader.exec_module(mod)
+
+    # Patch module-level path constants to point at tmp_path
+    config_env = tmp_path / "config.env"
+    debug_file = tmp_path / "debug.sys.bootup.md"
+    monkeypatch.setattr(mod, "CONFIG_ENV", config_env)
+    monkeypatch.setattr(mod, "DEBUG_BOOTUP_FILE", debug_file)
+
+    return mod, config_env, debug_file
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestInjectDebugBootup:
+    def test_no_debug_env_exits_silently(self, monkeypatch, tmp_path, capsys):
+        """When LOBSTER_DEBUG is not set, hook exits 0 and prints nothing."""
+        monkeypatch.delenv("LOBSTER_DEBUG", raising=False)
+        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+        # config.env absent → no fallback
+
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
+
+    def test_debug_false_exits_silently(self, monkeypatch, tmp_path, capsys):
+        """When LOBSTER_DEBUG=false, hook exits 0 and prints nothing."""
+        monkeypatch.setenv("LOBSTER_DEBUG", "false")
+        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_debug_true_env_injects_content(self, monkeypatch, tmp_path, capsys):
+        """When LOBSTER_DEBUG=true (env), hook prints bootup file to stdout."""
+        monkeypatch.setenv("LOBSTER_DEBUG", "true")
+        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+
+        expected = "# Debug Mode\n\nSome debug instructions here.\n"
+        debug_file.write_text(expected)
+
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert captured.out.strip() == expected.strip()
+        assert captured.err == ""
+
+    def test_debug_true_case_insensitive(self, monkeypatch, tmp_path, capsys):
+        """LOBSTER_DEBUG=TRUE (uppercase) should also trigger injection."""
+        monkeypatch.setenv("LOBSTER_DEBUG", "TRUE")
+        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+
+        debug_file.write_text("# Debug content")
+
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "# Debug content" in captured.out
+
+    def test_debug_true_mixed_case(self, monkeypatch, tmp_path, capsys):
+        """LOBSTER_DEBUG=True (mixed case) should also trigger injection."""
+        monkeypatch.setenv("LOBSTER_DEBUG", "True")
+        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+
+        debug_file.write_text("# Debug content")
+
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "# Debug content" in captured.out
+
+    def test_debug_true_from_config_env(self, monkeypatch, tmp_path, capsys):
+        """When LOBSTER_DEBUG is unset but config.env has LOBSTER_DEBUG=true, inject."""
+        monkeypatch.delenv("LOBSTER_DEBUG", raising=False)
+        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+
+        config_env.write_text("LOBSTER_DEBUG=true\n")
+        debug_file.write_text("# From config.env")
+
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "# From config.env" in captured.out
+
+    def test_debug_true_config_env_quoted(self, monkeypatch, tmp_path, capsys):
+        """config.env value with quotes (LOBSTER_DEBUG=\"true\") is handled."""
+        monkeypatch.delenv("LOBSTER_DEBUG", raising=False)
+        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+
+        config_env.write_text('LOBSTER_DEBUG="true"\n')
+        debug_file.write_text("# Quoted")
+
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "# Quoted" in captured.out
+
+    def test_env_overrides_config_env_false(self, monkeypatch, tmp_path, capsys):
+        """Env var LOBSTER_DEBUG=false takes precedence over config.env true."""
+        monkeypatch.setenv("LOBSTER_DEBUG", "false")
+        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+
+        # config.env says true, but env var says false — env var wins
+        config_env.write_text("LOBSTER_DEBUG=true\n")
+        debug_file.write_text("# Should not be injected")
+
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_missing_bootup_file_exits_with_warning(self, monkeypatch, tmp_path, capsys):
+        """When LOBSTER_DEBUG=true but bootup file is missing, exit 0 with stderr warning."""
+        monkeypatch.setenv("LOBSTER_DEBUG", "true")
+        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+        # debug_file deliberately not created
+
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "WARNING" in captured.err
+        assert "not found" in captured.err
+
+    def test_unreadable_bootup_file_exits_with_warning(self, monkeypatch, tmp_path, capsys):
+        """When bootup file exists but is unreadable, exit 0 with stderr warning."""
+        monkeypatch.setenv("LOBSTER_DEBUG", "true")
+        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+
+        debug_file.write_text("content")
+        debug_file.chmod(0o000)  # remove read permission
+
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                mod.main()
+
+            assert exc_info.value.code == 0
+            captured = capsys.readouterr()
+            assert captured.out == ""
+            assert "WARNING" in captured.err
+        finally:
+            debug_file.chmod(0o644)  # restore so tmp_path cleanup works


### PR DESCRIPTION
## Summary

- Implements issue #425, option B: a `SessionStart` hook that injects `debug.sys.bootup.md` into the agent's context when `LOBSTER_DEBUG=true`
- New hook `hooks/inject-debug-bootup.py` checks `LOBSTER_DEBUG` (env var takes priority, falls back to `config.env`) and prints the file to stdout for Claude Code to inject
- Registered in `install.sh` (idempotent, checks before adding) and deployed to `~/.claude/settings.json` locally
- 10 unit tests cover all cases: env absent, env false, env true, case-insensitive, config.env fallback, env overrides config.env, missing file, unreadable file

## Test plan

- [x] 10 unit tests pass: `pytest tests/unit/test_hooks/test_inject_debug_bootup.py` — 10 passed
- [x] Docker install test passes: `docker compose -f tests/docker/docker-compose.test.yml up install-test` — exit code 0
- [x] `install.sh` adds the hook idempotently (uses same `jq` + contains pattern as other SessionStart hooks)
- [x] `~/.claude/settings.json` updated locally for immediate effect

## Closes

Implements #425 (option B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)