### PR TITLE
fix(self-check): bound completed-task output and exclude done agents from status

### DIFF
--- a/scripts/agent-status.sh
+++ b/scripts/agent-status.sh
@@ -8,8 +8,8 @@
 # Usage:
 #   source agent-status.sh
 #   summary=$(scan_agent_status)
-#   # Returns: "Agents: abc123 (52 turns, running), def456 (49 turns, done)"
-#   # Returns: "" (empty string) if no agents found
+#   # Returns: "Agents: abc123 (52 turns, running), def456 (3 turns, starting)"
+#   # Returns: "" (empty string) if no agents found or all are done
 #
 #   completed=$(scan_completed_tasks)
 #   # Returns: JSON-like summary of completed tasks not yet reported
@@ -85,7 +85,8 @@ _get_stop_reason() {
 }
 
 # Scan agent output files and return a summary string.
-# Returns empty string if no agents found.
+# Only includes running/starting agents — completed (end_turn) agents are excluded.
+# Returns empty string if no agents found or all are done.
 scan_agent_status() {
     local tasks_glob
     tasks_glob=$(_default_tasks_glob)
@@ -100,7 +101,8 @@ scan_agent_status() {
     fi
 
     local entries=()
-    local total_count=${#output_files[@]}
+    local running_count=0
+    local running_skipped=0
 
     # Sort by mtime descending (most recently active first) and take top N
     local sorted_files=()
@@ -110,30 +112,36 @@ scan_agent_status() {
 
     local display_count=0
     for filepath in "${sorted_files[@]}"; do
-        if [ "$display_count" -ge "$AGENT_MAX_DISPLAY" ]; then
-            break
-        fi
-
         local basename_f
         basename_f=$(basename "$filepath" .output)
-
-        # Count assistant turns
-        local turns
-        turns=$(grep -c '"type":"assistant"' "$filepath" 2>/dev/null) || turns=0
 
         # Determine agent status from stop_reason (deterministic, ~1ms)
         local stop_reason
         stop_reason=$(_get_stop_reason "$filepath")
 
-        local status_text
+        # Skip completed agents — self-check is only for active work
         if [ "$stop_reason" = "end_turn" ]; then
-            status_text="done"
-        elif [ -z "$stop_reason" ]; then
+            continue
+        fi
+
+        local status_text
+        if [ -z "$stop_reason" ]; then
             status_text="starting"
         else
             # "tool_use" or any other value = actively running
             status_text="running"
         fi
+
+        running_count=$(( running_count + 1 ))
+
+        if [ "$display_count" -ge "$AGENT_MAX_DISPLAY" ]; then
+            running_skipped=$(( running_skipped + 1 ))
+            continue
+        fi
+
+        # Count assistant turns
+        local turns
+        turns=$(grep -c '"type":"assistant"' "$filepath" 2>/dev/null) || turns=0
 
         entries+=("${basename_f} (${turns} turns, ${status_text})")
         display_count=$(( display_count + 1 ))
@@ -155,18 +163,24 @@ scan_agent_status() {
         fi
     done
 
-    # Add "+N more" if we capped the display
-    local remaining=$(( total_count - display_count ))
-    if [ "$remaining" -gt 0 ]; then
-        result+=", +${remaining} more"
+    # Add "+N more" if we capped the display (only running agents count)
+    if [ "$running_skipped" -gt 0 ]; then
+        result+=", +${running_skipped} more"
     fi
 
     echo "$result"
 }
 
+# Maximum completed tasks to surface per self-check cycle.
+# Any backlog beyond this is silently marked as reported to prevent message bloat.
+COMPLETED_MAX_REPORT=3
+
 # Scan for completed tasks that haven't been reported yet.
 # A task is "completed" when its last stop_reason is "end_turn" (deterministic).
 # Previously used mtime heuristic — now uses the JSONL stop_reason field.
+#
+# Cap: reports at most COMPLETED_MAX_REPORT tasks per cycle. Any backlog beyond
+# that is immediately marked as reported so it never accumulates.
 #
 # Returns a structured completion summary or empty string if nothing new.
 scan_completed_tasks() {
@@ -186,8 +200,8 @@ scan_completed_tasks() {
         return 0
     fi
 
-    local completed=()
-
+    # Collect all unreported completed task paths first (to allow batch-marking overflow)
+    local unreported_completed=()
     for filepath in "${output_files[@]}"; do
         local basename_f
         basename_f=$(basename "$filepath" .output)
@@ -201,44 +215,55 @@ scan_completed_tasks() {
         local stop_reason
         stop_reason=$(_get_stop_reason "$filepath")
 
-        if [ "$stop_reason" != "end_turn" ]; then
-            continue
+        if [ "$stop_reason" = "end_turn" ]; then
+            unreported_completed+=("$filepath")
+        fi
+    done
+
+    if [ ${#unreported_completed[@]} -eq 0 ]; then
+        return 0
+    fi
+
+    # If backlog exceeds cap, mark all overflow as reported silently.
+    # This prevents a large backlog from ever producing an oversized message.
+    local total_unreported=${#unreported_completed[@]}
+    if [ "$total_unreported" -gt "$COMPLETED_MAX_REPORT" ]; then
+        local overflow_start=$COMPLETED_MAX_REPORT
+        for i in "${!unreported_completed[@]}"; do
+            if [ "$i" -ge "$overflow_start" ]; then
+                local overflow_base
+                overflow_base=$(basename "${unreported_completed[$i]}" .output)
+                echo "$overflow_base" >> "$reported_file"
+            fi
+        done
+    fi
+
+    # Report at most COMPLETED_MAX_REPORT entries
+    local completed=()
+    local report_count=0
+    for filepath in "${unreported_completed[@]}"; do
+        if [ "$report_count" -ge "$COMPLETED_MAX_REPORT" ]; then
+            break
         fi
 
-        # Extract the last assistant message text for a brief summary
-        local last_msg
-        last_msg=$(grep '"type":"assistant"' "$filepath" 2>/dev/null | tail -1 | \
-            python3 -c "
-import json, sys
-try:
-    line = sys.stdin.readline()
-    d = json.loads(line)
-    msg = d.get('message', {})
-    content = msg.get('content', [])
-    texts = [c.get('text', '') for c in content if c.get('type') == 'text']
-    result = ' '.join(texts).strip()
-    # Truncate to 200 chars for concise reporting
-    if len(result) > 200:
-        result = result[:197] + '...'
-    print(result)
-except Exception:
-    print('')
-" 2>/dev/null)
+        local basename_f
+        basename_f=$(basename "$filepath" .output)
 
         local turns
         turns=$(grep -c '"type":"assistant"' "$filepath" 2>/dev/null) || turns=0
 
         # Mark as reported
         echo "$basename_f" >> "$reported_file"
+        report_count=$(( report_count + 1 ))
 
-        completed+=("Task ${basename_f} completed (${turns} turns, stop_reason=end_turn): ${last_msg}")
+        completed+=("Task ${basename_f} completed (${turns} turns)")
     done
 
     if [ ${#completed[@]} -eq 0 ]; then
         return 0
     fi
 
-    # Build structured result
+    # Build structured result — no transcript content, just task ID and turn count
     local result=""
     for entry in "${completed[@]}"; do
         if [ -z "$result" ]; then

--- a/scripts/periodic-self-check.sh
+++ b/scripts/periodic-self-check.sh
@@ -69,28 +69,19 @@ if [ "$INBOX_COUNT" -ge "$MAX_INBOX_DEPTH" ]; then
     exit 0
 fi
 
-# Guard 5: Subagent check — only self-check when subagents are running
-# If claude count is <= 1, only the main session exists (no subagents to check on)
-CLAUDE_COUNT=$(pgrep -c -f "claude" 2>/dev/null || echo "0")
-
 # Source agent status scanner for both status and completion detection
 AGENT_STATUS_SCRIPT="${LOBSTER_INSTALL_DIR:-$HOME/lobster}/scripts/agent-status.sh"
 source "$AGENT_STATUS_SCRIPT"
 
-# Check for completed tasks first (works even if subagents already exited)
+# Check for completed tasks first (works even if subagents already exited).
+# scan_completed_tasks() is capped at COMPLETED_MAX_REPORT=3 entries per cycle;
+# any larger backlog is silently marked reported so it never bloats the message.
 COMPLETED_TASKS=$(scan_completed_tasks)
 
-if [ -n "$COMPLETED_TASKS" ]; then
-    # Completed task found — inject structured completion message.
-    # This replaces the generic "status?" prompt with actionable info,
-    # so the dispatcher can relay results directly without LLM reasoning
-    # about what to check.
-    SELF_CHECK_TEXT="[Task Completed] ${COMPLETED_TASKS}"
-else
-    # Check pending-agents.json tracker — subagents may have already exited
-    # but still need relay to Drew (processes gone, record still in file).
-    PENDING_AGENTS_FILE="${MESSAGES_DIR}/config/pending-agents.json"
-    PENDING_COUNT=$(python3 -c "
+# Check pending-agents.json tracker — subagents may have already exited
+# but still need relay to Drew (processes gone, record still in file).
+PENDING_AGENTS_FILE="${MESSAGES_DIR}/config/pending-agents.json"
+PENDING_COUNT=$(python3 -c "
 import json, sys
 try:
     with open('$PENDING_AGENTS_FILE') as f:
@@ -100,14 +91,26 @@ except Exception:
     print(0)
 " 2>/dev/null || echo "0")
 
-    # No completed tasks — only inject status check if subagents are still
-    # running OR there are pending agents in the tracker.
-    if [ "$CLAUDE_COUNT" -le 1 ] && [ "$PENDING_COUNT" -eq 0 ] 2>/dev/null; then
-        exit 0
+# scan_agent_status() only returns running/starting agents — done agents are excluded.
+AGENT_SUMMARY=$(scan_agent_status)
+
+# If nothing is actionable, exit silently — no message needed.
+# "Nothing running" is a valid, expected state that requires no dispatcher attention.
+if [ -z "$COMPLETED_TASKS" ] && [ -z "$AGENT_SUMMARY" ] && [ "$PENDING_COUNT" -eq 0 ] 2>/dev/null; then
+    exit 0
+fi
+
+if [ -n "$COMPLETED_TASKS" ]; then
+    # Completed task found — inject structured completion message (capped, no transcripts).
+    SELF_CHECK_TEXT="[Task Completed] ${COMPLETED_TASKS}"
+    if [ -n "$AGENT_SUMMARY" ]; then
+        SELF_CHECK_TEXT="${SELF_CHECK_TEXT} | ${AGENT_SUMMARY}"
     fi
-
-    AGENT_SUMMARY=$(scan_agent_status)
-
+    if [ "$PENDING_COUNT" -gt 0 ] 2>/dev/null; then
+        SELF_CHECK_TEXT="${SELF_CHECK_TEXT} [${PENDING_COUNT} agents pending]"
+    fi
+else
+    # Only inject status check if subagents are still running or pending.
     SELF_CHECK_TEXT="status? (Self-check)"
     if [ -n "$AGENT_SUMMARY" ]; then
         SELF_CHECK_TEXT="status? (Self-check) | ${AGENT_SUMMARY}"

--- a/tests/smoke/test_selfcheck_bounded.sh
+++ b/tests/smoke/test_selfcheck_bounded.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+#===============================================================================
+# Smoke Test: Self-check output is bounded
+#
+# Verifies that scan_completed_tasks() and scan_agent_status() never produce
+# output exceeding the cap, regardless of how many agent files exist.
+#
+# This directly tests the fix for issue #593, where 315+ completed agents
+# caused ~10k-token self-check messages every 3 minutes.
+#
+# Usage: bash tests/smoke/test_selfcheck_bounded.sh
+#===============================================================================
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/scripts"
+AGENT_STATUS_SCRIPT="$SCRIPT_DIR/agent-status.sh"
+
+TEST_TMPDIR=$(mktemp -d /tmp/lobster-smoke-bounded-XXXXXX)
+TEST_TASKS_DIR="$TEST_TMPDIR/tasks"
+TEST_STATE_DIR="$TEST_TMPDIR/state"
+
+cleanup() {
+    rm -rf "$TEST_TMPDIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$TEST_TASKS_DIR" "$TEST_STATE_DIR"
+
+begin_test() {
+    test_name="$1"
+    TOTAL=$((TOTAL + 1))
+}
+
+pass() {
+    PASS=$((PASS + 1))
+    echo -e "  ${GREEN}PASS${NC} $test_name"
+}
+
+fail() {
+    FAIL=$((FAIL + 1))
+    local msg="${1:-}"
+    echo -e "  ${RED}FAIL${NC} $test_name${msg:+: $msg}"
+}
+
+# Create a fake agent output file with stop_reason=end_turn (completed)
+create_completed_agent() {
+    local name="$1"
+    local turns="${2:-5}"
+    local filepath="$TEST_TASKS_DIR/${name}.output"
+    for ((i = 1; i <= turns; i++)); do
+        echo '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"turn '"$i"'"}]}}' >> "$filepath"
+    done
+    # Write terminal stop_reason
+    echo '{"type":"result","stop_reason":"end_turn"}' >> "$filepath"
+}
+
+# Create a fake agent output file with stop_reason=tool_use (running)
+create_running_agent() {
+    local name="$1"
+    local turns="${2:-5}"
+    local filepath="$TEST_TASKS_DIR/${name}.output"
+    for ((i = 1; i <= turns; i++)); do
+        echo '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"turn '"$i"'"}]}}' >> "$filepath"
+    done
+    # Write running stop_reason
+    echo '{"type":"result","stop_reason":"tool_use"}' >> "$filepath"
+}
+
+echo ""
+echo -e "${BOLD}=== Smoke: Self-check output bounded (issue #593) ===${NC}"
+
+#-------------------------------------------------------------------------------
+# Test 1: scan_completed_tasks() caps at 3 when 315 completed tasks exist
+#-------------------------------------------------------------------------------
+begin_test "scan_completed_tasks caps at COMPLETED_MAX_REPORT=3 with 315 completed tasks"
+
+rm -f "$TEST_TASKS_DIR"/*.output
+for i in $(seq 1 315); do
+    create_completed_agent "completed_$(printf '%04d' "$i")" 10
+done
+
+export AGENT_TASKS_DIR="$TEST_TASKS_DIR"
+export AGENT_STATE_DIR="$TEST_STATE_DIR"
+source "$AGENT_STATUS_SCRIPT"
+
+RESULT=$(scan_completed_tasks)
+
+# Count how many "Task ... completed" entries appear
+ENTRY_COUNT=$(echo "$RESULT" | grep -o "Task completed_" | wc -l)
+if [ "$ENTRY_COUNT" -le 3 ]; then
+    pass
+else
+    fail "Expected <= 3 entries, got $ENTRY_COUNT. Output length: ${#RESULT} chars"
+fi
+
+#-------------------------------------------------------------------------------
+# Test 2: All 315 overflow tasks are batch-marked as reported (no re-reporting)
+#-------------------------------------------------------------------------------
+begin_test "All overflow tasks marked reported — second call returns empty"
+
+RESULT2=$(scan_completed_tasks)
+if [ -z "$RESULT2" ]; then
+    pass
+else
+    ENTRY_COUNT2=$(echo "$RESULT2" | grep -o "Task completed_" | wc -l)
+    fail "Expected empty on second call, got $ENTRY_COUNT2 entries"
+fi
+
+#-------------------------------------------------------------------------------
+# Test 3: Output character length is bounded (no transcript content included)
+#-------------------------------------------------------------------------------
+begin_test "scan_completed_tasks output length is bounded (< 500 chars for 3 entries)"
+
+rm -f "$TEST_STATE_DIR"/reported-tasks
+rm -f "$TEST_TASKS_DIR"/*.output
+
+# Create 3 completed tasks with long names
+for i in 1 2 3; do
+    create_completed_agent "a-very-long-task-id-name-for-agent-${i}-test" 50
+done
+
+export AGENT_STATE_DIR="$TEST_STATE_DIR"
+RESULT=$(scan_completed_tasks)
+CHAR_LEN=${#RESULT}
+
+if [ "$CHAR_LEN" -lt 500 ]; then
+    pass
+else
+    fail "Output too long: $CHAR_LEN chars (expected < 500)"
+fi
+
+#-------------------------------------------------------------------------------
+# Test 4: scan_agent_status() excludes completed agents
+#-------------------------------------------------------------------------------
+begin_test "scan_agent_status excludes completed (end_turn) agents entirely"
+
+rm -f "$TEST_TASKS_DIR"/*.output
+rm -f "$TEST_STATE_DIR"/reported-tasks
+
+# Create 10 completed agents and 2 running ones
+for i in $(seq 1 10); do
+    create_completed_agent "done_agent_${i}" 5
+done
+create_running_agent "active_agent_1" 3
+create_running_agent "active_agent_2" 7
+
+export AGENT_TASKS_DIR="$TEST_TASKS_DIR"
+export AGENT_STATE_DIR="$TEST_STATE_DIR"
+source "$AGENT_STATUS_SCRIPT"
+
+RESULT=$(scan_agent_status)
+
+# Must not contain any done_agent entries
+if echo "$RESULT" | grep -q "done_agent"; then
+    fail "Completed agents found in scan_agent_status output: '$RESULT'"
+elif [[ "$RESULT" == *"active_agent"* ]]; then
+    pass
+else
+    fail "Expected active agents in output, got: '$RESULT'"
+fi
+
+#-------------------------------------------------------------------------------
+# Test 5: scan_agent_status returns empty when all agents are done
+#-------------------------------------------------------------------------------
+begin_test "scan_agent_status returns empty string when all agents are completed"
+
+rm -f "$TEST_TASKS_DIR"/*.output
+
+for i in $(seq 1 20); do
+    create_completed_agent "only_done_${i}" 5
+done
+
+export AGENT_TASKS_DIR="$TEST_TASKS_DIR"
+source "$AGENT_STATUS_SCRIPT"
+
+RESULT=$(scan_agent_status)
+if [ -z "$RESULT" ]; then
+    pass
+else
+    fail "Expected empty, got: '$RESULT'"
+fi
+
+#-------------------------------------------------------------------------------
+# Test 6: scan_agent_status caps at AGENT_MAX_DISPLAY=5 running agents
+#-------------------------------------------------------------------------------
+begin_test "scan_agent_status caps at 5 running agents (reports +N more for overflow)"
+
+rm -f "$TEST_TASKS_DIR"/*.output
+
+for i in $(seq 1 8); do
+    create_running_agent "run_agent_${i}" 3
+done
+
+export AGENT_TASKS_DIR="$TEST_TASKS_DIR"
+source "$AGENT_STATUS_SCRIPT"
+
+RESULT=$(scan_agent_status)
+ENTRY_COUNT=$(echo "$RESULT" | tr ',' '\n' | grep -c "turns" || echo 0)
+
+if [ "$ENTRY_COUNT" -le 5 ] && [[ "$RESULT" == *"+3 more"* ]]; then
+    pass
+elif [ "$ENTRY_COUNT" -le 5 ]; then
+    fail "Capped correctly at $ENTRY_COUNT but missing '+3 more': '$RESULT'"
+else
+    fail "Expected <= 5 entries, got $ENTRY_COUNT"
+fi
+
+#===============================================================================
+# Summary
+#===============================================================================
+
+echo ""
+echo -e "${BOLD}==============================${NC}"
+echo -e "${BOLD}Results: $TOTAL tests${NC}"
+echo -e "  ${GREEN}PASS: $PASS${NC}"
+if [ "$FAIL" -gt 0 ]; then
+    echo -e "  ${RED}FAIL: $FAIL${NC}"
+fi
+echo -e "${BOLD}==============================${NC}"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+else
+    echo -e "${GREEN}All bounded-output smoke tests passed!${NC}"
+    exit 0
+fi


### PR DESCRIPTION
## Problem

Self-check messages were growing to ~10k tokens every 3 minutes when many subagents completed between cycles. With 315+ completed tasks, `scan_completed_tasks()` concatenated all of them into a single inbox message — each entry up to ~250 chars, plus the full last-assistant-message transcript. This filled context rapidly and caused erratic dispatcher behavior.

Two root causes:

1. `scan_completed_tasks()` had no cap — it reported every unreported completion in one message, including 200-char transcript excerpts per task.
2. `scan_agent_status()` included completed (`end_turn`) agents in its output. Since the self-check fires even when only CLAUDE_COUNT > 1 (not necessarily active subagents), done agents were accumulating in the status summary.

## What changed

**`scripts/agent-status.sh`**

`scan_completed_tasks()` now collects all unreported completed tasks first, then immediately batch-marks any backlog beyond `COMPLETED_MAX_REPORT=3` as reported — silently, with no output. Only the 3 most recent entries are returned. Transcript content is removed entirely; entries are now `"Task <id> completed (N turns)"` only. Maximum message size for completions: ~150 chars.

`scan_agent_status()` now skips any agent with `stop_reason=end_turn`. Only `starting` and `running` agents appear. The `+N more` suffix counts only running agents, not total file count.

**`scripts/periodic-self-check.sh`**

Exits silently when `scan_agent_status` is empty, no completed tasks, and no pending agents. "Nothing running" is now correctly treated as a no-op — no message injected. Removes unused `CLAUDE_COUNT` guard (superseded). Completed and running summaries can now appear together in one message when both are present.

**`tests/smoke/test_selfcheck_bounded.sh`** (new)

Six smoke tests covering: cap holds at 315 agents, overflow is batch-marked (second call returns empty), output stays under 500 chars, done agents excluded from status, empty return when all are done, running-agent cap with "+N more".

## Functional patterns

Pure functions (no shared mutable state across calls beyond the reported-tasks file), declarative array collection before batch-marking overflow, clear separation between "collect" and "report" phases in `scan_completed_tasks`.

## Tests run

- [x] `bash tests/smoke/test_selfcheck_bounded.sh` — 6 passed, 0 failed
- [x] `bash tests/test-self-check.sh` — 14 passed, 1 failed (pre-existing on main: field count check expects 8 fields but message has 9)
- [x] `bash tests/test-agent-status.sh` — 10 passed, 8 failed (all pre-existing on main: tests check for mtime-based "last activity/stale" display that was replaced by stop_reason in a prior commit)
- [x] `bash -n scripts/agent-status.sh && bash -n scripts/periodic-self-check.sh` — both pass syntax check

No new test failures introduced. Pre-existing failures are documented above and unchanged from main.

Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)