### PR TITLE
Fix agent tracking: eliminate starting state, make registration hook-only

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -102,63 +102,28 @@ Before spawning a subagent, decide whether to send the dispatcher ack based on e
 ```
 1. Generate a short task_id (e.g. "fix-pr-475", "upstream-check", or a short slug describing the task)
 2. [If task will take >4s]: send_reply(chat_id, "On it.")   # brief ack, 1-3 words
-3. task_result = Task(
+3. Task(
        prompt="---\ntask_id: <task_id>\nchat_id: <chat_id>\nsource: <source>\n---\n\n...<rest of prompt>...",
        subagent_type="...",
        run_in_background=true
    )
-4. agent_id = extract agentId from task_result text (look for "agentId: <id>")
-5. output_file = extract output file path from task_result text (look for a /tmp/... path ending in .output)
-6. register_agent(
-       agent_id=agent_id,
-       task_id=task_id,           # REQUIRED — enables reliable DB matching in SubagentStop
-       description="Brief what/why + chat_id",
-       chat_id=chat_id,
-       source=msg.get("source", "telegram"),
-       output_file=output_file,
-       timeout_minutes=30,
-   )
-7. mark_processed(message_id)
-8. Return to wait_for_messages() IMMEDIATELY
+4. mark_processed(message_id)
+5. Return to wait_for_messages() IMMEDIATELY
 ```
+
+Agent registration is fully automatic — a PostToolUse hook fires immediately after each Task call and inserts a 'running' row into agent_sessions.db. You do not need to call register_agent or extract agentId/output_file.
 
 **Closing the loop when write_result arrives:**
 ```
 When wait_for_messages() returns a subagent_result/subagent_error:
 1. mark_processing(message_id)
-2. # Note: write_result auto-unregisters the agent server-side — no manual unregister_agent call needed.
-   # The tracker is updated atomically when write_result is called.
-3. ... relay or drop based on sent_reply_to_user field as usual ...
-4. mark_processed(message_id)
+2. ... relay or drop based on sent_reply_to_user field as usual ...
+3. mark_processed(message_id)
 ```
 
-**Agent tracking — why it matters:**
-
-`register_agent` writes to the SQLite agent session store (`~/messages/config/agent_sessions.db`) via `tracker.py`. Sessions survive restarts, accumulate full history (running, completed, failed), and are queryable at any time. Unlike the old JSON file, SQLite WAL mode prevents corruption and allows concurrent reads from the dashboard without blocking.
+The tracker is updated atomically when write_result is called — no dispatcher action required.
 
 Use `get_active_sessions` to answer "what agents are running?" at any time — it returns accurate data even across restarts and context compactions.
-
-When a subagent calls `write_result`, the inbox server **automatically marks** that agent as 'completed' in the session store — so the tracker stays accurate without any dispatcher action required.
-
-**Extracting the agentId from a Task result:**
-
-The Task tool returns text containing "agentId: <uuid>". Parse it with a simple search:
-```python
-import re
-match = re.search(r'agentId[:\s]+([a-f0-9\-]{8,})', task_result or "", re.IGNORECASE)
-agent_id = match.group(1) if match else f"agent-{int(time.time())}"
-```
-If the pattern does not match, fall back to a synthetic timestamp-based ID — the record is still useful for human review even without the real agent UUID.
-
-**Extracting the output_file path from a Task result:**
-
-The Task tool result text contains the path to the agent's live output file. Parse it:
-```python
-import re
-match = re.search(r'(/tmp/[^\s]+\.output)', task_result or "")
-output_file = match.group(1) if match else None
-```
-Pass this to `register_agent` as `output_file`. It enables future liveness detection — the self-check handler can stat the file's mtime to determine whether the agent is still active or has gone silent.
 
 ---
 
@@ -263,11 +228,6 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
        if pr_url_match and msg.get("sent_reply_to_user") != True:
            pr_url = pr_url_match.group(0)
            # Spawn a separate reviewer — do NOT relay engineer text to user
-           agent_id = register_agent(
-               name="pr-reviewer",
-               task_id=f"review-{msg.get('task_id', 'unknown')}",
-               chat_id=msg["chat_id"],
-           )
            Task(
                subagent_type="general-purpose",
                run_in_background=True,
@@ -739,7 +699,7 @@ The routing logic lives in the `subagent_result` handler above — when a GitHub
 
 Summary of the flow:
 1. Engineer's `write_result` arrives as `subagent_result` with a GitHub PR URL in `text`
-2. Dispatcher detects the URL, calls `register_agent(...)`, spawns reviewer via `Task(...)`, marks processed
+2. Dispatcher detects the URL, spawns reviewer via `Task(...)`, marks processed
 3. Reviewer reads the PR, posts findings with `gh pr review <N> --repo SiderealPress/lobster --comment --body "PASS/NEEDS-WORK/FAIL: ..."` (never `--approve` or `--request-changes` — same token = self-review error)
 4. Reviewer calls `write_result` with a short verdict (1–3 sentences)
 5. Dispatcher receives that `subagent_result`, relays the short verdict to the user

--- a/hooks/auto-register-agent.py
+++ b/hooks/auto-register-agent.py
@@ -3,9 +3,9 @@
 
 Fires after every Agent tool call. Extracts structured metadata from the
 agent prompt (YAML frontmatter or legacy "task_id is:" text), then inserts
-a 'starting' row into agent_sessions.db so the spawned agent is visible to
-the ghost detector and status queries without requiring the dispatcher to call
-register_agent manually.
+a 'running' row into agent_sessions.db so the spawned agent is immediately
+visible to the ghost detector and status queries. No intermediate 'starting'
+state is used — the agent IS running at the point this hook fires.
 
 ## Frontmatter format (preferred)
 
@@ -197,10 +197,14 @@ def insert_agent_session(
     session_id: str,
     output_file: str | None,
 ) -> None:
-    """Insert a 'starting' row into agent_sessions.db.
+    """Insert a 'running' row into agent_sessions.db.
 
-    Uses INSERT OR IGNORE so that a richer row written by register_agent
+    Uses INSERT OR IGNORE so that a richer row written by session_start
     (which may arrive concurrently) is left untouched.
+
+    The agent IS running at the point this PostToolUse hook fires — the Agent
+    tool was just called and the subagent process is live. There is no need for
+    a provisional 'starting' state.
 
     Raises on DB errors so the caller can log and swallow.
     """
@@ -242,7 +246,7 @@ def insert_agent_session(
                  status, output_file, spawned_at)
             VALUES
                 (?, ?, 'subagent', 'auto-registered by PostToolUse hook', ?, ?,
-                 'starting', ?, ?)
+                 'running', ?, ?)
             """,
             (
                 agent_id,

--- a/scripts/ghost-detector.py
+++ b/scripts/ghost-detector.py
@@ -364,7 +364,13 @@ def discover_filesystem_agents(
 
 
 def load_running_agents(db_path: Path) -> list[AgentRow]:
-    """Query agent_sessions.db for all running agents."""
+    """Query agent_sessions.db for all running or starting agents.
+
+    Includes 'starting' rows as a safety net: with hook-only registration
+    those rows should never accumulate, but any historical 'starting' rows
+    (from before the fix) will be caught and ghost-detected here rather than
+    silently leaking forever.
+    """
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
     try:
@@ -373,7 +379,7 @@ def load_running_agents(db_path: Path) -> list[AgentRow]:
             SELECT id, task_id, description, chat_id, status,
                    spawned_at, output_file, last_seen_at
             FROM agent_sessions
-            WHERE status = 'running'
+            WHERE status IN ('running', 'starting')
             ORDER BY spawned_at ASC
             """
         ).fetchall()

--- a/src/agents/session_store.py
+++ b/src/agents/session_store.py
@@ -495,7 +495,7 @@ def cleanup_stale_running_sessions(
         """
         SELECT id, output_file, spawned_at, timeout_minutes
         FROM agent_sessions
-        WHERE status = 'running'
+        WHERE status IN ('running', 'starting')
         """
     )
     rows = cursor.fetchall()
@@ -567,7 +567,7 @@ def cleanup_stale_running_sessions(
                 SET status = 'dead',
                     completed_at = ?,
                     result_summary = ?
-                WHERE id = ? AND status = 'running'
+                WHERE id = ? AND status IN ('running', 'starting')
                 """,
                 (completed_at, f"Marked dead at startup: {reason}", agent_id),
             )
@@ -637,7 +637,7 @@ def get_active_sessions(path: Path | None = None) -> list[dict]:
         SELECT id, task_id, agent_type, description, chat_id, source, status,
                output_file, timeout_minutes, parent_id, spawned_at
         FROM agent_sessions
-        WHERE status = 'running'
+        WHERE status IN ('running', 'starting')
         ORDER BY spawned_at ASC
         """
     )

--- a/tests/unit/test_hooks/test_auto_register_agent.py
+++ b/tests/unit/test_hooks/test_auto_register_agent.py
@@ -240,7 +240,7 @@ class TestHookAgentWithAgentId:
         assert row["task_id"] == "t-001"
         assert row["chat_id"] == "99999"
         assert row["source"] == "slack"
-        assert row["status"] == "starting"
+        assert row["status"] == "running"
 
     def test_inserts_row_with_legacy_text(self, tmp_path):
         """Legacy task_id text format inserts a row."""
@@ -294,7 +294,7 @@ class TestHookAgentWithAgentId:
         row = _get_row(tmp_path, "agent-dup")
         # Description should still be the original richer one
         assert row["description"] == "richer description"
-        assert row["status"] == "running"  # not overwritten to 'starting'
+        assert row["status"] == "running"  # INSERT OR IGNORE — existing row not overwritten
 
     def test_output_file_stored(self, tmp_path):
         """output_file from tool response is stored in DB."""


### PR DESCRIPTION
## Summary

22+ agents were permanently stuck in `starting` state because the intermediate state had no reliable path to promotion. The `auto-register-agent` PostToolUse hook inserted rows as `starting` expecting the dispatcher to follow up with `register_agent()` to promote them to `running`. Dispatchers don't always do this, so the rows leaked indefinitely — invisible to ghost detection and startup cleanup.

The fix eliminates the intermediate state entirely. The agent IS running at the point the PostToolUse hook fires (the Agent tool was just called), so there is no need for a provisional state.

## What changed

**`hooks/auto-register-agent.py`** — inserts `status='running'` instead of `'starting'`. Registration is now complete in one step; no dispatcher follow-up needed.

**`scripts/ghost-detector.py`** — `load_running_agents()` now queries `WHERE status IN ('running', 'starting')`. This is a permanent safety net: any `starting` rows that exist historically (or from a partial deploy) will be caught and ghost-detected rather than silently leaking.

**`src/agents/session_store.py`** — two query expansions:
- `cleanup_stale_running_sessions()`: SELECT and UPDATE both now match `IN ('running', 'starting')`, so startup cleanup handles stuck starters the same way as stale runners.
- `get_active_sessions()`: queries `IN ('running', 'starting')` so the dispatcher context block shows all live agents, including any residual `starting` rows.

**`.claude/sys.dispatcher.bootup.md`** — removed all instructions telling the dispatcher to call `register_agent()`, extract `agentId`, or extract `output_file` after spawning a Task. The delegation pseudocode now goes directly from `Task(...)` to `mark_processed()`. A brief note explains that registration is automatic via the PostToolUse hook. Also removed from the PR-reviewer-spawning block and the PR review flow summary.

**Live DB cleanup** — already applied: 23 rows that were stuck in `starting` have been marked `dead` with a result_summary noting the cleanup date. No `starting` rows remain in the live DB.

**Functional patterns**: pure functions unchanged; side-effect boundaries unchanged. The only behavior change is the DB value written by `insert_agent_session` and the broader WHERE clauses in three read/update paths.

## Tests run
- [x] `uv run pytest tests/unit/test_ghost_detector_filesystem.py tests/unit/test_hooks/test_auto_register_agent.py -q` — 65 passed, 0 failed
- [x] `uv run pytest tests/unit/ -q` — 1177 passed, 72 failed. The 72 failures are pre-existing (confirmed by stash-testing against main): they span `test_require_write_result`, `test_update_manager`, `test_message_tools`, `test_transcription`, `test_write_observation`, and `test_session_management` — none related to this change.

Closes #667

🤖🦞 Lobster (engineer): opened by fix-ghost-agent-tracking subagent