### PR TITLE
docs(subagent): PR and issue bodies are canonical state, not just openers

### DIFF
--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -239,3 +239,16 @@ Lobster uses a tiered model strategy to balance cost and quality. Each subagent 
 - **Linear API:** Access Linear via REST API. The `LINEAR_API_KEY` environment variable is set. GraphQL endpoint: `https://api.linear.app/graphql`. Use `curl -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json"`.
 
 - **Python:** Always use `uv run` not `python` or `python3`.
+
+## PR and Issue Body: Always Canonical
+
+The body of a PR or issue is the canonical state of that work — not just the opening post. As things evolve (reviews, new commits, design changes, resolved concerns, scope changes), update the body to reflect what the thing *is* now, not what it was when opened.
+
+A casual reader skimming the body should walk away understanding the current state without having to read and mentally "compact" the entire comment thread. The comment thread is history; the body is truth.
+
+When updating a body:
+- Note briefly that the body was updated and why (e.g., "*(Updated: design changed per comment thread — X now does Y instead of Z)*")
+- This preserves comment thread continuity — older comments won't seem strange without context
+- Prioritize clarity for a future reader over preserving the original framing
+
+Apply this to both PRs and issues. When you post a comment that changes the design, resolves a concern, or updates scope — also update the body.


### PR DESCRIPTION
## What this adds

A new rule in `sys.subagent.bootup.md` establishing that **PR and issue bodies must always reflect the current state of the work**, not just what was true at creation time.

## Why

Comment threads are history. Bodies are truth. A reader skimming a PR or issue body should understand what the thing *is now* — not have to read 30 comments and mentally apply a series of design changes to reconstruct the current state.

This is a real workflow failure mode: subagents (and humans) open a PR or issue with an accurate body, then evolve the design through comments, and leave the body stale. Future readers — or the same reader a week later — are left with misleading documentation at the top.

## The new standard

Added as `## PR and Issue Body: Always Canonical` at the end of the `sys.subagent.bootup.md` file:

- When design changes, scope changes, or concerns are resolved via comments, the body must also be updated
- When updating: note briefly what changed and why (e.g., *"Updated: X now does Y instead of Z per comment thread"*), so comment thread continuity is preserved
- Applies to both PRs and issues
- Clarity for a future reader takes priority over preserving the original framing

## Scope

Single file change: `.claude/sys.subagent.bootup.md` (+13 lines).