### PR TITLE
fix: skip Syncthing prompt when running non-interactively

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -666,6 +666,12 @@ setup_syncthing() {
         fi
     fi
 
+    # Skip prompt if not running interactively (cron, unattended upgrades, etc.)
+    if ! [ -t 0 ]; then
+        info "Non-interactive environment detected — skipping Syncthing setup (run with --skip-syncthing to suppress this message, or install manually)"
+        return 0
+    fi
+
     # Prompt - this is the only interactive part
     echo ""
     echo -e "${YELLOW}${BOLD}LobsterDrop${NC} uses Syncthing to sync files between your phone/laptop and this server."


### PR DESCRIPTION
upgrade.sh was hanging indefinitely in cron and other unattended contexts because of a bare \`read\` prompt at line 674 asking whether to install Syncthing. When stdin has no TTY — as is always the case in cron, systemd timers, or CI — the \`read\` call blocks forever.

## What changed

A \`[ -t 0 ]\` (stdin is a terminal) guard is inserted immediately before the prompt, inside \`setup_syncthing()\`. If no TTY is detected, the function prints an informative note and returns early, leaving the rest of the upgrade unaffected. Interactive runs see no change in behavior.

The \`--skip-syncthing\` flag and the early-exit for already-running Syncthing (lines 660–667) remain the canonical fast-paths; the new guard is a safety net for the case where neither applies and the script is running unattended.

No other interactive prompts were found: all other \`apt-get install\` calls in the file already use \`-y\`, and the \`read\` at line 674 is the only bare \`read\` call in the script (the others at lines 352, 515, 520, 530, 534 are all \`read -r line\` in \`while read\` loops over piped input, not prompts).

## Functional pattern

Pure guard: the new block has no side effects of its own — it reads an environment fact (TTY presence) and returns early without touching any state. The rest of the function is unchanged.

## Tests run

- [x] \`bash -n scripts/upgrade.sh\` — syntax check, no errors
- [x] Manual trace: \`echo "" | bash -c '[ -t 0 ] && echo interactive || echo non-interactive'\` returns \`non-interactive\`, confirming the guard fires correctly under piped/cron stdin
- [ ] Full end-to-end upgrade run — not executed; requires a fresh Lobster install and sudo access not available in this environment. No behavior change outside the Syncthing prompt path.