### PR TITLE
Dispatcher ack policy: only ack for tasks taking >4s

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -43,9 +43,20 @@ You are a **stateless dispatcher**. Your ONLY job on the main thread is to read 
 - ANY link archiving
 - ANY task taking more than one tool call beyond the core loop tools above
 
+**Ack policy — when to send "On it." before delegating:**
+
+Before spawning a subagent, decide whether to ack based on expected task duration:
+
+- **Send a brief ack** if the task will take more than ~4 seconds (any subagent doing real work: file I/O, GitHub calls, web fetch, code review, implementation, transcription, etc.). Use 1–3 words: "On it.", "Looking into this.", "Writing that up.", "On it — back shortly."
+- **Skip the ack** if you can answer immediately from context, or for non-user-initiated message types:
+  - Fast inline responses (answered from your own knowledge in one reply, no subagent)
+  - Button callbacks (`type: "callback"`) — respond directly with a confirmation, no ack
+  - Reaction messages — no ack, no response unless the reaction warrants one
+  - System messages (`source: "system"` or `chat_id: 0`) — never ack
+
 **How to delegate:**
 ```
-1. send_reply(chat_id, "On it — I'll report back shortly.")
+1. [If task will take >4s]: send_reply(chat_id, "On it.")   # brief ack, 1-3 words
 2. task_result = Task(prompt="...", subagent_type="general-purpose", run_in_background=true)
 3. agent_id = extract agentId from task_result text (look for "agentId: <id>")
 4. output_file = extract output file path from task_result text (look for a /tmp/... path ending in .output)
@@ -425,7 +436,7 @@ When you first start (or after reading this file), immediately begin your main l
 
 **Why triage at startup?** A dangerous message (e.g. a large audio transcription that causes OOM) can crash Lobster and land back in the retry queue. On the next boot, Lobster hits it again — crash loop. The fix is to survey all queued messages first, identify anything risky, and handle them carefully or defer them. Part of the failsafe is looking at the full picture before acting.
 
-**Normal operation (non-startup):** Use quick acknowledgment as described in the dispatcher pattern above — acknowledge first, then delegate or process. The triage step is specific to startup because that's when dangerous messages are most likely to be queued from a previous crash.
+**Normal operation (non-startup):** Apply the ack policy (>4s → brief ack, fast inline → no ack) as described above. The triage step is specific to startup because that's when dangerous messages are most likely to be queued from a previous crash.
 
 ## Hibernation
 


### PR DESCRIPTION
Closes #454

## Problem

Before this change, the dispatcher sent an ack ("On it — I'll report back shortly.") unconditionally before every subagent spawn. This caused a noisy extra message for fast inline responses — questions answered from context, button callbacks, reaction messages — that users received as an empty promise before the actual reply arrived immediately.

The gap was in the delegation pseudocode in `sys.dispatcher.bootup.md`, which made the ack mandatory rather than conditional.

## What changed

Added an explicit **Ack policy** section directly above the "How to delegate" pseudocode in `.claude/sys.dispatcher.bootup.md`. The rule:

- **Send a brief ack** (1–3 words: "On it.", "Looking into this.", etc.) when the task will take more than ~4 seconds — i.e., any subagent doing real work (file I/O, GitHub calls, web fetch, code review, implementation, transcription).
- **Skip the ack** for:
  - Fast inline responses answered from context (no subagent spawned)
  - Button callbacks (`type: "callback"`) — respond directly with a confirmation
  - Reaction messages — no ack unless the reaction warrants a substantive reply
  - System messages (`source: "system"` or `chat_id: 0`) — never ack

The delegation pseudocode step 1 is updated to reflect the conditional: `[If task will take >4s]: send_reply(chat_id, "On it.")`.

A secondary fix updates the "Normal operation" note in Startup Behavior, which previously said "acknowledge first, then delegate" — now it points to the ack policy instead.

## What is out of scope

This is a prompt/instruction change only. No Python code was modified. The `inbox_server.py`, `tracker.py`, and all runtime components are untouched. The enforcement is entirely at the dispatcher's reasoning layer, consistent with how all other dispatcher behavior is specified.

## Functional patterns

Pure declarative specification — the policy is stated as a decision rule (predicate → action) rather than imperative procedure. No side effects introduced.

## Tests run

- [x] Diff reviewed manually against acceptance criteria in issue #454 — all four criteria met:
  - Ack policy rule present in dispatcher prompt
  - Fast inline responses skip ack (rule explicit)
  - Button callbacks excluded (rule explicit)
  - Reaction messages excluded (rule explicit)
- [ ] Live dispatcher behavior test — requires production restart with updated prompt; no behavior change to existing code paths, safe to merge

**Blocked items needing attention before merge:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)