### PR TITLE
fix: remove restrictive tools list from lobster-ops agent

### DIFF
--- a/.claude/agents/lobster-ops.md
+++ b/.claude/agents/lobster-ops.md
@@ -1,7 +1,6 @@
 ---
 name: lobster-ops
 description: Lobster system operations specialist. Use for troubleshooting services, checking logs, managing configuration, and understanding the Lobster architecture.
-tools: Read, Grep, Glob, Bash
 model: haiku
 ---
 


### PR DESCRIPTION
## Summary

- Removes the `tools: Read, Grep, Glob, Bash` line from `lobster-ops` agent frontmatter
- Without MCP tools in scope, the agent could not call `write_result` or `send_reply`, causing SubagentStop hook violations
- This matches `lobster-generalist` behavior: no `tools:` restriction means all tools are available by default

## Test plan

- [ ] Invoke `lobster-ops` subagent and verify it can call `mcp__lobster-inbox__send_reply`
- [ ] Verify `mcp__lobster-inbox__write_result` is accessible to the agent
- [ ] Confirm operations diagnostics still work (Bash, Read, Grep, Glob are all included by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)