### PR TITLE
fix: prevent crontab overwrites with safe cron-manage.sh wrapper

### DIFF
--- a/.claude/agents/lobster-ops.md
+++ b/.claude/agents/lobster-ops.md
@@ -66,6 +66,12 @@ Options:
 
 When writing a PR that ships new subagent definitions, new config file locations, new required directories, service renames, or cron entries, add a corresponding numbered migration to `upgrade.sh` following the existing pattern.
 
+**Crontab safety:** Never write `echo "..." | crontab -` directly — it overwrites the entire crontab and destroys unrelated entries (this is how the LOBSTER-SELF-CHECK entry was lost). Always use:
+```bash
+~/lobster/scripts/cron-manage.sh add "# LOBSTER-MY-MARKER" "*/5 * * * * /path/to/script.sh # LOBSTER-MY-MARKER"
+~/lobster/scripts/cron-manage.sh remove "# LOBSTER-MY-MARKER"
+```
+
 ## Common Troubleshooting
 
 1. **Claude not responding**: Check tmux session exists, check for errors in session

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -295,6 +295,12 @@ Lobster uses a tiered model strategy to balance cost and quality. Each subagent 
 
 - **Python:** Always use `uv run` not `python` or `python3`.
 
+- **Crontab changes:** Never write `echo "..." | crontab -` directly — this overwrites the entire crontab and destroys unrelated entries. Always use `~/lobster/scripts/cron-manage.sh add/remove` instead:
+  ```bash
+  ~/lobster/scripts/cron-manage.sh add "# LOBSTER-MY-MARKER" "*/5 * * * * /path/to/script.sh # LOBSTER-MY-MARKER"
+  ~/lobster/scripts/cron-manage.sh remove "# LOBSTER-MY-MARKER"
+  ```
+
 ## PR and Issue Body: Always Canonical
 
 The body of a PR or issue is the canonical state of that work — not just the opening post. As things evolve (reviews, new commits, design changes, resolved concerns, scope changes), update the body to reflect what the thing *is* now, not what it was when opened.

--- a/install.sh
+++ b/install.sh
@@ -1359,9 +1359,8 @@ step "Setting up health monitoring..."
 chmod +x "$INSTALL_DIR/scripts/health-check-v3.sh" || true
 
 # Add health check to crontab (runs every 4 minutes)
-HEALTH_MARKER="# LOBSTER-HEALTH"
-({ crontab -l 2>/dev/null | grep -v "$HEALTH_MARKER" | grep -v "health-check" || true; }; \
- echo "*/4 * * * * $INSTALL_DIR/scripts/health-check-v3.sh $HEALTH_MARKER") | crontab -
+"$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-HEALTH" \
+    "*/4 * * * * $INSTALL_DIR/scripts/health-check-v3.sh # LOBSTER-HEALTH"
 
 success "Health monitoring configured (checks every 4 minutes)"
 
@@ -1374,9 +1373,8 @@ step "Setting up daily dependency health check..."
 chmod +x "$INSTALL_DIR/scripts/daily-health-check.sh" || true
 
 # Add daily health check to crontab (runs at 06:00 every day)
-DAILY_MARKER="# LOBSTER-DAILY-HEALTH"
-({ crontab -l 2>/dev/null | grep -v "$DAILY_MARKER" | grep -v "daily-health-check" || true; }; \
- echo "0 6 * * * $INSTALL_DIR/scripts/daily-health-check.sh $DAILY_MARKER") | crontab -
+"$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-DAILY-HEALTH" \
+    "0 6 * * * $INSTALL_DIR/scripts/daily-health-check.sh # LOBSTER-DAILY-HEALTH"
 
 success "Daily dependency health check configured (runs at 06:00 daily)"
 
@@ -1389,9 +1387,8 @@ step "Setting up nightly consolidation..."
 chmod +x "$INSTALL_DIR/scripts/nightly-consolidation.sh" || true
 
 # Add nightly consolidation to crontab (runs at 03:00 every night)
-CONSOLIDATION_MARKER="# LOBSTER-NIGHTLY-CONSOLIDATION"
-({ crontab -l 2>/dev/null | grep -v "$CONSOLIDATION_MARKER" | grep -v "nightly-consolidation" || true; }; \
- echo "0 3 * * * $INSTALL_DIR/scripts/nightly-consolidation.sh $CONSOLIDATION_MARKER") | crontab -
+"$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-NIGHTLY-CONSOLIDATION" \
+    "0 3 * * * $INSTALL_DIR/scripts/nightly-consolidation.sh # LOBSTER-NIGHTLY-CONSOLIDATION"
 
 success "Nightly consolidation configured (runs at 03:00 nightly)"
 
@@ -1423,9 +1420,8 @@ chmod +x "$INSTALL_DIR/scripts/periodic-self-check.sh" || true
 mkdir -p "$INSTALL_DIR/.state"
 
 # Add periodic self-check to crontab (runs every 3 minutes)
-SELFCHECK_MARKER="# LOBSTER-SELF-CHECK"
-({ crontab -l 2>/dev/null | grep -v "$SELFCHECK_MARKER" | grep -v "periodic-self-check" || true; }; \
- echo "*/3 * * * * $INSTALL_DIR/scripts/periodic-self-check.sh $SELFCHECK_MARKER") | crontab -
+"$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-SELF-CHECK" \
+    "*/3 * * * * $INSTALL_DIR/scripts/periodic-self-check.sh # LOBSTER-SELF-CHECK"
 
 CLAUDE_SETTINGS_DIR="$HOME/.claude"
 CLAUDE_SETTINGS="$CLAUDE_SETTINGS_DIR/settings.json"

--- a/scripts/cron-manage.sh
+++ b/scripts/cron-manage.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#===============================================================================
+# cron-manage.sh - Safe crontab entry management
+#
+# Usage:
+#   cron-manage.sh add    "# MARKER-COMMENT" "*/3 * * * * /path/to/script.sh"
+#   cron-manage.sh remove "# MARKER-COMMENT"
+#
+# Subcommands:
+#   add    - Add a cron entry idempotently. If an existing entry with the same
+#            marker is present, it is replaced. Never clobbers unrelated entries.
+#   remove - Remove all cron entries containing the given marker.
+#
+# Safety guarantee:
+#   Both subcommands use the (crontab -l | grep -v MARKER; ...) | crontab -
+#   pattern to avoid overwriting the entire crontab. Raw `echo | crontab -`
+#   usage is prohibited — always use this script instead.
+#===============================================================================
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<EOF
+Usage:
+  $(basename "$0") add    "<marker>" "<full cron entry including marker>"
+  $(basename "$0") remove "<marker>"
+
+Examples:
+  $(basename "$0") add "# LOBSTER-SELF-CHECK" "*/3 * * * * /home/lobster/lobster/scripts/periodic-self-check.sh # LOBSTER-SELF-CHECK"
+  $(basename "$0") remove "# LOBSTER-SELF-CHECK"
+EOF
+    exit 1
+}
+
+if [[ $# -lt 2 ]]; then
+    usage
+fi
+
+SUBCOMMAND="$1"
+MARKER="$2"
+
+case "$SUBCOMMAND" in
+    add)
+        if [[ $# -lt 3 ]]; then
+            echo "Error: 'add' requires a marker and a full cron entry." >&2
+            usage
+        fi
+        ENTRY="$3"
+        # Remove any existing entry with the same marker, then append the new one.
+        # The `|| true` guards against grep returning exit code 1 when no lines match.
+        (crontab -l 2>/dev/null | grep -vF "$MARKER" || true; echo "$ENTRY") | crontab -
+        echo "Cron entry added: $ENTRY"
+        ;;
+
+    remove)
+        # Strip all lines containing the marker. If none match, crontab is unchanged.
+        (crontab -l 2>/dev/null | grep -vF "$MARKER" || true) | crontab -
+        echo "Cron entry removed (marker: $MARKER)"
+        ;;
+
+    *)
+        echo "Error: unknown subcommand '$SUBCOMMAND'" >&2
+        usage
+        ;;
+esac

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -844,6 +844,36 @@ check_dashboard_server() {
     return 0
 }
 
+# Check 10: Required cron entries - auto-restore LOBSTER-SELF-CHECK if missing
+check_cron_entries() {
+    local install_dir="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
+    local cron_manage="$install_dir/scripts/cron-manage.sh"
+    local REQUIRED_CRON_MARKERS=("# LOBSTER-SELF-CHECK" "# LOBSTER-HEALTH")
+
+    for marker in "${REQUIRED_CRON_MARKERS[@]}"; do
+        if ! crontab -l 2>/dev/null | grep -qF "$marker"; then
+            log_warn "Missing cron entry: $marker"
+            case "$marker" in
+                "# LOBSTER-SELF-CHECK")
+                    if [[ -x "$cron_manage" ]]; then
+                        "$cron_manage" add "# LOBSTER-SELF-CHECK" \
+                            "*/3 * * * * $install_dir/scripts/periodic-self-check.sh # LOBSTER-SELF-CHECK"
+                        log_info "Auto-restored: $marker"
+                    else
+                        log_warn "cron-manage.sh not found or not executable at $cron_manage — cannot auto-restore $marker"
+                    fi
+                    ;;
+                *)
+                    # LOBSTER-HEALTH checking itself is circular (if we're running, the health cron is working).
+                    # Just warn; do not attempt auto-restore.
+                    ;;
+            esac
+        else
+            log_info "Cron entry present: $marker"
+        fi
+    done
+}
+
 #===============================================================================
 # Circuit Breaker - prevent restart loops for persistent stale messages
 #===============================================================================
@@ -1556,6 +1586,10 @@ main() {
     # --- Dashboard server check (soft restart, never RED) ---
 
     check_dashboard_server
+
+    # --- Cron entry guard (auto-restore SELF-CHECK if missing) ---
+
+    check_cron_entries
 
     # --- Resource checks (RED if critical) ---
 


### PR DESCRIPTION
## Problem

A subagent recently destroyed all Lobster cron entries by writing `echo "..." | crontab -`, which replaces the entire crontab rather than patching it. This wiped the `# LOBSTER-SELF-CHECK` entry. The same pattern was used in four places in `install.sh`, making any future agent that touches cron setup a loaded gun.

## What this PR does

Three layered safeguards:

**1. `scripts/cron-manage.sh` (new)**

A purpose-built wrapper with `add` and `remove` subcommands. Both use the safe pattern:
```bash
(crontab -l 2>/dev/null | grep -vF "$MARKER" || true; echo "$ENTRY") | crontab -
```
The wrapper validates arguments and exits non-zero on bad input. It is the single canonical way to touch the crontab in this codebase.

**2. `install.sh` — all four inline crontab pipelines replaced**

The four `({ crontab -l ... } | ...) | crontab -` patterns for LOBSTER-HEALTH, LOBSTER-DAILY-HEALTH, LOBSTER-NIGHTLY-CONSOLIDATION, and LOBSTER-SELF-CHECK are replaced with `cron-manage.sh add` calls. The script is made executable by the existing `chmod +x "$INSTALL_DIR/scripts/"*.sh` line already in install.sh — no additional steps needed.

**3. `health-check-v3.sh` — new `check_cron_entries` function**

Added as Check 10, called after the dashboard server check (soft, never RED). Every 2-minute health check cycle now verifies that `# LOBSTER-SELF-CHECK` and `# LOBSTER-HEALTH` markers are present in the crontab. If LOBSTER-SELF-CHECK is missing, it auto-restores via `cron-manage.sh`. LOBSTER-HEALTH is warned about but intentionally not auto-restored — if the health check is running, the health-check cron is self-evidently working.

**4. Agent instructions updated**

`sys.subagent.bootup.md` and `.claude/agents/lobster-ops.md` both now include an explicit prohibition on raw `echo | crontab -` with working examples of `cron-manage.sh` usage. Future agents reading their context will see this before touching cron.

## Scope

Does not change the actual cron schedules or markers. The health check level logic (GREEN/YELLOW/RED) is unchanged — `check_cron_entries` is advisory (warns and auto-restores) but never elevates to RED. `sync-crontab.sh` (the scheduled-jobs synchronizer) uses its own marker (`# LOBSTER-SCHEDULED`) and manages its own entries; that path is not touched here.

## Functional patterns

Pure functions (`check_cron_entries` has no side effects beyond the cron restore), isolated side effects at boundaries (all crontab writes go through one entry point), declarative guard pattern in `install.sh`.

## Tests run

- [x] `bash -n scripts/cron-manage.sh` — syntax OK
- [x] `bash -n scripts/health-check-v3.sh` — syntax OK  
- [x] `bash -n install.sh` — syntax OK
- [ ] Live cron integration test — skipped: would require modifying the production crontab. The wrapper logic is a direct transcription of the existing safe pattern already in sync-crontab.sh; no novel logic.