### PR TITLE
refactor: remove ghost-detector routing from sys dispatcher prompt

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -197,24 +197,18 @@ Scheduled reminders are injected by `scripts/post-reminder.sh`, called from cron
 ```json
 {
   "type": "scheduled_reminder",
-  "reminder_type": "ghost_detector",
+  "reminder_type": "oom_check",
   "source": "system",
   "chat_id": 0,
-  "text": "Scheduled reminder: ghost_detector",
+  "text": "Scheduled reminder: oom_check",
   "timestamp": "2026-01-01T00:00:00+00:00"
 }
 ```
 
-**Routing table** — maps `reminder_type` to the subagent and prompt to use. Fallback for unknown types: `lobster-generalist`. Extend this table to add new reminder types without touching dispatch logic.
+**Routing table** — maps `reminder_type` to the subagent and prompt to use. Fallback for unknown types: `lobster-generalist`. Extend this table to add new reminder types without touching dispatch logic. User-specific entries (e.g. diagnostic tools) belong in `user.dispatcher.bootup.md`.
 
 ```
 REMINDER_ROUTING = {
-  "ghost_detector": {
-    "subagent_type": "lobster-generalist",
-    "prompt": "---\ntask_id: ghost-detector\nchat_id: 0\nsource: system\n---\n\n"
-              "Run the ghost detector check. Script is at ~/lobster/scripts/ghost-detector.py. "
-              "Run it with uv run ~/lobster/scripts/ghost-detector.py and report findings.",
-  },
   "oom_check": {
     "subagent_type": "lobster-generalist",
     "prompt": "---\ntask_id: oom-check\nchat_id: 0\nsource: system\n---\n\n"


### PR DESCRIPTION
Ghost-detector is a diagnostic tool for investigating stale/zombie message issues. It should not be baked into the system dispatcher prompt — whether and how it runs is a user-config decision, not a system default.

Before this change, `sys.dispatcher.bootup.md` contained a `ghost_detector` entry in `REMINDER_ROUTING` and used `ghost_detector` as the illustrative example in the message shape JSON block. Any dispatcher instance would load these instructions even if the user had no ghost-detector cron job configured.

## What changed

- Removed the `ghost_detector` entry from `REMINDER_ROUTING` in `sys.dispatcher.bootup.md`
- Updated the example message shape JSON to use `oom_check` (a remaining system-level entry) as the illustrative shape
- Added a note to the routing table comment directing users to `user.dispatcher.bootup.md` for user-specific entries
- Added a "Diagnostic Tools" section to `~/lobster-user-config/agents/user.dispatcher.bootup.md` with the ghost-detector routing entry and manual run instructions (not committed — userland only)

## What is NOT changed

- `scripts/ghost-detector.py` — untouched
- All unit and integration tests for ghost-detector — untouched
- The `oom_check` entry and the scheduled reminder dispatch mechanism — untouched
- All other routing table entries — untouched

## Functional patterns

Pure data transformation — only the static configuration table and example JSON were modified. No control flow or logic changed.

## Tests run

- [x] `uv run pytest tests/smoke/test_require_write_result.py -q` — 5 failed, 2 passed (failures are pre-existing on `origin/main`, confirmed by stashing this change and rerunning: same result)
- [x] `git diff HEAD --name-only` — only `.claude/sys.dispatcher.bootup.md` modified, confirming no unintended changes

Closes #610