### PR TITLE
feat: edited_message handler (issue #434)

### DIFF
--- a/.claude/dispatcher.bootup.md
+++ b/.claude/dispatcher.bootup.md
@@ -267,6 +267,8 @@ When replying, always pass the correct `source` parameter to `send_reply` — Te
 
 **Handling images:** When a message has `type: "image"` or `type: "photo"`, it includes an `image_file` path. **Read images directly on the main thread** — after calling `mark_processing` first to prevent health check restarts.
 
+**Handling edited messages:** When a message has `_edit_of_telegram_id` set, it is the user's edited version of a previously sent message. Process it as a normal message. If `_replaces_inbox_id` is also present, the original message was still in the queue when the edit arrived — if you already dispatched a subagent for the original, its result will still be delivered with a note. If only `_edit_note` is present (no `_replaces_inbox_id`), the original was already processed — treat this as a fresh request based on the edited text.
+
 ```
 1. wait_for_messages() → image message arrives
 2. mark_processing(message_id)  ← claim it first (prevents health check restart)

--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -901,6 +901,89 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     # No text acknowledgment — the typing indicator already signals receipt.
 
 
+def _find_message_by_telegram_id(tg_message_id: int) -> Path | None:
+    """Scan inbox/ and processing/ for a message file with a matching telegram_message_id.
+
+    Returns the Path to the matching file, or None if not found.
+    Only text messages are checked — edits arrive as updated_message which carries
+    the same message_id as the original, so this check finds messages that haven't
+    been processed yet.
+    """
+    _processing_dir = _MESSAGES / "processing"
+    for search_dir in (INBOX_DIR, _processing_dir):
+        if not search_dir.exists():
+            continue
+        for f in search_dir.glob("*.json"):
+            try:
+                data = json.loads(f.read_text())
+                if data.get("telegram_message_id") == tg_message_id:
+                    return f
+            except Exception:
+                continue
+    return None
+
+
+async def handle_edited_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle edited_message events from Telegram.
+
+    Design principle: deliver, don't discard.
+
+    If the original message is still in inbox/ or processing/, queue the edit
+    as a new message with annotation fields so the dispatcher knows it's an edit.
+    If the original has already been processed, also queue it as new (the edit
+    may still be actionable).
+
+    The subagent working on the original is NOT cancelled — its result is delivered
+    with a note that the user has since edited their message.
+    """
+    message = update.edited_message
+    if not message:
+        return
+
+    user = update.effective_user
+    if not user or user.id not in ALLOWED_USERS:
+        return
+
+    text = message.text
+    if not text:
+        return  # Ignore non-text edits (media caption edits are not yet handled)
+
+    original_tg_id = message.message_id
+    original_file = _find_message_by_telegram_id(original_tg_id)
+
+    msg_id = f"{int(time.time() * 1000)}_edit_{message.message_id}"
+
+    msg_data = {
+        "id": msg_id,
+        "source": "telegram",
+        "type": "text",
+        "chat_id": message.chat_id,
+        "telegram_message_id": message.message_id,
+        "user_id": user.id,
+        "username": user.username,
+        "user_name": user.first_name,
+        "text": text,
+        "timestamp": datetime.utcnow().isoformat(),
+        "_edit_of_telegram_id": original_tg_id,
+    }
+
+    if original_file is not None:
+        msg_data["_replaces_inbox_id"] = original_file.stem
+        log.info(
+            f"Edit of tg_id={original_tg_id} queued as {msg_id} "
+            f"(original file: {original_file.name})"
+        )
+    else:
+        msg_data["_edit_note"] = "User edited a previously processed message."
+        log.info(
+            f"Edit of tg_id={original_tg_id} queued as {msg_id} "
+            "(original already processed)"
+        )
+
+    inbox_file = INBOX_DIR / f"{msg_id}.json"
+    atomic_write_json(inbox_file, msg_data)
+
+
 async def handle_audio_message(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
@@ -1289,6 +1372,7 @@ async def run_bot():
     bot_app.add_handler(MessageHandler(filters.PHOTO, handle_message))
     bot_app.add_handler(MessageHandler(filters.Document.ALL, handle_message))
     bot_app.add_handler(CallbackQueryHandler(handle_callback_query))
+    bot_app.add_handler(MessageHandler(filters.UpdateType.EDITED_MESSAGE & filters.TEXT, handle_edited_message))
     bot_app.add_error_handler(error_handler)
 
     # Initialize and start


### PR DESCRIPTION
## Summary

- Adds `handle_edited_message` to `lobster_bot.py` that handles Telegram `edited_message` events
- Implements the "deliver, don't discard" principle: when a user edits a message, it is queued as a new inbox entry with annotation fields rather than silently dropped
- Adds `_find_message_by_telegram_id` helper that scans `inbox/` and `processing/` to detect if the original is still pending
- Updates `.claude/dispatcher.bootup.md` with guidance on how to interpret `_edit_of_telegram_id`, `_replaces_inbox_id`, and `_edit_note` fields

## Annotation fields added to edited messages

- `_edit_of_telegram_id`: always present — the Telegram message ID of the original
- `_replaces_inbox_id`: present when the original is still in inbox or processing — the filename stem of the original message file
- `_edit_note`: present when the original was already processed — signals this is a fresh request based on the edited text

## What is NOT changed

- Subagents working on the original message are not cancelled — their results are delivered normally and the edit is queued separately for a follow-up dispatcher turn
- No MCP server changes required for this item (edit note injection in mark_processed is a separate future item)

Closes #434 (edited_message handler checklist item)

## Test plan

- [ ] Edit a Telegram message while it is still unprocessed — verify a new inbox file appears with `_replaces_inbox_id` set
- [ ] Edit a Telegram message after it has been processed — verify a new inbox file appears with `_edit_note` set
- [ ] Edit a non-text message (e.g. photo caption) — verify it is ignored (text-only guard)
- [ ] Verify dispatcher handles `_edit_of_telegram_id` field without errors on normal messages (field absent = no change in behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)