### PR TITLE
fix(hooks): remove require-write-result.py from Stop hook, keep only in SubagentStop

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1719,27 +1719,6 @@ else
     info "Skipping inject-debug-bootup hook (settings.json not yet created)"
 fi
 
-# Set up Claude Code Stop hook to enforce write_result in subagent sessions
-chmod +x "$INSTALL_DIR/hooks/require-write-result.py" || true
-if [ -f "$CLAUDE_SETTINGS" ]; then
-    if ! jq -e '.hooks.Stop[]? | select(.matcher == "")' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
-        TMP_SETTINGS=$(mktemp)
-        jq '.hooks.Stop = (.hooks.Stop // []) + [{
-            "matcher": "",
-            "hooks": [{
-                "type": "command",
-                "command": "python3 '"$INSTALL_DIR"'/hooks/require-write-result.py",
-                "timeout": 10
-            }]
-        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
-        success "require-write-result Stop hook installed"
-    else
-        info "require-write-result Stop hook already configured in Claude Code settings"
-    fi
-else
-    info "Skipping require-write-result Stop hook (settings.json not yet created)"
-fi
-
 # Set up Claude Code SubagentStop hook to enforce write_result in subagent sessions
 # SubagentStop fires when a background sidechain session considers stopping — this is
 # the hook that actually catches subagents, whereas Stop only fires for the main session.

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1258,6 +1258,36 @@ with open(path, 'w') as f:
         migrated=$((migrated + 1))
     fi
 
+    # Migration 17: Remove require-write-result.py from the Stop hook in settings.json
+    # The Stop event fires for the dispatcher main session; SubagentStop fires for
+    # Task-spawned subagents — they are mutually exclusive. The hook was incorrectly
+    # registered under Stop (which hit the dispatcher) as well as SubagentStop.
+    # The is_dispatcher() guard in the hook was a band-aid for this misregistration.
+    # Fix: remove the entry from Stop[], leave it only under SubagentStop.
+    if [ -f "$CLAUDE_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
+        local stop_has_write_result
+        stop_has_write_result=$(jq -r '
+            [.hooks.Stop[]?.hooks[]?.command // empty]
+            | map(select(contains("require-write-result")))
+            | length
+        ' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+        if [ "${stop_has_write_result:-0}" != "0" ] && [ "${stop_has_write_result:-0}" != "" ]; then
+            TMP_SETTINGS=$(mktemp)
+            jq '
+                .hooks.Stop = (
+                    (.hooks.Stop // [])
+                    | map(select(
+                        (.hooks // [])
+                        | map(.command // "")
+                        | all(contains("require-write-result") | not)
+                    ))
+                )
+            ' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+            substep "Removed require-write-result.py from Stop hook (was mis-registered; SubagentStop entry kept)"
+            migrated=$((migrated + 1))
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
Closes #588

## Summary

- Remove `require-write-result.py` from the `Stop` hook array in `install.sh` — new installs will no longer register it under `Stop`
- Add Migration 17 to `upgrade.sh` to strip the `Stop` entry from existing `settings.json` on upgrade
- The live `~/.claude/settings.json` was also updated directly (Stop now has an empty array)

`Stop` fires for the dispatcher main session; `SubagentStop` fires for Task-spawned subagents — these are mutually exclusive. The hook should only be under `SubagentStop`. The `is_dispatcher()` check in the hook was a band-aid for this misregistration and can remain as defensive code without harm.

Note: Part 2 from the issue (fixing the `is_dispatcher()` fallback to read `transcript_path`) is left as a follow-up — Part 1 is the root fix and makes Part 2 unnecessary for the Stop/dispatcher case.

## Test plan

- [ ] Fresh install: verify `settings.json` has `require-write-result.py` only under `SubagentStop`, not `Stop`
- [ ] Existing install upgrade: verify Migration 17 removes the `Stop` entry from `settings.json`
- [ ] Dispatcher session ends normally without hook interference
- [ ] Subagents without `write_result` are still blocked by the `SubagentStop` hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)