### PR TITLE
fix: resolve pre-existing failures in test_message_tools and test_transcription

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -3193,8 +3193,12 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
 
 async def handle_send_reply(args: dict) -> list[TextContent]:
     """Send a reply to a message with input validation."""
-    # Validate inputs (raises ValidationError on bad data)
-    args = validate_send_reply_args(args)
+    # Validate inputs — return error TextContent instead of raising so callers
+    # (and tests) always receive a list[TextContent] back.
+    try:
+        args = validate_send_reply_args(args)
+    except ValidationError as e:
+        return [TextContent(type="text", text=f"Error: {e}")]
     chat_id = args["chat_id"]
     text = args["text"]
     source = args["source"]
@@ -3361,7 +3365,10 @@ async def handle_send_sms_reply(args: dict) -> list[TextContent]:
 
 async def handle_mark_processed(args: dict) -> list[TextContent]:
     """Mark a message as processed."""
-    message_id = validate_message_id(args.get("message_id", ""))
+    try:
+        message_id = validate_message_id(args.get("message_id", ""))
+    except ValidationError as e:
+        return [TextContent(type="text", text=f"Error: {e}")]
     force = args.get("force", False)
 
     # Check processing/ first, then inbox/ as fallback

--- a/tests/unit/test_mcp_server/test_message_tools.py
+++ b/tests/unit/test_mcp_server/test_message_tools.py
@@ -300,7 +300,13 @@ class TestAutoThreading:
         (processing_dir / "12345_msg.json").write_text(json.dumps(msg))
 
     def test_auto_threads_when_processing_message_exists(self, dirs):
-        """When no reply_to_message_id is given, threading uses the message in processing/."""
+        """Auto-threading was removed (PR #420): reply is standalone even when processing/ has a message.
+
+        Previously send_reply would look up telegram_message_id from processing/ and set
+        reply_to_message_id automatically.  That behaviour was removed to avoid threading
+        under the wrong message when multiple messages are in-flight.  Without an explicit
+        reply_to_message_id the reply is now sent standalone.
+        """
         outbox, processing, processed, sent = dirs
         self._make_processing_msg(processing, chat_id=123456, tg_msg_id=9001)
 
@@ -316,15 +322,15 @@ class TestAutoThreading:
 
             asyncio.run(handle_send_reply({
                 "chat_id": 123456,
-                "text": "Auto-threaded reply",
+                "text": "Reply without auto-threading",
                 "source": "telegram",
             }))
 
         files = list(outbox.glob("*.json"))
         assert len(files) == 1
         content = json.loads(files[0].read_text())
-        assert content.get("reply_to_message_id") == 9001, (
-            "Expected reply_to_message_id=9001 from auto-threading"
+        assert "reply_to_message_id" not in content, (
+            "reply_to_message_id should not be auto-set: auto-threading was removed in PR #420"
         )
 
     def test_explicit_reply_id_takes_precedence_over_auto(self, dirs):
@@ -491,9 +497,12 @@ class TestAutoThreading:
         (processed_dir / filename).write_text(json.dumps(msg))
 
     def test_auto_threads_from_processed_when_processing_empty(self, dirs):
-        """Subagent path: processing/ is empty but message is in processed/ — should thread."""
+        """Auto-threading fallback via processed/ was also removed (PR #361 then #420).
+
+        Both the processing/ lookup and the processed/ fallback were removed.  Replies are
+        sent standalone unless reply_to_message_id is supplied explicitly.
+        """
         outbox, processing, processed, sent = dirs
-        # Simulate the subagent case: original message has already moved to processed/
         self._make_processed_msg(processed, chat_id=123456, tg_msg_id=9001)
         # processing/ is empty
 
@@ -516,14 +525,17 @@ class TestAutoThreading:
         files = list(outbox.glob("*.json"))
         assert len(files) == 1
         content = json.loads(files[0].read_text())
-        assert content.get("reply_to_message_id") == 9001, (
-            "Expected reply_to_message_id=9001 from auto-threading via processed/ fallback"
+        assert "reply_to_message_id" not in content, (
+            "reply_to_message_id should not be auto-set: processed/ fallback was removed in PR #361"
         )
 
     def test_processing_takes_priority_over_processed(self, dirs):
-        """When a message is in processing/, it is used — processed/ is not consulted."""
+        """Auto-threading removed: neither processing/ nor processed/ sets reply_to_message_id.
+
+        Previously processing/ took priority over processed/ for auto-threading.  Both lookups
+        were removed (PRs #361, #420).  With messages in both dirs, the reply is still standalone.
+        """
         outbox, processing, processed, sent = dirs
-        # processing/ has tg_msg_id=9001, processed/ has a different one for the same chat
         self._make_processing_msg(processing, chat_id=123456, tg_msg_id=9001)
         self._make_processed_msg(processed, chat_id=123456, tg_msg_id=7777)
 
@@ -539,14 +551,14 @@ class TestAutoThreading:
 
             asyncio.run(handle_send_reply({
                 "chat_id": 123456,
-                "text": "Should use processing/ message",
+                "text": "Should be sent standalone",
                 "source": "telegram",
             }))
 
         files = list(outbox.glob("*.json"))
         content = json.loads(files[0].read_text())
-        assert content.get("reply_to_message_id") == 9001, (
-            "processing/ match should take priority over processed/ match"
+        assert "reply_to_message_id" not in content, (
+            "reply_to_message_id should not be set: auto-threading removed in PRs #361 and #420"
         )
 
     def test_processed_fallback_wrong_chat_id_not_used(self, dirs):
@@ -578,15 +590,17 @@ class TestAutoThreading:
         )
 
     def test_processed_fallback_uses_most_recent(self, dirs):
-        """When multiple processed messages exist, the most recently modified one is used."""
+        """Auto-threading removed: multiple processed messages still yield no reply_to_message_id.
+
+        Previously the most recently modified processed/ message was used for threading.
+        That fallback was removed in PR #361; neither processed/ message sets reply_to_message_id.
+        """
         import time as _time
 
         outbox, processing, processed, sent = dirs
 
-        # Write older message first (tg_msg_id=1111)
         self._make_processed_msg(processed, chat_id=123456, tg_msg_id=1111, filename="old_msg.json")
-        _time.sleep(0.02)  # ensure distinct mtime
-        # Write newer message second (tg_msg_id=2222)
+        _time.sleep(0.02)
         self._make_processed_msg(processed, chat_id=123456, tg_msg_id=2222, filename="new_msg.json")
 
         with patch.multiple(
@@ -601,14 +615,14 @@ class TestAutoThreading:
 
             asyncio.run(handle_send_reply({
                 "chat_id": 123456,
-                "text": "Should use newest processed message",
+                "text": "Should be sent standalone regardless of processed/ contents",
                 "source": "telegram",
             }))
 
         files = list(outbox.glob("*.json"))
         content = json.loads(files[0].read_text())
-        assert content.get("reply_to_message_id") == 2222, (
-            "Expected reply_to_message_id=2222 from the most recently modified processed message"
+        assert "reply_to_message_id" not in content, (
+            "reply_to_message_id should not be set: processed/ fallback removed in PR #361"
         )
 
 
@@ -703,11 +717,17 @@ class TestMarkProcessed:
 
 
     def test_blocks_human_message_without_reply(self, setup_dirs, message_generator):
-        """Test that marking a human message without reply returns a warning."""
+        """Guard auto-sends fallback reply for real chat_ids; skips for test/fake chat_ids.
+
+        For chat_ids <= 1_000_000 (test/fake IDs that Telegram would reject), the guard
+        skips the auto-reply fallback but still marks the message as processed.  The old
+        soft-warning behaviour ("No reply sent") was replaced by an auto-send-then-proceed
+        pattern to prevent silent message drops in production.
+        """
         inbox, processed = setup_dirs
 
         msg = message_generator.generate_text_message(
-            source="telegram", chat_id=123456,
+            source="telegram", chat_id=123456,  # fake/test chat_id — guard skips auto-reply
         )
         msg_id = msg["id"]
         (inbox / f"{msg_id}.json").write_text(json.dumps(msg))
@@ -722,10 +742,10 @@ class TestMarkProcessed:
 
             result = asyncio.run(handle_mark_processed({"message_id": msg_id}))
 
-            assert "No reply sent" in result[0].text
-            # File should NOT have been moved
-            assert (inbox / f"{msg_id}.json").exists()
-            assert not (processed / f"{msg_id}.json").exists()
+            # For fake/test chat_ids the guard skips auto-reply but still marks processed
+            assert "processed" in result[0].text.lower()
+            assert not (inbox / f"{msg_id}.json").exists()
+            assert (processed / f"{msg_id}.json").exists()
 
     def test_allows_human_message_with_force(self, setup_dirs, message_generator):
         """Test that force=True bypasses the reply guard."""

--- a/tests/unit/test_mcp_server/test_transcription.py
+++ b/tests/unit/test_mcp_server/test_transcription.py
@@ -36,21 +36,24 @@ class TestTranscribeAudio:
         return inbox, audio_dir, msg_id, audio_path
 
     def test_transcribes_voice_message(self, setup_voice_message, temp_messages_dir):
-        """Test successful voice message transcription."""
+        """Test successful voice message transcription via whisper.cpp."""
         inbox, audio_dir, msg_id, audio_path = setup_voice_message
         processed = temp_messages_dir / "processed"
 
-        # Mock the whisper model and ffmpeg
-        mock_model = MagicMock()
-        mock_model.transcribe.return_value = {"text": "Hello, this is a test"}
-
+        # Transcription now goes through run_whisper_cpp (returns (success, text) tuple).
+        # The old get_whisper_model / model.transcribe() API was replaced with the
+        # whisper.cpp CLI integration.
         with patch.multiple(
             "src.mcp.inbox_server",
             INBOX_DIR=inbox,
             PROCESSED_DIR=processed,
             AUDIO_DIR=audio_dir,
         ):
-            with patch("src.mcp.inbox_server.get_whisper_model", return_value=mock_model):
+            with patch(
+                "src.mcp.inbox_server.run_whisper_cpp",
+                new_callable=AsyncMock,
+                return_value=(True, "Hello, this is a test"),
+            ):
                 with patch(
                     "src.mcp.inbox_server.convert_ogg_to_wav",
                     new_callable=AsyncMock,
@@ -171,21 +174,22 @@ class TestTranscribeAudio:
             assert "required" in result[0].text.lower()
 
     def test_handles_transcription_error(self, setup_voice_message, temp_messages_dir):
-        """Test that transcription errors are handled."""
+        """Test that transcription errors are handled gracefully."""
         inbox, audio_dir, msg_id, audio_path = setup_voice_message
         processed = temp_messages_dir / "processed"
 
-        # Mock whisper to raise an error
-        mock_model = MagicMock()
-        mock_model.transcribe.side_effect = Exception("Model error")
-
+        # Simulate run_whisper_cpp raising an unexpected exception (e.g. subprocess crash).
         with patch.multiple(
             "src.mcp.inbox_server",
             INBOX_DIR=inbox,
             PROCESSED_DIR=processed,
             AUDIO_DIR=audio_dir,
         ):
-            with patch("src.mcp.inbox_server.get_whisper_model", return_value=mock_model):
+            with patch(
+                "src.mcp.inbox_server.run_whisper_cpp",
+                new_callable=AsyncMock,
+                side_effect=Exception("whisper.cpp process crashed"),
+            ):
                 with patch(
                     "src.mcp.inbox_server.convert_ogg_to_wav",
                     new_callable=AsyncMock,


### PR DESCRIPTION
## Summary

Three categories of drift had accumulated between tests and production code, causing 10 failures in these two files:

- **ValidationError propagation** (3 tests): `handle_send_reply` and `handle_mark_processed` raised `reliability.ValidationError` on bad input instead of returning a `TextContent` error response. MCP tool handlers must never raise — callers expect `list[TextContent]` back. Fixed by wrapping the validation calls in `try/except` in both handlers.

- **Auto-threading removed** (4 tests): `TestAutoThreading` expected `reply_to_message_id` to be auto-populated from `processing/` and `processed/` directories. That behaviour was intentionally removed in PRs #361 and #420 to prevent replies threading under the wrong message when multiple messages are in-flight. Updated tests document the removal and assert that `reply_to_message_id` is absent when not explicitly provided.

- **mark_processed guard for test chat_ids** (1 test): The soft-warning "No reply sent" return path was replaced with an auto-send-or-skip pattern. For fake/test chat_ids (≤ 1_000_000), Telegram rejects delivery so the guard skips the auto-reply fallback and still marks the message processed. Test updated to match.

- **Transcription API changed** (2 tests): Tests patched `get_whisper_model` (Python whisper library) but transcription now goes through `run_whisper_cpp`, a whisper.cpp CLI wrapper returning `(success: bool, text: str)`. Tests updated to patch `run_whisper_cpp` with an `AsyncMock`.

## Functional patterns

- Pure error-return pattern in handlers (no exceptions crossing handler boundaries)
- Immutable test fixtures — all assertions read from files written by the code under test

## Tests run

- [x] `uv run python -m pytest tests/unit/test_mcp_server/test_message_tools.py tests/unit/test_mcp_server/test_transcription.py -v` — 56 passed, 0 failed (was 10 failed)
- [x] `uv run python -m pytest tests/unit/ --tb=no -q` — confirmed no regressions; all failures in broader suite are pre-existing on main and outside this PR's scope

**Blocked items needing attention before merge:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)