### PR TITLE
fix: use PID file in do_restart() to avoid ambiguous pgrep

### DIFF
--- a/scripts/claude-persistent.sh
+++ b/scripts/claude-persistent.sh
@@ -387,11 +387,31 @@ launch_claude() {
     # Once we hand off to claude, we're active.
     write_state "active" "claude running, attempt=$attempt"
 
-    claude --dangerously-skip-permissions \
-        --model sonnet \
-        --max-turns 150 \
-        -p "$init_prompt" \
-        2>&1 | tee -a "$LOG_DIR/claude-session.log" || claude_exit_code=$?
+    # Write the dispatcher PID file so the health check can target this specific
+    # process for cleanup without relying on ambiguous pgrep matches.
+    #
+    # We use a subshell that writes $BASHPID (the actual subshell PID) and then
+    # exec-replaces itself with claude. After exec, the running claude process
+    # has the same PID that was written to the file. $$ would give the *parent*
+    # shell's PID in bash, so $BASHPID is required here.
+    local dispatcher_pid_file="$MESSAGES_DIR/config/dispatcher.pid"
+    mkdir -p "$(dirname "$dispatcher_pid_file")"
+
+    (
+        echo "$BASHPID" > "$dispatcher_pid_file"
+        exec claude --dangerously-skip-permissions \
+            --model sonnet \
+            --max-turns 150 \
+            -p "$init_prompt"
+    ) 2>&1 | tee -a "$LOG_DIR/claude-session.log" || claude_exit_code=$?
+
+    # Clean up PID file on exit — the process is gone, the file is stale.
+    # Note: if claude-persistent.sh's parent is SIGKILLed, this cleanup won't run,
+    # leaving a stale PID file. On next launch, the health check reads it, finds the
+    # PID dead via kill -0, treats any kill as no-op, and self-heals when the new PID
+    # overwrites the file at launch start.
+    rm -f "$dispatcher_pid_file" 2>/dev/null || true
+    log "Claude exited (exit_code=$claude_exit_code), PID file removed"
 
     return $claude_exit_code
 }

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -61,6 +61,7 @@ WORKSPACE_DIR="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
 INBOX_DIR="$MESSAGES_DIR/inbox"
 MAINTENANCE_FLAG="$MESSAGES_DIR/config/lobster-maintenance"
 LOBSTER_STATE_FILE="${LOBSTER_STATE_FILE_OVERRIDE:-$MESSAGES_DIR/config/lobster-state.json}"
+DISPATCHER_PID_FILE="$MESSAGES_DIR/config/dispatcher.pid"
 STALE_THRESHOLD_SECONDS=240          # 4 minutes - RED if any message older (watchdog handles soft recovery at 90s)
 YELLOW_THRESHOLD_SECONDS=150         # 2.5 minutes - YELLOW warning
 
@@ -982,9 +983,27 @@ Manual intervention required:
     record_restart
 
     # Capture the Claude PID before stopping, so we can verify a new process
-    # is running after restart (not just the same surviving process).
-    local pre_restart_pid
-    pre_restart_pid=$(pgrep -x "claude" 2>/dev/null | head -1)
+    # is running after restart (not just the same surviving process), and so we
+    # can kill it directly if ExecStop fails silently.
+    #
+    # Read from the PID file written by claude-persistent.sh at launch time.
+    # This is unambiguous: pgrep -x "claude" could match an unrelated Claude
+    # process (e.g. a debug session), but the PID file records exactly the
+    # dispatcher that this health check is responsible for.
+    local pre_restart_pid=""
+    if [[ -f "$DISPATCHER_PID_FILE" ]]; then
+        pre_restart_pid=$(< "$DISPATCHER_PID_FILE")
+        # Sanity check: must be a non-empty integer
+        if [[ ! "$pre_restart_pid" =~ ^[0-9]+$ ]]; then
+            log_warn "dispatcher.pid contains non-numeric value '$pre_restart_pid' — ignoring"
+            pre_restart_pid=""
+        fi
+    fi
+    if [[ -n "$pre_restart_pid" ]]; then
+        log_info "Pre-restart dispatcher PID: $pre_restart_pid (from $DISPATCHER_PID_FILE)"
+    else
+        log_warn "No dispatcher.pid found — pre-restart PID unknown (new install or first restart)"
+    fi
 
     local tmux_uid
     tmux_uid=$(id -u)
@@ -1013,6 +1032,10 @@ Manual intervention required:
     # systemctl stop + tmux kill-server, kill it explicitly. SIGTERM first,
     # then SIGKILL after a brief wait. This handles cases where the process
     # detached from the tmux session before the kill-server ran.
+    #
+    # Unlike pgrep, targeting the PID file is unambiguous: it records exactly the
+    # dispatcher process launched by claude-persistent.sh, not any other Claude
+    # process that may be running (e.g. a debug session or subagent).
     if [[ -n "$pre_restart_pid" ]] && kill -0 "$pre_restart_pid" 2>/dev/null; then
         log_warn "Claude PID $pre_restart_pid survived systemctl stop + tmux kill-server — sending SIGTERM"
         kill -TERM "$pre_restart_pid" 2>/dev/null || true
@@ -1023,6 +1046,9 @@ Manual intervention required:
             sleep 1
         fi
     fi
+
+    # Clean up the PID file — the process is gone (or was already gone).
+    rm -f "$DISPATCHER_PID_FILE" 2>/dev/null || true
 
     # Verify the old process is actually dead before starting a new session.
     # If we cannot confirm it is gone, abort rather than risk two competing
@@ -1058,15 +1084,24 @@ Manual intervention required to kill the process before restarting:
     # must differ from the pre-restart PID (catching ghost sessions where the
     # old process survived alongside the newly started one).
     #
-    # PID retry loop: the new process may not have started quickly enough for
-    # pgrep to see it yet. Retry up to 3 times with 3-second gaps before
-    # concluding that the PID is genuinely unchanged (i.e. restart failed).
-    local post_restart_pid
+    # PID retry loop: the new claude-persistent.sh may not have written the PID
+    # file yet. Retry up to 3 times with 3-second gaps before concluding that
+    # the PID is genuinely unchanged (i.e. restart failed).
+    #
+    # Read from the PID file (same source as pre_restart_pid) for a consistent
+    # comparison. If the file is absent or empty, the new process hasn't written
+    # it yet — treat as "not ready" and keep retrying.
+    local post_restart_pid=""
     local pid_changed=true
     local pid_check_attempts=0
     while [[ $pid_check_attempts -lt 3 ]]; do
-        post_restart_pid=$(pgrep -x "claude" 2>/dev/null | head -1)
-        if [[ -z "$pre_restart_pid" || "$post_restart_pid" != "$pre_restart_pid" ]]; then
+        if [[ -f "$DISPATCHER_PID_FILE" ]]; then
+            post_restart_pid=$(< "$DISPATCHER_PID_FILE")
+            [[ ! "$post_restart_pid" =~ ^[0-9]+$ ]] && post_restart_pid=""
+        else
+            post_restart_pid=""
+        fi
+        if [[ -z "$pre_restart_pid" || ( -n "$post_restart_pid" && "$post_restart_pid" != "$pre_restart_pid" ) ]]; then
             break
         fi
         pid_check_attempts=$(( pid_check_attempts + 1 ))


### PR DESCRIPTION
## Problem

Health-check-initiated restarts can leave two dispatcher processes running concurrently. The failure path: when the tmux socket is stale at restart time, ExecStop runs `tmux kill-session`, which exits non-zero because the socket is gone, but systemd treats ExecStop failures as non-fatal — `systemctl stop` returns 0 and the service transitions to `inactive` without killing the old Claude process. ExecStart then brings up a new session, and both dispatchers compete on the inbox. The result is duplicate message processing and corrupted inbox state.

PR #562 addressed this by adding a kill block after `systemctl stop`, but used `pgrep -x "claude" | head -1` to identify the old PID. That is ambiguous: it can match an unrelated Claude process (a debug session, a subagent). The PID file approach in this PR is unambiguous.

## How it works

**`claude-persistent.sh`**: Before each claude launch, write the dispatcher PID to `~/messages/config/dispatcher.pid`. Implementation: a bash subshell writes `$BASHPID` then `exec claude`. After exec, the running process has the same PID that was written. (`$$` gives the parent shell PID even inside a subshell — bash behavior — so `$BASHPID` is required here.) File is removed on normal exit via trap.

**`health-check-v3.sh`** (`do_restart()`):
- Replace `pgrep -x "claude" | head -1` with a read from `dispatcher.pid` (with integer sanity check).
- After `systemctl stop`, if that specific PID is still alive (`kill -0`): send SIGTERM, sleep 2, escalate to SIGKILL if still running. Clean up the PID file.
- Post-restart PID verification also reads from the PID file, so both sides of the "did the PID change?" check use the same source.

## Tradeoffs & constraints

- **First-restart edge case**: if the PID file does not exist yet (first ever restart, or file was lost), `pre_restart_pid` is empty and the post-restart PID-changed check is skipped. The service/tmux health checks still verify the restart succeeded. Logged as a warning.
- **Stale PID file**: if the process dies abnormally without running the trap, the PID file may linger with a dead PID. `kill -0` on a dead PID returns an error, so the kill block is a no-op — safe. File is overwritten on next launch.
- **Assumption**: `$BASHPID` is a bash-specific variable (not POSIX sh). `claude-persistent.sh` must be run with bash, not sh. The shebang is `#!/bin/bash`.
- **Not live-tested**: the stale-tmux-socket path requires a running Lobster instance to test. Syntax checks pass; logic matches the described failure mode.

Nothing outside `do_restart()` and `claude-persistent.sh` is touched.

Closes #561