### PR TITLE
Add PreToolUse hooks to warn on dispatcher-blocking tool calls

### DIFF
--- a/hooks/dispatcher-inline-tool-guard.py
+++ b/hooks/dispatcher-inline-tool-guard.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: warns when tools that should run in background subagents are
+called inline by the dispatcher.
+
+The Lobster dispatcher runs in an infinite message-processing loop. Certain tools
+should never be called inline — they block message processing, sometimes for many
+seconds or minutes. This hook catches the most common cases and steers Claude
+toward delegating to a background subagent instead.
+
+Guarded tools and why:
+
+  WebFetch / WebSearch — network I/O that can take 5–30+ seconds. The dispatcher
+    has no reason to fetch web content directly; if web information is needed it
+    should always go to a background subagent.
+
+Exit codes:
+  0 — tool is not guarded, or usage is acceptable
+  1 — soft warning: Claude sees it and can reconsider, but is not hard-blocked
+
+Exit 1 (not 2) is intentional throughout. There may be edge cases where inline
+usage is genuinely warranted; hard-blocking would be counterproductive.
+"""
+import json
+import sys
+
+# Tools that should always go to a background subagent, never called inline.
+# Map tool name → reason shown in warning message.
+_GUARDED_TOOLS: dict[str, str] = {
+    "WebFetch": (
+        "WebFetch makes a network request that can take 5–30+ seconds, blocking "
+        "the dispatcher's message-processing loop for the full duration. "
+        "Delegate web fetching to a background subagent instead."
+    ),
+    "WebSearch": (
+        "WebSearch makes a network request that can take several seconds, blocking "
+        "the dispatcher's message-processing loop for the full duration. "
+        "Delegate web searches to a background subagent instead."
+    ),
+}
+
+data = json.load(sys.stdin)
+tool = data.get("tool_name", "")
+
+reason = _GUARDED_TOOLS.get(tool)
+if reason is None:
+    sys.exit(0)
+
+print(
+    f"Warning: {tool} called inline by the dispatcher. {reason}",
+    file=sys.stderr,
+)
+sys.exit(1)

--- a/hooks/dispatcher-inline-tool-guard.py
+++ b/hooks/dispatcher-inline-tool-guard.py
@@ -47,6 +47,5 @@ if reason is None:
 
 print(
     f"Warning: {tool} called inline by the dispatcher. {reason}",
-    file=sys.stderr,
 )
 sys.exit(1)

--- a/hooks/require-background-agent.py
+++ b/hooks/require-background-agent.py
@@ -33,6 +33,5 @@ print(
     "This blocks message processing for the duration of the agent. "
     "Pass run_in_background: true unless you genuinely need the result "
     "synchronously to decide your next step.",
-    file=sys.stderr,
 )
 sys.exit(1)

--- a/hooks/require-background-agent.py
+++ b/hooks/require-background-agent.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: warns when the Agent tool is called without run_in_background: true.
+
+The Lobster dispatcher runs in an infinite message-processing loop. A foreground
+Agent call (run_in_background omitted or false) blocks the dispatcher for the
+full duration of the agent — potentially minutes — while incoming messages queue
+up unprocessed.
+
+Exit codes:
+  0 — tool is not Agent, or Agent is called with run_in_background: true (OK)
+  1 — soft warning: Agent called without run_in_background: true
+
+Exit 1 (not 2) is intentional. Claude sees the warning and can reconsider, but
+is not hard-blocked. There are legitimate cases where a foreground Agent is
+genuinely needed (e.g., the result is required synchronously to decide the next
+step). Hard-blocking those would be counterproductive.
+"""
+import json
+import sys
+
+data = json.load(sys.stdin)
+tool = data.get("tool_name", "")
+inp = data.get("tool_input", {})
+
+if tool != "Agent":
+    sys.exit(0)
+
+if inp.get("run_in_background") is True:
+    sys.exit(0)
+
+print(
+    "Warning: Agent tool called without run_in_background: true. "
+    "This blocks message processing for the duration of the agent. "
+    "Pass run_in_background: true unless you genuinely need the result "
+    "synchronously to decide your next step.",
+    file=sys.stderr,
+)
+sys.exit(1)

--- a/install.sh
+++ b/install.sh
@@ -1302,6 +1302,48 @@ else
     info "Skipping require-subagent-type hook (settings.json not yet created)"
 fi
 
+# Set up Claude Code PreToolUse hook to warn when Agent is called without run_in_background
+chmod +x "$INSTALL_DIR/hooks/require-background-agent.py" || true
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.PreToolUse[]? | select(.hooks[]?.command | test("require-background-agent"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+            "matcher": "Agent",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 '"$INSTALL_DIR"'/hooks/require-background-agent.py",
+                "timeout": 5
+            }]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "require-background-agent hook installed"
+    else
+        info "require-background-agent hook already configured in Claude Code settings"
+    fi
+else
+    info "Skipping require-background-agent hook (settings.json not yet created)"
+fi
+
+# Set up Claude Code PreToolUse hook to warn when WebFetch/WebSearch are called inline
+chmod +x "$INSTALL_DIR/hooks/dispatcher-inline-tool-guard.py" || true
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.PreToolUse[]? | select(.hooks[]?.command | test("dispatcher-inline-tool-guard"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+            "matcher": "WebFetch|WebSearch",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 '"$INSTALL_DIR"'/hooks/dispatcher-inline-tool-guard.py",
+                "timeout": 5
+            }]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "dispatcher-inline-tool-guard hook installed"
+    else
+        info "dispatcher-inline-tool-guard hook already configured in Claude Code settings"
+    fi
+else
+    info "Skipping dispatcher-inline-tool-guard hook (settings.json not yet created)"
+fi
+
 # Set up Claude Code PreToolUse hook to block edits to system files unless LOBSTER_DEBUG=true
 chmod +x "$INSTALL_DIR/hooks/system-file-protect.py" || true
 if [ -f "$CLAUDE_SETTINGS" ]; then

--- a/tests/smoke/test_dispatcher_inline_tool_guard.py
+++ b/tests/smoke/test_dispatcher_inline_tool_guard.py
@@ -1,0 +1,118 @@
+"""
+Smoke tests for hooks/dispatcher-inline-tool-guard.py
+
+The hook guards against the dispatcher making inline network calls (WebFetch,
+WebSearch) that block the message-processing loop for the full duration of
+the request.
+
+Test cases:
+  B1. WebFetch called inline   → exit 1, warning on stderr mentioning WebFetch
+  B2. WebSearch called inline  → exit 1, warning on stderr mentioning WebSearch
+  B3. Non-guarded tool call    → exit 0, no output
+
+Failure modes by case:
+  B1/B2 — if the hook stays silent, the dispatcher can freely make slow network
+       calls that stall the message loop for 5–30+ seconds with no warning.
+  B3 — if the hook fires on arbitrary tools, Claude receives spurious warnings
+       on every tool call, degrading signal quality.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOK = Path(__file__).parent.parent.parent / "hooks" / "dispatcher-inline-tool-guard.py"
+
+
+def _run_hook(tool_name: str, tool_input: dict | None = None) -> subprocess.CompletedProcess:
+    """Run the hook with the given tool_name piped to stdin."""
+    payload = json.dumps({"tool_name": tool_name, "tool_input": tool_input or {}})
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=payload,
+        capture_output=True,
+        text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# B1 — WebFetch inline → soft warning
+# ---------------------------------------------------------------------------
+
+
+def test_webfetch_inline_warns():
+    """B1: WebFetch called inline → exit 1 with warning mentioning WebFetch.
+
+    Failure mode: a silent hook here means the dispatcher can issue multi-second
+    network requests inline, stalling the message loop with no indication to Claude.
+    """
+    result = _run_hook("WebFetch", {"url": "https://example.com"})
+
+    assert result.returncode == 1, (
+        f"Expected exit 1 (soft warning) for inline WebFetch, got {result.returncode}."
+    )
+    assert "WebFetch" in result.stderr, (
+        f"Warning must mention 'WebFetch'.\nGot stderr: {result.stderr!r}"
+    )
+    assert "background" in result.stderr.lower(), (
+        f"Warning should suggest using a background subagent.\nGot stderr: {result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# B2 — WebSearch inline → soft warning
+# ---------------------------------------------------------------------------
+
+
+def test_websearch_inline_warns():
+    """B2: WebSearch called inline → exit 1 with warning mentioning WebSearch.
+
+    Failure mode: same as B1, but for search queries that can also take several
+    seconds and block the dispatcher loop.
+    """
+    result = _run_hook("WebSearch", {"query": "what is the weather"})
+
+    assert result.returncode == 1, (
+        f"Expected exit 1 (soft warning) for inline WebSearch, got {result.returncode}."
+    )
+    assert "WebSearch" in result.stderr, (
+        f"Warning must mention 'WebSearch'.\nGot stderr: {result.stderr!r}"
+    )
+    assert "background" in result.stderr.lower(), (
+        f"Warning should suggest using a background subagent.\nGot stderr: {result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# B3 — Non-guarded tools → ignored entirely
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tool_name", [
+    "Bash",
+    "Read",
+    "Edit",
+    "Write",
+    "Agent",
+    "mcp__lobster-inbox__send_reply",
+    "mcp__github__issue_write",
+])
+def test_non_guarded_tool_exits_zero(tool_name: str):
+    """B3: Non-guarded tools are outside the hook's concern → exit 0, no output.
+
+    Failure mode: if the hook fires on arbitrary tools, Claude receives spurious
+    network-related warnings on every tool call.
+    """
+    result = _run_hook(tool_name, {"some_param": "value"})
+
+    assert result.returncode == 0, (
+        f"Expected exit 0 for non-guarded tool '{tool_name}', "
+        f"got {result.returncode}.\nstderr: {result.stderr!r}"
+    )
+    assert result.stderr.strip() == "", (
+        f"Expected no stderr for non-guarded tool '{tool_name}', "
+        f"got: {result.stderr!r}"
+    )

--- a/tests/smoke/test_dispatcher_inline_tool_guard.py
+++ b/tests/smoke/test_dispatcher_inline_tool_guard.py
@@ -6,8 +6,8 @@ WebSearch) that block the message-processing loop for the full duration of
 the request.
 
 Test cases:
-  B1. WebFetch called inline   → exit 1, warning on stderr mentioning WebFetch
-  B2. WebSearch called inline  → exit 1, warning on stderr mentioning WebSearch
+  B1. WebFetch called inline   → exit 1, warning on stdout mentioning WebFetch
+  B2. WebSearch called inline  → exit 1, warning on stdout mentioning WebSearch
   B3. Non-guarded tool call    → exit 0, no output
 
 Failure modes by case:
@@ -44,7 +44,7 @@ def _run_hook(tool_name: str, tool_input: dict | None = None) -> subprocess.Comp
 
 
 def test_webfetch_inline_warns():
-    """B1: WebFetch called inline → exit 1 with warning mentioning WebFetch.
+    """B1: WebFetch called inline → exit 1 with warning on stdout mentioning WebFetch.
 
     Failure mode: a silent hook here means the dispatcher can issue multi-second
     network requests inline, stalling the message loop with no indication to Claude.
@@ -54,11 +54,11 @@ def test_webfetch_inline_warns():
     assert result.returncode == 1, (
         f"Expected exit 1 (soft warning) for inline WebFetch, got {result.returncode}."
     )
-    assert "WebFetch" in result.stderr, (
-        f"Warning must mention 'WebFetch'.\nGot stderr: {result.stderr!r}"
+    assert "WebFetch" in result.stdout, (
+        f"Warning must mention 'WebFetch'.\nGot stdout: {result.stdout!r}"
     )
-    assert "background" in result.stderr.lower(), (
-        f"Warning should suggest using a background subagent.\nGot stderr: {result.stderr!r}"
+    assert "background" in result.stdout.lower(), (
+        f"Warning should suggest using a background subagent.\nGot stdout: {result.stdout!r}"
     )
 
 
@@ -68,7 +68,7 @@ def test_webfetch_inline_warns():
 
 
 def test_websearch_inline_warns():
-    """B2: WebSearch called inline → exit 1 with warning mentioning WebSearch.
+    """B2: WebSearch called inline → exit 1 with warning on stdout mentioning WebSearch.
 
     Failure mode: same as B1, but for search queries that can also take several
     seconds and block the dispatcher loop.
@@ -78,11 +78,11 @@ def test_websearch_inline_warns():
     assert result.returncode == 1, (
         f"Expected exit 1 (soft warning) for inline WebSearch, got {result.returncode}."
     )
-    assert "WebSearch" in result.stderr, (
-        f"Warning must mention 'WebSearch'.\nGot stderr: {result.stderr!r}"
+    assert "WebSearch" in result.stdout, (
+        f"Warning must mention 'WebSearch'.\nGot stdout: {result.stdout!r}"
     )
-    assert "background" in result.stderr.lower(), (
-        f"Warning should suggest using a background subagent.\nGot stderr: {result.stderr!r}"
+    assert "background" in result.stdout.lower(), (
+        f"Warning should suggest using a background subagent.\nGot stdout: {result.stdout!r}"
     )
 
 
@@ -110,9 +110,9 @@ def test_non_guarded_tool_exits_zero(tool_name: str):
 
     assert result.returncode == 0, (
         f"Expected exit 0 for non-guarded tool '{tool_name}', "
-        f"got {result.returncode}.\nstderr: {result.stderr!r}"
+        f"got {result.returncode}.\nstdout: {result.stdout!r}"
     )
-    assert result.stderr.strip() == "", (
-        f"Expected no stderr for non-guarded tool '{tool_name}', "
-        f"got: {result.stderr!r}"
+    assert result.stdout.strip() == "", (
+        f"Expected no stdout for non-guarded tool '{tool_name}', "
+        f"got: {result.stdout!r}"
     )

--- a/tests/smoke/test_require_background_agent.py
+++ b/tests/smoke/test_require_background_agent.py
@@ -1,0 +1,134 @@
+"""
+Smoke tests for hooks/require-background-agent.py
+
+The hook guards against the dispatcher being blocked by a foreground Agent call.
+An Agent call without run_in_background: true stalls the message-processing loop
+for the full duration of the agent — potentially minutes.
+
+Test cases:
+  A1. Agent with run_in_background: true  → exit 0, no output
+  A2. Agent with run_in_background: false → exit 1, warning on stderr
+  A3. Agent with run_in_background absent → exit 1, warning on stderr
+  A4. Non-Agent tool call                 → exit 0, no output
+
+Failure modes by case:
+  A1 — if the hook fires on correct usage, Claude is incorrectly warned away
+       from the right pattern, likely causing it to switch to foreground mode.
+  A2/A3 — if the hook stays silent, foreground Agent calls go unwarned and the
+       dispatcher stalls silently.
+  A4 — if the hook fires on non-Agent tools, unrelated tools generate spurious
+       warnings on every call.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOK = Path(__file__).parent.parent.parent / "hooks" / "require-background-agent.py"
+
+WARNING_FRAGMENT = "run_in_background: true"
+
+
+def _run_hook(tool_name: str, tool_input: dict) -> subprocess.CompletedProcess:
+    """Run the hook with the given tool_name and tool_input piped to stdin."""
+    payload = json.dumps({"tool_name": tool_name, "tool_input": tool_input})
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=payload,
+        capture_output=True,
+        text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# A1 — Agent with run_in_background: true → allowed silently
+# ---------------------------------------------------------------------------
+
+
+def test_background_agent_exits_zero():
+    """A1: Agent called with run_in_background=True → exit 0, no stderr warning.
+
+    Failure mode: if the hook warns on correct usage, Claude gets pushed toward
+    foreground calls, which is the opposite of what we want.
+    """
+    result = _run_hook("Agent", {"run_in_background": True, "prompt": "do stuff"})
+
+    assert result.returncode == 0, (
+        f"Expected exit 0 for background Agent, got {result.returncode}.\n"
+        f"stderr: {result.stderr!r}"
+    )
+    assert result.stderr.strip() == "", (
+        f"Expected no stderr for background Agent, got: {result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A2 — Agent with run_in_background: false → soft warning
+# ---------------------------------------------------------------------------
+
+
+def test_foreground_agent_explicit_false_warns():
+    """A2: Agent called with run_in_background=False → exit 1 with warning.
+
+    Failure mode: a silent hook here means Claude never sees that it is about
+    to block the dispatcher's message-processing loop.
+    """
+    result = _run_hook("Agent", {"run_in_background": False, "prompt": "do stuff"})
+
+    assert result.returncode == 1, (
+        f"Expected exit 1 (soft warning) for foreground Agent, got {result.returncode}."
+    )
+    assert WARNING_FRAGMENT in result.stderr, (
+        f"Warning must mention '{WARNING_FRAGMENT}' so Claude knows what to fix.\n"
+        f"Got stderr: {result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A3 — Agent with run_in_background absent → soft warning
+# ---------------------------------------------------------------------------
+
+
+def test_foreground_agent_field_absent_warns():
+    """A3: Agent called without run_in_background field → exit 1 with warning.
+
+    Omitting the field is the most common mistake; it must be treated the same
+    as run_in_background: false.
+
+    Failure mode: same as A2 — silent hook means silent dispatcher stall.
+    """
+    result = _run_hook("Agent", {"prompt": "do stuff"})
+
+    assert result.returncode == 1, (
+        f"Expected exit 1 when run_in_background is absent, got {result.returncode}."
+    )
+    assert WARNING_FRAGMENT in result.stderr, (
+        f"Warning must mention '{WARNING_FRAGMENT}'.\nGot stderr: {result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A4 — Non-Agent tool → ignored entirely
+# ---------------------------------------------------------------------------
+
+
+def test_non_agent_tool_exits_zero():
+    """A4: Non-Agent tools are outside the hook's concern → exit 0, no output.
+
+    Failure mode: if the hook fires on every tool, Claude receives spurious
+    run_in_background warnings for tools that have nothing to do with agents.
+    """
+    for tool_name in ["Bash", "Read", "Edit", "mcp__github__issue_write"]:
+        result = _run_hook(tool_name, {"some_param": "value"})
+
+        assert result.returncode == 0, (
+            f"Expected exit 0 for non-Agent tool '{tool_name}', "
+            f"got {result.returncode}.\nstderr: {result.stderr!r}"
+        )
+        assert result.stderr.strip() == "", (
+            f"Expected no stderr for non-Agent tool '{tool_name}', "
+            f"got: {result.stderr!r}"
+        )

--- a/tests/smoke/test_require_background_agent.py
+++ b/tests/smoke/test_require_background_agent.py
@@ -7,8 +7,8 @@ for the full duration of the agent — potentially minutes.
 
 Test cases:
   A1. Agent with run_in_background: true  → exit 0, no output
-  A2. Agent with run_in_background: false → exit 1, warning on stderr
-  A3. Agent with run_in_background absent → exit 1, warning on stderr
+  A2. Agent with run_in_background: false → exit 1, warning on stdout
+  A3. Agent with run_in_background absent → exit 1, warning on stdout
   A4. Non-Agent tool call                 → exit 0, no output
 
 Failure modes by case:
@@ -49,7 +49,7 @@ def _run_hook(tool_name: str, tool_input: dict) -> subprocess.CompletedProcess:
 
 
 def test_background_agent_exits_zero():
-    """A1: Agent called with run_in_background=True → exit 0, no stderr warning.
+    """A1: Agent called with run_in_background=True → exit 0, no warning output.
 
     Failure mode: if the hook warns on correct usage, Claude gets pushed toward
     foreground calls, which is the opposite of what we want.
@@ -58,10 +58,10 @@ def test_background_agent_exits_zero():
 
     assert result.returncode == 0, (
         f"Expected exit 0 for background Agent, got {result.returncode}.\n"
-        f"stderr: {result.stderr!r}"
+        f"stdout: {result.stdout!r}"
     )
-    assert result.stderr.strip() == "", (
-        f"Expected no stderr for background Agent, got: {result.stderr!r}"
+    assert result.stdout.strip() == "", (
+        f"Expected no stdout for background Agent, got: {result.stdout!r}"
     )
 
 
@@ -71,7 +71,7 @@ def test_background_agent_exits_zero():
 
 
 def test_foreground_agent_explicit_false_warns():
-    """A2: Agent called with run_in_background=False → exit 1 with warning.
+    """A2: Agent called with run_in_background=False → exit 1 with warning on stdout.
 
     Failure mode: a silent hook here means Claude never sees that it is about
     to block the dispatcher's message-processing loop.
@@ -81,9 +81,9 @@ def test_foreground_agent_explicit_false_warns():
     assert result.returncode == 1, (
         f"Expected exit 1 (soft warning) for foreground Agent, got {result.returncode}."
     )
-    assert WARNING_FRAGMENT in result.stderr, (
+    assert WARNING_FRAGMENT in result.stdout, (
         f"Warning must mention '{WARNING_FRAGMENT}' so Claude knows what to fix.\n"
-        f"Got stderr: {result.stderr!r}"
+        f"Got stdout: {result.stdout!r}"
     )
 
 
@@ -93,7 +93,7 @@ def test_foreground_agent_explicit_false_warns():
 
 
 def test_foreground_agent_field_absent_warns():
-    """A3: Agent called without run_in_background field → exit 1 with warning.
+    """A3: Agent called without run_in_background field → exit 1 with warning on stdout.
 
     Omitting the field is the most common mistake; it must be treated the same
     as run_in_background: false.
@@ -105,8 +105,8 @@ def test_foreground_agent_field_absent_warns():
     assert result.returncode == 1, (
         f"Expected exit 1 when run_in_background is absent, got {result.returncode}."
     )
-    assert WARNING_FRAGMENT in result.stderr, (
-        f"Warning must mention '{WARNING_FRAGMENT}'.\nGot stderr: {result.stderr!r}"
+    assert WARNING_FRAGMENT in result.stdout, (
+        f"Warning must mention '{WARNING_FRAGMENT}'.\nGot stdout: {result.stdout!r}"
     )
 
 
@@ -126,9 +126,9 @@ def test_non_agent_tool_exits_zero():
 
         assert result.returncode == 0, (
             f"Expected exit 0 for non-Agent tool '{tool_name}', "
-            f"got {result.returncode}.\nstderr: {result.stderr!r}"
+            f"got {result.returncode}.\nstdout: {result.stdout!r}"
         )
-        assert result.stderr.strip() == "", (
-            f"Expected no stderr for non-Agent tool '{tool_name}', "
-            f"got: {result.stderr!r}"
+        assert result.stdout.strip() == "", (
+            f"Expected no stdout for non-Agent tool '{tool_name}', "
+            f"got: {result.stdout!r}"
         )


### PR DESCRIPTION
## Problem

The dispatcher's message-processing loop can be stalled silently by two categories of inline tool call:

1. **Agent called without `run_in_background: true`** — a foreground agent blocks the dispatcher for the full duration of the agent run, potentially minutes, while incoming messages queue up unprocessed.

2. **WebFetch / WebSearch called inline** — these make network requests that can take 5–30+ seconds. The dispatcher has no legitimate reason to fetch web content directly; that work should always go to a background subagent.

In both cases, Claude receives no warning. The dispatcher simply stalls.

## Fix

Two new `PreToolUse` hooks, both using exit 1 (soft warning, not hard block):

**`hooks/require-background-agent.py`** — fires on every `Agent` call. Exits 0 if `run_in_background` is `True`; exits 1 with a warning otherwise. Exit 2 is intentionally avoided: there are legitimate edge cases where a foreground agent is genuinely needed (when the result is required synchronously to decide the next step).

**`hooks/dispatcher-inline-tool-guard.py`** — fires on `WebFetch` and `WebSearch`. Both always warrant a background subagent; the warning tells Claude to delegate instead. Implemented as a dict-keyed guard so adding future tools requires only a new entry.

The Agent hook registers under the existing `"Agent"` matcher alongside `require-subagent-type.py`. The web guard registers under `"WebFetch|WebSearch"`.

Both hooks are registered in `install.sh` using the same jq-idempotent pattern as `require-subagent-type.py` — re-running install does not add duplicate entries.

## Functional patterns used

Pure functions with no side effects. The `_GUARDED_TOOLS` dict in `dispatcher-inline-tool-guard.py` is a declarative map from tool name to warning rationale — extending coverage requires only a new dict entry, no conditional branching.

## Tests run

- [x] `uv run pytest tests/smoke/test_require_background_agent.py -v` — 4 passed, 0 failed
- [x] `uv run pytest tests/smoke/test_dispatcher_inline_tool_guard.py -v` — 9 passed, 0 failed
- [x] Manual invocation of deployed hooks via stdin — all exit codes and warning messages verified correct

Closes #427