### PR TITLE
fix: replace OWNER_CHAT_ID_PLACEHOLDER with runtime config lookup

### DIFF
--- a/scripts/ghost-detector.py
+++ b/scripts/ghost-detector.py
@@ -588,7 +588,43 @@ def send_alert(
 # Mark-failed remediation (isolated side effects — DB write + inbox drop)
 # ---------------------------------------------------------------------------
 
-RELAUNCH_CHAT_ID = OWNER_CHAT_ID_PLACEHOLDER
+
+def _resolve_owner_chat_id() -> str:
+    """Return the owner's Telegram chat_id as a string.
+
+    Lookup order:
+      1. OWNER_CHAT_ID env var (explicit override)
+      2. TELEGRAM_ALLOWED_USERS env var (first entry)
+      3. TELEGRAM_ALLOWED_USERS from ~/lobster-config/config.env (first entry)
+      4. Empty string (alerts will silently drop if delivery is attempted)
+    """
+    explicit = os.environ.get("OWNER_CHAT_ID", "").strip()
+    if explicit:
+        return explicit
+
+    allowed_env = os.environ.get("TELEGRAM_ALLOWED_USERS", "").strip()
+    if allowed_env:
+        first = allowed_env.split(",")[0].strip()
+        if first:
+            return first
+
+    config_env = Path.home() / "lobster-config" / "config.env"
+    if config_env.exists():
+        try:
+            for line in config_env.read_text().splitlines():
+                stripped = line.strip()
+                if stripped.startswith("TELEGRAM_ALLOWED_USERS="):
+                    val = stripped.split("=", 1)[1].strip().strip('"').strip("'")
+                    first = val.split(",")[0].strip()
+                    if first:
+                        return first
+        except Exception:
+            pass
+
+    return ""
+
+
+RELAUNCH_CHAT_ID = _resolve_owner_chat_id()
 
 
 def mark_agent_completed(db_path: Path, agent_id: str) -> None:

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -23,6 +23,10 @@ sys.path.insert(0, str(SRC_DIR))
 
 from agents import session_store
 
+# Placeholder string used as a test chat_id value. Several tests pass this as
+# a bare name (not a quoted string literal), so it must be defined here.
+OWNER_CHAT_ID_PLACEHOLDER = "OWNER_CHAT_ID_PLACEHOLDER"
+
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/unit/test_mcp_server/test_write_observation.py
+++ b/tests/unit/test_mcp_server/test_write_observation.py
@@ -22,6 +22,10 @@ if str(_MCP_DIR) not in sys.path:
 # as an attribute of the `src.mcp` package before patch.multiple opens.
 import src.mcp.inbox_server  # noqa: F401
 
+# Placeholder string used as a test chat_id value. Used as a bare name in
+# some test assertions, so it must be defined as a module-level constant.
+OWNER_CHAT_ID_PLACEHOLDER = "OWNER_CHAT_ID_PLACEHOLDER"
+
 
 class TestHandleWriteObservation:
     """Tests for the write_observation handler."""


### PR DESCRIPTION
## Problem

\`ghost-detector.py\` crashed with a \`NameError\` at import time — before it could do anything useful. The crash came from line 591:

\`\`\`python
RELAUNCH_CHAT_ID = OWNER_CHAT_ID_PLACEHOLDER
\`\`\`

\`OWNER_CHAT_ID_PLACEHOLDER\` is a bare Python identifier that was never defined. It appears to have been intended as an install-time substitution target, but \`install.sh\` contains no \`sed\` or substitution step for it. So every install that runs \`ghost-detector.py\` (including the scheduled ghost-detection cron) crashes immediately.

The same undefined name appeared in two test files (\`tests/test_agent_sessions.py\` and \`tests/unit/test_mcp_server/test_write_observation.py\`), causing \`NameError\` during pytest collection — meaning those test modules were silently skipped or erroring out rather than running.

## What changed

**\`scripts/ghost-detector.py\`** — Replaces the bare placeholder with \`_resolve_owner_chat_id()\`, a pure function that runs at module load time. Lookup order:
1. \`OWNER_CHAT_ID\` env var (explicit override)
2. \`TELEGRAM_ALLOWED_USERS\` env var (first entry)
3. \`TELEGRAM_ALLOWED_USERS\` from \`~/lobster-config/config.env\` (same source \`inbox_server.py\` uses)
4. Empty string fallback — module always imports cleanly, even on unconfigured installs

On an installed system this resolves to the correct owner chat ID without any env var needing to be manually set.

**\`tests/test_agent_sessions.py\`** and **\`tests/unit/test_mcp_server/test_write_observation.py\`** — Add \`OWNER_CHAT_ID_PLACEHOLDER = "OWNER_CHAT_ID_PLACEHOLDER"\` as a module-level constant. The test assertions that compare against this string (e.g. \`assert found["chat_id"] == "OWNER_CHAT_ID_PLACEHOLDER"\`) are intentionally testing that the literal string is stored as-is — the constant just makes the bare-name references valid Python.

## What is not changed

\`install.sh\` is untouched. No behavior changes to the ghost detection logic itself.

## Functional patterns

\`_resolve_owner_chat_id()\` is a pure function with no side effects — it only reads env vars and the filesystem. The result is bound once at module load into \`RELAUNCH_CHAT_ID\`, keeping the rest of the module's structure unchanged.

## Tests run

- [x] \`uv run pytest tests/test_agent_sessions.py tests/unit/test_mcp_server/test_write_observation.py -v\` — 52 passed, 2 failed (pre-existing failures in \`test_observation_type_*\` unrelated to this PR — they test user_model dispatch behavior and fail on main as well)
- [x] \`uv run python -c "exec(open('scripts/ghost-detector.py').read()...)"\` — module imports cleanly, \`RELAUNCH_CHAT_ID\` resolves to \`'8305714125'\` from \`~/lobster-config/config.env\`

Closes #544