### PR TITLE
fix(session-tracking): dynamic ghost-detector path and agent-status age expiry

### DIFF
--- a/scripts/agent-status.sh
+++ b/scripts/agent-status.sh
@@ -124,11 +124,26 @@ scan_agent_status() {
             continue
         fi
 
+        # An agent with stop_reason=tool_use whose output file hasn't been modified
+        # in more than STALE_THRESHOLD_SECONDS is treated as dead (crashed mid-tool-call).
+        # Without this check a crashed agent would show as "running" forever.
+        local STALE_THRESHOLD_SECONDS=$(( 30 * 60 ))
+        if [ "$stop_reason" = "tool_use" ]; then
+            local now file_mtime file_age_seconds
+            now=$(date +%s)
+            # stat -c %Y is GNU coreutils; stat -f %m is BSD/macOS fallback
+            file_mtime=$(stat -c %Y "$filepath" 2>/dev/null || stat -f %m "$filepath" 2>/dev/null || echo "$now")
+            file_age_seconds=$(( now - file_mtime ))
+            if [ "$file_age_seconds" -gt "$STALE_THRESHOLD_SECONDS" ]; then
+                continue  # file too old — agent is dead, not running
+            fi
+        fi
+
         local status_text
         if [ -z "$stop_reason" ]; then
             status_text="starting"
         else
-            # "tool_use" or any other value = actively running
+            # "tool_use" (recently active) or any other value = actively running
             status_text="running"
         fi
 

--- a/scripts/ghost-detector.py
+++ b/scripts/ghost-detector.py
@@ -58,7 +58,17 @@ DB_PATH = Path.home() / "messages" / "config" / "agent_sessions.db"
 
 # Glob pattern for Claude Code session task directories.
 # The middle component is a session UUID that changes per Claude Code invocation.
-AGENT_OUTPUT_GLOB = "/tmp/claude-1000/-home-admin-lobster-workspace/*/tasks/"
+# The path component is derived dynamically from the actual home directory so the
+# script works on any install regardless of the username (e.g. /home/lobster vs
+# /home/admin).  Claude Code maps workspace paths to /tmp by replacing '/' with '-'.
+def _default_agent_output_glob() -> str:
+    home = os.path.expanduser("~")
+    # /home/lobster -> -home-lobster-
+    path_slug = home.strip("/").replace("/", "-")
+    return f"/tmp/claude-1000/-{path_slug}-lobster-workspace/*/tasks/"
+
+
+AGENT_OUTPUT_GLOB = _default_agent_output_glob()
 
 # Pattern for agent JSONL symlink filenames: agent-<hex_id>.jsonl
 AGENT_SYMLINK_PATTERN = re.compile(r"^agent-([0-9a-f]+)\.jsonl$")


### PR DESCRIPTION
## What problem this solves

Two bugs caused session monitoring to silently fail, making ghost agent detection unreliable on this system.

**Bug 1 (closes #601):** `ghost-detector.py` hardcoded `-home-admin-lobster-workspace` in the filesystem scan glob. On any system where `$HOME` is not `/home/admin` (here it is `/home/lobster`), the glob matched nothing. The unregistered-agent scan returned zero results on every run — real orphaned agents were invisible to monitoring.

**Bug 2 (closes #602):** `agent-status.sh` determined liveness solely from `stop_reason`. An agent that crashes mid-tool-call leaves `stop_reason=tool_use` frozen in its output file permanently. `scan_agent_status()` had no age check, so a crashed agent appeared as "running" forever, accumulating stale entries in every self-check message.

## What changed

**ghost-detector.py:** `AGENT_OUTPUT_GLOB` is now constructed at module load time via a pure helper `_default_agent_output_glob()` that derives the path slug from `os.path.expanduser("~")`. On `/home/lobster` this produces `-home-lobster-lobster-workspace`. No configuration required; portable to any install.

**agent-status.sh:** In `scan_agent_status()`, after detecting `stop_reason=tool_use`, an age check reads the file's mtime via `stat -c %Y` (GNU) with a `stat -f %m` (BSD) fallback. If the file is older than `STALE_THRESHOLD_SECONDS` (1800s / 30 min), the entry is skipped as dead. Agents with a fresh mtime continue to show as "running" normally.

Neither change affects `end_turn` handling or `scan_completed_tasks()`.

## Functional patterns used

- `_default_agent_output_glob()` is a pure function with no side effects; the constant it produces is captured once at module load.
- The bash age check uses only local variables and is isolated to the loop body.

## Tests run

- [x] `uv run pytest tests/unit/test_ghost_detector_filesystem.py -v` — 36 passed, 0 failed
- [x] `bash tests/test-agent-status.sh` — 10 passed, 8 failed (all 8 failures are pre-existing on `main`; confirmed identical failure set before and after this change)
- [x] Manual smoke test: file with `stop_reason=tool_use` + 35-minute-old mtime excluded from output; same file with current mtime shown as "running" — behaves correctly
- [x] `bash -n scripts/agent-status.sh` — syntax OK
- [x] `python3 -c "import ast; ast.parse(open('scripts/ghost-detector.py').read())"` — syntax OK

**Blocked items needing attention before merge:** none