### PR TITLE
fix(message-types): taxonomy cleanup phases 1-3 (issue #635)

### DIFF
--- a/scheduled-tasks/post-reminder.sh
+++ b/scheduled-tasks/post-reminder.sh
@@ -58,7 +58,7 @@ status = sys.argv[7]
 msg = {
     "id": msg_id,
     "source": "system",
-    "type": "cron_reminder",
+    "type": "scheduled_reminder",
     "chat_id": 0,
     "user_id": 0,
     "username": "lobster-cron",

--- a/scripts/check-agent-outputs.sh
+++ b/scripts/check-agent-outputs.sh
@@ -108,7 +108,7 @@ while IFS= read -r agent_id; do
 {
   "id": "${MSG_ID}",
   "source": "system",
-  "type": "system",
+  "type": "health_check",
   "chat_id": 0,
   "user_id": 0,
   "username": "lobster-system",

--- a/scripts/daily-health-check.sh
+++ b/scripts/daily-health-check.sh
@@ -165,7 +165,7 @@ if [ ${#FAILURES[@]} -gt 0 ]; then
     MSG_FILE="$INBOX_DIR/daily-health-$(date +%Y%m%d-%H%M%S).json"
     cat > "$MSG_FILE" << MSGEOF
 {
-  "type": "task-output",
+  "type": "health_check",
   "source": "daily-health-check",
   "timestamp": "$TIMESTAMP",
   "subject": "Daily health check: ${#FAILURES[@]} failure(s)",

--- a/scripts/whatsapp-health-check.sh
+++ b/scripts/whatsapp-health-check.sh
@@ -24,7 +24,7 @@ if [ "$BRIDGE_STATUS" != "active" ]; then
 {
   "id": "${MSG_ID}",
   "source": "system",
-  "type": "system",
+  "type": "health_check",
   "subtype": "bridge_down",
   "chat_id": "system",
   "user_id": "system",
@@ -54,7 +54,7 @@ if [ "$BRIDGE_STATUS" = "active" ] && [ -f "$HEARTBEAT_FILE" ]; then
 {
   "id": "${MSG_ID}",
   "source": "system",
-  "type": "system",
+  "type": "health_check",
   "subtype": "bridge_stale",
   "chat_id": "system",
   "user_id": "system",

--- a/src/bot/slack_router.py
+++ b/src/bot/slack_router.py
@@ -315,7 +315,7 @@ def download_slack_file(file_info: dict, msg_id: str, msg_data: dict) -> None:
     if mimetype.startswith("image/"):
         save_path = IMAGES_DIR / f"{msg_id}{ext}"
         msg_data["image_file"] = str(save_path)
-        msg_data["type"] = "image"
+        msg_data["type"] = "photo"
     else:
         save_path = FILES_DIR / f"{msg_id}{ext}"
         msg_data["file_path"] = str(save_path)

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -560,6 +560,35 @@ from message_types import (  # noqa: E402 — placed after path-setup at top of 
     USER_FACING_TYPES,
 )
 
+# ---------------------------------------------------------------------------
+# Message type normalization (issue #635)
+# Aliases are resolved at ingest so the rest of the system only sees canonical
+# names. Adding a new alias here is the only change needed to support a new
+# producer that uses a legacy or non-standard type string.
+# ---------------------------------------------------------------------------
+TYPE_ALIASES: dict[str, str] = {
+    "message": "text",
+    "audio": "voice",
+    "image": "photo",
+    "cron_reminder": "scheduled_reminder",
+    "task-output": "health_check",
+    "system": "health_check",  # when type="system" from health check scripts
+}
+
+
+def normalize_message_type(msg: dict) -> dict:
+    """Return msg with the type field normalized to its canonical name.
+
+    Pure function: returns a new dict (immutable input contract); logs alias
+    resolution at DEBUG level so normalization is traceable without being noisy.
+    """
+    t = msg.get("type", "text")
+    if t in TYPE_ALIASES:
+        log.debug("normalizing type %r -> %r", t, TYPE_ALIASES[t])
+        msg = {**msg, "type": TYPE_ALIASES[t]}
+    return msg
+
+
 # Heartbeat file for health monitoring
 HEARTBEAT_FILE = _WORKSPACE / "logs" / "claude-heartbeat"
 
@@ -2626,7 +2655,7 @@ def _stale_timeout_for_message(msg: dict) -> int:
     Text messages are expected to complete quickly; media types (voice, audio,
     photo, document) may take longer due to transcription or download time.
     """
-    slow_types = {"voice", "audio", "photo", "document"}
+    slow_types = {"voice", "photo", "document"}  # "audio" removed: normalized to "voice" at ingest
     msg_type = msg.get("type", "text")
     return 300 if msg_type in slow_types else 90
 
@@ -3454,6 +3483,10 @@ async def handle_mark_processing(args: dict) -> list[TextContent]:
         msg_data = json.loads(found.read_text())
     except Exception:
         msg_data = {}
+
+    # Normalize type aliases to canonical names before any routing logic sees
+    # the message (issue #635). This is the single ingest normalization point.
+    msg_data = normalize_message_type(msg_data)
 
     # Atomic move to processing
     dest = PROCESSING_DIR / found.name

--- a/src/mcp/message_types.py
+++ b/src/mcp/message_types.py
@@ -17,16 +17,17 @@ from this module; nothing else should define its own ad-hoc type strings.
 # ---------------------------------------------------------------------------
 INBOX_USER_TYPES: frozenset[str] = frozenset({
     "text",       # plain text message
-    "message",    # generic message (alias used by some connectors)
+    "message",    # DEPRECATED alias — normalizes to "text" on ingest
     "photo",      # image/photo attachment
-    "image",      # image (alias)
+    "image",      # DEPRECATED alias — normalizes to "photo" on ingest (Slack producer)
     "voice",      # voice/audio message (needs transcription)
-    "audio",      # audio attachment (alias)
+    "audio",      # DEPRECATED alias — normalizes to "voice" on ingest
     "video",      # video attachment
     "document",   # file/document attachment
     "sticker",    # sticker message
     "location",   # location pin
     "callback",   # inline keyboard button press
+    "reaction",   # Telegram emoji reaction (fields: emoji, signal, reacted_to_text, telegram_message_id)
 })
 
 # ---------------------------------------------------------------------------
@@ -36,18 +37,22 @@ INBOX_SYSTEM_TYPES: frozenset[str] = frozenset({
     "self_check",             # periodic health/reminder injection
     "subagent_result",        # subagent completed work (fields: task_id, payload, artifacts?)
     "subagent_error",         # subagent failed (fields: task_id, error, retry_count)
-    "subagent_notification",  # subagent already sent reply via send_reply (no re-delivery)
+    "subagent_ack",           # subagent already sent reply via send_reply (no re-delivery); canonical name
+    "subagent_notification",  # DEPRECATED alias — use subagent_ack; kept for backward compat
     "subagent_observation",   # subagent noticed something in passing (debug/context)
     "subagent_stale_check",   # dispatch registry found agent with stale heartbeat
     "subagent_recovered",     # subagent fallback recovery event (chat_id unknown; dispatcher handles, never relay directly)
     "compact_group",          # grouped compact messages (internal, produced by check_inbox)
     "compact_reminder",       # on-compact hook reminder (hooks/on-compact.py)
-    "cron_reminder",          # scheduled reminder (scheduled-tasks/post-reminder.sh)
-    "scheduled_reminder",     # scheduled reminder (scripts/post-reminder.sh)
+    "cron_reminder",          # DEPRECATED alias — normalizes to "scheduled_reminder" on ingest
+    "scheduled_reminder",     # scheduled reminder (scripts/post-reminder.sh, scheduled-tasks/post-reminder.sh)
     "update_notification",    # system update available (scripts/daily-update-check.sh)
     "consolidation",          # nightly consolidation result
     "observation",            # OOM-monitor or similar system observation
-    "system",                 # generic system message (whatsapp health check, etc.)
+    "health_check",           # health check output (replaces "task-output" and "system" from health check scripts)
+    "system",                 # DEPRECATED alias — normalizes to "health_check" on ingest (from health check scripts)
+    "task-output",            # DEPRECATED alias — normalizes to "health_check" on ingest (scripts/daily-health-check.sh)
+    "debug_observation",      # debug output from inbox_server.py internals; excluded from skill processing
 })
 
 # ---------------------------------------------------------------------------

--- a/src/transcription/worker.py
+++ b/src/transcription/worker.py
@@ -365,8 +365,8 @@ async def transcribe_pending_file(pending_file: Path) -> None:
         log.error(f"Cannot read {pending_file}: {e}")
         return  # leave file in place — it may still be mid-write
 
-    # Validate it's a voice or audio message
-    if msg_data.get("type") not in ("voice", "audio"):
+    # Validate it's a voice message ("audio" normalized to "voice" at ingest; issue #635)
+    if msg_data.get("type") != "voice":
         move_to_dead_letter(
             pending_file, msg_data,
             f"Unexpected type in pending-transcription: {msg_data.get('type')!r}"


### PR DESCRIPTION
## What problem this solves

The inbox message `type` field had accumulated aliases and gaps over time: Slack sent `image` where Telegram sent `photo`, health-check scripts used `task-output` and `system` as type strings, `reaction` and `debug_observation` were produced but not registered, and `cron_reminder` and `scheduled_reminder` were two names for the same thing. The dispatcher had to handle all variants silently, and any new routing logic checking for `photo` would miss Slack image messages.

This PR brings the taxonomy into a consistent state without breaking existing message producers or any messages currently in the queue.

## What changed

**Phase 1 — registry cleanup (`src/mcp/message_types.py`):**
- Added `reaction` to `INBOX_USER_TYPES` (produced by `lobster_bot.py`, previously unregistered)
- Added `debug_observation` to `INBOX_SYSTEM_TYPES` (produced internally by `inbox_server.py`, previously unregistered)
- Added `health_check` as the canonical name for health-check messages (replaces `task-output` and `system` used as type)
- Added `subagent_ack` as the canonical name alongside `subagent_notification` (marked deprecated)
- Annotated deprecated aliases with `# DEPRECATED alias` comments: `message`, `audio`, `image`, `cron_reminder`, `task-output`, `system`

**Phase 2 — normalization at ingest (`src/mcp/inbox_server.py`):**
- Added `TYPE_ALIASES` dict and `normalize_message_type()` pure function after imports
- Called `normalize_message_type(msg_data)` at the single ingest point in `handle_mark_processing()`, before type validation and before the atomic move to `processing/`
- Removed `"audio"` from the `slow_types` set — it is now normalized to `"voice"` before that check is reached

The normalization is pure and immutable: it returns `{**msg, "type": canonical}` rather than mutating the dict in place. Any message already in the queue with an alias type is transparently normalized when the dispatcher calls `mark_processing`.

**Phase 3 — producer updates (cleanup pass):**
- `src/bot/slack_router.py`: `"image"` → `"photo"` for image attachments
- `scheduled-tasks/post-reminder.sh`: `"cron_reminder"` → `"scheduled_reminder"`
- `scripts/check-agent-outputs.sh`: `"system"` → `"health_check"`
- `scripts/daily-health-check.sh`: `"task-output"` → `"health_check"`
- `scripts/whatsapp-health-check.sh`: `"system"` → `"health_check"` (two call sites)
- `src/transcription/worker.py`: `not in ("voice", "audio")` → `!= "voice"`

## What was not changed

- `subagent_notification` is retained in the registry as a deprecated alias; the rename to `subagent_ack` across `inbox_server.py` comparison sites is Phase 4 (requires coordinating with dispatcher docs and is a separate, more careful change)
- No changes to dispatcher routing logic, `SKIP_TIER1_TYPES`, or any comparison sites in `inbox_server.py` other than `slow_types` and the new normalization call
- `lobster_bot.py`, `whatsapp_router.py`, `sms_router.py` — no changes needed

## Tests run

- [x] `uv run python -c "from message_types import INBOX_USER_TYPES, INBOX_SYSTEM_TYPES; assert 'reaction' in INBOX_USER_TYPES; assert 'debug_observation' in INBOX_SYSTEM_TYPES; assert 'health_check' in INBOX_SYSTEM_TYPES; assert 'subagent_ack' in INBOX_SYSTEM_TYPES"` — passed
- [x] `uv run python -c "from message_types import INBOX_MESSAGE_TYPES; print(sorted(INBOX_MESSAGE_TYPES))"` — all expected types present, no import errors
- [ ] Full test suite (`uv run pytest`) — skipped: test runner requires live MCP server and Telegram credentials not available in this environment
- [ ] Live routing test — blocked: requires production restart; safe to merge as normalization is additive and backward-compatible

Relates to #635