### PR TITLE
fix: skip auto-reply fallback for fake/test chat_ids

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -2982,6 +2982,9 @@ async def handle_mark_processed(args: dict) -> list[TextContent]:
                     # the bot already answered the callback query inline.
                     if msg_type == "callback":
                         log.info(f"Skipping auto-reply fallback for callback message {message_id}")
+                    elif abs(chat_id) <= 1_000_000:
+                        # Fake/test chat_id — Telegram rejects delivery; skip to avoid dead-letter buildup
+                        log.info(f"Skipping auto-reply fallback for fake/test chat_id {chat_id}")
                     else:
                         # Auto-send a fallback reply so the user isn't silently ignored
                         fallback_text = "Noted."


### PR DESCRIPTION
## Summary

- The `mark_processed` auto-reply fallback ("Noted.") now skips sending when `abs(chat_id) <= 1_000_000`
- Telegram rejects delivery to fake/test chat IDs (e.g. 100001, 123456), causing replies to pile up in the dead-letter directory
- This guard prevents that buildup with a minimal, self-documenting condition

## Test plan

- [ ] Verify that real user messages (chat_id > 1_000_000) still receive "Noted." fallback when no reply was sent
- [ ] Verify that messages with fake chat_ids (e.g. 100001) log "Skipping auto-reply fallback for fake/test chat_id" and do not write to outbox
- [ ] Confirm dead-letter directory stays clean after processing test messages with fake chat_ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)