### PR TITLE
docs: surface upgrade.sh in CLAUDE.md and lobster-ops

### DIFF
--- a/.claude/agents/lobster-ops.md
+++ b/.claude/agents/lobster-ops.md
@@ -52,6 +52,21 @@ You are a Lobster operations specialist. Lobster is an always-on Claude Code mes
 - `lobster logs [bot|claude]` - View logs
 - `lobster inbox/outbox` - Check message queues
 
+## Upgrading an Existing Install
+
+Run `~/lobster/scripts/upgrade.sh` to apply all pending migrations to an existing installation.
+
+Options:
+- `--dry-run` — show what would change without applying it
+- `--force` — continue past non-critical errors
+- Migrations are numbered (0–N) and idempotent — safe to run repeatedly
+- Creates timestamped backups to `~/lobster-backups/` before applying changes
+- Runs a health check at the end
+
+**upgrade.sh vs. install.sh:** Use `upgrade.sh` for day-to-day updates. `install.sh` is a bootstrap installer that re-registers MCP servers unconditionally — running it on an existing install drops active MCP registrations and is disruptive.
+
+When writing a PR that ships new subagent definitions, new config file locations, new required directories, service renames, or cron entries, add a corresponding numbered migration to `upgrade.sh` following the existing pattern.
+
 ## Common Troubleshooting
 
 1. **Claude not responding**: Check tmux session exists, check for errors in session

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,10 @@ All Lobster-managed projects live in `$LOBSTER_WORKSPACE/projects/[project-name]
   - Install packages: `uv add <package>` or `uv pip install <package>` (not `pip install`)
   - Execute modules: `uv run -m module` (not `python -m module`)
 
+## Migration Tool
+
+For changes that affect existing installs (new cron entries, new directories, config renames, new service files), add a numbered migration to `scripts/upgrade.sh` — not just `install.sh`. See `.claude/agents/lobster-ops.md` for the migration format and upgrade procedure.
+
 ## Key Directories
 
 - `~/lobster/` - Repository (code only, no personal data)


### PR DESCRIPTION
## Summary

Subagents and reviewer agents had no repo-side pointer to `upgrade.sh`, which has 12+ numbered idempotent migrations, dry-run support, and backup to `~/lobster-backups/`. PRs that changed install layout, cron entries, or service files could ship without a migration, and agents tasked with upgrading had no canonical path to follow. The `user.subagent.bootup.md` (private config) now names it — this PR closes the gap on the repo side.

**Two changes:**

- `CLAUDE.md` — adds a "Migration Tool" section (one short paragraph) that names `upgrade.sh` and points to `lobster-ops` for details, per Sahar's guidance that CLAUDE.md should have exactly one line and lobster-ops should be the expert.
- `.claude/agents/lobster-ops.md` — adds an "Upgrading" section covering: available flags (`--dry-run`, `--force`), the idempotency guarantee, the `upgrade.sh` vs `install.sh` distinction (install.sh drops active MCP registrations on re-run — disruptive for existing installs), and the reviewer convention to add numbered migrations when PRs affect install layout.

**What this does not change:** `upgrade.sh` itself, `install.sh`, the schema version tracking proposal from the issue, the dispatcher startup check, or any runtime behavior. This is purely documentation surfacing.

**Functional patterns:** pure documentation additions — no behavior changes, no side effects.

## Tests run

- [x] `git diff --stat` — 2 files changed, 19 insertions(+), 0 deletions — matches intent
- [ ] Live dispatcher context load — not testable without a running dispatcher session; the changes add new sections to files already loaded at startup, so no regression risk

Closes #441 (partial — covers item 2 from the issue: "upgrade.sh is underadvertised")