### PR TITLE
feat(hooks): SubagentStop fallback — emit synthetic result after 5 hook fires

### DIFF
--- a/hooks/require-write-result.py
+++ b/hooks/require-write-result.py
@@ -58,9 +58,29 @@ Claude Code injects a "Stop hook feedback: ... No stderr output" system message
 into the agent even when the hook exits 0. To prevent this feedback from
 triggering a new agent turn, the hook outputs JSON with `{"suppressOutput": true}`
 on all success paths. Per the CC hook spec, this suppresses feedback injection.
+
+## Fallback after N retry fires
+
+When write_result is not called and the hook blocks with exit 2, CC re-runs the
+subagent with the error message injected. If the subagent still cannot call
+write_result (e.g. turn exhaustion, crash loop), the hook fires repeatedly and
+the agent never terminates.
+
+After MAX_HOOK_FIRES fires without a successful write_result, the hook gives up
+blocking and emits a synthetic subagent_result to ~/messages/inbox/ with the
+last meaningful transcript content (extracted from turns BEFORE the hook started
+firing). This ensures the dispatcher always gets something instead of nothing.
+
+Fire count is tracked in /tmp/lobster-hook-fires-{agent_key} as JSON:
+    {"count": N, "first_fire_ts": <unix timestamp>}
+
+The file is cleaned up after the fallback emit.
 """
 import json
+import os
 import sys
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 # Import shared session role utility.
@@ -71,6 +91,12 @@ from session_role import is_dispatcher, get_session_id
 # "Stop hook feedback: No stderr output" injection that CC 2.1.76+ produces
 # even when the hook exits 0 with no output.
 _SILENT_OK = json.dumps({"suppressOutput": True})
+
+# Maximum number of hook fires before giving up and emitting a synthetic result.
+MAX_HOOK_FIRES = 5
+
+# Number of pre-hook transcript turns to extract for the synthetic result.
+_FALLBACK_TURNS = 3
 
 
 def _exit_ok() -> None:
@@ -203,6 +229,213 @@ def _collect_tool_use_and_text(transcript: list) -> tuple[list, list]:
     return all_tool_use_items, text_content_parts
 
 
+# ---------------------------------------------------------------------------
+# Retry-fire tracking
+# ---------------------------------------------------------------------------
+
+def _agent_key(data: dict) -> str:
+    """Return a stable key for the fire-count temp file.
+
+    Prefer agent_id (SubagentStop) over session_id (Stop). Falls back to
+    a constant so the temp file path is always well-defined.
+    """
+    agent_id = data.get("agent_id") or ""
+    session_id = data.get("session_id") or ""
+    key = agent_id or session_id or "unknown"
+    # Sanitise: keep only alphanumeric, dash, and dot characters.
+    return "".join(c if c.isalnum() or c in "-._" else "_" for c in key)
+
+
+def _fire_count_path(agent_key: str) -> Path:
+    """Return the Path of the temp file that tracks hook fires for this agent."""
+    return Path(f"/tmp/lobster-hook-fires-{agent_key}")
+
+
+def _read_fire_state(path: Path) -> tuple[int, float]:
+    """Read (fire_count, first_fire_ts) from the temp file.
+
+    Returns (0, 0.0) if the file is absent or unreadable.
+    """
+    try:
+        state = json.loads(path.read_text())
+        count = int(state.get("count", 0))
+        first_ts = float(state.get("first_fire_ts", 0.0))
+        return count, first_ts
+    except Exception:
+        return 0, 0.0
+
+
+def _write_fire_state(path: Path, count: int, first_fire_ts: float) -> None:
+    """Write (count, first_fire_ts) to the temp file. Best-effort."""
+    try:
+        path.write_text(json.dumps({"count": count, "first_fire_ts": first_fire_ts}))
+    except Exception:
+        pass
+
+
+def _cleanup_fire_state(path: Path) -> None:
+    """Remove the fire-count temp file. Best-effort."""
+    try:
+        path.unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+def _increment_fire_count(data: dict) -> tuple[int, float]:
+    """Increment the fire count for this agent and return (new_count, first_fire_ts).
+
+    On the first fire, records the current timestamp as first_fire_ts.
+    """
+    key = _agent_key(data)
+    path = _fire_count_path(key)
+    count, first_fire_ts = _read_fire_state(path)
+
+    now = time.time()
+    count += 1
+    if count == 1:
+        first_fire_ts = now
+
+    _write_fire_state(path, count, first_fire_ts)
+    return count, first_fire_ts
+
+
+# ---------------------------------------------------------------------------
+# Fallback: extract pre-hook transcript content and write synthetic result
+# ---------------------------------------------------------------------------
+
+def _entry_timestamp(entry: dict) -> float:
+    """Extract a unix timestamp from a JSONL transcript entry.
+
+    CC 2.1.76+ transcript entries have a 'timestamp' field (ISO-8601 or epoch).
+    Returns 0.0 if absent or unparseable — entries without timestamps are
+    treated as pre-hook (included in fallback content).
+    """
+    ts = entry.get("timestamp")
+    if ts is None:
+        return 0.0
+    if isinstance(ts, (int, float)):
+        return float(ts)
+    if isinstance(ts, str):
+        # Try ISO-8601 first, then numeric string.
+        try:
+            return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            pass
+        try:
+            return float(ts)
+        except ValueError:
+            return 0.0
+    return 0.0
+
+
+def _extract_pre_hook_text(transcript: list, first_fire_ts: float, n_turns: int) -> str:
+    """Extract meaningful text from transcript turns that predate the hook firing.
+
+    Filters to entries whose timestamp < first_fire_ts (or all entries if
+    first_fire_ts is 0 / timestamps are missing), then takes the last n_turns
+    assistant text blocks and joins them.
+
+    Returns a non-empty string, or an empty string if nothing useful was found.
+    """
+    # Select entries that predate the first hook fire.
+    # If first_fire_ts is 0 (unknown), include all entries.
+    if first_fire_ts > 0:
+        pre_hook = [e for e in transcript if _entry_timestamp(e) < first_fire_ts]
+    else:
+        pre_hook = list(transcript)
+
+    # Collect text parts from the pre-hook portion of the transcript.
+    # Walk entries in order so we can take the last N meaningful turns.
+    turns = []
+    for entry in pre_hook:
+        if not isinstance(entry, dict):
+            continue
+        nested_msg = entry.get("message")
+        if isinstance(nested_msg, dict):
+            content = nested_msg.get("content", [])
+        else:
+            content = entry.get("content", [])
+        if not isinstance(content, list):
+            continue
+
+        texts = [
+            item.get("text", "").strip()
+            for item in content
+            if isinstance(item, dict) and item.get("type") == "text"
+        ]
+        combined = "\n".join(t for t in texts if t)
+        if combined:
+            turns.append(combined)
+
+    # Take the last n_turns non-empty turns.
+    recent_turns = turns[-n_turns:] if turns else []
+    return "\n\n---\n\n".join(recent_turns)
+
+
+def _write_synthetic_inbox_message(
+    data: dict,
+    content: str,
+    task_id_hint: str,
+) -> None:
+    """Write a synthetic subagent_result message to ~/messages/inbox/.
+
+    The message has the same JSON structure as a normal write_result inbox
+    message (type='subagent_result', status='success'), with a note that the
+    content was recovered from the transcript after the agent failed to call
+    write_result. chat_id defaults to 0 (system route) when not discoverable.
+
+    Best-effort: any failure is silently swallowed.
+    """
+    try:
+        inbox_dir = Path(os.path.expanduser("~/messages/inbox"))
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+
+        now = datetime.now(timezone.utc)
+        ts_ms = int(now.timestamp() * 1000)
+
+        # Derive a task_id: prefer the hint extracted from the transcript,
+        # fall back to session/agent id, then a generic fallback.
+        task_id = task_id_hint or data.get("agent_id") or data.get("session_id") or "recovered-agent"
+        safe_task_id = "".join(c if c.isalnum() or c in "-_" else "_" for c in task_id)[:40]
+        message_id = f"{ts_ms}_{safe_task_id}_recovered"
+
+        # chat_id: we don't know the original chat_id when the agent didn't call
+        # write_result. Use 0 as the dispatcher system route so the dispatcher
+        # can decide what to do with the recovered result.
+        chat_id = 0
+
+        recovery_note = (
+            "Agent exited without calling write_result. "
+            f"Content recovered from transcript after {MAX_HOOK_FIRES} hook fires."
+        )
+
+        if content:
+            text = f"{recovery_note}\n\nRecovered content:\n\n{content}"
+        else:
+            text = f"{recovery_note}\n\n(No recoverable transcript content found.)"
+
+        message = {
+            "id": message_id,
+            "type": "subagent_result",
+            "source": "telegram",
+            "chat_id": chat_id,
+            "text": text,
+            "task_id": task_id,
+            "status": "recovered",
+            "sent_reply_to_user": False,
+            "timestamp": now.isoformat(),
+            "recovered": True,
+        }
+
+        inbox_file = inbox_dir / f"{message_id}.json"
+        # Atomic write: write to .tmp then rename.
+        tmp_file = inbox_file.with_suffix(".tmp")
+        tmp_file.write_text(json.dumps(message, indent=2))
+        tmp_file.rename(inbox_file)
+    except Exception:
+        pass  # Never block exit on fallback emit failure
+
+
 def main():
     try:
         data = json.load(sys.stdin)
@@ -294,6 +527,11 @@ def main():
             if session_id:
                 _mark_session_notified(session_id)
 
+            # Clean up any fire-count temp file — the agent eventually called
+            # write_result, so reset the counter for this session.
+            key = _agent_key(data)
+            _cleanup_fire_state(_fire_count_path(key))
+
             _exit_ok()
         else:
             # write_result was called but chat_id was None in every call —
@@ -309,7 +547,35 @@ def main():
             )
             sys.exit(2)
 
-    # Subagent finished without calling write_result — block exit.
+    # Subagent finished without calling write_result.
+    # Increment the fire counter and decide whether to block or fall back.
+    fire_count, first_fire_ts = _increment_fire_count(data)
+
+    if fire_count > MAX_HOOK_FIRES:
+        # Give up blocking — extract the best pre-hook content and emit a
+        # synthetic subagent_result so the dispatcher gets something.
+        task_id_hint = ""
+        # Try to extract a task_id hint from the prompt text in the transcript.
+        # A common pattern is "Your task_id is: <id>" injected by the dispatcher.
+        for part in text_content_parts:
+            if "task_id" in part.lower():
+                import re
+                m = re.search(r"task[_\s-]?id\s*(?:is\s*)?[:\-]?\s*([A-Za-z0-9_-]+)", part, re.IGNORECASE)
+                if m:
+                    task_id_hint = m.group(1)
+                    break
+
+        content = _extract_pre_hook_text(transcript, first_fire_ts, _FALLBACK_TURNS)
+        _write_synthetic_inbox_message(data, content, task_id_hint)
+
+        # Clean up the fire-count temp file.
+        key = _agent_key(data)
+        _cleanup_fire_state(_fire_count_path(key))
+
+        _exit_ok()
+
+    # Still within the retry window — block with exit 2 and a reminder message.
+    fires_remaining = MAX_HOOK_FIRES - fire_count
     # Check whether write_result appeared as text output (pseudocode failure mode)
     # to give a more actionable error message.
     combined_text = "\n".join(text_content_parts)
@@ -320,7 +586,8 @@ def main():
             "description, not an invocation. You must call write_result using the tool "
             "invocation mechanism (the same way you call Read, Edit, Bash, etc.) — not "
             "by writing it as code output.\n\n"
-            "Call write_result now using the tool mechanism.",
+            f"Call write_result now using the tool mechanism. "
+            f"({fires_remaining} attempt(s) remaining before the hook gives up.)",
             file=sys.stderr,
         )
     else:
@@ -328,7 +595,8 @@ def main():
             "STOP: You must call mcp__lobster-inbox__write_result before finishing. "
             "The dispatcher is waiting for your result. "
             "If the task failed, report the failure — but you must call write_result. "
-            "Call it now with your findings, then you may exit.",
+            f"Call it now with your findings, then you may exit. "
+            f"({fires_remaining} attempt(s) remaining before the hook gives up.)",
             file=sys.stderr,
         )
     sys.exit(2)  # Exit 2 to hard-block the session from terminating

--- a/tests/unit/test_hooks/test_require_write_result.py
+++ b/tests/unit/test_hooks/test_require_write_result.py
@@ -14,6 +14,9 @@ Tests cover:
 - write_result with chat_id=None blocks exit (exit 2)
 - write_result with chat_id=0 allows exit (valid background agent call)
 - Success exit outputs JSON with suppressOutput=true to prevent feedback injection
+- Fallback after MAX_HOOK_FIRES: exits 0 and writes synthetic inbox message
+- Fallback extracts pre-hook transcript content (turns before first fire)
+- Fire count resets when write_result is eventually called
 """
 
 import importlib.util
@@ -381,3 +384,342 @@ class TestDispatcherExemption:
 
         monkeypatch.setattr(session_role, "DISPATCHER_SESSION_FILE", original)
         assert exit_code == 0, f"Dispatcher should always exit 0, got {exit_code}"
+
+
+# ---------------------------------------------------------------------------
+# Fallback after N fires tests
+# ---------------------------------------------------------------------------
+
+def _make_subagentstop_hook_input_with_agent_id(
+    agent_transcript_path: str,
+    session_id: str = "sess-sub-001",
+    agent_id: str = "agent-fallback-test",
+) -> dict:
+    return {
+        "hook_event_name": "SubagentStop",
+        "session_id": session_id,
+        "agent_id": agent_id,
+        "agent_transcript_path": agent_transcript_path,
+    }
+
+
+def _make_transcript_with_text_turns(texts: list[str], timestamps: list[float] | None = None) -> list:
+    """Build a JSONL transcript with assistant text turns, optionally timestamped."""
+    entries = []
+    for i, text in enumerate(texts):
+        entry: dict = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": text}],
+            },
+            "uuid": f"uuid-{i}",
+            "sessionId": "test-session",
+        }
+        if timestamps is not None and i < len(timestamps):
+            entry["timestamp"] = timestamps[i]
+        entries.append(entry)
+    return entries
+
+
+class TestFallbackAfterNFires:
+    """Tests for the retry-fire-count fallback behavior."""
+
+    def _fire_hook_n_times(self, mod, hook_input: dict, n: int) -> tuple[int, str, str]:
+        """Run the hook n times and return the result of the last run."""
+        result = (None, "", "")
+        for _ in range(n):
+            result = _run_hook(mod, hook_input)
+        return result
+
+    def test_first_5_fires_block_with_exit_2(self, monkeypatch, tmp_path):
+        """First MAX_HOOK_FIRES fires without write_result should block (exit 2)."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        transcript_file = tmp_path / "agent.jsonl"
+        _write_jsonl_transcript(transcript_file, _make_transcript_no_write_result())
+
+        hook_input = _make_subagentstop_hook_input_with_agent_id(
+            str(transcript_file),
+            agent_id="test-agent-block",
+        )
+
+        # Redirect fire-count temp file to tmp_path so tests don't pollute /tmp.
+        fire_path = tmp_path / "lobster-hook-fires-test-agent-block"
+        monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
+
+        for fire_num in range(1, mod.MAX_HOOK_FIRES + 1):
+            exit_code, _, stderr = _run_hook(mod, hook_input)
+            assert exit_code == 2, (
+                f"Expected exit 2 on fire #{fire_num}, got {exit_code}"
+            )
+            assert "write_result" in stderr
+
+    def test_after_max_fires_exits_0(self, monkeypatch, tmp_path):
+        """After MAX_HOOK_FIRES + 1 total fires, hook should exit 0."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        transcript_file = tmp_path / "agent.jsonl"
+        _write_jsonl_transcript(transcript_file, _make_transcript_no_write_result())
+
+        hook_input = _make_subagentstop_hook_input_with_agent_id(
+            str(transcript_file),
+            agent_id="test-agent-fallback",
+        )
+
+        fire_path = tmp_path / "lobster-hook-fires-test-agent-fallback"
+        monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
+
+        inbox_dir = tmp_path / "messages" / "inbox"
+        inbox_dir.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        # Fire MAX_HOOK_FIRES times — should all block.
+        for _ in range(mod.MAX_HOOK_FIRES):
+            _run_hook(mod, hook_input)
+
+        # The (MAX_HOOK_FIRES + 1)th fire should exit 0.
+        exit_code, stdout, stderr = _run_hook(mod, hook_input)
+        assert exit_code == 0, f"Expected exit 0 on fallback fire, got {exit_code}. stderr={stderr}"
+
+    def test_fallback_emits_suppressoutput_json(self, monkeypatch, tmp_path):
+        """Fallback exit must emit suppressOutput JSON (same as success path)."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        transcript_file = tmp_path / "agent.jsonl"
+        _write_jsonl_transcript(transcript_file, _make_transcript_no_write_result())
+
+        hook_input = _make_subagentstop_hook_input_with_agent_id(
+            str(transcript_file),
+            agent_id="test-agent-suppress",
+        )
+
+        fire_path = tmp_path / "lobster-hook-fires-test-agent-suppress"
+        monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
+
+        inbox_dir = tmp_path / "messages" / "inbox"
+        inbox_dir.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        for _ in range(mod.MAX_HOOK_FIRES):
+            _run_hook(mod, hook_input)
+
+        exit_code, stdout, _ = _run_hook(mod, hook_input)
+        assert exit_code == 0
+        output = json.loads(stdout.strip())
+        assert output.get("suppressOutput") is True
+
+    def test_fallback_writes_inbox_message(self, monkeypatch, tmp_path):
+        """Fallback must write a synthetic subagent_result file to the inbox."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        transcript_file = tmp_path / "agent.jsonl"
+        _write_jsonl_transcript(
+            transcript_file,
+            _make_transcript_with_text_turns(["Step 1 done", "Step 2 done"]),
+        )
+
+        hook_input = _make_subagentstop_hook_input_with_agent_id(
+            str(transcript_file),
+            agent_id="test-agent-inbox",
+        )
+
+        fire_path = tmp_path / "lobster-hook-fires-test-agent-inbox"
+        monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
+
+        inbox_dir = tmp_path / "messages" / "inbox"
+        inbox_dir.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        for _ in range(mod.MAX_HOOK_FIRES):
+            _run_hook(mod, hook_input)
+
+        _run_hook(mod, hook_input)
+
+        inbox_files = list(inbox_dir.glob("*.json"))
+        assert len(inbox_files) == 1, f"Expected 1 inbox file, got {len(inbox_files)}"
+
+        msg = json.loads(inbox_files[0].read_text())
+        assert msg["type"] == "subagent_result"
+        assert msg["status"] == "recovered"
+        assert msg.get("recovered") is True
+        assert "write_result" in msg["text"] or "recovered" in msg["text"].lower()
+
+    def test_fallback_includes_transcript_content(self, monkeypatch, tmp_path):
+        """Fallback inbox message must include meaningful pre-hook transcript content."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        transcript_file = tmp_path / "agent.jsonl"
+        _write_jsonl_transcript(
+            transcript_file,
+            _make_transcript_with_text_turns(
+                ["Analysis: found critical bug in module X", "Fixed the bug by patching Y"]
+            ),
+        )
+
+        hook_input = _make_subagentstop_hook_input_with_agent_id(
+            str(transcript_file),
+            agent_id="test-agent-content",
+        )
+
+        fire_path = tmp_path / "lobster-hook-fires-test-agent-content"
+        monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
+
+        inbox_dir = tmp_path / "messages" / "inbox"
+        inbox_dir.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        for _ in range(mod.MAX_HOOK_FIRES):
+            _run_hook(mod, hook_input)
+
+        _run_hook(mod, hook_input)
+
+        inbox_files = list(inbox_dir.glob("*.json"))
+        msg = json.loads(inbox_files[0].read_text())
+        # Both meaningful text turns should appear in the recovered content.
+        assert "Analysis" in msg["text"] or "Fixed" in msg["text"]
+
+    def test_fallback_filters_post_hook_noise(self, monkeypatch, tmp_path):
+        """Pre-hook filter: turns timestamped after first fire should be excluded."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        first_fire_ts = 1000000.0  # will be recorded on first fire
+        pre_hook_ts = first_fire_ts - 10.0   # clearly before
+        post_hook_ts = first_fire_ts + 60.0  # clearly after (loop noise)
+
+        transcript_file = tmp_path / "agent.jsonl"
+        _write_jsonl_transcript(
+            transcript_file,
+            _make_transcript_with_text_turns(
+                ["Good pre-hook work", "Noisy retry loop output"],
+                timestamps=[pre_hook_ts, post_hook_ts],
+            ),
+        )
+
+        hook_input = _make_subagentstop_hook_input_with_agent_id(
+            str(transcript_file),
+            agent_id="test-agent-filter",
+        )
+
+        fire_path = tmp_path / "lobster-hook-fires-test-agent-filter"
+        monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
+
+        inbox_dir = tmp_path / "messages" / "inbox"
+        inbox_dir.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        # Simulate first fire at the expected timestamp.
+        with patch("time.time", return_value=first_fire_ts):
+            _run_hook(mod, hook_input)
+
+        # Remaining fires at a later time.
+        with patch("time.time", return_value=first_fire_ts + 30.0):
+            for _ in range(mod.MAX_HOOK_FIRES - 1):
+                _run_hook(mod, hook_input)
+            _run_hook(mod, hook_input)  # fallback fire
+
+        inbox_files = list(inbox_dir.glob("*.json"))
+        assert len(inbox_files) == 1
+        msg = json.loads(inbox_files[0].read_text())
+
+        # Pre-hook content should be present.
+        assert "Good pre-hook work" in msg["text"]
+        # Post-hook noise should NOT appear.
+        assert "Noisy retry loop output" not in msg["text"]
+
+    def test_fire_count_resets_when_write_result_called(self, monkeypatch, tmp_path):
+        """If write_result is eventually called, the fire-count temp file is cleaned up."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        # First: transcript without write_result (fires twice to set counter).
+        transcript_file = tmp_path / "agent.jsonl"
+        _write_jsonl_transcript(transcript_file, _make_transcript_no_write_result())
+
+        hook_input = _make_subagentstop_hook_input_with_agent_id(
+            str(transcript_file),
+            agent_id="test-agent-reset",
+        )
+
+        fire_path = tmp_path / "lobster-hook-fires-test-agent-reset"
+        monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
+
+        # Fire twice (counter should be at 2).
+        _run_hook(mod, hook_input)
+        _run_hook(mod, hook_input)
+        assert fire_path.exists(), "Fire-count file should exist after blocking fires"
+
+        # Now update transcript to include write_result.
+        _write_jsonl_transcript(transcript_file, _make_transcript_with_write_result())
+        exit_code, _, _ = _run_hook(mod, hook_input)
+
+        assert exit_code == 0, "write_result call should allow exit"
+        assert not fire_path.exists(), "Fire-count file should be cleaned up after write_result"
+
+    def test_fire_count_state_file_cleaned_up_after_fallback(self, monkeypatch, tmp_path):
+        """After the fallback emit, the fire-count temp file must be removed."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        transcript_file = tmp_path / "agent.jsonl"
+        _write_jsonl_transcript(transcript_file, _make_transcript_no_write_result())
+
+        hook_input = _make_subagentstop_hook_input_with_agent_id(
+            str(transcript_file),
+            agent_id="test-agent-cleanup",
+        )
+
+        fire_path = tmp_path / "lobster-hook-fires-test-agent-cleanup"
+        monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
+
+        inbox_dir = tmp_path / "messages" / "inbox"
+        inbox_dir.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        for _ in range(mod.MAX_HOOK_FIRES + 1):
+            _run_hook(mod, hook_input)
+
+        assert not fire_path.exists(), "Fire-count file should be removed after fallback emit"
+
+    def test_fires_remaining_shown_in_stderr(self, monkeypatch, tmp_path):
+        """The block message must mention how many attempts remain."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        transcript_file = tmp_path / "agent.jsonl"
+        _write_jsonl_transcript(transcript_file, _make_transcript_no_write_result())
+
+        hook_input = _make_subagentstop_hook_input_with_agent_id(
+            str(transcript_file),
+            agent_id="test-agent-remaining",
+        )
+
+        fire_path = tmp_path / "lobster-hook-fires-test-agent-remaining"
+        monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
+
+        exit_code, _, stderr = _run_hook(mod, hook_input)
+
+        assert exit_code == 2
+        # The remaining-attempts hint should appear in the block message.
+        assert "remaining" in stderr.lower()
+
+    def test_extract_pre_hook_text_no_timestamps(self, monkeypatch, tmp_path):
+        """_extract_pre_hook_text with first_fire_ts=0 includes all turns."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        transcript = _make_transcript_with_text_turns(["turn A", "turn B", "turn C", "turn D"])
+        result = mod._extract_pre_hook_text(transcript, first_fire_ts=0.0, n_turns=3)
+
+        # Should include the last 3 turns.
+        assert "turn B" in result or "turn C" in result or "turn D" in result
+
+    def test_extract_pre_hook_text_with_timestamps(self, monkeypatch, tmp_path):
+        """_extract_pre_hook_text with first_fire_ts set filters out post-hook turns."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        first_ts = 5000.0
+        transcript = _make_transcript_with_text_turns(
+            ["early", "late"],
+            timestamps=[first_ts - 100, first_ts + 100],
+        )
+        result = mod._extract_pre_hook_text(transcript, first_fire_ts=first_ts, n_turns=10)
+
+        assert "early" in result
+        assert "late" not in result


### PR DESCRIPTION
## Problem

When \`write_result\` is not called, \`require-write-result.py\` blocks the subagent with exit 2. If the agent enters a loop it cannot escape (turn exhaustion, crash, genuine forget), the hook fires indefinitely and the dispatcher receives nothing instead of something partial. The agent hangs forever with no recovery.

## What changed

The hook now tracks how many times it has fired for each agent session (keyed by \`agent_id\`/\`session_id\`, stored in \`/tmp/lobster-hook-fires-{agent_key}\`). After \`MAX_HOOK_FIRES = 5\` fires without a valid \`write_result\` call, it gives up blocking and emits a synthetic \`subagent_result\` message to \`~/messages/inbox/\` containing the best available transcript content — specifically, the last 3 assistant text turns from **before the hook started firing** (filtered by timestamp so loop noise is excluded). The hook then exits 0.

When \`write_result\` is eventually called on any fire, the temp file is cleaned up and the counter resets.

The existing block path (exits 2) is unchanged for the first 5 fires. The block message now also shows how many attempts remain, giving agents better context.

## What this does not change

- The write_result-found success path is identical to before.
- The dispatcher-exemption logic is unchanged.
- The chat_id=None blocking path is unchanged.
- The session completion/notified DB marking on success is unchanged.

## Synthetic message format

The recovered inbox message uses \`type: "subagent_result"\`, \`status: "recovered"\`, and \`recovered: true\`. \`chat_id\` is set to 0 (the dispatcher system route) since the original chat_id is not knowable when the agent didn't call \`write_result\`. The text includes a recovery notice and the extracted transcript content.

## Functional patterns

Pure functions for all state reads/writes (\`_read_fire_state\`, \`_write_fire_state\`, \`_extract_pre_hook_text\`). Side effects (temp file I/O, inbox write) isolated to named functions with best-effort semantics — every failure is swallowed so the hook never blocks on fallback infrastructure failures.

## Tests run

- [x] \`uv run pytest tests/unit/test_hooks/test_require_write_result.py -v\` — 25 passed, 0 failed (14 existing + 11 new for fallback behavior)

New test coverage includes: 5-fire block behavior, exit-0 on fallback fire, suppressOutput JSON on fallback, inbox file written with correct structure, transcript content included, post-hook noise filtered by timestamp, fire count reset on write_result success, temp file cleanup after fallback, fires-remaining hint in block stderr, \`_extract_pre_hook_text\` unit tests with and without timestamps.

Closes #579