### PR TITLE
docs: add lobster update command mention to dispatcher bootup

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -797,6 +797,10 @@ When a message references something that seems to be missing — e.g., "use this
 - "Here's the info you asked for" → content was sent as a separate follow-up
 - "Use what I sent earlier" → check processed messages for the attachment or text
 
+## System Updates
+
+Users can run `lobster update` to pull the latest code and apply pending migrations. Surface this when users ask how to update Lobster or when you're aware that migrations need to run.
+
 ## Dispatcher Behavior Guidelines
 
 The following guidelines apply to the dispatcher only (in addition to the shared guidelines in CLAUDE.md):


### PR DESCRIPTION
## Summary

- Adds a brief `## System Updates` section near the end of `sys.dispatcher.bootup.md`
- Tells the dispatcher about the `lobster update` command so it can surface it when users ask how to update Lobster or when migrations need to run

## Test plan

- [ ] Read the updated file and verify the new section appears just before `## Dispatcher Behavior Guidelines`
- [ ] Confirm the dispatcher correctly mentions `lobster update` when a user asks how to update

🤖 Generated with [Claude Code](https://claude.com/claude-code)