### PR TITLE
fix: apply age threshold to empty stop_reason sessions in agent-status.sh

### DIFF
--- a/scripts/agent-status.sh
+++ b/scripts/agent-status.sh
@@ -124,17 +124,25 @@ scan_agent_status() {
             continue
         fi
 
-        # An agent with stop_reason=tool_use whose output file hasn't been modified
-        # in more than STALE_THRESHOLD_SECONDS is treated as dead (crashed mid-tool-call).
-        # Without this check a crashed agent would show as "running" forever.
-        local STALE_THRESHOLD_SECONDS=$(( 30 * 60 ))
-        if [ "$stop_reason" = "tool_use" ]; then
+        # Agents whose output files are stale are treated as dead.
+        # - stop_reason=tool_use: stale after 30 min (crashed mid-tool-call)
+        # - empty stop_reason:    stale after 60 min (never progressed past "starting")
+        # Without these checks a crashed agent would show as "running"/"starting" forever.
+        local STALE_TOOL_USE_SECONDS=$(( 30 * 60 ))
+        local STALE_STARTING_SECONDS=$(( 60 * 60 ))
+        if [ "$stop_reason" = "tool_use" ] || [ -z "$stop_reason" ]; then
             local now file_mtime file_age_seconds
             now=$(date +%s)
             # stat -c %Y is GNU coreutils; stat -f %m is BSD/macOS fallback
             file_mtime=$(stat -c %Y "$filepath" 2>/dev/null || stat -f %m "$filepath" 2>/dev/null || echo "$now")
             file_age_seconds=$(( now - file_mtime ))
-            if [ "$file_age_seconds" -gt "$STALE_THRESHOLD_SECONDS" ]; then
+            local threshold
+            if [ "$stop_reason" = "tool_use" ]; then
+                threshold=$STALE_TOOL_USE_SECONDS
+            else
+                threshold=$STALE_STARTING_SECONDS
+            fi
+            if [ "$file_age_seconds" -gt "$threshold" ]; then
                 continue  # file too old — agent is dead, not running
             fi
         fi


### PR DESCRIPTION
## What problem this solves

Sessions with empty `stop_reason` (the "starting" state) were never evicted from the self-check agent list. The stale threshold check added in #603 only guarded `stop_reason=tool_use`. As a result, output files from agents that crashed before writing any stop_reason would appear as "starting" in every self-check indefinitely — exactly what happened with sessions bban36a5n, biw463jin, bmc5razqg, b19jn46z8, b983h8l76 diagnosed on 2026-03-17.

## What changed

The stale check in `scan_agent_status()` now covers two cases:

- `stop_reason=tool_use` — excluded after **30 minutes** (unchanged, agent crashed mid-tool-call)
- empty `stop_reason` — excluded after **60 minutes** (new, agent never progressed past startup)

The 60-minute threshold for "starting" is intentionally longer than the 30-minute threshold for "running" to avoid falsely evicting legitimately slow-starting agents.

The implementation is a pure conditional extension of the existing pattern: one outer `if` covering both cases, selecting the appropriate threshold by a nested `if`. No new state, no new files.

## Functional patterns

Pure function — the stale check is a stateless predicate over (stop_reason, file_age) with no side effects.

## Tests run

- [x] `bash -n scripts/agent-status.sh` — syntax clean
- [x] Manual functional test: 61-min old empty-stop_reason file excluded, 5-min old file shown as "starting" — both correct
- [x] `bash tests/test-agent-status.sh` — 10 passed, 8 failed. The 8 failures are pre-existing and test an old output format ("last activity Xs ago", "stale Xh") that was removed in an earlier refactor. Pass/fail count is identical to pre-fix baseline.

Closes #614