### PR TITLE
fix: add task_id generation to dispatcher delegation pattern

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -56,20 +56,26 @@ Before spawning a subagent, decide whether to ack based on expected task duratio
 
 **How to delegate:**
 ```
-1. [If task will take >4s]: send_reply(chat_id, "On it.")   # brief ack, 1-3 words
-2. task_result = Task(prompt="...", subagent_type="general-purpose", run_in_background=true)
-3. agent_id = extract agentId from task_result text (look for "agentId: <id>")
-4. output_file = extract output file path from task_result text (look for a /tmp/... path ending in .output)
-5. register_agent(
+1. Generate a short task_id (e.g. "fix-pr-475", "upstream-check", or a short slug describing the task)
+2. [If task will take >4s]: send_reply(chat_id, "On it.")   # brief ack, 1-3 words
+3. task_result = Task(
+       prompt="...Your task_id is <task_id>. Pass it to write_result...",
+       subagent_type="...",
+       run_in_background=true
+   )
+4. agent_id = extract agentId from task_result text (look for "agentId: <id>")
+5. output_file = extract output file path from task_result text (look for a /tmp/... path ending in .output)
+6. register_agent(
        agent_id=agent_id,
+       task_id=task_id,           # REQUIRED — enables reliable DB matching in SubagentStop
        description="Brief what/why + chat_id",
        chat_id=chat_id,
        source=msg.get("source", "telegram"),
-       output_file=output_file,   # enables liveness detection via mtime
-       timeout_minutes=30,        # adjust for long-running tasks
+       output_file=output_file,
+       timeout_minutes=30,
    )
-6. mark_processed(message_id)
-7. Return to wait_for_messages() IMMEDIATELY
+7. mark_processed(message_id)
+8. Return to wait_for_messages() IMMEDIATELY
 ```
 
 **Closing the loop when write_result arrives:**


### PR DESCRIPTION
## Summary

- The "How to delegate" section previously showed `register_agent` without mentioning that `task_id` must be generated **before** spawning the agent
- Without `task_id`, the `require-register-agent-task-id` hook blocks `register_agent` entirely
- Without `task_id` flowing through to `write_result`, the `SubagentStop` hook cannot match DB rows to auto-unregister completed agents

## What changed

Updated the delegation pattern in `sys.dispatcher.bootup.md` to:
1. Generate `task_id` first (step 1, before spawning or acking)
2. Include `task_id` in the agent prompt so subagents pass it to `write_result`
3. Pass `task_id` explicitly to `register_agent` with a comment marking it as REQUIRED

## Why this matters

The hook `require-register-agent-task-id.py` validates that `task_id` is present when `register_agent` is called. If the dispatcher follows the old pattern, every agent registration fails at the hook. Additionally, the `SubagentStop` handler uses `task_id` to look up the DB row and mark agents as completed — without it, agents stay in "running" state indefinitely and the tracker goes stale.

## Test plan

- [ ] Verify the delegation pattern in the updated file matches the new step numbering (1-8)
- [ ] Confirm `task_id` appears in the `register_agent` call with the REQUIRED comment
- [ ] Confirm the agent prompt template includes `task_id` placeholder text

🤖 Generated with [Claude Code](https://claude.com/claude-code)