### PR TITLE
fix: require before/after flow diagrams for multi-step flow PRs

### DIFF
--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -108,6 +108,8 @@ A PR description is a communication artifact, not a changelog. Its audience is a
 
 **Include the functional patterns used.** For this codebase, briefly note which functional patterns the implementation relies on (pure functions, composition, immutability, etc.) — this helps reviewers understand the design intent and verify that the code follows project conventions.
 
+**Include a before/after flow diagram for any PR that changes a multi-step flow, notification sequence, state machine, or retry logic.** ASCII diagrams are fine. The diagram must show the states that exist, which transitions are affected, and what the change does to that flow. A reviewer should be able to answer "what could I no longer do after this merges, and what can I now do?" without reading the diff. If the change is purely internal (no state transitions or sequencing altered), note that explicitly so the reviewer knows no diagram is needed.
+
 **Calibration check — before writing, ask yourself:**
 - Can a reviewer understand *why* this change exists from the first two sentences?
 - If they can only read 30 seconds of your description, do they have enough to decide "safe to merge"?


### PR DESCRIPTION
PR #685 (a multi-path notification control flow change) shipped without a state machine diagram, leaving the reviewer unable to trace what the change actually did to the flow. The PR description standards in `functional-engineer.md` had no requirement for diagrams — this closes that gap.

A single paragraph is added to the **Writing the PR description** section, after the "Include the functional patterns used" principle. It requires that any PR altering a multi-step flow, notification sequence, state machine, or retry logic include a before/after diagram. ASCII is acceptable. The diagram must show states, transitions affected, and the net effect of the change. PRs with no state or sequencing changes are explicitly asked to say so, so reviewers know the omission is intentional rather than an oversight.

Nothing else in the file changed — all existing principles, examples, and tests-run format are untouched.

Closes #686

## Tests run
- [ ] No automated tests apply to a documentation-only change — this is a `.md` file edit with no code changes.

**Blocked items needing attention before merge:** none