### PR TITLE
fix(health-check): explicitly kill old Claude PID when ExecStop fails silently

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -985,6 +985,19 @@ Manual intervention required:
         log_info "systemctl stop: $line"
     done
 
+    # Explicitly kill the old Claude PID if it is still alive after systemctl stop.
+    # When the tmux socket is stale, ExecStop ("tmux kill-session") exits non-zero
+    # but systemd swallows the failure — the service transitions to inactive and
+    # systemctl stop returns 0, but the old process is never killed. Without this
+    # guard, the new session starts and two dispatchers run concurrently, causing
+    # duplicate message processing and corrupted inbox state.
+    if [[ -n "$pre_restart_pid" ]] && kill -0 "$pre_restart_pid" 2>/dev/null; then
+        log_warn "ExecStop did not kill PID $pre_restart_pid — sending SIGTERM"
+        kill "$pre_restart_pid" 2>/dev/null || true
+        sleep 2
+        kill -0 "$pre_restart_pid" 2>/dev/null && kill -9 "$pre_restart_pid" 2>/dev/null || true
+    fi
+
     # Clean up the socket only if stop left it behind.
     # A successful ExecStop removes it via tmux kill-session; if stop failed or
     # the socket was already stale, we clean it up here so ExecStart can bind.


### PR DESCRIPTION
## Problem

A health-check-initiated restart can leave two dispatcher processes running concurrently. This happens when the tmux socket is stale at restart time: `ExecStop` runs `tmux kill-session`, which exits non-zero because the socket is gone, but systemd treats `ExecStop` failures as non-fatal — `systemctl stop` returns 0 and the service transitions to `inactive` without ever killing the old Claude PID. `ExecStart` then brings up a new session, and both dispatchers compete on the inbox.

The result is a silent correctness failure: the health check considers the restart successful, the service looks healthy, but duplicate message processing and missed `mark_processed` calls corrupt inbox state.

## Fix

After the `systemctl stop` call in `do_restart()`, check whether `pre_restart_pid` is still alive using `kill -0`. If it is, send SIGTERM and wait 2 seconds; if it still hasn't exited, send SIGKILL. In the normal path where `ExecStop` succeeds, this block is a no-op — `kill -0` fails immediately and the block is skipped.

The change is 13 lines, entirely within `do_restart()`, between the `systemctl stop` block and the existing stale-socket cleanup section. No other logic is touched.

Functional pattern: pure defensive check — the kill block reads no shared state and has no side effects in the happy path.

Closes #561

## Tests run

- [ ] Live restart with stale tmux socket — blocked: requires a running Lobster instance to reproduce; the code path is straightforward enough that the logic can be verified by inspection. No automated test harness exists for this script.
- [x] `bash -n scripts/health-check-v3.sh` — syntax check passes, no errors