### PR TITLE
rename: ghost-detector.py → agent-monitor.py, cron every 5 min

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -176,9 +176,9 @@ Scheduled reminders are injected by `scripts/post-reminder.sh`, called from cron
 REMINDER_ROUTING = {
   "ghost_detector": {
     "subagent_type": "lobster-generalist",
-    "prompt": "---\ntask_id: ghost-detector\nchat_id: 0\nsource: system\n---\n\n"
-              "Run the ghost detector check. Script is at ~/lobster/scripts/ghost-detector.py. "
-              "Run it with uv run ~/lobster/scripts/ghost-detector.py and report findings.",
+    "prompt": "---\ntask_id: agent-monitor\nchat_id: 0\nsource: system\n---\n\n"
+              "Run the agent monitor check. Script is at ~/lobster/scripts/agent-monitor.py. "
+              "Run it with uv run ~/lobster/scripts/agent-monitor.py and report findings.",
   },
   "oom_check": {
     "subagent_type": "lobster-generalist",
@@ -294,7 +294,7 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
 
 ## Handling Agent Failures (`agent_failed`)
 
-The reconciler and ghost-detector route dead/failed agent events to `chat_id=0` with `type: "agent_failed"`. These are **system-internal** — never relay them to the user's Telegram directly. The dispatcher reads the context and decides the right action.
+The reconciler and agent-monitor route dead/failed agent events to `chat_id=0` with `type: "agent_failed"`. These are **system-internal** — never relay them to the user's Telegram directly. The dispatcher reads the context and decides the right action.
 
 **When `wait_for_messages` returns a message with `type: "agent_failed"`:**
 
@@ -315,7 +315,7 @@ The reconciler and ghost-detector route dead/failed agent events to `chat_id=0` 
       summary to the original_chat_id:
         send_reply(chat_id=msg["original_chat_id"], text="A background task failed: <description>. Let me know if you would like to retry.")
    C. Log and drop silently: if the task_id suggests a background/system job (e.g.,
-      "ghost-mark-failed-*", "oom-check", "ghost-detector", reconciler tasks with
+      "ghost-mark-failed-*", "oom-check", "agent-monitor", reconciler tasks with
       no original_chat_id or original_chat_id=0/"") — just mark_processed without
       notifying the user.
 

--- a/hooks/auto-register-agent.py
+++ b/hooks/auto-register-agent.py
@@ -294,7 +294,7 @@ def main() -> None:
             # No agent ID in response -- nothing to register
             sys.exit(0)
 
-        # Store first 500 chars of the prompt as input_summary so ghost-detector
+        # Store first 500 chars of the prompt as input_summary so agent-monitor
         # and the dispatcher can reconstruct context if the agent fails.
         input_summary = prompt[:500] if prompt else None
 

--- a/scripts/agent-monitor.py
+++ b/scripts/agent-monitor.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Ghost agent detector — finds agents that may have died without calling write_result.
+"""Agent monitor — detects stale, dead, and stuck agents that never called write_result.
 
 A "ghost agent" is a background subagent registered in agent_sessions.db with
 status=running that never completed (never called write_result). This tool
@@ -15,12 +15,12 @@ called. These are reported but NOT corrected — if they appear, it means the
 SubagentStop hook (PR #418) isn't working. Auto-correcting would hide the bug.
 
 Usage:
-    uv run scripts/ghost-detector.py
-    uv run scripts/ghost-detector.py --threshold-minutes 60
-    uv run scripts/ghost-detector.py --output-file-threshold-minutes 5
-    uv run scripts/ghost-detector.py --alert
-    uv run scripts/ghost-detector.py --mark-failed
-    uv run scripts/ghost-detector.py --no-fs-scan
+    uv run scripts/agent-monitor.py
+    uv run scripts/agent-monitor.py --threshold-minutes 60
+    uv run scripts/agent-monitor.py --output-file-threshold-minutes 5
+    uv run scripts/agent-monitor.py --alert
+    uv run scripts/agent-monitor.py --mark-failed
+    uv run scripts/agent-monitor.py --no-fs-scan
 
 Exit codes:
     0 — no GHOST_CONFIRMED or UNREGISTERED agents found
@@ -568,7 +568,7 @@ def send_alert(
     alert_text = (
         "Ghost agent alert:\n\n"
         + "\n\n".join(parts)
-        + "\n\nRun `uv run scripts/ghost-detector.py` for full report."
+        + "\n\nRun `uv run scripts/agent-monitor.py` for full report."
     )
 
     # The MCP server is not available as a subprocess; use the lobster-inbox
@@ -649,7 +649,7 @@ def mark_agent_completed(db_path: Path, agent_id: str) -> None:
     try:
         conn.execute(
             "UPDATE agent_sessions SET status='completed', result_summary=? WHERE id=?",
-            ("auto-corrected by ghost-detector: transcript confirmed write_result was called", agent_id),
+            ("auto-corrected by agent-monitor: transcript confirmed write_result was called", agent_id),
         )
         conn.commit()
     finally:
@@ -662,7 +662,7 @@ def mark_agent_failed(db_path: Path, agent_id: str) -> None:
     try:
         conn.execute(
             "UPDATE agent_sessions SET status='failed', result_summary=? WHERE id=?",
-            ("marked failed by ghost-detector --mark-failed", agent_id),
+            ("marked failed by agent-monitor --mark-failed", agent_id),
         )
         conn.commit()
     finally:
@@ -712,7 +712,7 @@ def build_mark_failed_inbox_message(agent: ClassifiedAgent) -> dict:
         "text": (
             f"Ghost agent detected and marked failed: '{desc}'\n"
             f"Agent age: {age_str} | Last output: {file_age_str} ago\n"
-            f"Detected by ghost-detector.py. Dispatcher should decide whether to re-queue."
+            f"Detected by agent-monitor.py. Dispatcher should decide whether to re-queue."
         ),
         "task_id": f"ghost-mark-failed-{short_id}",
         "agent_id": agent_id,
@@ -765,7 +765,7 @@ def build_unregistered_mark_failed_payload(agent: UnregisteredAgent) -> dict:
         "source": "system",
         "chat_id": 0,
         "text": (
-            f"Unregistered dead agent {agent.agent_id} detected by ghost-detector.py. "
+            f"Unregistered dead agent {agent.agent_id} detected by agent-monitor.py. "
             f"Output file last modified {agent.output_file_age_minutes:.0f}m ago. "
             f"This agent was never registered in agent_sessions.db — likely a registration failure."
         ),
@@ -849,7 +849,7 @@ def mark_failed_unregistered_dead(unregistered: list[UnregisteredAgent]) -> None
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Detect ghost agents — running sessions that never called write_result.",
+        description="Agent monitor — detect stale, dead, and stuck agents that never called write_result.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )

--- a/scripts/oom-monitor.py
+++ b/scripts/oom-monitor.py
@@ -268,7 +268,7 @@ def format_telegram_alert(events: list[OomKillEvent]) -> str:
             lines.append(f"  • `{e.process_name}` (PID {e.pid})")
 
     lines.append("")
-    lines.append("Run `uv run scripts/ghost-detector.py` to check for ghost agents.")
+    lines.append("Run `uv run scripts/agent-monitor.py` to check for ghost agents.")
 
     return "\n".join(lines)
 
@@ -290,7 +290,7 @@ def format_inbox_message(events: list[OomKillEvent]) -> dict:
     text = (
         f"OOM kill alert: {len(events)} process(es) killed by the Linux OOM killer. "
         f"{lobster_count} Lobster-related process(es) affected ({process_names}). "
-        f"Subagents may have become ghosts — run ghost-detector.py to check."
+        f"Subagents may have become ghosts — run agent-monitor.py to check."
     )
     return {
         "id": msg_id,

--- a/src/mcp/message_types.py
+++ b/src/mcp/message_types.py
@@ -42,7 +42,7 @@ INBOX_SYSTEM_TYPES: frozenset[str] = frozenset({
     "subagent_observation",   # subagent noticed something in passing (debug/context)
     "subagent_stale_check",   # dispatch registry found agent with stale heartbeat
     "subagent_recovered",     # subagent fallback recovery event (chat_id unknown; dispatcher handles, never relay directly)
-    "agent_failed",           # reconciler/ghost-detector detected dead agent (chat_id=0; dispatcher decides re-queue vs escalate vs drop)
+    "agent_failed",           # reconciler/agent-monitor detected dead agent (chat_id=0; dispatcher decides re-queue vs escalate vs drop)
     "compact_group",          # grouped compact messages (internal, produced by check_inbox)
     "compact_reminder",       # on-compact hook reminder (hooks/on-compact.py)
     "cron_reminder",          # DEPRECATED alias — normalizes to "scheduled_reminder" on ingest

--- a/tests/unit/test_ghost_detector_filesystem.py
+++ b/tests/unit/test_ghost_detector_filesystem.py
@@ -1,4 +1,4 @@
-"""Unit tests for the filesystem-based ghost detection additions in ghost-detector.py.
+"""Unit tests for the filesystem-based ghost detection additions in agent-monitor.py.
 
 All tests operate on pure functions — no DB access, no real filesystem reads
 beyond temp-dir fixtures.
@@ -15,9 +15,9 @@ import importlib.util
 
 import pytest
 
-# ghost-detector.py has a hyphenated filename so it can't be imported via
+# agent-monitor.py has a hyphenated filename so it can't be imported via
 # normal sys.path manipulation. Use importlib to load it directly.
-_SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "ghost-detector.py"
+_SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "agent-monitor.py"
 _spec = importlib.util.spec_from_file_location("ghost_detector", _SCRIPT_PATH)
 assert _spec is not None and _spec.loader is not None
 gd = importlib.util.module_from_spec(_spec)

--- a/tests/unit/test_mcp_server/test_agent_failure_recovery.py
+++ b/tests/unit/test_mcp_server/test_agent_failure_recovery.py
@@ -4,7 +4,7 @@ Tests for agent failure recovery — issue #669.
 Verifies:
 - _build_reconciler_message routes 'dead' outcomes to chat_id=0 / type='agent_failed'
 - _build_reconciler_message routes 'completed' outcomes to originating chat_id / type='subagent_result'
-- build_mark_failed_inbox_message (ghost-detector) uses chat_id=0 / type='agent_failed'
+- build_mark_failed_inbox_message (agent-monitor) uses chat_id=0 / type='agent_failed'
 - build_unregistered_mark_failed_payload uses chat_id=0 / type='agent_failed'
 - auto-register-agent stores input_summary in DB
 - agent_failed is present in INBOX_SYSTEM_TYPES
@@ -30,7 +30,7 @@ _MCP_DIR = str(_ROOT / "src" / "mcp")
 if _MCP_DIR not in sys.path:
     sys.path.insert(0, _MCP_DIR)
 
-_GHOST_DETECTOR_PATH = _ROOT / "scripts" / "ghost-detector.py"
+_GHOST_DETECTOR_PATH = _ROOT / "scripts" / "agent-monitor.py"
 _spec = importlib.util.spec_from_file_location("ghost_detector_669", _GHOST_DETECTOR_PATH)
 assert _spec is not None and _spec.loader is not None
 _gd = importlib.util.module_from_spec(_spec)
@@ -125,7 +125,7 @@ class TestBuildReconcilerMessage:
         session = dict(_BASE_SESSION)
         # Dead agents are those with outcome == "dead"
         # The function should produce a message with chat_id=0 and type=agent_failed
-        # We verify this through the ghost-detector path which shares the same contract.
+        # We verify this through the agent-monitor path which shares the same contract.
         # Direct function test is done below via a minimal reimplementation.
         assert True  # Placeholder — see TestBuildReconcilerMessageDirect below
 
@@ -220,11 +220,11 @@ class TestBuildReconcilerMessageDirect:
 
 
 # ---------------------------------------------------------------------------
-# Test: ghost-detector build_mark_failed_inbox_message
+# Test: agent-monitor build_mark_failed_inbox_message
 # ---------------------------------------------------------------------------
 
 class TestGhostDetectorMarkFailedPayload:
-    """Verify ghost-detector routes agent_failed to chat_id=0."""
+    """Verify agent-monitor routes agent_failed to chat_id=0."""
 
     def _make_classified_agent(self, chat_id: str = "8305714125") -> object:
         """Create a minimal ClassifiedAgent-like object for testing."""
@@ -283,7 +283,7 @@ class TestGhostDetectorMarkFailedPayload:
 
 
 class TestGhostDetectorUnregisteredPayload:
-    """Verify ghost-detector unregistered agent notifications route to chat_id=0."""
+    """Verify agent-monitor unregistered agent notifications route to chat_id=0."""
 
     def _make_unregistered(self) -> object:
         return _gd.UnregisteredAgent(


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

The script was named for one narrow failure mode ("ghosts") but it already catches stale, dead, stuck, and unregistered agents, plus COMPLETED_NOT_UPDATED divergences. The old name undersold its scope and caused confusion about when to use it.

This PR renames it to `agent-monitor.py` and wires everything up so no caller is left pointing at the old path.

## What changed

**Renamed:** `scripts/ghost-detector.py` → `scripts/agent-monitor.py`
- Docstring, usage examples, argparse description, and DB audit-trail strings updated to reference `agent-monitor`
- No behavior changes — pure rename plus internal string updates

**Updated callers inside the repo:**
- `.claude/sys.dispatcher.bootup.md` — reminder routing prompt and task_id updated (`ghost-detector` → `agent-monitor`)
- `scripts/oom-monitor.py` — cross-reference in report output and inbox message updated
- `hooks/auto-register-agent.py` — comment updated
- `src/mcp/message_types.py` — inline comment updated
- `tests/unit/test_ghost_detector_filesystem.py` — loads `agent-monitor.py` via importlib
- `tests/unit/test_mcp_server/test_agent_failure_recovery.py` — loads `agent-monitor.py` via importlib

**Outside the repo (applied directly):**
- Crontab: removed `*/10` ghost-detector entry, added `*/5` agent-monitor entry (same flags: `--alert --mark-failed`, same log redirect to `logs/agent-monitor.log`)
- `~/lobster-user-config/agents/user.base.bootup.md` — "Ghost Agent Detector" section renamed to "Agent Monitor"

## What is not changed

The script's classification logic, alert behavior, and mark-failed flow are untouched. The `GHOST_CONFIRMED` / `GHOST_SUSPECTED` / `STALE_NO_FILE` / `HEALTHY` classification names are kept as-is — they are accurate within the script.

The dispatcher's `REMINDER_ROUTING` key is still `ghost_detector` (only the prompt/task_id strings inside it changed). Renaming the routing key would require a migration; that's a separate concern.

## Functional patterns

Pure rename — no logic changes. The script itself is built on pure data functions (`classify`, `build_report`, `build_mark_failed_inbox_message`) with side effects isolated at the boundary (`mark_failed_ghost`, `drop_inbox_message`). This PR doesn't touch that structure.

## Tests run

- [x] `uv run pytest tests/unit/test_ghost_detector_filesystem.py tests/unit/test_mcp_server/test_agent_failure_recovery.py -v` — 60 passed, 0 failed