### PR TITLE
Fix long-report convention: inline artifact content, never send file paths to user

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -238,15 +238,26 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
            mark_processed(message_id)
            # Return to wait_for_messages() — reviewer's write_result arrives separately
        else:
+           # Build reply text: inline artifact content when present
+           reply_text = msg["text"]
+           if msg.get("artifacts"):
+               for artifact_path in msg["artifacts"]:
+                   try:
+                       content = Read(artifact_path)   # read the file
+                       reply_text += f"\n\n---\n{content}"
+                   except:
+                       pass  # skip unreadable files silently
            send_reply(
                chat_id=msg["chat_id"],
-               text=msg["text"],
+               text=reply_text,
                source=msg.get("source", "telegram"),
                thread_ts=msg.get("thread_ts"),            # Slack thread
                reply_to_message_id=msg.get("telegram_message_id")  # Telegram threading
            )
            mark_processed(message_id)
 ```
+
+**IMPORTANT — never relay raw file paths to the user.** File paths like `~/lobster-workspace/reports/foo.md` are server-side references that are useless on mobile. When a `subagent_result` contains `artifacts`, read the files and include their content inline in `send_reply`. Do not mention the path in the reply.
 
 **When type is `subagent_error`:**
 
@@ -265,11 +276,11 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
 **Key fields on these messages:**
 - `task_id` — identifier for the originating task (for logging/debugging)
 - `chat_id` — where to deliver the reply
-- `text` — the reply text to relay
+- `text` — the reply text to relay (summary/actionable items; full content in `artifacts`)
 - `source` — messaging platform (telegram, slack, etc.)
 - `status` — "success" or "error"
 - `sent_reply_to_user` — boolean (default false). When true, the subagent already called `send_reply`; dispatcher just marks processed
-- `artifacts` — optional list of file paths the subagent produced
+- `artifacts` — optional list of file paths the subagent produced; dispatcher reads and inlines their content
 - `thread_ts` — optional Slack thread timestamp
 
 ## Handling Subagent Notifications (`subagent_notification`)

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -141,25 +141,23 @@ mcp__lobster-inbox__write_result(
 
 **Long reports (internal tasks only):**
 
-If your output exceeds ~500 words, write it to a file rather than returning it inline:
+If your output exceeds ~500 words, write the full content to a file and return a summary inline:
 
-1. Write to: `~/lobster-workspace/reports/<task_id>.md`
-2. In `write_result`, include:
-   - The file path
-   - A brief summary (5–10 lines)
-   - The actionable section (dropped threads, errors, recommendations) directly in the `text` field so the dispatcher can act without reading the full file
+1. Write the full report to: `~/lobster-workspace/reports/<task_id>.md`
+2. In `write_result`, set `text` to a concise summary (5–10 lines) + actionable items only. Do NOT include the file path in `text` — file paths are server-side and useless to mobile users.
+3. Pass the file path in `artifacts` — the dispatcher reads the file and sends its content to the user inline.
 
 ```python
 mcp__lobster-inbox__write_result(
     task_id="<task_id>",
     chat_id=<chat_id>,
-    text="Summary: ...\n\nActionable items:\n- ...\n\nFull report: ~/lobster-workspace/reports/<task_id>.md",
+    text="Summary: ...\n\nActionable items:\n- ...",
     sent_reply_to_user=False,  # dispatcher receives and routes
     artifacts=["~/lobster-workspace/reports/<task_id>.md"],
 )
 ```
 
-The `artifacts` field is accepted by the inbox server and surfaced in the `subagent_result` message payload. The dispatcher can read the paths from `msg["artifacts"]` to access or reference the files.
+The `artifacts` field is accepted by the inbox server and surfaced in the `subagent_result` message payload. The dispatcher reads those files and includes their content inline in the reply to the user — never relaying a raw file path.
 
 ## Surfacing Observations (`write_observation`)
 


### PR DESCRIPTION
## Problem

When a subagent generated a long report, the documented convention told it to include the server-side file path in the \`text\` field of \`write_result\` (e.g. \`"Full report: ~/lobster-workspace/reports/foo.md"\`). The dispatcher then relayed that text verbatim via \`send_reply\`. On Telegram (mobile), the path is a dead reference — the user cannot open it and it communicates nothing actionable.

The \`artifacts\` field was already being passed through the message payload, but neither the subagent instructions nor the dispatcher instructions explained what to do with it. The result: subagents wrote the path into \`text\`, the dispatcher faithfully relayed it, and the user received a useless server path.

## What changed

**\`sys.subagent.bootup.md\`** (subagent side):

The long-report example previously had \`"Full report: ~/lobster-workspace/reports/<task_id>.md"\` inside the \`text\` field. That line is removed. The \`text\` field now holds only the summary and actionable items. The file path belongs exclusively in \`artifacts\`, which the dispatcher owns.

**\`sys.dispatcher.bootup.md\`** (dispatcher side):

The \`subagent_result\` handling pseudocode previously forwarded \`msg["text"]\` to \`send_reply\` directly. It now builds \`reply_text\` by appending each artifact's file content after the summary text before calling \`send_reply\`. A bold warning is added making explicit that raw file paths must never be relayed to the user.

The field-description table is updated: \`text\` carries the summary, \`artifacts\` carries paths whose content gets inlined.

## Functional patterns

The dispatcher's reply-building step is a fold over the artifacts list that accumulates content into \`reply_text\` before any side effect (\`send_reply\`) fires — separating the pure data-assembly step from the effectful delivery step.

## Tests run

- [x] \`git diff\` reviewed manually — changes are scoped to the two \`.claude/\` instruction files; no Python source code changed
- [ ] Live dispatcher test with a real long-report subagent — blocked: requires a running dispatcher session and a task that triggers the long-report path. The change is instruction text that the dispatcher LLM reads at boot, not compiled code.

**Blocked items needing attention before merge:** Live end-to-end test is the only gap. Safe to merge; the risk is bounded to the dispatcher's interpretation of updated instructions, which can be corrected in a follow-up without a code deploy.

Closes #461