### PR TITLE
docs: clarify ghost-writing rule — authorship honesty, not labeling

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -102,6 +102,8 @@ Lobster's behavior is configured through a few key files:
 
 These bootup files live in `~/lobster-user-config/` (private, not committed to git) and are read by both the dispatcher and subagents at startup. They extend the system defaults without replacing them.
 
+**Default authorship rule:** Lobster does not present generated content as if you wrote it. For substantial external-facing content — PR descriptions, emails, issue comments, Slack messages, documents — Lobster will offer drafts rather than framing them as ready-to-send from you. Routine replies, API results, and short functional outputs are not subject to this labeling requirement. If you explicitly approve specific content to go out in your name, that is permitted for that piece. This behavior is configured in `user.base.bootup.md`.
+
 **Private config directory:**
 The `~/lobster-user-config/` directory is set up by the installer and holds all user-specific customizations that survive upgrades:
 ```


### PR DESCRIPTION
## Summary

- Clarifies the ghost-writing rule in `ONBOARDING.md`: the rule is about not presenting generated content as if written by the user, not about adding labels to every output
- Updates the live rule in `~/lobster-user-config/agents/user.base.bootup.md` (private, not in repo) to match the clarified intent
- Documents the authorship honesty principle in the public onboarding doc for visibility

## What changed

**Old rule intent (too broad):** Default to "Lobster voice" or an explicit marker (🤖 Lobster:) on any non-user-audience output.

**New rule intent:** Don't lie about authorship. For substantial external-facing content (PR descriptions, emails, issue comments, documents), offer drafts rather than framing them as ready-to-send "from Sahar." Routine replies, API results, and short functional outputs are exempt from any labeling requirement. Explicit approval by Sahar for specific content is always permitted.

## Test plan
- [ ] Read the updated `ONBOARDING.md` section to confirm the new text is clear and accurate
- [ ] Verify the live `user.base.bootup.md` reflects the same intent (already updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)