### PR TITLE
fix: on-compact Telegram notify silent after compaction (moves guards)

### DIFF
--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -241,30 +241,37 @@ def main() -> None:
     except (json.JSONDecodeError, ValueError):
         data = {}
 
-    # Only act for the dispatcher session. Subagent compactions must not
-    # inject compact-reminders into the shared inbox or write the sentinel,
-    # because those signals are only meaningful to the dispatcher.
+    # Always record compaction timestamp — runs for both dispatcher and subagent
+    # compactions.  The health check reads this to suppress false-positive
+    # "stale inbox" restarts during any compaction pause window.
+    write_compacted_at()
+
+    # Always send the debug Telegram notification when LOBSTER_DEBUG=true.
+    # This must fire even for the dispatcher compact, where is_dispatcher() would
+    # return False because context compaction assigns a new session_id that no
+    # longer matches the stored dispatcher-session-id marker file.
+    # NOTE: In debug mode this also fires for subagent compactions (rare), which
+    # is acceptable — the notification is informational.
+    maybe_send_dev_telegram_notify()
+
+    # Guard the inbox reminder and sentinel writes to the dispatcher only.
+    # Subagent compactions must not inject compact-reminders into the shared
+    # inbox or write the compact-pending sentinel, because those signals are
+    # only meaningful to the dispatcher.
     if not is_dispatcher(data):
         sys.exit(0)
-
-    # Always record compaction timestamp first — before any early returns.
-    # This ensures the health check can suppress false-positive restarts even
-    # if a compact-reminder is already pending.
-    write_compacted_at()
 
     if already_pending():
         # Sentinel still needs refreshing even if the inbox reminder is a dupe
         # (double compaction without intervening wait_for_messages). Touch resets
         # the TTL clock so the gate keeps blocking correctly.
         write_sentinel()
-        maybe_send_dev_telegram_notify()
         return
     write_sentinel()
     try:
         write_reminder()
     except Exception:  # noqa: BLE001
         pass  # Reminder failure is non-fatal — sentinel is the critical artifact
-    maybe_send_dev_telegram_notify()
 
 
 if __name__ == "__main__":

--- a/tests/smoke/test_on_compact.py
+++ b/tests/smoke/test_on_compact.py
@@ -23,14 +23,27 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import io
 import json
 import os
 import sys
 import types
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+
+
+@contextmanager
+def _stdin_from_module(mod: types.ModuleType):
+    """Replace sys.stdin with a StringIO containing the module's test hook input."""
+    old_stdin = sys.stdin
+    sys.stdin = io.StringIO(mod._test_stdin_data)
+    try:
+        yield
+    finally:
+        sys.stdin = old_stdin
 
 
 # ---------------------------------------------------------------------------
@@ -44,6 +57,7 @@ def _load_hook(
     inbox_dir: Path,
     state_file: Path,
     sentinel_file: Path,
+    session_id: str = "test-dispatcher-session",
 ) -> types.ModuleType:
     """
     Load hooks/on-compact.py as a fresh module with patched path constants.
@@ -68,6 +82,19 @@ def _load_hook(
     # Suppress the Telegram dev-notify side-effect — we never want real network
     # calls in smoke tests and we don't want to depend on config.env being present.
     mod.maybe_send_dev_telegram_notify = lambda: None  # type: ignore[attr-defined]
+
+    # Stub is_dispatcher to return True so tests exercise the dispatcher path.
+    # The real is_dispatcher() checks a marker file + transcript; in tests there
+    # is no marker file and no stdin transcript, so it would return False and
+    # silently exit without writing any inbox/state files.
+    mod.is_dispatcher = lambda _data: True  # type: ignore[attr-defined]
+
+    # Patch sys.stdin so main()'s json.load(sys.stdin) gets a valid compact event
+    # rather than hitting pytest's captured stdin which raises OSError.
+    hook_input = json.dumps(
+        {"session_id": session_id, "hook_event_name": "SessionStart", "is_compact": True}
+    )
+    mod._test_stdin_data = hook_input  # store for reference
 
     return mod
 
@@ -102,7 +129,8 @@ def test_on_compact_runs_without_crashing(tmp_path: Path) -> None:
     mod = _load_hook(inbox_dir, state_file, sentinel_file)
 
     # Should complete without raising.
-    mod.main()
+    with _stdin_from_module(mod):
+        mod.main()
 
 
 # ---------------------------------------------------------------------------
@@ -124,7 +152,8 @@ def test_on_compact_writes_compact_reminder(tmp_path: Path) -> None:
     sentinel_file = tmp_path / "config" / "compact-pending"
 
     mod = _load_hook(inbox_dir, state_file, sentinel_file)
-    mod.main()
+    with _stdin_from_module(mod):
+        mod.main()
 
     reminders = _compact_reminders(inbox_dir)
     assert len(reminders) == 1, (
@@ -161,7 +190,8 @@ def test_on_compact_writes_compacted_at_to_state(tmp_path: Path) -> None:
     sentinel_file = tmp_path / "config" / "compact-pending"
 
     mod = _load_hook(inbox_dir, state_file, sentinel_file)
-    mod.main()
+    with _stdin_from_module(mod):
+        mod.main()
 
     assert state_file.exists(), f"lobster-state.json was not created at {state_file}"
 
@@ -217,12 +247,14 @@ def test_on_compact_idempotent(tmp_path: Path) -> None:
 
     # First invocation — normal path.
     mod = _load_hook(inbox_dir, state_file, sentinel_file)
-    mod.main()
+    with _stdin_from_module(mod):
+        mod.main()
 
     # Second invocation — simulates double-compaction (compact event fires
     # again before the dispatcher has consumed the first reminder).
     mod2 = _load_hook(inbox_dir, state_file, sentinel_file)
-    mod2.main()
+    with _stdin_from_module(mod2):
+        mod2.main()
 
     reminders = _compact_reminders(inbox_dir)
     assert len(reminders) == 1, (


### PR DESCRIPTION
Fixes #524.

## Summary

- After context compaction, Claude Code assigns a new session_id to the continuing dispatcher. `is_dispatcher()` compares this against the stored `dispatcher-session-id` marker file (still holding the pre-compact session_id), sees a mismatch, returns `False`, and the hook silently exits before sending the Telegram notification or writing `compacted_at`.
- PR #397 placed `write_compacted_at()` and `maybe_send_dev_telegram_notify()` after the `is_dispatcher()` guard. Both should fire for any compaction. Only the inbox reminder and sentinel writes need the dispatcher guard.
- PR #397 also broke all 4 `test_on_compact.py` smoke tests: `json.load(sys.stdin)` hits pytest's captured stdin and raises `OSError`.

## Changes

- `hooks/on-compact.py`: move `write_compacted_at()` and `maybe_send_dev_telegram_notify()` before the `is_dispatcher()` guard
- `tests/smoke/test_on_compact.py`: add `_stdin_from_module()` context manager, stub `is_dispatcher` to True, wrap all `mod.main()` calls

## Test plan

- [ ] `uv run python -m pytest tests/smoke/test_on_compact.py -v` passes (all 4)
- [ ] With `LOBSTER_DEBUG=true`, trigger a compaction and confirm Telegram message is received
- [ ] Subagent compacts (rare) now also send Telegram notify in debug mode — acceptable, informational only

🤖 Generated with [Claude Code](https://claude.com/claude-code)