### PR TITLE
Message processing: reduce stale timeout, remove text ack, add ack policy

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -898,8 +898,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     log.info(f"Wrote message to inbox: {msg_id}")
 
-    # Send acknowledgment
-    await message.reply_text("📨 Message received. Processing...")
+    # No text acknowledgment — the typing indicator already signals receipt.
 
 
 async def handle_audio_message(

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -2462,16 +2462,36 @@ def _find_message_file(directory: Path, message_id: str) -> Path | None:
     return None
 
 
-def _recover_stale_processing(max_age_seconds: int = 300):
-    """Move stale messages from processing/ back to inbox/."""
+def _stale_timeout_for_message(msg: dict) -> int:
+    """Return the stale processing timeout in seconds based on message type.
+
+    Text messages are expected to complete quickly; media types (voice, audio,
+    photo, document) may take longer due to transcription or download time.
+    """
+    slow_types = {"voice", "audio", "photo", "document"}
+    msg_type = msg.get("type", "text")
+    return 300 if msg_type in slow_types else 90
+
+
+def _recover_stale_processing():
+    """Move stale messages from processing/ back to inbox/.
+
+    Uses a type-aware timeout: 90s for text messages, 300s for media
+    (voice/audio/photo/document) where transcription or download can be slow.
+    """
     now = time.time()
     for f in PROCESSING_DIR.glob("*.json"):
         try:
             age = now - f.stat().st_mtime
-            if age > max_age_seconds:
+            msg = json.loads(f.read_text())
+            max_age = _stale_timeout_for_message(msg)
+            if age > max_age:
                 dest = INBOX_DIR / f.name
                 f.rename(dest)
-                log.warning(f"Recovered stale message from processing: {f.name} (age: {int(age)}s)")
+                log.warning(
+                    f"Recovered stale message from processing: {f.name} "
+                    f"(type: {msg.get('type', 'text')}, age: {int(age)}s, timeout: {max_age}s)"
+                )
         except Exception:
             continue
 


### PR DESCRIPTION
Three small, independent improvements to message processing. Each can be reasoned about separately but ships together since they are all low-risk and address the same theme: reducing unnecessary noise and tightening recovery behavior.

## What changed and why

**1. Type-aware stale processing recovery (inbox_server.py)**

The stale recovery timeout was a flat 300s for all message types. This meant a hung text message would sit in `processing/` for 5 minutes before recovery — far longer than needed. Text messages processed by the dispatcher typically complete in seconds. The new behavior: 90s for text, 300s for media (voice/audio/photo/document) where transcription or download genuinely can take longer.

Implementation: a pure helper `_stale_timeout_for_message(msg: dict) -> int` reads the `type` field from the message JSON and returns the appropriate timeout. The recovery loop reads the file to get the type before deciding whether to recover. The policy (which types are slow) is separated from the recovery mechanism.

**2. Remove text message ack (lobster_bot.py)**

`handle_message` was sending "📨 Message received. Processing..." for every plain text message, immediately after writing to the inbox. The typing indicator (started one line earlier and kept alive by a 4s refresh loop) already communicates "received and processing." The text ack is redundant and adds noise — especially visible when the dispatcher responds quickly, making the conversation look like: ack → actual reply, both arriving nearly simultaneously.

Acks for voice, audio, photo, and document messages are unchanged — those have longer latency and the ack text is more informative ("Transcribing...", "Processing...").

**3. Ack policy in dispatcher.bootup.md**

The convention for when the dispatcher should send an ack was implicit. Added an explicit policy section before the delegation pattern: ack only when delegating to a background subagent (expected >4s), keep it to 2-4 words, no emoji. Fast inline responses skip the ack entirely. This codifies behavior that was already intended but undocumented.

Note: `dispatcher.bootup.md` lives outside the repo in `~/lobster-workspace/.claude/` and is deployed directly — this change is described here for context but is applied to the live file separately.

## Functional patterns

`_stale_timeout_for_message` is a pure function: same input always produces the same output, no side effects. The recovery loop now composes the policy lookup with the file rename, keeping the two concerns cleanly separated.

## Tests run

- [x] `uv run ruff check src/mcp/inbox_server.py src/bot/lobster_bot.py` — clean, no errors
- [ ] Live message flow test — requires a running bot instance with Telegram token; not available in this environment. The change to `handle_message` is a one-line deletion of a `reply_text` call; risk is minimal.