### PR TITLE
fix: register system-file-protect hook correctly in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1596,7 +1596,7 @@ fi
 # Set up Claude Code PreToolUse hook to block edits to system files unless LOBSTER_DEBUG=true
 chmod +x "$INSTALL_DIR/hooks/system-file-protect.py" || true
 if [ -f "$CLAUDE_SETTINGS" ]; then
-    if ! jq -e '.hooks.PreToolUse[]? | select(.matcher == "Edit|Write|NotebookEdit")' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+    if ! jq -e '.hooks.PreToolUse[]? | select(.hooks[]?.command | contains("system-file-protect"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
         TMP_SETTINGS=$(mktemp)
         jq '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
             "matcher": "Edit|Write|NotebookEdit",

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1340,11 +1340,12 @@ with open(path, 'w') as f:
         ' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
         if [ "${has_file_protect:-0}" = "0" ] || [ "${has_file_protect:-0}" = "" ]; then
             TMP_SETTINGS=$(mktemp)
-            jq '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+            jq --arg cmd "python3 $INSTALL_DIR/hooks/system-file-protect.py" \
+               '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
                 "matcher": "Edit|Write|NotebookEdit",
                 "hooks": [{
                     "type": "command",
-                    "command": "python3 '"$INSTALL_DIR"'/hooks/system-file-protect.py",
+                    "command": $cmd,
                     "timeout": 5
                 }]
             }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
@@ -1361,11 +1362,12 @@ with open(path, 'w') as f:
         ' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
         if [ "${has_auditor:-0}" = "0" ] || [ "${has_auditor:-0}" = "" ]; then
             TMP_SETTINGS=$(mktemp)
-            jq '.hooks.SubagentStop = (.hooks.SubagentStop // []) + [{
+            jq --arg cmd "python3 $INSTALL_DIR/hooks/require-auditor-context-update.py" \
+               '.hooks.SubagentStop = (.hooks.SubagentStop // []) + [{
                 "matcher": "",
                 "hooks": [{
                     "type": "command",
-                    "command": "python3 '"$INSTALL_DIR"'/hooks/require-auditor-context-update.py",
+                    "command": $cmd,
                     "timeout": 10
                 }]
             }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1324,6 +1324,56 @@ with open(path, 'w') as f:
         fi
     fi
 
+    # Migration 21: Register missing system-file-protect and require-auditor-context-update hooks
+    # install.sh used a fragile matcher-equality check (.matcher == "Edit|Write|NotebookEdit")
+    # to detect if the hook was already installed. This check matched on the matcher string
+    # rather than the command, so the hook was silently skipped on installs where settings.json
+    # was created by Claude Code after install.sh ran. Both hooks are absent from live settings.json
+    # on affected systems. Add them now if missing.
+    if [ -f "$CLAUDE_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
+        # Add system-file-protect PreToolUse hook if missing
+        local has_file_protect
+        has_file_protect=$(jq -r '
+            [.hooks.PreToolUse[]?.hooks[]?.command // empty]
+            | map(select(contains("system-file-protect")))
+            | length
+        ' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+        if [ "${has_file_protect:-0}" = "0" ] || [ "${has_file_protect:-0}" = "" ]; then
+            TMP_SETTINGS=$(mktemp)
+            jq '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+                "matcher": "Edit|Write|NotebookEdit",
+                "hooks": [{
+                    "type": "command",
+                    "command": "python3 '"$INSTALL_DIR"'/hooks/system-file-protect.py",
+                    "timeout": 5
+                }]
+            }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+            substep "Registered missing system-file-protect PreToolUse hook"
+            migrated=$((migrated + 1))
+        fi
+
+        # Add require-auditor-context-update SubagentStop hook if missing
+        local has_auditor
+        has_auditor=$(jq -r '
+            [.hooks.SubagentStop[]?.hooks[]?.command // empty]
+            | map(select(contains("require-auditor-context-update")))
+            | length
+        ' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+        if [ "${has_auditor:-0}" = "0" ] || [ "${has_auditor:-0}" = "" ]; then
+            TMP_SETTINGS=$(mktemp)
+            jq '.hooks.SubagentStop = (.hooks.SubagentStop // []) + [{
+                "matcher": "",
+                "hooks": [{
+                    "type": "command",
+                    "command": "python3 '"$INSTALL_DIR"'/hooks/require-auditor-context-update.py",
+                    "timeout": 10
+                }]
+            }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+            substep "Registered missing require-auditor-context-update SubagentStop hook"
+            migrated=$((migrated + 1))
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What was broken

Two hooks — `system-file-protect` (PreToolUse) and `require-auditor-context-update` (SubagentStop) — exist as scripts in `hooks/` and are registered in `install.sh`, but were absent from the live `settings.json`. Without `system-file-protect`, nothing prevents Claude Code from editing files under `~/lobster/` during normal operation (the protection the hook exists to provide was silently missing).

## Root cause

`install.sh`'s idempotency check for `system-file-protect` used exact string equality on the matcher field:

```bash
jq -e '.hooks.PreToolUse[]? | select(.matcher == "Edit|Write|NotebookEdit")' "$CLAUDE_SETTINGS"
```

This is the wrong field to check. The matcher string is not globally unique — multiple hooks can share the same matcher — and its order is arbitrary. When `settings.json` was created by Claude Code after `install.sh` ran (the common case on this system), neither hook was ever written, and subsequent runs of `install.sh` were blocked by a false-positive match against the `no-auto-memory.py` entry which also uses an `Edit|Write` matcher.

The `require-auditor-context-update` hook used the correct `contains(...)` check but was still absent, indicating the settings file was created after install ran on this system.

## Changes

**`install.sh`** — fix the idempotency check for `system-file-protect` to match on the command string (consistent with how all other hooks in `install.sh` detect themselves):

```bash
# Before (fragile: matches any entry with this exact matcher string)
jq -e '.hooks.PreToolUse[]? | select(.matcher == "Edit|Write|NotebookEdit")'

# After (robust: matches on the command containing the hook script name)
jq -e '.hooks.PreToolUse[]? | select(.hooks[]?.command | contains("system-file-protect"))'
```

**`scripts/upgrade.sh`** — add Migration 21 that backfills both missing hooks on existing installs. Uses the same command-contains pattern for idempotency so re-running is safe.

**Live `settings.json`** — both hooks were added directly to the running system so it is protected immediately (this change is out of band, not part of the diff).

## Functional patterns

Both the install and migration changes use `jq` pipelines that read → check → transform → write, with idempotency by construction (check before write). The migration is a pure data transformation with no side effects on the success path.

## Tests run

- [x] `jq -e '.hooks.PreToolUse[]? | select(.hooks[]?.command | contains("system-file-protect"))' ~/.claude/settings.json` — FOUND after live fix; confirms check is correct
- [x] Migration 21 idempotency: running the jq count expressions against the now-fixed settings.json returns `1` for both hooks — a re-run would skip both additions correctly
- [x] Verified all hook script files exist at their registered paths — all `EXISTS=True`
- [ ] Full `install.sh` dry-run — skipped: would attempt to install system packages, not safe to run in this environment

Closes #621