### PR TITLE
feat(report): /report slash command with SQLite-backed report store (BIS-84)

### DIFF
--- a/src/agents/session_store.py
+++ b/src/agents/session_store.py
@@ -72,6 +72,30 @@ CREATE TABLE IF NOT EXISTS agent_sessions (
 );
 """
 
+# Reports table DDL — stores user-filed /report slash command records.
+# Unified into agent_sessions.db to keep all operational data in one place.
+_SCHEMA_REPORTS_TABLE = """
+CREATE TABLE IF NOT EXISTS reports (
+    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+    report_id               TEXT NOT NULL UNIQUE,
+    description             TEXT NOT NULL,
+    chat_id                 TEXT NOT NULL,
+    source                  TEXT NOT NULL DEFAULT 'telegram',
+    recent_messages_json    TEXT,
+    agent_session_ids_json  TEXT,
+    snapshot_state_json     TEXT,
+    created_at              TEXT NOT NULL DEFAULT (datetime('now')),
+    status                  TEXT NOT NULL DEFAULT 'open'
+);
+"""
+
+# Reports table indexes
+_SCHEMA_REPORTS_INDEXES = """
+CREATE INDEX IF NOT EXISTS idx_reports_chat_id   ON reports (chat_id);
+CREATE INDEX IF NOT EXISTS idx_reports_created_at ON reports (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_reports_status    ON reports (status);
+"""
+
 # Indexes — run after all columns are guaranteed to exist (i.e., after migrations)
 _SCHEMA_INDEXES = """
 CREATE INDEX IF NOT EXISTS idx_status ON agent_sessions (status);
@@ -151,6 +175,10 @@ def init_db(path: Path | None = None) -> None:
     conn.executescript(_SCHEMA_CREATE_TABLE)
     conn.commit()
 
+    # Step 1b: Create the reports table (idempotent — IF NOT EXISTS guard).
+    conn.executescript(_SCHEMA_REPORTS_TABLE)
+    conn.commit()
+
     # Step 2: Safe ALTER TABLE migrations for existing DBs — each is idempotent.
     # SQLite raises OperationalError if the column already exists; we ignore it.
     # Order matters: run before creating indexes that reference the new columns.
@@ -163,6 +191,10 @@ def init_db(path: Path | None = None) -> None:
 
     # Step 3: Create indexes — run after migrations so all referenced columns exist.
     conn.executescript(_SCHEMA_INDEXES)
+    conn.commit()
+
+    # Step 3b: Create reports indexes.
+    conn.executescript(_SCHEMA_REPORTS_INDEXES)
     conn.commit()
 
     # One-time JSON migration
@@ -930,3 +962,155 @@ def _migrate_json_to_sqlite(json_path: Path, conn: sqlite3.Connection) -> int:
         pass  # Rename failed — not fatal, migration data is in DB
 
     return count
+
+
+# ---------------------------------------------------------------------------
+# Public: reports
+# ---------------------------------------------------------------------------
+
+def _next_report_id(conn: sqlite3.Connection) -> str:
+    """Generate the next sequential report ID in the form RPT-NNN.
+
+    Reads the current max id from the reports table to derive the next
+    integer. Pure determination from DB state — no external counters.
+    """
+    cursor = conn.execute("SELECT MAX(id) FROM reports")
+    row = cursor.fetchone()
+    next_int = (row[0] or 0) + 1
+    return f"RPT-{next_int:03d}"
+
+
+def create_report(
+    description: str,
+    chat_id: str | int,
+    source: str = "telegram",
+    recent_messages: list | None = None,
+    active_session_ids: list[str] | None = None,
+    snapshot_state: dict | None = None,
+    path: Path | None = None,
+) -> dict:
+    """Insert a new report record and return its data dict.
+
+    Captures a point-in-time snapshot of recent messages and active agent
+    sessions alongside the user-supplied description. The report_id is
+    auto-generated as a sequential RPT-NNN identifier.
+
+    Args:
+        description:        User-provided problem description.
+        chat_id:            Chat that filed the report (stored as TEXT).
+        source:             Messaging platform the report came from.
+        recent_messages:    Last N messages from conversation history (list of dicts).
+        active_session_ids: IDs of agent sessions active at report time.
+        snapshot_state:     Any additional ambient state to capture (arbitrary dict).
+        path:               DB path override (for tests).
+
+    Returns:
+        Dict with keys: report_id, id, description, chat_id, source,
+        created_at, status.
+    """
+    import json as _json
+
+    resolved = path if path is not None else _DEFAULT_DB_PATH
+    conn = _get_connection(resolved)
+    now = datetime.now(timezone.utc).isoformat()
+
+    report_id = _next_report_id(conn)
+
+    recent_json = _json.dumps(recent_messages) if recent_messages is not None else None
+    session_ids_json = _json.dumps(active_session_ids) if active_session_ids is not None else None
+    snapshot_json = _json.dumps(snapshot_state) if snapshot_state is not None else None
+
+    conn.execute(
+        """
+        INSERT INTO reports
+            (report_id, description, chat_id, source,
+             recent_messages_json, agent_session_ids_json,
+             snapshot_state_json, created_at, status)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'open')
+        """,
+        (
+            report_id,
+            description,
+            str(chat_id),
+            source,
+            recent_json,
+            session_ids_json,
+            snapshot_json,
+            now,
+        ),
+    )
+    conn.commit()
+
+    return {
+        "report_id": report_id,
+        "description": description,
+        "chat_id": str(chat_id),
+        "source": source,
+        "created_at": now,
+        "status": "open",
+    }
+
+
+def get_report(
+    report_id: str,
+    path: Path | None = None,
+) -> dict | None:
+    """Return the full report record for the given report_id, or None.
+
+    Args:
+        report_id: The RPT-NNN identifier string.
+        path:      DB path override (for tests).
+    """
+    resolved = path if path is not None else _DEFAULT_DB_PATH
+    conn = _get_connection(resolved)
+
+    cursor = conn.execute(
+        "SELECT * FROM reports WHERE report_id = ? LIMIT 1",
+        (report_id,),
+    )
+    row = cursor.fetchone()
+    return dict(row) if row is not None else None
+
+
+def list_reports(
+    chat_id: str | int | None = None,
+    status: str | None = None,
+    limit: int = 20,
+    path: Path | None = None,
+) -> list[dict]:
+    """Return reports newest-first, optionally filtered by chat_id and status.
+
+    Args:
+        chat_id: If provided, restrict to reports from this chat.
+        status:  If provided, restrict to reports with this status.
+        limit:   Maximum number of rows to return.
+        path:    DB path override (for tests).
+    """
+    resolved = path if path is not None else _DEFAULT_DB_PATH
+    conn = _get_connection(resolved)
+
+    conditions: list[str] = []
+    params: list = []
+
+    if chat_id is not None:
+        conditions.append("chat_id = ?")
+        params.append(str(chat_id))
+    if status is not None:
+        conditions.append("status = ?")
+        params.append(status)
+
+    where_clause = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+    params.append(limit)
+
+    cursor = conn.execute(
+        f"""
+        SELECT id, report_id, description, chat_id, source, created_at, status
+        FROM reports
+        {where_clause}
+        ORDER BY created_at DESC
+        LIMIT ?
+        """,
+        params,
+    )
+    rows = cursor.fetchall()
+    return [dict(r) for r in rows]

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -2318,6 +2318,41 @@ async def list_tools() -> list[Tool]:
                 "required": ["telegram_chat_id"],
             },
         ),
+        # /report Slash Command Tool
+        Tool(
+            name="create_report",
+            description=(
+                "File a user report triggered by the /report slash command. "
+                "Captures a point-in-time snapshot: the user's description, the last 10 "
+                "messages for context, and the IDs of any active agent sessions. "
+                "Stores the record in the reports table of agent_sessions.db and returns "
+                "a unique report ID (e.g. RPT-001). "
+                "Call this when the user sends '/report <description>' — the response "
+                "should be sent back to the user with the report ID as confirmation."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string",
+                        "description": "The problem or feedback description from the user (everything after '/report ').",
+                    },
+                    "chat_id": {
+                        "oneOf": [
+                            {"type": "integer"},
+                            {"type": "string"},
+                        ],
+                        "description": "The chat_id of the user filing the report.",
+                    },
+                    "source": {
+                        "type": "string",
+                        "description": "Messaging source (telegram, slack, etc.). Default: telegram.",
+                        "default": "telegram",
+                    },
+                },
+                "required": ["description", "chat_id"],
+            },
+        ),
     ] + (
         # User Model Tools (only registered when feature flag is enabled)
         [
@@ -2501,6 +2536,9 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[TextConte
         return await handle_create_calendar_event(arguments)
     elif name == "list_calendar_events":
         return await handle_list_calendar_events(arguments)
+    # /report Slash Command Tool
+    elif name == "create_report":
+        return await handle_create_report(arguments)
     # User Model Tools (dispatched to user_model subsystem)
     elif name in _user_model_tool_names and _user_model is not None:
         result_json = _user_model.dispatch(name, arguments)
@@ -2701,6 +2739,100 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
         observer.join(timeout=1)
 
 
+def _is_report_command(text: str) -> bool:
+    """Return True if text is a /report slash command (with a description).
+
+    Matches "/report <description>" at the start of the message.
+    The command token must be exactly "/report" (case-insensitive), followed by
+    whitespace and a non-empty description. Does NOT match "/reports" or other
+    commands that begin with "/report" but have extra characters.
+    """
+    if not text:
+        return False
+    stripped = text.strip()
+    lower = stripped.lower()
+    # Must start with "/report" followed by whitespace or end of string
+    if lower == "/report":
+        return False  # No description — ignore bare command
+    if lower.startswith("/report ") or lower.startswith("/report\t"):
+        rest = stripped[len("/report"):].strip()
+        return bool(rest)
+    return False
+
+
+def _extract_report_description(text: str) -> str:
+    """Extract the description part from a /report command text."""
+    stripped = text.strip()
+    rest = stripped[len("/report"):].strip()
+    return rest
+
+
+async def _handle_report_slash_command(msg: dict, msg_file: Path) -> None:
+    """Auto-handle a /report slash command message.
+
+    Creates the report record, queues a confirmation reply to the user, and
+    moves the message to processed/. This is called from handle_check_inbox
+    before the message reaches the main dispatcher loop.
+
+    Args:
+        msg:      The parsed message dict from the inbox JSON file.
+        msg_file: The Path to the inbox JSON file.
+    """
+    text = msg.get("text", "")
+    chat_id = msg.get("chat_id", "")
+    source = msg.get("source", "telegram")
+    msg_id = msg.get("id", msg_file.stem)
+
+    description = _extract_report_description(text)
+
+    # Capture active agent sessions
+    active_session_ids: list[str] = []
+    try:
+        active = _session_store.get_active_sessions()
+        active_session_ids = [s.get("id", "") for s in active if s.get("id")]
+    except Exception:
+        pass
+
+    snapshot_state = {
+        "active_session_count": len(active_session_ids),
+        "lobster_state": _read_lobster_state(),
+    }
+
+    # Store the report
+    try:
+        report = _session_store.create_report(
+            description=description,
+            chat_id=chat_id,
+            source=source,
+            recent_messages=None,  # not captured in pre-processor to stay fast
+            active_session_ids=active_session_ids if active_session_ids else None,
+            snapshot_state=snapshot_state,
+        )
+        report_id = report["report_id"]
+        log.info(f"/report pre-processor: created {report_id} for chat {chat_id}")
+    except Exception as exc:
+        log.error(f"/report pre-processor: failed to create report: {exc}", exc_info=True)
+        report_id = "RPT-ERR"
+
+    # Send confirmation reply and mark processed atomically
+    confirmation = f"Report filed as {report_id}. We'll look into it."
+    try:
+        await handle_send_reply({
+            "chat_id": chat_id,
+            "text": confirmation,
+            "source": source,
+            "message_id": msg_id,
+        })
+    except Exception as exc:
+        log.error(f"/report pre-processor: send_reply failed: {exc}", exc_info=True)
+        # Fall back to just marking processed
+        try:
+            dest = PROCESSED_DIR / msg_file.name
+            msg_file.rename(dest)
+        except Exception:
+            pass
+
+
 async def handle_check_inbox(args: dict) -> list[TextContent]:
     """Check for new messages in inbox."""
     source_filter = args.get("source", "").lower()
@@ -2713,6 +2845,15 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
                 msg = json.load(fp)
                 if source_filter and msg.get("source", "").lower() != source_filter:
                     continue
+                # /report slash command pre-processor: handle automatically without
+                # surfacing the raw message to the main dispatcher loop.
+                msg_text = msg.get("text", "")
+                if _is_report_command(msg_text):
+                    try:
+                        await _handle_report_slash_command(msg, f)
+                    except Exception as exc:
+                        log.error(f"check_inbox: /report pre-processor error: {exc}", exc_info=True)
+                    continue  # skip — already handled
                 msg["_filename"] = f.name
                 messages.append(msg)
                 if len(messages) >= limit:
@@ -6166,6 +6307,83 @@ async def handle_list_calendar_events(args: dict) -> list[TextContent]:
         for e in events
     ]
     return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+
+# ---------------------------------------------------------------------------
+# /report Slash Command Handler
+# ---------------------------------------------------------------------------
+
+async def handle_create_report(args: dict) -> list[TextContent]:
+    """Handle the create_report MCP tool.
+
+    Captures a point-in-time snapshot (recent conversation messages, active
+    agent sessions) alongside the user's description and stores it in the
+    reports table of agent_sessions.db. Returns a confirmation dict with
+    the generated report_id.
+
+    This is the backend for the /report slash command pre-processor.
+    """
+    description = str(args.get("description", "")).strip()
+    chat_id = args.get("chat_id", "")
+    source = str(args.get("source", "telegram")).strip() or "telegram"
+
+    if not description:
+        return [TextContent(type="text", text='{"error": "description is required"}')]
+    if not chat_id:
+        return [TextContent(type="text", text='{"error": "chat_id is required"}')]
+
+    # Capture ambient state: last 10 messages for this chat from conversation history
+    recent_messages: list = []
+    try:
+        history_result = await handle_get_conversation_history({
+            "chat_id": chat_id,
+            "limit": 10,
+            "direction": "all",
+        })
+        # The handler returns JSON text — parse it back to extract raw message list
+        if history_result:
+            raw = history_result[0].text
+            try:
+                parsed = json.loads(raw)
+                if isinstance(parsed, list):
+                    recent_messages = parsed
+                elif isinstance(parsed, dict) and "messages" in parsed:
+                    recent_messages = parsed["messages"]
+            except (json.JSONDecodeError, ValueError):
+                pass  # Non-JSON response format — skip snapshot
+    except Exception:
+        pass  # Conversation history is best-effort; never block report creation
+
+    # Capture active agent session IDs
+    active_session_ids: list[str] = []
+    try:
+        active = _session_store.get_active_sessions()
+        active_session_ids = [s.get("id", "") for s in active if s.get("id")]
+    except Exception:
+        pass  # Session capture is best-effort
+
+    # Build a minimal ambient snapshot
+    snapshot_state = {
+        "active_session_count": len(active_session_ids),
+        "lobster_state": _read_lobster_state(),
+    }
+
+    # Store the report
+    try:
+        report = _session_store.create_report(
+            description=description,
+            chat_id=chat_id,
+            source=source,
+            recent_messages=recent_messages if recent_messages else None,
+            active_session_ids=active_session_ids if active_session_ids else None,
+            snapshot_state=snapshot_state,
+        )
+    except Exception as exc:
+        log.error(f"create_report failed: {exc}", exc_info=True)
+        return [TextContent(type="text", text=f'{{"error": "Failed to create report: {exc}"}}')]
+
+    log.info(f"Report filed: {report['report_id']} from chat {chat_id}")
+    return [TextContent(type="text", text=json.dumps(report))]
 
 
 def _enqueue_reconciler_notification(session: dict, outcome: str) -> None:


### PR DESCRIPTION
## Summary

- Implements BIS-84: `/report` slash command for filing bug reports and feedback
- Reports are stored in a new `reports` table inside the existing `agent_sessions.db` (SQLite, WAL mode) — no new database files
- The command is handled transparently: the MCP layer intercepts `/report` messages before they reach the dispatcher, so the main Claude loop sees nothing

## What was implemented

**`src/agents/session_store.py`**
- Added `reports` table schema (`report_id` RPT-NNN, `description`, `chat_id`, `source`, `recent_messages_json`, `agent_session_ids_json`, `snapshot_state_json`, `created_at`, `status`)
- Added three indexes on `chat_id`, `created_at DESC`, `status`
- `init_db()` now creates the table and indexes idempotently on every startup (safe on existing DBs)
- Added `create_report()`, `get_report()`, `list_reports()` pure functions using the existing SQLite connection pattern

**`src/mcp/inbox_server.py`**
- Added `create_report` MCP tool for direct use by the dispatcher when needed
- Added `_is_report_command()` — pure function, detects `/report <description>` at message start (case-insensitive, rejects `/reports`, bare `/report`, etc.)
- Added `_extract_report_description()` — pure extraction
- Added `_handle_report_slash_command()` — creates report, queues confirmation reply, atomically marks message processed
- `handle_check_inbox()` now runs the pre-processor: `/report` messages are auto-handled and excluded from the returned message list

## Functional patterns used

- Pure functions for detection and extraction (`_is_report_command`, `_extract_report_description`)
- Side effects isolated to `_handle_report_slash_command` and `create_report`
- Idempotent DB migrations (CREATE TABLE IF NOT EXISTS + separate index creation)
- Graceful degradation: snapshot capture errors never block report creation

## Testing

- `python3 -c "import ast; ast.parse(...)"` — both files parse cleanly
- Manual functional test of `create_report`, `get_report`, `list_reports` against a temp SQLite DB confirmed sequential RPT-NNN IDs and correct round-trip
- `_is_report_command` tested against 8 edge cases (bare command, whitespace-only, `/reports` variant, embedded command, tab separator)

## Usage

Send `/report <description>` from Telegram. Response: `Report filed as RPT-001. We'll look into it.`

Closes #BIS-84

🤖 Generated with [Claude Code](https://claude.com/claude-code)