### PR TITLE
fix(observation): break tier 1 signal extraction feedback loop on debug messages

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -162,8 +162,17 @@ def _ensure_observation_worker() -> None:
 
 
 def _queue_observation(msg_text: str, msg_id: str, source: str | None = None, ts: str | None = None) -> None:
-    """Non-blocking: enqueue a message for background observation. Drops if full."""
+    """Non-blocking: enqueue a message for background observation. Drops if full.
+
+    Guard: skip debug/system messages so tier 1 signal extraction never fires on
+    its own output (which would create an infinite debug-observation loop).
+    """
     if _user_model is None:
+        return
+    # Skip messages that are system/debug output — not real user content.
+    # The [debug|...] prefix is written by _emit_debug_observation; source="system"
+    # and chat_id=0 are markers used by internal synthetic messages.
+    if msg_text.startswith("[debug|"):
         return
     try:
         _observation_queue.put_nowait((msg_text, msg_id, source, ts))
@@ -3105,7 +3114,8 @@ async def handle_mark_processing(args: dict) -> list[TextContent]:
     msg_text = msg_data.get("text", "") or msg_data.get("transcription", "")
     msg_type = msg_data.get("type", "")
     _SKIP_OBSERVATION_TYPES = (
-        "subagent_result", "subagent_error", "self_check", "subagent_observation"
+        "subagent_result", "subagent_error", "self_check", "subagent_observation",
+        "debug_observation",  # never run tier 1 on our own debug output (would loop)
     )
     if msg_text and msg_type not in _SKIP_OBSERVATION_TYPES:
         _queue_observation(

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -162,17 +162,8 @@ def _ensure_observation_worker() -> None:
 
 
 def _queue_observation(msg_text: str, msg_id: str, source: str | None = None, ts: str | None = None) -> None:
-    """Non-blocking: enqueue a message for background observation. Drops if full.
-
-    Guard: skip debug/system messages so tier 1 signal extraction never fires on
-    its own output (which would create an infinite debug-observation loop).
-    """
+    """Non-blocking: enqueue a message for background observation. Drops if full."""
     if _user_model is None:
-        return
-    # Skip messages that are system/debug output — not real user content.
-    # The [debug|...] prefix is written by _emit_debug_observation; source="system"
-    # and chat_id=0 are markers used by internal synthetic messages.
-    if msg_text.startswith("[debug|"):
         return
     try:
         _observation_queue.put_nowait((msg_text, msg_id, source, ts))
@@ -3129,7 +3120,7 @@ async def handle_mark_processing(args: dict) -> list[TextContent]:
     short_msg_id = message_id[:20] if len(message_id) > 20 else message_id
     _SKIP_CONTEXT_TYPES = (
         "subagent_result", "subagent_error", "self_check", "callback", "system",
-        "subagent_observation",  # avoid debug observations triggering more debug observations
+        "subagent_observation", "debug_observation",  # internal messages — not real user content
     )
     if _user_model is not None and msg_text and msg_type not in _SKIP_CONTEXT_TYPES:
         if _should_inject_user_context(msg_text):


### PR DESCRIPTION
## What and why

When \`LOBSTER_DEBUG=true\`, tier 1 signal extraction was firing on its own debug output, creating an infinite loop. \`_emit_debug_observation\` writes messages with \`type="debug_observation"\` into the inbox. When the dispatcher called \`mark_processing\` on those messages, they passed the existing type filter and were queued for observation. The observation worker ran \`extract_signals\` on the debug text, found a "correction" signal, emitted another debug observation — and the cycle repeated indefinitely.

The loop only fires in debug mode (\`LOBSTER_DEBUG=true\`), but once started it generates unbounded inbox traffic and log noise.

## What changed

The fix lives entirely at the routing layer in \`handle_mark_processing\`, which is the correct abstraction: before a message is handed to \`_queue_observation\`, its \`type\` field is checked against a skip list. Adding \`"debug_observation"\` to \`_SKIP_OBSERVATION_TYPES\` means the call to \`_queue_observation\` never happens for debug messages. The type field is set by \`_emit_debug_observation\` itself, so the fix uses the same metadata that already identifies these messages — no text inspection required.

The earlier approach (checking \`msg_text.startswith("[debug|")\` inside \`_queue_observation\`) has been removed. That guard was at the wrong abstraction layer: \`_queue_observation\` receives raw text and has no business knowing what prefix a debug emitter uses. The type field on the message is the correct signal.

\`"debug_observation"\` is also added to \`_SKIP_CONTEXT_TYPES\` so debug messages cannot trigger user model context injection — the same class of problem at the same routing point.

## Functional patterns

Pure predicate guard at the dispatch layer. The skip-list check is a pure function of the message's \`type\` field. No side effects; no dependency on message content. Follows the same pattern as the other entries in \`_SKIP_OBSERVATION_TYPES\` (\`subagent_result\`, \`self_check\`, etc.).

## Tests run

- [x] \`uv run pytest tests/unit/test_mcp_server/test_debug_alerts.py -v\` — 34 passed, 0 failed
- [x] \`uv run pytest tests/unit/ -q\` — 1062 passed, 68 pre-existing failures (same failures present on the branch before this commit; none are in inbox_server or observation code)
- [ ] Live debug-mode loop reproduction — blocked: requires a running Lobster instance with \`LOBSTER_DEBUG=true\` and a real Telegram token. No behavior change to non-debug paths, safe to merge without this.

**Blocked items needing attention before merge:** none — the pre-existing test failures are unrelated to this change.