### PR TITLE
docs: enforce GitHub attribution prefix in all subagent GitHub output

### DIFF
--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -243,6 +243,13 @@ Every PR description must meet this bar (tracked in issue #463): a moderately-fa
   3. Then call `write_result` with a concise summary for the user (scene → problem → fix → impact, 3–6 lines, include PR link).
   - If no PR exists yet (local changes only), skip step 1 and report findings entirely via `write_result`.
 
+- **GitHub attribution:** All PR descriptions, review comments, and issue comments written by Lobster must include an attribution prefix. The `gh` CLI is authenticated as Sahar's account — without this prefix, GitHub content appears to come from Sahar personally.
+  - PR body (when opening a PR): first line is `🤖 Lobster (engineer):` followed by a blank line
+  - Review comments (`gh pr review --comment`): body starts with `🤖 Lobster (reviewer):\n\n`
+  - Issue comments: body starts with `🤖 Lobster (ops):` or the appropriate role
+  - Short one-liner comments (e.g., closing a stale issue) may use the prefix inline: `🤖 Lobster: <reason>`
+  - Never omit this prefix when posting substantial content to GitHub under Sahar's account.
+
 - **Default repo:** `SiderealPress/lobster` (owner=SiderealPress, repo=lobster). If no repo is specified in your task, use this.
 
 - **Linear API:** Access Linear via REST API. The `LINEAR_API_KEY` environment variable is set. GraphQL endpoint: `https://api.linear.app/graphql`. Use `curl -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json"`.


### PR DESCRIPTION
🤖 Lobster (engineer):

The `gh` CLI is authenticated as Sahar's personal GitHub account. Every PR description, review comment, and issue comment posted by Lobster agents currently appears to come from Sahar with no indication it was machine-generated. This is a ghostwriting violation — content authored by an AI agent is being attributed to a real person.

The attribution rule (`🤖 Lobster (<role>):`) already existed in the handoff doc but was missing from `sys.subagent.bootup.md`, meaning agents had no instruction to apply it. This PR adds the rule where agents will actually read it.

The new bullet in the Tooling conventions section specifies the prefix format for each content type: PR bodies, review comments, issue comments, and short one-liners. It also states the reason (gh CLI authenticated as Sahar's account) so agents understand *why* the rule exists, not just *what* to do.

No behavior changes to the runtime system. Only `.claude/sys.subagent.bootup.md` is modified — a `.claude/` file that is live immediately on merge via the workspace symlink.

## Tests run
- [x] Read the modified file to verify the bullet appears in the correct location (after "Code reviews", before "Default repo") — confirmed correct placement
- [ ] Live agent test — not applicable; this is a documentation-only change with no executable code