### PR TITLE
fix: add review deduplication in reviewer agent and dispatcher

### DIFF
--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -68,6 +68,34 @@ Use the following signals to infer which mode is appropriate. These are heuristi
 
 **Default repo:** If no repo is specified in the task context, infer it from context first (PR URL, issue body, task prompt — all of these contain owner/repo). Only ask the user if the repo is still ambiguous after inference. Do not default to `SiderealPress/lobster` — that is the Lobster system repo, not the user's work target.
 
+
+### Deduplication check (run before reading anything else)
+
+Before diving into the diff, check whether this PR has already been reviewed:
+
+```bash
+gh pr view <PR_NUMBER> --repo <owner/repo> --json reviews,commits,comments
+```
+
+Parse the output and look for either of:
+- A **PASS review** (a review comment whose body starts with `PASS:`)
+- **Substantive review comments** — comments containing technical findings, not just housekeeping notes like "labeled ready-to-merge" or "triggered CI"
+
+If you find an existing PASS review or substantive comments, compare the timestamp of the most recent one against the timestamp of the most recent commit. If no significant commits have landed since that review/comment, you should default to skipping.
+
+Call `write_result` with:
+```
+Already reviewed at [timestamp] (no new commits since). Skipping re-review.
+```
+then exit.
+
+**This is discretion, not a hard gate.** Override the skip if:
+- The existing review has a NEEDS-WORK or FAIL verdict (the author may have addressed feedback)
+- You were explicitly asked to re-review
+- The existing comments look like housekeeping rather than real technical findings
+
+When in doubt, skip — a duplicate PASS is noise; a missed issue can be caught in a follow-up.
+
 ### Review sources — what to handle
 
 1. **PR with a linked issue (GitHub or Linear)** — read the issue/ticket for context, read the PR diff, review the code, post a PR review comment, and update the issue body.

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -289,26 +289,39 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
        pr_url_match = re.search(r"https://github\.com/.*/pull/\d+", msg["text"])
        if pr_url_match and msg.get("sent_reply_to_user") != True:
            pr_url = pr_url_match.group(0)
-           # Spawn a separate reviewer — do NOT relay engineer text to user
-           Task(
-               subagent_type="general-purpose",
-               run_in_background=True,
-               prompt=(
-                   f"---\n"
-                   f"task_id: review-{msg.get('task_id', 'unknown')}\n"
-                   f"chat_id: {msg['chat_id']}\n"
-                   f"source: {msg.get('source', 'telegram')}\n"
-                   f"---\n\n"
-                   f"Review PR {pr_url} and post your findings using:\n"
-                   f"  gh pr review <N> --repo <owner/repo> --comment --body \"PASS/NEEDS-WORK/FAIL: ...\"\n"
-                   f"The owner/repo is in the PR URL above — extract it from there (e.g. https://github.com/owner/repo/pull/N).\n"
-                   f"Use --comment only (never --approve or --request-changes — same token = self-review error).\n\n"
-                   f"After posting, call write_result with a short verdict summary (1–3 sentences).\n\n"
-                   f"Engineer's briefing:\n{msg['text']}"
-               ),
+           # Dedup check: skip if a reviewer is already running for this PR.
+           # This prevents double-reviews caused by restarts or re-processed results.
+           pr_number = pr_url.rstrip("/").split("/")[-1]
+           active_sessions = get_active_sessions()
+           reviewer_task_id = f"review-{msg.get('task_id', 'unknown')}"
+           already_running = any(
+               s.get("task_id") == reviewer_task_id
+               or str(pr_number) in str(s.get("description", ""))
+               for s in active_sessions
            )
-           mark_processed(message_id)
-           # Return to wait_for_messages() — reviewer's write_result arrives separately
+           if already_running:
+               log(f"Reviewer already running for PR #{pr_number}, skipping duplicate spawn")
+               mark_processed(message_id)
+           else:
+               # Spawn a separate reviewer — do NOT relay engineer text to user
+               Task(
+                   subagent_type="general-purpose",
+                   run_in_background=True,
+                   prompt=(
+                       f"---\n"
+                       f"task_id: review-{msg.get('task_id', 'unknown')}\n"
+                       f"chat_id: {msg['chat_id']}\n"
+                       f"source: {msg.get('source', 'telegram')}\n"
+                       f"---\n\n"
+                       f"Review PR {pr_url} and post your findings using:\n"
+                       f"  gh pr review <N> --repo SiderealPress/lobster --comment --body \"PASS/NEEDS-WORK/FAIL: ...\"\n"
+                       f"Use --comment only (never --approve or --request-changes — same token = self-review error).\n\n"
+                       f"After posting, call write_result with a short verdict summary (1–3 sentences).\n\n"
+                       f"Engineer's briefing:\n{msg['text']}"
+                   ),
+               )
+               mark_processed(message_id)
+               # Return to wait_for_messages() — reviewer's write_result arrives separately
        else:
            # Build reply text: inline artifact content when present
            reply_text = msg["text"]


### PR DESCRIPTION
## Summary

PRs were accumulating excessive reviews because the reviewer agent had no awareness of prior reviews, and the dispatcher had no guard against spawning a second reviewer for the same PR (e.g. after a restart or a re-processed result).

Two complementary fixes:

- **`review.md`** — reviewer agent now checks for an existing PASS review or substantive technical comments before starting. If found and no new commits have landed since, it skips with a `write_result` explaining why. This is framed as discretion, not a hard block: a NEEDS-WORK verdict, an explicit re-review request, or purely housekeeping prior comments all override the skip.

- **`sys.dispatcher.bootup.md`** — dispatcher now calls `get_active_sessions()` before spawning a reviewer subagent. If a session is already running with a matching `task_id` (`review-<task_id>`) or matching PR number, it logs "Reviewer already running for PR #N, skipping duplicate spawn" and marks the message processed without spawning.

These two guards work at different layers: the dispatcher check prevents duplicate spawns at dispatch time; the reviewer check prevents duplicate reviews if two reviewers somehow start for the same PR.

## Functional patterns used

Pure data lookup (the `get_active_sessions` call is a read-only predicate with no side effects). The dedup logic in the dispatcher is a simple `any(...)` predicate over the sessions list — no mutation, no external state.

## Tests run

- [ ] No automated tests exist for dispatcher pseudocode or agent instruction files — these are prose/instruction documents, not executable code. Behavior is verified by reading the diff against the stated intent.
- [ ] Live end-to-end test (trigger an engineer result, confirm reviewer spawns once) — skipped: requires a running Lobster instance and a real PR. Safe to merge without this; the change is additive and the fallback (no active sessions found) is identical to pre-change behavior.

**Blocked items needing attention before merge:** none