### PR TITLE
fix: harden require-background-agent hook to hard-block dispatcher

### DIFF
--- a/hooks/require-background-agent.py
+++ b/hooks/require-background-agent.py
@@ -1,22 +1,26 @@
 #!/usr/bin/env python3
-"""PreToolUse hook: warns when the Agent tool is called without run_in_background: true.
+"""PreToolUse hook: blocks the dispatcher from calling Agent without run_in_background: true.
 
 The Lobster dispatcher runs in an infinite message-processing loop. A foreground
 Agent call (run_in_background omitted or false) blocks the dispatcher for the
 full duration of the agent — potentially minutes — while incoming messages queue
-up unprocessed.
+up unprocessed and health-check pings go unanswered.
+
+This hook enforces the 7-second rule as a hard constraint for the dispatcher.
+Subagents are exempt: they may legitimately spawn nested agents synchronously
+when the result is needed to decide the next step.
 
 Exit codes:
-  0 — tool is not Agent, or Agent is called with run_in_background: true (OK)
-  1 — soft warning: Agent called without run_in_background: true
-
-Exit 1 (not 2) is intentional. Claude sees the warning and can reconsider, but
-is not hard-blocked. There are legitimate cases where a foreground Agent is
-genuinely needed (e.g., the result is required synchronously to decide the next
-step). Hard-blocking those would be counterproductive.
+  0 — tool is not Agent, Agent has run_in_background: true, or session is a subagent
+  2 — hard block: dispatcher called Agent without run_in_background: true
 """
 import json
 import sys
+from pathlib import Path
+
+# Import the shared dispatcher/subagent detection utility.
+sys.path.insert(0, str(Path(__file__).parent))
+from session_role import is_dispatcher
 
 data = json.load(sys.stdin)
 tool = data.get("tool_name", "")
@@ -28,10 +32,15 @@ if tool != "Agent":
 if inp.get("run_in_background") is True:
     sys.exit(0)
 
+# Only enforce for the dispatcher. Subagents may call Agent synchronously.
+if not is_dispatcher(data):
+    sys.exit(0)
+
 print(
-    "Warning: Agent tool called without run_in_background: true. "
-    "This blocks message processing for the duration of the agent. "
-    "Pass run_in_background: true unless you genuinely need the result "
-    "synchronously to decide your next step.",
+    "BLOCKED: Dispatcher called Agent without run_in_background: true. "
+    "This blocks the message-processing loop for the full duration of the "
+    "subagent. Always pass run_in_background=True when spawning agents from "
+    "the dispatcher. The result will be delivered via write_result.",
+    file=sys.stderr,
 )
-sys.exit(1)
+sys.exit(2)

--- a/tests/unit/test_hooks/test_require_background_agent.py
+++ b/tests/unit/test_hooks/test_require_background_agent.py
@@ -1,0 +1,279 @@
+"""
+Unit tests for hooks/require-background-agent.py
+
+Tests cover:
+- Non-Agent tool calls pass through (exit 0)
+- Agent with run_in_background=True passes through (exit 0)
+- Agent without run_in_background called by dispatcher: hard block (exit 2)
+- Agent without run_in_background called by subagent: allowed (exit 0)
+- Dispatcher detection via marker file
+- Missing run_in_background key (falsy) from dispatcher: blocked (exit 2)
+- Block message goes to stderr
+"""
+
+import importlib.util
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add hooks directory to path so session_role can be imported by both
+# the hook under test (via exec) and directly by test methods.
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+HOOKS_DIR = _HOOKS_DIR
+HOOK_PATH = HOOKS_DIR / "require-background-agent.py"
+
+
+def _load_hook(monkeypatch, tmp_path):
+    """Load require-background-agent.py as a fresh module for each test."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    spec = importlib.util.spec_from_file_location("require_background_agent", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run_hook(hook_input: dict) -> tuple[int, str, str]:
+    """
+    Run the hook script as a subprocess-like call via exec.
+    Returns (exit_code, stdout_text, stderr_text).
+    """
+    stdout_capture = StringIO()
+    stderr_capture = StringIO()
+    stdin_data = json.dumps(hook_input)
+
+    exit_code = None
+    with (
+        patch("sys.stdin", StringIO(stdin_data)),
+        patch("sys.stdout", stdout_capture),
+        patch("sys.stderr", stderr_capture),
+    ):
+        try:
+            # Execute the hook script directly; __file__ must be set so the
+            # hook's sys.path.insert(0, Path(__file__).parent) works correctly.
+            hook_globals = {"__name__": "__main__", "__file__": str(HOOK_PATH)}
+            exec(compile(HOOK_PATH.read_text(), str(HOOK_PATH), "exec"), hook_globals)
+        except SystemExit as e:
+            exit_code = e.code
+
+    return exit_code, stdout_capture.getvalue(), stderr_capture.getvalue()
+
+
+def _make_hook_input(
+    tool_name: str,
+    tool_input: dict,
+    session_id: str = "sess-sub-001",
+) -> dict:
+    return {
+        "hook_event_name": "PreToolUse",
+        "session_id": session_id,
+        "tool_name": tool_name,
+        "tool_input": tool_input,
+    }
+
+
+def _setup_dispatcher_marker(tmp_path: Path, session_id: str) -> None:
+    """Write the dispatcher session marker file under tmp_path/messages/config/."""
+    config_dir = tmp_path / "messages" / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "dispatcher-session-id").write_text(session_id)
+
+
+# ---------------------------------------------------------------------------
+# Non-Agent tool passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestNonAgentTool:
+    def test_non_agent_tool_exits_0(self, monkeypatch, tmp_path):
+        """Any tool that is not Agent passes through immediately."""
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+        hook_input = _make_hook_input("Bash", {"command": "ls"})
+        exit_code, stdout, stderr = _run_hook(hook_input)
+        assert exit_code == 0
+
+    def test_mcp_tool_exits_0(self, monkeypatch, tmp_path):
+        """MCP tools are not the Agent tool and must pass through."""
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+        hook_input = _make_hook_input(
+            "mcp__lobster-inbox__check_inbox", {}, session_id="dispatcher-sess"
+        )
+        exit_code, _, _ = _run_hook(hook_input)
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Agent with run_in_background=True
+# ---------------------------------------------------------------------------
+
+
+class TestAgentWithBackground:
+    def test_agent_with_background_true_exits_0_dispatcher(self, monkeypatch, tmp_path):
+        """Dispatcher calling Agent with run_in_background=True is always OK."""
+        _setup_dispatcher_marker(tmp_path, "dispatcher-sess-001")
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+        hook_input = _make_hook_input(
+            "Agent",
+            {"prompt": "do work", "run_in_background": True},
+            session_id="dispatcher-sess-001",
+        )
+        exit_code, _, _ = _run_hook(hook_input)
+        assert exit_code == 0
+
+    def test_agent_with_background_true_exits_0_subagent(self, monkeypatch, tmp_path):
+        """Subagent calling Agent with run_in_background=True is also fine."""
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+        hook_input = _make_hook_input(
+            "Agent",
+            {"prompt": "do work", "run_in_background": True},
+            session_id="subagent-sess-999",
+        )
+        exit_code, _, _ = _run_hook(hook_input)
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher calling Agent synchronously (the bad case)
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherSynchronousAgent:
+    def test_dispatcher_agent_no_background_key_exits_2(self, monkeypatch, tmp_path):
+        """Dispatcher omitting run_in_background is hard-blocked (exit 2)."""
+        _setup_dispatcher_marker(tmp_path, "dispatcher-sess-001")
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+        hook_input = _make_hook_input(
+            "Agent",
+            {"prompt": "do work"},
+            session_id="dispatcher-sess-001",
+        )
+        exit_code, stdout, stderr = _run_hook(hook_input)
+        assert exit_code == 2, f"Expected hard block (exit 2), got {exit_code}"
+
+    def test_dispatcher_agent_background_false_exits_2(self, monkeypatch, tmp_path):
+        """Dispatcher passing run_in_background=False explicitly is hard-blocked."""
+        _setup_dispatcher_marker(tmp_path, "dispatcher-sess-001")
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+        hook_input = _make_hook_input(
+            "Agent",
+            {"prompt": "do work", "run_in_background": False},
+            session_id="dispatcher-sess-001",
+        )
+        exit_code, stdout, stderr = _run_hook(hook_input)
+        assert exit_code == 2, f"Expected hard block (exit 2), got {exit_code}"
+
+    def test_block_message_goes_to_stderr(self, monkeypatch, tmp_path):
+        """Block message must appear on stderr so Claude Code injects it as feedback."""
+        _setup_dispatcher_marker(tmp_path, "dispatcher-sess-001")
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+        hook_input = _make_hook_input(
+            "Agent",
+            {"prompt": "do work"},
+            session_id="dispatcher-sess-001",
+        )
+        exit_code, stdout, stderr = _run_hook(hook_input)
+        assert exit_code == 2
+        assert "BLOCKED" in stderr, f"Expected BLOCKED in stderr, got: {stderr!r}"
+        assert "run_in_background" in stderr, f"Expected guidance in stderr, got: {stderr!r}"
+
+    def test_block_message_not_in_stdout(self, monkeypatch, tmp_path):
+        """Block message must not appear on stdout (stdout is for JSON responses)."""
+        _setup_dispatcher_marker(tmp_path, "dispatcher-sess-001")
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+        hook_input = _make_hook_input(
+            "Agent",
+            {"prompt": "do work"},
+            session_id="dispatcher-sess-001",
+        )
+        exit_code, stdout, stderr = _run_hook(hook_input)
+        assert exit_code == 2
+        assert "BLOCKED" not in stdout
+
+
+# ---------------------------------------------------------------------------
+# Subagent calling Agent synchronously (must be allowed)
+# ---------------------------------------------------------------------------
+
+
+class TestSubagentSynchronousAgent:
+    def test_subagent_agent_no_background_exits_0(self, monkeypatch, tmp_path):
+        """Subagents may call Agent synchronously — hook must not fire for them."""
+        # Marker file points to a different session ID (dispatcher is someone else).
+        _setup_dispatcher_marker(tmp_path, "dispatcher-sess-001")
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+        hook_input = _make_hook_input(
+            "Agent",
+            {"prompt": "do nested work"},
+            session_id="subagent-sess-999",  # Different from dispatcher session
+        )
+        exit_code, stdout, stderr = _run_hook(hook_input)
+        assert exit_code == 0, (
+            f"Subagent should be allowed to call Agent synchronously, got exit {exit_code}. "
+            f"stderr={stderr!r}"
+        )
+
+    def test_subagent_no_marker_file_exits_0(self, monkeypatch, tmp_path):
+        """No marker file means is_dispatcher() returns False → treat as subagent → allow."""
+        import session_role
+        # Point to a nonexistent file so marker check returns None → fallback → False
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+        hook_input = _make_hook_input(
+            "Agent",
+            {"prompt": "do nested work"},
+            session_id="some-sess",
+        )
+        exit_code, stdout, stderr = _run_hook(hook_input)
+        assert exit_code == 0, (
+            f"Missing marker file should default to subagent (allow), got exit {exit_code}. "
+            f"stderr={stderr!r}"
+        )


### PR DESCRIPTION
Closes #537

## What this fixes

The `require-background-agent` hook existed to prevent the dispatcher from blocking its main loop with synchronous `Agent` calls, but it had two gaps that made it ineffective:

1. **Soft warning only (exit 1):** The hook emitted a warning Claude could ignore, not a hard block. The dispatcher could — and did — proceed anyway.
2. **No session discrimination:** The hook fired for all sessions, meaning subagents also received the warning even when nested synchronous agent calls are legitimate.

The result was a hook that created a false sense of protection while doing nothing to actually prevent the loop-blocking behavior it was designed to catch.

## What changed

`require-background-agent.py` now uses `is_dispatcher()` from the existing `session_role.py` utility to determine whether the current session is the dispatcher:

- **Dispatcher + no `run_in_background: true`** → exit 2 (hard block, Claude Code injects the error as feedback and prevents the tool call)
- **Dispatcher + `run_in_background: true`** → exit 0 (correct usage, allow)
- **Subagent (any)** → exit 0 (unconditionally allowed; synchronous nested agents are legitimate)
- **Non-Agent tool** → exit 0 (pass-through, unchanged)

The block message goes to stderr (as required for exit-2 hooks) and names the corrective action explicitly.

## Design notes

The session detection relies on the marker-file approach in `session_role.py`: at dispatcher startup, the session ID is written to `~/messages/config/dispatcher-session-id`. The hook reads this file and compares it to the `session_id` field in the hook JSON input. If the marker file is absent (e.g. during a fresh install before first startup), `is_dispatcher()` returns `False` — the conservative/safe default, which means the hook allows the call rather than blocking it.

No changes to `~/.claude/settings.json` are needed; the hook is already wired under `PreToolUse` for the `Agent` matcher.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_require_background_agent.py -v` — 10 passed, 0 failed (new tests for this hook)
- [x] `uv run pytest tests/unit/test_hooks/ -v` — 37 passed, 0 failed (full hook test suite, no regressions)