### PR TITLE
fix: test isolation — prevent tests from corrupting production hibernate state and logs

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -623,14 +623,23 @@ LOG_DIR.mkdir(parents=True, exist_ok=True)
 
 log = logging.getLogger("lobster-mcp")
 log.setLevel(logging.INFO)
-_file_handler = RotatingFileHandler(
-    LOG_DIR / "mcp-server.log",
-    maxBytes=5 * 1024 * 1024,  # 5MB
-    backupCount=3,
-)
-_file_handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
-log.addHandler(_file_handler)
-log.addHandler(logging.StreamHandler())
+
+
+def setup_logging() -> None:
+    """Attach file and stream handlers to the module logger.
+
+    Called only when running as a server (from the __main__ block), not when
+    imported as a library by tests or other modules. This prevents test runs
+    from writing to the production mcp-server.log file.
+    """
+    _file_handler = RotatingFileHandler(
+        LOG_DIR / "mcp-server.log",
+        maxBytes=5 * 1024 * 1024,  # 5MB
+        backupCount=3,
+    )
+    _file_handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
+    log.addHandler(_file_handler)
+    log.addHandler(logging.StreamHandler())
 
 # Seed canonical templates on startup (idempotent — only copies missing files)
 def _seed_canonical_templates():
@@ -2773,9 +2782,15 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
             log.info(f"wait_for_messages timed out after {timeout}s")
 
             if hibernate_on_timeout:
-                # Write hibernate state so the bot knows to wake us on next message
-                _write_lobster_state(LOBSTER_STATE_FILE, "hibernate")
-                log.info("Hibernating: wrote state=hibernate, signalling graceful exit")
+                # Write hibernate state so the bot knows to wake us on next message.
+                # Only write when running in the main session — tests that import this
+                # module and call handle_wait_for_messages directly must not corrupt
+                # the production state file.
+                if _is_main_session():
+                    _write_lobster_state(LOBSTER_STATE_FILE, "hibernate")
+                    log.info("Hibernating: wrote state=hibernate, signalling graceful exit")
+                else:
+                    log.info("Hibernating: skipping state write (not main session)")
                 return [TextContent(
                     type="text",
                     text=(
@@ -6899,4 +6914,5 @@ async def main():
 
 if __name__ == "__main__":
     import asyncio
+    setup_logging()
     asyncio.run(main())

--- a/tests/unit/test_hibernation.py
+++ b/tests/unit/test_hibernation.py
@@ -20,6 +20,14 @@ from unittest.mock import MagicMock, patch, call
 
 import pytest
 
+# Ensure inbox_server is importable. Must happen before any test class references
+# the module so that patch.multiple("inbox_server", ...) always targets the cached
+# module object rather than a freshly-imported one (which would not yet be patched).
+_MCP_SRC = str(Path(__file__).parent.parent.parent / "src" / "mcp")
+if _MCP_SRC not in sys.path:
+    sys.path.insert(0, _MCP_SRC)
+import inbox_server  # noqa: E402 — intentional late import after path setup
+
 
 # ---------------------------------------------------------------------------
 # Helpers shared between test classes
@@ -71,28 +79,21 @@ class TestStateFile:
 
     def test_missing_state_file_defaults_active(self, state_dir: Path):
         """Missing state file should default to 'active'."""
-        # Import the helper from the MCP server
-        sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src" / "mcp"))
-        from inbox_server import _read_lobster_state
-        result = _read_lobster_state(state_dir / "lobster-state.json")
+        result = inbox_server._read_lobster_state(state_dir / "lobster-state.json")
         assert result == "active"
 
     def test_corrupt_state_file_defaults_active(self, state_dir: Path):
         """Corrupt state file JSON should default to 'active'."""
-        sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src" / "mcp"))
-        from inbox_server import _read_lobster_state
         state_file = state_dir / "lobster-state.json"
         state_file.write_text("NOT_VALID_JSON{{{{")
-        result = _read_lobster_state(state_file)
+        result = inbox_server._read_lobster_state(state_file)
         assert result == "active"
 
     def test_empty_json_object_defaults_active(self, state_dir: Path):
         """State file with no 'mode' key should default to 'active'."""
-        sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src" / "mcp"))
-        from inbox_server import _read_lobster_state
         state_file = state_dir / "lobster-state.json"
         state_file.write_text("{}")
-        result = _read_lobster_state(state_file)
+        result = inbox_server._read_lobster_state(state_file)
         assert result == "active"
 
     def test_atomic_write_no_tmp_files_remain(self, state_dir: Path):
@@ -103,19 +104,14 @@ class TestStateFile:
 
     def test_write_state_via_server_function(self, state_dir: Path):
         """_write_lobster_state helper in inbox_server writes correctly."""
-        sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src" / "mcp"))
-        from inbox_server import _write_lobster_state
         state_file = state_dir / "lobster-state.json"
-        _write_lobster_state(state_file, "hibernate")
+        inbox_server._write_lobster_state(state_file, "hibernate")
         data = json.loads(state_file.read_text())
         assert data["mode"] == "hibernate"
         assert "updated_at" in data
 
     def test_reset_state_on_startup(self, state_dir: Path):
         """_reset_state_on_startup resets 'hibernate' to 'active' and adds woke_at."""
-        sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src" / "mcp"))
-        from inbox_server import _reset_state_on_startup, LOBSTER_STATE_FILE
-
         # Write hibernate state
         state_file = state_dir / "lobster-state.json"
         _write_state(state_dir, "hibernate")
@@ -123,7 +119,7 @@ class TestStateFile:
 
         # Patch the global and call the function
         with patch("inbox_server.LOBSTER_STATE_FILE", state_file):
-            _reset_state_on_startup()
+            inbox_server._reset_state_on_startup()
 
         # Verify state was reset
         data = json.loads(state_file.read_text())
@@ -132,15 +128,12 @@ class TestStateFile:
 
     def test_reset_state_on_startup_noop_when_active(self, state_dir: Path):
         """_reset_state_on_startup does nothing when state is already 'active'."""
-        sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src" / "mcp"))
-        from inbox_server import _reset_state_on_startup
-
         state_file = state_dir / "lobster-state.json"
         _write_state(state_dir, "active")
         original = state_file.read_text()
 
         with patch("inbox_server.LOBSTER_STATE_FILE", state_file):
-            _reset_state_on_startup()
+            inbox_server._reset_state_on_startup()
 
         # File should be unchanged (no unnecessary write)
         assert state_file.read_text() == original
@@ -171,8 +164,8 @@ class TestWaitForMessagesHibernation:
 
     def test_timeout_writes_hibernate_state(self, dirs):
         """When wait_for_messages times out, state file is written as 'hibernate'."""
-        sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src" / "mcp"))
-
+        # inbox_server is imported at module level above; patch targets the cached object.
+        # _is_main_session is patched to True so the session guard allows the state write.
         with patch.multiple(
             "inbox_server",
             INBOX_DIR=dirs["inbox"],
@@ -183,12 +176,12 @@ class TestWaitForMessagesHibernation:
             with patch("inbox_server.touch_heartbeat"):
                 with patch("inbox_server._recover_stale_processing"):
                     with patch("inbox_server._recover_retryable_messages"):
-                        import inbox_server
-                        result = asyncio.run(
-                            inbox_server.handle_wait_for_messages(
-                                {"timeout": 1, "hibernate_on_timeout": True}
+                        with patch("inbox_server._is_main_session", return_value=True):
+                            result = asyncio.run(
+                                inbox_server.handle_wait_for_messages(
+                                    {"timeout": 1, "hibernate_on_timeout": True}
+                                )
                             )
-                        )
 
         # State file must exist and be "hibernate"
         assert dirs["state_file"].exists(), "State file not created on timeout"
@@ -203,8 +196,6 @@ class TestWaitForMessagesHibernation:
 
     def test_timeout_without_hibernate_flag_does_not_write_state(self, dirs):
         """When hibernate_on_timeout=False, no state file is written on timeout."""
-        sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src" / "mcp"))
-
         with patch.multiple(
             "inbox_server",
             INBOX_DIR=dirs["inbox"],
@@ -214,7 +205,6 @@ class TestWaitForMessagesHibernation:
             with patch("inbox_server.touch_heartbeat"):
                 with patch("inbox_server._recover_stale_processing"):
                     with patch("inbox_server._recover_retryable_messages"):
-                        import inbox_server
                         asyncio.run(
                             inbox_server.handle_wait_for_messages(
                                 {"timeout": 1, "hibernate_on_timeout": False}
@@ -227,8 +217,6 @@ class TestWaitForMessagesHibernation:
 
     def test_message_arrival_does_not_trigger_hibernate(self, dirs, tmp_path):
         """When a message arrives, state must NOT be set to hibernate."""
-        sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src" / "mcp"))
-
         # Pre-populate inbox with one message
         msg = {"id": "test_001", "text": "hello", "source": "telegram",
                "chat_id": 1, "timestamp": "2026-01-01T00:00:00"}
@@ -246,12 +234,12 @@ class TestWaitForMessagesHibernation:
             with patch("inbox_server.touch_heartbeat"):
                 with patch("inbox_server._recover_stale_processing"):
                     with patch("inbox_server._recover_retryable_messages"):
-                        import inbox_server
-                        asyncio.run(
-                            inbox_server.handle_wait_for_messages(
-                                {"timeout": 5, "hibernate_on_timeout": True}
+                        with patch("inbox_server._is_main_session", return_value=True):
+                            asyncio.run(
+                                inbox_server.handle_wait_for_messages(
+                                    {"timeout": 5, "hibernate_on_timeout": True}
+                                )
                             )
-                        )
 
         # State should still be "active" (message was processed, not timeout)
         if dirs["state_file"].exists():


### PR DESCRIPTION
## Problem

Running \`pytest tests/unit/test_hibernation.py\` on a production machine had two failure modes that could damage the live system:

1. The test put the production system into hibernate mode. \`handle_wait_for_messages\` wrote \`mode=hibernate\` to the real \`LOBSTER_STATE_FILE\` with no check for whether it was running in the main session. The \`patch.multiple\` in the test was supposed to redirect this write, but it didn't always fire (see #3 below).

2. Importing \`inbox_server\` in any test process attached a \`RotatingFileHandler\` at module level, writing test-generated log entries to \`~/lobster-workspace/logs/mcp-server.log\`.

3. \`patch.multiple("inbox_server", ...)\` opened before \`import inbox_server\` ran inside each test method. If \`inbox_server\` was not yet in \`sys.modules\` when the patch context opened, the patch targeted nothing — or targeted an object that was immediately replaced by the fresh import inside the \`with\` block.

## What changed

**\`src/mcp/inbox_server.py\`**

- \`handle_wait_for_messages\`: the \`_write_lobster_state(..., "hibernate")\` call is now gated on \`_is_main_session()\`. Test processes that import the module directly and call this function cannot set production state to hibernate. The existing session guard used by other tools is the right mechanism here; this change applies the same pattern to the hibernate write path.

- Log handler setup extracted into \`setup_logging()\`, called only from the \`__main__\` block. The \`logging.getLogger\` call stays at module level so callers get a usable logger — it just has no file handler attached unless running as the server.

**\`tests/unit/test_hibernation.py\`**

- \`inbox_server\` is now imported once at module level (after \`sys.path\` setup) so \`patch.multiple("inbox_server", ...)\` always targets the cached module object, not a freshly-loaded one.

- All inline \`sys.path.insert\` + \`from inbox_server import X\` patterns inside test methods are replaced with references to the module-level import.

- Tests in \`TestWaitForMessagesHibernation\` that exercise the hibernate state write now patch \`_is_main_session\` to return \`True\`, since the production guard that was missing before is now present and correct.

## Functional patterns

Pure function composition: \`setup_logging()\` is a side-effect–isolating wrapper with no return value. The session guard is a simple predicate. The test patches follow the same mock-at-boundary pattern already used throughout the suite.

## Tests run

- [x] \`uv run pytest tests/unit/test_hibernation.py -v\` — 28 passed, 0 failed
- [x] \`uv run pytest tests/unit/ -v\` — 1156 passed, 71 failed; all 71 failures are pre-existing on \`main\` (confirmed by running the same suite against main — same failures, same count)

**Blocked items needing attention before merge:** none

Closes #641