### PR TITLE
fix: lobster restart no longer kills itself before starting

### DIFF
--- a/src/cli
+++ b/src/cli
@@ -125,9 +125,48 @@ cmd_stop() {
 
 cmd_restart() {
     print_header "Restarting Lobster"
-    cmd_stop
-    sleep 1
-    cmd_start
+
+    # Schedule the start as a detached systemd transient unit BEFORE stopping.
+    # This is necessary because lobster-claude runs inside the very tmux session
+    # that `systemctl stop lobster-claude` will kill — so cmd_stop would destroy
+    # this process before cmd_start ever ran.
+    #
+    # systemd-run schedules a oneshot unit that fires 2 seconds after now,
+    # completely independent of the calling process. The delay gives the stop
+    # time to complete cleanly before the start fires.
+    #
+    # Note: we do NOT write the maintenance flag here. cmd_stop writes it to
+    # tell the health check "don't auto-restart, I intentionally stopped this".
+    # During a restart that flag is wrong — we WANT the services back up.
+    # cmd_start already removes the flag, but only if it runs; by scheduling
+    # start before stop we guarantee it runs even if this process dies.
+    echo "Scheduling start via systemd-run in 2s..."
+    if ! sudo systemd-run --on-active=2s --unit=lobster-restart-oneshot \
+            /bin/bash -c "rm -f '${MAINTENANCE_FLAG}'; systemctl start lobster-router lobster-claude" \
+            2>/dev/null; then
+        echo -e "${RED}systemd-run failed — falling back to stop+start${NC}"
+        echo -e "${YELLOW}Warning: if running inside lobster-claude, the start may not execute.${NC}"
+        cmd_stop
+        sleep 1
+        cmd_start
+        return
+    fi
+
+    # Stop services without writing the maintenance flag.
+    # (We stop directly rather than calling cmd_stop so the flag is not set.)
+    echo "Stopping services..."
+    for service in "${SERVICES[@]}"; do
+        echo -n "Stopping $service... "
+        if sudo systemctl stop "$service" 2>/dev/null; then
+            echo -e "${GREEN}OK${NC}"
+        else
+            echo -e "${YELLOW}not running${NC}"
+        fi
+    done
+
+    echo ""
+    echo -e "${GREEN}Services stopped. Start scheduled in ~2s (lobster-restart-oneshot).${NC}"
+    echo "Check status with: lobster status"
 }
 
 cmd_status() {


### PR DESCRIPTION
## Problem

When Claude runs `lobster restart` from inside the `lobster-claude` tmux session, `cmd_stop` calls `sudo systemctl stop lobster-claude` — which kills the tmux session, which kills the shell running `cmd_stop`. `cmd_start` is never reached. This caused the 75-minute outage described in #464.

A second compounding problem: `cmd_stop` always writes `~/messages/config/lobster-maintenance`, which tells the healthcheck "don't auto-recover". So even if the healthcheck was running, it would see maintenance mode and do nothing. Services stayed dead until a human intervened.

## Fix

`cmd_restart` now schedules the start as a **systemd transient timer unit** (`systemd-run --on-active=2s`) before it stops anything. This unit is registered with systemd and fires 2 seconds after scheduling, completely independent of the calling process tree. Even if `systemctl stop lobster-claude` kills this shell mid-execution, the start is already queued in systemd and will run.

The stop loop is then inlined directly (not via `cmd_stop`) so the maintenance flag is never written during a restart. There is no reason to tell the healthcheck "don't recover" when the intent is to restart — and `cmd_start` already removes the flag, so leaving it absent is consistent.

`lobster stop` behavior is unchanged: it still writes the maintenance flag, and the health check still respects it.

A fallback is included: if `systemd-run` fails for any reason (unusual environment, missing permissions), the old stop+start sequence runs with a warning that it may not complete if invoked from inside the service.

## Why systemd-run over the alternatives

- **nohup/setsid background process**: survives parent death but is untracked — no journal entry, no audit trail, and a stray background shell that may race with the stop
- **Dedicated `lobster-restart.service`**: clean, but requires a new service file and install.sh changes to deploy it; ongoing maintenance burden
- **`systemd-run --on-active=2s`**: tracked by systemd, appears in journald as `lobster-restart-oneshot`, fires deterministically after the stop completes, no new files to install

## Functional patterns

`cmd_restart` no longer delegates to `cmd_stop` (which had the side effect of writing the maintenance flag). The stop logic is inlined with the maintenance-flag write removed, making the restart path's behavior explicit rather than inherited — avoiding action-at-a-distance through shared side effects.

## Tests run

- [x] `bash -n src/cli` — shell syntax check, no errors
- [ ] Live end-to-end restart test — skipped: would require stopping the running lobster-claude service in this environment, which would kill this session. The fix is specifically designed for this scenario and is safe to verify post-merge by running `lobster restart` from inside the tmux session.

**Blocked items needing attention before merge:** live restart test should be done by Sahar after merge.

Closes #464