### PR TITLE
fix(run-job): export LOBSTER_MAIN_SESSION=1 so scheduled jobs can call send_reply

### DIFF
--- a/scheduled-tasks/run-job.sh
+++ b/scheduled-tasks/run-job.sh
@@ -11,6 +11,12 @@ export PATH="$HOME/.local/bin:$PATH"
 # CLAUDECODE leaks when run-job.sh is manually tested from a Claude session.
 unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
 
+# Allow scheduled jobs to call send_reply and other session-guarded MCP tools.
+# Without this, inbox_server.py's session guard blocks send_reply silently
+# because cron-launched processes are not descendants of the lobster tmux session.
+# See issue #571.
+export LOBSTER_MAIN_SESSION=1
+
 JOB_NAME="$1"
 
 if [ -z "$JOB_NAME" ]; then


### PR DESCRIPTION
## Purpose

Fixes a bug where scheduled task Claude sessions (launched by `run-job.sh` via cron) could not call `send_reply` or other session-guarded MCP tools, because the session guard in `inbox_server.py` blocked them silently.

Closes #571.

## Root Cause

`inbox_server.py` guards tools like `send_reply` using two checks:
1. **Primary**: tmux process ancestry walk — cron jobs are NOT descendants of the lobster tmux session
2. **Fallback**: `LOBSTER_MAIN_SESSION=1` env var — not previously set in `run-job.sh`

Both checks failed for scheduled jobs, causing silent blocks.

## Fix

Added `export LOBSTER_MAIN_SESSION=1` immediately after the `unset CLAUDECODE` block in `run-job.sh`. This takes the env-var fallback path, granting scheduled job Claude instances the same outbox access as the main dispatcher.

## Change

- `scheduled-tasks/run-job.sh`: add `export LOBSTER_MAIN_SESSION=1` with explanatory comment

## Test plan

- [ ] Run a scheduled job manually via `run-job.sh <job-name>` and confirm `send_reply` succeeds without SESSION GUARD error
- [ ] Confirm existing behavior unchanged for normal dispatcher (env var doesn't affect it since it already passes the tmux ancestry check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)