### PR TITLE
feat: add cron-to-inbox reminder so dispatcher learns when jobs complete

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -372,6 +372,44 @@ Additional message fields:
 - `is_dm` — Indicates if the message is a direct message
 - `channel_name` — Human-readable channel name
 
+## Cron Job Reminders (`cron_reminder`)
+
+When a scheduled job finishes, `run-job.sh` calls `scheduled-tasks/post-reminder.sh`, which writes a `cron_reminder` message to the inbox. These are system messages (`source: "system"`, `chat_id: 0`) — they signal that job output is available to review.
+
+**When `wait_for_messages` returns a message with `type: "cron_reminder"`:**
+
+```
+1. mark_processing(message_id)
+2. job_name = msg["job_name"]
+3. status = msg["status"]          # "success" or "failed"
+4. duration = msg["duration_seconds"]
+
+5. Call check_task_outputs(job_name=job_name, limit=1) to read the latest output
+
+6. if output exists AND is noteworthy (non-trivial content, failure, or actionable finding):
+       send_reply(chat_id=ADMIN_CHAT_ID, text=<concise summary>, source="telegram")
+   else:
+       # Silent — routine success with no news is not worth interrupting the user
+
+7. mark_processed(message_id)
+```
+
+**Key fields:**
+- `type` — always `"cron_reminder"`
+- `source` — always `"system"` (do NOT call send_reply to the chat_id, which is 0)
+- `chat_id` — always `0` (system message, no user to reply to directly)
+- `job_name` — the name of the job that just ran (use for `check_task_outputs`)
+- `exit_code` — raw shell exit code (0 = success)
+- `duration_seconds` — how long the job ran
+- `status` — `"success"` or `"failed"` (derived from exit_code)
+
+**Triage heuristic:**
+- Always relay **failures** (`status: "failed"`) with the job output or "no output recorded"
+- For successes, relay if the output contains findings, alerts, or explicit user-relevant content
+- Routine "nothing to report" outputs → silent (mark processed only)
+
+**Note:** Jobs that already call `send_reply` + `write_result` directly will produce a `subagent_result`/`subagent_notification` in addition to the `cron_reminder`. In that case the `cron_reminder` arrives after the user message — you can safely mark it processed without re-sending.
+
 ## Self-Check Reminders
 
 Self-check messages (`status? (Self-check)`) are injected automatically by the cron-based `scripts/periodic-self-check.sh` (runs every 3 minutes). You do not need to schedule them manually.

--- a/install.sh
+++ b/install.sh
@@ -1174,9 +1174,94 @@ if '$JOB_NAME' in data.get('jobs', {}):
     fi
 fi
 
+# Post a reminder to the dispatcher inbox so it learns the job completed
+POST_REMINDER="$REPO_DIR/scheduled-tasks/post-reminder.sh"
+if [ -f "$POST_REMINDER" ]; then
+    bash "$POST_REMINDER" "$JOB_NAME" "$EXIT_CODE" "$DURATION" 2>&1 | tee -a "$LOG_FILE" || true
+fi
+
 exit $EXIT_CODE
 RUNJOB
 chmod +x "$INSTALL_DIR/scheduled-tasks/run-job.sh" || true
+
+# Create post-reminder.sh
+cat > "$INSTALL_DIR/scheduled-tasks/post-reminder.sh" << 'POSTREMINDER'
+#!/bin/bash
+# Cron Job Post-Reminder
+# Called by run-job.sh after each scheduled job. Writes a cron_reminder message
+# to the Lobster inbox so the dispatcher is notified that output is available.
+#
+# Usage: post-reminder.sh <job-name> <exit-code> <duration-seconds>
+
+set -e
+
+JOB_NAME="$1"
+EXIT_CODE="${2:-0}"
+DURATION_SECONDS="${3:-0}"
+
+if [ -z "$JOB_NAME" ]; then
+    echo "Usage: $0 <job-name> <exit-code> <duration-seconds>"
+    exit 1
+fi
+
+INBOX_DIR="${LOBSTER_MESSAGES:-$HOME/messages}/inbox"
+mkdir -p "$INBOX_DIR"
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+    STATUS="success"
+else
+    STATUS="failed"
+fi
+
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%S.%6N)
+EPOCH_MS=$(date +%s%3N)
+MSG_ID="${EPOCH_MS}_cron_${JOB_NAME}"
+
+python3 - \
+    "${INBOX_DIR}/${MSG_ID}.json" \
+    "${MSG_ID}" \
+    "${TIMESTAMP}" \
+    "${JOB_NAME}" \
+    "${EXIT_CODE}" \
+    "${DURATION_SECONDS}" \
+    "${STATUS}" \
+    << 'PYEOF'
+import json, sys, os
+out_path = sys.argv[1]
+msg_id = sys.argv[2]
+timestamp = sys.argv[3]
+job_name = sys.argv[4]
+exit_code = int(sys.argv[5])
+duration_seconds = int(sys.argv[6])
+status = sys.argv[7]
+
+msg = {
+    "id": msg_id,
+    "source": "system",
+    "type": "cron_reminder",
+    "chat_id": 0,
+    "user_id": 0,
+    "username": "lobster-cron",
+    "user_name": "Cron",
+    "text": f"[Cron] Job '{job_name}' finished ({status}, {duration_seconds}s)",
+    "job_name": job_name,
+    "exit_code": exit_code,
+    "duration_seconds": duration_seconds,
+    "status": status,
+    "timestamp": timestamp,
+}
+
+tmp_path = out_path + ".tmp"
+with open(tmp_path, "w") as f:
+    json.dump(msg, f, ensure_ascii=False, indent=2)
+    f.flush()
+
+os.replace(tmp_path, out_path)
+PYEOF
+
+echo "Reminder posted for job: $JOB_NAME (status=$STATUS, duration=${DURATION_SECONDS}s)"
+POSTREMINDER
+chmod +x "$INSTALL_DIR/scheduled-tasks/post-reminder.sh" || true
 
 # Create sync-crontab.sh
 cat > "$INSTALL_DIR/scheduled-tasks/sync-crontab.sh" << 'SYNCCRON'

--- a/scheduled-tasks/post-reminder.sh
+++ b/scheduled-tasks/post-reminder.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#===============================================================================
+# Cron Job Post-Reminder
+#
+# Called by run-job.sh after each scheduled job completes. Writes a lightweight
+# cron_reminder message to the Lobster inbox so the dispatcher is notified that
+# a job finished and output is available to review.
+#
+# Usage: post-reminder.sh <job-name> <exit-code> <duration-seconds>
+#
+# The dispatcher handles cron_reminder by calling check_task_outputs for the
+# named job and surfacing the result to the user if noteworthy.
+#===============================================================================
+
+set -e
+
+JOB_NAME="$1"
+EXIT_CODE="${2:-0}"
+DURATION_SECONDS="${3:-0}"
+
+if [ -z "$JOB_NAME" ]; then
+    echo "Usage: $0 <job-name> <exit-code> <duration-seconds>"
+    exit 1
+fi
+
+INBOX_DIR="${LOBSTER_MESSAGES:-$HOME/messages}/inbox"
+mkdir -p "$INBOX_DIR"
+
+# Derive status string from exit code
+if [ "$EXIT_CODE" -eq 0 ]; then
+    STATUS="success"
+else
+    STATUS="failed"
+fi
+
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%S.%6N)
+EPOCH_MS=$(date +%s%3N)
+MSG_ID="${EPOCH_MS}_cron_${JOB_NAME}"
+
+python3 - \
+    "${INBOX_DIR}/${MSG_ID}.json" \
+    "${MSG_ID}" \
+    "${TIMESTAMP}" \
+    "${JOB_NAME}" \
+    "${EXIT_CODE}" \
+    "${DURATION_SECONDS}" \
+    "${STATUS}" \
+    << 'PYEOF'
+import json, sys
+out_path = sys.argv[1]
+msg_id = sys.argv[2]
+timestamp = sys.argv[3]
+job_name = sys.argv[4]
+exit_code = int(sys.argv[5])
+duration_seconds = int(sys.argv[6])
+status = sys.argv[7]
+
+msg = {
+    "id": msg_id,
+    "source": "system",
+    "type": "cron_reminder",
+    "chat_id": 0,
+    "user_id": 0,
+    "username": "lobster-cron",
+    "user_name": "Cron",
+    "text": f"[Cron] Job '{job_name}' finished ({status}, {duration_seconds}s)",
+    "job_name": job_name,
+    "exit_code": exit_code,
+    "duration_seconds": duration_seconds,
+    "status": status,
+    "timestamp": timestamp,
+}
+
+tmp_path = out_path + ".tmp"
+with open(tmp_path, "w") as f:
+    json.dump(msg, f, ensure_ascii=False, indent=2)
+    f.flush()
+
+import os
+os.replace(tmp_path, out_path)
+PYEOF
+
+echo "Reminder posted for job: $JOB_NAME (status=$STATUS, duration=${DURATION_SECONDS}s)"

--- a/scheduled-tasks/post-reminder.sh
+++ b/scheduled-tasks/post-reminder.sh
@@ -37,7 +37,7 @@ TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%S.%6N)
 EPOCH_MS=$(date +%s%3N)
 MSG_ID="${EPOCH_MS}_cron_${JOB_NAME}"
 
-python3 - \
+uv run - \
     "${INBOX_DIR}/${MSG_ID}.json" \
     "${MSG_ID}" \
     "${TIMESTAMP}" \

--- a/scheduled-tasks/run-job.sh
+++ b/scheduled-tasks/run-job.sh
@@ -112,4 +112,10 @@ if '$JOB_NAME' in data.get('jobs', {}):
     fi
 fi
 
+# Post a reminder to the dispatcher inbox so it learns the job completed
+POST_REMINDER="$REPO_DIR/scheduled-tasks/post-reminder.sh"
+if [ -f "$POST_REMINDER" ]; then
+    bash "$POST_REMINDER" "$JOB_NAME" "$EXIT_CODE" "$DURATION" 2>&1 | tee -a "$LOG_FILE" || true
+fi
+
 exit $EXIT_CODE


### PR DESCRIPTION
## What problem this solves

Scheduled jobs run via cron and write output to `~/messages/task-outputs/` using `write_task_output`. The dispatcher is never notified they ran — the only way to see results is manual polling via `check_task_outputs`. Output from every job goes unreviewed until the user or dispatcher explicitly asks.

## What this does

Adds `scheduled-tasks/post-reminder.sh`, called by `run-job.sh` after every job. It writes a `cron_reminder` message directly to the Lobster inbox — the same atomic JSON write pattern used by `periodic-self-check.sh`. The dispatcher picks it up on its next `wait_for_messages` cycle and calls `check_task_outputs` for the job.

The dispatcher is now documented to:
- Always relay **failures** with the job output (or "no output recorded")
- Relay successes only when output contains actionable findings
- Stay silent for routine empty/trivial outputs

## What is out of scope

Does not change how jobs report results — `write_task_output` remains the job's responsibility. Does not add retry logic or alerting for repeated failures (future work). Jobs that already call `send_reply` + `write_result` directly are unaffected; the `cron_reminder` arrives as a system message and is marked processed without re-sending.

## Implementation notes

The script is a pure data transformation: exit code → status string, arguments → JSON message struct, written via `os.replace()` for crash-safe atomicity. No new dependencies, no MCP calls, no Claude instance needed — runs in ~100ms after every job.

`install.sh` is updated with an inline heredoc so both fresh installs and `install.sh` re-runs produce the updated scripts.

## Tests run

- [x] `bash scheduled-tasks/post-reminder.sh test-job 0 42` — wrote valid `cron_reminder` JSON to inbox, confirmed message shape matches dispatcher doc
- [x] Pre-push security scanner — clean, no issues
- [ ] Full integration test (live cron + dispatcher handling) — requires a running Lobster session; safe to merge, the dispatcher change is additive (new message type, existing types unaffected)

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)