### PR TITLE
fix(health-check): pre-emptively mark near-threshold messages before restart

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -63,6 +63,7 @@ MAINTENANCE_FLAG="$MESSAGES_DIR/config/lobster-maintenance"
 LOBSTER_STATE_FILE="${LOBSTER_STATE_FILE_OVERRIDE:-$MESSAGES_DIR/config/lobster-state.json}"
 STALE_THRESHOLD_SECONDS=240          # 4 minutes - RED if any message older (watchdog handles soft recovery at 90s)
 YELLOW_THRESHOLD_SECONDS=150         # 2.5 minutes - YELLOW warning
+RESTART_WINDOW_BUFFER_SECONDS=120    # Pre-mark messages within this window of the stale threshold before a restart
 
 MAINTENANCE_EXPIRY_SECONDS=3600      # 1 hour - stale maintenance flag is auto-cleared and checks resume
 
@@ -876,9 +877,14 @@ record_stale_inbox_markers() {
         [[ -z "$file_time" ]] && continue
 
         local age=$((now - file_time))
-        if [[ $age -gt $STALE_THRESHOLD_SECONDS ]]; then
+        local mark_threshold=$(( STALE_THRESHOLD_SECONDS - RESTART_WINDOW_BUFFER_SECONDS ))
+        if [[ $age -gt $mark_threshold ]]; then
             touch "$STALE_INBOX_MARKER_DIR/$basename_f"
-            log_info "Circuit breaker: marked $basename_f as restart-triggering"
+            if [[ $age -gt $STALE_THRESHOLD_SECONDS ]]; then
+                log_info "Circuit breaker: marked $basename_f as restart-triggering (stale: ${age}s)"
+            else
+                log_info "Circuit breaker: pre-emptively marked $basename_f (near-threshold: ${age}s, within ${RESTART_WINDOW_BUFFER_SECONDS}s restart window)"
+            fi
         fi
     done < <(find "$INBOX_DIR" -maxdepth 1 -name "*.json" -print0 2>/dev/null)
 }


### PR DESCRIPTION
## Problem

When `do_restart()` fires for a stale-inbox condition, `record_stale_inbox_markers()` marks inbox messages as circuit-breakered so the post-restart `check_inbox_drain()` call doesn't re-alarm on the same files. The bug: only messages already over `STALE_THRESHOLD_SECONDS` (240s) were marked. Messages in the 120–240s range at restart time are not marked — and during the 10–60s restart sequence, they cross the threshold and appear as "new stale" to the post-restart check. The restart succeeded (PID changed, system GREEN), but the alert fires anyway.

This is the root cause of the 2026-03-17 03:16 UTC incident in #555: a message predating the restart was found stale post-restart, generating a false "Restarted, but new stale messages detected" Telegram alert.

## Fix

Add `RESTART_WINDOW_BUFFER_SECONDS=120` — a conservative buffer above the worst-case restart duration (~60s). In `record_stale_inbox_markers()`, the mark threshold is lowered from `STALE_THRESHOLD_SECONDS` to `STALE_THRESHOLD_SECONDS - RESTART_WINDOW_BUFFER_SECONDS` (240 - 120 = 120s). Any message older than 120s at restart time is pre-emptively circuit-breakered, ensuring it won't be treated as "new stale" by the post-restart check even if it crosses 240s during the restart sequence.

The log message now distinguishes between genuinely stale messages and pre-emptively marked near-threshold ones, making operator logs clearer.

This fix is complementary to PR #504 (post-restart cooldown for restart loops). That PR addresses a separate problem (loop prevention); this one addresses the false-positive alert on successful restarts.

## Call sequence (verified)

In `do_restart()`:
1. `record_stale_inbox_markers()` — now marks messages > 120s old
2. Restart (stop + kill-server + start + up to ~30s wait + retries)
3. `check_inbox_drain()` — skips circuit-breakered files, only alarms on genuinely new stale messages

The fix sits entirely in step 1 — earlier pre-emption of the circuit breaker.

## Functional patterns

The fix replaces the hardcoded threshold with a derived value (`mark_threshold = STALE_THRESHOLD - BUFFER`), making the relationship between constants explicit and the intent clear in logs.

Closes #555

## Tests run

- [ ] Live restart test — blocked: requires production environment with real inbox files and systemd. No automated test harness for health-check-v3.sh exists in the repo.
- [x] `bash -n scripts/health-check-v3.sh` — syntax check passed, no errors.

**Note for reviewer:** The threshold arithmetic (240 - 120 = 120s mark threshold) should be verified against the worst-case restart duration. The script header documents ~60s worst-case; the 120s buffer is intentionally 2x that.