### PR TITLE
feat: follow-up compaction — merge correction messages with original context

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -280,6 +280,19 @@ When replying, always pass the correct `source` parameter to `send_reply` — Te
 
 **Handling edited messages:** When a message has `_edit_of_telegram_id` set, it is the user's edited version of a previously sent message. Process it as a normal message. If `_replaces_inbox_id` is also present, the original message was still in the queue when the edit arrived — if you already dispatched a subagent for the original, its result will still be delivered with a note. If only `_edit_note` is present (no `_replaces_inbox_id`), the original was already processed — treat this as a fresh request based on the edited text.
 
+**Handling compact_group messages:** Messages of type `compact_group` contain multiple related messages merged together by the inbox server. The constituent messages are displayed in chronological order under the message header. Read all of them and resolve what the user wants. The most recent message takes precedence on conflicts, but earlier messages may contain additive context.
+
+If the compact_group carries an `_original_filepath`, that file is from `inbox/` or `processing/` and represents the original message that was merged. After you mark_processed the compact_group's own message_id, also mark_processed the original file's message_id so it does not re-appear. The original message_id can be found in `_original_filename` (e.g. `1234_5.json` → message_id `1234_5`).
+
+```
+1. wait_for_messages() → compact_group message arrives
+2. mark_processing(message_id)  ← claim the compact_group
+3. Read constituent messages from the "messages" list — understand merged intent
+4. Act on the merged intent (delegate to subagent if needed)
+5. mark_processed(message_id)   ← marks compact_group done
+6. If _original_filename is set, also mark_processed(_original_filename without .json)
+```
+
 ```
 1. wait_for_messages() → image message arrives
 2. mark_processing(message_id)  ← claim it first (prevents health check restart)

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -2690,9 +2690,13 @@ def _find_original_message(message_id: int | str, chat_id: int | str) -> dict | 
 
 
 def _has_negation_marker(text: str) -> bool:
-    """Return True if text begins with or contains a recognized negation marker."""
+    """Return True if text starts with a recognized negation marker.
+
+    Restricted to message-start to avoid false-positives like "I'll wait for you"
+    triggering compaction mid-sentence.
+    """
     lowered = text.lower().strip()
-    return any(lowered.startswith(marker) or f" {marker}" in lowered for marker in NEGATION_MARKERS)
+    return any(lowered.startswith(marker) for marker in NEGATION_MARKERS)
 
 
 def _seconds_between(ts1: str, ts2: str) -> float | None:
@@ -3021,8 +3025,13 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
                 indented = "\n".join(f"  {line}" for line in cm_text.splitlines())
                 output += f"{indented}\n\n"
             orig_fp = msg.get("_original_filepath")
+            orig_fn = msg.get("_original_filename")
             if orig_fp:
-                output += f"_original_filepath: `{orig_fp}` (mark_processed this file after handling)\n\n"
+                output += f"_original_filepath: `{orig_fp}` (mark_processed this file after handling)\n"
+            if orig_fn:
+                output += f"_original_filename: `{orig_fn}`\n"
+            if orig_fp or orig_fn:
+                output += "\n"
         else:
             # Show full reply-to context if present
             reply_to = msg.get("reply_to")

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -2637,6 +2637,268 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
         observer.join(timeout=1)
 
 
+# ---------------------------------------------------------------------------
+# Follow-up compaction
+# ---------------------------------------------------------------------------
+
+NEGATION_MARKERS: list[str] = [
+    "actually",
+    "wait",
+    "no,",
+    "scratch that",
+    "instead",
+    "forget that",
+    "cancel",
+    "never mind",
+    "nevermind",
+    "disregard",
+    "ignore that",
+]
+
+# Maximum age gap between two messages for time-window compaction (seconds).
+_COMPACTION_WINDOW_S: int = 8
+
+
+def _find_original_message(message_id: int | str, chat_id: int | str) -> dict | None:
+    """Look up a message by Telegram message_id in inbox and processing directories.
+
+    Searches inbox/ then processing/ (not processed/) — we only compact when the
+    original message is still in queue, matching the Option 1 design decision.
+
+    Returns the message dict if found, None otherwise.
+    """
+    target_id = int(message_id) if str(message_id).isdigit() else None
+    if target_id is None:
+        return None
+
+    for search_dir in (INBOX_DIR, PROCESSING_DIR):
+        for f in search_dir.glob("*.json"):
+            try:
+                with open(f) as fp:
+                    candidate = json.load(fp)
+                # Match on Telegram message_id and same chat
+                if (
+                    candidate.get("telegram_message_id") == target_id
+                    and str(candidate.get("chat_id")) == str(chat_id)
+                ):
+                    candidate["_filename"] = f.name
+                    candidate["_filepath"] = str(f)
+                    return candidate
+            except Exception:
+                continue
+    return None
+
+
+def _has_negation_marker(text: str) -> bool:
+    """Return True if text begins with or contains a recognized negation marker."""
+    lowered = text.lower().strip()
+    return any(lowered.startswith(marker) or f" {marker}" in lowered for marker in NEGATION_MARKERS)
+
+
+def _seconds_between(ts1: str, ts2: str) -> float | None:
+    """Return absolute seconds between two ISO 8601 timestamps, or None on parse failure."""
+    try:
+        from datetime import timezone as _tz
+
+        def _parse(ts: str) -> datetime:
+            # Handle both aware and naive timestamps
+            try:
+                return datetime.fromisoformat(ts)
+            except ValueError:
+                # Strip trailing Z and treat as UTC
+                return datetime.fromisoformat(ts.rstrip("Z")).replace(tzinfo=_tz.utc)
+
+        t1 = _parse(ts1)
+        t2 = _parse(ts2)
+        # Make both timezone-aware if needed
+        if t1.tzinfo is None:
+            t1 = t1.replace(tzinfo=_tz.utc)
+        if t2.tzinfo is None:
+            t2 = t2.replace(tzinfo=_tz.utc)
+        return abs((t2 - t1).total_seconds())
+    except Exception:
+        return None
+
+
+def _build_compact_group(
+    original: dict,
+    follow_up: dict,
+    compact_reason: str,
+) -> dict:
+    """Merge two messages into a single compact_group message.
+
+    The compact_group message:
+    - carries type="compact_group"
+    - preserves both constituent messages verbatim under "messages"
+    - uses the follow-up's id, chat_id, source, timestamp as the envelope
+    - sets a plain-text "text" summary so callers that only read "text" see something useful
+    """
+    constituent_original = {
+        "id": original.get("id", ""),
+        "text": original.get("text", ""),
+        "timestamp": original.get("timestamp", ""),
+        "telegram_message_id": original.get("telegram_message_id"),
+    }
+    constituent_follow_up = {
+        "id": follow_up.get("id", ""),
+        "text": follow_up.get("text", ""),
+        "timestamp": follow_up.get("timestamp", ""),
+        "telegram_message_id": follow_up.get("telegram_message_id"),
+    }
+    return {
+        "id": f"compact_{int(time.time() * 1000)}",
+        "source": follow_up.get("source", "telegram"),
+        "type": "compact_group",
+        "chat_id": follow_up.get("chat_id"),
+        "user_id": follow_up.get("user_id"),
+        "username": follow_up.get("username"),
+        "user_name": follow_up.get("user_name"),
+        "messages": [constituent_original, constituent_follow_up],
+        "compact_reason": compact_reason,
+        "text": f"[Compact group: 2 messages merged]",
+        "timestamp": follow_up.get("timestamp", datetime.now(timezone.utc).isoformat()),
+        # Preserve telegram_message_id from the follow-up for reply threading
+        "telegram_message_id": follow_up.get("telegram_message_id"),
+        # Carry forward any reply_to context from the follow-up
+        "reply_to": follow_up.get("reply_to"),
+        # Internal bookkeeping: track which inbox files were consumed
+        "_filename": follow_up.get("_filename"),
+        "_original_filename": original.get("_filename"),
+        "_original_filepath": original.get("_filepath"),
+    }
+
+
+def _maybe_compact_follow_ups(messages: list[dict]) -> list[dict]:
+    """Merge follow-up correction messages with their originals into compact_group messages.
+
+    Two compaction signals are checked, in priority order:
+
+    1. Reply threading (primary): the follow-up has a reply_to.message_id pointing
+       to another message still in inbox/ or processing/.  When found, the two are
+       merged and the original is removed from the returned list.
+
+    2. Time window + negation marker (secondary): consecutive messages from the
+       same chat within _COMPACTION_WINDOW_S seconds where the later one starts
+       with a negation marker.
+
+    Only messages whose type is "text" participate in compaction.  System messages,
+    subagent results, voice notes, photos, etc. are passed through unchanged.
+
+    The original message is NOT written back — it remains on disk for the dispatcher
+    to mark_processed along with the compact_group.  The compact_group carries
+    _original_filepath so the dispatcher can clean up both files.
+
+    Returns a new list (same length or shorter) with compact_group messages
+    substituted where compaction occurred.
+    """
+    if len(messages) < 2:
+        return messages
+
+    # Build an index from telegram_message_id → position in messages list
+    # so we can quickly find the original when a reply arrives.
+    tg_id_to_index: dict[int, int] = {}
+    for i, msg in enumerate(messages):
+        tg_mid = msg.get("telegram_message_id")
+        if tg_mid is not None:
+            tg_id_to_index[int(tg_mid)] = i
+
+    # consumed: indices replaced by a compact_group (must be excluded from output).
+    # replacements: maps follow-up index → compact_group message to insert at that position.
+    consumed: set[int] = set()
+    replacements: dict[int, dict] = {}
+
+    for i, msg in enumerate(messages):
+        if i in consumed:
+            continue
+
+        msg_type = msg.get("type", "text")
+
+        # Only plain text messages participate in compaction
+        if msg_type != "text":
+            continue
+
+        # --- Signal 1: Reply threading ---
+        reply_to = msg.get("reply_to")
+        if reply_to:
+            orig_tg_id = reply_to.get("message_id") or reply_to.get("reply_to_message_id")
+            if orig_tg_id is not None:
+                orig_tg_id = int(orig_tg_id)
+                # Check if the original is already in the messages list
+                if orig_tg_id in tg_id_to_index:
+                    orig_idx = tg_id_to_index[orig_tg_id]
+                    if orig_idx not in consumed:
+                        original = messages[orig_idx]
+                        if original.get("type", "text") == "text":
+                            compact = _build_compact_group(original, msg, "reply_thread")
+                            consumed.add(orig_idx)
+                            consumed.add(i)
+                            replacements[i] = compact
+                            log.info(
+                                f"follow-up compaction: merged msg {original.get('id')} "
+                                f"+ {msg.get('id')} via reply_thread"
+                            )
+                            continue
+                else:
+                    # Original not in inbox — look it up on disk (inbox/ and processing/)
+                    original = _find_original_message(orig_tg_id, msg.get("chat_id", ""))
+                    if original and original.get("type", "text") == "text":
+                        compact = _build_compact_group(original, msg, "reply_thread")
+                        consumed.add(i)
+                        replacements[i] = compact
+                        log.info(
+                            f"follow-up compaction: merged on-disk msg {original.get('id')} "
+                            f"+ {msg.get('id')} via reply_thread"
+                        )
+                        continue
+
+        # --- Signal 2: Time window + negation marker ---
+        msg_text = msg.get("text", "")
+        if _has_negation_marker(msg_text):
+            # Find the most recent preceding message in the same chat
+            msg_chat = msg.get("chat_id")
+            msg_ts = msg.get("timestamp", "")
+            predecessor: dict | None = None
+            pred_idx: int | None = None
+            for j in range(i - 1, -1, -1):
+                if j in consumed:
+                    continue
+                cand = messages[j]
+                if cand.get("chat_id") != msg_chat:
+                    continue
+                if cand.get("type", "text") != "text":
+                    continue
+                gap = _seconds_between(cand.get("timestamp", ""), msg_ts)
+                if gap is not None and gap <= _COMPACTION_WINDOW_S:
+                    predecessor = cand
+                    pred_idx = j
+                break  # Only look at the nearest preceding message
+
+            if predecessor is not None and pred_idx is not None:
+                compact = _build_compact_group(predecessor, msg, "negation_marker")
+                consumed.add(pred_idx)
+                consumed.add(i)
+                replacements[i] = compact
+                log.info(
+                    f"follow-up compaction: merged msg {predecessor.get('id')} "
+                    f"+ {msg.get('id')} via negation_marker"
+                )
+                continue
+
+    # Second pass: build output, skipping consumed indices and inserting compact_groups
+    # at the position of the follow-up (higher index of each merged pair).
+    compacted: list[dict] = []
+    for i, msg in enumerate(messages):
+        if i in consumed and i not in replacements:
+            # This index was the original — absorbed into a compact_group at the follow-up's position
+            continue
+        if i in replacements:
+            compacted.append(replacements[i])
+        else:
+            compacted.append(msg)
+
+    return compacted
+
+
 async def handle_check_inbox(args: dict) -> list[TextContent]:
     """Check for new messages in inbox."""
     source_filter = args.get("source", "").lower()
@@ -2658,6 +2920,9 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
 
     if not messages:
         return [TextContent(type="text", text="📭 No new messages in inbox.")]
+
+    # Apply follow-up compaction before returning to the dispatcher
+    messages = _maybe_compact_follow_ups(messages)
 
     log.info(f"check_inbox returning {len(messages)} message(s)")
 
@@ -2688,6 +2953,11 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
         elif msg_type == "document":
             file_name = msg.get("file_name", "file")
             output += f"**[{source}]** 📎 from **{user}** ({file_name})\n"
+        elif msg_type == "compact_group":
+            reason = msg.get("compact_reason", "unknown")
+            constituent_msgs = msg.get("messages", [])
+            output += f"**[{source}]** [COMPACT GROUP ({reason})] from **{user}** — {len(constituent_msgs)} messages merged\n"
+            output += "dispatcher_hint: COMPACT_GROUP — read all constituent messages below and resolve what the user wants. The most recent message takes precedence on conflicts, but earlier messages may contain additive context.\n"
         elif msg_type in ("subagent_result", "subagent_error"):
             status_icon = "✅" if msg_type == "subagent_result" else "❌"
             label = "RESULT" if msg_type == "subagent_result" else "ERROR"
@@ -2740,27 +3010,41 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
                 output += f"Original name: {doc_file_name}\n\n"
             else:
                 output += f"**Attached file**: {doc_file_name} (file not downloaded)\n\n"
-        # Show full reply-to context if present
-        reply_to = msg.get("reply_to")
-        if reply_to:
-            reply_text = reply_to.get("reply_to_text") or reply_to.get("text")
-            reply_type = reply_to.get("reply_to_type", "text")
-            reply_msg_id = reply_to.get("reply_to_message_id") or reply_to.get("message_id")
-            reply_from = reply_to.get("reply_to_from_user") or reply_to.get("from_user")
-
-            # Build the reply header line
-            type_label = f" [{reply_type}]" if reply_type and reply_type != "text" else ""
-            from_label = f" from @{reply_from}" if reply_from else ""
-            id_label = f" (msg_id={reply_msg_id})" if reply_msg_id else ""
-            output += f"↩️ Replying to{type_label}{from_label}{id_label}:\n"
-
-            if reply_text:
-                # Display the full text, indented for visual clarity
-                indented = "\n".join(f"  {line}" for line in reply_text.splitlines())
+        # For compact_group messages: display constituent messages in order
+        if msg_type == "compact_group":
+            constituent_msgs = msg.get("messages", [])
+            for idx, cm in enumerate(constituent_msgs):
+                cm_text = cm.get("text", "(no text)")
+                cm_ts = cm.get("timestamp", "")
+                label = "Original" if idx == 0 else f"Follow-up {idx}"
+                output += f"**[{label}]** ({cm_ts})\n"
+                indented = "\n".join(f"  {line}" for line in cm_text.splitlines())
                 output += f"{indented}\n\n"
-            else:
-                output += f"  (no text content)\n\n"
-        output += f"> {text}\n\n"
+            orig_fp = msg.get("_original_filepath")
+            if orig_fp:
+                output += f"_original_filepath: `{orig_fp}` (mark_processed this file after handling)\n\n"
+        else:
+            # Show full reply-to context if present
+            reply_to = msg.get("reply_to")
+            if reply_to:
+                reply_text = reply_to.get("reply_to_text") or reply_to.get("text")
+                reply_type = reply_to.get("reply_to_type", "text")
+                reply_msg_id = reply_to.get("reply_to_message_id") or reply_to.get("message_id")
+                reply_from = reply_to.get("reply_to_from_user") or reply_to.get("from_user")
+
+                # Build the reply header line
+                type_label = f" [{reply_type}]" if reply_type and reply_type != "text" else ""
+                from_label = f" from @{reply_from}" if reply_from else ""
+                id_label = f" (msg_id={reply_msg_id})" if reply_msg_id else ""
+                output += f"↩️ Replying to{type_label}{from_label}{id_label}:\n"
+
+                if reply_text:
+                    # Display the full text, indented for visual clarity
+                    indented = "\n".join(f"  {line}" for line in reply_text.splitlines())
+                    output += f"{indented}\n\n"
+                else:
+                    output += f"  (no text content)\n\n"
+            output += f"> {text}\n\n"
 
     output += "---\n"
     output += "Use `send_reply` to respond, `mark_processed` when done."

--- a/tests/unit/test_mcp_server/test_follow_up_compaction.py
+++ b/tests/unit/test_mcp_server/test_follow_up_compaction.py
@@ -1,0 +1,422 @@
+"""
+Tests for follow-up compaction (_maybe_compact_follow_ups).
+
+Covers:
+- Primary signal: reply threading (reply_to.message_id points to a prior inbox message)
+- Secondary signal: time window (≤8s) + negation marker
+- Pass-through: messages that don't match either signal
+- Non-text messages are not compacted
+- Output format: compact_group schema and check_inbox display
+"""
+
+import asyncio
+import json
+import sys
+import time
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import pytest
+from unittest.mock import patch
+
+# Add src/mcp/ to sys.path so inbox_server imports work.
+_MCP_DIR = str(Path(__file__).resolve().parent.parent.parent.parent / "src" / "mcp")
+if _MCP_DIR not in sys.path:
+    sys.path.insert(0, _MCP_DIR)
+
+import src.mcp.inbox_server as _inbox_mod
+from src.mcp.inbox_server import (
+    _maybe_compact_follow_ups,
+    _has_negation_marker,
+    _seconds_between,
+    _build_compact_group,
+    _find_original_message,
+    NEGATION_MARKERS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ts(offset_seconds: float = 0) -> str:
+    """Return an ISO 8601 UTC timestamp offset by `offset_seconds` from now."""
+    t = datetime.now(timezone.utc) + timedelta(seconds=offset_seconds)
+    return t.isoformat()
+
+
+def _text_msg(
+    msg_id: str,
+    text: str,
+    chat_id: int = 1111,
+    tg_message_id: int | None = None,
+    timestamp: str | None = None,
+    reply_to: dict | None = None,
+) -> dict:
+    """Build a minimal text-type inbox message dict."""
+    return {
+        "id": msg_id,
+        "source": "telegram",
+        "type": "text",
+        "chat_id": chat_id,
+        "user_id": chat_id,
+        "username": "testuser",
+        "user_name": "Test",
+        "text": text,
+        "telegram_message_id": tg_message_id or int(msg_id.split("_")[0]),
+        "timestamp": timestamp or _ts(),
+        **({"reply_to": reply_to} if reply_to else {}),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit: _has_negation_marker
+# ---------------------------------------------------------------------------
+
+
+class TestHasNegationMarker:
+    def test_leading_marker(self):
+        assert _has_negation_marker("actually, forget it") is True
+
+    def test_embedded_marker(self):
+        assert _has_negation_marker("wait, I meant something else") is True
+
+    def test_no_marker(self):
+        assert _has_negation_marker("please do the task") is False
+
+    def test_case_insensitive(self):
+        assert _has_negation_marker("ACTUALLY never mind") is True
+
+    def test_all_defined_markers(self):
+        for marker in NEGATION_MARKERS:
+            assert _has_negation_marker(marker + " do something") is True, (
+                f"marker {marker!r} was not detected"
+            )
+
+    def test_empty_string(self):
+        assert _has_negation_marker("") is False
+
+
+# ---------------------------------------------------------------------------
+# Unit: _seconds_between
+# ---------------------------------------------------------------------------
+
+
+class TestSecondsBetween:
+    def test_two_seconds_apart(self):
+        t1 = datetime(2026, 3, 1, 12, 0, 0, tzinfo=timezone.utc).isoformat()
+        t2 = datetime(2026, 3, 1, 12, 0, 2, tzinfo=timezone.utc).isoformat()
+        assert _seconds_between(t1, t2) == pytest.approx(2.0)
+
+    def test_order_independent(self):
+        t1 = datetime(2026, 3, 1, 12, 0, 0, tzinfo=timezone.utc).isoformat()
+        t2 = datetime(2026, 3, 1, 12, 0, 5, tzinfo=timezone.utc).isoformat()
+        assert _seconds_between(t2, t1) == pytest.approx(5.0)
+
+    def test_invalid_timestamp_returns_none(self):
+        assert _seconds_between("not-a-timestamp", "2026-03-01T00:00:00Z") is None
+
+
+# ---------------------------------------------------------------------------
+# Unit: _build_compact_group
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCompactGroup:
+    def test_type_is_compact_group(self):
+        orig = _text_msg("100_1", "Do X")
+        follow = _text_msg("100_2", "Actually do Y", reply_to={"message_id": 1})
+        result = _build_compact_group(orig, follow, "reply_thread")
+        assert result["type"] == "compact_group"
+
+    def test_messages_list_has_two_items(self):
+        orig = _text_msg("100_1", "Do X")
+        follow = _text_msg("100_2", "Actually do Y")
+        result = _build_compact_group(orig, follow, "negation_marker")
+        assert len(result["messages"]) == 2
+
+    def test_messages_preserve_text(self):
+        orig = _text_msg("100_1", "Do X")
+        follow = _text_msg("100_2", "Actually do Y")
+        result = _build_compact_group(orig, follow, "negation_marker")
+        assert result["messages"][0]["text"] == "Do X"
+        assert result["messages"][1]["text"] == "Actually do Y"
+
+    def test_compact_reason_stored(self):
+        orig = _text_msg("100_1", "Do X")
+        follow = _text_msg("100_2", "Actually do Y")
+        result = _build_compact_group(orig, follow, "reply_thread")
+        assert result["compact_reason"] == "reply_thread"
+
+    def test_envelope_uses_follow_up_chat_id(self):
+        orig = _text_msg("100_1", "Do X", chat_id=9999)
+        follow = _text_msg("100_2", "Actually do Y", chat_id=9999)
+        result = _build_compact_group(orig, follow, "reply_thread")
+        assert result["chat_id"] == 9999
+
+    def test_text_field_is_summary(self):
+        orig = _text_msg("100_1", "Do X")
+        follow = _text_msg("100_2", "Actually do Y")
+        result = _build_compact_group(orig, follow, "negation_marker")
+        assert "Compact group" in result["text"]
+        assert "2 messages" in result["text"]
+
+
+# ---------------------------------------------------------------------------
+# Unit: _maybe_compact_follow_ups — reply threading signal
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeCompactFollowUpsReplyThread:
+    def test_reply_triggers_compaction(self):
+        """Follow-up that replies to a prior message in the same batch is compacted."""
+        orig = _text_msg("100_1", "Do X", tg_message_id=40)
+        follow = _text_msg(
+            "100_2",
+            "Actually do Y instead",
+            reply_to={"message_id": 40},
+        )
+        result = _maybe_compact_follow_ups([orig, follow])
+        assert len(result) == 1
+        assert result[0]["type"] == "compact_group"
+
+    def test_compact_group_preserves_both_texts(self):
+        orig = _text_msg("100_1", "Write a short email", tg_message_id=41)
+        follow = _text_msg(
+            "100_2",
+            "Actually make it longer",
+            reply_to={"message_id": 41},
+        )
+        result = _maybe_compact_follow_ups([orig, follow])
+        texts = [m["text"] for m in result[0]["messages"]]
+        assert "Write a short email" in texts
+        assert "Actually make it longer" in texts
+
+    def test_compact_reason_is_reply_thread(self):
+        orig = _text_msg("100_1", "Do X", tg_message_id=42)
+        follow = _text_msg("100_2", "Actually do Y", reply_to={"message_id": 42})
+        result = _maybe_compact_follow_ups([orig, follow])
+        assert result[0]["compact_reason"] == "reply_thread"
+
+    def test_unrelated_reply_not_compacted(self):
+        """Reply to a message not in the batch passes through unchanged (no compaction)."""
+        now = datetime.now(timezone.utc)
+        orig = _text_msg("100_1", "Do X", tg_message_id=50, timestamp=now.isoformat())
+        # "Make it longer" has no negation marker, so the fallback signal can't fire either.
+        # The reply_to points to message_id 99, which is not in the batch.
+        follow = _text_msg(
+            "100_2",
+            "Make it longer",
+            reply_to={"message_id": 99},
+            timestamp=(now + timedelta(seconds=2)).isoformat(),
+        )
+        # message_id 99 is not in the batch and not on disk (patch _find_original_message)
+        with patch.object(_inbox_mod, "_find_original_message", return_value=None):
+            result = _maybe_compact_follow_ups([orig, follow])
+        assert len(result) == 2
+        assert all(m["type"] == "text" for m in result)
+
+    def test_non_text_original_not_compacted(self):
+        """Voice message as original is not compacted even if referenced by reply."""
+        voice_msg = _text_msg("100_1", "[Voice]", tg_message_id=60)
+        voice_msg["type"] = "voice"
+        follow = _text_msg("100_2", "Actually cancel that", reply_to={"message_id": 60})
+        result = _maybe_compact_follow_ups([voice_msg, follow])
+        assert len(result) == 2
+        assert result[0]["type"] == "voice"
+
+
+# ---------------------------------------------------------------------------
+# Unit: _maybe_compact_follow_ups — negation marker + time window signal
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeCompactFollowUpsNegationMarker:
+    def test_negation_within_window_triggers_compaction(self):
+        now = datetime.now(timezone.utc)
+        orig = _text_msg("200_1", "Do X", timestamp=now.isoformat())
+        follow = _text_msg(
+            "200_2",
+            "actually, do Y instead",
+            timestamp=(now + timedelta(seconds=5)).isoformat(),
+        )
+        result = _maybe_compact_follow_ups([orig, follow])
+        assert len(result) == 1
+        assert result[0]["type"] == "compact_group"
+        assert result[0]["compact_reason"] == "negation_marker"
+
+    def test_negation_outside_window_not_compacted(self):
+        now = datetime.now(timezone.utc)
+        orig = _text_msg("200_1", "Do X", timestamp=now.isoformat())
+        follow = _text_msg(
+            "200_2",
+            "actually, do Y instead",
+            # 20 seconds later — outside the 8s window
+            timestamp=(now + timedelta(seconds=20)).isoformat(),
+        )
+        result = _maybe_compact_follow_ups([orig, follow])
+        assert len(result) == 2
+
+    def test_negation_different_chat_not_compacted(self):
+        now = datetime.now(timezone.utc)
+        orig = _text_msg("200_1", "Do X", chat_id=1111, timestamp=now.isoformat())
+        follow = _text_msg(
+            "200_2",
+            "actually, do Y",
+            chat_id=2222,
+            timestamp=(now + timedelta(seconds=2)).isoformat(),
+        )
+        result = _maybe_compact_follow_ups([orig, follow])
+        assert len(result) == 2
+
+    def test_no_negation_no_compaction(self):
+        now = datetime.now(timezone.utc)
+        orig = _text_msg("200_1", "Do X", timestamp=now.isoformat())
+        follow = _text_msg(
+            "200_2",
+            "and also do Z",
+            timestamp=(now + timedelta(seconds=3)).isoformat(),
+        )
+        result = _maybe_compact_follow_ups([orig, follow])
+        assert len(result) == 2
+
+    def test_compact_group_has_two_constituent_messages(self):
+        now = datetime.now(timezone.utc)
+        orig = _text_msg("200_1", "Do X", timestamp=now.isoformat())
+        follow = _text_msg(
+            "200_2",
+            "wait, actually do Y",
+            timestamp=(now + timedelta(seconds=4)).isoformat(),
+        )
+        result = _maybe_compact_follow_ups([orig, follow])
+        assert len(result[0]["messages"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Unit: _maybe_compact_follow_ups — pass-through cases
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeCompactFollowUpsPassThrough:
+    def test_single_message_unchanged(self):
+        msg = _text_msg("300_1", "Hello")
+        result = _maybe_compact_follow_ups([msg])
+        assert result == [msg]
+
+    def test_empty_list_unchanged(self):
+        assert _maybe_compact_follow_ups([]) == []
+
+    def test_non_text_messages_passed_through(self):
+        voice = _text_msg("300_1", "[Voice]")
+        voice["type"] = "voice"
+        photo = _text_msg("300_2", "[Photo]")
+        photo["type"] = "photo"
+        result = _maybe_compact_follow_ups([voice, photo])
+        assert len(result) == 2
+        assert result[0]["type"] == "voice"
+        assert result[1]["type"] == "photo"
+
+    def test_subagent_result_not_compacted(self):
+        msg = {
+            "id": "300_3",
+            "type": "subagent_result",
+            "source": "telegram",
+            "chat_id": 1111,
+            "text": "Done!",
+            "timestamp": _ts(),
+        }
+        result = _maybe_compact_follow_ups([msg])
+        assert result == [msg]
+
+
+# ---------------------------------------------------------------------------
+# Integration: handle_check_inbox formats compact_group correctly
+# ---------------------------------------------------------------------------
+
+
+class TestCheckInboxCompactGroupDisplay:
+    """Verify that handle_check_inbox renders compact_group messages with the
+    correct dispatcher_hint and constituent messages."""
+
+    @pytest.fixture
+    def inbox_dir(self, temp_messages_dir: Path) -> Path:
+        return temp_messages_dir / "inbox"
+
+    def _check_inbox(self, inbox_dir: Path) -> str:
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox_dir,
+            PROCESSING_DIR=inbox_dir.parent / "processing",
+        ):
+            from src.mcp.inbox_server import handle_check_inbox
+            result = asyncio.run(handle_check_inbox({}))
+            return result[0].text
+
+    def test_compact_group_hint_present(self, inbox_dir: Path):
+        """compact_group messages must include the COMPACT_GROUP dispatcher_hint."""
+        now = datetime.now(timezone.utc)
+        orig = _text_msg("400_1", "Do X", timestamp=now.isoformat())
+        follow = _text_msg(
+            "400_2",
+            "actually do Y",
+            timestamp=(now + timedelta(seconds=3)).isoformat(),
+        )
+        # Write messages to inbox
+        (inbox_dir / "400_1.json").write_text(json.dumps(orig))
+        (inbox_dir / "400_2.json").write_text(json.dumps(follow))
+
+        text = self._check_inbox(inbox_dir)
+
+        assert "dispatcher_hint: COMPACT_GROUP" in text
+
+    def test_compact_group_constituent_texts_displayed(self, inbox_dir: Path):
+        """Both constituent message texts must appear in the output."""
+        now = datetime.now(timezone.utc)
+        orig = _text_msg("401_1", "Write a short summary", timestamp=now.isoformat())
+        follow = _text_msg(
+            "401_2",
+            "actually make it longer",
+            timestamp=(now + timedelta(seconds=2)).isoformat(),
+        )
+        (inbox_dir / "401_1.json").write_text(json.dumps(orig))
+        (inbox_dir / "401_2.json").write_text(json.dumps(follow))
+
+        text = self._check_inbox(inbox_dir)
+
+        assert "Write a short summary" in text
+        assert "actually make it longer" in text
+
+    def test_compact_group_reduces_message_count(self, inbox_dir: Path):
+        """Two compactable messages appear as one compact_group in the output."""
+        now = datetime.now(timezone.utc)
+        orig = _text_msg("402_1", "Do the thing", timestamp=now.isoformat())
+        follow = _text_msg(
+            "402_2",
+            "wait, cancel that",
+            timestamp=(now + timedelta(seconds=4)).isoformat(),
+        )
+        (inbox_dir / "402_1.json").write_text(json.dumps(orig))
+        (inbox_dir / "402_2.json").write_text(json.dumps(follow))
+
+        text = self._check_inbox(inbox_dir)
+
+        # "1 new message" not "2 new messages"
+        assert "1 new message" in text
+
+    def test_plain_text_not_compacted_in_output(self, inbox_dir: Path):
+        """Unrelated messages in different chats are not merged."""
+        now = datetime.now(timezone.utc)
+        msg_a = _text_msg("403_1", "Hello from A", chat_id=1111, timestamp=now.isoformat())
+        msg_b = _text_msg(
+            "403_2",
+            "actually hello from B",
+            chat_id=2222,
+            timestamp=(now + timedelta(seconds=2)).isoformat(),
+        )
+        (inbox_dir / "403_1.json").write_text(json.dumps(msg_a))
+        (inbox_dir / "403_2.json").write_text(json.dumps(msg_b))
+
+        text = self._check_inbox(inbox_dir)
+
+        assert "2 new message" in text
+        assert "compact_group" not in text.lower().replace("COMPACT_GROUP", "")

--- a/tests/unit/test_mcp_server/test_follow_up_compaction.py
+++ b/tests/unit/test_mcp_server/test_follow_up_compaction.py
@@ -78,8 +78,16 @@ class TestHasNegationMarker:
     def test_leading_marker(self):
         assert _has_negation_marker("actually, forget it") is True
 
-    def test_embedded_marker(self):
+    def test_leading_wait_marker(self):
+        # "wait" appears at the start — should fire
         assert _has_negation_marker("wait, I meant something else") is True
+
+    def test_mid_sentence_wait_does_not_fire(self):
+        # "wait" buried mid-sentence should NOT trigger compaction (false-positive guard)
+        assert _has_negation_marker("I'll wait for you") is False
+
+    def test_mid_sentence_actually_does_not_fire(self):
+        assert _has_negation_marker("that's actually fine") is False
 
     def test_no_marker(self):
         assert _has_negation_marker("please do the task") is False
@@ -420,3 +428,21 @@ class TestCheckInboxCompactGroupDisplay:
 
         assert "2 new message" in text
         assert "compact_group" not in text.lower().replace("COMPACT_GROUP", "")
+
+    def test_compact_group_original_filename_present(self, inbox_dir: Path):
+        """check_inbox output for a compact_group must include _original_filename
+        so the dispatcher can extract message_id without parsing a filepath."""
+        now = datetime.now(timezone.utc)
+        orig = _text_msg("404_1", "Do the thing", timestamp=now.isoformat())
+        follow = _text_msg(
+            "404_2",
+            "actually cancel that",
+            timestamp=(now + timedelta(seconds=3)).isoformat(),
+        )
+        (inbox_dir / "404_1.json").write_text(json.dumps(orig))
+        (inbox_dir / "404_2.json").write_text(json.dumps(follow))
+
+        text = self._check_inbox(inbox_dir)
+
+        assert "_original_filename" in text
+        assert "404_1.json" in text


### PR DESCRIPTION
## Summary

When a user corrects a prior message ("actually make it longer"), the current system treats the correction as a completely fresh message, losing the context of what was originally asked. This PR gives the dispatcher a merged view of both messages before any subagent is spawned.

- Adds `_maybe_compact_follow_ups(messages)` to `inbox_server.py`, called inside `handle_check_inbox` before returning results to the dispatcher
- Produces `compact_group` messages containing both the original and the follow-up verbatim — no text is dropped
- Updates `sys.dispatcher.bootup.md` to explain how to handle `compact_group` messages

## Design

Two compaction signals, checked in priority order:

**Primary — reply threading:** If the follow-up has `reply_to.message_id` pointing to a message that is still in-flight (still in `inbox/` or `processing/`, not yet fully handled), the two are merged. This is the common case: the user sends M2 as a Telegram reply to M1 before M1 has been claimed and processed. Note: `_find_original_message()` only searches `inbox/` and `processing/` — Lobster's own outbound messages are never there, so this signal is purely about in-flight user messages.

**Secondary — time window + negation marker:** If a follow-up arrives within 8 seconds of the preceding message in the same chat, and its text **starts with** a recognized negation marker (`actually`, `wait`, `scratch that`, `cancel`, etc.), they are merged. Matching is restricted to message-start to prevent false-positives from phrases like "I'll wait for you" triggering compaction mid-sentence.

**Graceful degradation (Option 1 from issue comments):** If the original is already in `processing/` when the follow-up arrives and isn't found in the batch, the follow-up passes through as a normal message. Both run independently. The race is rare and not catastrophic — the more common case (M2 arrives before M1 is claimed) is handled correctly.

**Functional patterns used:** pure functions (`_has_negation_marker`, `_seconds_between`, `_build_compact_group`), two-pass immutable transformation (first pass identifies compaction pairs, second pass builds output list), no mutation of input messages.

## compact_group schema

The `check_inbox` output for a compact_group now includes both `_original_filename` (basename) and `_original_filepath` (full path). The dispatcher uses `_original_filename` to extract `message_id` directly, without fragile path parsing.

```json
{
  "id": "compact_1234567890",
  "type": "compact_group",
  "compact_reason": "reply_thread",
  "text": "[Compact group: 2 messages merged]",
  "_original_filename": "abc_123.json",
  "_original_filepath": "/home/lobster/messages/inbox/abc_123.json",
  "messages": [
    {"id": "...", "text": "Do X", "timestamp": "..."},
    {"id": "...", "text": "Actually do Y instead", "timestamp": "..."}
  ]
}
```

The dispatcher prompt is updated: "Read all constituent messages and resolve what the user wants. The most recent message takes precedence on conflicts, but earlier messages may contain additive context."

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_follow_up_compaction.py -v` — 36 passed, 0 failed (added 3 new tests: mid-sentence false-positive guards for `wait` and `actually`, and `_original_filename` presence in `check_inbox` output)
- [x] `uv run pytest tests/unit/test_mcp_server/ -v` — 229 passed, 17 failed (all 17 failures are pre-existing on main, confirmed against main branch)

Closes #456