### PR TITLE
fix: suppress system_context observations from Telegram debug delivery

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -4974,7 +4974,11 @@ async def handle_write_observation(args: dict) -> list[TextContent]:
     # write above always happens first regardless of debug mode.
     # Visibility is "mcp-only": this fires at the MCP layer before the dispatcher
     # picks up the inbox message, so the dispatcher has not yet seen it.
-    if _DEBUG_MODE:
+    #
+    # system_context observations are internal routing decisions — never forward
+    # to Telegram (noisy, not actionable). Only system_error warrants real-time
+    # visibility; user_context is also forwarded as it may affect dispatcher behavior.
+    if _DEBUG_MODE and category != "system_context":
         emitter = f"task:{task_id}" if task_id else "unknown"
         _emit_debug_observation(text, category=category, visibility="mcp-only", emitter=emitter)
 

--- a/tests/unit/test_mcp_server/test_write_observation.py
+++ b/tests/unit/test_mcp_server/test_write_observation.py
@@ -363,8 +363,12 @@ class TestHandleWriteObservation:
     # Debug mode: automatic routing (LOBSTER_DEBUG=true)
     # ------------------------------------------------------------------
 
-    def test_system_context_writes_inbox_and_mirrors_in_debug_mode(self, inbox_dir: Path):
-        """system_context observations write to inbox AND emit a debug mirror when LOBSTER_DEBUG=true."""
+    def test_system_context_writes_inbox_but_not_mirrored_in_debug_mode(self, inbox_dir: Path):
+        """system_context observations write to inbox but are NOT forwarded to Telegram even when LOBSTER_DEBUG=true.
+
+        system_context is an internal routing decision — noisy and not actionable.
+        Only system_error and user_context warrant real-time debug visibility.
+        """
         emitted: list[dict] = []
 
         def fake_emit(
@@ -392,11 +396,8 @@ class TestHandleWriteObservation:
         # Inbox file written — dispatcher still sees it (additive, not bypass)
         files = list(inbox_dir.glob("*.json"))
         assert len(files) == 1
-        # Debug mirror also emitted directly to Telegram with mcp-only visibility
-        assert len(emitted) == 1
-        assert emitted[0]["category"] == "system_context"
-        assert emitted[0]["visibility"] == "mcp-only"
-        assert "Config drift detected." in emitted[0]["text"]
+        # No direct Telegram delivery — system_context is muted even in debug mode
+        assert emitted == []
         assert "Observation queued" in result[0].text
 
     def test_system_error_writes_inbox_and_mirrors_in_debug_mode(self, inbox_dir: Path):
@@ -504,7 +505,11 @@ class TestHandleWriteObservation:
         assert "Observation queued" in result[0].text
 
     def test_debug_mirror_includes_task_id_as_emitter(self, inbox_dir: Path):
-        """In debug mode, task_id is passed as the emitter to _emit_debug_observation."""
+        """In debug mode, task_id is passed as the emitter to _emit_debug_observation.
+
+        Uses system_error category (forwarded in debug mode) to verify the emitter field.
+        system_context is suppressed and cannot be used to test the emitter path.
+        """
         emitted: list[dict] = []
 
         def fake_emit(
@@ -525,8 +530,8 @@ class TestHandleWriteObservation:
             from src.mcp.inbox_server import handle_write_observation
             asyncio.run(handle_write_observation({
                 "chat_id": 123,
-                "text": "Something happened.",
-                "category": "system_context",
+                "text": "Something went wrong.",
+                "category": "system_error",
                 "task_id": "task-42",
             }))
 


### PR DESCRIPTION
When \`LOBSTER_DEBUG=true\`, every \`write_observation\` call with \`category="system_context"\` was being forwarded to Telegram as a \`[debug|mcp-only] system_context\` message. These are internal routing decisions — things like "config state normal" or "subagent registered" — that are not actionable by the user and generate constant noise during debug sessions.

The fix adds a single condition to the debug emission gate in \`handle_write_observation\`: \`if _DEBUG_MODE and category != "system_context"\`. The inbox write (which the dispatcher needs) is unaffected — this only suppresses the real-time Telegram mirror for that category.

\`system_error\` continues to be forwarded (genuine failures warrant visibility) and \`user_context\` does too (may affect dispatcher behavior).

## What changed

- \`src/mcp/inbox_server.py\` — one condition added to the \`_emit_debug_observation\` gate in \`handle_write_observation\`
- \`tests/unit/test_mcp_server/test_write_observation.py\` — two tests updated to match the new contract:
  - \`test_system_context_writes_inbox_but_not_mirrored_in_debug_mode\` (renamed) now asserts \`emitted == []\`
  - \`test_debug_mirror_includes_task_id_as_emitter\` switched to \`system_error\` category since \`system_context\` is now suppressed

## What is out of scope

The inbox write itself is unchanged — the dispatcher still receives and processes \`system_context\` observations exactly as before. Only the debug Telegram mirror is suppressed.

## Functional patterns

Pure conditional logic — no new state, no side effects introduced.

## Tests run
- [x] \`uv run pytest tests/unit/test_mcp_server/test_write_observation.py tests/unit/test_mcp_server/test_debug_alerts.py -v\` — 59 passed, 4 failed (all 4 pre-existing: 2 testing \`_user_model\` dispatch; 2 testing text preview format)
- [x] \`uv run pytest tests/unit/\` (broader suite) — 1165 passed, 68 failed (all pre-existing: GitHub rate limiting in \`test_update_manager.py\` and unrelated MCP server failures)

**Blocked items needing attention before merge:** none

Closes #652