### PR TITLE
fix(agents): remove tool restriction from lobster-ops — enables write_result and send_reply

### DIFF
--- a/.claude/agents/lobster-ops.md
+++ b/.claude/agents/lobster-ops.md
@@ -1,7 +1,6 @@
 ---
 name: lobster-ops
 description: Lobster system operations specialist. Use for troubleshooting services, checking logs, managing configuration, and understanding the Lobster architecture.
-tools: Read, Grep, Glob, Bash
 model: haiku
 ---
 


### PR DESCRIPTION
## Summary

The `lobster-ops` subagent had a `tools: Read, Grep, Glob, Bash` line in its frontmatter that hard-restricted it to filesystem tools only. This meant it could not call `mcp__lobster-inbox__send_reply` or `mcp__lobster-inbox__write_result` — the two MCP tools every subagent is required to call at task completion. The result was SubagentStop hook violations on every lobster-ops invocation.

This fix removes the `tools:` line so lobster-ops inherits all available tools by default, matching the behavior of lobster-generalist and every other subagent in the system. The agent's instructions already document the correct send_reply → write_result pattern; this change unblocks it from actually executing that pattern.

The `model: haiku` line and all agent behavior are untouched — only the tool restriction is removed.

## Context

This same fix was previously applied in 7bb3fd4 and then reverted in 45ee1c0 as part of a broader revert. This PR re-applies only the tool restriction fix, cleanly, without the reverted commit's other changes.

## Functional patterns

Pure configuration change — no code logic involved.

## Tests run

- [ ] Live dispatcher test with lobster-ops invocation — blocked: requires production restart and Sahar's sign-off before merge

**Blocked items needing attention before merge:** Needs Sahar's review and a live test confirming lobster-ops can successfully call write_result after the change is deployed.

🤖 Lobster