### PR TITLE
fix: specify timeout=1800 to prevent post-compaction hibernation

### DIFF
--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -66,7 +66,7 @@ REMINDER_TEXT = (
     "  \u2190 active projects, key people, priorities\n\n"
     "After reading: spawn the compact_catchup subagent to recover context from the\n"
     "last ~30 minutes (see sys.dispatcher.bootup.md \u2192 'Handling compact-reminder').\n"
-    "Then resume your main loop by calling wait_for_messages()."
+    "Then resume your main loop by calling wait_for_messages(timeout=1800, hibernate_on_timeout=True)."
 )
 
 SENTINEL_FILE = Path(os.path.expanduser("~/messages/config/compact-pending"))

--- a/scripts/claude-persistent.sh
+++ b/scripts/claude-persistent.sh
@@ -370,7 +370,7 @@ launch_claude() {
     fi
 
     # Build the initial prompt for Claude
-    local init_prompt="Read CLAUDE.md and begin your main loop. Call wait_for_messages(hibernate_on_timeout=true) to start listening for Telegram messages. Process each message as it arrives, then return to wait_for_messages(). Never exit unless hibernating."
+    local init_prompt="Read CLAUDE.md and begin your main loop. Call wait_for_messages(timeout=1800, hibernate_on_timeout=true) to start listening for Telegram messages. Process each message as it arrives, then return to wait_for_messages(timeout=1800, hibernate_on_timeout=true). Never exit unless hibernating."
 
     # Always start fresh. Never use --continue.
     #


### PR DESCRIPTION
After context compaction, the dispatcher was immediately hibernating if the inbox happened to be empty for a brief moment. The root cause: neither the initial launch prompt nor the post-compact reminder specified a `timeout` argument to `wait_for_messages()`, so the dispatcher was receiving the default `timeout=1` — a 1-second window that expired before any message arrived.

## What changed

Two call sites updated to pass `timeout=1800, hibernate_on_timeout=True` explicitly:

- **`scripts/claude-persistent.sh`** (init prompt): the dispatcher is now told to call `wait_for_messages(timeout=1800, hibernate_on_timeout=true)` from the start, not a bare call with no timeout.
- **`hooks/on-compact.py`** (`REMINDER_TEXT`): the compact-recovery message now ends with `wait_for_messages(timeout=1800, hibernate_on_timeout=True)` so the dispatcher enters the normal 30-minute blocking wait after re-orienting, not a 1-second poll.

Both call sites were independently broken — either one alone was enough to trigger silent hibernation.

## What is not changed

No changes to the `wait_for_messages` server implementation, the compaction detection logic, the sentinel file mechanism, or any other dispatcher behavior. This is a prompt/instruction fix only.

## Functional pattern

Pure instruction change — no logic, just making implicit behavior (default timeout) explicit and correct.

## Tests run

- [x] `git diff` reviewed — two targeted one-line changes, both correct
- [ ] Live dispatcher test — requires production restart; no behavior change at the code level, safe to merge

**Blocked items needing attention before merge:** none

Fixes post-compaction hibernation bug.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>