### PR TITLE
fix(hooks): use transcript agentId for session_end in SubagentStop hook

### DIFF
--- a/hooks/require-write-result.py
+++ b/hooks/require-write-result.py
@@ -19,7 +19,26 @@ sys.path.insert(0, str(Path(__file__).parent))
 from session_role import is_dispatcher, get_session_id
 
 
-def _mark_session_completed(session_id: str) -> None:
+def _extract_agent_id_from_transcript(transcript: list) -> str | None:
+    """Return the agentId from the first transcript entry that has one.
+
+    Every transcript entry carries an `agentId` field set by CC's infrastructure
+    (not by the LLM). This UUID matches the value the dispatcher stores when it
+    calls register_agent — it is the correct key for the agent_sessions.db `id`
+    column. CC's internal `session_id` is a different UUID and does not match
+    the DB row, so this value is preferred when available.
+
+    Returns None if the transcript is empty or no entry carries agentId.
+    """
+    for entry in transcript:
+        if isinstance(entry, dict):
+            agent_id = entry.get("agentId")
+            if agent_id:
+                return agent_id
+    return None
+
+
+def _mark_session_completed(id_or_task_id: str) -> None:
     """Mark the agent session completed in agent_sessions.db.
 
     Best-effort: any failure is silently swallowed so the hook always exits 0.
@@ -32,7 +51,7 @@ def _mark_session_completed(session_id: str) -> None:
         sys.path.insert(0, str(repo_src))
         from agents.session_store import session_end  # noqa: PLC0415
         session_end(
-            id_or_task_id=session_id,
+            id_or_task_id=id_or_task_id,
             status="completed",
             result_summary="Completed via SubagentStop hook",
         )
@@ -54,29 +73,77 @@ def main():
 
     transcript = data.get("transcript", [])
 
-    tool_calls = []
+    # Collect all tool call items so we can inspect both name and input.
+    # Also collect text content parts for pseudocode detection.
+    all_tool_use_items = []
+    text_content_parts = []
     for msg in transcript:
         if isinstance(msg, dict):
             content = msg.get("content", [])
             if isinstance(content, list):
                 for item in content:
-                    if isinstance(item, dict) and item.get("type") == "tool_use":
-                        tool_calls.append(item.get("name", ""))
+                    if isinstance(item, dict):
+                        if item.get("type") == "tool_use":
+                            all_tool_use_items.append(item)
+                        elif item.get("type") == "text":
+                            text_content_parts.append(item.get("text", ""))
 
-    # If this session called write_result, mark it completed in the DB and allow exit.
-    if "mcp__lobster-inbox__write_result" in tool_calls:
-        session_id = get_session_id(data)
-        if session_id:
-            _mark_session_completed(session_id)
-        sys.exit(0)
+    tool_call_names = [item.get("name", "") for item in all_tool_use_items]
 
-    # Subagent finished without calling write_result — block exit
-    print(
-        "STOP: You must call mcp__lobster-inbox__write_result before finishing. "
-        "The dispatcher is waiting for your result. "
-        "If the task failed, report the failure — but you must call write_result. "
-        "Call it now with your findings, then you may exit."
-    )
+    if "mcp__lobster-inbox__write_result" in tool_call_names:
+        # write_result was called — verify it was called with a non-null chat_id.
+        # chat_id=0 is explicitly allowed: it is the dispatcher system route for
+        # background agents that were spawned without a user chat_id.
+        write_result_items = [
+            item for item in all_tool_use_items
+            if item.get("name") == "mcp__lobster-inbox__write_result"
+        ]
+        valid_calls = [
+            item for item in write_result_items
+            if item.get("input", {}).get("chat_id") is not None
+        ]
+        if valid_calls:
+            # At least one valid call found — mark session and allow exit.
+            # Prefer agentId from transcript (matches the DB's id column);
+            # fall back to session_id if agentId is absent (defensive).
+            agent_id = _extract_agent_id_from_transcript(transcript)
+            lookup_id = agent_id or get_session_id(data)
+            if lookup_id:
+                _mark_session_completed(lookup_id)
+            sys.exit(0)
+        else:
+            # write_result was called but chat_id was None in every call —
+            # the MCP server rejected the call and the result was not stored.
+            print(
+                "STOP: write_result was called but chat_id was None in every call. "
+                "The MCP server rejects write_result without a chat_id, so your result "
+                "was not delivered. "
+                "Call write_result again with a valid chat_id. "
+                "If you were not given a user chat_id, use chat_id=0 — that is the "
+                "dispatcher system route for background agents with no user context."
+            )
+            sys.exit(2)
+
+    # Subagent finished without calling write_result — block exit.
+    # Check whether write_result appeared as text output (pseudocode failure mode)
+    # to give a more actionable error message.
+    combined_text = "\n".join(text_content_parts)
+    if "mcp__lobster-inbox__write_result" in combined_text:
+        print(
+            "STOP: write_result was described as text but not called as a tool.\n\n"
+            "The tool call appeared in your text output as Python code — this is a "
+            "description, not an invocation. You must call write_result using the tool "
+            "invocation mechanism (the same way you call Read, Edit, Bash, etc.) — not "
+            "by writing it as code output.\n\n"
+            "Call write_result now using the tool mechanism."
+        )
+    else:
+        print(
+            "STOP: You must call mcp__lobster-inbox__write_result before finishing. "
+            "The dispatcher is waiting for your result. "
+            "If the task failed, report the failure — but you must call write_result. "
+            "Call it now with your findings, then you may exit."
+        )
     sys.exit(2)  # Exit 2 to hard-block the session from terminating
 
 


### PR DESCRIPTION
## Summary

The SubagentStop hook was calling `session_end()` with CC's internal `session_id`, which is a different UUID from the one stored in `agent_sessions.db`. The DB's `id` column stores the `agentId` that CC sets in every transcript entry — the same UUID the dispatcher passes to `register_agent`. Using `session_id` instead meant every call to `session_end` in the hook was silently a no-op, leaving rows stuck in `running` state and causing false ghost-agent alerts.

This PR extracts `agentId` from the transcript (using the first entry that has one, since all entries carry this field set by CC's infrastructure) and uses it as the lookup key. If the transcript has no `agentId` (e.g. minimal test fixtures), it falls back to `session_id` defensively.

## Changes

- Added `_extract_agent_id_from_transcript(transcript)` — pure function that returns the first non-null `agentId` from transcript entries, or `None`.
- Updated `_mark_session_completed` parameter name from `session_id` to `id_or_task_id` to reflect that it accepts either form.
- Updated the call site in `main()` to prefer `agentId` from transcript, with `get_session_id(data)` as fallback.

The PR also includes the uncommitted improvements to the hook already present in `~/lobster` (text-content pseudocode detection and chat_id=None guard), which were added locally but not yet committed.

Functional patterns used: pure helper function (`_extract_agent_id_from_transcript`), explicit fallback chain rather than implicit mutation.

## Hook audit

No other hooks need this change. The only hook that calls `session_end` is `require-write-result.py`. Other hooks that do session-related work:

- `write-dispatcher-session-id.py` — uses `session_id` from hook input to identify the dispatcher and auto-register subagent stubs. This is correct: the stub row is keyed by `session_id` at write time, and `session_end` matches on both `id` and `task_id`. The race with `register_agent` (which writes a richer row with `agentId`) is handled by `INSERT OR IGNORE`, so the stub is only written if `register_agent` hasn't written first.
- `on-compact.py`, `post-compact-gate.py` — use `session_id` only for dispatcher detection (comparing to the marker file). No DB lookup involved.
- All PreToolUse/PostToolUse hooks — do not interact with agent tracking at all.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/ -x -q` — 10 passed, 0 failed
- [x] `uv run pytest tests/unit/ -x -q` — 127 passed, 1 failed (pre-existing: `test_bot/test_authorization.py::TestIsAuthorized::test_authorized_user_returns_true` fails on main with the same error, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)