### PR TITLE
fix(scripts): upgrade.sh git_pull() fails on detached HEAD or non-main branch

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -321,6 +321,22 @@ git_pull() {
         fi
     fi
 
+    # Ensure we're on main before pulling.
+    # If ~/lobster/ is on a feature branch or detached HEAD (e.g. after local
+    # testing), git merge --ff-only would fail. Switch to main first so the
+    # update always lands correctly.
+    local current_branch
+    current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "DETACHED")
+    if [ "$current_branch" != "main" ]; then
+        if $DRY_RUN; then
+            info "[dry-run] Not on main branch (currently: $current_branch). Would switch to main before updating."
+        else
+            warn "Not on main branch (currently: $current_branch). Switching to main before updating..."
+            git checkout main --quiet || die "Could not checkout main. Resolve manually and re-run." 3
+            success "Switched to main"
+        fi
+    fi
+
     # Fetch
     info "Fetching from origin..."
     if $DRY_RUN; then


### PR DESCRIPTION
## What this fixes

`lobster update` calls `upgrade.sh`, which runs `git merge origin/main --ff-only`. If `~/lobster/` is on a feature branch or detached HEAD — common after local branch testing — the fast-forward fails and the update aborts with a cryptic error. The user hit this today.

The fix detects this before attempting any pull and switches to `main` automatically, with a clear warning message.

## Changes

`scripts/upgrade.sh`, inside `git_pull()`:

After the stash block (uncommitted changes safely saved) and before `git fetch`, a branch check is inserted:

```bash
current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "DETACHED")
if [ "$current_branch" != "main" ]; then
    warn "Not on main branch (currently: $current_branch). Switching to main before updating..."
    git checkout main --quiet || die "Could not checkout main. Resolve manually and re-run." 3
    success "Switched to main"
fi
```

`git symbolic-ref --short HEAD` returns the branch name or fails (exit nonzero) on detached HEAD, in which case we fall back to the string `"DETACHED"`. Both detached HEAD and any non-main branch name trigger the checkout. The `die` call uses exit code 3 (pre-flight failure), consistent with the pattern used elsewhere in the file.

The dry-run path logs what would happen without making changes.

Nothing else in `upgrade.sh` is changed. Tarball installs are unaffected (the function returns early before this block).

## Functional pattern

Guard-clause style: detect the bad precondition, fix it, then proceed. The logic is deterministic — `git symbolic-ref` output is the only input, no LLM judgment involved.

## Tests run

- [x] Code review: `git symbolic-ref --short HEAD` correctly returns `"main"` on main, a branch name on a feature branch, and fails (triggering the `|| echo "DETACHED"` fallback) on detached HEAD — verified against git docs and manual test.
- [ ] Live upgrade run on non-main branch — not run: would require resetting `~/lobster/` to a feature branch and running `lobster update`, which risks disrupting the live system. The change is small enough to verify by inspection.

**Blocked items needing attention before merge:** none

Closes #590