### PR TITLE
feat: add code-internals rule to dispatcher bootup

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -85,8 +85,8 @@ mark_processed(message_id)
 
 If you find yourself reaching for `Read`, `Bash`, `mcp__github__*`, `WebFetch`, or any tool not in the core loop list, stop. Write "On it.", spawn a subagent, and return to the loop.
 
-**Code internals questions → spawn an auditor, don't speculate**
-If Sahar asks how a system works internally, what a function does, or about the architecture of any Lobster component, spawn a `lobster-auditor` subagent to read the actual code. Do NOT reason from context or give plausible-sounding explanations without reading the source. A wrong answer is worse than "let me check."
+**Code internals questions → delegate, don't speculate**
+When asked how something works internally (a function, a module, a system), spawn a subagent to read the actual code — unless the answer is already present in the current context from a recently returned subagent report. Do not reason from memory or give plausible-sounding explanations without source confirmation.
 
 **Ack policy — when to send "On it." before delegating:**
 

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -85,6 +85,9 @@ mark_processed(message_id)
 
 If you find yourself reaching for `Read`, `Bash`, `mcp__github__*`, `WebFetch`, or any tool not in the core loop list, stop. Write "On it.", spawn a subagent, and return to the loop.
 
+**Code internals questions → spawn an auditor, don't speculate**
+If Sahar asks how a system works internally, what a function does, or about the architecture of any Lobster component, spawn a `lobster-auditor` subagent to read the actual code. Do NOT reason from context or give plausible-sounding explanations without reading the source. A wrong answer is worse than "let me check."
+
 **Ack policy — when to send "On it." before delegating:**
 
 **Two-layer ack architecture:** The Telegram bot (`lobster_bot.py`) automatically sends "📨 Message received. Processing..." to the user at the transport layer as soon as it writes a text message to the inbox. This fires for all plain text messages before you ever see the message. Your "On it." is a *second*, dispatcher-level ack — it signals that work is underway, not that the message was received.


### PR DESCRIPTION
## Summary

- Adds a new rule to the 7-Second Rule section of `sys.dispatcher.bootup.md`
- Instructs the dispatcher to always spawn a `lobster-auditor` subagent when Sahar asks how any Lobster component works internally
- Prevents the dispatcher from giving plausible-sounding but potentially wrong explanations from context alone

## Test plan

- [ ] Verify rule appears in the correct location in the file (after the 7-Second Rule enforcement paragraph)
- [ ] Confirm live file at `~/lobster-workspace/.claude/sys.dispatcher.bootup.md` reflects the change (symlink is already live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)