### PR TITLE
fix: close hex-agentId DB rows in SubagentStop hook (regression from #452)

### DIFF
--- a/hooks/require-write-result.py
+++ b/hooks/require-write-result.py
@@ -9,6 +9,29 @@ the dispatcher never calls write_result, so the check only applies to subagents.
 When write_result was called, this hook also marks the session completed in
 agent_sessions.db synchronously — without relying on the unreliable server-side
 auto-unregister path in inbox_server.py.
+
+## Session ID strategy
+
+The SubagentStop hook receives a session_id that is CC's internal UUID for the
+subagent session. The agent_sessions.db can have two rows for the same subagent:
+
+  1. A "proper" row: id = hex agentId (e.g. "a78e2e20dbc483b2e"), registered by
+     the dispatcher via register_agent() after spawning the Task.
+
+  2. An "auto-register stub": id = session UUID (e.g. "29e27af2-..."), created by
+     the SessionStart hook (write-dispatcher-session-id.py) when the subagent's
+     session starts.
+
+To close both rows we call session_end() with up to three identifiers:
+  a. The task_id from the write_result call input (matches the `task_id` column
+     when the dispatcher set task_id in register_agent, or when the subagent uses
+     a stable task_id that both parties know).
+  b. The session_id from hook data (matches the auto-register stub by `id`).
+
+The proper hex-ID row is the primary target but is only reachable when
+task_id matches. When it is not reachable via this hook, the reconciler in
+inbox_server.py will close it when it detects stop_reason=end_turn in the
+output file.
 """
 import json
 import sys
@@ -19,23 +42,26 @@ sys.path.insert(0, str(Path(__file__).parent))
 from session_role import is_dispatcher, get_session_id
 
 
-def _extract_agent_id_from_transcript(transcript: list) -> str | None:
-    """Return the agentId from the first transcript entry that has one.
+def _extract_write_result_task_ids(all_tool_use_items: list) -> list[str]:
+    """Return all non-empty task_id values from write_result tool call inputs.
 
-    Every transcript entry carries an `agentId` field set by CC's infrastructure
-    (not by the LLM). This UUID matches the value the dispatcher stores when it
-    calls register_agent — it is the correct key for the agent_sessions.db `id`
-    column. CC's internal `session_id` is a different UUID and does not match
-    the DB row, so this value is preferred when available.
+    The task_id passed to write_result often matches either the `id` column
+    (when the subagent uses the hex agentId as task_id) or the `task_id` column
+    (when the dispatcher set task_id in register_agent). session_end() matches
+    on id OR task_id, so trying every task_id found in write_result calls gives
+    the best chance of closing the correct DB row.
 
-    Returns None if the transcript is empty or no entry carries agentId.
+    Returns a list of unique non-empty task_id strings (order preserved).
     """
-    for entry in transcript:
-        if isinstance(entry, dict):
-            agent_id = entry.get("agentId")
-            if agent_id:
-                return agent_id
-    return None
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in all_tool_use_items:
+        if item.get("name") == "mcp__lobster-inbox__write_result":
+            tid = item.get("input", {}).get("task_id")
+            if tid and isinstance(tid, str) and tid not in seen:
+                seen.add(tid)
+                result.append(tid)
+    return result
 
 
 def _mark_session_completed(id_or_task_id: str) -> None:
@@ -103,13 +129,25 @@ def main():
             if item.get("input", {}).get("chat_id") is not None
         ]
         if valid_calls:
-            # At least one valid call found — mark session and allow exit.
-            # Prefer agentId from transcript (matches the DB's id column);
-            # fall back to session_id if agentId is absent (defensive).
-            agent_id = _extract_agent_id_from_transcript(transcript)
-            lookup_id = agent_id or get_session_id(data)
-            if lookup_id:
-                _mark_session_completed(lookup_id)
+            # At least one valid call found — mark session(s) and allow exit.
+            #
+            # Use multiple identifiers to maximise the chance of closing the
+            # correct DB row (see module docstring for why multiple rows exist):
+            #
+            #   1. task_id(s) from write_result inputs — reaches the "proper"
+            #      hex-agentId row when task_id matches (id OR task_id column).
+            #   2. session_id from hook data — reaches the auto-register stub
+            #      row (id = session UUID).
+            #
+            # All calls are idempotent, so calling the same id twice is safe.
+            write_result_task_ids = _extract_write_result_task_ids(all_tool_use_items)
+            session_id = get_session_id(data)
+
+            for tid in write_result_task_ids:
+                _mark_session_completed(tid)
+            if session_id:
+                _mark_session_completed(session_id)
+
             sys.exit(0)
         else:
             # write_result was called but chat_id was None in every call —

--- a/scripts/ghost-detector.py
+++ b/scripts/ghost-detector.py
@@ -144,19 +144,53 @@ def compute_output_file_age_minutes(output_file: str | None, now: datetime) -> f
 
 
 def check_transcript_for_write_result(output_file: str) -> bool:
-    """Return True if the agent's transcript shows write_result was called successfully.
+    """Return True if the agent's transcript shows write_result was called as a tool.
 
-    Scans the JSONL output file for evidence of a successful
-    mcp__lobster-inbox__write_result tool call. The tool name appears
-    verbatim in JSONL tool_use blocks. Both substrings must be present
-    to avoid false positives from unrelated content mentioning "write_result".
+    Scans the JSONL output file for evidence of an actual
+    mcp__lobster-inbox__write_result tool_use block. Looks for the tool name
+    inside a JSON "tool_use" block to avoid false positives from the subagent
+    bootup instructions, which mention the tool name verbatim in plain text.
+
+    A line is counted only when it contains both '"type": "tool_use"' (or
+    '"type":"tool_use"') and '"mcp__lobster-inbox__write_result"' within the
+    same JSON object. This is more precise than a plain substring scan.
     """
     if not output_file or not os.path.exists(output_file):
         return False
     try:
         with open(output_file, "r") as f:
-            content = f.read()
-        return "write_result" in content and "mcp__lobster-inbox" in content
+            for raw_line in f:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                # Fast pre-filter: both substrings must be present on this line
+                if "mcp__lobster-inbox__write_result" not in line:
+                    continue
+                if "tool_use" not in line:
+                    continue
+                # Parse the line to verify this is an actual tool_use record
+                try:
+                    obj = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                # Check inside the 'message' field (JSONL entry format) or
+                # directly at the top level (tool_result / assistant message format).
+                def _has_write_result_tool_use(node: object) -> bool:
+                    if isinstance(node, dict):
+                        if node.get("type") == "tool_use" and node.get("name") == "mcp__lobster-inbox__write_result":
+                            return True
+                        for v in node.values():
+                            if _has_write_result_tool_use(v):
+                                return True
+                    elif isinstance(node, list):
+                        for item in node:
+                            if _has_write_result_tool_use(item):
+                                return True
+                    return False
+
+                if _has_write_result_tool_use(obj):
+                    return True
+        return False
     except Exception:
         return False
 

--- a/tests/smoke/test_require_write_result.py
+++ b/tests/smoke/test_require_write_result.py
@@ -1,9 +1,10 @@
 """
-Smoke tests — Groups C1, C2, C3: hooks/require-write-result.py
+Smoke tests — Groups C1, C2, C3, C4: hooks/require-write-result.py
 
 C1. No reminder is emitted when write_result was called during the session.
 C2. A reminder IS emitted when a subagent session had tool calls but no write_result.
 C3. No reminder is emitted for dispatcher sessions (identified by wait_for_messages).
+C4. session_end is attempted with task_id from write_result AND with session_id.
 
 Failure modes:
   C1 — if the hook fires spuriously for sessions that already called write_result,
@@ -12,6 +13,8 @@ Failure modes:
        blocks waiting for a result that never arrives.
   C3 — if the hook fires for the dispatcher, the main loop receives a spurious
        reminder on every compaction cycle, breaking the dispatcher's control flow.
+  C4 — if the hook only uses session_id (UUID) for session_end, the "proper"
+       hex-agentId DB row stays stuck at status=running forever (COMPLETED_NOT_UPDATED).
 """
 
 import json
@@ -39,6 +42,28 @@ def _build_transcript(*tool_names: str) -> str:
     return json.dumps({"transcript": messages})
 
 
+def _build_transcript_with_write_result_input(task_id: str, chat_id: int = 12345) -> str:
+    """Build a transcript where write_result was called with a specific task_id."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "mcp__lobster-inbox__write_result",
+                    "id": "call_wr",
+                    "input": {
+                        "task_id": task_id,
+                        "chat_id": chat_id,
+                        "text": "done",
+                    },
+                }
+            ],
+        }
+    ]
+    return json.dumps({"session_id": "test-session-uuid-1234", "transcript": messages})
+
+
 def _run_hook(transcript_json: str) -> subprocess.CompletedProcess:
     """Run the require-write-result hook with transcript piped to stdin."""
     return subprocess.run(
@@ -55,16 +80,21 @@ def _run_hook(transcript_json: str) -> subprocess.CompletedProcess:
 
 
 def test_no_reminder_when_write_result_called():
-    """C1: Hook emits nothing when the transcript contains write_result.
+    """C1: Hook emits nothing when the transcript contains write_result with chat_id.
 
     Failure mode caught: if the hook incorrectly emits the STOP reminder for
     sessions that DID call write_result, well-behaved subagents would receive
     a spurious prompt telling them to call write_result again, potentially
     causing duplicate result messages or confused retries.
+
+    Note: write_result must include a non-null chat_id. Without it the hook
+    treats the call as invalid (the MCP server rejects write_result without
+    chat_id) and still emits a reminder.
     """
-    transcript = _build_transcript(
-        "some_other_tool",
-        "mcp__lobster-inbox__write_result",
+    # Use _build_transcript_with_write_result_input so chat_id is present —
+    # that is the only path where the hook allows silent exit.
+    transcript = _build_transcript_with_write_result_input(
+        task_id="test-task-id", chat_id=12345
     )
     result = _run_hook(transcript)
 
@@ -81,12 +111,15 @@ def test_no_reminder_when_write_result_called():
 
 
 def test_reminder_emitted_when_write_result_not_called():
-    """C2: Hook emits a reminder when a subagent had tool calls but no write_result.
+    """C2: Hook hard-blocks (exit 2) when a subagent had tool calls but no write_result.
 
     Failure mode caught: a subagent that finishes work without calling
     write_result leaves the dispatcher blocked waiting for a result message
-    that never arrives.  The hook injects a STOP prompt so Claude is forced
-    to report back before the session ends.
+    that never arrives.  The hook exits 2 to hard-block the session from
+    terminating, and prints a STOP message so Claude is forced to report back.
+
+    CC SubagentStop hooks that exit non-zero prevent the agent session from
+    ending — this is the intentional enforcement mechanism.
     """
     transcript = _build_transcript(
         "mcp__github__issue_read",
@@ -94,9 +127,9 @@ def test_reminder_emitted_when_write_result_not_called():
     )
     result = _run_hook(transcript)
 
-    assert result.returncode == 0, (
-        f"Hook must exit 0 (inject mode), got {result.returncode}. "
-        "A non-zero exit would block Claude Code from proceeding."
+    assert result.returncode == 2, (
+        f"Hook must exit 2 (hard-block mode), got {result.returncode}. "
+        "Exit 2 prevents the subagent session from terminating without calling write_result."
     )
     assert result.stdout.strip(), (
         "Hook must print a reminder to stdout when write_result was not called.\n"
@@ -109,14 +142,17 @@ def test_reminder_emitted_when_write_result_not_called():
 
 
 def test_reminder_emitted_when_transcript_is_empty():
-    """C2 (edge case): an empty transcript also counts as missing write_result.
+    """C2 (edge case): an empty transcript also hard-blocks (exit 2).
 
     A session with no tool calls at all is still a subagent that failed to
-    report back; the hook should fire here too.
+    report back; the hook should fire here too and exit 2 to hard-block.
     """
     result = _run_hook(json.dumps({"transcript": []}))
 
-    assert result.returncode == 0
+    assert result.returncode == 2, (
+        f"Hook must exit 2 (hard-block) even when the transcript has no tool calls at all. "
+        f"Got exit {result.returncode}."
+    )
     assert result.stdout.strip(), (
         "Hook must emit a reminder even when the transcript has no tool calls at all."
     )
@@ -150,5 +186,90 @@ def test_dispatcher_skips_enforcement():
     )
     assert result.stdout.strip() == "", (
         "Hook must produce no output for dispatcher sessions. "
+        f"Got: {result.stdout!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# C4 — _extract_write_result_task_ids returns task_id from write_result input
+# ---------------------------------------------------------------------------
+
+
+def test_extract_write_result_task_ids_found():
+    """C4: Hook extracts task_id from write_result inputs for session_end calls.
+
+    The hook calls session_end() with the task_id passed to write_result so
+    it can close the dispatcher-registered hex-agentId DB row (which is keyed
+    on task_id when the dispatcher set it in register_agent).
+
+    Failure mode caught: if the hook only uses session_id (UUID), the proper
+    hex-agentId DB row never gets updated and stays stuck at status=running,
+    producing COMPLETED_NOT_UPDATED alerts forever.
+    """
+    # Import the helper directly to unit-test it without needing a DB.
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "require_write_result",
+        str(HOOK),
+    )
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[attr-defined]
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+    items = [
+        {
+            "type": "tool_use",
+            "name": "mcp__lobster-inbox__write_result",
+            "input": {"task_id": "my-task-id", "chat_id": 12345, "text": "done"},
+        },
+        {
+            "type": "tool_use",
+            "name": "some_other_tool",
+            "input": {},
+        },
+    ]
+    result = mod._extract_write_result_task_ids(items)
+    assert result == ["my-task-id"], (
+        f"Expected ['my-task-id'], got {result!r}. "
+        "Hook must extract task_id from write_result input for session_end."
+    )
+
+
+def test_extract_write_result_task_ids_empty_when_no_task_id():
+    """C4 (edge): returns empty list when write_result has no task_id input."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "require_write_result",
+        str(HOOK),
+    )
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[attr-defined]
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+    items = [
+        {
+            "type": "tool_use",
+            "name": "mcp__lobster-inbox__write_result",
+            "input": {"chat_id": 12345, "text": "done"},  # no task_id
+        },
+    ]
+    result = mod._extract_write_result_task_ids(items)
+    assert result == [], (
+        f"Expected [], got {result!r}. "
+        "Should return empty list when task_id is absent from write_result input."
+    )
+
+
+def test_hook_exits_0_with_write_result_including_task_id():
+    """C4 (integration): hook exits 0 when write_result is called with task_id + chat_id."""
+    transcript_json = _build_transcript_with_write_result_input(
+        task_id="my-descriptive-task-id"
+    )
+    result = _run_hook(transcript_json)
+
+    assert result.returncode == 0, (
+        f"Hook must exit 0 when write_result was called with task_id + chat_id. "
+        f"Got exit {result.returncode}. stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert result.stdout.strip() == "", (
+        f"Hook must produce no output when write_result was called. "
         f"Got: {result.stdout!r}"
     )


### PR DESCRIPTION
## Problem

After PR #452, all 4 subagent sessions showed as COMPLETED_NOT_UPDATED in the ghost detector — `session_end()` was effectively never reaching the hex-agentId rows registered by the dispatcher.

PR #452 introduced `_extract_agent_id_from_transcript()` based on the premise that CC includes an `agentId` field in every SubagentStop transcript entry. This is false. The SubagentStop transcript contains role/content messages (not raw JSONL entries), so `agentId` is absent and the function always returns `None`. As a result, `session_end()` was called only with the session UUID, which matches the auto-register stub row (`id = UUID`) but not the hex-agentId row registered by the dispatcher (`id = hex agentId`, with the dispatcher-chosen `task_id` in the `task_id` column).

The hex-agentId row is the important one — it's what the dispatcher tracks and what triggers COMPLETED_NOT_UPDATED alerts when stuck. The UUID stub row was being updated correctly before and after #452.

## Fix

Instead of trying to extract the hex agentId from the transcript (which isn't there), extract the `task_id` from the `write_result` tool call inputs. `session_end()` matches `WHERE id=? OR task_id=?`, so calling it with the task_id passed to `write_result` reaches the hex-agentId row when the dispatcher used that same task_id in `register_agent()`.

Two session_end calls are made:
1. For each task_id found in write_result inputs — targets the hex-agentId row via the `task_id` column
2. For the session UUID — targets the UUID stub row via the `id` column

Both calls are idempotent, so no harm if inbox_server already updated a row.

Functional patterns used: pure extraction function `_extract_write_result_task_ids()` returns a list with no side effects; all side effects (session_end DB calls) are isolated in `_mark_session_completed()` which is best-effort and swallows exceptions.

## Ghost detector false positive (also fixed)

The previous `check_transcript_for_write_result()` used substring search for `"mcp__lobster-inbox__write_result"`, which matched bootup instruction text containing this string — not actual tool invocations. Fixed by parsing each JSONL line and recursively checking for `{"type": "tool_use", "name": "mcp__lobster-inbox__write_result"}` structure.

## Tests run

- [x] `uv run pytest tests/smoke/test_require_write_result.py -v` — 7 passed, 0 failed
  - C1: hook exits 0 and emits nothing when write_result called with valid chat_id
  - C2: hook exits 2 (hard-block) when write_result not called
  - C3: hook exits 0 and emits nothing for dispatcher sessions
  - C4 (new): `_extract_write_result_task_ids()` extracts task_id correctly; returns empty list when absent; integration test confirms hook exits 0 with task_id+chat_id present
- [x] Corrected C1/C2 test assertions to match actual hook behavior: C2 must assert `exit 2` not `exit 0` (the hook hard-blocks, not inject-mode), and C1 must supply `chat_id` in the write_result input (the hook rejects write_result calls without chat_id)

**Blocked items needing attention before merge:** none — the reconciler in inbox_server.py remains the fallback path for sessions where task_id doesn't match the DB row; this PR improves coverage without removing that path.

Closes the COMPLETED_NOT_UPDATED regression introduced by #452.