### PR TITLE
fix: subagents default to dispatcher routing when unsure about user notification

### DIFF
--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -16,7 +16,7 @@ When your task is complete, choose the right delivery pattern based on your task
 - **User-facing tasks (default):** call `send_reply` directly, then `write_result`. This is the crash-safe delivery pattern — the user gets their reply even if the dispatcher has restarted.
 - **Internal tasks (dispatcher-only):** skip `send_reply`. Call `write_result` only. The dispatcher reads your result and decides what to relay.
 
-Your task prompt will say "do NOT call send_reply" or "Use write_result only" for internal tasks. If it says nothing, treat it as user-facing.
+Your task prompt will say "do NOT call send_reply" or "Use write_result only" for internal tasks. If it says nothing, treat it as user-facing — with one important exception: **when your task produces output the dispatcher should review before notifying the user (e.g., you opened a PR), do NOT call `send_reply`. Call `write_result` only and let the dispatcher route.** When in doubt about whether to reply directly or route through the dispatcher, default to routing through the dispatcher (`write_result` without `sent_reply_to_user=True`, no `send_reply`). The dispatcher will decide what to relay and when.
 
 See the **"Internal vs. User-Facing Tasks"** section below for full patterns and code examples.
 

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -16,7 +16,7 @@ When your task is complete, choose the right delivery pattern based on your task
 - **User-facing tasks (default):** call `send_reply` directly, then `write_result`. This is the crash-safe delivery pattern — the user gets their reply even if the dispatcher has restarted.
 - **Internal tasks (dispatcher-only):** skip `send_reply`. Call `write_result` only. The dispatcher reads your result and decides what to relay.
 
-Your task prompt will say "do NOT call send_reply" or "Use write_result only" for internal tasks. If it says nothing, treat it as user-facing — with one important exception: **when your task produces output the dispatcher should review before notifying the user (e.g., you opened a PR), do NOT call `send_reply`. Call `write_result` only and let the dispatcher route.** When in doubt about whether to reply directly or route through the dispatcher, default to routing through the dispatcher (`write_result` without `sent_reply_to_user=True`, no `send_reply`). The dispatcher will decide what to relay and when.
+Your task prompt will say "do NOT call send_reply" or "Use write_result only" for internal tasks. If it says nothing, treat it as user-facing — **except** for structured outputs (PR opened, commit pushed, report generated): always call `write_result` only and let the dispatcher route. When in doubt, default to `write_result` without `send_reply`. The dispatcher can always relay; a premature reply cannot be un-sent.
 
 See the **"Internal vs. User-Facing Tasks"** section below for full patterns and code examples.
 


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

Closes #690. Replaces the intent of (now-closed) PR #519 with a simpler, general rule.

## What changed and why

Before this change, subagents had a simple binary: if the task prompt says "do NOT call send_reply", treat it as internal; otherwise treat it as user-facing and call `send_reply` directly. This created a gap — subagents that open PRs were calling `send_reply` immediately, bypassing any chance for the dispatcher to spawn a reviewer first.

This PR adds a qualification to that default: when a task produces output that the dispatcher should act on before the user sees it (the clearest example: you just opened a PR and a code review should happen first), skip `send_reply` and call `write_result` only. And when it's not clear which applies, the rule is to route through the dispatcher rather than reply directly. The dispatcher can always relay; a premature `send_reply` cannot be un-sent.

The change is a single sentence addition to the delivery-pattern summary at the top of `sys.subagent.bootup.md`, immediately where subagents learn the user-facing vs. internal distinction.

## Scope

One line changed in `.claude/sys.subagent.bootup.md`. No code changes, no behavior changes to existing tools or infrastructure.

## Tests run

- [x] Manual diff review — change is exactly one sentence added to the summary paragraph, no other lines touched
- [ ] Runtime behavior — doc-only change; no automated test coverage for prompt behavior