### PR TITLE
fix: session_end closes 'starting' rows so write_result completes the agent lifecycle

### DIFF
--- a/src/agents/session_store.py
+++ b/src/agents/session_store.py
@@ -316,12 +316,16 @@ def session_end(
     conn = _get_connection(resolved)
     now = datetime.now(timezone.utc).isoformat()
 
-    # Try matching on id first, then task_id
+    # Match on id or task_id.  Accept both 'running' (registered by the
+    # dispatcher via session_start) and 'starting' (auto-registered by the
+    # PostToolUse hook before the agent has fully initialised).  This closes
+    # the lifecycle gap where rows inserted as 'starting' were never updated
+    # because the old WHERE clause only matched 'running'.
     conn.execute(
         """
         UPDATE agent_sessions
         SET status = ?, completed_at = ?, result_summary = ?
-        WHERE (id = ? OR task_id = ?) AND status = 'running'
+        WHERE (id = ? OR task_id = ?) AND status IN ('running', 'starting')
         """,
         (status, now, result_summary, id_or_task_id, id_or_task_id),
     )

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -161,6 +161,42 @@ def test_session_end_does_not_double_close(isolated_db):
     assert result["result_summary"] == "First close"
 
 
+def test_session_end_closes_starting_row(isolated_db):
+    """session_end closes rows with status='starting' (auto-registered by PostToolUse hook).
+
+    The auto-register-agent.py hook inserts rows as 'starting' before the agent
+    has fully initialised. Previously, session_end only matched 'running' rows,
+    so write_result calls on 'starting' rows were silently no-ops and the rows
+    accumulated indefinitely. This test verifies the fix: session_end now accepts
+    both 'running' and 'starting'.
+    """
+    import sqlite3
+    db = isolated_db
+    conn = sqlite3.connect(str(db))
+    # Insert a 'starting' row directly — mimics the PostToolUse hook
+    conn.execute(
+        """
+        INSERT INTO agent_sessions
+            (id, task_id, agent_type, description, chat_id, source, status, spawned_at)
+        VALUES
+            (?, ?, 'subagent', 'auto-registered by PostToolUse hook', '123', 'telegram',
+             'starting', datetime('now'))
+        """,
+        ("hook-agent-id", "hook-task-id"),
+    )
+    conn.commit()
+    conn.close()
+
+    # End by task_id (as write_result does)
+    session_store.session_end("hook-task-id", "completed", "Done.", path=db)
+
+    result = session_store.find_session("hook-task-id", path=db)
+    assert result is not None
+    assert result["status"] == "completed"
+    assert result["completed_at"] is not None
+    assert result["result_summary"] == "Done."
+
+
 def test_multiple_sessions(isolated_db):
     """Multiple concurrent sessions are tracked independently."""
     db = isolated_db


### PR DESCRIPTION
## Summary

The `auto-register-agent` PostToolUse hook (landed in #605) inserts agent_sessions rows with `status='starting'` when an agent is spawned. When the agent later calls `write_result`, `handle_write_result` calls `session_store.session_end` — but `session_end`'s WHERE clause only matched `status='running'`. Rows inserted as `'starting'` were therefore never closed, accumulating as permanent ghost rows in `agent_sessions.db`.

The fix is a one-line change to `session_end`: expand the filter from `status = 'running'` to `status IN ('running', 'starting')`. This completes the agent lifecycle for both registration paths:
- Agents registered by the dispatcher via `session_start` (status `'running'`)
- Agents auto-registered by the PostToolUse hook via INSERT OR IGNORE (status `'starting'`)

No change to `inbox_server.py` was needed — `handle_write_result` already calls `session_store.session_end` correctly. The bug was entirely in the WHERE clause of the `session_end` update.

The `completed_at` column already exists in the schema (present since the original session_store DDL), so no migration is needed.

**Functional patterns:** pure SQL update with explicit status guard; all side effects remain isolated to `session_end`; idempotency preserved (completed/failed rows are unaffected by the expanded clause).

## Tests run

- [x] `uv run pytest tests/test_agent_sessions.py -v` — 33 passed, 0 failed (includes new `test_session_end_closes_starting_row` which directly reproduces the bug)
- [ ] Full unit suite (`tests/unit/`) — 70 pre-existing failures in `test_update_manager` and `test_memory` (wrong ELF class for sqlite_vec) unrelated to this change; not introduced here

Closes #615