### PR TITLE
fix: decouple system repo from user work target in agent bootup files

### DIFF
--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -66,7 +66,7 @@ Use the following signals to infer which mode is appropriate. These are heuristi
 - A GitHub issue number, PR number, or Linear ticket ID
 - `chat_id`, `source`, `task_id`, and optionally `repo`
 
-**Default repo:** If no repo is specified, default to `SiderealPress/lobster` (owner=SiderealPress, repo=lobster).
+**Default repo:** If no repo is specified in the task context, look at the PR URL (which contains the owner/repo) or ask the user. Do not default to `SiderealPress/lobster` — that is the Lobster system repo, not the user's work target.
 
 ### Review sources — what to handle
 
@@ -97,7 +97,7 @@ Before forming any opinion, read:
 Post PR review comments using the `gh` CLI via the Bash tool, not MCP tools:
 
 ```bash
-gh pr review <PR_NUMBER> --repo SiderealPress/lobster --comment --body "Your review text here"
+gh pr review <PR_NUMBER> --repo <owner/repo> --comment --body "Your review text here"
 ```
 
 Substitute the actual PR number and repo as appropriate. Use `--repo owner/repo` explicitly if the working directory is not inside the target repo.
@@ -211,8 +211,8 @@ If `LINEAR_API_KEY` is not set in the environment, note that Linear context was 
 ## Constraints that are not obvious
 
 - **Use `gh` CLI for posting reviews and comments** (not MCP tools). Examples:
-  - Code review: `gh pr review 47 --repo SiderealPress/lobster --comment --body "PASS/NEEDS-WORK/FAIL: ..."`
-  - Design review: `gh issue comment 42 --repo SiderealPress/lobster --body "APPROVE/MODIFY/REJECT: ..."`
+  - Code review: `gh pr review 47 --repo <owner/repo> --comment --body "PASS/NEEDS-WORK/FAIL: ..."`
+  - Design review: `gh issue comment 42 --repo <owner/repo> --body "APPROVE/MODIFY/REJECT: ..."`
 - **Deliver results in two steps:** call `send_reply(chat_id, text, source=source)` first (crash-safe), then call `write_result(..., sent_reply_to_user=True)` so the dispatcher marks processed without re-sending. Pass `source` through from your input.
 - If no PR is linked to a code review request, post a comment on the issue noting that and report back — don't silently fail.
 - If running in a context without a cloned repo, use `gh` and `curl` for all data access.

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -66,7 +66,7 @@ Use the following signals to infer which mode is appropriate. These are heuristi
 - A GitHub issue number, PR number, or Linear ticket ID
 - `chat_id`, `source`, `task_id`, and optionally `repo`
 
-**Default repo:** If no repo is specified in the task context, look at the PR URL (which contains the owner/repo) or ask the user. Do not default to `SiderealPress/lobster` — that is the Lobster system repo, not the user's work target.
+**Default repo:** If no repo is specified in the task context, infer it from context first (PR URL, issue body, task prompt — all of these contain owner/repo). Only ask the user if the repo is still ambiguous after inference. Do not default to `SiderealPress/lobster` — that is the Lobster system repo, not the user's work target.
 
 ### Review sources — what to handle
 

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -250,7 +250,8 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
                    f"source: {msg.get('source', 'telegram')}\n"
                    f"---\n\n"
                    f"Review PR {pr_url} and post your findings using:\n"
-                   f"  gh pr review <N> --repo SiderealPress/lobster --comment --body \"PASS/NEEDS-WORK/FAIL: ...\"\n"
+                   f"  gh pr review <N> --repo <owner/repo> --comment --body \"PASS/NEEDS-WORK/FAIL: ...\"\n"
+                   f"The owner/repo is in the PR URL above — extract it from there (e.g. https://github.com/owner/repo/pull/N).\n"
                    f"Use --comment only (never --approve or --request-changes — same token = self-review error).\n\n"
                    f"After posting, call write_result with a short verdict summary (1–3 sentences).\n\n"
                    f"Engineer's briefing:\n{msg['text']}"
@@ -766,7 +767,7 @@ The routing logic lives in the `subagent_result` handler above — when a GitHub
 Summary of the flow:
 1. Engineer's `write_result` arrives as `subagent_result` with a GitHub PR URL in `text`
 2. Dispatcher detects the URL, spawns reviewer via `Task(...)`, marks processed
-3. Reviewer reads the PR, posts findings with `gh pr review <N> --repo SiderealPress/lobster --comment --body "PASS/NEEDS-WORK/FAIL: ..."` (never `--approve` or `--request-changes` — same token = self-review error)
+3. Reviewer reads the PR, posts findings with `gh pr review <N> --repo <owner/repo> --comment --body "PASS/NEEDS-WORK/FAIL: ..."` — using the owner/repo from the PR URL (never `--approve` or `--request-changes` — same token = self-review error)
 4. Reviewer calls `write_result` with a short verdict (1–3 sentences)
 5. Dispatcher receives that `subagent_result`, relays the short verdict to the user
 

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -9,7 +9,7 @@ Lobster is an always-on AI assistant that processes messages from Telegram and S
 - **Dispatcher (main loop):** Receives incoming messages via `wait_for_messages`, sends quick acknowledgments, and spawns background subagents for any work taking more than ~7 seconds.
 - **Subagents (you):** Handle specific tasks — research, code review, GitHub ops, implementation — then report back.
 
-Users communicate through a chat interface (Telegram or Slack), typically on mobile. Keep replies concise and mobile-friendly. The GitHub repo is `SiderealPress/lobster`.
+Users communicate through a chat interface (Telegram or Slack), typically on mobile. Keep replies concise and mobile-friendly. The Lobster system repo is `SiderealPress/lobster` — this is where Lobster product code lives. The user's work target (the repo they want you to act on for a given task) is separate: determine it from the task context or message, not from a hardcoded assumption.
 
 When your task is complete, choose the right delivery pattern based on your task type:
 
@@ -273,9 +273,9 @@ Lobster uses a tiered model strategy to balance cost and quality. Each subagent 
 ## Tooling conventions
 
 - **GitHub operations:** Use `gh` CLI (via Bash tool) for all GitHub operations — posting PR reviews, merging PRs, creating issues, etc. Do NOT use `mcp__github__*` MCP tools in agent code.
-  - Post a PR review: `gh pr review <number> --comment --body "..." --repo SiderealPress/lobster`
-  - Merge a PR: `gh pr merge <number> --squash --repo SiderealPress/lobster`
-  - Create an issue: `gh issue create --title "..." --body "..." --repo SiderealPress/lobster`
+  - Post a PR review: `gh pr review <number> --comment --body "..." --repo <owner/repo>`
+  - Merge a PR: `gh pr merge <number> --squash --repo <owner/repo>`
+  - Create an issue: `gh issue create --title "..." --body "..." --repo <owner/repo>`
 
 - **Code reviews — always post to the PR:** When conducting a code review of a GitHub PR, you MUST post the review directly to the PR using `gh pr review`, then also send the summary back via `write_result`.
   1. Post to the PR: `gh pr review <PR_NUMBER> --repo <owner/repo> --comment --body "REVIEW TEXT"`
@@ -289,7 +289,7 @@ Lobster uses a tiered model strategy to balance cost and quality. Each subagent 
   - Short one-liner comments (e.g., closing a stale issue) may use the prefix inline: `🤖🦞 Lobster: <reason>`
   - Never omit this prefix when posting substantial content to GitHub under Sahar's account.
 
-- **Default repo:** `SiderealPress/lobster` (owner=SiderealPress, repo=lobster). If no repo is specified in your task, use this.
+- **Default repo:** `SiderealPress/lobster` (owner=SiderealPress, repo=lobster) is the Lobster *system* repo — for Lobster maintenance tasks. For user work tasks, get the target repo from the task context or message; do not default to the system repo.
 
 - **Linear API:** Access Linear via REST API. The `LINEAR_API_KEY` environment variable is set. GraphQL endpoint: `https://api.linear.app/graphql`. Use `curl -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json"`.
 


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Problem

Agent prompts have been treating `SiderealPress/lobster` as the default GitHub repo for all operations — including code reviews, PR creation, and issue management on *user work tasks*. This is wrong. `SiderealPress/lobster` is the Lobster *system* repo where product code lives. The user's work target is whatever repo they're asking Lobster to help with for a given task, which could be anything.

The bug: an agent asked to "review PR #47" with no explicit repo would silently default to running `gh pr review 47 --repo SiderealPress/lobster`, likely operating on the wrong repo entirely.

Closes #688. Step 1 of 2; step 2 (per-project context architecture) is #546.

## What changed

Three files, all in `.claude/`:

**`sys.subagent.bootup.md`** — Two fixes:
1. The system primer ("The GitHub repo is `SiderealPress/lobster`") now correctly identifies this as the *system* repo and explicitly states that the user's work target must come from task context.
2. The tooling conventions "Default repo" instruction and CLI examples (`gh pr review`, `gh pr merge`, `gh issue create`) no longer hardcode the system repo as a default — they now use `<owner/repo>` placeholders.

**`review.md`** — The code review agent's "Default repo" fallback ("if no repo is specified, default to SiderealPress/lobster") is replaced with: look at the PR URL (which contains the owner/repo), or ask the user. CLI examples updated to `<owner/repo>` placeholders.

**`sys.dispatcher.bootup.md`** — The reviewer prompt template (the string injected into spawned reviewer subagents) hardcoded `--repo SiderealPress/lobster`. Now uses `<owner/repo>` and instructs the reviewer to extract owner/repo from the PR URL already present in the prompt.

## What is not changed

- `lobster-auditor.md` references to `SiderealPress/lobster` — the auditor monitors the Lobster system itself, so these are correct.
- `user.base.bootup.md` "Default repo" line — this is a user config file (private, not in repo). For the current install it reflects Sahar's workflow accurately. The correct fix (per #546) is to surface this through the per-project context layer, not to remove it now.
- No behavior changes outside bootup/agent prompt files.

## Functional patterns

Pure textual substitution — no logic changes. The changes are to instruction text that is interpreted by LLM agents at runtime, not executable code.

## Tests run

- [x] `grep -rn "SiderealPress/lobster" .claude/` in worktree — only 3 intentional remaining mentions, all clearly labeled as "this is the system repo, not the user's work target"
- [x] `git diff` reviewed — changes are surgical, no unintended modifications
- [ ] Live reviewer agent test (spawning a reviewer for a non-lobster repo PR) — skipped: would require a live dispatcher session and a test PR on another repo. The change is in prompt text; the reviewer will now correctly extract the repo from the PR URL it receives.