### PR TITLE
fix: dead-letter on TimedOut to prevent duplicate Telegram delivery

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -1463,14 +1463,27 @@ async def sweep_outbox():
                     await handler.process_reply(fname)
                     _outbox_fail_counts.pop(fname, None)
                 except Exception as e:
-                    _outbox_fail_counts[fname] = _outbox_fail_counts.get(fname, 0) + 1
-                    count = _outbox_fail_counts[fname]
-                    log.error(f"Sweep: failed to process {filepath.name} (attempt {count}/5): {e}")
-                    if count >= 5:
+                    from telegram.error import TimedOut as TelegramTimedOut
+                    if isinstance(e, TelegramTimedOut):
+                        # TimedOut means the HTTP request was dispatched but the response
+                        # was lost. Telegram almost certainly received and delivered the
+                        # message. Retrying would send a duplicate. Dead-letter immediately.
                         dest = DEAD_LETTER_DIR / filepath.name
                         shutil.move(fname, str(dest))
                         _outbox_fail_counts.pop(fname, None)
-                        log.error(f"Moved to dead-letter after 5 failures: {filepath.name}")
+                        _processing_files.discard(fname)
+                        log.error(
+                            f"Dead-lettered after TimedOut (likely delivered): {filepath.name}"
+                        )
+                    else:
+                        _outbox_fail_counts[fname] = _outbox_fail_counts.get(fname, 0) + 1
+                        count = _outbox_fail_counts[fname]
+                        log.error(f"Sweep: failed to process {filepath.name} (attempt {count}/5): {e}")
+                        if count >= 5:
+                            dest = DEAD_LETTER_DIR / filepath.name
+                            shutil.move(fname, str(dest))
+                            _outbox_fail_counts.pop(fname, None)
+                            log.error(f"Moved to dead-letter after 5 failures: {filepath.name}")
         except Exception as e:
             log.error(f"Outbox sweep error: {e}")
 
@@ -1504,7 +1517,7 @@ async def run_bot():
     log.info("Watching outbox for replies...")
 
     # Create bot application
-    bot_app = Application.builder().token(BOT_TOKEN).build()
+    bot_app = Application.builder().token(BOT_TOKEN).write_timeout(30).build()
 
     # Add handlers
     bot_app.add_handler(CommandHandler("start", start_command))


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Summary

Before this fix, a Telegram API timeout during `sweep_outbox` would cause the user to receive the same message up to 6 times. This happened because `telegram.error.TimedOut` fires after the HTTP request to Telegram is already dispatched — the message is delivered, but the bot never sees the acknowledgment. The sweep treated this as a retriable failure and resent the message on each subsequent sweep cycle (up to 5 retries), producing 5-6 copies of the same message.

The incident on 2026-03-18 (issue #630) produced 5 duplicate deliveries of a 1455-byte status message. The root cause was confirmed: one `send_reply` MCP call, five sweep attempts all `TimedOut`, each one successfully delivered.

## What changed

**`src/bot/lobster_bot.py` — `sweep_outbox()`:** `telegram.error.TimedOut` is now caught as a separate case before the generic `Exception` handler. On `TimedOut`, the outbox file is immediately moved to `dead-letter/` (which is already created at startup) and removed from `_processing_files`. No retry. The log line makes the situation clear: `"Dead-lettered after TimedOut (likely delivered)"`.

The existing 5-retry path is preserved for all other exceptions (network errors, API rejections, parsing failures) where retry is safe and appropriate.

**`src/bot/lobster_bot.py` — `Application.builder()`:** `write_timeout=30` added (up from the default 5s). This raises the threshold at which large messages or slow connections trigger a timeout in the first place, reducing the frequency of the problem without eliminating the need for the dead-letter handling above.

The `dead-letter/` directory already exists in the codebase (defined at line 103, created at line 355) — no migration needed.

## What is out of scope

This fix does not address the watchdog path (`OutboxHandler.process_reply`) — that path doesn't retry on `TimedOut` either, so no duplicate risk there. The `_processing_files` discard added here mirrors the cleanup that `process_reply` already performs on success.

## Functional patterns

Pure function boundaries unchanged. The fix adds an early-exit branch in the existing `try/except` structure — no new state, no new side-effect surfaces beyond what already existed for the 5-failure dead-letter path.

## Tests run

- [x] `git diff origin/main..HEAD -- src/bot/lobster_bot.py` — diff verified: only `sweep_outbox` exception handler and `Application.builder()` line changed, no unintended modifications
- [ ] Live Telegram timeout test — blocked: requires production restart and a way to force a `write_timeout` on a real message. Safe to merge; the dead-letter path is exercised by the existing 5-failure code path which is already in production.

Closes #630