### PR TITLE
rename: complete sys.*/user.* rename — drop .bootup. from filenames

### DIFF
--- a/.claude/sys.dispatcher.md
+++ b/.claude/sys.dispatcher.md
@@ -125,9 +125,9 @@ Pass this to `register_agent` as `output_file`. It enables future liveness detec
 ---
 
 **After reading the sections above**, also check for and read user context files if they exist:
-- `~/lobster-user-config/agents/user.base.bootup.md` — applies to all roles (behavioral preferences)
+- `~/lobster-user-config/agents/user.base.md` — applies to all roles (behavioral preferences)
 - `~/lobster-user-config/agents/user.base.context.md` — applies to all roles (personal facts)
-- `~/lobster-user-config/agents/user.dispatcher.bootup.md` — dispatcher-specific user overrides
+- `~/lobster-user-config/agents/user.dispatcher.md` — dispatcher-specific user overrides
 
 These files are private and not in the git repo. They extend and override the defaults here.
 

--- a/.claude/sys.subagent.md
+++ b/.claude/sys.subagent.md
@@ -25,9 +25,9 @@ Do NOT call `wait_for_messages` — that is only for the main loop.
 ---
 
 **After reading this file**, also check for and read user context files if they exist:
-- `~/lobster-user-config/agents/user.base.bootup.md` — applies to all roles (behavioral preferences)
+- `~/lobster-user-config/agents/user.base.md` — applies to all roles (behavioral preferences)
 - `~/lobster-user-config/agents/user.base.context.md` — applies to all roles (personal facts)
-- `~/lobster-user-config/agents/user.subagent.bootup.md` — subagent-specific user overrides
+- `~/lobster-user-config/agents/user.subagent.md` — subagent-specific user overrides
 
 These files are private and not in the git repo. They extend and override the defaults here.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,14 +9,14 @@ You are **Lobster**, an always-on AI assistant that never exits. You run in a pe
 This file provides shared context. Depending on your role, read the appropriate supplement:
 
 **System context** (always read):
-- **If you are the dispatcher (main loop):** read `.claude/sys.dispatcher.bootup.md` — it covers the main loop pseudocode, the 7-second rule, the dispatcher pattern, handling subagent results, message source handling (Telegram/Slack), self-check reminders, message flow diagram, startup behavior, hibernation, context recovery, Google Calendar handling, and voice/brain-dump routing.
-- **If you are a subagent:** read `.claude/sys.subagent.bootup.md` — it covers the `write_result` requirement, identity rules, and the model selection table.
+- **If you are the dispatcher (main loop):** read `.claude/sys.dispatcher.md` — it covers the main loop pseudocode, the 7-second rule, the dispatcher pattern, handling subagent results, message source handling (Telegram/Slack), self-check reminders, message flow diagram, startup behavior, hibernation, context recovery, Google Calendar handling, and voice/brain-dump routing.
+- **If you are a subagent:** read `.claude/sys.subagent.md` — it covers the `write_result` requirement, identity rules, and the model selection table.
 
 **User context** (read after system files, if the files exist):
-- Both roles: `~/lobster-user-config/agents/user.base.bootup.md` (behavioral preferences)
+- Both roles: `~/lobster-user-config/agents/user.base.md` (behavioral preferences)
 - Both roles: `~/lobster-user-config/agents/user.base.context.md` (personal facts and context)
-- Dispatcher: `~/lobster-user-config/agents/user.dispatcher.bootup.md`
-- Subagent: `~/lobster-user-config/agents/user.subagent.bootup.md`
+- Dispatcher: `~/lobster-user-config/agents/user.dispatcher.md`
+- Subagent: `~/lobster-user-config/agents/user.subagent.md`
 
 User context files are private and not committed to git. They contain user-specific preferences, decisions, and constraints that extend the system defaults. When the user says "remember X" and it belongs to a specific scope, write it to the appropriate user file.
 
@@ -48,7 +48,7 @@ User context files are private and not committed to git. They contain user-speci
 - `get_stats()` - Inbox statistics
 - `transcribe_audio(message_id)` - Transcribe voice messages using local whisper.cpp (no API key needed)
 
-> **Dispatcher-only tools** (`wait_for_messages`, `mark_processing`, `mark_processed`, `mark_failed`) are documented in `.claude/sys.dispatcher.bootup.md`.
+> **Dispatcher-only tools** (`wait_for_messages`, `mark_processing`, `mark_processed`, `mark_failed`) are documented in `.claude/sys.dispatcher.md`.
 
 ### Task Management
 - `list_tasks(status?)` - List all tasks
@@ -91,7 +91,7 @@ Skills are rich four-dimensional units (behavior + context + preferences + tooli
 
 **Skill MCP tools:** `get_skill_context`, `list_skills`, `activate_skill`, `deactivate_skill`, `get_skill_preferences`, `set_skill_preference`
 
-> **Dispatcher-only:** skill loading at message start and `/shop`/`/skill` command handling are documented in `.claude/sys.dispatcher.bootup.md`.
+> **Dispatcher-only:** skill loading at message start and `/shop`/`/skill` command handling are documented in `.claude/sys.dispatcher.md`.
 
 ## Behavior Guidelines
 
@@ -135,10 +135,10 @@ For changes that affect existing installs (new cron entries, new directories, co
 - `~/lobster-user-config/` - User-specific config and memory (private, not in repo)
   - `memory/canonical/` - Handoff, priorities, people, projects
   - `memory/archive/digests/` - Archived daily digests
-  - `agents/user.base.bootup.md` - Behavioral preferences (all roles)
+  - `agents/user.base.md` - Behavioral preferences (all roles)
   - `agents/user.base.context.md` - Personal facts and context (all roles)
-  - `agents/user.dispatcher.bootup.md` - Dispatcher-specific overrides
-  - `agents/user.subagent.bootup.md` - Subagent-specific overrides
+  - `agents/user.dispatcher.md` - Dispatcher-specific overrides
+  - `agents/user.subagent.md` - Subagent-specific overrides
   - `agents/subagents/` - User-defined custom subagent definitions
 - `~/lobster-workspace/` - Runtime data (never in repo)
   - `.claude` → symlink to `~/lobster/.claude/` — **editing files here is immediately live, no deploy needed**

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -93,14 +93,14 @@ Lobster's behavior is configured through a few key files:
 
 | File | What it controls |
 |------|-----------------|
-| `~/lobster-user-config/agents/user.base.bootup.md` | Behavioral preferences (response style, tone, rules) — applies to all roles |
+| `~/lobster-user-config/agents/user.base.md` | Behavioral preferences (response style, tone, rules) — applies to all roles |
 | `~/lobster-user-config/agents/user.base.context.md` | Personal facts and context (projects, people, preferences) |
-| `~/lobster-user-config/agents/user.dispatcher.bootup.md` | Dispatcher-specific behavior overrides |
-| `~/lobster-user-config/agents/user.subagent.bootup.md` | Subagent-specific behavior overrides |
+| `~/lobster-user-config/agents/user.dispatcher.md` | Dispatcher-specific behavior overrides |
+| `~/lobster-user-config/agents/user.subagent.md` | Subagent-specific behavior overrides |
 | `config/lobster.conf` | Feature flags (brain dumps on/off, repo names) |
 | `config/config.env` | Credentials (Telegram token, GitHub PAT) |
 
-These bootup files live in `~/lobster-user-config/` (private, not committed to git) and are read by both the dispatcher and subagents at startup. They extend the system defaults without replacing them.
+These context files live in `~/lobster-user-config/` (private, not committed to git) and are read by both the dispatcher and subagents at startup. They extend the system defaults without replacing them.
 
 **Private config directory:**
 The `~/lobster-user-config/` directory is set up by the installer and holds all user-specific customizations that survive upgrades:

--- a/docker/staging/entrypoint-staging.sh
+++ b/docker/staging/entrypoint-staging.sh
@@ -53,7 +53,7 @@ echo '{"phase":"STOPPED","started_at":null,"session_id":null}' > "$MESSAGES_DIR/
 #
 # This runs the subset of install.sh that is safe and necessary in a container:
 #   - Creates runtime directories and canonical memory templates
-#   - Creates stub user-config agent files (base.bootup.md etc.)
+#   - Creates stub user-config agent files (user.base.md etc.)
 #   - Verifies sqlite-vec loads correctly; fixes ELFCLASS32 on aarch64 (#368)
 #   - Creates CLAUDE.md and .claude/ symlinks in $WORKSPACE_DIR (#366, #367)
 #

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -106,7 +106,7 @@ After pulling updates on the VPS (`git pull` + `uv pip install -e .`):
 
 ## Related documentation
 
-- `.claude/sys.dispatcher.bootup.md` — runtime behavior and the worktree constraint from the dispatcher's perspective
+- `.claude/sys.dispatcher.md` — runtime behavior and the worktree constraint from the dispatcher's perspective
 - `docs/engineering-lessons-learned.md` — recurring patterns to check during PR review
 - `docs/REMOTE-AUTH.md` — headless OAuth re-authentication for the VPS
 - `CLAUDE.md` — full system architecture and key directories

--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -50,7 +50,7 @@ REMINDER_TEXT = (
     "- You NEVER exit. You NEVER stop calling wait_for_messages.\n"
     "- You are a stateless dispatcher. Anything >7 seconds goes to a background subagent.\n\n"
     "Read these files now to restore full context:\n"
-    "1. ~/lobster-workspace/.claude/sys.dispatcher.bootup.md\n"
+    "1. ~/lobster-workspace/.claude/sys.dispatcher.md\n"
     "  \u2190 dispatcher instructions, main loop, 7-second rule\n"
     "2. ~/lobster-user-config/memory/canonical/handoff.md\n"
     "  \u2190 active projects, key people, priorities\n\n"

--- a/hooks/post-compact-gate.py
+++ b/hooks/post-compact-gate.py
@@ -73,7 +73,7 @@ CONFIRMATION_TOKEN = "LOBSTER_COMPACTED_REORIENTED"  # noqa: S105 — not a secr
 
 DENY_REASON_NEEDS_TOKEN = (
     "GATE BLOCKED: Context compaction was just detected. "
-    "Read `~/lobster-workspace/.claude/sys.dispatcher.bootup.md` for the confirmation token, "
+    "Read `~/lobster-workspace/.claude/sys.dispatcher.md` for the confirmation token, "
     "then call `mcp__lobster-inbox__wait_for_messages(confirmation='LOBSTER_COMPACTED_REORIENTED')` directly. "
     "No ToolSearch needed — the MCP schema is pre-registered."
 )

--- a/install.sh
+++ b/install.sh
@@ -343,7 +343,7 @@ if [ "$CONTAINER_SETUP" = true ]; then
     fi
 
     # Create stub user-config agent files if they don't exist
-    for stub_file in "user.base.bootup.md" "user.base.context.md" "user.dispatcher.bootup.md" "user.subagent.bootup.md"; do
+    for stub_file in "user.base.md" "user.base.context.md" "user.dispatcher.md" "user.subagent.md"; do
         stub_dest="$USER_CONFIG_DIR/agents/$stub_file"
         if [ ! -f "$stub_dest" ]; then
             touch "$stub_dest"
@@ -1002,7 +1002,7 @@ if [ -f "$AUDIT_CONTEXT_SEED" ] && [ ! -f "$AUDIT_CONTEXT_DEST" ]; then
 fi
 
 # Create stub user-config agent files if they don't exist
-for stub_file in "user.base.bootup.md" "user.base.context.md" "user.dispatcher.bootup.md" "user.subagent.bootup.md"; do
+for stub_file in "user.base.md" "user.base.context.md" "user.dispatcher.md" "user.subagent.md"; do
     stub_dest="$USER_CONFIG_DIR/agents/$stub_file"
     if [ ! -f "$stub_dest" ]; then
         touch "$stub_dest"

--- a/scripts/migrate-to-user-config.sh
+++ b/scripts/migrate-to-user-config.sh
@@ -10,10 +10,10 @@
 #     memory/
 #       canonical/          <- was ~/lobster-workspace/memory/canonical/
 #     agents/
-#       user.base.bootup.md        <- was ~/lobster-workspace/.claude/user.md (behavioral)
+#       user.base.md        <- was ~/lobster-workspace/.claude/user.md (behavioral)
 #       user.base.context.md <- new file for personal facts (stub if not present)
-#       user.dispatcher.bootup.md  <- was ~/lobster-workspace/.claude/dispatcher.md
-#       user.subagent.bootup.md    <- was ~/lobster-workspace/.claude/subagent.md
+#       user.dispatcher.md  <- was ~/lobster-workspace/.claude/dispatcher.md
+#       user.subagent.md    <- was ~/lobster-workspace/.claude/subagent.md
 #       subagents/          <- empty dir for user-defined custom subagents
 #
 # Safe to run multiple times (idempotent).
@@ -145,43 +145,43 @@ step "Migrating .claude/ user context files..."
 
 NEW_AGENTS="$USER_CONFIG_DIR/agents"
 
-# Migrate user.md -> user.base.bootup.md
+# Migrate user.md -> user.base.md
 if [ -f "$OLD_CLAUDE_DIR/user.md" ]; then
-    dest="$NEW_AGENTS/user.base.bootup.md"
+    dest="$NEW_AGENTS/user.base.md"
     if [ ! -s "$dest" ]; then
         cp "$OLD_CLAUDE_DIR/user.md" "$dest"
-        success "Migrated: .claude/user.md -> agents/user.base.bootup.md"
+        success "Migrated: .claude/user.md -> agents/user.base.md"
         MIGRATED=$((MIGRATED + 1))
     else
-        info "agents/user.base.bootup.md already populated — skipping"
+        info "agents/user.base.md already populated — skipping"
     fi
 else
     info ".claude/user.md not found — skipping"
 fi
 
-# Migrate dispatcher.md -> user.dispatcher.bootup.md
+# Migrate dispatcher.md -> user.dispatcher.md
 if [ -f "$OLD_CLAUDE_DIR/dispatcher.md" ]; then
-    dest="$NEW_AGENTS/user.dispatcher.bootup.md"
+    dest="$NEW_AGENTS/user.dispatcher.md"
     if [ ! -s "$dest" ]; then
         cp "$OLD_CLAUDE_DIR/dispatcher.md" "$dest"
-        success "Migrated: .claude/dispatcher.md -> agents/user.dispatcher.bootup.md"
+        success "Migrated: .claude/dispatcher.md -> agents/user.dispatcher.md"
         MIGRATED=$((MIGRATED + 1))
     else
-        info "agents/user.dispatcher.bootup.md already populated — skipping"
+        info "agents/user.dispatcher.md already populated — skipping"
     fi
 else
     info ".claude/dispatcher.md not found — skipping"
 fi
 
-# Migrate subagent.md -> user.subagent.bootup.md
+# Migrate subagent.md -> user.subagent.md
 if [ -f "$OLD_CLAUDE_DIR/subagent.md" ]; then
-    dest="$NEW_AGENTS/user.subagent.bootup.md"
+    dest="$NEW_AGENTS/user.subagent.md"
     if [ ! -s "$dest" ]; then
         cp "$OLD_CLAUDE_DIR/subagent.md" "$dest"
-        success "Migrated: .claude/subagent.md -> agents/user.subagent.bootup.md"
+        success "Migrated: .claude/subagent.md -> agents/user.subagent.md"
         MIGRATED=$((MIGRATED + 1))
     else
-        info "agents/user.subagent.bootup.md already populated — skipping"
+        info "agents/user.subagent.md already populated — skipping"
     fi
 else
     info ".claude/subagent.md not found — skipping"
@@ -193,7 +193,7 @@ fi
 
 step "Ensuring stub agent files exist..."
 
-for stub in "user.base.bootup.md" "user.base.context.md" "user.dispatcher.bootup.md" "user.subagent.bootup.md"; do
+for stub in "user.base.md" "user.base.context.md" "user.dispatcher.md" "user.subagent.md"; do
     dest="$USER_CONFIG_DIR/agents/$stub"
     if [ ! -f "$dest" ]; then
         touch "$dest"
@@ -242,7 +242,7 @@ fi
 echo ""
 info "User config dir: $USER_CONFIG_DIR"
 info "  memory/canonical/ — canonical memory (handoff, priorities, projects)"
-info "  agents/           — behavioral overrides (base.bootup.md, base.context.md, etc.)"
+info "  agents/           — behavioral overrides (user.base.md, user.base.context.md, etc.)"
 echo ""
 warn "Original files in $WORKSPACE_DIR/memory/ and $OLD_CLAUDE_DIR/ are preserved."
 warn "You can remove them manually once you have verified the migration."

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1070,7 +1070,7 @@ run_migrations() {
         fi
     fi
 
-    # Migration 10: Rename bootup files to sys.*/user.* naming convention
+    # Migration 10: Rename bootup files to sys.*/user.* naming convention (phase 1)
     # Must run BEFORE Migration 11 (stub creation) so that existing populated files are
     # renamed into place before Migration 11 would create empty stubs at the new names.
     # System files (.claude/ in workspace): dispatcher.bootup.md -> sys.dispatcher.bootup.md, subagent.bootup.md -> sys.subagent.bootup.md
@@ -1110,6 +1110,8 @@ run_migrations() {
 
     # Migration 11: Create stub agent files in lobster-user-config if missing
     # Runs after Migration 10 so that files renamed into place are not clobbered by empty stubs.
+    # NOTE: stub names here still use the intermediate user.*.bootup.md form intentionally —
+    # Migration 15 (below) will rename them to the final user.*.md form on existing installs.
     mkdir -p "$USER_CONFIG_DIR/agents/subagents"
     for stub_file in "user.base.bootup.md" "user.base.context.md" "user.dispatcher.bootup.md" "user.subagent.bootup.md"; do
         stub_dest="$USER_CONFIG_DIR/agents/$stub_file"
@@ -1169,6 +1171,48 @@ run_migrations() {
         substep "Removed orphan agents.db from $WORKSPACE_DIR/data/ (empty file, not used by any code)"
         migrated=$((migrated + 1))
     fi
+
+    # Migration 15: Complete sys.*/user.* rename — drop .bootup. from filenames (phase 2)
+    # Phase 1 (Migration 10) added the sys./user. prefix; phase 2 removes the .bootup. infix.
+    # System files in workspace .claude/ (symlinked from repo): rename via the symlink target.
+    # These are controlled by the repo, so git mv handles them on fresh pulls, but the
+    # workspace symlink may still point to the old filename on existing installs.
+    if [ -f "$ws_claude_dir/sys.dispatcher.bootup.md" ] && [ ! -s "$ws_claude_dir/sys.dispatcher.md" ]; then
+        mv "$ws_claude_dir/sys.dispatcher.bootup.md" "$ws_claude_dir/sys.dispatcher.md"
+        substep "Renamed .claude/sys.dispatcher.bootup.md -> .claude/sys.dispatcher.md"
+        migrated=$((migrated + 1))
+    fi
+    if [ -f "$ws_claude_dir/sys.subagent.bootup.md" ] && [ ! -s "$ws_claude_dir/sys.subagent.md" ]; then
+        mv "$ws_claude_dir/sys.subagent.bootup.md" "$ws_claude_dir/sys.subagent.md"
+        substep "Renamed .claude/sys.subagent.bootup.md -> .claude/sys.subagent.md"
+        migrated=$((migrated + 1))
+    fi
+    # User-config files: rename user.*.bootup.md -> user.*.md
+    local agents_dir15="$USER_CONFIG_DIR/agents"
+    if [ -f "$agents_dir15/user.base.bootup.md" ] && [ ! -s "$agents_dir15/user.base.md" ]; then
+        mv "$agents_dir15/user.base.bootup.md" "$agents_dir15/user.base.md"
+        substep "Renamed agents/user.base.bootup.md -> agents/user.base.md"
+        migrated=$((migrated + 1))
+    fi
+    if [ -f "$agents_dir15/user.dispatcher.bootup.md" ] && [ ! -s "$agents_dir15/user.dispatcher.md" ]; then
+        mv "$agents_dir15/user.dispatcher.bootup.md" "$agents_dir15/user.dispatcher.md"
+        substep "Renamed agents/user.dispatcher.bootup.md -> agents/user.dispatcher.md"
+        migrated=$((migrated + 1))
+    fi
+    if [ -f "$agents_dir15/user.subagent.bootup.md" ] && [ ! -s "$agents_dir15/user.subagent.md" ]; then
+        mv "$agents_dir15/user.subagent.bootup.md" "$agents_dir15/user.subagent.md"
+        substep "Renamed agents/user.subagent.bootup.md -> agents/user.subagent.md"
+        migrated=$((migrated + 1))
+    fi
+    # Ensure stubs exist at the new names (for fresh installs where Mig 11 created old-name stubs)
+    for stub_file in "user.base.md" "user.base.context.md" "user.dispatcher.md" "user.subagent.md"; do
+        stub_dest="$agents_dir15/$stub_file"
+        if [ ! -f "$stub_dest" ]; then
+            touch "$stub_dest"
+            substep "Created stub: agents/$stub_file"
+            migrated=$((migrated + 1))
+        fi
+    done
 
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"


### PR DESCRIPTION
## What this fixes

The previous rename PR (issue 318, merged) added the `sys.` and `user.` prefixes but left `.bootup.` in the middle of each filename. The resulting names (`sys.dispatcher.bootup.md`, `user.base.bootup.md`, etc.) still carry redundant noise — ownership is now readable from the prefix, so `.bootup.` adds nothing.

This PR completes the rename to the clean form described in issue #442.

## Changes

**System files in `.claude/` (git mv):**
- `sys.dispatcher.bootup.md` → `sys.dispatcher.md`
- `sys.subagent.bootup.md` → `sys.subagent.md`

**User-config path references updated in all repo files:**
- `user.base.bootup.md` → `user.base.md`
- `user.dispatcher.bootup.md` → `user.dispatcher.md`
- `user.subagent.bootup.md` → `user.subagent.md`
- (`user.base.context.md` is unchanged — no `.bootup.` to drop)

**Files changed:** `CLAUDE.md`, `.claude/sys.dispatcher.md`, `.claude/sys.subagent.md`, `ONBOARDING.md`, `docs/DEVELOPMENT.md`, `hooks/on-compact.py`, `hooks/post-compact-gate.py`, `install.sh`, `scripts/migrate-to-user-config.sh`, `docker/staging/entrypoint-staging.sh`, `scripts/upgrade.sh`.

**Migration 15** in `upgrade.sh` handles existing installs idempotently: renames `sys.*.bootup.md` → `sys.*.md` in workspace `.claude/` and `user.*.bootup.md` → `user.*.md` in `lobster-user-config/agents/`. Checks old name exists and new name absent before acting; also creates stubs at the new names for any that are missing.

## What is NOT changed

- `sys.debug.bootup.md` — the debug injection file keeps its name (it was never part of this rename series; its name reflects the debug function, not the bootup concept)
- Hook registration, `settings.json`, or service files — none reference bootup filenames directly
- Migrations 10–14 — left intact as historical record of earlier rename steps; Migration 15 builds on them

## Functional design

All path strings are literals — no runtime logic changed. Correctness is verifiable by inspection of the diff.

## Tests run

- [x] `git diff --stat HEAD` — 11 files changed, renames confirmed correct, no stray old names in non-migration code
- [ ] Full test suite — not run; this is a pure rename with no logic changes. All paths are string literals in markdown/shell.

Closes #442

🤖🦞 Generated with [Claude Code](https://claude.com/claude-code)