### PR TITLE
feat(auditor): lobster-auditor subagent with enforced context-update hook

### DIFF
--- a/hooks/require-auditor-context-update.py
+++ b/hooks/require-auditor-context-update.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+SubagentStop hook: ensure lobster-auditor sessions update system-audit.context.md.
+
+For non-auditor sessions this hook is a no-op (exits 0 immediately).
+
+For auditor sessions it enforces one of two exit conditions:
+  1. system-audit.context.md was modified during this session
+     (mtime >= session start time found in the transcript), OR
+  2. the transcript contains the safe word AUDIT_CONTEXT_UNCHANGED
+     (agent explicitly confirmed that nothing new was found).
+
+If neither condition is met the hook prints an error message and exits 2,
+hard-blocking the session from terminating until the agent complies.
+
+Detection strategy for "is this an auditor session":
+  Scan the transcript for a ReadFile tool call whose path contains
+  "system-audit.context.md". The auditor definition requires reading this
+  file at session start, so its presence is a reliable signal.
+"""
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+CONTEXT_FILE = Path(os.path.expanduser(
+    "~/lobster-user-config/agents/system-audit.context.md"
+))
+
+SAFE_WORD = "AUDIT_CONTEXT_UNCHANGED"
+
+# Path fragment used to detect auditor sessions in the transcript.
+AUDIT_CONTEXT_FILENAME = "system-audit.context.md"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_tool_calls(transcript: list) -> list[dict]:
+    """Return all tool_use blocks from the transcript."""
+    tool_calls = []
+    for msg in transcript:
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content", [])
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "tool_use":
+                tool_calls.append(item)
+    return tool_calls
+
+
+def _is_auditor_session(tool_calls: list[dict]) -> bool:
+    """Return True if any tool call reads system-audit.context.md.
+
+    The auditor subagent definition requires reading this file at the start of
+    every session.  A Read/cat/Bash call whose input references the filename is
+    sufficient evidence.
+    """
+    for call in tool_calls:
+        name = call.get("name", "")
+        # Check Read tool (Claude Code built-in)
+        if name == "Read":
+            path = call.get("input", {}).get("file_path", "")
+            if AUDIT_CONTEXT_FILENAME in path:
+                return True
+        # Check Bash tool — auditor might cat/head the file
+        if name == "Bash":
+            cmd = call.get("input", {}).get("command", "")
+            if AUDIT_CONTEXT_FILENAME in cmd:
+                return True
+    return False
+
+
+def _safe_word_in_transcript(tool_calls: list[dict]) -> bool:
+    """Return True if write_result was called with AUDIT_CONTEXT_UNCHANGED."""
+    for call in tool_calls:
+        if call.get("name") != "mcp__lobster-inbox__write_result":
+            continue
+        inp = call.get("input", {})
+        text = inp.get("text", "")
+        if SAFE_WORD in text:
+            return True
+    return False
+
+
+def _session_start_time(hook_input: dict) -> float | None:
+    """Estimate session start time from the transcript's first message timestamp.
+
+    Falls back to None if no timestamp is available (hook input varies).
+    """
+    # Claude Code hook input may carry a top-level timestamp or we can parse
+    # the transcript for the earliest role='user' message timestamp.
+    ts = hook_input.get("session_start_time") or hook_input.get("timestamp")
+    if ts:
+        try:
+            return float(ts)
+        except (TypeError, ValueError):
+            pass
+
+    # Try to find the minimum timestamp inside transcript messages.
+    transcript = hook_input.get("transcript", [])
+    min_ts = None
+    for msg in transcript:
+        if not isinstance(msg, dict):
+            continue
+        t = msg.get("timestamp")
+        if t:
+            try:
+                t_float = float(t)
+                if min_ts is None or t_float < min_ts:
+                    min_ts = t_float
+            except (TypeError, ValueError):
+                continue
+    return min_ts
+
+
+def _context_file_updated_since(since: float | None) -> bool:
+    """Return True if system-audit.context.md was modified at or after `since`.
+
+    If `since` is None (unknown session start), we cannot verify via mtime —
+    return False so the safe word remains the only exit path.
+    """
+    if since is None:
+        return False
+    try:
+        mtime = CONTEXT_FILE.stat().st_mtime
+        # Allow a 1-second clock skew margin.
+        return mtime >= (since - 1.0)
+    except OSError:
+        # File doesn't exist yet — not updated.
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)  # Unreadable input — never block
+
+    transcript = hook_input.get("transcript", [])
+    tool_calls = _extract_tool_calls(transcript)
+
+    # Fast path: not an auditor session — pass through.
+    if not _is_auditor_session(tool_calls):
+        sys.exit(0)
+
+    # --- Auditor session detected ---
+
+    # Condition 1: context file was updated during this session.
+    session_start = _session_start_time(hook_input)
+    if _context_file_updated_since(session_start):
+        sys.exit(0)
+
+    # Condition 2: transcript contains the explicit safe word.
+    if _safe_word_in_transcript(tool_calls):
+        sys.exit(0)
+
+    # Neither condition met — block exit.
+    print(
+        "Error: lobster-auditor session ended without updating "
+        "system-audit.context.md. "
+        "Either update the file with your findings, or include "
+        f"{SAFE_WORD!r} as the first line of your write_result call "
+        "if nothing new was found."
+    )
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/install.sh
+++ b/install.sh
@@ -874,6 +874,14 @@ if [ -d "$TEMPLATES_DIR" ]; then
     done
 fi
 
+# Seed system-audit.context.md to user-config/agents/ on first run
+AUDIT_CONTEXT_SEED="$INSTALL_DIR/memory/canonical-templates/system-audit.context.md"
+AUDIT_CONTEXT_DEST="$USER_CONFIG_DIR/agents/system-audit.context.md"
+if [ -f "$AUDIT_CONTEXT_SEED" ] && [ ! -f "$AUDIT_CONTEXT_DEST" ]; then
+    cp "$AUDIT_CONTEXT_SEED" "$AUDIT_CONTEXT_DEST"
+    info "  Seeded system-audit.context.md to user-config/agents/"
+fi
+
 # Create stub user-config agent files if they don't exist
 for stub_file in "base.bootup.md" "base.context.md" "dispatcher.bootup.md" "subagent.bootup.md"; do
     stub_dest="$USER_CONFIG_DIR/agents/$stub_file"
@@ -1470,6 +1478,29 @@ if [ -f "$CLAUDE_SETTINGS" ]; then
     fi
 else
     info "Skipping require-write-result SubagentStop hook (settings.json not yet created)"
+fi
+
+# Set up Claude Code SubagentStop hook to enforce auditor context updates.
+# This hook fires when a lobster-auditor session ends and ensures the agent
+# either updated system-audit.context.md or emitted AUDIT_CONTEXT_UNCHANGED.
+chmod +x "$INSTALL_DIR/hooks/require-auditor-context-update.py" || true
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.SubagentStop[]? | select(.hooks[]?.command | contains("require-auditor-context-update"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq '.hooks.SubagentStop = (.hooks.SubagentStop // []) + [{
+            "matcher": "",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 '"$INSTALL_DIR"'/hooks/require-auditor-context-update.py",
+                "timeout": 10
+            }]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "require-auditor-context-update SubagentStop hook installed"
+    else
+        info "require-auditor-context-update SubagentStop hook already configured in Claude Code settings"
+    fi
+else
+    info "Skipping require-auditor-context-update SubagentStop hook (settings.json not yet created)"
 fi
 
 #===============================================================================

--- a/memory/canonical-templates/system-audit.context.md
+++ b/memory/canonical-templates/system-audit.context.md
@@ -1,0 +1,50 @@
+# System Audit Context
+
+*Maintained by lobster-auditor. Updated at the end of every audit session.*
+
+---
+
+## Instructions for lobster-auditor
+
+This file is your living architecture context. At the start of every session:
+1. Read this file to understand the current known state of the system.
+2. Compare it against what you observe during the investigation.
+3. At the end of every session, update this file with any new findings.
+
+If nothing changed and nothing new was discovered, include the string
+`AUDIT_CONTEXT_UNCHANGED` as the first line of your `write_result` call body.
+This signals to the SubagentStop hook that you explicitly acknowledged the state.
+
+**Do not leave a session without either updating this file or emitting
+`AUDIT_CONTEXT_UNCHANGED`. The hook will block your exit if neither condition
+is met.**
+
+---
+
+## System Audit History
+
+*No audit sessions recorded yet. The lobster-auditor will populate this section
+after its first run.*
+
+---
+
+## Known Anomalies
+
+*Populate with: ghost agents observed, reconciler errors, MCP failures,
+transcription pipeline issues, or any other anomaly worth remembering across
+sessions.*
+
+---
+
+## Root Causes Identified
+
+*Populate with confirmed root causes and the resolution taken (or "unresolved"
+if still open).*
+
+---
+
+## Architecture Notes
+
+*Populate with durable observations about system internals — schema quirks,
+edge cases in hooks, environment-specific behaviours — that are not captured
+in the main codebase docs.*


### PR DESCRIPTION
## Summary

Each system investigation starts from scratch today — no accumulated knowledge, no durable record of root causes. This PR introduces the `lobster-auditor` subagent (designed in #429) along with the enforcement hook that makes its context-update contract machine-verifiable.

**What ships in this PR:**

- **`hooks/require-auditor-context-update.py`** — SubagentStop hook that detects when a lobster-auditor session is ending and blocks exit unless the agent either updated `system-audit.context.md` or emitted `AUDIT_CONTEXT_UNCHANGED` as the first line of its `write_result` call. Detection is transcript-based: if any tool call in the session read `system-audit.context.md`, this is treated as an auditor session. This is the same exit-2 enforcement pattern used by `require-write-result.py`.

- **`memory/canonical-templates/system-audit.context.md`** — Seed template with sections for audit history, known anomalies, root causes, and architecture notes. `install.sh` copies this to `~/lobster-user-config/agents/system-audit.context.md` on first run (skipped if the file already exists).

- **`install.sh`** — Two additions: (1) seed copy for `system-audit.context.md` at directory setup time, (2) SubagentStop hook registration for `require-auditor-context-update.py`.

**What does NOT ship in this PR (by design):**

- The subagent definition (`lobster-auditor.md`) lives in user-config, not in the repo — same pattern as all subagent definitions.
- Hook registration in `~/.claude/settings.json` is intentionally omitted pending review. The `install.sh` block is ready; it just needs to run after approval.

## Functional patterns used

Pure functions throughout the hook: all detection logic is expressed as boolean-returning functions over the transcript data structure (`_is_auditor_session`, `_safe_word_in_transcript`, `_context_file_updated_since`). Side effects (the blocking print + sys.exit) are isolated to `main()`.

## Tests run

- [x] `python3 ~/lobster/hooks/require-auditor-context-update.py < /dev/null` — exits 0 (unreadable input → pass through)
- [x] Manual transcript fixture with a Read call to `system-audit.context.md` and no safe word → exits 2 with expected message
- [x] Same fixture with `AUDIT_CONTEXT_UNCHANGED` in write_result text → exits 0
- [ ] Full integration test with a live auditor session — skipped: requires hook registration in settings.json, which is pending review

**Blocked items needing attention before merge:** hook registration in `~/.claude/settings.json` should be done post-review (either via `install.sh` re-run or manual `jq` edit).

Closes #429