### PR TITLE
fix(inbox): make write_result idempotent per task_id (CC 2.1.77 flood fix)

### DIFF
--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -90,6 +90,14 @@ Failing to pass `sent_reply_to_user=True` causes duplicate messages — the disp
 
 **If you were not given a `chat_id`:** do not call `send_reply` or `write_result` — your results will be returned directly to the caller.
 
+**CC platform noise — do NOT call `write_result` again after seeing this:** After you call `write_result` and your task ends, the CC runtime (≥ 2.1.77) may inject a message like:
+
+```
+Stop hook feedback: [hook-name]: No stderr output
+```
+
+This is platform noise from the SubagentStop hook and does NOT mean your `write_result` failed or was rejected. Your result was already delivered. Do NOT call `write_result` a second time — the server will ignore the duplicate and return an explicit error message to confirm the first call was recorded.
+
 ## Internal vs. User-Facing Tasks
 
 Not all subagent tasks are user-facing. Some are dispatched for internal analysis — log review, codebase research, pre-processing — where the result goes to the dispatcher only, not to the user.

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -401,6 +401,7 @@ AUDIO_DIR = BASE_DIR / "audio"
 SENT_DIR = BASE_DIR / "sent"
 SENT_REPLIES_DIR = BASE_DIR / "sent-replies"
 TASK_REPLIED_DIR = BASE_DIR / "task-replied"
+WRITE_RESULT_DEDUP_DIR = BASE_DIR / "write-result-dedup"
 TASKS_FILE = BASE_DIR / "tasks.json"
 TASK_OUTPUTS_DIR = BASE_DIR / "task-outputs"
 BISQUE_OUTBOX_DIR = BASE_DIR / "bisque-outbox"
@@ -525,6 +526,64 @@ def _was_task_replied(task_id: str, chat_id: Any) -> bool:
         return False
 
 
+# write_result call deduplication — prevents duplicate inbox entries when a
+# subagent calls write_result more than once with the same task_id.
+#
+# Root cause this addresses: CC 2.1.77 injects "Stop hook feedback: [hook]: No
+# stderr output" into subagent conversations even when SubagentStop returns
+# {"suppressOutput": true}. Subagents that misread this platform noise as a
+# signal sometimes call write_result again, producing duplicate inbox messages.
+# The worst observed case: 19 identical write_result calls for a single task_id.
+#
+# First call wins. Subsequent calls with the same task_id return early with a
+# clear message so the model knows its result was already recorded.
+#
+# Dedup markers are stored as small files in WRITE_RESULT_DEDUP_DIR, named by a
+# hash of the task_id, so the guard survives MCP server restarts.  Files are
+# expired lazily after _WRITE_RESULT_DEDUP_WINDOW_SECS.
+_WRITE_RESULT_DEDUP_WINDOW_SECS = 3600  # 1-hour window covers any realistic subagent lifetime
+
+
+def _write_result_dedup_key(task_id: str) -> str:
+    """Return a filesystem-safe marker key for task_id."""
+    import hashlib
+    return f"wr_{hashlib.sha256(task_id.encode()).hexdigest()[:24]}"
+
+
+def _record_write_result(task_id: str) -> None:
+    """Mark task_id as having already produced a write_result."""
+    try:
+        key = _write_result_dedup_key(task_id)
+        marker = WRITE_RESULT_DEDUP_DIR / key
+        marker.write_text(str(time.time()))
+        # Lazily evict expired entries
+        cutoff = time.time() - _WRITE_RESULT_DEDUP_WINDOW_SECS
+        for f in WRITE_RESULT_DEDUP_DIR.iterdir():
+            try:
+                if float(f.read_text()) < cutoff:
+                    f.unlink(missing_ok=True)
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+
+def _was_write_result_called(task_id: str) -> bool:
+    """Return True if write_result was already called with task_id within the dedup window."""
+    try:
+        key = _write_result_dedup_key(task_id)
+        marker = WRITE_RESULT_DEDUP_DIR / key
+        if not marker.exists():
+            return False
+        written_at = float(marker.read_text())
+        if (time.time() - written_at) >= _WRITE_RESULT_DEDUP_WINDOW_SECS:
+            marker.unlink(missing_ok=True)
+            return False
+        return True
+    except Exception:
+        return False
+
+
 # Sources that represent human users (not system/automated)
 # NOTE: Do NOT use this to classify whether a message needs a reply — source is
 # the routing destination, not the message type. A subagent_result has
@@ -590,7 +649,7 @@ CANONICAL_DIR = _USER_CONFIG / "memory" / "canonical"
 
 # Ensure directories exist
 for d in [INBOX_DIR, OUTBOX_DIR, PROCESSED_DIR, PROCESSING_DIR, FAILED_DIR, SENT_DIR, SENT_REPLIES_DIR,
-          TASK_REPLIED_DIR, CONFIG_DIR, AUDIO_DIR, TASK_OUTPUTS_DIR, BISQUE_OUTBOX_DIR,
+          TASK_REPLIED_DIR, WRITE_RESULT_DEDUP_DIR, CONFIG_DIR, AUDIO_DIR, TASK_OUTPUTS_DIR, BISQUE_OUTBOX_DIR,
           SCHEDULED_TASKS_TASKS_DIR, SCHEDULED_JOBS_DIR, SCHEDULED_TASKS_LOGS_DIR, CANONICAL_DIR]:
     d.mkdir(parents=True, exist_ok=True)
 
@@ -4563,6 +4622,30 @@ async def handle_write_result(args: dict) -> list[TextContent]:
         return [TextContent(type="text", text="Error: chat_id is required")]
     if not text:
         return [TextContent(type="text", text="Error: text is required")]
+
+    # write_result call deduplication — first call wins; subsequent calls with the
+    # same task_id are silently no-oped.
+    #
+    # Context: CC 2.1.77 injects "Stop hook feedback: [hook]: No stderr output"
+    # into subagent conversations even when the SubagentStop hook returns
+    # {"suppressOutput": true}.  Subagents that misread this platform noise as
+    # actionable feedback sometimes call write_result again, producing duplicate
+    # inbox entries.  This guard makes write_result idempotent per task_id.
+    if _was_write_result_called(task_id):
+        log.info(
+            f"write_result dedup: ignoring duplicate call for task_id={task_id!r} — "
+            "first write_result already recorded; subsequent calls are no-ops."
+        )
+        return [TextContent(
+            type="text",
+            text=(
+                f"write_result already recorded for task_id={task_id!r}. "
+                "Your result was already delivered. This duplicate call was ignored. "
+                "If you are seeing 'Stop hook feedback: No stderr output', that is "
+                "CC platform noise — do NOT call write_result again."
+            ),
+        )]
+    _record_write_result(task_id)
 
     # Server-side deduplication: promote sent_reply_to_user to True when the subagent
     # already delivered a reply directly via send_reply, preventing duplicates.

--- a/tests/unit/test_mcp_server/test_write_result_dedup.py
+++ b/tests/unit/test_mcp_server/test_write_result_dedup.py
@@ -1,0 +1,199 @@
+"""
+Tests for write_result call deduplication.
+
+Verifies that calling write_result twice with the same task_id is a no-op on
+the second call — the inbox receives exactly one file regardless of how many
+times the handler is invoked.
+
+Root cause being defended against: CC 2.1.77 injects "Stop hook feedback:
+[hook]: No stderr output" into subagent conversations even when the
+SubagentStop hook returns {"suppressOutput": true}. Subagents that misread
+this platform noise sometimes call write_result again, producing duplicate
+inbox entries.
+"""
+
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+# Ensure src/mcp is on sys.path so that `reliability` (a sibling module) can
+# be resolved when inbox_server is imported via the `src.mcp.inbox_server`
+# dotted path.  The root conftest adds `src/` but not `src/mcp/`, so we add
+# the latter here; this is a no-op if the path is already present.
+_MCP_DIR = Path(__file__).parent.parent.parent.parent / "src" / "mcp"
+if str(_MCP_DIR) not in sys.path:
+    sys.path.insert(0, str(_MCP_DIR))
+
+# Pre-load the module so that unittest.mock can resolve "src.mcp.inbox_server"
+# as an attribute of the `src.mcp` package before patch.multiple opens.
+import src.mcp.inbox_server  # noqa: F401
+
+
+class TestWriteResultDedup:
+    """Tests for write_result call deduplication (task_id-level idempotency)."""
+
+    @pytest.fixture
+    def dirs(self, temp_messages_dir: Path):
+        """Return inbox and dedup directories inside a temp base."""
+        inbox = temp_messages_dir / "inbox"
+        dedup = temp_messages_dir / "write-result-dedup"
+        task_replied = temp_messages_dir / "task-replied"
+        sent_replies = temp_messages_dir / "sent-replies"
+        for d in [inbox, dedup, task_replied, sent_replies]:
+            d.mkdir(parents=True, exist_ok=True)
+        return {"inbox": inbox, "dedup": dedup, "task_replied": task_replied, "sent_replies": sent_replies}
+
+    def _run(self, args: dict, dirs: dict) -> list:
+        """Run handle_write_result with patched directories and no async side effects."""
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=dirs["inbox"],
+            WRITE_RESULT_DEDUP_DIR=dirs["dedup"],
+            TASK_REPLIED_DIR=dirs["task_replied"],
+            SENT_REPLIES_DIR=dirs["sent_replies"],
+            _DEBUG_MODE=False,
+            _DEBUG_RESOLVED=True,
+            # Suppress the asyncio.create_task(_notify_wire_server()) call.
+            # Must be an AsyncMock so create_task receives a coroutine.
+            _notify_wire_server=AsyncMock(),
+        ):
+            # Stub out session_store.session_end so we don't need a real DB
+            import src.mcp.inbox_server as srv
+            original_session_store = srv._session_store
+
+            class _FakeSessionStore:
+                def session_end(self, **kwargs):
+                    pass
+
+            srv._session_store = _FakeSessionStore()
+            try:
+                from src.mcp.inbox_server import handle_write_result
+                return asyncio.run(handle_write_result(args))
+            finally:
+                srv._session_store = original_session_store
+
+    # ------------------------------------------------------------------
+    # Happy path — first call succeeds
+    # ------------------------------------------------------------------
+
+    def test_first_call_writes_inbox_file(self, dirs):
+        """First write_result call creates exactly one inbox file."""
+        result = self._run(
+            {"task_id": "task-abc", "chat_id": 12345, "text": "All done."},
+            dirs,
+        )
+
+        assert "queued" in result[0].text.lower()
+        files = list(dirs["inbox"].glob("*.json"))
+        assert len(files) == 1
+        payload = json.loads(files[0].read_text())
+        assert payload["task_id"] == "task-abc"
+
+    # ------------------------------------------------------------------
+    # Dedup — second call is rejected
+    # ------------------------------------------------------------------
+
+    def test_second_call_same_task_id_is_rejected(self, dirs):
+        """Calling write_result twice with the same task_id produces only one inbox file."""
+        args = {"task_id": "task-dup", "chat_id": 12345, "text": "Result text."}
+
+        first = self._run(args, dirs)
+        second = self._run(args, dirs)
+
+        # First call succeeds
+        assert "queued" in first[0].text.lower()
+
+        # Second call is rejected with an informative error
+        assert "already recorded" in second[0].text.lower() or "duplicate" in second[0].text.lower()
+
+        # Inbox contains exactly one file
+        files = list(dirs["inbox"].glob("*.json"))
+        assert len(files) == 1, f"Expected 1 inbox file, got {len(files)}"
+
+    def test_second_call_response_mentions_platform_noise(self, dirs):
+        """The rejection message explains that the CC Stop hook message is platform noise."""
+        args = {"task_id": "task-noise", "chat_id": 12345, "text": "Done."}
+        self._run(args, dirs)
+        second = self._run(args, dirs)
+
+        # The response should guide the model not to retry
+        assert "No stderr output" in second[0].text or "platform noise" in second[0].text.lower()
+
+    def test_19_duplicate_calls_produce_one_inbox_file(self, dirs):
+        """Worst-case scenario: 19 duplicate write_result calls → exactly 1 inbox file."""
+        args = {"task_id": "task-flood", "chat_id": 99999, "text": "Flooding..."}
+
+        results = [self._run(args, dirs) for _ in range(19)]
+
+        # First call accepted, rest rejected
+        assert "queued" in results[0][0].text.lower()
+        for r in results[1:]:
+            assert "already recorded" in r[0].text.lower() or "duplicate" in r[0].text.lower()
+
+        files = list(dirs["inbox"].glob("*.json"))
+        assert len(files) == 1, f"Expected 1 inbox file, got {len(files)}"
+
+    # ------------------------------------------------------------------
+    # Different task_ids are independent
+    # ------------------------------------------------------------------
+
+    def test_different_task_ids_each_write_own_file(self, dirs):
+        """Two distinct task_ids both succeed independently."""
+        self._run({"task_id": "task-a", "chat_id": 1, "text": "Result A."}, dirs)
+        self._run({"task_id": "task-b", "chat_id": 1, "text": "Result B."}, dirs)
+
+        files = list(dirs["inbox"].glob("*.json"))
+        assert len(files) == 2
+
+        task_ids = {json.loads(f.read_text())["task_id"] for f in files}
+        assert task_ids == {"task-a", "task-b"}
+
+    # ------------------------------------------------------------------
+    # Dedup expires after the window
+    # ------------------------------------------------------------------
+
+    def test_expired_dedup_marker_allows_retry(self, dirs):
+        """After the dedup window expires, the same task_id can write_result again."""
+        args = {"task_id": "task-expired", "chat_id": 1, "text": "Old result."}
+
+        # First call
+        first = self._run(args, dirs)
+        assert "queued" in first[0].text.lower()
+
+        # Manually back-date the dedup marker to force expiry
+        import src.mcp.inbox_server as srv
+        key = srv._write_result_dedup_key("task-expired")
+        marker = dirs["dedup"] / key
+        old_time = time.time() - srv._WRITE_RESULT_DEDUP_WINDOW_SECS - 1
+        marker.write_text(str(old_time))
+
+        # Second call should now succeed (marker expired)
+        second = self._run({"task_id": "task-expired", "chat_id": 1, "text": "New result."}, dirs)
+        assert "queued" in second[0].text.lower()
+
+        # Two files now in the inbox
+        files = list(dirs["inbox"].glob("*.json"))
+        assert len(files) == 2
+
+    # ------------------------------------------------------------------
+    # Dedup marker persistence (helper functions unit tests)
+    # ------------------------------------------------------------------
+
+    def test_was_write_result_called_returns_false_before_any_call(self, dirs):
+        """_was_write_result_called returns False when no marker exists."""
+        with patch("src.mcp.inbox_server.WRITE_RESULT_DEDUP_DIR", dirs["dedup"]):
+            from src.mcp.inbox_server import _was_write_result_called
+            assert _was_write_result_called("task-fresh") is False
+
+    def test_record_and_check_write_result_called(self, dirs):
+        """_record_write_result + _was_write_result_called round-trip."""
+        with patch("src.mcp.inbox_server.WRITE_RESULT_DEDUP_DIR", dirs["dedup"]):
+            from src.mcp.inbox_server import _record_write_result, _was_write_result_called
+            assert _was_write_result_called("task-round-trip") is False
+            _record_write_result("task-round-trip")
+            assert _was_write_result_called("task-round-trip") is True


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Problem

CC 2.1.77 introduced a regression in the SubagentStop hook: even when the hook returns `{"suppressOutput": true}`, the CC runtime still injects a "Stop hook feedback: [hook]: No stderr output" message into the subagent's conversation. Subagents that misread this as evidence that `write_result` failed call it again. The worst observed case: one subagent called `write_result` 19 times for the same task_id, flooding the dispatcher inbox with duplicate entries.

The existing send_reply deduplication (`TASK_REPLIED_DIR`, `SENT_REPLIES_DIR`) prevents duplicate *delivery* to the user, but it does not prevent duplicate inbox entries from being written. Each duplicate call still creates a new JSON file in `~/messages/inbox/`, and the dispatcher has to process all of them.

## Fix

**Primary fix (`src/mcp/inbox_server.py`):** `handle_write_result` is now idempotent per `task_id`. The first call records a marker in a new `WRITE_RESULT_DEDUP_DIR` directory (same filesystem-marker pattern as `TASK_REPLIED_DIR`). Subsequent calls with the same `task_id` return early with an explicit rejection message that names the CC platform noise so the model can recognize it and stop retrying. First write wins; markers expire after 1 hour.

The rejection response reads: *"write_result already recorded for task_id=... Your result was already delivered. This duplicate call was ignored. If you are seeing 'Stop hook feedback: No stderr output', that is CC platform noise — do NOT call write_result again."*

**Defense-in-depth (`.claude/sys.subagent.bootup.md`):** Added an explicit instruction explaining that the "Stop hook feedback: [hook]: No stderr output" message after a successful `write_result` is CC platform noise — not an indication that the result failed — and that calling `write_result` again will be rejected.

## What is not changed

- The existing send_reply → write_result relay deduplication (`_was_task_replied`, `_was_sent_directly`) is unchanged.
- The `TASK_REPLIED_DIR` mechanism (suppressing duplicate relay when subagent already sent via `send_reply`) is unchanged.
- The dispatcher's inbox processing logic is unchanged; the fix is entirely in the MCP layer.

## Tests

New file: `tests/unit/test_mcp_server/test_write_result_dedup.py`

The tests cover:
- First call succeeds and writes exactly one inbox file
- Second call with the same task_id is rejected with a message mentioning CC platform noise
- 19-duplicate-call scenario produces exactly 1 inbox file
- Different task_ids are independent (each writes its own file)
- Expired dedup marker allows retry (verifies the 1-hour expiry window works)
- Helper function unit tests (`_record_write_result`, `_was_write_result_called`)

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_write_result_dedup.py -v` — 8 passed, 0 failed
- [x] `uv run pytest tests/unit/test_mcp_server/ -v` — 239 passed, 16 failed. All 16 failures are pre-existing on `main` (cover `get_whisper_model`, `mark_processing`, `mark_processed`, auto-threading, user model dispatch in `test_write_observation`) — none introduced by this change.
- [ ] `sudo docker compose -f tests/docker/docker-compose.test.yml up unit-tests` — Docker image rebuild blocked (whisper.cpp compile step requires network access); ran tests directly via `uv run pytest` instead. The existing cached image (873 passed, pre-change) does not include the new test file. New tests confirmed passing via direct `uv run` above.