### PR TITLE
feat: add development workflow discipline (spec→test→build→review)

### DIFF
--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -20,6 +20,26 @@ You strongly prefer functional style in your implementations:
 - Isolate side effects at the boundaries of your system
 - Use pattern matching and algebraic data types where the language supports them
 
+## Development Workflow
+
+All feature and bug-fix work follows this order — no shortcuts:
+
+1. **Spec** — Define what is being built and why. File a GitHub issue if one doesn't exist.
+2. **Tests** — Write the test suite *before* building. Unit tests are mandatory where they make sense. Docker/integration tests for infra changes.
+3. **Build** — Implement against the tests.
+4. **Run tests** — All tests must pass before moving on.
+5. **Code review** — Open a PR and request review. The PR description must follow the quality standard (system flow explanation, not just a file list).
+
+**Sahar's entry points:** spec (step 1) and code review (step 5). Do not skip to implementation without a spec, and do not merge without Sahar's explicit sign-off.
+
+### Architecture changes: add a design step
+
+For changes that alter system architecture (new data flows, new components, replacing existing mechanisms, changes affecting multiple subsystems):
+
+0. **Design doc** — Write a design document as a GitHub issue section *before* spec. Cover: what problem, proposed approach, alternatives considered, tradeoffs, scope estimate. Get Sahar's explicit sign-off on the design before any code is written.
+
+Architecture flow: design doc → Sahar sign-off → spec → tests → build → run tests → code review → Sahar merge approval.
+
 ## Workflow Protocol
 
 When assigned to work on a GitHub issue, you follow this structured workflow. **Critical: Update project status at each phase transition.**


### PR DESCRIPTION
## Summary

This PR formalizes the development discipline Sahar outlined: no jumping straight to implementation without a spec, no merging without a review. It makes two changes:

- **functional-engineer agent**: adds a `## Development Workflow` section near the top (after Core Philosophy, before the Workflow Protocol) that defines the mandatory sequence: spec → tests → build → run tests → code review. Sahar's two explicit entry points — spec sign-off and merge approval — are called out. For architecture changes (new data flows, new components, changes spanning multiple subsystems), a design doc step is added *before* the spec, with Sahar's sign-off required before any code is written. This addresses the "design evolves during implementation" failure mode.

- **user.subagent.bootup.md** (private config, not in this repo): adds a brief pointer directing all implementation subagents to the functional-engineer workflow discipline. This file change is applied directly to `~/lobster-user-config/` and is not committed here.

## Why this matters

The previous agent instructions described *how* to implement but not *what order* to do it in relative to spec and review. Subagents could rationalize starting implementation before a spec existed, or opening a PR without tests. The new section makes the sequence explicit and names the failure modes it prevents.

The architecture-change design-doc requirement is the higher-stakes addition: it creates a forcing function for getting design agreement before code is written, rather than discovering design disagreements during code review when the cost of change is higher.

## Tests run

- [ ] No automated tests for agent bootup files — correctness is structural (section present, in the right place, content matches spec). Verified manually by reading the diff.
- [ ] Live behavior test (subagent picks up new discipline on next invocation) — not verifiable without a live run; safe to merge, change is additive.

**Blocked items needing attention before merge:** none

---
*This PR was opened by Lobster (subagent) on behalf of @sayhar.*