### PR TITLE
feat(hooks): add require-register-agent-task-id PreToolUse hook

### DIFF
--- a/hooks/require-register-agent-task-id.py
+++ b/hooks/require-register-agent-task-id.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: blocks register_agent calls missing a task_id parameter.
+
+The task_id is required so the SubagentStop hook can reliably match the DB row
+by primary key when closing ghost agent entries.
+"""
+import json, sys
+
+data = json.load(sys.stdin)
+tool = data.get("tool_name", "")
+inp = data.get("tool_input", {})
+
+if tool != "mcp__lobster-inbox__register_agent":
+    sys.exit(0)
+
+task_id = inp.get("task_id")
+
+if not task_id:
+    print(
+        "BLOCKED: register_agent called without task_id. "
+        "Set task_id to the same value the subagent will use in write_result. "
+        "This enables reliable DB matching in the SubagentStop hook.",
+        file=sys.stderr,
+    )
+    sys.exit(2)


### PR DESCRIPTION
## Summary

- Commits `hooks/require-register-agent-task-id.py` which was present on disk but never committed to the repo
- This hook blocks `register_agent` calls missing a `task_id` parameter, enabling reliable DB row matching in the SubagentStop hook
- The hook was already wired into `~/.claude/settings.json` (added during PR #520 rollout), so it was actively running but untracked — causing the `[WARN] Local changes detected` upgrade warning

## Test plan

- [ ] Verify `hooks/require-register-agent-task-id.py` is present in the repo after merge
- [ ] Confirm `lobster update` no longer reports local changes warning after merge + pull
- [ ] Verify the hook still blocks `register_agent` calls without `task_id` in a subagent session

🤖 Generated with [Claude Code](https://claude.com/claude-code)