### PR TITLE
docs: add Task System section to dispatcher bootup

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -991,6 +991,66 @@ When a message references something that seems to be missing — e.g., "use this
 
 Users can run `lobster update` to pull the latest code and apply pending migrations. Surface this when users ask how to update Lobster or when you're aware that migrations need to run.
 
+## Task System
+
+The task system is a first-class part of the dispatcher workflow. Use it to track work across sessions and subagents.
+
+### At session start
+
+After reading handoff and user model, call `list_tasks(status="pending")` to recover any in-progress work. If tasks exist, they are the starting point before processing new messages. Mention open tasks briefly in your initial orientation — they represent commitments that may need follow-up.
+
+```
+1. Read handoff.md
+2. Read user-model/_context.md (if exists)
+3. list_tasks(status="pending")  ← recover any open work
+4. If pending tasks exist, decide: are any stale? Any that need user notification?
+5. wait_for_messages()
+```
+
+### When user gives a task
+
+When the user assigns a task that will be handled by a subagent, create a task record immediately before spawning the subagent. Pass the task_id to the subagent in the prompt header.
+
+```
+1. create_task(subject="...", description="...")  ← get task_id back
+2. update_task(task_id, status="in_progress")
+3. send_reply(chat_id, "On it.")
+4. Task(
+       prompt="---\ntask_id: <task_id>\nchat_id: <chat_id>\n...\n---\n\n...",
+       subagent_type="...",
+       run_in_background=True,
+   )
+5. mark_processed(message_id)
+```
+
+The task_id in the subagent prompt header is how the subagent identifies itself when calling write_result. Use descriptive subjects: "Review PR #42", "Research BEADS task system", "Fix bug in scheduler".
+
+### When subagent completes
+
+When a subagent_result or subagent_notification arrives for a tracked task, close it out:
+
+```
+update_task(task_id, status="completed")
+```
+
+### When task stalls or is abandoned
+
+If a task is abandoned (user changes direction, subagent fails, or context is lost), mark it pending again with a note rather than leaving it in_progress forever:
+
+```
+update_task(
+    task_id,
+    status="pending",
+    description="<original description>\n\n[Stalled: <reason>. Pick up from here next session.]"
+)
+```
+
+### Rules
+
+- Keep the task list short — completed tasks accumulate. Periodically delete old completed tasks so the list stays useful.
+- The task list is a session-recovery tool, not a permanent project tracker. If a task spans multiple sessions, the description should have enough context to resume without reading history.
+- Do NOT create tasks for instant/inline responses (answering a question, brief lookups). Tasks are for delegated subagent work that takes >30 seconds.
+
 ## Dispatcher Behavior Guidelines
 
 The following guidelines apply to the dispatcher only (in addition to the shared guidelines in CLAUDE.md):


### PR DESCRIPTION
## Summary

- Adds a new `## Task System` section to `sys.dispatcher.bootup.md` documenting how the task system integrates with the dispatcher workflow
- Covers four lifecycle moments: session start (recover pending tasks), task assignment (create + delegate), completion (mark done), and stall/abandonment (reset to pending with note)
- Includes explicit rules: keep the list short, tasks are for delegated work not inline answers, descriptions should carry enough context to resume across sessions

## Test plan

- [ ] Verify dispatcher reads `list_tasks(status="pending")` at session start in next boot
- [ ] Verify tasks get created and tracked when subagents are spawned for user requests
- [ ] File edit is already live (`.claude/` symlink) — no deploy step needed

Note: pure doc/prompt change, smoke test exemption applies per PR prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)