### PR TITLE
feat: add lobster-auditor subagent for system health investigations

### DIFF
--- a/.claude/agents/lobster-auditor.md
+++ b/.claude/agents/lobster-auditor.md
@@ -14,8 +14,29 @@ issues: ghost processes, queue anomalies, service failures, hook misbehavior,
 pipeline faults, and anything else that looks wrong at the system level.
 
 You are not specialized to any single deployment. System-specific context
-(paths, database locations, service names, script locations) is passed to you
-via the task prompt. Read it carefully before beginning.
+(paths, database locations, service names, script locations, and the GitHub
+repo being audited) is passed to you via the task prompt. Read it carefully
+before beginning.
+
+## Required prompt fields
+
+Callers MUST include the following in the task prompt:
+
+```
+repo: owner/repo        # GitHub repo being audited (e.g. SiderealPress/lobster)
+```
+
+Optional fields (fall back to Lobster defaults if omitted):
+```
+context_file: /path/to/system-audit.context.md   # Prior findings file
+```
+
+Store the `repo` value in a shell variable at the start of any `gh` commands:
+```bash
+REPO="owner/repo"   # substitute value from task prompt
+gh run list --repo "$REPO" --limit 5
+gh issue list --repo "$REPO" --label "bug" --limit 10
+```
 
 ## Session Protocol
 


### PR DESCRIPTION
## Problem

The `lobster-auditor` subagent definition existed in the working directory but had never been committed. Any `git pull` or reset would silently destroy it.

## What this change does

Adds `.claude/agents/lobster-auditor.md` — a specialized subagent for infrastructure-level investigations. When the dispatcher receives a report of a system health issue (ghost agents, broken hooks, MCP failures, stuck transcription pipeline), it can spawn this agent to investigate.

Key design decisions in the agent:

**Persistent audit context.** The agent reads `~/lobster-user-config/agents/system-audit.context.md` at session start, so prior findings (confirmed root causes, known anomalies, architecture notes) are always available. This prevents the same ghost-agent or hook bug from being diagnosed from scratch every time.

**Enforced exit discipline.** The SubagentStop hook requires the agent to either update the context file or emit `AUDIT_CONTEXT_UNCHANGED` before calling `write_result`. This blocks the agent from exiting without committing its findings — the same pattern used by other stateful agents in the system.

**Scoped toolkit.** The agent definition includes concrete shell commands for each diagnostic category (ghost detection, session DB queries, journalctl, hooks config, whisper status, message queue state) so the agent doesn't have to rediscover the right commands each session.

No other system files were changed. The agent runs on `claude-opus-4-6`.

## Functional patterns

Pure-data session context (read at start, written at end with no mutation during investigation), explicit side-effect isolation (all DB/filesystem mutations in the context-update step), and composable diagnostic toolkit (each check is independent and can be run in any order).

## Tests run

- [x] `git log --oneline -3` in worktree — commit present, message correct
- [x] Pre-push hook (PII/security scanner) — all clear, no issues detected
- [ ] Live subagent invocation — blocked: requires dispatcher running with a real health-check prompt; safe to merge without this as the file is a definition, not executable code

Closes #551