### PR TITLE
docs: add PR Description Standard to subagent bootup

### DIFF
--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -221,6 +221,17 @@ Lobster uses a tiered model strategy to balance cost and quality. Each subagent 
 
 **For general background tasks** with no specific agent type, use `subagent_type='lobster-generalist'` rather than omitting `subagent_type` or using an untyped Agent call. The `lobster-generalist` agent is the correct default for open-ended background work that doesn't map to a more specialized agent.
 
+## PR Description Standard
+
+Every PR description must meet this bar (tracked in issue #463): a moderately-familiar reader should finish reading MORE confident they understand the system, not just informed that something changed.
+
+- **Lead with the problem, not the solution.** The first sentence answers "why does this exist?" — not "what files were changed?"
+- **Explain system flow.** Describe how data or control moves through the affected code: what enters, what happens, what comes out. A reader who didn't write the code should be able to trace the path.
+- **Match abstraction to your reader.** State what was impossible before and is now possible (or enforced, or fixed). Do not narrate the diff — narrate the effect.
+- **Note what is out of scope.** Explicitly stating what you did NOT change reassures the reviewer that adjacent systems are untouched.
+- **Record only tests actually run.** Each checked test item must include the exact command and its outcome. Unchecked items must explain why they were skipped. Never write a forward-looking test plan.
+- **Listing changed files as the body is a hard fail.** That is what the diff is for.
+
 ## Tooling conventions
 
 - **GitHub operations:** Use `gh` CLI (via Bash tool) for all GitHub operations — posting PR reviews, merging PRs, creating issues, etc. Do NOT use `mcp__github__*` MCP tools in agent code.


### PR DESCRIPTION
## Why this exists

Behavior rule #14 — established in the handoff — requires that PR descriptions explain system flow clearly enough that a moderately-familiar reader leaves more confident they understand the system. That rule never made it into any bootup file that agents actually read, so it had no enforcement path. Closes #463.

## What changed and why it goes here

Added a "PR Description Standard" section to `.claude/subagent.bootup.md`. The functional-engineer agent is the one that opens PRs; it reads the subagent bootup file on every invocation. The dispatcher does not open PRs, so `dispatcher.bootup.md` is the wrong place. `CLAUDE.md` is shared context that is role-agnostic and already long — the standard belongs in the file read by the agent type that acts on it.

## System flow

When a functional-engineer subagent starts, it reads `subagent.bootup.md` as part of its context. The new "PR Description Standard" section appears before "Tooling conventions" (the section covering GitHub operations), so it is loaded into context at the moment the agent is about to engage with GitHub work. No runtime behavior changes — this is a context injection that shapes agent output at PR-creation time.

The rule is written once, in one file. It is not duplicated across CLAUDE.md or dispatcher.bootup.md.

## What is out of scope

No dispatcher behavior changes. No changes to any Python source, scheduled jobs, or MCP server code. The symlink (`~/lobster-workspace/.claude/ -> ~/lobster/.claude/`) means this change is live immediately for any running instance that re-reads context — no deploy step needed.

## Tests run

- [x] `git diff HEAD~1` — 11 lines added to `subagent.bootup.md`, no other files touched, confirms single-file docs-only change
- [ ] Live agent invocation — not run; this is a context file, not executable code. The change takes effect the next time a functional-engineer subagent is spawned.

**Blocked items needing attention before merge:** none

---

This PR description is itself written to the standard it codifies: it leads with the problem (rule existed only in handoff, not in agent context), explains the flow (subagent reads bootup file → rule is in context → agent applies it at PR time), and notes what is out of scope.