### PR TITLE
docs: fix attribution emoji (🤖🦞) and add doc-review substance check

### DIFF
--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -242,12 +242,13 @@ Every PR description must meet this bar (tracked in issue #463): a moderately-fa
   2. Always use `--comment`, never `--request-changes` (GitHub blocks REQUEST_CHANGES when reviewer equals author).
   3. Then call `write_result` with a concise summary for the user (scene → problem → fix → impact, 3–6 lines, include PR link).
   - If no PR exists yet (local changes only), skip step 1 and report findings entirely via `write_result`.
+  - **For doc PRs about system behavior**, go beyond form: verify that (1) the documented behavior is actually in the system code/config, not just in user-config files (`~/lobster-user-config/`), (2) the behavior applies to all Lobster users (not Sahar-specific), (3) claims about defaults are true on a fresh install. A well-written doc PR that documents the wrong thing is a FAIL.
 
 - **GitHub attribution:** All PR descriptions, review comments, and issue comments written by Lobster must include an attribution prefix. The `gh` CLI is authenticated as Sahar's account — without this prefix, GitHub content appears to come from Sahar personally.
-  - PR body (when opening a PR): first line is `🤖 Lobster (engineer):` followed by a blank line
-  - Review comments (`gh pr review --comment`): body starts with `🤖 Lobster (reviewer):\n\n`
-  - Issue comments: body starts with `🤖 Lobster (ops):` or the appropriate role
-  - Short one-liner comments (e.g., closing a stale issue) may use the prefix inline: `🤖 Lobster: <reason>`
+  - PR body (when opening a PR): first line is `🤖🦞 Lobster (engineer):` followed by a blank line
+  - Review comments (`gh pr review --comment`): body starts with `🤖🦞 Lobster (reviewer):\n\n`
+  - Issue comments: body starts with `🤖🦞 Lobster (ops):` or the appropriate role
+  - Short one-liner comments (e.g., closing a stale issue) may use the prefix inline: `🤖🦞 Lobster: <reason>`
   - Never omit this prefix when posting substantial content to GitHub under Sahar's account.
 
 - **Default repo:** `SiderealPress/lobster` (owner=SiderealPress, repo=lobster). If no repo is specified in your task, use this.


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

PR #535 established the attribution prefix convention but used `🤖 Lobster` without the lobster emoji. This PR corrects the prefix to `🤖🦞 Lobster` across all four usage patterns in the doc (PR body, review comments, issue comments, inline one-liners).

The second change addresses a gap in review guidance: reviewers currently check doc PRs for clarity and form, but nothing prompts them to verify that the documented behavior is actually true for the system. This PR adds an explicit sub-bullet under "Code reviews" requiring that doc PRs about system behavior be verified against actual code/config — not just user-config files — and checked to confirm the behavior applies to all users on a fresh install.

## What changed

- `.claude/sys.subagent.bootup.md`: four `🤖` → `🤖🦞` replacements in the GitHub attribution section
- `.claude/sys.subagent.bootup.md`: one new sub-bullet added under "Code reviews" for doc-PR substance verification

## What did NOT change

No behavior changes. No other files touched. The `.claude/` directory is symlinked from `~/lobster-workspace/.claude`, so this is live immediately on merge without a redeploy.

## Tests run

- [x] Manual diff review — changes are isolated to the two intended edits, no unintended whitespace or formatting changes
- [ ] Live system test — not applicable; this is a documentation-only change with no code path affected