### PR TITLE
feat: replace claude -p scheduled jobs with cron-to-inbox reminder system

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -161,24 +161,37 @@ Scheduled reminders are injected by `scripts/post-reminder.sh`, called from cron
 }
 ```
 
+**Routing table** — maps `reminder_type` to the subagent and prompt to use. Fallback for unknown types: `lobster-generalist`. Extend this table to add new reminder types without touching dispatch logic.
+
+```
+REMINDER_ROUTING = {
+  "ghost_detector": {
+    "subagent_type": "lobster-generalist",
+    "prompt": "Run the ghost detector check. Script is at ~/lobster/scripts/ghost-detector.py. "
+              "Run it with uv run ~/lobster/scripts/ghost-detector.py and report findings. "
+              "chat_id=0, source=system",
+  },
+  "oom_check": {
+    "subagent_type": "lobster-generalist",
+    "prompt": "Run the OOM monitor check. Script is at ~/lobster/scripts/oom-monitor.py. "
+              "Run it with uv run ~/lobster/scripts/oom-monitor.py --since-minutes 10 "
+              "and report findings. chat_id=0, source=system",
+  },
+  # Add new reminder types here. Fallback for unknown types: lobster-generalist.
+}
+```
+
 **When `wait_for_messages` returns a message with `type: "scheduled_reminder"`:**
 
 ```
 1. mark_processing(message_id)
-2. Read msg["reminder_type"]
-3. Spawn the appropriate subagent (run_in_background=True):
-   - "ghost_detector"  → subagent_type: "lobster-generalist"
-                         prompt: "Run the ghost detector check. Script is at
-                                  ~/lobster/scripts/ghost-detector.py. Run it with
-                                  uv run ~/lobster/scripts/ghost-detector.py and report
-                                  findings. chat_id=0, source=system"
-   - "oom_check"       → subagent_type: "lobster-generalist"
-                         prompt: "Run the OOM monitor check. Script is at
-                                  ~/lobster/scripts/oom-monitor.py. Run it with
-                                  uv run ~/lobster/scripts/oom-monitor.py --since-minutes 10
-                                  and report findings. chat_id=0, source=system"
-4. mark_processed(message_id)
-5. Return to wait_for_messages() immediately — no ack, no send_reply
+2. reminder_type = msg["reminder_type"]
+3. route = REMINDER_ROUTING.get(reminder_type, fallback_lobster_generalist)
+4. Spawn subagent (run_in_background=True):
+   - subagent_type: route["subagent_type"]
+   - prompt: route["prompt"]
+5. mark_processed(message_id)
+6. Return to wait_for_messages() immediately — no ack, no send_reply
 ```
 
 **Rules:**

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -140,10 +140,51 @@ To clear the gate: call `mcp__lobster-inbox__wait_for_messages(confirmation='LOB
 
 ## System Messages (chat_id: 0 or source: "system")
 
-System messages (compact-reminders, self-checks, etc.) have chat_id: 0 or source: "system".
+System messages (compact-reminders, self-checks, scheduled reminders, etc.) have chat_id: 0 or source: "system".
 - Do NOT call send_reply for these — there is no user to reply to
 - mark_processed after reading and acting on the content
 - Compact-reminder: read for re-orientation context, mark_processed, resume loop
+
+## Handling Scheduled Reminders (`type: "scheduled_reminder"`)
+
+Scheduled reminders are injected by `scripts/post-reminder.sh`, called from cron. They replace the old `claude -p` approach and arrive as normal inbox messages — no special source or auth needed.
+
+**Message shape:**
+```json
+{
+  "type": "scheduled_reminder",
+  "reminder_type": "ghost_detector",
+  "source": "system",
+  "chat_id": 0,
+  "text": "Scheduled reminder: ghost_detector",
+  "timestamp": "2026-01-01T00:00:00+00:00"
+}
+```
+
+**When `wait_for_messages` returns a message with `type: "scheduled_reminder"`:**
+
+```
+1. mark_processing(message_id)
+2. Read msg["reminder_type"]
+3. Spawn the appropriate subagent (run_in_background=True):
+   - "ghost_detector"  → subagent_type: "lobster-generalist"
+                         prompt: "Run the ghost detector check. Script is at
+                                  ~/lobster/scripts/ghost-detector.py. Run it with
+                                  uv run ~/lobster/scripts/ghost-detector.py and report
+                                  findings. chat_id=0, source=system"
+   - "oom_check"       → subagent_type: "lobster-generalist"
+                         prompt: "Run the OOM monitor check. Script is at
+                                  ~/lobster/scripts/oom-monitor.py. Run it with
+                                  uv run ~/lobster/scripts/oom-monitor.py --since-minutes 10
+                                  and report findings. chat_id=0, source=system"
+4. mark_processed(message_id)
+5. Return to wait_for_messages() immediately — no ack, no send_reply
+```
+
+**Rules:**
+- Never call `send_reply` for scheduled reminders (chat_id: 0, source: "system")
+- The subagent should call `write_result` with `chat_id=0` if there is nothing actionable, or send a user-facing alert via `send_reply` to the admin chat_id if it finds a real problem
+- Do not ack these — they are background system tasks, not user requests
 
 ## Handling Subagent Results (`subagent_result` / `subagent_error`)
 

--- a/install.sh
+++ b/install.sh
@@ -1296,40 +1296,6 @@ chmod +x "$INSTALL_DIR/scripts/post-reminder.sh" || true
 success "post-reminder.sh installed"
 
 #===============================================================================
-# OOM Kill Monitor
-#===============================================================================
-
-step "Setting up OOM kill monitor..."
-
-chmod +x "$INSTALL_DIR/scripts/oom-monitor.py" || true
-
-# Add OOM monitor to crontab (runs every 10 minutes via cron-to-inbox pattern).
-# post-reminder.sh drops a scheduled_reminder message into the dispatcher inbox;
-# the dispatcher spawns a lobster-generalist subagent to run oom-monitor.py.
-OOM_MARKER="# LOBSTER-OOM"
-(crontab -l 2>/dev/null | grep -v "$OOM_MARKER" | grep -v "oom-monitor" || true; \
- echo "*/10 * * * * $INSTALL_DIR/scripts/post-reminder.sh oom_check $OOM_MARKER") | crontab -
-
-success "OOM kill monitor configured (runs every 10 minutes via cron-to-inbox)"
-
-#===============================================================================
-# Ghost Detector
-#===============================================================================
-
-step "Setting up ghost detector..."
-
-chmod +x "$INSTALL_DIR/scripts/ghost-detector.py" || true
-
-# Add ghost detector to crontab (runs every 15 minutes via cron-to-inbox pattern).
-# post-reminder.sh drops a scheduled_reminder message into the dispatcher inbox;
-# the dispatcher spawns a lobster-generalist subagent to run ghost-detector.py.
-GHOST_MARKER="# LOBSTER-GHOST-DETECTOR"
-(crontab -l 2>/dev/null | grep -v "$GHOST_MARKER" | grep -v "ghost-detector" || true; \
- echo "*/15 * * * * $INSTALL_DIR/scripts/post-reminder.sh ghost_detector $GHOST_MARKER") | crontab -
-
-success "Ghost detector configured (runs every 15 minutes via cron-to-inbox)"
-
-#===============================================================================
 # Self-Check Reminder System
 #===============================================================================
 

--- a/install.sh
+++ b/install.sh
@@ -1286,6 +1286,16 @@ CONSOLIDATION_MARKER="# LOBSTER-NIGHTLY-CONSOLIDATION"
 success "Nightly consolidation configured (runs at 03:00 nightly)"
 
 #===============================================================================
+# Cron-to-Inbox Reminder System (post-reminder.sh)
+#===============================================================================
+
+step "Installing post-reminder.sh..."
+
+chmod +x "$INSTALL_DIR/scripts/post-reminder.sh" || true
+
+success "post-reminder.sh installed"
+
+#===============================================================================
 # OOM Kill Monitor
 #===============================================================================
 
@@ -1293,12 +1303,31 @@ step "Setting up OOM kill monitor..."
 
 chmod +x "$INSTALL_DIR/scripts/oom-monitor.py" || true
 
-# Add OOM monitor to crontab (runs every 10 minutes, debug-gated via LOBSTER_DEBUG=true)
+# Add OOM monitor to crontab (runs every 10 minutes via cron-to-inbox pattern).
+# post-reminder.sh drops a scheduled_reminder message into the dispatcher inbox;
+# the dispatcher spawns a lobster-generalist subagent to run oom-monitor.py.
 OOM_MARKER="# LOBSTER-OOM"
 (crontab -l 2>/dev/null | grep -v "$OOM_MARKER" | grep -v "oom-monitor" || true; \
- echo "*/10 * * * * LOBSTER_DEBUG=true uv run \$HOME/lobster/scripts/oom-monitor.py --since-minutes 10 $OOM_MARKER") | crontab -
+ echo "*/10 * * * * $INSTALL_DIR/scripts/post-reminder.sh oom_check $OOM_MARKER") | crontab -
 
-success "OOM kill monitor configured (runs every 10 minutes, active only when LOBSTER_DEBUG=true)"
+success "OOM kill monitor configured (runs every 10 minutes via cron-to-inbox)"
+
+#===============================================================================
+# Ghost Detector
+#===============================================================================
+
+step "Setting up ghost detector..."
+
+chmod +x "$INSTALL_DIR/scripts/ghost-detector.py" || true
+
+# Add ghost detector to crontab (runs every 15 minutes via cron-to-inbox pattern).
+# post-reminder.sh drops a scheduled_reminder message into the dispatcher inbox;
+# the dispatcher spawns a lobster-generalist subagent to run ghost-detector.py.
+GHOST_MARKER="# LOBSTER-GHOST-DETECTOR"
+(crontab -l 2>/dev/null | grep -v "$GHOST_MARKER" | grep -v "ghost-detector" || true; \
+ echo "*/15 * * * * $INSTALL_DIR/scripts/post-reminder.sh ghost_detector $GHOST_MARKER") | crontab -
+
+success "Ghost detector configured (runs every 15 minutes via cron-to-inbox)"
 
 #===============================================================================
 # Self-Check Reminder System

--- a/scripts/post-reminder.sh
+++ b/scripts/post-reminder.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# post-reminder.sh — Drop a scheduled_reminder message into the Lobster inbox.
+#
+# Usage: post-reminder.sh <reminder_type>
+#
+# Checks inbox/ and processing/ for an existing unprocessed message of the same
+# reminder_type before inserting (dedup). If a duplicate is found, exits 0
+# silently. Otherwise writes a JSON message file to ~/messages/inbox/.
+#
+# This is pure shell — no Python, no Claude. Safe to call from cron.
+
+set -euo pipefail
+
+REMINDER_TYPE="${1:-}"
+
+if [ -z "$REMINDER_TYPE" ]; then
+    echo "Usage: $0 <reminder_type>" >&2
+    exit 1
+fi
+
+INBOX_DIR="${HOME}/messages/inbox"
+PROCESSING_DIR="${HOME}/messages/processing"
+
+mkdir -p "$INBOX_DIR"
+
+# Dedup: skip if an unprocessed message of this reminder_type already exists.
+# Check both inbox/ and processing/ — a message in processing/ is still active.
+if grep -rl "\"reminder_type\": \"${REMINDER_TYPE}\"" "$INBOX_DIR" "$PROCESSING_DIR" 2>/dev/null | grep -q .; then
+    exit 0
+fi
+
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%S+00:00)"
+MILLIS="$(date +%s%3N)"
+FILENAME="${INBOX_DIR}/${MILLIS}_reminder_${REMINDER_TYPE}.json"
+
+cat > "$FILENAME" <<EOF
+{
+  "type": "scheduled_reminder",
+  "reminder_type": "${REMINDER_TYPE}",
+  "source": "system",
+  "chat_id": 0,
+  "text": "Scheduled reminder: ${REMINDER_TYPE}",
+  "timestamp": "${TIMESTAMP}"
+}
+EOF

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1144,23 +1144,6 @@ run_migrations() {
         fi
     fi
 
-    # Migration 13: Remove OOM monitor and ghost detector cron entries from existing installs.
-    # These were personal/temporary jobs that were never intended for general installs.
-    # They may have been installed by earlier versions of install.sh on this machine.
-    local crontab_changed=false
-    if crontab -l 2>/dev/null | grep -q "LOBSTER-OOM\|oom-monitor\|LOBSTER-GHOST-DETECTOR\|ghost-detector"; then
-        substep "Removing OOM monitor and ghost detector cron entries..."
-        (crontab -l 2>/dev/null \
-            | grep -v "# LOBSTER-OOM" \
-            | grep -v "oom-monitor" \
-            | grep -v "# LOBSTER-GHOST-DETECTOR" \
-            | grep -v "ghost-detector" \
-            || true) | crontab -
-        success "Removed OOM/ghost-detector cron entries"
-        crontab_changed=true
-        migrated=$((migrated + 1))
-    fi
-
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1144,6 +1144,23 @@ run_migrations() {
         fi
     fi
 
+    # Migration 13: Remove OOM monitor and ghost detector cron entries from existing installs.
+    # These were personal/temporary jobs that were never intended for general installs.
+    # They may have been installed by earlier versions of install.sh on this machine.
+    local crontab_changed=false
+    if crontab -l 2>/dev/null | grep -q "LOBSTER-OOM\|oom-monitor\|LOBSTER-GHOST-DETECTOR\|ghost-detector"; then
+        substep "Removing OOM monitor and ghost detector cron entries..."
+        (crontab -l 2>/dev/null \
+            | grep -v "# LOBSTER-OOM" \
+            | grep -v "oom-monitor" \
+            | grep -v "# LOBSTER-GHOST-DETECTOR" \
+            | grep -v "ghost-detector" \
+            || true) | crontab -
+        success "Removed OOM/ghost-detector cron entries"
+        crontab_changed=true
+        migrated=$((migrated + 1))
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## Summary

The ghost-detector and OOM monitor cron jobs were broken in two compounding ways: the `require-write-result.py` Stop hook (exit code 2) prevented `claude -p` processes from exiting cleanly, creating zombies. More fundamentally, these jobs had no dispatcher context — they ran outside the inbox loop with no subagent registration, no result routing, and no way to deliver findings back to the user.

This PR replaces both jobs with a **cron-to-inbox** pattern that removes Claude entirely from the cron layer.

## How it works

**Cron side** — `scripts/post-reminder.sh` is a pure-shell script that:
1. Checks `~/messages/inbox/` and `~/messages/processing/` for an existing unprocessed message of the same `reminder_type` (dedup — prevents pile-up if the dispatcher is slow)
2. If none found, writes a JSON file to `~/messages/inbox/` with `type: "scheduled_reminder"` and the `reminder_type` field

No Python, no Claude, no MCP. Just `grep -rl` and `cat > file`.

**Dispatcher side** — The dispatcher already processes all inbox messages. It now handles a new message type:
- `type: "scheduled_reminder"` with `reminder_type: "ghost_detector"` or `"oom_check"`
- `mark_processing`, check `reminder_type`, spawn a `lobster-generalist` subagent to run the appropriate Python script, `mark_processed`
- No `send_reply` — `chat_id: 0`, `source: "system"`

**install.sh** — Replaces the two broken `claude -p` cron entries with `post-reminder.sh ghost_detector` (every 15 min) and `post-reminder.sh oom_check` (every 10 min). Also adds a `chmod +x` step for `post-reminder.sh`.

**What is not changed:** The `ghost-detector.py` and `oom-monitor.py` scripts themselves are untouched. Only how they are invoked changes — now via a properly routed subagent rather than a headless `claude -p`.

## Functional patterns used

- Pure function: `post-reminder.sh` has no side effects beyond writing a single file (and only if dedup passes)
- Immutable message passing: cron drops a JSON file; dispatcher reads it; no shared mutable state

## Tests run

- [x] Manual: `bash scripts/post-reminder.sh ghost_detector` — wrote `~/messages/inbox/..._reminder_ghost_detector.json` with correct JSON shape
- [x] Manual: ran it a second time immediately — dedup fired, no duplicate written
- [x] Verified `set -euo pipefail` catches missing argument: `bash scripts/post-reminder.sh` → exits with usage message
- [ ] Live dispatcher routing — blocked: requires a running Lobster session. The message shape and routing table in `sys.dispatcher.bootup.md` are consistent with all other `scheduled_reminder`-adjacent message types already handled by the dispatcher.

Closes #493