### PR TITLE
feat: auto post-compaction catch-up agent (compact_catchup)

### DIFF
--- a/.claude/agents/compact-catchup.md
+++ b/.claude/agents/compact-catchup.md
@@ -1,0 +1,69 @@
+---
+name: compact-catchup
+description: "Post-compaction catch-up agent. Recovers situational awareness for the dispatcher after a context compaction by scanning recent message history and summarising what happened. Spawned automatically by the dispatcher when it processes a compact-reminder."
+model: haiku
+---
+
+> **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `write_result` (NOT `send_reply`) when your task is complete — the dispatcher reads your result as structured context, not a user message.
+
+You are the **compact_catchup** subagent. Your sole job is to scan recent message history and produce a structured summary for the dispatcher to restore situational awareness after a context compaction.
+
+## Your task
+
+1. Read `~/lobster-workspace/data/compaction-state.json` to get timestamps.
+2. Compute the catch-up window start: `max(last_compaction_ts, last_restart_ts, last_catchup_ts)` — use whichever fields are present. If none are present, default to 30 minutes ago.
+3. Call `check_inbox(since_ts=<window_start>, limit=50)` to fetch messages from that window.
+4. Filter the results — include only:
+   - User messages (source: telegram, slack, sms, etc.)
+   - `subagent_result` messages
+   - Notable system events: `update_notification`, `consolidation`
+   - Exclude: `self_check`, `compact-reminder`, `compact_catchup`, `subagent_notification`, test messages
+5. Produce a concise structured summary (see format below).
+6. Update `last_catchup_ts` in `compaction-state.json` to now (prevents duplicate windows on the next compaction).
+7. Call `write_result` — **not** `send_reply`. The dispatcher reads this as a context recovery signal.
+
+## Output format
+
+Structure your `write_result` text as follows:
+
+```
+## Catch-up: <window_start> → now
+
+### User messages (<N>)
+- [HH:MM] <user>: <brief summary>
+- ...
+
+### Subagent results (<N>)
+- [HH:MM] task=<task_id>: <brief outcome>
+- ...
+
+### System events (<N>)
+- [HH:MM] <event_type>: <brief note>
+- ...
+
+### Nothing to report
+(only if all three sections are empty)
+```
+
+Keep each line to one sentence. The dispatcher is on mobile — brevity matters.
+
+## Rules
+
+- Do NOT call `send_reply` — this is internal context recovery, not a user message.
+- Do NOT relay catch-up content to the user unless an event is urgent (e.g. a failed subagent that the user has not been notified about).
+- If `check_inbox` returns no messages in the window, that is valid — report "Nothing to report."
+- If `compaction-state.json` is missing or corrupt, default to scanning the last 30 minutes.
+- Always update `last_catchup_ts` in `compaction-state.json` before calling `write_result`.
+
+## Delivering results
+
+```python
+mcp__lobster-inbox__write_result(
+    task_id="compact-catchup",          # always use this fixed task_id
+    chat_id=0,                          # internal — not user-facing
+    text=<structured summary above>,
+    source="system",
+    status="success",
+    # sent_reply_to_user omitted (defaults to False) — dispatcher reads this inline
+)
+```

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -164,7 +164,54 @@ To clear the gate: call `mcp__lobster-inbox__wait_for_messages(confirmation='LOB
 System messages (compact-reminders, self-checks, scheduled reminders, etc.) have chat_id: 0 or source: "system".
 - Do NOT call send_reply for these — there is no user to reply to
 - mark_processed after reading and acting on the content
-- Compact-reminder: read for re-orientation context, mark_processed, resume loop
+- Compact-reminder: read for re-orientation context, spawn compact_catchup subagent (see below), mark_processed, resume loop
+
+## Handling compact-reminder (subtype: "compact-reminder")
+
+After a context compaction you lose situational awareness of the last ~30 minutes. The compact_catchup subagent recovers it for you.
+
+**When `wait_for_messages` returns a message with `subtype: "compact-reminder"`:**
+
+```
+1. mark_processing(message_id)
+2. Read the compact-reminder text to re-orient (identity, main loop, key files)
+3. Spawn compact_catchup subagent (run_in_background=True):
+   - subagent_type: "compact-catchup"
+   - prompt: (see below)
+4. mark_processed(message_id)
+5. Resume wait_for_messages() loop — do NOT wait for the subagent result inline
+```
+
+**Prompt to pass to compact_catchup:**
+
+```
+---
+task_id: compact-catchup
+chat_id: 0
+source: system
+---
+
+Recover dispatcher context after compaction. Read ~/lobster-workspace/data/compaction-state.json,
+compute the catch-up window (max of last_compaction_ts, last_restart_ts, last_catchup_ts in that
+file; default to 30 minutes ago if absent), call check_inbox(since_ts=<window_start>, limit=50),
+summarise what happened (user messages, subagent results, notable system events), update
+last_catchup_ts in compaction-state.json, then call write_result.
+```
+
+**When the compact_catchup `subagent_result` arrives:**
+
+```
+1. mark_processing(message_id)
+2. Read msg["text"] — it is a structured summary of recent activity (user messages,
+   subagent results, system events). Use it to restore situational awareness.
+3. Do NOT send_reply — this is internal context, not a user message.
+4. mark_processed(message_id)
+```
+
+**Rules:**
+- Never send the catch-up summary to the user unless you spot something urgent (e.g. a failed subagent that was never acknowledged).
+- The catch-up result arrives as a normal `subagent_result` with `task_id: "compact-catchup"` and `chat_id: 0`. The `chat_id: 0` signals it is internal — do not relay.
+- If the catch-up window has no messages, that is valid — the subagent reports "Nothing to report."
 
 ## Handling Scheduled Reminders (`type: "scheduled_reminder"`)
 

--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -16,6 +16,8 @@ notification reaches the user per compaction event.
 
 State: always writes compacted_at to lobster-state.json so that the health
 check can suppress stale-inbox false-positives during the compaction pause.
+Also writes last_compaction_ts to compaction-state.json so that the catch-up
+subagent knows which window of history to recover after compaction.
 
 Dispatcher-only: exits immediately for subagent sessions (detected via
 session_role.is_dispatcher()). Subagent compactions must not write compact-
@@ -42,6 +44,13 @@ STATE_FILE = Path(
         os.path.expanduser("~/messages/config/lobster-state.json"),
     )
 )
+# Compaction state: records last_compaction_ts for catch-up subagent windowing.
+COMPACTION_STATE_FILE = Path(
+    os.environ.get(
+        "LOBSTER_COMPACTION_STATE_FILE_OVERRIDE",
+        os.path.expanduser("~/lobster-workspace/data/compaction-state.json"),
+    )
+)
 
 REMINDER_TEXT = (
     "COMPACT REMINDER \u2014 RE-ORIENT NOW\n\n"
@@ -55,7 +64,9 @@ REMINDER_TEXT = (
     "  \u2190 dispatcher instructions, main loop, 7-second rule\n"
     "2. ~/lobster-user-config/memory/canonical/handoff.md\n"
     "  \u2190 active projects, key people, priorities\n\n"
-    "After reading: resume your main loop by calling wait_for_messages()."
+    "After reading: spawn the compact_catchup subagent to recover context from the\n"
+    "last ~30 minutes (see sys.dispatcher.bootup.md \u2192 'Handling compact-reminder').\n"
+    "Then resume your main loop by calling wait_for_messages()."
 )
 
 SENTINEL_FILE = Path(os.path.expanduser("~/messages/config/compact-pending"))
@@ -122,6 +133,33 @@ def write_sentinel() -> None:
     try:
         SENTINEL_FILE.parent.mkdir(parents=True, exist_ok=True)
         SENTINEL_FILE.touch()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def write_compaction_state() -> None:
+    """
+    Write last_compaction_ts to compaction-state.json.
+
+    This timestamp is used by the compact_catchup subagent to determine the
+    query window: it fetches messages since max(last_compaction_ts,
+    last_restart_ts, last_catchup_ts) to avoid duplicating history across
+    multiple rapid compaction or restart events.
+
+    Silent on any failure — must never crash the hook.
+    """
+    try:
+        COMPACTION_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        state: dict = {}
+        if COMPACTION_STATE_FILE.exists():
+            try:
+                state = json.loads(COMPACTION_STATE_FILE.read_text())
+            except (json.JSONDecodeError, OSError):
+                state = {}
+        state["last_compaction_ts"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        tmp_path = COMPACTION_STATE_FILE.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(state, indent=2) + "\n")
+        tmp_path.replace(COMPACTION_STATE_FILE)  # atomic on Linux (same filesystem)
     except Exception:  # noqa: BLE001
         pass
 
@@ -242,6 +280,11 @@ def main() -> None:
     # compactions.  The health check reads this to suppress false-positive
     # "stale inbox" restarts during any compaction pause window.
     write_compacted_at()
+
+    # Always record last_compaction_ts for the catch-up subagent, regardless
+    # of whether this is a dispatcher or subagent compaction.  The catch-up
+    # subagent uses this to define its query window on next spawn.
+    write_compaction_state()
 
     # Always send the Telegram notification for any compaction (dispatcher or
     # subagent).  This must fire even for the dispatcher compact, where

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1376,6 +1376,15 @@ with open(path, 'w') as f:
         fi
     fi
 
+    # Migration 22: Ensure lobster-workspace/data/ directory exists for compaction-state.json
+    # The compact_catchup agent writes last_compaction_ts to this file after each compaction.
+    local data_dir="$WORKSPACE_DIR/data"
+    if [ ! -d "$data_dir" ]; then
+        mkdir -p "$data_dir"
+        substep "Created $data_dir/ for compaction-state.json"
+        migrated=$((migrated + 1))
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -1007,6 +1007,15 @@ async def list_tools() -> list[Tool]:
                         "description": "Maximum number of messages to return. Default 10.",
                         "default": 10,
                     },
+                    "since_ts": {
+                        "type": "string",
+                        "description": (
+                            "ISO 8601 UTC timestamp (e.g. '2026-01-01T12:00:00Z'). "
+                            "When provided, only messages with a timestamp >= since_ts are returned. "
+                            "Applies to processed/ and inbox/ directories. "
+                            "Useful for catch-up agents that need to scan history after compaction."
+                        ),
+                    },
                 },
             },
         ),
@@ -3130,47 +3139,119 @@ def _enqueue_recovery_notification(msg: dict) -> None:
         log.error(f"subagent_recovered: failed to enqueue recovery notification: {exc}", exc_info=True)
 
 
+def _parse_iso_timestamp(ts: str) -> float | None:
+    """
+    Parse an ISO 8601 UTC timestamp string to a Unix epoch float.
+
+    Accepts formats like '2026-01-01T12:00:00Z', '2026-01-01T12:00:00+00:00',
+    and '2026-01-01T12:00:00.000000'. Returns None if parsing fails.
+    """
+    if not ts:
+        return None
+    # Normalise: replace trailing Z with +00:00 for fromisoformat compat
+    normalised = ts.strip().replace("Z", "+00:00")
+    # If no timezone offset is present, assume UTC
+    if "+" not in normalised and normalised.count("-") < 3:
+        normalised = normalised + "+00:00"
+    try:
+        from datetime import datetime, timezone as _tz
+        dt = datetime.fromisoformat(normalised)
+        # Ensure timezone-aware; treat naive as UTC
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=_tz.utc)
+        return dt.timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
 async def handle_check_inbox(args: dict) -> list[TextContent]:
-    """Check for new messages in inbox."""
+    """Check for new messages in inbox.
+
+    When since_ts is provided, scans both inbox/ and processed/ directories
+    for messages with timestamp >= since_ts. This mode is designed for catch-up
+    agents that need to recover context after compaction. The limit still applies
+    to the combined result set.
+    """
     source_filter = args.get("source", "").lower()
     limit = args.get("limit", 10)
+    since_ts_str = args.get("since_ts", "")
+    since_epoch = _parse_iso_timestamp(since_ts_str) if since_ts_str else None
 
     messages = []
-    for f in sorted(INBOX_DIR.glob("*.json")):
-        try:
-            with open(f) as fp:
-                msg = json.load(fp)
+
+    if since_epoch is not None:
+        # Historical scan mode: read from both processed/ and inbox/, sorted by timestamp.
+        # Skip dispatcher-internal system subtypes that are not useful for catch-up context.
+        _CATCHUP_EXCLUDED_SUBTYPES = frozenset({
+            "self_check",
+            "compact-reminder",
+            "compact_catchup",
+            "subagent_notification",
+        })
+
+        all_files = sorted(
+            list(PROCESSED_DIR.glob("*.json")) + list(INBOX_DIR.glob("*.json"))
+        )
+        for f in all_files:
+            try:
+                with open(f) as fp:
+                    msg = json.load(fp)
+                ts_str = msg.get("timestamp", "")
+                msg_epoch = _parse_iso_timestamp(ts_str)
+                if msg_epoch is None or msg_epoch < since_epoch:
+                    continue
                 if source_filter and msg.get("source", "").lower() != source_filter:
                     continue
-                # /report slash command pre-processor: handle automatically without
-                # surfacing the raw message to the main dispatcher loop.
-                msg_text = msg.get("text", "")
-                if _is_report_command(msg_text):
-                    try:
-                        await _handle_report_slash_command(msg, f)
-                    except Exception as exc:
-                        log.error(f"check_inbox: /report pre-processor error: {exc}", exc_info=True)
-                    continue  # skip — already handled
-                # subagent_recovered pre-processor: enqueue an owner notification so the
-                # user is informed about the failed agent. The raw recovery message still
-                # flows through to the dispatcher (with a dispatcher_hint) so it can call
-                # mark_processed — but the salvaged dump is never relayed directly.
-                if msg.get("type") == "subagent_recovered":
-                    try:
-                        _enqueue_recovery_notification(msg)
-                    except Exception as exc:
-                        log.error(f"check_inbox: subagent_recovered pre-processor error: {exc}", exc_info=True)
+                if msg.get("subtype") in _CATCHUP_EXCLUDED_SUBTYPES:
+                    continue
                 msg["_filename"] = f.name
+                msg["_directory"] = f.parent.name  # "inbox" or "processed"
                 messages.append(msg)
                 if len(messages) >= limit:
                     break
-        except Exception as e:
-            continue
+            except Exception:
+                continue
 
-    if not messages:
-        return [TextContent(type="text", text="📭 No new messages in inbox.")]
+        if not messages:
+            return [TextContent(type="text", text=f"📭 No messages found since {since_ts_str}.")]
 
-    log.info(f"check_inbox returning {len(messages)} message(s)")
+        log.info(f"check_inbox (since_ts={since_ts_str!r}) returning {len(messages)} message(s)")
+    else:
+        for f in sorted(INBOX_DIR.glob("*.json")):
+            try:
+                with open(f) as fp:
+                    msg = json.load(fp)
+                    if source_filter and msg.get("source", "").lower() != source_filter:
+                        continue
+                    # /report slash command pre-processor: handle automatically without
+                    # surfacing the raw message to the main dispatcher loop.
+                    msg_text = msg.get("text", "")
+                    if _is_report_command(msg_text):
+                        try:
+                            await _handle_report_slash_command(msg, f)
+                        except Exception as exc:
+                            log.error(f"check_inbox: /report pre-processor error: {exc}", exc_info=True)
+                        continue  # skip — already handled
+                    # subagent_recovered pre-processor: enqueue an owner notification so the
+                    # user is informed about the failed agent. The raw recovery message still
+                    # flows through to the dispatcher (with a dispatcher_hint) so it can call
+                    # mark_processed — but the salvaged dump is never relayed directly.
+                    if msg.get("type") == "subagent_recovered":
+                        try:
+                            _enqueue_recovery_notification(msg)
+                        except Exception as exc:
+                            log.error(f"check_inbox: subagent_recovered pre-processor error: {exc}", exc_info=True)
+                    msg["_filename"] = f.name
+                    messages.append(msg)
+                    if len(messages) >= limit:
+                        break
+            except Exception as e:
+                continue
+
+        if not messages:
+            return [TextContent(type="text", text="📭 No new messages in inbox.")]
+
+        log.info(f"check_inbox returning {len(messages)} message(s)")
 
     # Format messages nicely
     output = f"📬 **{len(messages)} new message(s):**\n\n"

--- a/tests/unit/test_hooks/test_compaction_state.py
+++ b/tests/unit/test_hooks/test_compaction_state.py
@@ -1,0 +1,214 @@
+"""
+Unit tests for compaction-state.json writing in hooks/on-compact.py.
+
+Tests that write_compaction_state() correctly persists last_compaction_ts
+and that the timestamp deduplication logic (max of last_compaction_ts,
+last_restart_ts, last_catchup_ts) can be computed correctly from the file.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "on-compact.py"
+
+
+def _load_on_compact(state_file_override: str = None, compaction_state_override: str = None):
+    """
+    Load on-compact.py as a module, optionally overriding the state file paths
+    via environment variables so tests do not touch the real system files.
+    """
+    env_patch = {}
+    if state_file_override:
+        env_patch["LOBSTER_STATE_FILE_OVERRIDE"] = state_file_override
+    if compaction_state_override:
+        env_patch["LOBSTER_COMPACTION_STATE_FILE_OVERRIDE"] = compaction_state_override
+
+    with patch_env(env_patch):
+        spec = importlib.util.spec_from_file_location("on_compact", _HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+
+class patch_env:
+    """Context manager to temporarily set environment variables."""
+    def __init__(self, env: dict):
+        self._env = env
+        self._saved = {}
+
+    def __enter__(self):
+        for k, v in self._env.items():
+            self._saved[k] = os.environ.get(k)
+            os.environ[k] = v
+        return self
+
+    def __exit__(self, *_):
+        for k, saved_v in self._saved.items():
+            if saved_v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = saved_v
+
+
+class TestWriteCompactionState:
+    """Tests for write_compaction_state() in on-compact.py."""
+
+    def test_creates_compaction_state_file(self, tmp_path):
+        """write_compaction_state creates the file when it does not exist."""
+        state_file = tmp_path / "compaction-state.json"
+        # dummy lobster-state.json so the hook does not need it
+        ls_file = tmp_path / "lobster-state.json"
+        ls_file.write_text(json.dumps({"mode": "active"}))
+
+        mod = _load_on_compact(
+            state_file_override=str(ls_file),
+            compaction_state_override=str(state_file),
+        )
+        mod.write_compaction_state()
+
+        assert state_file.exists()
+        data = json.loads(state_file.read_text())
+        assert "last_compaction_ts" in data
+
+    def test_last_compaction_ts_is_iso_utc(self, tmp_path):
+        """last_compaction_ts must be a valid ISO 8601 UTC string ending in Z."""
+        state_file = tmp_path / "compaction-state.json"
+        ls_file = tmp_path / "lobster-state.json"
+        ls_file.write_text(json.dumps({"mode": "active"}))
+
+        mod = _load_on_compact(
+            state_file_override=str(ls_file),
+            compaction_state_override=str(state_file),
+        )
+        mod.write_compaction_state()
+
+        data = json.loads(state_file.read_text())
+        ts = data["last_compaction_ts"]
+        assert isinstance(ts, str)
+        assert ts.endswith("Z"), f"Expected UTC timestamp ending in Z, got: {ts!r}"
+        # Must parse as ISO 8601
+        normalised = ts.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalised)
+        assert parsed.tzinfo is not None
+
+    def test_preserves_existing_fields(self, tmp_path):
+        """write_compaction_state preserves existing fields in the state file."""
+        state_file = tmp_path / "compaction-state.json"
+        state_file.write_text(
+            json.dumps({"last_catchup_ts": "2026-01-01T00:00:00Z"}) + "\n"
+        )
+        ls_file = tmp_path / "lobster-state.json"
+        ls_file.write_text(json.dumps({"mode": "active"}))
+
+        mod = _load_on_compact(
+            state_file_override=str(ls_file),
+            compaction_state_override=str(state_file),
+        )
+        mod.write_compaction_state()
+
+        data = json.loads(state_file.read_text())
+        assert "last_compaction_ts" in data
+        assert "last_catchup_ts" in data
+        assert data["last_catchup_ts"] == "2026-01-01T00:00:00Z"
+
+    def test_overwrites_existing_last_compaction_ts(self, tmp_path):
+        """A second call to write_compaction_state updates the timestamp."""
+        state_file = tmp_path / "compaction-state.json"
+        state_file.write_text(
+            json.dumps({"last_compaction_ts": "2026-01-01T00:00:00Z"}) + "\n"
+        )
+        ls_file = tmp_path / "lobster-state.json"
+        ls_file.write_text(json.dumps({"mode": "active"}))
+
+        mod = _load_on_compact(
+            state_file_override=str(ls_file),
+            compaction_state_override=str(state_file),
+        )
+        mod.write_compaction_state()
+
+        data = json.loads(state_file.read_text())
+        ts = data["last_compaction_ts"]
+        assert ts != "2026-01-01T00:00:00Z", "Timestamp should have been updated"
+
+    def test_silent_on_unwritable_path(self, tmp_path):
+        """write_compaction_state must not raise if the path is unwritable."""
+        # /proc is not a regular filesystem; writes will fail
+        bad_path = Path("/proc/lobster-test/data/compaction-state.json")
+        ls_file = tmp_path / "lobster-state.json"
+        ls_file.write_text(json.dumps({"mode": "active"}))
+
+        mod = _load_on_compact(
+            state_file_override=str(ls_file),
+            compaction_state_override=str(bad_path),
+        )
+        # Must not raise
+        mod.write_compaction_state()
+
+
+class TestCompactionWindowLogic:
+    """Tests for timestamp deduplication logic used by catch-up agent.
+
+    The catch-up agent computes max(last_compaction_ts, last_restart_ts,
+    last_catchup_ts) to define its query window. These tests validate the
+    pure comparison logic without needing any external dependencies.
+    """
+
+    def _max_ts(self, *ts_strings):
+        """Pure helper: return max timestamp from a list of ISO 8601 strings."""
+        results = []
+        for ts in ts_strings:
+            if not ts:
+                continue
+            normalised = ts.strip().replace("Z", "+00:00")
+            try:
+                parsed = datetime.fromisoformat(normalised)
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                results.append(parsed)
+            except ValueError:
+                continue
+        return max(results) if results else None
+
+    def test_max_of_three_timestamps(self):
+        """max() of compaction/restart/catchup selects the most recent."""
+        result = self._max_ts(
+            "2026-01-01T10:00:00Z",
+            "2026-01-01T11:00:00Z",  # most recent
+            "2026-01-01T09:00:00Z",
+        )
+        expected = datetime.fromisoformat("2026-01-01T11:00:00+00:00")
+        assert result == expected
+
+    def test_max_with_only_compaction_ts(self):
+        """Works correctly when only last_compaction_ts is present."""
+        result = self._max_ts("2026-03-01T12:00:00Z")
+        expected = datetime.fromisoformat("2026-03-01T12:00:00+00:00")
+        assert result == expected
+
+    def test_max_with_empty_list_returns_none(self):
+        """Returns None when no timestamps are provided."""
+        result = self._max_ts()
+        assert result is None
+
+    def test_max_ignores_empty_strings(self):
+        """Ignores missing/None/empty string timestamps."""
+        result = self._max_ts("", "2026-03-01T12:00:00Z", "")
+        expected = datetime.fromisoformat("2026-03-01T12:00:00+00:00")
+        assert result == expected
+
+    def test_compaction_later_than_catchup_is_selected(self):
+        """When compaction happened after last catchup, compaction TS is used."""
+        result = self._max_ts(
+            "2026-03-01T10:00:00Z",  # last_catchup_ts (older)
+            "2026-03-01T11:30:00Z",  # last_compaction_ts (newer — use this)
+        )
+        expected = datetime.fromisoformat("2026-03-01T11:30:00+00:00")
+        assert result == expected

--- a/tests/unit/test_mcp_server/test_check_inbox_since_ts.py
+++ b/tests/unit/test_mcp_server/test_check_inbox_since_ts.py
@@ -1,0 +1,218 @@
+"""
+Tests for check_inbox since_ts parameter (issue #607 compact_catchup feature).
+
+Verifies that:
+- since_ts filters messages by timestamp from both inbox/ and processed/
+- Messages older than since_ts are excluded
+- Excluded subtypes (self_check, compact-reminder, compact_catchup,
+  subagent_notification) are stripped from since_ts results
+- Absence of since_ts preserves original inbox-only behaviour
+- _parse_iso_timestamp handles various ISO 8601 formats
+"""
+
+import asyncio
+import json
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_MCP_DIR = Path(__file__).parent.parent.parent.parent / "src" / "mcp"
+if str(_MCP_DIR) not in sys.path:
+    sys.path.insert(0, str(_MCP_DIR))
+
+import src.mcp.inbox_server  # noqa: F401
+
+
+def _iso(dt: datetime) -> str:
+    """Format datetime to ISO 8601 UTC string as stored in messages."""
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")
+
+
+def _make_msg(msg_id: str, ts: datetime, subtype: str = None, msg_type: str = "text", source: str = "telegram") -> dict:
+    msg = {
+        "id": msg_id,
+        "source": source,
+        "chat_id": 12345,
+        "user_id": 12345,
+        "username": "testuser",
+        "user_name": "Test",
+        "type": msg_type,
+        "text": f"message {msg_id}",
+        "timestamp": _iso(ts),
+    }
+    if subtype:
+        msg["subtype"] = subtype
+    return msg
+
+
+_BASE = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+_BEFORE = _BASE - timedelta(hours=1)   # 11:00
+_WINDOW_START = _BASE                   # 12:00 — since_ts
+_AFTER = _BASE + timedelta(hours=1)    # 13:00
+
+
+class TestParseIsoTimestamp:
+    """Tests for _parse_iso_timestamp helper."""
+
+    def test_z_suffix(self):
+        from src.mcp.inbox_server import _parse_iso_timestamp
+        ts = _parse_iso_timestamp("2026-01-01T12:00:00Z")
+        assert ts is not None
+        assert abs(ts - _WINDOW_START.timestamp()) < 1
+
+    def test_utc_offset(self):
+        from src.mcp.inbox_server import _parse_iso_timestamp
+        ts = _parse_iso_timestamp("2026-01-01T12:00:00+00:00")
+        assert ts is not None
+        assert abs(ts - _WINDOW_START.timestamp()) < 1
+
+    def test_microseconds(self):
+        from src.mcp.inbox_server import _parse_iso_timestamp
+        ts = _parse_iso_timestamp("2026-01-01T12:00:00.000000")
+        assert ts is not None
+
+    def test_none_on_empty_string(self):
+        from src.mcp.inbox_server import _parse_iso_timestamp
+        assert _parse_iso_timestamp("") is None
+
+    def test_none_on_invalid_string(self):
+        from src.mcp.inbox_server import _parse_iso_timestamp
+        assert _parse_iso_timestamp("not-a-timestamp") is None
+
+
+class TestCheckInboxSinceTs:
+    """Tests for check_inbox with since_ts parameter."""
+
+    @pytest.fixture
+    def dirs(self, tmp_path):
+        inbox = tmp_path / "inbox"
+        processed = tmp_path / "processed"
+        inbox.mkdir()
+        processed.mkdir()
+        return {"inbox": inbox, "processed": processed}
+
+    def _run(self, dirs, args):
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=dirs["inbox"],
+            PROCESSED_DIR=dirs["processed"],
+        ):
+            from src.mcp.inbox_server import handle_check_inbox
+            return asyncio.run(handle_check_inbox(args))
+
+    def test_since_ts_returns_only_messages_at_or_after_window(self, dirs):
+        """Messages before since_ts are excluded; messages at/after are included."""
+        old_msg = _make_msg("old", _BEFORE)
+        new_msg = _make_msg("new", _AFTER)
+
+        (dirs["processed"] / "old.json").write_text(json.dumps(old_msg))
+        (dirs["processed"] / "new.json").write_text(json.dumps(new_msg))
+
+        result = self._run(dirs, {"since_ts": "2026-01-01T12:00:00Z"})
+        text = result[0].text
+        assert "new" in text
+        assert "old" not in text or "No messages" in text
+
+    def test_since_ts_scans_both_inbox_and_processed(self, dirs):
+        """Messages in inbox/ AND processed/ are included when since_ts is set."""
+        inbox_msg = _make_msg("inbox1", _AFTER)
+        processed_msg = _make_msg("proc1", _AFTER)
+
+        (dirs["inbox"] / "inbox1.json").write_text(json.dumps(inbox_msg))
+        (dirs["processed"] / "proc1.json").write_text(json.dumps(processed_msg))
+
+        result = self._run(dirs, {"since_ts": "2026-01-01T12:00:00Z"})
+        text = result[0].text
+        assert "inbox1" in text
+        assert "proc1" in text
+
+    def test_since_ts_excludes_compact_reminder_subtype(self, dirs):
+        """compact-reminder messages are excluded even if within the time window."""
+        msg = _make_msg("c1", _AFTER, subtype="compact-reminder", source="system")
+        (dirs["processed"] / "c1.json").write_text(json.dumps(msg))
+
+        result = self._run(dirs, {"since_ts": "2026-01-01T12:00:00Z"})
+        text = result[0].text
+        assert "c1" not in text or "No messages" in text
+
+    def test_since_ts_excludes_self_check_subtype(self, dirs):
+        """self_check messages are excluded even if within the time window."""
+        msg = _make_msg("sc1", _AFTER, subtype="self_check", source="system")
+        (dirs["processed"] / "sc1.json").write_text(json.dumps(msg))
+
+        result = self._run(dirs, {"since_ts": "2026-01-01T12:00:00Z"})
+        text = result[0].text
+        assert "sc1" not in text or "No messages" in text
+
+    def test_since_ts_excludes_compact_catchup_subtype(self, dirs):
+        """compact_catchup messages are excluded."""
+        msg = _make_msg("cu1", _AFTER, subtype="compact_catchup", source="system")
+        (dirs["processed"] / "cu1.json").write_text(json.dumps(msg))
+
+        result = self._run(dirs, {"since_ts": "2026-01-01T12:00:00Z"})
+        text = result[0].text
+        assert "cu1" not in text or "No messages" in text
+
+    def test_since_ts_excludes_subagent_notification_subtype(self, dirs):
+        """subagent_notification messages are excluded."""
+        msg = _make_msg("sn1", _AFTER, subtype="subagent_notification", msg_type="subagent_notification")
+        (dirs["processed"] / "sn1.json").write_text(json.dumps(msg))
+
+        result = self._run(dirs, {"since_ts": "2026-01-01T12:00:00Z"})
+        text = result[0].text
+        assert "sn1" not in text or "No messages" in text
+
+    def test_since_ts_includes_user_messages(self, dirs):
+        """Regular user messages within the window are included."""
+        msg = _make_msg("u1", _AFTER, source="telegram")
+        (dirs["processed"] / "u1.json").write_text(json.dumps(msg))
+
+        result = self._run(dirs, {"since_ts": "2026-01-01T12:00:00Z"})
+        text = result[0].text
+        assert "u1" in text or "1 message" in text.lower()
+
+    def test_since_ts_empty_window_returns_no_messages(self, dirs):
+        """No messages in window returns appropriate empty response."""
+        # All messages are before the window
+        old_msg = _make_msg("old1", _BEFORE)
+        (dirs["processed"] / "old1.json").write_text(json.dumps(old_msg))
+
+        result = self._run(dirs, {"since_ts": "2026-01-01T12:00:00Z"})
+        text = result[0].text
+        assert "No messages" in text
+
+    def test_without_since_ts_only_reads_inbox(self, dirs):
+        """Without since_ts, check_inbox only reads from inbox/ not processed/."""
+        inbox_msg = _make_msg("i1", _AFTER)
+        processed_msg = _make_msg("p1", _AFTER)
+
+        (dirs["inbox"] / "i1.json").write_text(json.dumps(inbox_msg))
+        (dirs["processed"] / "p1.json").write_text(json.dumps(processed_msg))
+
+        result = self._run(dirs, {})
+        text = result[0].text
+        assert "i1" in text
+        assert "p1" not in text  # processed not scanned without since_ts
+
+    def test_since_ts_respects_limit(self, dirs):
+        """limit parameter still caps results in since_ts mode."""
+        for i in range(10):
+            msg = _make_msg(f"m{i}", _AFTER)
+            (dirs["processed"] / f"m{i}.json").write_text(json.dumps(msg))
+
+        result = self._run(dirs, {"since_ts": "2026-01-01T12:00:00Z", "limit": 3})
+        text = result[0].text
+        # The output header says "3 new message(s)" — assert exactly 3 were returned
+        assert "3 new message" in text
+
+    def test_since_ts_includes_boundary_message(self, dirs):
+        """A message exactly at since_ts should be included (>= boundary)."""
+        msg = _make_msg("exact", _WINDOW_START)
+        (dirs["processed"] / "exact.json").write_text(json.dumps(msg))
+
+        result = self._run(dirs, {"since_ts": "2026-01-01T12:00:00Z"})
+        text = result[0].text
+        assert "exact" in text or "1 message" in text.lower()


### PR DESCRIPTION
🤖🦞 Lobster (engineer): Closes #607

## Problem

After a context compaction the dispatcher loses awareness of the last ~30 minutes of activity. Previously this required a manual "search history" prompt to recover. Users experience the dispatcher as amnesiac — it doesn't know what it was just doing.

## What this PR does

The solution is a background catch-up subagent that fires automatically on every compaction and feeds the dispatcher a structured summary of what it missed. Three components work together:

**1. Compaction state file** (`on-compact.py`)

`on-compact.py` now writes `last_compaction_ts` to `~/lobster-workspace/data/compaction-state.json` on every compaction (both dispatcher and subagent, so the timestamp is always current). This file is the anchor for the catch-up window.

**2. `check_inbox` gains a `since_ts` parameter** (`inbox_server.py`)

When `since_ts` is provided, `check_inbox` scans both `inbox/` and `processed/` directories for messages with `timestamp >= since_ts`. Dispatcher-internal noise is stripped server-side via a `_CATCHUP_EXCLUDED_SUBTYPES` frozenset (`self_check`, `compact-reminder`, `compact_catchup`, `subagent_notification`). Without `since_ts`, the function behaves identically to before — the new code path is fully isolated.

**3. `compact-catchup` agent** (`.claude/agents/compact-catchup.md`)

A new haiku-tier agent definition. It reads `compaction-state.json`, computes `max(last_compaction_ts, last_restart_ts, last_catchup_ts)` to define its query window (preventing duplicate windows when multiple events happen in rapid succession), calls `check_inbox(since_ts=...)`, produces a structured markdown summary (user messages / subagent results / system events), updates `last_catchup_ts` in the state file, and calls `write_result` with `chat_id=0`. The `chat_id: 0` signals the dispatcher to read this as internal context and not relay it to the user.

**4. Dispatcher routing** (`sys.dispatcher.bootup.md`)

A new "Handling compact-reminder" section in the dispatcher bootup file specifies the exact dispatch pattern: mark_processing → re-orient → spawn compact_catchup in the background → mark_processed → resume loop. When the `subagent_result` arrives with `task_id: "compact-catchup"` and `chat_id: 0`, the dispatcher reads it silently without relaying.

**5. Migration 21** (`scripts/upgrade.sh`)

Ensures `~/lobster-workspace/data/` exists on existing installs (it's the new home of `compaction-state.json`).

## What is not in scope

- The `REMINDER_TEXT` still instructs re-orientation from the dispatcher bootup and handoff files; the catch-up subagent is additive, not a replacement.
- No changes to the post-compact gate logic — the sentinel and gate behaviour is unchanged.
- No changes to `wait_for_messages` — the catch-up subagent result arrives as a normal `subagent_result`.

## Functional patterns

Pure functions for timestamp comparison; immutable state via temp-then-rename atomic writes; declarative `frozenset` exclusion for message filtering; isolated side-effect boundary in `write_compaction_state`.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_compaction_state.py tests/unit/test_mcp_server/test_check_inbox_since_ts.py -v` — 26 passed, 0 failed
- [x] `uv run pytest tests/unit/test_hooks/ tests/unit/test_mcp_server/ -v` — 17 pre-existing failures (unrelated to this PR: `test_message_tools` send_reply validation, `test_transcription` missing `get_whisper_model`, `test_write_observation` observation queuing) — all failures exist on `main` before this change
- [ ] Live end-to-end compaction test — blocked: requires production restart to pick up new `on-compact.py` and MCP server reload. Safe to merge; the catch-up path is purely additive and fails silently if `compaction-state.json` is absent.

**Blocked items needing attention before merge:** none