### PR TITLE
docs: clarify lobster-config vs lobster-user-config in GLOBAL-ENV.md

### DIFF
--- a/docs/GLOBAL-ENV.md
+++ b/docs/GLOBAL-ENV.md
@@ -9,9 +9,19 @@ to be shared across multiple services, scripts, and CLI tools on the same machin
 ~/lobster-config/global.env
 ```
 
-This file lives in your personal Lobster config directory (`$LOBSTER_CONFIG_DIR`,
+This file lives in your private Lobster config directory (`$LOBSTER_CONFIG_DIR`,
 which defaults to `~/lobster-config/`). It is **never committed to any repository**
 and should have restricted file permissions (`600`).
+
+> **Directory layout note:** Lobster uses two separate directories with distinct purposes:
+>
+> - `~/lobster-config/` (`$LOBSTER_CONFIG_DIR`) — Private credentials and config overlay.
+>   Contains `global.env` (API tokens), `config.env` (Lobster service config), and any
+>   private overrides applied during install.
+> - `~/lobster-user-config/` (`$LOBSTER_USER_CONFIG`) — User-visible behavioral config.
+>   Contains agent bootup files, memory, and context files that shape how Lobster behaves.
+>
+> `global.env` belongs in `~/lobster-config/`, not `~/lobster-user-config/`.
 
 ## Format
 


### PR DESCRIPTION
## Summary

`GLOBAL-ENV.md` described `~/lobster-config/` as the location for `global.env` but never mentioned `~/lobster-user-config/`, leaving readers who know about the second directory uncertain which one holds API tokens.

The fix adds a directory layout callout immediately after the Location section, explaining that the two directories serve distinct purposes:
- `~/lobster-config/` (`$LOBSTER_CONFIG_DIR`) — credentials and config overlay (`global.env`, `config.env`)
- `~/lobster-user-config/` (`$LOBSTER_USER_CONFIG`) — behavioral config (bootup files, memory, context)

The callout closes with an explicit statement that `global.env` belongs in `~/lobster-config/`, not `~/lobster-user-config/`. No other content was changed — all existing path references were already correct.

Closes #625

## Tests run

- [ ] No automated tests applicable — documentation-only change