### PR TITLE
fix: remove truncated preview from write_result debug alerts

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -4881,7 +4881,6 @@ async def handle_write_result(args: dict) -> list[TextContent]:
     # so the user sees the subagent message arrive in real time.
     # _emit_debug_observation is a no-op when debug alerts are disabled — single gate.
     agent_id = args.get("agent_id", "").strip() or None
-    text_preview = text[:60] + "…" if len(text) > 60 else text
     alert_lines = [
         f"\U0001f4e8 [subagent\u2192dispatcher] type: {msg_type}",
         f"task: {task_id}",
@@ -4891,7 +4890,6 @@ async def handle_write_result(args: dict) -> list[TextContent]:
     if status:
         alert_lines.append(f"status: {status}")
     alert_lines.append(f"sent_reply: {bool(sent_reply_to_user)}")
-    alert_lines.append(f"preview: {text_preview}")
     _emit_debug_observation(
         "\n".join(alert_lines),
         category="system_context",


### PR DESCRIPTION
When \`LOBSTER_DEBUG=true\`, \`write_result\` emits a debug observation message to the Telegram inbox so the user sees subagent activity in real time. That message included a \`preview:\` line containing the first 60 characters of the result text. When a result begins with or contains a URL, this truncation cuts the URL mid-string — Telegram's link parser then renders the partial URL as a broken clickable link.

The preview adds no information the dispatcher doesn't already receive: the full result text lands in the inbox as the \`subagent_result\` payload immediately after. Removing the line keeps the debug alert to the five fields that matter: type, task, agent (if set), status (if set), and sent_reply.

No other debug observation paths are touched. The \`write_observation\` and \`memory_store\` debug alerts are unaffected — they don't include a preview field.

**Functional pattern:** pure deletion — the remaining alert construction is still a plain list-build-then-join with no replacement logic.

## Tests run
- [x] \`git diff HEAD~1\` — verified only the two lines (text_preview assignment + preview append) are removed, nothing else
- [ ] Live debug-mode Telegram test — skipped: requires a running Lobster instance with \`LOBSTER_DEBUG=true\`; safe to merge without it (no logic change, only omission of a field)