### PR TITLE
fix: derive agent tasks path dynamically from uid and workspace hash

### DIFF
--- a/scripts/agent-status.sh
+++ b/scripts/agent-status.sh
@@ -30,6 +30,22 @@ AGENT_STATE_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}/.state"
 # Maximum agents to show in summary (keep messages concise)
 AGENT_MAX_DISPLAY=5
 
+# Derive the Claude Code tmp base for this user and workspace.
+# Claude Code stores session data under /tmp/claude-<uid>/<workspace-hash>/
+# where workspace-hash = workspace path with '/' replaced by '-'.
+# Task output files live in per-session UUID subdirs: <base>/<uuid>/tasks/*.output
+# If AGENT_TASKS_DIR is set, it overrides this (used by tests).
+_default_tasks_glob() {
+    if [ -n "${AGENT_TASKS_DIR:-}" ]; then
+        echo "${AGENT_TASKS_DIR}/*.output"
+        return
+    fi
+    local claude_tmp_base="/tmp/claude-$(id -u)"
+    local workspace_hash
+    workspace_hash=$(echo "${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}" | sed 's|/|-|g')
+    echo "${claude_tmp_base}/${workspace_hash}/*/tasks/*.output"
+}
+
 # Format seconds into human-readable duration: 30s, 5m, 2h
 _format_duration() {
     local seconds="$1"
@@ -71,17 +87,13 @@ _get_stop_reason() {
 # Scan agent output files and return a summary string.
 # Returns empty string if no agents found.
 scan_agent_status() {
-    local tasks_dir="${AGENT_TASKS_DIR:-/tmp/claude-1000/-home-admin-lobster-workspace/tasks}"
-
-    # No directory or no .output files -> empty
-    if [ ! -d "$tasks_dir" ]; then
-        return 0
-    fi
+    local tasks_glob
+    tasks_glob=$(_default_tasks_glob)
 
     local output_files=()
-    while IFS= read -r -d '' f; do
+    while IFS= read -r f; do
         output_files+=("$f")
-    done < <(find "$tasks_dir" -maxdepth 1 -name "*.output" -print0 2>/dev/null)
+    done < <(compgen -G "$tasks_glob" 2>/dev/null | sort)
 
     if [ ${#output_files[@]} -eq 0 ]; then
         return 0
@@ -158,20 +170,17 @@ scan_agent_status() {
 #
 # Returns a structured completion summary or empty string if nothing new.
 scan_completed_tasks() {
-    local tasks_dir="${AGENT_TASKS_DIR:-/tmp/claude-1000/-home-admin-lobster-workspace/tasks}"
+    local tasks_glob
+    tasks_glob=$(_default_tasks_glob)
     local reported_file="$AGENT_STATE_DIR/reported-tasks"
 
     mkdir -p "$AGENT_STATE_DIR"
     touch "$reported_file" 2>/dev/null
 
-    if [ ! -d "$tasks_dir" ]; then
-        return 0
-    fi
-
     local output_files=()
-    while IFS= read -r -d '' f; do
+    while IFS= read -r f; do
         output_files+=("$f")
-    done < <(find "$tasks_dir" -maxdepth 1 -name "*.output" -print0 2>/dev/null)
+    done < <(compgen -G "$tasks_glob" 2>/dev/null | sort)
 
     if [ ${#output_files[@]} -eq 0 ]; then
         return 0


### PR DESCRIPTION
## What was broken

`periodic-self-check.sh` was always emitting generic `status?` pings instead of structured `[Task Completed]` completion messages. The root cause was two bugs in the hardcoded path used to locate Claude Code task output files:

1. **Wrong username segment**: path contained `-home-admin-lobster-workspace` but the actual directory on this system is `-home-lobster-lobster-workspace`
2. **No session UUID awareness**: Claude Code stores task outputs in per-session UUID subdirectories (`<base>/<uuid>/tasks/*.output`), but the code looked directly in the parent directory with `find -maxdepth 1`

Both functions that scanned for task files (`scan_agent_status` and `scan_completed_tasks`) shared the same broken default.

## What this fixes

Adds `_default_tasks_glob()`, a shared helper that derives the correct path at runtime:
- Computes `claude_tmp_base` from the actual running user's UID: `/tmp/claude-$(id -u)`
- Computes `workspace_hash` by replacing `/` with `-` in the `LOBSTER_WORKSPACE` path (matching what Claude Code does)
- Returns a glob that covers all session UUID subdirs: `<base>/<hash>/*/tasks/*.output`

Both `scan_agent_status` and `scan_completed_tasks` now call `_default_tasks_glob()` and use `compgen -G` to expand it, replacing the `find -maxdepth 1` calls.

The `AGENT_TASKS_DIR` env override is preserved unchanged — it still short-circuits the entire derivation for test isolation.

Functional patterns: pure function (`_default_tasks_glob` has no side effects), composable helper used by both scanning functions.

## Tests run

- [x] `source scripts/agent-status.sh && scan_agent_status` — found 94+ agent entries across real session dirs (correct)
- [x] `source scripts/agent-status.sh && scan_completed_tasks` — returned completed task summaries from real session dirs (correct)
- [x] `AGENT_TASKS_DIR=/tmp/fake-dir scan_agent_status` — correctly read from override directory, found `fake-task-abc123` (PASS)
- [ ] Full `periodic-self-check.sh` with new script live — can only be verified after merge since the script sources from `$HOME/lobster/scripts/agent-status.sh` (the installed path, not the worktree)

Closes #521 (if tracked); otherwise this is a standalone fix.