### PR TITLE
fix(hooks): is_dispatcher() transcript fallback broken for CC 2.1.76+

### DIFF
--- a/hooks/session_role.py
+++ b/hooks/session_role.py
@@ -13,9 +13,11 @@ dispatcher or a background subagent.
    compares to the `session_id` field in the hook JSON input.
    Match → dispatcher.  Mismatch or file absent → try fallback.
 
-2. **Transcript fallback (secondary)**: Scan the `transcript` field (present in
-   Stop hooks; absent in PreToolUse hooks) for tool_use blocks containing the
-   dispatcher-only tool `wait_for_messages` or `check_inbox`.
+2. **Transcript fallback (secondary)**: Scan the transcript for tool_use blocks
+   containing the dispatcher-only tools `wait_for_messages` or `check_inbox`.
+   CC 2.1.76+ passes a file path (`transcript_path` for Stop hooks,
+   `agent_transcript_path` for SubagentStop hooks) rather than an inline
+   `transcript` list. Both file-based and inline forms are tried in order.
    Found → dispatcher.  Not found → subagent.
 
 3. **Default**: If neither signal is available (e.g. a PreToolUse hook with no
@@ -67,9 +69,20 @@ def is_dispatcher(hook_input: dict) -> bool:
         return marker_result
 
     # --- Secondary: transcript scan ---
+    # Try inline transcript first (legacy CC < 2.1.76).
     transcript = hook_input.get("transcript")
     if transcript is not None:
         return _transcript_has_dispatcher_tool(transcript)
+
+    # Try file-based transcript (CC 2.1.76+):
+    #   Stop hook       → transcript_path
+    #   SubagentStop    → agent_transcript_path
+    for key in ("transcript_path", "agent_transcript_path"):
+        path = hook_input.get(key)
+        if path:
+            transcript = _load_transcript_from_jsonl(path)
+            if transcript:
+                return _transcript_has_dispatcher_tool(transcript)
 
     # --- Default: no signal → treat as subagent (conservative) ---
     return False
@@ -125,12 +138,48 @@ def _check_marker_file(session_id: str | None) -> bool | None:
     return session_id == stored
 
 
+def _load_transcript_from_jsonl(path: str) -> list:
+    """Load transcript messages from a JSONL file.
+
+    CC 2.1.76+ Stop hooks pass transcript_path (a .jsonl file) rather than an
+    inline transcript list. Each line is a JSON object. Returns [] on any error.
+    """
+    try:
+        messages = []
+        with open(path) as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    try:
+                        messages.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        pass
+        return messages
+    except Exception:
+        return []
+
+
 def _transcript_has_dispatcher_tool(transcript: list) -> bool:
-    """Return True if any tool_use block in transcript calls a dispatcher-only tool."""
+    """Return True if any tool_use block in transcript calls a dispatcher-only tool.
+
+    Handles both JSONL format (CC 2.1.76+) and legacy inline format:
+
+    JSONL format (each line is a JSONL entry):
+        {"type": "assistant", "message": {"role": "assistant", "content": [...]}, ...}
+
+    Legacy inline format (transcript is a list of messages):
+        {"role": "assistant", "content": [...]}
+    """
     for msg in transcript:
         if not isinstance(msg, dict):
             continue
-        content = msg.get("content", [])
+        # JSONL format: content is under msg["message"]["content"]
+        # Legacy format: content is directly under msg["content"]
+        nested_msg = msg.get("message")
+        if isinstance(nested_msg, dict):
+            content = nested_msg.get("content", [])
+        else:
+            content = msg.get("content", [])
         if not isinstance(content, list):
             continue
         for item in content:


### PR DESCRIPTION
## What this fixes

When the dispatcher session marker file check is inconclusive (session ID mismatch or file absent), `is_dispatcher()` falls back to scanning the transcript for dispatcher-only tool calls. In CC 2.1.76+, Stop hooks no longer embed the transcript inline — they pass `transcript_path` (a JSONL file path) instead. `session_role.is_dispatcher()` only checked `hook_input.get("transcript")`, which returns `None` on 2.1.76+, so the fallback always failed silently and the function returned `False` (subagent). The practical effect: a dispatcher session was misidentified as a subagent, causing `require-write-result.py` to hard-block the dispatcher from exiting with `sys.exit(2)`.

`require-write-result.py` already handles both `transcript_path` and `agent_transcript_path` via `_load_transcript_from_jsonl()`. `session_role.py` had no equivalent — this PR closes that gap.

## Changes

`hooks/session_role.py`:

- **`_load_transcript_from_jsonl(path)`** — new helper, copied from `require-write-result.py`. Reads a JSONL transcript file and returns a list of parsed entries. Returns `[]` on any failure (never raises).
- **`is_dispatcher()`** — after the inline `transcript` check, now iterates `transcript_path` then `agent_transcript_path` and loads from file if present. This mirrors the logic already in `require-write-result.py`.
- **`_transcript_has_dispatcher_tool()`** — updated to handle both JSONL format (`entry["message"]["content"]`) and legacy inline format (`entry["content"]`). Previously only the legacy path was checked, so even a correctly-loaded JSONL transcript would not find any tool calls.

Nothing outside `session_role.py` is changed. `require-write-result.py` continues to do its own transcript loading independently — this change does not consolidate those paths (that would be a separate refactor).

## Functional pattern

Pure functions throughout: each helper is a total function with explicit fallback values (`[]`, `False`) rather than raising. The layered `is_dispatcher()` logic is a guard-clause pipeline — marker file first, then inline transcript, then file-based transcript, then conservative default.

## Tests run

- [x] Manual inspection: the three-path fallback chain in `is_dispatcher()` covers all known CC versions (pre-2.1.76 inline, 2.1.76+ Stop, 2.1.76+ SubagentStop).
- [ ] Automated unit tests — skipped: no test suite exists for `hooks/session_role.py` in the repo. Logic is straightforward enough to verify by inspection.

**Blocked items needing attention before merge:** none

Closes #589