### PR TITLE
fix: add Migration 14 to backfill periodic-self-check.sh cron entry

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1157,6 +1157,21 @@ run_migrations() {
         migrated=$((migrated + 1))
     fi
 
+    # Migration 14: Ensure periodic-self-check.sh cron entry exists
+    # The cron entry was added to install.sh in commit 420903e but was never
+    # backfilled as a migration. Existing installs are missing the entry,
+    # so the self-check system (background agent completion checks) never fires.
+    local SELFCHECK_MARKER="# LOBSTER-SELF-CHECK"
+    if ! crontab -l 2>/dev/null | grep -q "$SELFCHECK_MARKER"; then
+        local selfcheck_script="$LOBSTER_DIR/scripts/periodic-self-check.sh"
+        chmod +x "$selfcheck_script" 2>/dev/null || true
+        mkdir -p "$LOBSTER_DIR/.state"
+        ({ crontab -l 2>/dev/null | grep -v "$SELFCHECK_MARKER" | grep -v "periodic-self-check" || true; }; \
+         echo "*/3 * * * * $selfcheck_script $SELFCHECK_MARKER") | crontab -
+        substep "Added periodic-self-check.sh to crontab (every 3 minutes)"
+        migrated=$((migrated + 1))
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## Problem

Existing installs are missing the `periodic-self-check.sh` cron entry entirely, so the background agent completion check never fires. The cron job — which runs every 3 minutes and checks whether background subagents have finished work to report — was added to `install.sh` in commit 420903e, but no upgrade migration was ever written to backfill it on existing installs.

The install.sh cron section at line 1401-1403 correctly uses the `# LOBSTER-SELF-CHECK` idempotency marker, but `upgrade.sh` has no corresponding migration, leaving all pre-420903e installs with only the health-check cron entry (`# LOBSTER-HEALTH`) and no self-check.

## What this changes

Adds Migration 14 to `upgrade.sh`, following the same pattern as Migration 13 (the health-check backfill). If the `# LOBSTER-SELF-CHECK` marker is absent from the crontab, the migration:

- makes `periodic-self-check.sh` executable
- creates `.state/` (required by the script's rate-limiting logic)
- adds `*/3 * * * * .../periodic-self-check.sh # LOBSTER-SELF-CHECK` to the crontab

The guard is idempotent: installs that already have the entry (from a fresh install after 420903e) are unaffected.

`install.sh` is unchanged — the cron entry was already correct there.

## Audit findings

- `periodic-self-check.sh` was introduced in commit 420903e ("Add self-check reminder system with tests and installer integration"), which also added the cron entry to `install.sh`.
- The cron entry was never in `upgrade.sh` — it was omitted from the original PR and no follow-up migration was filed.
- The entry is not present in the current crontab on this system (`crontab -l` shows only `# LOBSTER-HEALTH`), confirming the gap affects live installs.

## Functional patterns used

Pure shell with idempotent guard (`grep -q` before write), immutable crontab replacement (read-filter-append pipeline), no shared state mutation.

## Tests run

- [x] `git diff scripts/upgrade.sh` — reviewed the 15-line addition, matches Migration 13 structure exactly
- [x] `bash -n scripts/upgrade.sh` — syntax check passed
- [ ] Live migration run — skipped: would modify the host crontab; the guard logic is identical to Migration 13 which is already deployed and working

**Blocked items needing attention before merge:** none