### PR TITLE
feat: YAML frontmatter auto-registration hook + migrate all agent spawns (Phase 1 + 2)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -101,7 +101,7 @@ Before spawning a subagent, decide whether to ack based on expected task duratio
 1. Generate a short task_id (e.g. "fix-pr-475", "upstream-check", or a short slug describing the task)
 2. [If task will take >4s]: send_reply(chat_id, "On it.")   # brief ack, 1-3 words
 3. task_result = Task(
-       prompt="...Your task_id is <task_id>. Pass it to write_result...",
+       prompt="---\ntask_id: <task_id>\nchat_id: <chat_id>\nsource: <source>\n---\n\n...<rest of prompt>...",
        subagent_type="...",
        run_in_background=true
    )
@@ -209,15 +209,16 @@ Scheduled reminders are injected by `scripts/post-reminder.sh`, called from cron
 REMINDER_ROUTING = {
   "ghost_detector": {
     "subagent_type": "lobster-generalist",
-    "prompt": "Run the ghost detector check. Script is at ~/lobster/scripts/ghost-detector.py. "
-              "Run it with uv run ~/lobster/scripts/ghost-detector.py and report findings. "
-              "chat_id=0, source=system",
+    "prompt": "---\ntask_id: ghost-detector\nchat_id: 0\nsource: system\n---\n\n"
+              "Run the ghost detector check. Script is at ~/lobster/scripts/ghost-detector.py. "
+              "Run it with uv run ~/lobster/scripts/ghost-detector.py and report findings.",
   },
   "oom_check": {
     "subagent_type": "lobster-generalist",
-    "prompt": "Run the OOM monitor check. Script is at ~/lobster/scripts/oom-monitor.py. "
+    "prompt": "---\ntask_id: oom-check\nchat_id: 0\nsource: system\n---\n\n"
+              "Run the OOM monitor check. Script is at ~/lobster/scripts/oom-monitor.py. "
               "Run it with uv run ~/lobster/scripts/oom-monitor.py --since-minutes 10 "
-              "and report findings. chat_id=0, source=system",
+              "and report findings.",
   },
   # Add new reminder types here. Fallback for unknown types: lobster-generalist.
 }
@@ -269,12 +270,16 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
                subagent_type="general-purpose",
                run_in_background=True,
                prompt=(
+                   f"---\n"
+                   f"task_id: review-{msg.get('task_id', 'unknown')}\n"
+                   f"chat_id: {msg['chat_id']}\n"
+                   f"source: {msg.get('source', 'telegram')}\n"
+                   f"---\n\n"
                    f"Review PR {pr_url} and post your findings using:\n"
                    f"  gh pr review <N> --repo SiderealPress/lobster --comment --body \"PASS/NEEDS-WORK/FAIL: ...\"\n"
                    f"Use --comment only (never --approve or --request-changes — same token = self-review error).\n\n"
                    f"After posting, call write_result with a short verdict summary (1–3 sentences).\n\n"
-                   f"Engineer's briefing:\n{msg['text']}\n\n"
-                   f"chat_id: {msg['chat_id']}, source: {msg.get('source', 'telegram')}"
+                   f"Engineer's briefing:\n{msg['text']}"
                ),
            )
            mark_processed(message_id)
@@ -751,6 +756,11 @@ The `review` agent also handles design reviews — proposals, architectural idea
 
 ```python
 parts = [
+    f"---\n",
+    f"task_id: {task_id}\n",
+    f"chat_id: {chat_id}\n",
+    f"source: {source}\n",
+    f"---\n\n",
     "Design review requested.\n\n",
     f"Design description:\n{design_text}\n\n",
 ]
@@ -759,7 +769,6 @@ if issue_url_or_number:
     parts.append(f"GitHub issue: {issue_url_or_number}\n")
 if linear_ticket_id:
     parts.append(f"Linear ticket: {linear_ticket_id}\n")
-parts.append(f"chat_id: {chat_id}, source: {source}, task_id: {task_id}")
 
 Task(
     subagent_type="review",
@@ -804,7 +813,7 @@ When you receive a **voice message** that appears to be a "brain dump" (unstruct
 4. If transcription looks like a brain dump, spawn brain-dumps agent:
    ```
    Task(
-     prompt="Process this brain dump:\nTranscription: {text}\nMessage ID: {id}\nChat ID: {chat_id}",
+     prompt=f"---\ntask_id: brain-dump-{id}\nchat_id: {chat_id}\nsource: {source}\nreply_to_message_id: {id}\n---\n\nProcess this brain dump:\nTranscription: {text}",
      subagent_type="brain-dumps"
    )
    ```

--- a/hooks/auto-register-agent.py
+++ b/hooks/auto-register-agent.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: auto-register spawned agents into agent_sessions.db.
+
+Fires after every Agent tool call. Extracts structured metadata from the
+agent prompt (YAML frontmatter or legacy "task_id is:" text), then inserts
+a 'starting' row into agent_sessions.db so the spawned agent is visible to
+the ghost detector and status queries without requiring the dispatcher to call
+register_agent manually.
+
+## Frontmatter format (preferred)
+
+    ---
+    task_id: my-task
+    chat_id: 8305714125
+    reply_to_message_id: 10924
+    source: telegram
+    ---
+
+## Legacy text format (backward compat)
+
+    Your task_id is: my-task
+
+## Failure policy
+
+On any error (malformed input, DB unavailable, etc.) this hook appends a
+timestamped line to ~/lobster-workspace/logs/hook-failures.log and exits 0
+so the Agent call is never blocked.
+
+## settings.json configuration
+
+Add this to ~/.claude/settings.json under "hooks" -> "PostToolUse":
+
+    {
+      "matcher": "Agent",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 $HOME/lobster/hooks/auto-register-agent.py",
+          "timeout": 10
+        }
+      ]
+    }
+"""
+
+import json
+import os
+import re
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_MESSAGES_DIR = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages"))
+_DB_PATH = _MESSAGES_DIR / "config" / "agent_sessions.db"
+_LOG_PATH = (
+    Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+    / "logs"
+    / "hook-failures.log"
+)
+
+
+# ---------------------------------------------------------------------------
+# Logging (failures only -- never to stdout, never exit non-zero)
+# ---------------------------------------------------------------------------
+
+def _log_failure(message: str) -> None:
+    """Append a timestamped failure entry to hook-failures.log."""
+    try:
+        _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(timezone.utc).isoformat()
+        with _LOG_PATH.open("a") as f:
+            f.write(f"[{ts}] auto-register-agent: {message}\n")
+    except Exception:  # noqa: BLE001
+        pass  # If we can't log, there's nothing left to do
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter / metadata extraction
+# ---------------------------------------------------------------------------
+
+def _parse_yaml_frontmatter(prompt: str) -> dict:
+    """Extract key/value pairs from a YAML frontmatter block at the top of prompt.
+
+    Only handles simple scalar key: value pairs (strings and integers). Does
+    not import PyYAML to avoid external dependencies; the frontmatter format
+    is intentionally constrained.
+
+    Returns an empty dict if no valid frontmatter is found.
+    """
+    prompt = prompt.lstrip()
+    if not prompt.startswith("---"):
+        return {}
+
+    # Find the closing ---
+    rest = prompt[3:]
+    end = rest.find("\n---")
+    if end == -1:
+        return {}
+
+    block = rest[:end].strip()
+    result = {}
+    for line in block.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        result[key.strip()] = value.strip()
+    return result
+
+
+def _extract_task_id_from_text(prompt: str) -> str | None:
+    """Fall back: extract task_id from legacy 'task_id is: X' pattern."""
+    match = re.search(r"task_id\s+is:\s*(\S+)", prompt, re.IGNORECASE)
+    return match.group(1) if match else None
+
+
+def extract_metadata(prompt: str) -> dict:
+    """Return a dict with task_id, chat_id, source, reply_to_message_id from prompt.
+
+    Tries YAML frontmatter first. Falls back to text parsing for task_id.
+    All values are strings (or None if absent).
+    """
+    fm = _parse_yaml_frontmatter(prompt)
+
+    task_id = fm.get("task_id") or _extract_task_id_from_text(prompt)
+    chat_id = fm.get("chat_id")
+    source = fm.get("source", "telegram")
+    reply_to_message_id = fm.get("reply_to_message_id")
+
+    return {
+        "task_id": task_id,
+        "chat_id": str(chat_id) if chat_id is not None else None,
+        "source": source or "telegram",
+        "reply_to_message_id": (
+            str(reply_to_message_id) if reply_to_message_id is not None else None
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Agent ID extraction from tool response
+# ---------------------------------------------------------------------------
+
+def extract_agent_id(tool_response: object) -> str | None:
+    """Extract agentId from the Agent tool response.
+
+    The response may be a dict or a list of content items. Handles both.
+    """
+    if isinstance(tool_response, dict):
+        agent_id = tool_response.get("agentId")
+        if agent_id:
+            return str(agent_id)
+
+    if isinstance(tool_response, list):
+        for item in tool_response:
+            if isinstance(item, dict):
+                agent_id = item.get("agentId")
+                if agent_id:
+                    return str(agent_id)
+
+    return None
+
+
+def extract_output_file(tool_response: object) -> str | None:
+    """Extract output_file from the Agent tool response if present."""
+    if isinstance(tool_response, dict):
+        output_file = tool_response.get("output_file") or tool_response.get("outputFile")
+        if output_file:
+            return str(output_file)
+
+    if isinstance(tool_response, list):
+        for item in tool_response:
+            if isinstance(item, dict):
+                output_file = item.get("output_file") or item.get("outputFile")
+                if output_file:
+                    return str(output_file)
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# DB insert
+# ---------------------------------------------------------------------------
+
+def insert_agent_session(
+    *,
+    agent_id: str,
+    task_id: str | None,
+    chat_id: str | None,
+    source: str,
+    session_id: str,
+    output_file: str | None,
+) -> None:
+    """Insert a 'starting' row into agent_sessions.db.
+
+    Uses INSERT OR IGNORE so that a richer row written by register_agent
+    (which may arrive concurrently) is left untouched.
+
+    Raises on DB errors so the caller can log and swallow.
+    """
+    _DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(str(_DB_PATH))
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout = 5000")
+        # Ensure the table exists (minimal DDL -- session_store owns the full schema).
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS agent_sessions (
+                id                  TEXT PRIMARY KEY,
+                task_id             TEXT,
+                agent_type          TEXT,
+                description         TEXT NOT NULL,
+                chat_id             TEXT NOT NULL,
+                source              TEXT NOT NULL DEFAULT 'telegram',
+                status              TEXT NOT NULL DEFAULT 'running',
+                output_file         TEXT,
+                timeout_minutes     INTEGER,
+                input_summary       TEXT,
+                result_summary      TEXT,
+                parent_id           TEXT,
+                spawned_at          TEXT NOT NULL,
+                completed_at        TEXT,
+                last_seen_at        TEXT,
+                notified_at         TEXT,
+                trigger_message_id  TEXT,
+                trigger_snippet     TEXT,
+                reply_message_ids   TEXT
+            )
+        """)
+        now = datetime.now(timezone.utc).isoformat()
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO agent_sessions
+                (id, task_id, agent_type, description, chat_id, source,
+                 status, output_file, spawned_at)
+            VALUES
+                (?, ?, 'subagent', 'auto-registered by PostToolUse hook', ?, ?,
+                 'starting', ?, ?)
+            """,
+            (
+                agent_id,
+                task_id,
+                chat_id if chat_id is not None else "0",
+                source,
+                output_file,
+                now,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except Exception as exc:  # noqa: BLE001
+        _log_failure(f"failed to parse hook input JSON: {exc}")
+        sys.exit(0)
+
+    # Only handle Agent tool calls
+    tool_name = data.get("tool_name", "")
+    if tool_name != "Agent":
+        sys.exit(0)
+
+    try:
+        tool_input = data.get("tool_input", {})
+        tool_response = data.get("tool_response")
+        session_id = data.get("session_id", "")
+
+        prompt = tool_input.get("prompt", "")
+        metadata = extract_metadata(prompt)
+        agent_id = extract_agent_id(tool_response)
+        output_file = extract_output_file(tool_response)
+
+        if not agent_id:
+            # No agent ID in response -- nothing to register
+            sys.exit(0)
+
+        insert_agent_session(
+            agent_id=agent_id,
+            task_id=metadata["task_id"],
+            chat_id=metadata["chat_id"],
+            source=metadata["source"],
+            session_id=session_id,
+            output_file=output_file,
+        )
+
+    except Exception as exc:  # noqa: BLE001
+        _log_failure(f"unexpected error: {exc}")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/require-task-id-in-prompt.py
+++ b/hooks/require-task-id-in-prompt.py
@@ -8,8 +8,53 @@ from write_result args in the transcript.
 This is the spawn-side mirror of require-register-agent-task-id.py: that hook
 blocks register_agent calls without task_id; this hook blocks Agent spawns where
 the prompt doesn't carry task_id into the subagent's context at all.
+
+## Accepted formats
+
+YAML frontmatter (preferred):
+
+    ---
+    task_id: my-task
+    chat_id: 8305714125
+    source: telegram
+    ---
+
+Legacy text format (backward compat, still accepted):
+
+    Your task_id is: my-task
 """
-import json, sys
+import json
+import re
+import sys
+
+
+def _has_task_id_in_frontmatter(prompt: str) -> bool:
+    """Return True if prompt starts with YAML frontmatter containing a task_id key."""
+    prompt = prompt.lstrip()
+    if not prompt.startswith("---"):
+        return False
+
+    rest = prompt[3:]
+    end = rest.find("\n---")
+    if end == -1:
+        return False
+
+    block = rest[:end]
+    for line in block.splitlines():
+        line = line.strip()
+        if re.match(r"^task_id\s*:", line):
+            # Check the value is non-empty
+            _, _, value = line.partition(":")
+            if value.strip():
+                return True
+
+    return False
+
+
+def _has_task_id_in_text(prompt: str) -> bool:
+    """Return True if prompt contains the legacy 'task_id is: X' pattern."""
+    return bool(re.search(r"task_id\s+is:\s*\S+", prompt, re.IGNORECASE))
+
 
 try:
     data = json.load(sys.stdin)
@@ -24,11 +69,14 @@ if tool != "Agent":
 
 prompt = inp.get("prompt", "")
 
-if "task_id is:" not in prompt:
-    print(
-        'BLOCKED: Agent spawned without task_id in prompt. '
-        'Include "Your task_id is: <slug>" so the subagent can pass it to write_result. '
-        'This enables reliable DB matching in the SubagentStop hook.',
-        file=sys.stderr,
-    )
-    sys.exit(2)
+if _has_task_id_in_frontmatter(prompt) or _has_task_id_in_text(prompt):
+    sys.exit(0)
+
+print(
+    'BLOCKED: Agent spawned without task_id in prompt. '
+    'Include a YAML frontmatter block (---\\ntask_id: <slug>\\n---) at the top of the prompt, '
+    'or the legacy format "Your task_id is: <slug>". '
+    'This enables reliable DB matching in the SubagentStop hook.',
+    file=sys.stderr,
+)
+sys.exit(2)

--- a/install.sh
+++ b/install.sh
@@ -1634,6 +1634,27 @@ else
     info "Skipping restore-exec-bit hook (settings.json not yet created)"
 fi
 
+# Set up Claude Code PostToolUse hook to auto-register Agent spawns in agent_sessions.db
+chmod +x "$INSTALL_DIR/hooks/auto-register-agent.py" || true
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.PostToolUse[]? | select(.hooks[]?.command | test("auto-register-agent"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq '.hooks.PostToolUse = (.hooks.PostToolUse // []) + [{
+            "matcher": "Agent",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 '"$INSTALL_DIR"'/hooks/auto-register-agent.py",
+                "timeout": 10
+            }]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "auto-register-agent hook installed"
+    else
+        info "auto-register-agent hook already configured in Claude Code settings"
+    fi
+else
+    info "Skipping auto-register-agent hook (settings.json not yet created)"
+fi
+
 # Set up Claude Code PreToolUse hook to block tool use after compaction without context reload
 chmod +x "$INSTALL_DIR/hooks/post-compact-gate.py" || true
 if [ -f "$CLAUDE_SETTINGS" ]; then

--- a/tests/unit/test_hooks/test_auto_register_agent.py
+++ b/tests/unit/test_hooks/test_auto_register_agent.py
@@ -1,0 +1,410 @@
+"""
+Unit tests for hooks/auto-register-agent.py
+
+Tests cover:
+- Non-Agent tool calls are ignored (exit 0, no DB write)
+- YAML frontmatter: task_id, chat_id, source, reply_to_message_id parsed correctly
+- Legacy text format: task_id extracted from "task_id is: X"
+- agentId extracted from tool_response dict and list forms
+- output_file extracted from tool_response
+- DB row inserted with correct values
+- INSERT OR IGNORE: existing row not overwritten
+- Missing agentId: exits 0 without DB write
+- DB failure: logs to hook-failures.log and exits 0
+- Malformed stdin JSON: logs and exits 0
+"""
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+HOOK_PATH = _HOOKS_DIR / "auto-register-agent.py"
+
+
+# ---------------------------------------------------------------------------
+# Direct imports of pure functions (no side effects)
+# ---------------------------------------------------------------------------
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("auto_register_agent", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_module()
+extract_metadata = _mod.extract_metadata
+extract_agent_id = _mod.extract_agent_id
+extract_output_file = _mod.extract_output_file
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run_hook(hook_input: dict, tmp_path: Path) -> tuple[int, str, str]:
+    """Run the hook via exec, capturing stdout/stderr and exit code."""
+    stdout_cap = StringIO()
+    stderr_cap = StringIO()
+    stdin_data = json.dumps(hook_input)
+
+    exit_code = None
+    with (
+        patch("sys.stdin", StringIO(stdin_data)),
+        patch("sys.stdout", stdout_cap),
+        patch("sys.stderr", stderr_cap),
+        patch.dict("os.environ", {
+            "LOBSTER_MESSAGES": str(tmp_path / "messages"),
+            "LOBSTER_WORKSPACE": str(tmp_path / "workspace"),
+        }),
+    ):
+        try:
+            hook_globals = {"__name__": "__main__", "__file__": str(HOOK_PATH)}
+            exec(compile(HOOK_PATH.read_text(), str(HOOK_PATH), "exec"), hook_globals)
+        except SystemExit as e:
+            exit_code = e.code
+
+    return exit_code, stdout_cap.getvalue(), stderr_cap.getvalue()
+
+
+def _make_hook_input(
+    tool_name: str = "Agent",
+    prompt: str = "",
+    tool_response: object = None,
+    session_id: str = "sess-123",
+) -> dict:
+    return {
+        "hook_event_name": "PostToolUse",
+        "session_id": session_id,
+        "tool_name": tool_name,
+        "tool_input": {"prompt": prompt},
+        "tool_response": tool_response,
+    }
+
+
+def _open_db(tmp_path: Path) -> sqlite3.Connection:
+    db_path = tmp_path / "messages" / "config" / "agent_sessions.db"
+    return sqlite3.connect(str(db_path))
+
+
+def _get_row(tmp_path: Path, agent_id: str) -> dict | None:
+    conn = _open_db(tmp_path)
+    try:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT * FROM agent_sessions WHERE id = ?", (agent_id,)
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# extract_metadata: pure function tests
+# ---------------------------------------------------------------------------
+
+class TestExtractMetadata:
+    def test_yaml_frontmatter_all_fields(self):
+        prompt = "---\ntask_id: my-task\nchat_id: 8305714125\nsource: telegram\nreply_to_message_id: 10924\n---\nsome content"
+        meta = extract_metadata(prompt)
+        assert meta["task_id"] == "my-task"
+        assert meta["chat_id"] == "8305714125"
+        assert meta["source"] == "telegram"
+        assert meta["reply_to_message_id"] == "10924"
+
+    def test_yaml_frontmatter_minimal(self):
+        prompt = "---\ntask_id: slim-task\n---\n"
+        meta = extract_metadata(prompt)
+        assert meta["task_id"] == "slim-task"
+        assert meta["source"] == "telegram"  # default
+        assert meta["chat_id"] is None
+        assert meta["reply_to_message_id"] is None
+
+    def test_yaml_frontmatter_leading_whitespace(self):
+        """Prompt may have leading whitespace before the ---."""
+        prompt = "\n  \n---\ntask_id: ws-task\n---\n"
+        meta = extract_metadata(prompt)
+        assert meta["task_id"] == "ws-task"
+
+    def test_legacy_text_format(self):
+        prompt = "Your task_id is: legacy-task\nDo some work."
+        meta = extract_metadata(prompt)
+        assert meta["task_id"] == "legacy-task"
+        assert meta["chat_id"] is None
+
+    def test_legacy_text_case_insensitive(self):
+        prompt = "TASK_ID IS: upper-task"
+        meta = extract_metadata(prompt)
+        assert meta["task_id"] == "upper-task"
+
+    def test_no_task_id(self):
+        prompt = "Just a plain prompt with no id."
+        meta = extract_metadata(prompt)
+        assert meta["task_id"] is None
+
+    def test_yaml_wins_over_legacy_text(self):
+        """When both formats are present, frontmatter task_id wins."""
+        prompt = "---\ntask_id: yaml-id\n---\nYour task_id is: legacy-id"
+        meta = extract_metadata(prompt)
+        assert meta["task_id"] == "yaml-id"
+
+    def test_no_closing_delimiter_falls_back(self):
+        """Unclosed frontmatter (no closing ---) is not treated as frontmatter."""
+        prompt = "---\ntask_id: unclosed\n\nYour task_id is: textid"
+        meta = extract_metadata(prompt)
+        # Frontmatter parse fails, legacy text used
+        assert meta["task_id"] == "textid"
+
+
+# ---------------------------------------------------------------------------
+# extract_agent_id: pure function tests
+# ---------------------------------------------------------------------------
+
+class TestExtractAgentId:
+    def test_dict_response(self):
+        assert extract_agent_id({"agentId": "agt-001"}) == "agt-001"
+
+    def test_list_response(self):
+        assert extract_agent_id([{"agentId": "agt-002"}]) == "agt-002"
+
+    def test_list_first_match(self):
+        response = [{"type": "text", "text": "..."}, {"agentId": "agt-003"}]
+        assert extract_agent_id(response) == "agt-003"
+
+    def test_missing_agent_id(self):
+        assert extract_agent_id({"result": "ok"}) is None
+
+    def test_none_response(self):
+        assert extract_agent_id(None) is None
+
+    def test_empty_list(self):
+        assert extract_agent_id([]) is None
+
+
+# ---------------------------------------------------------------------------
+# extract_output_file: pure function tests
+# ---------------------------------------------------------------------------
+
+class TestExtractOutputFile:
+    def test_snake_case_key(self):
+        assert extract_output_file({"output_file": "/tmp/out.txt"}) == "/tmp/out.txt"
+
+    def test_camel_case_key(self):
+        assert extract_output_file({"outputFile": "/tmp/out2.txt"}) == "/tmp/out2.txt"
+
+    def test_missing(self):
+        assert extract_output_file({"agentId": "x"}) is None
+
+    def test_in_list(self):
+        assert extract_output_file([{"output_file": "/tmp/f.txt"}]) == "/tmp/f.txt"
+
+
+# ---------------------------------------------------------------------------
+# Integration: hook execution
+# ---------------------------------------------------------------------------
+
+class TestHookNonAgentTool:
+    def test_non_agent_exits_0_no_db(self, tmp_path):
+        """Non-Agent tool calls are ignored entirely."""
+        hook_input = _make_hook_input(
+            tool_name="Bash",
+            prompt="ls",
+            tool_response={"output": "file.txt"},
+        )
+        exit_code, _, _ = _run_hook(hook_input, tmp_path)
+        assert exit_code == 0
+        db_path = tmp_path / "messages" / "config" / "agent_sessions.db"
+        assert not db_path.exists()
+
+
+class TestHookAgentWithAgentId:
+    def test_inserts_row_with_frontmatter(self, tmp_path):
+        """Full frontmatter inserts a complete row."""
+        prompt = "---\ntask_id: t-001\nchat_id: 99999\nsource: slack\n---\nDo stuff."
+        hook_input = _make_hook_input(
+            prompt=prompt,
+            tool_response={"agentId": "agent-abc"},
+        )
+        exit_code, _, _ = _run_hook(hook_input, tmp_path)
+        assert exit_code == 0
+
+        row = _get_row(tmp_path, "agent-abc")
+        assert row is not None
+        assert row["task_id"] == "t-001"
+        assert row["chat_id"] == "99999"
+        assert row["source"] == "slack"
+        assert row["status"] == "starting"
+
+    def test_inserts_row_with_legacy_text(self, tmp_path):
+        """Legacy task_id text format inserts a row."""
+        prompt = "Your task_id is: t-legacy\nDo work."
+        hook_input = _make_hook_input(
+            prompt=prompt,
+            tool_response={"agentId": "agent-legacy"},
+        )
+        exit_code, _, _ = _run_hook(hook_input, tmp_path)
+        assert exit_code == 0
+
+        row = _get_row(tmp_path, "agent-legacy")
+        assert row is not None
+        assert row["task_id"] == "t-legacy"
+
+    def test_insert_or_ignore_preserves_existing_row(self, tmp_path):
+        """A pre-existing row (from register_agent) is NOT overwritten."""
+        # Pre-populate with a richer row
+        db_dir = tmp_path / "messages" / "config"
+        db_dir.mkdir(parents=True)
+        conn = sqlite3.connect(str(db_dir / "agent_sessions.db"))
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS agent_sessions (
+                id TEXT PRIMARY KEY, task_id TEXT, agent_type TEXT,
+                description TEXT NOT NULL, chat_id TEXT NOT NULL,
+                source TEXT NOT NULL DEFAULT 'telegram',
+                status TEXT NOT NULL DEFAULT 'running',
+                output_file TEXT, timeout_minutes INTEGER,
+                input_summary TEXT, result_summary TEXT, parent_id TEXT,
+                spawned_at TEXT NOT NULL, completed_at TEXT,
+                last_seen_at TEXT, notified_at TEXT,
+                trigger_message_id TEXT, trigger_snippet TEXT,
+                reply_message_ids TEXT
+            )
+        """)
+        conn.execute(
+            "INSERT INTO agent_sessions (id, description, chat_id, status, spawned_at)"
+            " VALUES ('agent-dup', 'richer description', '12345', 'running', '2026-01-01T00:00:00+00:00')"
+        )
+        conn.commit()
+        conn.close()
+
+        prompt = "---\ntask_id: dup-task\n---"
+        hook_input = _make_hook_input(
+            prompt=prompt,
+            tool_response={"agentId": "agent-dup"},
+        )
+        exit_code, _, _ = _run_hook(hook_input, tmp_path)
+        assert exit_code == 0
+
+        row = _get_row(tmp_path, "agent-dup")
+        # Description should still be the original richer one
+        assert row["description"] == "richer description"
+        assert row["status"] == "running"  # not overwritten to 'starting'
+
+    def test_output_file_stored(self, tmp_path):
+        """output_file from tool response is stored in DB."""
+        prompt = "---\ntask_id: t-of\n---"
+        hook_input = _make_hook_input(
+            prompt=prompt,
+            tool_response={"agentId": "agent-of", "output_file": "/tmp/result.json"},
+        )
+        exit_code, _, _ = _run_hook(hook_input, tmp_path)
+        assert exit_code == 0
+
+        row = _get_row(tmp_path, "agent-of")
+        assert row["output_file"] == "/tmp/result.json"
+
+    def test_no_chat_id_defaults_to_zero(self, tmp_path):
+        """Missing chat_id stores '0' to satisfy NOT NULL constraint."""
+        prompt = "---\ntask_id: t-nochat\n---"
+        hook_input = _make_hook_input(
+            prompt=prompt,
+            tool_response={"agentId": "agent-nochat"},
+        )
+        exit_code, _, _ = _run_hook(hook_input, tmp_path)
+        assert exit_code == 0
+
+        row = _get_row(tmp_path, "agent-nochat")
+        assert row["chat_id"] == "0"
+
+
+class TestHookNoAgentId:
+    def test_missing_agent_id_exits_0_no_write(self, tmp_path):
+        """If tool response has no agentId, exit 0 without touching DB."""
+        prompt = "---\ntask_id: t-noid\n---"
+        hook_input = _make_hook_input(
+            prompt=prompt,
+            tool_response={"result": "some output"},
+        )
+        exit_code, _, _ = _run_hook(hook_input, tmp_path)
+        assert exit_code == 0
+        db_path = tmp_path / "messages" / "config" / "agent_sessions.db"
+        assert not db_path.exists()
+
+    def test_none_response_exits_0(self, tmp_path):
+        prompt = "---\ntask_id: t-none\n---"
+        hook_input = _make_hook_input(
+            prompt=prompt,
+            tool_response=None,
+        )
+        exit_code, _, _ = _run_hook(hook_input, tmp_path)
+        assert exit_code == 0
+
+
+class TestHookFailureSafety:
+    def test_malformed_json_exits_0(self, tmp_path):
+        """Malformed stdin JSON must never crash the hook (exit 0)."""
+        stdout_cap = StringIO()
+        stderr_cap = StringIO()
+        exit_code = None
+        with (
+            patch("sys.stdin", StringIO("not-valid-json{")),
+            patch("sys.stdout", stdout_cap),
+            patch("sys.stderr", stderr_cap),
+            patch.dict("os.environ", {
+                "LOBSTER_MESSAGES": str(tmp_path / "messages"),
+                "LOBSTER_WORKSPACE": str(tmp_path / "workspace"),
+            }),
+        ):
+            try:
+                hook_globals = {"__name__": "__main__", "__file__": str(HOOK_PATH)}
+                exec(compile(HOOK_PATH.read_text(), str(HOOK_PATH), "exec"), hook_globals)
+            except SystemExit as e:
+                exit_code = e.code
+
+        assert exit_code == 0
+
+    def test_db_failure_logs_and_exits_0(self, tmp_path):
+        """DB write failure is logged to hook-failures.log, not re-raised."""
+        # Point DB to a read-only directory to force failure
+        ro_dir = tmp_path / "readonly"
+        ro_dir.mkdir()
+        (ro_dir / "config").mkdir()
+        import os
+        os.chmod(str(ro_dir / "config"), 0o444)
+
+        prompt = "---\ntask_id: t-fail\n---"
+        hook_input = _make_hook_input(
+            prompt=prompt,
+            tool_response={"agentId": "agent-fail"},
+        )
+        exit_code = None
+        stdout_cap = StringIO()
+        stderr_cap = StringIO()
+        with (
+            patch("sys.stdin", StringIO(json.dumps(hook_input))),
+            patch("sys.stdout", stdout_cap),
+            patch("sys.stderr", stderr_cap),
+            patch.dict("os.environ", {
+                "LOBSTER_MESSAGES": str(ro_dir),
+                "LOBSTER_WORKSPACE": str(tmp_path / "workspace"),
+            }),
+        ):
+            try:
+                hook_globals = {"__name__": "__main__", "__file__": str(HOOK_PATH)}
+                exec(compile(HOOK_PATH.read_text(), str(HOOK_PATH), "exec"), hook_globals)
+            except SystemExit as e:
+                exit_code = e.code
+
+        os.chmod(str(ro_dir / "config"), 0o755)  # restore for cleanup
+        assert exit_code == 0
+
+        log_path = tmp_path / "workspace" / "logs" / "hook-failures.log"
+        assert log_path.exists(), "Expected failure to be logged"
+        log_content = log_path.read_text()
+        assert "auto-register-agent" in log_content

--- a/tests/unit/test_hooks/test_require_task_id_in_prompt.py
+++ b/tests/unit/test_hooks/test_require_task_id_in_prompt.py
@@ -1,0 +1,182 @@
+"""
+Unit tests for hooks/require-task-id-in-prompt.py
+
+Tests cover:
+- Non-Agent tool calls pass through (exit 0)
+- YAML frontmatter with task_id passes (exit 0)
+- YAML frontmatter without task_id is blocked (exit 2)
+- Legacy "task_id is: X" text passes (exit 0)
+- Prompt with both frontmatter and legacy text passes (exit 0)
+- Prompt with neither format is blocked (exit 2)
+- Empty frontmatter task_id value is blocked (exit 2)
+- Block message appears on stderr
+- Malformed stdin is tolerated (exit 0)
+"""
+
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+HOOK_PATH = _HOOKS_DIR / "require-task-id-in-prompt.py"
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _run_hook(hook_input: dict) -> tuple[int, str, str]:
+    stdout_cap = StringIO()
+    stderr_cap = StringIO()
+    stdin_data = json.dumps(hook_input)
+    exit_code = None
+    with (
+        patch("sys.stdin", StringIO(stdin_data)),
+        patch("sys.stdout", stdout_cap),
+        patch("sys.stderr", stderr_cap),
+    ):
+        try:
+            hook_globals = {"__name__": "__main__", "__file__": str(HOOK_PATH)}
+            exec(compile(HOOK_PATH.read_text(), str(HOOK_PATH), "exec"), hook_globals)
+        except SystemExit as e:
+            exit_code = e.code
+    return exit_code, stdout_cap.getvalue(), stderr_cap.getvalue()
+
+
+def _make_input(tool_name: str = "Agent", prompt: str = "") -> dict:
+    return {
+        "hook_event_name": "PreToolUse",
+        "session_id": "sess-test",
+        "tool_name": tool_name,
+        "tool_input": {"prompt": prompt},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Non-Agent tools
+# ---------------------------------------------------------------------------
+
+class TestNonAgentPassthrough:
+    def test_bash_exits_0(self):
+        exit_code, _, _ = _run_hook(_make_input("Bash", "no id here"))
+        assert exit_code == 0
+
+    def test_read_exits_0(self):
+        exit_code, _, _ = _run_hook(_make_input("Read", ""))
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# YAML frontmatter format
+# ---------------------------------------------------------------------------
+
+class TestYamlFrontmatter:
+    def test_frontmatter_with_task_id_passes(self):
+        prompt = "---\ntask_id: my-task\nchat_id: 123\n---\nDo work."
+        exit_code, _, _ = _run_hook(_make_input(prompt=prompt))
+        assert exit_code == 0
+
+    def test_frontmatter_without_task_id_blocked(self):
+        prompt = "---\nchat_id: 123\nsource: telegram\n---\nDo work."
+        exit_code, _, stderr = _run_hook(_make_input(prompt=prompt))
+        assert exit_code == 2
+        assert "BLOCKED" in stderr
+
+    def test_frontmatter_empty_task_id_blocked(self):
+        """A task_id key with no value must not pass."""
+        prompt = "---\ntask_id:\n---\nDo work."
+        exit_code, _, stderr = _run_hook(_make_input(prompt=prompt))
+        assert exit_code == 2
+
+    def test_frontmatter_unclosed_falls_back(self):
+        """Unclosed frontmatter is not treated as valid frontmatter."""
+        prompt = "---\ntask_id: no-close\n\nsome text"
+        exit_code, _, stderr = _run_hook(_make_input(prompt=prompt))
+        # No task_id found in either format -> blocked
+        assert exit_code == 2
+
+    def test_frontmatter_task_id_with_whitespace_passes(self):
+        """Leading whitespace before --- is tolerated."""
+        prompt = "\n---\ntask_id: ws-task\n---\n"
+        exit_code, _, _ = _run_hook(_make_input(prompt=prompt))
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Legacy text format
+# ---------------------------------------------------------------------------
+
+class TestLegacyTextFormat:
+    def test_legacy_format_passes(self):
+        prompt = "Your task_id is: my-slug\nDo the work."
+        exit_code, _, _ = _run_hook(_make_input(prompt=prompt))
+        assert exit_code == 0
+
+    def test_legacy_format_case_insensitive(self):
+        prompt = "TASK_ID IS: uppercase-slug"
+        exit_code, _, _ = _run_hook(_make_input(prompt=prompt))
+        assert exit_code == 0
+
+    def test_legacy_format_inline(self):
+        prompt = "Please run. task_id is: inline-id. Thanks."
+        exit_code, _, _ = _run_hook(_make_input(prompt=prompt))
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Neither format
+# ---------------------------------------------------------------------------
+
+class TestNoTaskId:
+    def test_plain_prompt_blocked(self):
+        prompt = "Just do some stuff."
+        exit_code, _, stderr = _run_hook(_make_input(prompt=prompt))
+        assert exit_code == 2
+        assert "BLOCKED" in stderr
+
+    def test_empty_prompt_blocked(self):
+        exit_code, _, _ = _run_hook(_make_input(prompt=""))
+        assert exit_code == 2
+
+    def test_block_message_on_stderr_not_stdout(self):
+        exit_code, stdout, stderr = _run_hook(_make_input(prompt="no id"))
+        assert exit_code == 2
+        assert "BLOCKED" in stderr
+        assert "BLOCKED" not in stdout
+
+
+# ---------------------------------------------------------------------------
+# Both formats present
+# ---------------------------------------------------------------------------
+
+class TestBothFormats:
+    def test_both_present_passes(self):
+        prompt = "---\ntask_id: yaml-id\n---\nYour task_id is: legacy-id"
+        exit_code, _, _ = _run_hook(_make_input(prompt=prompt))
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Error tolerance
+# ---------------------------------------------------------------------------
+
+class TestErrorTolerance:
+    def test_malformed_json_exits_0(self):
+        stdout_cap = StringIO()
+        stderr_cap = StringIO()
+        exit_code = None
+        with (
+            patch("sys.stdin", StringIO("{not valid")),
+            patch("sys.stdout", stdout_cap),
+            patch("sys.stderr", stderr_cap),
+        ):
+            try:
+                hook_globals = {"__name__": "__main__", "__file__": str(HOOK_PATH)}
+                exec(compile(HOOK_PATH.read_text(), str(HOOK_PATH), "exec"), hook_globals)
+            except SystemExit as e:
+                exit_code = e.code
+        assert exit_code == 0


### PR DESCRIPTION
## What this solves

When the dispatcher spawns a background Agent, the spawned agent's identity and task metadata (task_id, chat_id, source) often aren't captured in \`agent_sessions.db\` until the agent explicitly calls \`register_agent\` — which can fail silently or be skipped. This means ghost-detector queries and status lookups see incomplete or absent rows for recently-spawned agents.

This PR closes that gap without changing the dispatcher or requiring any LLM action. A PostToolUse hook fires synchronously after every Agent tool call, extracts metadata from the prompt, and writes a \`starting\` row to \`agent_sessions.db\` immediately. The existing \`SessionStart\` hook still writes its minimal stub; the new hook's \`INSERT OR IGNORE\` means whichever arrives first wins, and a richer \`register_agent\` row is never overwritten.

## Changes

**\`hooks/auto-register-agent.py\` (new)** — PostToolUse hook on the Agent tool. Parses YAML frontmatter from the prompt to extract \`task_id\`, \`chat_id\`, \`source\`, and \`reply_to_message_id\`. Falls back to the legacy \`"task_id is: X"\` text pattern for backward compatibility during migration. Extracts \`agentId\` from the tool response (handles both dict and list response shapes). Inserts a \`starting\` row into \`agent_sessions.db\` using \`INSERT OR IGNORE\`. Any failure is appended to \`~/lobster-workspace/logs/hook-failures.log\` and the hook always exits 0 — Agent spawns are never blocked.

**\`hooks/require-task-id-in-prompt.py\` (updated)** — Previously only accepted \`"task_id is: X"\` text format. Now also accepts YAML frontmatter with a non-empty \`task_id\` key. Both formats pass; neither format blocks. The block message on stderr is updated to describe both options.

**\`install.sh\` (updated)** — Registers \`auto-register-agent.py\` as a PostToolUse hook on \`Agent\` using the same idempotent jq pattern used by all other hook registrations.

## Functional patterns used

Pure extraction functions (\`extract_metadata\`, \`extract_agent_id\`, \`extract_output_file\`) are tested independently of DB and subprocess side effects. Side effects (DB insert, log write) are isolated to \`insert_agent_session\` and \`_log_failure\`. The hook's \`main()\` is purely a composition of these.

## Areas to review closely

- \`insert_agent_session\`: The DDL in the hook is a subset of \`session_store._SCHEMA_CREATE_TABLE\`. If the real DB already exists (which it will on any live install), \`CREATE TABLE IF NOT EXISTS\` is a no-op and the hook relies on the real schema. This is intentional — session_store owns the schema. However, reviewers should verify the column subset used in the INSERT matches the actual schema's NOT NULL constraints (confirmed against \`session_store.py\` lines 52–74: \`description\`, \`chat_id\`, \`source\`, \`status\`, \`spawned_at\` are all provided).
- The \`session_id\` field from the hook input is accepted but not currently stored (the schema has no \`session_id\` column — that's the \`id\` column which gets the \`agentId\`). This is consistent with how \`write-dispatcher-session-id.py\` uses it.

## Concerns / known gaps

- \`agentId\` in the tool response: format confirmed from Claude Code docs and existing hooks, but I could not run a live Agent tool call to validate the exact JSON shape. The hook handles both dict and list response forms defensively.
- Project board status update skipped: token lacks \`read:project\` scope.

## Tests run

- [x] \`uv run pytest tests/unit/test_hooks/test_auto_register_agent.py tests/unit/test_hooks/test_require_task_id_in_prompt.py -v\` — 43 passed, 0 failed
- [x] \`uv run pytest tests/unit/ -q\` — 1173 passed on this branch vs 1168 on main (net +5 from new tests); pre-existing failures in \`test_update_manager.py\` and \`test_memory.py\` are unchanged
- [ ] Live Agent spawn with YAML frontmatter — blocked: requires production dispatcher restart; safe to merge without it since the hook exits 0 on any failure

Closes #604