### PR TITLE
fix: pkill stale wrapper processes on lobster stop

### DIFF
--- a/src/cli
+++ b/src/cli
@@ -117,6 +117,11 @@ cmd_stop() {
         fi
     done
 
+    # Kill any stale wrapper processes that may be running outside of systemd
+    # (e.g. after a manual mode switch between debug and non-debug sessions)
+    pkill -u lobster -f 'claude-persistent.sh' 2>/dev/null || true
+    pkill -u lobster -f 'claude-wrapper.exp' 2>/dev/null || true
+
     # Set maintenance flag so health check doesn't restart services
     mkdir -p "$(dirname "$MAINTENANCE_FLAG")"
     echo "stopped_at=$(date -Iseconds) stopped_by=$(whoami)" > "$MAINTENANCE_FLAG"


### PR DESCRIPTION
## Summary

\`lobster stop\` previously only called \`systemctl stop\` on the managed services. If a wrapper process (\`claude-persistent.sh\` or \`claude-wrapper.exp\`) was started outside of systemd — for example, after a manual mode switch between debug and non-debug — it would survive the stop and keep running, leaving an orphaned Claude session.

After the systemctl loop completes, \`cmd_stop\` now sweeps for those processes with \`pkill -u lobster -f\` on both wrapper script names. Both calls use \`2>/dev/null || true\` so the stop is never aborted when no matching processes exist.

Nothing outside \`cmd_stop\` is changed. The \`cmd_restart\` path that stops services directly (bypassing \`cmd_stop\`) is intentionally left alone — that path triggers a scheduled restart immediately after, so a pkill there would race with the incoming start.

## Functional patterns

Pure sequential side effects isolated at the boundary of the stop command; no logic branching added.

## Tests run

- [x] \`git diff src/cli\` — diff reviewed, only the intended 5 lines added
- [ ] Live stop test with a stale tmux wrapper — skipped: requires a running Lobster instance with a detached wrapper session. Safe to merge; worst case is pkill finds no processes (exits 0 via \`|| true\`).

**Blocked items needing attention before merge:** none