### PR TITLE
fix: mark stale 'running' agent rows as dead on server startup (#510)

### DIFF
--- a/src/agents/session_store.py
+++ b/src/agents/session_store.py
@@ -19,11 +19,14 @@ Design principles:
   - WAL mode eliminates reader/writer blocking across processes
 """
 
+import logging
 import os
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # DB path resolution
@@ -415,6 +418,12 @@ def cleanup_stale_running_sessions(
        since ``spawned_at`` exceeds ``timeout_minutes`` (or a generous default
        of 120 minutes) — best-effort cleanup for unregistered output files.
 
+    **Assumption:** subagents cannot outlive a server restart. Claude Code
+    subagents run as child processes of the MCP server; when the server is
+    killed (e.g. ``systemctl restart``), all subagents are killed with it.
+    This means any ``status='running'`` row found at startup time cannot
+    belong to a genuinely live agent — it is always safe to mark it dead.
+
     All matched rows are marked ``status='dead'`` with a ``completed_at``
     timestamp of ``server_start_time`` so callers know when the cleanup ran.
 
@@ -487,6 +496,17 @@ def cleanup_stale_running_sessions(
                         )
                 except (ValueError, TypeError):
                     pass
+            else:
+                # No output_file and no spawned_at — cannot determine age.
+                # This row stays 'running' and will never be auto-cleaned by this
+                # function. Log a warning so the condition is visible rather than
+                # silently ignored.
+                log.warning(
+                    "[startup-cleanup] session %r has no output_file and no "
+                    "spawned_at — cannot determine age, leaving as 'running'. "
+                    "Manual cleanup may be required.",
+                    agent_id,
+                )
 
         if should_kill:
             conn.execute(

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -652,6 +652,13 @@ except Exception as _ss_err:
 # stop_reason=tool_use, which the reconciler treats as still-running. We fix this
 # here by checking file existence and mtime against the server start time — any
 # output file that predates this process startup cannot belong to a live agent.
+#
+# Note on asymmetric notification: this sweep intentionally does NOT enqueue user
+# notifications for the sessions it marks dead. This is a bulk-cleanup pass, not a
+# live event. Any sessions that were completed/dead before this restart but not yet
+# notified are handled by the reconciler's _startup_sweep(), which fires immediately
+# after the reconciler loop starts and handles the notification backlog. Separating
+# the two concerns keeps this code path simple and idempotent.
 try:
     _dead_ids = _session_store.cleanup_stale_running_sessions(
         server_start_time=_SERVER_START_TIME

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -7,9 +7,12 @@ Tests:
   - format_active_sessions_block: compact display helper
 """
 
+import os
 import pathlib
 import sys
 import tempfile
+import time as _time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -461,9 +464,6 @@ def test_json_migration_missing_json_is_noop(tmp_path):
 # Test: cleanup_stale_running_sessions (issue #510)
 # ---------------------------------------------------------------------------
 
-import time as _time
-from datetime import datetime, timezone, timedelta
-
 
 def test_cleanup_stale_running_no_output_file(isolated_db):
     """Session with no output_file and elapsed > timeout_minutes is marked dead."""
@@ -519,7 +519,6 @@ def test_cleanup_stale_running_output_old_mtime(isolated_db, tmp_path):
 
     # Set mtime to 10 minutes ago
     old_ts = _time.time() - 600
-    import os
     os.utime(str(output_file), (old_ts, old_ts))
 
     session_store.session_start(
@@ -595,3 +594,114 @@ def test_cleanup_stale_running_skips_no_file_within_timeout(isolated_db):
     assert "recent-no-file" not in dead
     result = session_store.find_session("recent-no-file", path=db)
     assert result["status"] == "running"
+
+
+def test_cleanup_stale_running_oserror_marks_dead(isolated_db, tmp_path):
+    """Session whose output_file raises OSError is marked dead (unreadable path)."""
+    db = isolated_db
+    # Use a path inside a non-existent directory to provoke OSError on resolve/stat.
+    # Path.resolve() on a dangling path inside a missing parent dir can raise OSError
+    # on some filesystems; we simulate by patching Path.resolve to raise.
+    import unittest.mock as mock
+
+    output_path = str(tmp_path / "unreadable.output")
+
+    session_store.session_start(
+        id="oserror-agent",
+        description="Agent with unreadable output",
+        chat_id="123",
+        output_file=output_path,
+        path=db,
+    )
+
+    # Patch Path.resolve to raise OSError for this specific path
+    original_resolve = Path.resolve
+
+    def patched_resolve(self, **kwargs):
+        if str(self) == output_path:
+            raise OSError("Permission denied (simulated)")
+        return original_resolve(self, **kwargs)
+
+    with mock.patch.object(Path, "resolve", patched_resolve):
+        server_start = datetime.now(timezone.utc)
+        dead = session_store.cleanup_stale_running_sessions(server_start, path=db)
+
+    assert "oserror-agent" in dead
+    result = session_store.find_session("oserror-agent", path=db)
+    assert result["status"] == "dead"
+    assert "unreadable" in result["result_summary"]
+
+
+def test_cleanup_stale_running_null_spawned_at_no_output_file_skips_with_warning(
+    isolated_db, caplog
+):
+    """Session with no output_file AND no spawned_at stays running and logs a warning.
+
+    The current schema has spawned_at NOT NULL, so this combination cannot arise
+    through normal inserts. The warning branch is defensive code for future schema
+    changes or direct DB manipulation. We test it by patching the DB cursor to
+    return a synthetic row with both fields set to None.
+    """
+    import logging
+    import unittest.mock as mock
+
+    db = isolated_db
+    server_start = datetime.now(timezone.utc)
+
+    # Build a fake row dict that looks like what the cursor would return
+    fake_row = {
+        "id": "null-everything",
+        "output_file": None,
+        "spawned_at": None,
+        "timeout_minutes": None,
+    }
+
+    # Patch _get_connection to return a mock whose .execute().fetchall() returns our row
+    mock_cursor = mock.MagicMock()
+    mock_cursor.fetchall.return_value = [fake_row]
+    mock_conn = mock.MagicMock()
+    mock_conn.execute.return_value = mock_cursor
+
+    with mock.patch.object(session_store, "_get_connection", return_value=mock_conn):
+        with caplog.at_level(logging.WARNING, logger="agents.session_store"):
+            dead = session_store.cleanup_stale_running_sessions(server_start, path=db)
+
+    # Row has no actionable info — should not be marked dead
+    assert "null-everything" not in dead
+
+    # Should have logged a warning about the uncleanable row
+    assert any("null-everything" in record.message for record in caplog.records)
+    assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+
+def test_reconciler_check_output_file_status_running_for_stuck_tool_use(tmp_path):
+    """check_output_file_status returns 'running' for a file with stop_reason=tool_use.
+
+    This exercises the precondition for the reconciler's 60-min dead-threshold
+    branch: a file stuck at tool_use is treated as 'running', not 'missing' or
+    'done', so the normal 25-min threshold does not fire and only the 60-min
+    threshold applies.
+    """
+    output_file = tmp_path / "stuck_agent.output"
+    # JSONL with last stop_reason = tool_use (simulating mid-turn stuck state)
+    output_file.write_text(
+        '{"type": "result", "stop_reason": "tool_use", "subtype": "tool_use"}\n'
+    )
+
+    status = session_store.check_output_file_status(str(output_file))
+    assert status == "running", (
+        f"Expected 'running' for tool_use output file, got {status!r}"
+    )
+
+
+def test_reconciler_check_output_file_status_done_for_end_turn(tmp_path):
+    """check_output_file_status returns 'done' for a file with stop_reason=end_turn."""
+    output_file = tmp_path / "finished_agent.output"
+    output_file.write_text(
+        '{"type": "result", "stop_reason": "end_turn", "subtype": "end_turn"}\n'
+    )
+
+    status = session_store.check_output_file_status(str(output_file))
+    assert status == "done", (
+        f"Expected 'done' for end_turn output file, got {status!r}"
+    )


### PR DESCRIPTION
## Problem

After a force-restart (`systemctl restart`), subagents that were mid-execution are killed before writing a final `stop_reason=end_turn`. Their output files are stuck at `stop_reason=tool_use`. The reconciler's `check_output_file_status()` returns `"running"` for those files, so the normal dead-threshold logic (which only fires on `"missing"` files) never applies. Those rows stay `status='running'` forever — inflating the active-session count and misleading the dispatcher.

## Two-component fix

### Component 1: Startup sweep (`cleanup_stale_running_sessions`)

Called once at module load in `inbox_server.py`, before the reconciler loop begins. Iterates every `status='running'` row and marks it `'dead'` if any of these is true:

- Its `output_file` doesn't exist on disk
- Its `output_file` mtime predates `_SERVER_START_TIME` (cannot belong to an agent from this server run)
- Fallback: no `output_file` registered and `elapsed > timeout_minutes` (or 120m default)

This sweep marks rows dead with `completed_at = _SERVER_START_TIME` and `notified_at IS NULL`. It does **not** send user notifications — that is the reconciler's job (see below).

### Component 2: Reconciler dead-threshold for `file_status == "running"`

Adds the missing branch in `reconcile_agent_sessions()`. If a session's output file has been stuck at `tool_use` for more than 60 minutes, the reconciler marks it dead and enqueues a notification. This is a fallback for sessions the startup sweep misses (e.g. the output file mtime was updated by an unrelated process after restart).

## How the two components connect (the notification handoff)

The startup sweep and `_startup_sweep()` (the reconciler's own startup routine) are complementary and run in sequence:

1. **Module load** (synchronous): `cleanup_stale_running_sessions()` marks pre-restart rows `status='dead'`, `notified_at=NULL`.
2. **Reconciler first tick** (async, seconds later): `_startup_sweep()` calls `get_unnotified_completed(since_hours=24)`, which queries `status IN ('completed', 'dead') AND notified_at IS NULL`. The rows from step 1 match this query — so `_startup_sweep()` picks them up and enqueues user notifications.

This means: yes, the reconciler reliably delivers notifications for every session the startup sweep closes. The two passes are decoupled by design — cleanup and notification are separate concerns.

## Before / after

**Before:** A force-restart left rows at `status='running'` indefinitely. No notification was ever sent. The dispatcher saw phantom active sessions.

**After:** Within seconds of server start, all pre-restart sessions are closed and their notifications are queued. The dispatcher sees a clean active-session count.

## Functional patterns used

- Pure function `cleanup_stale_running_sessions` — takes `server_start_time` as an explicit argument, no global state, deterministic given the same DB and filesystem
- Immutable comparison: file mtime vs. `_SERVER_START_TIME` (recorded once at module load, never mutated)
- Separation of concerns: startup sweep = bulk status closer; reconciler `_startup_sweep` = notification sender; reconciler loop = live 60-min fallback

## Scope

Only `session_store.py`, `inbox_server.py` (startup block + reconciler), and `tests/test_agent_sessions.py` are changed. No schema migrations needed — no new columns. No behavior change for live agents (fresh output files pass the mtime check; sessions within timeout are skipped).

## Tests

- [x] `uv run pytest tests/test_agent_sessions.py -v` — 25 passed, 3 failed. The 3 failures (`test_optional_fields`, `test_tracker_add_with_all_params`, `test_json_migration`) are pre-existing on `main` (undefined `OWNER_CHAT_ID_PLACEHOLDER`). All 6 new tests pass.

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)