### PR TITLE
fix(install): seed lobster-state.json with booted_at on fresh install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -326,6 +326,16 @@ if [ "$CONTAINER_SETUP" = true ]; then
     mkdir -p "$USER_CONFIG_DIR/agents/subagents"
     # Safety: remove orphan agents.db if it was created (real store is agent_sessions.db)
     rm -f "$MESSAGES_DIR/config/agents.db" "$WORKSPACE_DIR/data/agents.db"
+
+    # Seed lobster-state.json with booted_at so the health check's boot grace period
+    # applies immediately on first start. Without this, is_boot_grace_period() returns
+    # false (missing field) and the health check fires within seconds of first launch,
+    # triggering a restart loop before Claude has had time to initialize.
+    local state_file="$MESSAGES_DIR/config/lobster-state.json"
+    if [ ! -f "$state_file" ]; then
+        echo '{"mode": "active", "booted_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' > "$state_file"
+        info "  Seeded lobster-state.json with initial booted_at timestamp"
+    fi
     success "Directories created"
 
     # Seed canonical templates (idempotent — skip existing files)
@@ -975,6 +985,16 @@ mkdir -p "$USER_CONFIG_DIR/memory"/{canonical/{people,projects},archive/digests}
 mkdir -p "$USER_CONFIG_DIR/agents/subagents"
 # Safety: remove orphan agents.db if it was created (real store is agent_sessions.db)
 rm -f "$MESSAGES_DIR/config/agents.db" "$WORKSPACE_DIR/data/agents.db"
+
+# Seed lobster-state.json with booted_at so the health check's boot grace period
+# applies immediately on first start. Without this, is_boot_grace_period() returns
+# false (missing field) and the health check fires within seconds of first launch,
+# triggering a restart loop before Claude has had time to initialize.
+STATE_FILE="$MESSAGES_DIR/config/lobster-state.json"
+if [ ! -f "$STATE_FILE" ]; then
+    echo '{"mode": "active", "booted_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' > "$STATE_FILE"
+    info "  Seeded lobster-state.json with initial booted_at timestamp"
+fi
 
 # Legacy: also create ~/projects/ for backward compatibility
 mkdir -p "$HOME/projects"/{personal,business}

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1187,6 +1187,49 @@ run_migrations() {
         migrated=$((migrated + 1))
     fi
 
+    # Migration 16: Ensure lobster-state.json has a booted_at field.
+    # Fresh installs before this fix never wrote an initial lobster-state.json,
+    # so is_boot_grace_period() in health-check-v3.sh always returned false on
+    # first start — the grace window never applied and the health check fired
+    # immediately, triggering a restart loop. We backfill booted_at only when
+    # the field is absent; existing timestamps are left untouched.
+    local state_json="$MESSAGES_DIR/config/lobster-state.json"
+    if [ -f "$state_json" ]; then
+        local has_booted_at
+        has_booted_at=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open('$state_json'))
+    print('yes' if 'booted_at' in d else 'no')
+except Exception:
+    print('no')
+" 2>/dev/null)
+        if [ "$has_booted_at" = "no" ]; then
+            python3 -c "
+import json, sys
+from datetime import datetime, timezone
+path = '$state_json'
+now = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+try:
+    with open(path) as f:
+        d = json.load(f)
+except Exception:
+    d = {}
+d['booted_at'] = now
+with open(path, 'w') as f:
+    json.dump(d, f, indent=2)
+    f.write('\n')
+" 2>/dev/null
+            substep "Backfilled booted_at in lobster-state.json (fixes fresh-install restart loop)"
+            migrated=$((migrated + 1))
+        fi
+    else
+        # State file is absent entirely — create it so the next start has a grace period.
+        echo '{"mode": "active", "booted_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' > "$state_json"
+        substep "Created lobster-state.json with initial booted_at (fixes fresh-install restart loop)"
+        migrated=$((migrated + 1))
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## The problem

On a fresh install, Lobster enters a restart loop immediately after first start. The root cause: \`lobster-state.json\` is never written during install, so \`is_boot_grace_period()\` in \`health-check-v3.sh\` always returns false on the first run. The function checks for a \`booted_at\` field — if the file is missing or the field is absent, it returns \`1\` (grace period not active). The health check then fires its full inbox/process/WFM checks against a session that is still initializing (~60-90s startup time), finds nothing running, and triggers a restart. Restart writes \`booted_at\`, which is why the loop stabilizes after one cycle, but the first-boot experience is broken.

## What this changes

**\`install.sh\`** — after creating \`messages/config/\`, both the container-setup path and the full-install path now write an initial \`lobster-state.json\` with \`mode: active\` and a \`booted_at\` timestamp set to install time. The write is guarded by \`[ ! -f ]\` so it is idempotent on re-runs.

**\`scripts/upgrade.sh\`** — Migration 16 covers existing installs that have a state file without \`booted_at\` (stale or partially initialized). It uses Python to merge \`booted_at\` into the existing JSON without clobbering other fields. If the file is absent entirely, it creates it from scratch. This migration is a no-op on installs that already have a valid \`booted_at\`.

## Why this is the right fix

The health check already has the grace period logic — \`is_boot_grace_period()\` works correctly when \`booted_at\` is present. The gap was that install never established the precondition that function depends on. This fix closes that gap at the source (install) and provides a backfill path (upgrade) for existing broken installs.

The change does not touch \`health-check-v3.sh\`, \`claude-persistent.sh\`, or any runtime behavior. The only new runtime state is the \`booted_at\` field in a JSON file that the health check was already reading.

## Functional patterns

Pure data initialization (no side effects beyond the guarded file write), idempotent by design, no mutation of existing state.

## Tests run

- [x] \`sudo docker compose -f tests/docker/docker-compose.test.yml up install-test\` — exited 0, "Installation Test Complete"
- [ ] Live end-to-end fresh-install test (requires a clean VM and production credentials) — skipped: not available in this environment. The Docker test exercises the install path; the restart-loop scenario requires a live systemd+health-check environment to observe.