### PR TITLE
fix: remove orphan agents.db files (stale empty file, not used by any code)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -324,6 +324,8 @@ if [ "$CONTAINER_SETUP" = true ]; then
     mkdir -p "$PROJECTS_DIR"
     mkdir -p "$USER_CONFIG_DIR/memory"/{canonical/{people,projects},archive/digests}
     mkdir -p "$USER_CONFIG_DIR/agents/subagents"
+    # Safety: remove orphan agents.db if it was created (real store is agent_sessions.db)
+    rm -f "$MESSAGES_DIR/config/agents.db" "$WORKSPACE_DIR/data/agents.db"
     success "Directories created"
 
     # Seed canonical templates (idempotent — skip existing files)
@@ -971,6 +973,8 @@ mkdir -p "$CONFIG_DIR"
 mkdir -p "$PROJECTS_DIR"
 mkdir -p "$USER_CONFIG_DIR/memory"/{canonical/{people,projects},archive/digests}
 mkdir -p "$USER_CONFIG_DIR/agents/subagents"
+# Safety: remove orphan agents.db if it was created (real store is agent_sessions.db)
+rm -f "$MESSAGES_DIR/config/agents.db" "$WORKSPACE_DIR/data/agents.db"
 
 # Legacy: also create ~/projects/ for backward compatibility
 mkdir -p "$HOME/projects"/{personal,business}

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1157,6 +1157,19 @@ run_migrations() {
         migrated=$((migrated + 1))
     fi
 
+    # Migration 14: Remove orphan agents.db files — stale empty files not used by any code
+    # (real session store is agent_sessions.db in ~/messages/config/ and ~/lobster-workspace/data/)
+    if [ -f "$MESSAGES_DIR/config/agents.db" ]; then
+        rm -f "$MESSAGES_DIR/config/agents.db"
+        substep "Removed orphan agents.db from $MESSAGES_DIR/config/ (empty file, not used by any code)"
+        migrated=$((migrated + 1))
+    fi
+    if [ -f "$WORKSPACE_DIR/data/agents.db" ]; then
+        rm -f "$WORKSPACE_DIR/data/agents.db"
+        substep "Removed orphan agents.db from $WORKSPACE_DIR/data/ (empty file, not used by any code)"
+        migrated=$((migrated + 1))
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## What problem this solves

Two 0-byte \`agents.db\` files exist on all installs — one at \`~/messages/config/agents.db\` and one at \`~/lobster-workspace/data/agents.db\`. Neither has any tables. Neither is referenced by any code. The real session store is \`agent_sessions.db\` (in \`~/messages/config/\`, healthy with 470 rows). The orphan files caused a false anomaly in the 2026-03-17 system audit: the auditor concluded session tracking was non-functional because it found an empty DB, when it was looking at the wrong file.

## What changed

**\`scripts/upgrade.sh\` — Migration 14:** Deletes both orphan \`agents.db\` files if they exist. Idempotent — uses \`rm -f\` so it is safe to run on installs that already cleaned them up or never had them.

**\`install.sh\`:** Two safety \`rm -f\` lines added to the directory-creation sections (main install path and container setup path). This prevents the orphan from being recreated if something in the setup phase generates the file as a side effect.

Nothing in the session tracking path, MCP server, hooks, or reconciler is touched. This change only removes the orphan files.

## Functional patterns

Pure cleanup: idempotent \`rm -f\` calls with no conditional branching other than the existence check already standard in the migration pattern.

## Tests run

- [x] \`bash -n scripts/upgrade.sh\` — syntax check clean
- [x] \`bash -n install.sh\` — syntax check clean
- [ ] Full upgrade.sh dry-run on a live install — skipped: would require a second shell session outside this subagent context. Migration 14 is structurally identical to all prior migrations; the \`rm -f\` is the simplest possible operation.