### PR TITLE
fix(hooks): fix SubagentStop loop — read JSONL transcript and suppress feedback injection

### DIFF
--- a/hooks/require-write-result.py
+++ b/hooks/require-write-result.py
@@ -43,6 +43,15 @@ CC 2.1.76+. Both pass a file path instead:
 This hook reads the appropriate file path for each event type. An inline
 `transcript` field is supported as a legacy fallback for older CC versions.
 
+## JSONL message format
+
+Each line of the JSONL transcript file has the structure:
+    {"type": "assistant", "message": {"role": "assistant", "content": [...]}, ...}
+
+Tool use items are nested under entry["message"]["content"], NOT entry["content"].
+`_collect_tool_use_and_text` handles both the JSONL format and the legacy inline
+format where content is directly on the message dict.
+
 ## Suppressing feedback injection on success
 
 Claude Code injects a "Stop hook feedback: ... No stderr output" system message
@@ -156,13 +165,32 @@ def _load_transcript_from_jsonl(path: str) -> list:
 
 
 def _collect_tool_use_and_text(transcript: list) -> tuple[list, list]:
-    """Walk a transcript and return (tool_use_items, text_content_parts)."""
+    """Walk a transcript and return (tool_use_items, text_content_parts).
+
+    Handles both JSONL format (CC 2.1.76+) and legacy inline format:
+
+    JSONL format (each line is a JSONL entry):
+        {"type": "assistant", "message": {"role": "assistant", "content": [...]}, ...}
+
+    Legacy inline format (transcript is a list of messages):
+        {"role": "assistant", "content": [...]}
+
+    Both formats are tried so the hook works regardless of CC version.
+    """
     all_tool_use_items = []
     text_content_parts = []
-    for msg in transcript:
-        if not isinstance(msg, dict):
+    for entry in transcript:
+        if not isinstance(entry, dict):
             continue
-        content = msg.get("content", [])
+
+        # JSONL format: content is under entry["message"]["content"]
+        # Legacy format: content is directly under entry["content"]
+        nested_msg = entry.get("message")
+        if isinstance(nested_msg, dict):
+            content = nested_msg.get("content", [])
+        else:
+            content = entry.get("content", [])
+
         if not isinstance(content, list):
             continue
         for item in content:

--- a/tests/unit/test_hooks/test_require_write_result.py
+++ b/tests/unit/test_hooks/test_require_write_result.py
@@ -55,8 +55,49 @@ def _make_tool_use_item(name: str, input_data: dict) -> dict:
     return {"type": "tool_use", "name": name, "input": input_data}
 
 
+def _make_jsonl_entry_with_write_result(chat_id=12345, task_id="task-abc") -> dict:
+    """Return a single JSONL entry (CC 2.1.76+ format) containing a write_result call."""
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                _make_tool_use_item(
+                    "mcp__lobster-inbox__write_result",
+                    {"chat_id": chat_id, "task_id": task_id, "text": "done"},
+                )
+            ],
+        },
+        "uuid": "test-uuid-1",
+        "sessionId": "test-session",
+    }
+
+
+def _make_jsonl_entry_no_write_result() -> dict:
+    """Return a single JSONL entry with no write_result call."""
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "I finished the task."}],
+        },
+        "uuid": "test-uuid-2",
+        "sessionId": "test-session",
+    }
+
+
 def _make_transcript_with_write_result(chat_id=12345, task_id="task-abc") -> list:
-    """Return a minimal inline transcript containing a write_result call."""
+    """Return a JSONL-format transcript list containing a write_result call."""
+    return [_make_jsonl_entry_with_write_result(chat_id=chat_id, task_id=task_id)]
+
+
+def _make_transcript_no_write_result() -> list:
+    """Return a JSONL-format transcript list with no write_result call."""
+    return [_make_jsonl_entry_no_write_result()]
+
+
+def _make_transcript_with_write_result_legacy(chat_id=12345, task_id="task-abc") -> list:
+    """Return a legacy inline transcript (content directly on message dict)."""
     return [
         {
             "role": "assistant",
@@ -66,16 +107,6 @@ def _make_transcript_with_write_result(chat_id=12345, task_id="task-abc") -> lis
                     {"chat_id": chat_id, "task_id": task_id, "text": "done"},
                 )
             ],
-        }
-    ]
-
-
-def _make_transcript_no_write_result() -> list:
-    """Return a minimal inline transcript with no write_result call."""
-    return [
-        {
-            "role": "assistant",
-            "content": [{"type": "text", "text": "I finished the task."}],
         }
     ]
 
@@ -221,9 +252,9 @@ class TestStopHook:
         assert "STOP:" not in stdout
 
     def test_legacy_inline_transcript_still_works(self, monkeypatch, tmp_path):
-        """Legacy CC: inline transcript[] field works when transcript_path absent."""
+        """Legacy CC: inline transcript[] with legacy message format works."""
         mod = _load_hook(monkeypatch, tmp_path)
-        transcript = _make_transcript_with_write_result(chat_id=12345)
+        transcript = _make_transcript_with_write_result_legacy(chat_id=12345)
         hook_input = _make_stop_hook_input_legacy(transcript)
 
         exit_code, stdout, stderr = _run_hook(mod, hook_input)


### PR DESCRIPTION
## Root cause

Two bugs in `hooks/require-write-result.py` caused subagents to loop after calling `write_result`:

**Bug 1: SubagentStop passes transcript as a file, not inline**

`SubagentStop` hook events do NOT include a `transcript` field in the stdin JSON. Instead they pass `agent_transcript_path` — a path to a `.jsonl` file. The hook was calling `data.get("transcript", [])` which always returned `[]` for SubagentStop events. Result: `write_result` was never found in the transcript, the hook exited 2 (block), and the subagent was forced to keep running — even though it had already called `write_result`.

**Bug 2: CC 2.1.76+ injects feedback even on exit 0**

Claude Code injects a `"Stop hook feedback: [python3 ...require-write-result.py]: No stderr output"` system message into the agent even when the hook exits 0 with no output. The agent saw this feedback and entered a new turn, reading the hook file to understand why it got a "stop hook feedback" message. Per the CC hook spec, outputting `{"suppressOutput": true}` on exit 0 suppresses this injection.

**Bonus fix: blocking messages now use stderr**

The CC hook spec says exit-2 feedback comes from stderr, not stdout. The original code used `print()` (stdout) for blocking messages. Fixed to use `print(..., file=sys.stderr)`.

## Changes

- `hooks/require-write-result.py`: detect `SubagentStop` event by `hook_event_name` field; read transcript from `agent_transcript_path` JSONL file; emit `{"suppressOutput": true}` JSON on all success exits; move blocking messages to stderr
- `tests/unit/test_hooks/test_require_write_result.py`: 13 new unit tests covering both Stop and SubagentStop paths

## Test plan

- [x] All 13 new unit tests pass (`uv run --with pytest pytest tests/unit/test_hooks/test_require_write_result.py -v`)
- [x] Stop hook: exits 0 + suppressOutput JSON when write_result was called
- [x] Stop hook: exits 2 + stderr when write_result was not called
- [x] SubagentStop hook: reads JSONL transcript from agent_transcript_path
- [x] SubagentStop hook: exits 0 when write_result found in JSONL
- [x] SubagentStop hook: exits 2 when write_result not found in JSONL
- [x] SubagentStop hook: exits 0 (safe fallback) when transcript path is empty
- [x] Dispatcher sessions always exit 0
- [x] chat_id=0 is valid (background agents)
- [x] Fix deployed to ~/lobster/ (live immediately via symlink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)