### PR TITLE
fix: write booted_at on hibernate wakeup to activate boot grace period

### DIFF
--- a/scripts/claude-persistent.sh
+++ b/scripts/claude-persistent.sh
@@ -521,6 +521,11 @@ Claude persistent session initializing."
         if handle_exit "$exit_code"; then
             # Clean hibernation - wait for new messages
             wait_for_wake
+            # Write a fresh boot stamp so the health-check's BOOT_GRACE_SECONDS
+            # suppression window activates for the upcoming wakeup launch.
+            # Without this, hibernate wakeups have no grace period and the
+            # stale-inbox check fires during the ~60-90s initialization window.
+            write_boot_stamp
             attempt=0  # Reset attempt counter after clean cycle
         else
             # Abnormal exit - brief pause before restart


### PR DESCRIPTION
## What this fixes

Hibernate wakeups had no boot grace period, so the health check's stale-inbox check could fire during the 60-90 seconds it takes a fresh Claude session to initialize. This caused unnecessary restarts immediately after every hibernate wakeup.

The existing `BOOT_GRACE_SECONDS=90` suppression in `health-check-v3.sh` works correctly for initial boots and health-check-initiated restarts, because both paths call `write_boot_stamp()` before launching Claude. The hibernate wakeup path was the only one that didn't.

## Root cause

`write_boot_stamp()` was called once in `main()` on the very first boot, but the main loop's hibernate branch — after `wait_for_wake()` returns — proceeded directly to the next `launch_claude()` call without writing a fresh `booted_at` timestamp. The health check's `is_boot_grace_period()` function reads `booted_at` from `lobster-state.json` and returns false (no grace) when the field is absent or stale, so wakeup launches got no protection.

## Change

One call added to `scripts/claude-persistent.sh` — `write_boot_stamp()` immediately after `wait_for_wake()` returns, before the loop continues to `launch_claude()`. The function already exists and does a read-modify-write, preserving all other fields in `lobster-state.json`. No changes to the health check or state file format.

The fix is intentionally minimal: the same function the initial boot uses, called in the one place that was missing it.

## Functional patterns

Pure function reuse — `write_boot_stamp()` is a side-effectful boundary function already tested by the initial boot path; the fix simply calls it in the missing context rather than duplicating logic.

## Tests run

- [x] `bash -n scripts/claude-persistent.sh` — syntax check passed
- [ ] Live hibernate/wakeup cycle — requires the running lobster-claude service; safe to verify post-merge by watching `lobster-state.json` for a fresh `booted_at` after the next hibernate wakeup

Closes #639