### PR TITLE
cleanup: remove unused imports (_get_active_skills, duplicate re, InlineKeyboardButton)

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -29,7 +29,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Optional
 
-from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, ReplyParameters
+from telegram import Update, InlineKeyboardMarkup, ReplyParameters
 from telegram.ext import Application, CommandHandler, MessageHandler, CallbackQueryHandler, MessageReactionHandler, filters, ContextTypes
 from collections import deque
 

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -15,6 +15,7 @@ import json
 import logging
 from logging.handlers import RotatingFileHandler
 import os
+import re
 import socket
 import sys
 import time
@@ -60,7 +61,6 @@ import agents.session_store as _session_store
 from skill_manager import (
     list_available_skills as _list_available_skills,
     get_skill_context as _get_skill_context,
-    get_active_skills as _get_active_skills,
     activate_skill as _activate_skill,
     deactivate_skill as _deactivate_skill,
     get_skill_preferences as _get_skill_preferences,
@@ -354,9 +354,7 @@ def _emit_debug_observation(
 # ---------------------------------------------------------------------------
 # User model context injection heuristic
 # ---------------------------------------------------------------------------
-import re as _re
-
-_USER_CONTEXT_TRIGGERS = _re.compile(
+_USER_CONTEXT_TRIGGERS = re.compile(
     r'(?i)(?:'
     r'(?:what|where)\s+should\s+i'             # "what should I focus on"
     r'|priorit(?:y|ies|ize)'                    # priorities
@@ -4254,8 +4252,7 @@ async def handle_fetch_page(args: dict) -> list[TextContent]:
             # Clean up the text
             if text_content:
                 # Remove excessive whitespace/newlines
-                import re as re_mod
-                text_content = re_mod.sub(r'\n{3,}', '\n\n', text_content)
+                text_content = re.sub(r'\n{3,}', '\n\n', text_content)
                 text_content = text_content.strip()
 
                 # Truncate if very long
@@ -4284,7 +4281,6 @@ async def handle_fetch_page(args: dict) -> list[TextContent]:
 # =============================================================================
 
 import subprocess
-import re
 
 
 def load_scheduled_jobs() -> dict:
@@ -5590,7 +5586,6 @@ async def handle_get_brain_dump_status(args: dict) -> list[TextContent]:
     for comment in comments:
         body = comment.get("body", "")
         # Look for patterns like "Action item created: #123" or "#{number}"
-        import re
         matches = re.findall(r"Action item created: #(\d+)", body)
         action_items.extend([int(m) for m in matches])
 


### PR DESCRIPTION
## Summary

Three imports flagged in the librarian audit (issue #622) were never used and added noise to already large files.

- `inbox_server.py` imported `get_active_skills as _get_active_skills` from `skill_manager` but never called it anywhere in the 6,900-line file. Removed from the import block.
- `inbox_server.py` had three separate `re` import statements: a top-level `import re as _re` aliased for a single use, a mid-file `import re` in the scheduled jobs section, and two inline `import re` statements inside function bodies. Consolidated to a single top-level `import re` and updated all call sites.
- `lobster_bot.py` imported `InlineKeyboardButton` alongside `InlineKeyboardMarkup` but only the latter is used anywhere in the file. Removed `InlineKeyboardButton` from the import.

No behavior changes — all removed names were dead code at import time.

Functional patterns: pure removal of dead code; no logic changes.

Closes #622

## Tests run
- [x] `git diff --stat` — 4 insertions, 9 deletions across 2 files, consistent with removing 3 unused imports
- [ ] `uv run pytest` — skipped: no test suite to run against this style-only cleanup (the changes are removals with no logic impact)
- [ ] Live service smoke test — not required; these are import-time removals that cannot affect runtime behavior of used code paths