### PR TITLE
Fix chat_id=0 system route for background agents without user chat_id

### DIFF
--- a/.claude/subagent.bootup.md
+++ b/.claude/subagent.bootup.md
@@ -86,7 +86,22 @@ Failing to pass `sent_reply_to_user=True` causes duplicate messages — the disp
 
 **Server-side safety net:** If you pass `task_id` to `send_reply`, the inbox server automatically sets `sent_reply_to_user=True` in `write_result` for that `task_id` — even if you forget. This is a belt-and-suspenders guard, not a substitute for passing `sent_reply_to_user=True` explicitly.
 
-**If you were not given a `chat_id`:** do not call `send_reply` or `write_result` — your results will be returned directly to the caller.
+**If you were not given a `chat_id` and you are a synchronous subagent** (not run in background — the Agent tool call blocks and the result flows back to the caller): do not call `send_reply` or `write_result` — your results will be returned directly to the caller.
+
+**If you were not given a `chat_id` but you ARE a background agent** (spawned with `run_in_background: true`, or you are unsure): you have no return channel. You MUST call `write_result` with `chat_id=0` so the dispatcher inbox can receive your result. Background agents have no caller to return results to — skipping `write_result` means your output is permanently lost.
+
+```python
+# Background agent with no chat_id — use chat_id=0 as dispatcher system route
+mcp__lobster-inbox__write_result(
+    task_id="<your-task-id>",
+    chat_id=0,
+    text="<your result>",
+    source="telegram",
+    sent_reply_to_user=False,
+)
+```
+
+**If unsure whether you are sync or background:** use `chat_id=0` as a safe fallback. The dispatcher will log and store the result rather than dropping it.
 
 ## Surfacing Observations (`write_observation`)
 

--- a/hooks/require-write-result.py
+++ b/hooks/require-write-result.py
@@ -54,21 +54,48 @@ def main():
 
     transcript = data.get("transcript", [])
 
-    tool_calls = []
+    # Collect all tool call items so we can inspect both name and input.
+    all_tool_use_items = []
     for msg in transcript:
         if isinstance(msg, dict):
             content = msg.get("content", [])
             if isinstance(content, list):
                 for item in content:
                     if isinstance(item, dict) and item.get("type") == "tool_use":
-                        tool_calls.append(item.get("name", ""))
+                        all_tool_use_items.append(item)
 
-    # If this session called write_result, mark it completed in the DB and allow exit.
-    if "mcp__lobster-inbox__write_result" in tool_calls:
-        session_id = get_session_id(data)
-        if session_id:
-            _mark_session_completed(session_id)
-        sys.exit(0)
+    tool_call_names = [item.get("name", "") for item in all_tool_use_items]
+
+    if "mcp__lobster-inbox__write_result" in tool_call_names:
+        # write_result was called — verify it was called with a non-null chat_id.
+        # chat_id=0 is explicitly allowed: it is the dispatcher system route for
+        # background agents that were spawned without a user chat_id.
+        write_result_items = [
+            item for item in all_tool_use_items
+            if item.get("name") == "mcp__lobster-inbox__write_result"
+        ]
+        valid_calls = [
+            item for item in write_result_items
+            if item.get("input", {}).get("chat_id") is not None
+        ]
+        if valid_calls:
+            # At least one valid call found — mark session and allow exit.
+            session_id = get_session_id(data)
+            if session_id:
+                _mark_session_completed(session_id)
+            sys.exit(0)
+        else:
+            # write_result was called but chat_id was None in every call —
+            # the MCP server rejected the call and the result was not stored.
+            print(
+                "STOP: write_result was called but chat_id was None in every call. "
+                "The MCP server rejects write_result without a chat_id, so your result "
+                "was not delivered. "
+                "Call write_result again with a valid chat_id. "
+                "If you were not given a user chat_id, use chat_id=0 — that is the "
+                "dispatcher system route for background agents with no user context."
+            )
+            sys.exit(2)
 
     # Subagent finished without calling write_result — block exit
     print(

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -4340,6 +4340,12 @@ async def handle_write_result(args: dict) -> list[TextContent]:
         return [TextContent(type="text", text="Error: task_id is required")]
     if chat_id is None:
         return [TextContent(type="text", text="Error: chat_id is required")]
+    # chat_id=0 is accepted as a dispatcher system route for background agents that
+    # were spawned without a user chat_id.  The message is written to the inbox with
+    # chat_id=0 and type="subagent_result" so wait_for_messages returns it to the
+    # dispatcher, which can log or store it rather than silently dropping it.
+    # This is intentionally distinct from real Telegram/Slack chat IDs (which are
+    # always positive integers or non-empty strings).
     if not text:
         return [TextContent(type="text", text="Error: text is required")]
 


### PR DESCRIPTION
## Problem

Background agents spawned without a \`chat_id\` had no safe path to deliver results. The result was permanently lost through three compounding failures:

1. **Bootup instructions** told agents with no \`chat_id\` to skip \`write_result\` entirely — correct for synchronous subagents (where the Agent tool call returns the result to the caller), but wrong for background agents (\`run_in_background: true\`), which have no return channel.

2. **\`inbox_server.py\` \`handle_write_result\`** rejects calls with \`chat_id=None\` with an error. Even a well-intentioned agent that called \`write_result\` without a \`chat_id\` would have its result discarded silently. \`chat_id=0\` already passes the \`is None\` guard (the guard only rejects \`None\`, not \`0\`), but this was undocumented and agents had no reason to use it.

3. **\`require-write-result.py\`** checked only that \`write_result\` appeared in tool calls (correct — it reads \`type == "tool_use"\`, not text mentions), but did not verify \`chat_id\` was non-null in the call input. An agent could call \`write_result(chat_id=None)\`, the hook would pass, but the MCP server would reject the call, and the result would still be lost.

## Changes

**\`subagent.bootup.md\`** — replaces the single "no chat_id → skip write_result" instruction with a sync/background split. Synchronous subagents still skip write_result (unchanged behavior). Background agents — or any agent unsure of its execution mode — are directed to call \`write_result(chat_id=0)\`, which routes to the dispatcher inbox for logging/storage.

**\`inbox_server.py\`** — adds an explicit comment documenting \`chat_id=0\` as the dispatcher system route. The \`None\`-guard already passes \`0\` (no logic change needed), but this was invisible to callers. The comment makes the contract explicit and intentional, preventing future "cleanup" from accidentally tightening the guard to \`chat_id is None or chat_id == 0\`.

**\`require-write-result.py\`** — after confirming \`write_result\` was tool-called, now inspects the call input to verify \`chat_id\` is non-null. If every \`write_result\` call had \`chat_id=None\` (MCP server would reject all of them), blocks exit with a redirect to \`chat_id=0\`. \`chat_id=0\` passes as a valid call.

## What is out of scope

This PR does not add dispatcher-side handling for \`chat_id=0\` messages beyond what already exists — \`wait_for_messages\` will return them, and the dispatcher can log/store them. A follow-on improvement (suggested as Fix 4 in the audit report) would add a \`PreToolUse\` hook that warns at spawn time when an Agent call omits \`chat_id\`. That is not included here.

## Functional patterns used

Pure functions throughout: the hook logic is a side-effect-free scan over the transcript list using list comprehensions; the inbox_server guard change is a targeted comment addition to an existing predicate; the bootup instruction update adds a declarative decision table for execution mode.

## Tests run

- [x] \`uv run -m pytest tests/unit/test_mcp_server/ tests/unit/test_hooks/ -q\` — 209 passed, 14 failed (same 14 failures on main; no regression introduced)
- [x] \`uv run -m pytest tests/ -x -q\` — stopped at first integration failure (\`test_check_inbox_then_reply_flow\`) which also fails on main (pre-existing)
- [ ] Live end-to-end test (background agent without chat_id → dispatcher receives chat_id=0 result) — **not yet performed**. The code path is a guard relaxation (not a new delivery path), so the risk is low, but this has not been confirmed running in production.

## Deployment status

**NOT merged to main.** As of 2026-03-16, all three changes (subagent.bootup.md, inbox_server.py comment, require-write-result.py) are on the \`fix/issue-chat-id-zero-system-route\` branch only. The live system is running main at commit \`fe591ec\`.

Note: \`chat_id=0\` messages already exist in the processed/ queue (used by self-check messages), confirming the \`None\`-guard already accepts \`0\`. The PR's inbox_server.py change is a comment-only addition; the behavioral fix is in subagent.bootup.md and require-write-result.py.

Closes #439