### PR TITLE
fix: detect and explain pseudocode tool-call failure in SubagentStop hook

### DIFF
--- a/.claude/subagent.bootup.md
+++ b/.claude/subagent.bootup.md
@@ -51,6 +51,8 @@ You MUST both deliver results to the user directly AND call `write_result` at th
 
 **Required at end of every subagent task — two steps:**
 
+> **CRITICAL: The examples below are tool invocations, not code output.** Call `mcp__lobster-inbox__send_reply` and `mcp__lobster-inbox__write_result` using the tool invocation mechanism — the same mechanism you use for Read, Edit, Bash, and other tools. Do NOT write these as Python code blocks in your text output. Writing `mcp__lobster-inbox__write_result(...)` as text output does nothing — the tool is not called, the result is not delivered, and the SubagentStop hook will block you with exit 2.
+
 ```python
 # Step 1: Deliver directly to the user (crash-safe delivery)
 # Pass task_id to enable server-side auto-dedup: the inbox server will

--- a/hooks/require-write-result.py
+++ b/hooks/require-write-result.py
@@ -55,13 +55,17 @@ def main():
     transcript = data.get("transcript", [])
 
     tool_calls = []
+    text_content_parts = []
     for msg in transcript:
         if isinstance(msg, dict):
             content = msg.get("content", [])
             if isinstance(content, list):
                 for item in content:
-                    if isinstance(item, dict) and item.get("type") == "tool_use":
-                        tool_calls.append(item.get("name", ""))
+                    if isinstance(item, dict):
+                        if item.get("type") == "tool_use":
+                            tool_calls.append(item.get("name", ""))
+                        elif item.get("type") == "text":
+                            text_content_parts.append(item.get("text", ""))
 
     # If this session called write_result, mark it completed in the DB and allow exit.
     if "mcp__lobster-inbox__write_result" in tool_calls:
@@ -70,13 +74,26 @@ def main():
             _mark_session_completed(session_id)
         sys.exit(0)
 
-    # Subagent finished without calling write_result — block exit
-    print(
-        "STOP: You must call mcp__lobster-inbox__write_result before finishing. "
-        "The dispatcher is waiting for your result. "
-        "If the task failed, report the failure — but you must call write_result. "
-        "Call it now with your findings, then you may exit."
-    )
+    # Subagent finished without calling write_result — block exit.
+    # Check whether write_result appeared as text output (pseudocode failure mode)
+    # to give a more actionable error message.
+    combined_text = "\n".join(text_content_parts)
+    if "mcp__lobster-inbox__write_result" in combined_text:
+        print(
+            "STOP: write_result was described as text but not called as a tool.\n\n"
+            "The tool call appeared in your text output as Python code — this is a "
+            "description, not an invocation. You must call write_result using the tool "
+            "invocation mechanism (the same way you call Read, Edit, Bash, etc.) — not "
+            "by writing it as code output.\n\n"
+            "Call write_result now using the tool mechanism."
+        )
+    else:
+        print(
+            "STOP: You must call mcp__lobster-inbox__write_result before finishing. "
+            "The dispatcher is waiting for your result. "
+            "If the task failed, report the failure — but you must call write_result. "
+            "Call it now with your findings, then you may exit."
+        )
     sys.exit(2)  # Exit 2 to hard-block the session from terminating
 
 


### PR DESCRIPTION
## Summary

Subagents occasionally write `mcp__lobster-inbox__write_result(...)` as Python text output instead of invoking it as a tool. The SubagentStop hook already blocks this with exit 2, but the error message is generic and gives the agent no signal about what went wrong — so it can loop indefinitely without understanding why it's blocked.

Closes #445.

**Two changes:**

- **`hooks/require-write-result.py`**: When `write_result` is absent from tool_use items, scan assistant text content for the string `mcp__lobster-inbox__write_result`. If found, replace the generic error with a targeted message explaining that the tool was described as text output rather than invoked as a tool. The generic message is preserved for the case where the string appears in neither tool calls nor text.

- **`.claude/subagent.bootup.md`**: Adds a CRITICAL blockquote immediately before the send_reply/write_result code examples, explicitly stating these are tool invocations and that writing them as Python code in text output does nothing — and that the hook will block with exit 2.

The hook change is purely additive: it only affects the error message path (when write_result was not called). Success path and session completion marking are unchanged.

Functional patterns used: pure predicate scan over transcript items (no mutation), branching on scan result to select error message.

## Tests run

- [x] `uv run hooks/require-write-result.py` (in worktree) — import check passes; exits cleanly on missing stdin without blocking
- [ ] Full SubagentStop integration test — no automated harness exists for hook firing; requires a live agent session. No behavior change to success path.

**Blocked items needing attention before merge:** none — the hook change only affects the failure-mode error message, not any success or routing logic.