### PR TITLE
fix(upgrade): define CLAUDE_SETTINGS in Migration 17 to prevent unbound variable crash

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1280,6 +1280,7 @@ with open(path, 'w') as f:
     # registered under Stop (which hit the dispatcher) as well as SubagentStop.
     # The is_dispatcher() guard in the hook was a band-aid for this misregistration.
     # Fix: remove the entry from Stop[], leave it only under SubagentStop.
+    local CLAUDE_SETTINGS="$HOME/.claude/settings.json"
     if [ -f "$CLAUDE_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
         local stop_has_write_result
         stop_has_write_result=$(jq -r '


### PR DESCRIPTION
## Summary

Migration 17 (added in #594) crashes `upgrade.sh` on any install where `$CLAUDE_SETTINGS` has not been manually defined. With `set -euo pipefail` active at the top of the script, referencing an unbound variable is fatal — users running `lobster update` hit `CLAUDE_SETTINGS: unbound variable` and the upgrade aborts.

The fix is a single line: `local CLAUDE_SETTINGS="$HOME/.claude/settings.json"` added at the top of the Migration 17 block. This is the actual path to the Claude settings file. The rest of the migration logic is unchanged and correct.

The migration itself was a no-op on installs where the Stop hook array was already empty, which is why it wasn't caught before merge — but it would crash on any fresh install that has `require-write-result.py` registered under `Stop`.

**Functional patterns used:** none — this is a pure shell variable definition fix.

## Tests run

- [x] `bash -n scripts/upgrade.sh` — syntax check passes, no errors
- [x] Manual inspection of Migration 17 block — variable is now defined before first use, all three references resolve correctly
- [ ] Full `lobster update` run on an install with the hook registered — skipped: requires specific environment setup; fix is mechanical and verifiable by inspection

**Blocked items needing attention before merge:** none