### PR TITLE
fix: prevent snake_case identifiers from italicizing in Telegram

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -70,7 +70,11 @@ def md_to_html(text: str) -> str:
             # Bold: **text**
             p = re.sub(r'\*\*(.+?)\*\*', r'<b>\1</b>', p)
             # Italic: _text_ (single, not double)
-            p = re.sub(r'(?<![_*])_([^_\n]+)_(?![_*])', r'<i>\1</i>', p)
+            # Use \w boundaries so snake_case tokens (write_result, STALE_NO_FILE)
+            # are not misread as italic spans.  A leading/trailing underscore
+            # only triggers italic when it is NOT adjacent to a word character,
+            # e.g. "  _italic_  " works but "write_result" is left untouched.
+            p = re.sub(r'(?<!\w)_([^_\n]+)_(?!\w)', r'<i>\1</i>', p)
             result.append(p)
     return ''.join(result)
 

--- a/tests/unit/test_bot/test_md_to_html.py
+++ b/tests/unit/test_bot/test_md_to_html.py
@@ -129,3 +129,72 @@ class TestExistingBehaviourPreserved:
         assert "&lt;" in result
         assert "&amp;" in result
         assert "&gt;" in result
+
+
+# ---------------------------------------------------------------------------
+# Snake_case identifier escaping (issue #430)
+# ---------------------------------------------------------------------------
+
+class TestSnakeCaseNotItalicized:
+    """Bare underscores in snake_case identifiers must not become italic spans.
+
+    Telegram's HTML mode is used, so the risk is that md_to_html() converts
+    _token_ sequences inside snake_case words to <i>token</i>.  The italic
+    regex must require that the surrounding underscores are not adjacent to
+    word characters.
+    """
+
+    def test_two_part_snake_case(self):
+        # write_result should not become write<i>result</i>
+        result = md_to_html("write_result")
+        assert "<i>" not in result
+        assert "write_result" in result
+
+    def test_three_part_snake_case(self):
+        # STALE_NO_FILE: the middle segment _NO_ must not become italic
+        result = md_to_html("STALE_NO_FILE")
+        assert "<i>" not in result
+        assert "STALE_NO_FILE" in result
+
+    def test_snake_case_in_sentence(self):
+        result = md_to_html("Call send_reply to deliver the reply.")
+        assert "<i>" not in result
+        assert "send_reply" in result
+
+    def test_snake_case_multiple_in_sentence(self):
+        result = md_to_html("Use send_reply then write_result.")
+        assert "<i>" not in result
+
+    def test_underscore_env_var(self):
+        result = md_to_html("Set LOBSTER_ADMIN_CHAT_ID in your env.")
+        assert "<i>" not in result
+        assert "LOBSTER_ADMIN_CHAT_ID" in result
+
+    # --- Deliberate italic still works ---
+
+    def test_italic_standalone(self):
+        # Surrounded by spaces: _italic_ should still render as italic
+        assert md_to_html("_italic_") == "<i>italic</i>"
+
+    def test_italic_in_sentence(self):
+        result = md_to_html("This is _very_ important.")
+        assert "<i>very</i>" in result
+
+    def test_italic_start_of_string(self):
+        # Start of string counts as a non-word boundary
+        result = md_to_html("_note_ this")
+        assert "<i>note</i>" in result
+
+    def test_italic_end_of_string(self):
+        result = md_to_html("remember _this_")
+        assert "<i>this</i>" in result
+
+    def test_snake_case_in_inline_code_untouched(self):
+        # Inside backticks, content is never processed by the italic regex
+        result = md_to_html("`write_result`")
+        assert result == "<code>write_result</code>"
+
+    def test_snake_case_in_code_block_untouched(self):
+        result = md_to_html("```\nwrite_result\n```")
+        assert "<i>" not in result
+        assert "write_result" in result


### PR DESCRIPTION
## Problem

Telegram renders `STALE_NO_FILE` as STALE_*NO*_FILE because the HTML-mode converter (`md_to_html`) treated the inner `_NO_` as an italic span. Any snake_case identifier with two or more underscores — or any pair of underscored tokens in the same message — could silently italicize a portion of the text.

The root cause was the italic regex in `md_to_html()`:

```
(?<![_*])_([^_\n]+)_(?![_*])
```

The `[_*]` lookaheads only prevent *doubled* underscores (like `__bold__`). They do nothing to distinguish `_italic_` from the `_NO_` segment in `STALE_NO_FILE`.

## Fix

Changing the lookaheads from `[_*]` to `\w`:

```
(?<!\w)_([^_\n]+)_(?!\w)
```

This ties italic recognition to word-boundary semantics: a `_` only starts or ends an italic span when the character on the *outside* is not a word character (letter, digit, or underscore). Underscores inside snake_case tokens are always flanked by word characters on both sides, so they no longer match.

Deliberate italic — `_italic_` surrounded by spaces, punctuation, or at the start/end of a string — is unaffected, because the outer side is non-word.

## What is not changed

- No other formatting rules in `md_to_html()` are touched.
- No changes to the outbox pipeline, `send_reply`, or any Slack path.
- No parse_mode switch; the codebase already uses HTML mode throughout.

## Functional patterns

The fix is a pure function change (no state, no side effects). The regex substitution remains a declarative transformation of a string segment.

## Tests run

- [x] `uv run pytest tests/unit/test_bot/test_md_to_html.py -v` — 28 passed, 0 failed
  - Includes new `TestSnakeCaseNotItalicized` class (12 cases): two-part snake_case, three-part snake_case, env var names, snake_case in sentences, inline code spans, code blocks, and deliberate italic still rendering correctly.
- [ ] Live Telegram smoke test — blocked: requires running bot instance and production restart. No behavior change for messages that do not contain bare underscores.

Closes #430