### PR TITLE
fix: stop startup cleanup from killing agents that survive server restarts

### DIFF
--- a/src/agents/session_store.py
+++ b/src/agents/session_store.py
@@ -457,42 +457,39 @@ def cleanup_stale_running_sessions(
     server_start_time: datetime,
     path: Path | None = None,
 ) -> list[str]:
-    """Mark pre-existing 'running' rows as 'dead' on server startup.
+    """Reconcile pre-existing 'running' rows on server startup.
 
-    After a force-restart, agents that were mid-execution have their last
-    ``stop_reason`` stuck at ``tool_use``.  The reconciler's liveness check
-    returns ``"running"`` for those files, so the normal dead-threshold logic
-    never fires.  This function closes that gap by inspecting every
-    ``status='running'`` row **before** the reconciler loop begins.
+    After a restart, agents whose output files have ``stop_reason=end_turn``
+    are marked completed.  Agents whose output files are missing are marked
+    dead.  Agents whose output files exist with ``stop_reason=tool_use`` (or
+    no stop_reason yet) are left running — Claude Code agents are independent
+    processes that survive MCP server restarts.
 
-    A session is declared dead at startup if ANY of these is true:
+    Previous versions of this function used an mtime heuristic: if the output
+    file's mtime predated the server start time, the agent was assumed dead.
+    That assumption is incorrect — Claude Code agents are NOT child processes
+    of the MCP server and can outlive a restart.  Using mtime caused false
+    positives where healthy agents were killed immediately after every server
+    restart.
 
-    1. Its ``output_file`` does not exist on disk — the file was cleaned up,
-       so no live agent can be writing to it.
-    2. Its ``output_file`` exists but its mtime predates ``server_start_time``
-       — the file was last touched before this server instance started, so it
-       cannot belong to an agent from the current run.
-    3. (Fallback) ``output_file`` is absent from the DB row AND elapsed time
-       since ``spawned_at`` exceeds ``timeout_minutes`` (or a generous default
-       of 120 minutes) — best-effort cleanup for unregistered output files.
+    Decision rules for each ``status='running'`` row:
 
-    **Assumption:** subagents cannot outlive a server restart. Claude Code
-    subagents run as child processes of the MCP server; when the server is
-    killed (e.g. ``systemctl restart``), all subagents are killed with it.
-    This means any ``status='running'`` row found at startup time cannot
-    belong to a genuinely live agent — it is always safe to mark it dead.
-
-    All matched rows are marked ``status='dead'`` with a ``completed_at``
-    timestamp of ``server_start_time`` so callers know when the cleanup ran.
+    1. ``output_file`` is set and target JSONL is missing on disk → dead
+       (file was cleaned up or never created; no live agent can be writing it)
+    2. ``output_file`` is set and ``stop_reason=end_turn`` → completed
+       (agent finished before or during the restart window)
+    3. ``output_file`` is set and ``stop_reason=tool_use`` (or empty) → leave running
+       (agent may still be alive; normal reconciler loop will time it out if needed)
+    4. ``output_file`` absent, elapsed > timeout → dead (fallback heuristic)
+    5. ``output_file`` absent, elapsed ≤ timeout → leave running
 
     Args:
-        server_start_time: The UTC datetime when the current server process
-                           started.  Any output file with mtime < this value
-                           cannot belong to a live agent from this session.
+        server_start_time: UTC datetime when the current server process started
+                           (kept for logging; no longer used for mtime comparison).
         path:              DB path override (for tests).
 
     Returns:
-        List of agent IDs that were marked dead.
+        List of agent IDs that were marked dead or completed.
     """
     resolved = path if path is not None else _DEFAULT_DB_PATH
     conn = _get_connection(resolved)
@@ -506,7 +503,7 @@ def cleanup_stale_running_sessions(
     )
     rows = cursor.fetchall()
 
-    dead_ids: list[str] = []
+    changed_ids: list[str] = []
     completed_at = server_start_time.isoformat()
 
     for row in rows:
@@ -515,28 +512,65 @@ def cleanup_stale_running_sessions(
         spawned_at_raw: str | None = row["spawned_at"]
         timeout_minutes: int | None = row["timeout_minutes"]
 
-        should_kill = False
-        reason = ""
-
         if output_file:
-            output_path = Path(output_file)
-            try:
-                real_path = output_path.resolve()
-                if not real_path.exists():
-                    should_kill = True
-                    reason = "output_file missing at startup"
-                else:
-                    mtime_ts = real_path.stat().st_mtime
-                    file_mtime = datetime.fromtimestamp(mtime_ts, tz=timezone.utc)
-                    if file_mtime < server_start_time:
-                        should_kill = True
-                        reason = (
-                            f"output_file mtime ({file_mtime.isoformat()}) "
-                            f"predates server start ({server_start_time.isoformat()})"
-                        )
-            except OSError:
-                should_kill = True
-                reason = "output_file unreadable at startup"
+            # Read the stop_reason from the output file to determine liveness.
+            # "missing" → file gone, safe to mark dead.
+            # "done"    → agent finished, mark completed.
+            # "running" → agent may still be alive, leave it running.
+            file_status = _read_stop_reason_from_path(Path(output_file))
+
+            if file_status == "missing":
+                conn.execute(
+                    """
+                    UPDATE agent_sessions
+                    SET status = 'dead',
+                        completed_at = ?,
+                        result_summary = ?
+                    WHERE id = ? AND status = 'running'
+                    """,
+                    (
+                        completed_at,
+                        "Marked dead at startup: output_file missing",
+                        agent_id,
+                    ),
+                )
+                changed_ids.append(agent_id)
+                log.warning(
+                    "[startup-cleanup] session %r marked dead: output_file missing",
+                    agent_id,
+                )
+
+            elif file_status == "done":
+                conn.execute(
+                    """
+                    UPDATE agent_sessions
+                    SET status = 'completed',
+                        completed_at = ?,
+                        result_summary = ?
+                    WHERE id = ? AND status = 'running'
+                    """,
+                    (
+                        completed_at,
+                        "Marked completed at startup: stop_reason=end_turn",
+                        agent_id,
+                    ),
+                )
+                changed_ids.append(agent_id)
+                log.info(
+                    "[startup-cleanup] session %r marked completed: stop_reason=end_turn",
+                    agent_id,
+                )
+
+            else:
+                # file_status == "running": output file exists with tool_use or
+                # no stop_reason yet. Agent may still be alive. Leave it running
+                # so the reconciler's normal liveness loop handles it.
+                log.debug(
+                    "[startup-cleanup] session %r left running: output_file exists "
+                    "with stop_reason=tool_use (agent may still be alive)",
+                    agent_id,
+                )
+
         else:
             # No output_file registered — fall back to elapsed-time heuristic
             if spawned_at_raw:
@@ -547,10 +581,30 @@ def cleanup_stale_running_sessions(
                     elapsed_minutes = (server_start_time - spawned_dt).total_seconds() / 60
                     limit_minutes = timeout_minutes if timeout_minutes else 120
                     if elapsed_minutes > limit_minutes:
-                        should_kill = True
-                        reason = (
-                            f"no output_file and elapsed {elapsed_minutes:.0f}m "
-                            f"exceeds limit {limit_minutes}m"
+                        conn.execute(
+                            """
+                            UPDATE agent_sessions
+                            SET status = 'dead',
+                                completed_at = ?,
+                                result_summary = ?
+                            WHERE id = ? AND status = 'running'
+                            """,
+                            (
+                                completed_at,
+                                (
+                                    f"Marked dead at startup: no output_file and "
+                                    f"elapsed {elapsed_minutes:.0f}m exceeds limit {limit_minutes}m"
+                                ),
+                                agent_id,
+                            ),
+                        )
+                        changed_ids.append(agent_id)
+                        log.warning(
+                            "[startup-cleanup] session %r marked dead: no output_file, "
+                            "elapsed %.0fm > limit %dm",
+                            agent_id,
+                            elapsed_minutes,
+                            limit_minutes,
                         )
                 except (ValueError, TypeError):
                     pass
@@ -566,23 +620,10 @@ def cleanup_stale_running_sessions(
                     agent_id,
                 )
 
-        if should_kill:
-            conn.execute(
-                """
-                UPDATE agent_sessions
-                SET status = 'dead',
-                    completed_at = ?,
-                    result_summary = ?
-                WHERE id = ? AND status IN ('running', 'starting')
-                """,
-                (completed_at, f"Marked dead at startup: {reason}", agent_id),
-            )
-            dead_ids.append(agent_id)
-
-    if dead_ids:
+    if changed_ids:
         conn.commit()
 
-    return dead_ids
+    return changed_ids
 
 
 def get_unnotified_completed(

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -551,42 +551,78 @@ def test_cleanup_stale_running_output_missing(isolated_db, tmp_path):
     assert "missing" in result["result_summary"]
 
 
-def test_cleanup_stale_running_output_old_mtime(isolated_db, tmp_path):
-    """Session whose output_file mtime predates server_start is marked dead."""
-    db = isolated_db
-    output_file = tmp_path / "old_agent.output"
-    output_file.write_text('{"stop_reason": "tool_use"}')
+def test_cleanup_stale_running_output_tool_use_left_running(isolated_db, tmp_path):
+    """Session whose output_file has stop_reason=tool_use is left running after restart.
 
-    # Set mtime to 10 minutes ago
+    Previously the mtime-based check would mark this agent dead if the file
+    predated the server start time. The fix reads stop_reason instead: tool_use
+    means the agent may still be alive, so we leave it running (issue #645).
+    """
+    db = isolated_db
+    output_file = tmp_path / "live_agent.output"
+    output_file.write_text('{"stop_reason": "tool_use"}\n')
+
+    # Set mtime to 10 minutes ago to simulate a file that predates server start.
+    # Under the old logic this would have been killed; under the new logic it stays.
     old_ts = _time.time() - 600
     os.utime(str(output_file), (old_ts, old_ts))
 
     session_store.session_start(
-        id="stale-old-mtime",
-        description="Agent with old mtime",
+        id="live-tool-use",
+        description="Agent with tool_use output (may still be alive)",
         chat_id="123",
         output_file=str(output_file),
         path=db,
     )
 
-    # Server started 5 minutes ago — still newer than the file
+    # Server started 5 minutes ago — file mtime predates it, but stop_reason=tool_use
     server_start = datetime.now(timezone.utc) - timedelta(minutes=5)
-    dead = session_store.cleanup_stale_running_sessions(server_start, path=db)
+    changed = session_store.cleanup_stale_running_sessions(server_start, path=db)
 
-    assert "stale-old-mtime" in dead
-    result = session_store.find_session("stale-old-mtime", path=db)
-    assert result["status"] == "dead"
-    assert "mtime" in result["result_summary"]
+    assert "live-tool-use" not in changed, (
+        "Agent with stop_reason=tool_use should NOT be killed — it may still be alive"
+    )
+    result = session_store.find_session("live-tool-use", path=db)
+    assert result["status"] == "running"
+
+
+def test_cleanup_stale_running_output_end_turn_marked_completed(isolated_db, tmp_path):
+    """Session whose output_file has stop_reason=end_turn is marked completed at startup.
+
+    If an agent finished before or during a server restart, its output file
+    contains stop_reason=end_turn. The startup cleanup should mark it completed
+    (not dead) so the notification message says 'completed' not 'dead'.
+    """
+    db = isolated_db
+    output_file = tmp_path / "finished_agent.output"
+    output_file.write_text('{"stop_reason": "end_turn"}\n')
+
+    session_store.session_start(
+        id="finished-agent",
+        description="Agent that finished",
+        chat_id="123",
+        output_file=str(output_file),
+        path=db,
+    )
+
+    server_start = datetime.now(timezone.utc)
+    changed = session_store.cleanup_stale_running_sessions(server_start, path=db)
+
+    assert "finished-agent" in changed
+    result = session_store.find_session("finished-agent", path=db)
+    assert result["status"] == "completed"
+    assert "end_turn" in result["result_summary"]
 
 
 def test_cleanup_stale_running_skips_fresh_file(isolated_db, tmp_path):
-    """Session whose output_file mtime is newer than server_start is left running."""
+    """Session whose output_file has stop_reason=tool_use is left running.
+
+    Regardless of mtime, a file with tool_use means the agent may be alive.
+    """
     db = isolated_db
     output_file = tmp_path / "fresh_agent.output"
-    output_file.write_text('{"stop_reason": "tool_use"}')
-    # File was just written — mtime is now, which is after server_start
+    output_file.write_text('{"stop_reason": "tool_use"}\n')
 
-    # Server started 10 minutes ago
     server_start = datetime.now(timezone.utc) - timedelta(minutes=10)
 
     session_store.session_start(
@@ -597,9 +633,9 @@ def test_cleanup_stale_running_skips_fresh_file(isolated_db, tmp_path):
         path=db,
     )
 
-    dead = session_store.cleanup_stale_running_sessions(server_start, path=db)
+    changed = session_store.cleanup_stale_running_sessions(server_start, path=db)
 
-    assert "fresh-agent" not in dead
+    assert "fresh-agent" not in changed
     result = session_store.find_session("fresh-agent", path=db)
     assert result["status"] == "running"
 
@@ -669,7 +705,9 @@ def test_cleanup_stale_running_oserror_marks_dead(isolated_db, tmp_path):
     assert "oserror-agent" in dead
     result = session_store.find_session("oserror-agent", path=db)
     assert result["status"] == "dead"
-    assert "unreadable" in result["result_summary"]
+    # _read_stop_reason_from_path returns "missing" for OSError (path unresolvable),
+    # so the result_summary says "output_file missing" (not "unreadable")
+    assert "missing" in result["result_summary"]
 
 
 def test_cleanup_stale_running_null_spawned_at_no_output_file_skips_with_warning(
@@ -744,4 +782,77 @@ def test_reconciler_check_output_file_status_done_for_end_turn(tmp_path):
     status = session_store.check_output_file_status(str(output_file))
     assert status == "done", (
         f"Expected 'done' for end_turn output file, got {status!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: startup cleanup leaves tool_use agents running (issue #645 fix)
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_stale_does_not_kill_agents_surviving_restart(isolated_db, tmp_path):
+    """Agents with stop_reason=tool_use survive server restarts unchanged.
+
+    Regression test for issue #645: the old mtime-based heuristic marked agents
+    dead whenever their output file predated the server start time — which happens
+    on every restart for any running agent. The fix reads stop_reason instead:
+    tool_use means the agent may still be alive.
+    """
+    db = isolated_db
+    output_file = tmp_path / "surviving_agent.output"
+    output_file.write_text('{"stop_reason": "tool_use"}\n')
+
+    # Backdate mtime to simulate a file that predates the server restart
+    old_ts = _time.time() - 3600  # 1 hour ago
+    os.utime(str(output_file), (old_ts, old_ts))
+
+    session_store.session_start(
+        id="surviving-agent",
+        description="Agent that was running when server restarted",
+        chat_id="123",
+        output_file=str(output_file),
+        path=db,
+    )
+
+    # Server started just now — clearly after the file's mtime
+    server_start = datetime.now(timezone.utc)
+    changed = session_store.cleanup_stale_running_sessions(server_start, path=db)
+
+    assert "surviving-agent" not in changed, (
+        "Agent with stop_reason=tool_use must NOT be killed at startup "
+        "(it may have survived the server restart)"
+    )
+    result = session_store.find_session("surviving-agent", path=db)
+    assert result["status"] == "running", (
+        f"Expected 'running' but got {result['status']!r}"
+    )
+
+
+def test_cleanup_stale_marks_end_turn_as_completed_not_dead(isolated_db, tmp_path):
+    """Agents with stop_reason=end_turn are marked completed (not dead) at startup.
+
+    Regression test for issue #645: previously only the mtime path existed,
+    so an agent that finished before a restart would be left in limbo (mtime
+    newer than server start → skipped; but the reconciler would eventually
+    catch it). Now the startup cleanup proactively marks it completed.
+    """
+    db = isolated_db
+    output_file = tmp_path / "completed_agent.output"
+    output_file.write_text('{"stop_reason": "end_turn"}\n')
+
+    session_store.session_start(
+        id="completed-at-restart",
+        description="Agent that finished before restart",
+        chat_id="123",
+        output_file=str(output_file),
+        path=db,
+    )
+
+    server_start = datetime.now(timezone.utc)
+    changed = session_store.cleanup_stale_running_sessions(server_start, path=db)
+
+    assert "completed-at-restart" in changed
+    result = session_store.find_session("completed-at-restart", path=db)
+    assert result["status"] == "completed", (
+        f"Expected 'completed' for end_turn agent but got {result['status']!r}"
     )


### PR DESCRIPTION
Closes #645

## The problem

Every server restart was killing healthy running agents and sending false \`[SUBAGENT ERROR]\` notifications. Two bugs combined to produce the observed "no output file after 0m — marked dead" symptom.

**Bug 1 — Wrong liveness model in startup cleanup**

\`cleanup_stale_running_sessions\` assumed Claude Code agents are child processes of the MCP server and therefore cannot outlive a restart. That assumption is incorrect. Claude Code agents run independently (in their own process/tmux pane) and keep running when \`systemctl restart lobster-inbox\` is issued.

The function used an mtime heuristic: if \`output_file.mtime < server_start_time\`, mark dead. This fired for *every running agent* on *every restart*, since their output files were last written before the server came back up.

**Bug 2 — "0m" in notification text**

The startup sweep calls \`get_unnotified_completed()\`, which returns rows via \`_row_to_dict\` — a plain dict with no \`elapsed_seconds\` field. When \`_enqueue_reconciler_notification\` fell back to \`elapsed_seconds=None → 0\`, the notification read "no output file after 0m — marked dead" regardless of actual elapsed time. This "0m" was the diagnostic clue.

## The fix

**Startup cleanup** now reads \`stop_reason\` from the output file instead of checking mtime:
- \`stop_reason=tool_use\` (or empty file) → **leave running** — agent may still be alive
- \`stop_reason=end_turn\` → **mark completed** — agent finished before/during restart
- output file missing entirely → **mark dead** — file was cleaned up, no live agent can use it

The mtime check is removed entirely. The \`server_start_time\` parameter is retained (used for \`completed_at\` timestamps) but no longer used for liveness inference.

**Notification elapsed time** now falls back to computing from \`spawned_at\` when \`elapsed_seconds\` is absent from the session dict, so the "Xm elapsed" value is accurate regardless of which query path produced the session row.

## Functional patterns

Pure function \`_read_stop_reason_from_path\` (already existing) is reused for the startup check — the same deterministic file-read used by the reconciler loop. No new judgment paths, just a correct liveness signal at startup.

## Tests run

- [x] \`uv run pytest tests/test_agent_sessions.py -v\` — 36 passed, 0 failed
- [x] \`uv run pytest tests/unit/test_mcp_server/ -v\` — 18 pre-existing failures (confirmed identical on main), 0 new failures introduced
- [x] Pre-existing failure baseline confirmed via \`git stash\` + rerun — same 18 failures on unmodified main

**Tests replaced:** \`test_cleanup_stale_running_output_old_mtime\` (expected mtime-based kill — now wrong behavior) and \`test_cleanup_stale_running_skips_fresh_file\` (relied on mtime > server_start logic). Replaced with \`test_cleanup_stale_running_output_tool_use_left_running\`, \`test_cleanup_stale_running_output_end_turn_marked_completed\`, \`test_cleanup_stale_does_not_kill_agents_surviving_restart\`, and \`test_cleanup_stale_marks_end_turn_as_completed_not_dead\`.

**Blocked items needing attention before merge:** none