### PR TITLE
fix(health-check): kill tmux server and verify process dead before restarting

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -985,6 +985,46 @@ Manual intervention required:
         log_info "systemctl stop: $line"
     done
 
+    # Kill the tmux server directly — this terminates all sessions and their
+    # child processes. Under RemainAfterExit=yes, systemctl stop marks the
+    # service inactive but does not reliably kill the tmux server or the Claude
+    # process tree. kill-server sends SIGTERM to every attached process and then
+    # tears down the server, ensuring no orphan Claude process survives.
+    if tmux -L "$TMUX_SOCKET" kill-server 2>/dev/null; then
+        log_info "Tmux server on socket '$TMUX_SOCKET' killed successfully"
+    else
+        log_info "Tmux kill-server returned non-zero (socket may already be gone — OK)"
+    fi
+
+    # Belt-and-suspenders: if the pre-restart Claude PID is still alive after
+    # systemctl stop + tmux kill-server, kill it explicitly. SIGTERM first,
+    # then SIGKILL after a brief wait. This handles cases where the process
+    # detached from the tmux session before the kill-server ran.
+    if [[ -n "$pre_restart_pid" ]] && kill -0 "$pre_restart_pid" 2>/dev/null; then
+        log_warn "Claude PID $pre_restart_pid survived systemctl stop + tmux kill-server — sending SIGTERM"
+        kill -TERM "$pre_restart_pid" 2>/dev/null || true
+        sleep 2
+        if kill -0 "$pre_restart_pid" 2>/dev/null; then
+            log_warn "Claude PID $pre_restart_pid still alive after SIGTERM — sending SIGKILL"
+            kill -KILL "$pre_restart_pid" 2>/dev/null || true
+            sleep 1
+        fi
+    fi
+
+    # Verify the old process is actually dead before starting a new session.
+    # If we cannot confirm it is gone, abort rather than risk two competing
+    # dispatchers running simultaneously.
+    if [[ -n "$pre_restart_pid" ]] && kill -0 "$pre_restart_pid" 2>/dev/null; then
+        log_error "ABORT: Could not kill pre-restart Claude PID $pre_restart_pid — refusing to start new session to prevent duplicate dispatcher"
+        send_telegram_alert "Restart aborted — could not kill existing Claude process (PID $pre_restart_pid).
+
+Reason: $reason
+
+Manual intervention required to kill the process before restarting:
+\`kill -9 $pre_restart_pid && lobster restart\`"
+        return 1
+    fi
+
     # Clean up the socket only if stop left it behind.
     # A successful ExecStop removes it via tmux kill-session; if stop failed or
     # the socket was already stale, we clean it up here so ExecStart can bind.


### PR DESCRIPTION
## Problem

The health check restart was failing repeatedly because the old Claude process survived. \`systemctl stop\` with \`RemainAfterExit=yes\` marks the service inactive but does not reliably terminate the tmux server or its child processes. The existing \`do_restart()\` detected this via PID comparison and logged an error, but took no corrective action — it then started a new session anyway, leaving two competing dispatchers running simultaneously.

## What changed

\`do_restart()\` in \`scripts/health-check-v3.sh\` gets three additions between \`systemctl stop\` and \`systemctl start\`:

**Step 1 — Kill the tmux server directly.** After \`systemctl stop\`, \`tmux -L lobster kill-server\` is called. This terminates all tmux sessions and sends SIGTERM to every process attached to that server. A non-zero return is treated as informational (the socket may already be gone), not a failure.

**Step 2 — Explicit PID kill with SIGTERM/SIGKILL fallback.** If the pre-restart Claude PID is still alive after the kill-server call (e.g. the process detached from tmux before it ran), SIGTERM is sent, then SIGKILL after 2 seconds if needed.

**Step 3 — Pre-start verification guard.** If the old PID is still alive after all kill attempts, \`systemctl start\` is not called. The function returns 1 and sends a Telegram alert with the exact \`kill -9 PID && lobster restart\` command needed to recover manually. This is the "abort rather than duplicate" guarantee: if we cannot confirm the old process is dead, we refuse to start a new one.

The existing PID comparison and post-restart service/tmux verification loop are untouched — they continue to catch the case where a new process started but didn't come up cleanly.

## What is not changed

- The subagent guard (skips restart if subagents are active) is unchanged.
- The circuit breaker (stale-inbox markers) is unchanged.
- The PID comparison and post-restart service/tmux retry loop are unchanged.
- No new scripts or directories are introduced, so no migration entry is needed in \`upgrade.sh\`.
- This applies cleanly on top of #504 (restart cooldown) and #530 (4-minute threshold) — those PRs do not touch the kill sequence.

## Functional patterns

Pure sequential functions with explicit side-effect isolation: each kill step is guarded by a \`kill -0\` liveness check before acting, so the function is a no-op on the happy path (process already dead after \`systemctl stop\`) and only executes the kill sequence when actually needed.

## Tests run

- [x] \`bash -n scripts/health-check-v3.sh\` — syntax OK, no errors
- [x] \`sudo docker compose -f tests/docker/docker-compose.test.yml up install-test\` — exited with code 0
- [ ] Live restart integration test — requires a running Lobster instance with a cron-driven health check; not available in this environment

Closes #586