### PR TITLE
fix: use USER_FACING_TYPES allowlist for tier-1 signal extraction and context injection

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -3480,12 +3480,7 @@ async def handle_mark_processing(args: dict) -> list[TextContent]:
 
     # Queue background observation (non-blocking, best-effort)
     msg_text = msg_data.get("text", "") or msg_data.get("transcription", "")
-    _SKIP_OBSERVATION_TYPES = (
-        "subagent_result", "subagent_error", "self_check", "subagent_observation",
-        "subagent_recovered",  # recovery events are system-internal; salvaged text is not user content
-        "debug_observation",  # never run tier 1 on our own debug output (would loop)
-    )
-    if msg_text and msg_type not in _SKIP_OBSERVATION_TYPES:
+    if msg_text and msg_type in USER_FACING_TYPES:
         _queue_observation(
             msg_text, message_id,
             source=msg_data.get("source"),
@@ -3495,11 +3490,7 @@ async def handle_mark_processing(args: dict) -> list[TextContent]:
     # Conditionally inject user model context for messages that would benefit
     context_block = ""
     short_msg_id = message_id[:20] if len(message_id) > 20 else message_id
-    _SKIP_CONTEXT_TYPES = (
-        "subagent_result", "subagent_error", "self_check", "callback", "system",
-        "subagent_observation", "subagent_recovered", "debug_observation",  # internal messages — not real user content
-    )
-    if _user_model is not None and msg_text and msg_type not in _SKIP_CONTEXT_TYPES:
+    if _user_model is not None and msg_text and msg_type in USER_FACING_TYPES:
         if _should_inject_user_context(msg_text):
             try:
                 ctx = _user_model.get_context()


### PR DESCRIPTION
## Problem

Two blocks in `mark_processing` used manually-maintained denylist tuples (`_SKIP_OBSERVATION_TYPES` and `_SKIP_CONTEXT_TYPES`) to decide whether to fire tier-1 signal extraction and user model context injection. Both tuples were missing system message types — `subagent_notification`, `cron_reminder`, `compact_group`, `update_notification`, and others — so those system messages would trigger tier-1 observations and user context injection even though they contain no user-originated content. This is both wasteful and incorrect: tier-1 extraction is supposed to learn from what the user writes, not from system notifications.

## Fix

Replace both denylist tuples with a membership check against `USER_FACING_TYPES` (already imported from `message_types.py`, already used in `check_inbox` for the same purpose). The allowlist approach is closed-world: only message types explicitly recognized as user-originated (text, voice, photo, callback, etc.) pass through; any new system type added in the future is blocked by default rather than requiring a manual denylist update.

Both blocks are changed:
- Tier-1 signal extraction (`_queue_observation` call)
- User model context injection (`_user_model.get_context()` call)

The fix removes 11 lines and adds 2. No new symbols are introduced; `USER_FACING_TYPES` was already imported at line 560.

This is the same pattern established by issues #209 / PRs #207 and #213.

## Tests run
- [x] `uv run pytest tests/unit/` — 71 failed, 1184 passed (all 71 failures are pre-existing on `main`; zero new failures introduced by this change, confirmed by running the same suite against `main` with `git stash`)
- [x] `uv run pytest tests/unit/test_mcp_server/` — 18 failed, 260 passed (same 18 pre-existing failures on both `main` and this branch)

**Blocked items needing attention before merge:** none — all failing tests are pre-existing and unrelated to this change.