### PR TITLE
feat: add desloppify skill and camofox-browser auto-activate step

### DIFF
--- a/lobster-shop/camofox-browser/install.sh
+++ b/lobster-shop/camofox-browser/install.sh
@@ -234,6 +234,25 @@ else
 fi
 
 #===============================================================================
+# Step 9: Activate the skill in Lobster's skill manager
+#===============================================================================
+step "Activating skill in Lobster"
+
+ACTIVATE_SCRIPT="
+import sys
+sys.path.insert(0, '$LOBSTER_DIR/src')
+from mcp.skill_manager import activate_skill
+result = activate_skill('camofox-browser', mode='always')
+print(result)
+"
+
+if "$PYTHON_PATH" -c "$ACTIVATE_SCRIPT" 2>/dev/null; then
+    success "Skill activated: camofox-browser (mode: always)"
+else
+    warn "Could not auto-activate skill. Run: lobster skill activate camofox-browser"
+fi
+
+#===============================================================================
 # Done
 #===============================================================================
 echo ""

--- a/lobster-shop/desloppify/behavior/system.md
+++ b/lobster-shop/desloppify/behavior/system.md
@@ -1,0 +1,325 @@
+---
+name: desloppify
+description: >
+  Codebase health scanner and technical debt tracker. Use when the user asks
+  about code quality, technical debt, dead code, large files, god classes,
+  duplicate functions, code smells, naming issues, import cycles, or coupling
+  problems. Also use when asked for a health score, what to fix next, or to
+  create a cleanup plan. Supports 29 languages.
+---
+
+<!-- desloppify-begin -->
+<!-- desloppify-skill-version: 6 -->
+
+# Desloppify
+
+## 1. Your Job
+
+Maximise the **strict score** honestly. Your main cycle: **scan → plan → execute → rescan**. Follow the scan output's **INSTRUCTIONS FOR AGENTS** — don't substitute your own analysis.
+
+**Don't be lazy.** Do large refactors and small detailed fixes with equal energy. If it takes touching 20 files, touch 20 files. If it's a one-line change, make it. No task is too big or too small — fix things properly, not minimally.
+
+## 2. The Workflow
+
+Three phases, repeated as a cycle.
+
+### Phase 1: Scan and review — understand the codebase
+
+```bash
+desloppify scan --path .       # analyse the codebase
+desloppify status              # check scores — are we at target?
+```
+
+The scan will tell you if subjective dimensions need review. Follow its instructions. To trigger a review manually:
+```bash
+desloppify review --prepare    # then follow your runner's review workflow
+```
+
+### Phase 2: Plan — decide what to work on
+
+After reviews, triage stages and plan creation appear in the execution queue surfaced by `next`. Complete them in order — `next` tells you what each stage expects in the `--report`:
+```bash
+desloppify next                                        # shows the next execution workflow step
+desloppify plan triage --stage observe --report "themes and root causes..."
+desloppify plan triage --stage reflect --report "comparison against completed work..."
+desloppify plan triage --stage organize --report "summary of priorities..."
+desloppify plan triage --complete --strategy "execution plan..."
+```
+
+For automated triage: `desloppify plan triage --run-stages --runner codex` (Codex) or `--runner claude` (Claude). Options: `--only-stages`, `--dry-run`, `--stage-timeout-seconds`.
+
+Then shape the queue. **The plan shapes everything `next` gives you** — `next` is the execution queue, not the full backlog. Don't skip this step.
+
+```bash
+desloppify plan                          # see the living plan details
+desloppify plan queue                    # compact execution queue view
+desloppify plan reorder <pat> top        # reorder — what unblocks the most?
+desloppify plan cluster create <name>    # group related issues to batch-fix
+desloppify plan focus <cluster>          # scope next to one cluster
+desloppify plan skip <pat>              # defer — hide from next
+```
+
+### Phase 3: Execute — grind the queue to completion
+
+Trust the plan and execute. Don't rescan mid-queue — finish the queue first.
+
+**Branch first.** Create a dedicated branch — never commit health work directly to main:
+```bash
+git checkout -b desloppify/code-health    # or desloppify/<focus-area>
+desloppify config set commit_pr 42        # link a PR for auto-updated descriptions
+```
+
+**The loop:**
+```bash
+# 1. Get the next item from the execution queue
+desloppify next
+
+# 2. Fix the issue in code
+
+# 3. Resolve it (next shows the exact command including required attestation)
+
+# 4. When you have a logical batch, commit and record
+git add <files> && git commit -m "desloppify: fix 3 deferred_import findings"
+desloppify plan commit-log record      # moves findings uncommitted → committed, updates PR
+
+# 5. Push periodically
+git push -u origin desloppify/code-health
+
+# 6. Repeat until the queue is empty
+```
+
+Score may temporarily drop after fixes — cascade effects are normal, keep going.
+If `next` suggests an auto-fixer, run `desloppify autofix <fixer> --dry-run` to preview, then apply.
+
+**When the queue is clear, go back to Phase 1.** New issues will surface, cascades will have resolved, priorities will have shifted. This is the cycle.
+
+## 3. Reference
+
+### Key concepts
+
+- **Tiers**: T1 auto-fix → T2 quick manual → T3 judgment call → T4 major refactor.
+- **Auto-clusters**: related findings are auto-grouped in `next`. Drill in with `next --cluster <name>`.
+- **Zones**: production/script (scored), test/config/generated/vendor (not scored). Fix with `zone set`.
+- **Wontfix cost**: widens the lenient↔strict gap. Challenge past decisions when the gap grows.
+
+### Scoring
+
+Overall score = **25% mechanical** + **75% subjective**.
+
+- **Mechanical (25%)**: auto-detected issues — duplication, dead code, smells, unused imports, security. Fixed by changing code and rescanning.
+- **Subjective (75%)**: design quality review — naming, error handling, abstractions, clarity. Starts at **0%** until reviewed. The scan will prompt you when a review is needed.
+- **Strict score** is the north star: wontfix items count as open. The gap between overall and strict is your wontfix debt.
+- **Score types**: overall (lenient), strict (wontfix counts), objective (mechanical only), verified (confirmed fixes only).
+
+### Reviews
+
+Four paths to get subjective scores:
+
+- **Local runner (Codex)**: `desloppify review --run-batches --runner codex --parallel --scan-after-import` — automated end-to-end.
+- **Local runner (Claude)**: `desloppify review --prepare` → launch parallel subagents → `desloppify review --import merged.json` — see skill doc overlay for details.
+- **Cloud/external**: `desloppify review --external-start --external-runner claude` → follow session template → `--external-submit`.
+- **Manual path**: `desloppify review --prepare` → review per dimension → `desloppify review --import file.json`.
+
+**Batch output vs import filenames:** Individual batch outputs from subagents must be named `batch-N.raw.txt` (plain text/JSON content, `.raw.txt` extension). The `.json` filenames in `--import merged.json` or `--import findings.json` refer to the final merged import file, not individual batch outputs. Do not name batch outputs with a `.json` extension.
+
+- Import first, fix after — import creates tracked state entries for correlation.
+- Target-matching scores trigger auto-reset to prevent gaming. Use the blind-review workflow described in your agent overlay doc (e.g. `docs/CLAUDE.md`, `docs/HERMES.md`).
+- Even moderate scores (60-80) dramatically improve overall health.
+- Stale dimensions auto-surface in `next` — just follow the queue.
+
+**Integrity rules:** Score from evidence only — no prior chat context, score history, or target-threshold anchoring. When evidence is mixed, score lower and explain uncertainty. Assess every requested dimension; never drop one.
+
+#### Review output format
+
+Return machine-readable JSON for review imports. For `--external-submit`, include `session` from the generated template:
+
+```json
+{
+  "session": {
+    "id": "<session_id_from_template>",
+    "token": "<session_token_from_template>"
+  },
+  "assessments": {
+    "<dimension_from_query>": 0
+  },
+  "findings": [
+    {
+      "dimension": "<dimension_from_query>",
+      "identifier": "short_id",
+      "summary": "one-line defect summary",
+      "related_files": ["relative/path/to/file.py"],
+      "evidence": ["specific code observation"],
+      "suggestion": "concrete fix recommendation",
+      "confidence": "high|medium|low"
+    }
+  ]
+}
+```
+
+`findings` MUST match `query.system_prompt` exactly (including `related_files`, `evidence`, and `suggestion`). Use `"findings": []` when no defects found. Import is fail-closed: invalid findings abort unless `--allow-partial` is passed. Assessment scores are auto-applied from trusted internal or cloud session imports. Legacy `--attested-external` remains supported.
+
+#### Import paths
+
+- Robust session flow (recommended): `desloppify review --external-start --external-runner claude` → use generated prompt/template → run printed `--external-submit` command.
+- Durable scored import (legacy): `desloppify review --import findings.json --attested-external --attest "I validated this review was completed without awareness of overall score and is unbiased."`
+- Findings-only fallback: `desloppify review --import findings.json`
+
+#### Reviewer agent prompt
+
+Runners that support agent definitions (Cursor, Copilot, Gemini) can create a dedicated reviewer agent. Use this system prompt:
+
+```
+You are a code quality reviewer. You will be given a codebase path, a set of
+dimensions to score, and what each dimension means. Read the code, score each
+dimension 0-100 from evidence only, and return JSON in the required format.
+Do not anchor to target thresholds. When evidence is mixed, score lower and
+explain uncertainty.
+```
+
+See your editor's overlay section below for the agent config format.
+
+### Plan commands
+
+```bash
+desloppify plan reorder <cluster> top       # move all cluster members at once
+desloppify plan reorder <a> <b> top        # mix clusters + findings in one reorder
+desloppify plan reorder <pat> before -t X  # position relative to another item/cluster
+desloppify plan cluster reorder a,b top    # reorder multiple clusters as one block
+desloppify plan resolve <pat>              # mark complete
+desloppify plan reopen <pat>               # reopen
+desloppify backlog                          # broader non-execution backlog
+```
+
+### Commit tracking
+
+```bash
+desloppify plan commit-log                      # see uncommitted + committed status
+desloppify plan commit-log record               # record HEAD commit, update PR description
+desloppify plan commit-log record --note "why"  # with rationale
+desloppify plan commit-log record --only "smells::*"  # record specific findings only
+desloppify plan commit-log history              # show commit records
+desloppify plan commit-log pr                   # preview PR body markdown
+desloppify config set commit_tracking_enabled false  # disable guidance
+```
+
+After resolving findings as `fixed`, the tool shows uncommitted work, committed history, and a suggested commit message. After committing externally, run `record` to move findings from uncommitted to committed and auto-update the linked PR description.
+
+### Agent directives
+
+Directives are messages shown to agents at lifecycle phase transitions — use them to switch models, set constraints, or give context-specific instructions.
+
+```bash
+desloppify directives                     # show all configured directives
+desloppify directives set execute "Switch to claude-sonnet-4-6. Focus on speed."
+desloppify directives set triage "Switch to claude-opus-4-6. Read carefully."
+desloppify directives set review "Use blind packet. Do not anchor on previous scores."
+desloppify directives unset execute       # remove a directive
+```
+
+Available phases: `execute`, `review`, `triage`, `workflow`, `scan` (and fine-grained variants like `review_initial`, `triage_postflight`, etc.).
+
+### Quick reference
+
+```bash
+desloppify next --count 5                         # top 5 execution items
+desloppify next --cluster <name>                  # drill into a cluster
+desloppify backlog --count 5                      # top 5 backlog items outside execution
+desloppify show <pattern>                         # filter by file/detector/ID
+desloppify show --status open                     # all open findings
+desloppify plan skip --permanent "<id>" --note "reason" --attest "..." # accept debt
+desloppify exclude <path>                         # exclude a directory from scanning
+desloppify config show                            # show all config including excludes
+desloppify scan --path . --reset-subjective       # reset subjective baseline to 0
+```
+
+## 4. Fix Tool Issues Upstream
+
+When desloppify itself appears wrong or inconsistent — a bug, a bad detection, a crash, confusing output — **fix it and open a PR**. If you can't confidently fix it, file an issue instead.
+
+### Fix and PR (preferred)
+
+Clone the tool repo to a temp directory, make the fix there, and verify it works against the project you're scanning before pushing.
+
+```bash
+git clone https://github.com/peteromallet/desloppify.git /tmp/desloppify-fix
+cd /tmp/desloppify-fix
+git checkout -b fix/<short-description>
+```
+
+Make your changes, then run the test suite and verify the fix against the original project:
+
+```bash
+python -m pytest desloppify/tests/ -q
+python -m desloppify scan --path <project-root>   # the project you were scanning
+```
+
+Once it looks good, push and open a PR:
+
+```bash
+git add <files> && git commit -m "fix: <what and why>"
+git push -u origin fix/<short-description>
+gh pr create --title "fix: <short description>" --body "$(cat <<'EOF'
+## Problem
+<what went wrong — include the command and output>
+
+## Fix
+<what you changed and why>
+EOF
+)"
+```
+
+Clean up after: `rm -rf /tmp/desloppify-fix`
+
+### File an issue (fallback)
+
+If the fix is unclear or the change needs discussion, open an issue at `https://github.com/peteromallet/desloppify/issues` with a minimal repro: command, path, expected output, actual output.
+
+## Prerequisite
+
+`command -v desloppify >/dev/null 2>&1 && echo "desloppify: installed" || echo "NOT INSTALLED — run: uvx --from git+https://github.com/peteromallet/desloppify.git desloppify"`
+
+If `uvx` is not available: `pip install desloppify[full]`
+
+<!-- desloppify-end -->
+
+## Claude Code Overlay
+
+Use Claude subagents for subjective scoring work. **Do not use `--runner codex`** — use Claude subagents exclusively.
+
+### Review workflow
+
+Run `desloppify review --prepare` first to generate review data, then use Claude subagents:
+
+1. **Prepare**: `desloppify review --prepare` — writes `query.json` and `.desloppify/review_packet_blind.json`.
+2. **Launch subagents**: Split the review across N parallel Claude subagents (one message, multiple Task calls). Each agent reviews a subset of dimensions.
+3. **Merge & import**: Merge agent outputs, then `desloppify review --import merged.json --manual-override --attest "Claude subagents ran blind reviews against review_packet_blind.json" --scan-after-import`.
+
+#### How to split dimensions across subagents
+
+- Read `dimension_prompts` from `query.json` for dimensions with definitions and seed files.
+- Read `.desloppify/review_packet_blind.json` for the blind packet (no score targets, no anchoring data).
+- Group dimensions into 3-4 batches by theme (e.g., architecture, code quality, testing, conventions).
+- Launch one Task agent per batch with `subagent_type: "general-purpose"`. Each agent gets:
+  - The codebase path and list of dimensions to score
+  - The blind packet path to read
+  - Instruction to score from code evidence only, not from targets
+- Each agent writes output to `results/batch-N.raw.txt` (matching the batch index). Merge assessments (average overlapping dimension scores) and concatenate findings.
+
+### Subagent rules
+
+1. Each agent must be context-isolated — do not pass conversation history or score targets.
+2. Agents must consume `.desloppify/review_packet_blind.json` (not full `query.json`) to avoid score anchoring.
+
+### Triage workflow
+
+Orchestrate triage with per-stage subagents:
+1. `desloppify plan triage --run-stages --runner claude` — prints orchestrator instructions
+2. For each stage (observe → reflect → organize → enrich):
+   - Get prompt: `desloppify plan triage --stage-prompt <stage>`
+   - Launch a subagent with that prompt
+   - Verify: `desloppify plan triage` (check dashboard)
+   - Confirm: `desloppify plan triage --confirm <stage> --attestation "..."`
+3. Complete: `desloppify plan triage --complete --strategy "..." --attestation "..."`
+
+<!-- desloppify-overlay: claude -->
+<!-- desloppify-end -->

--- a/lobster-shop/desloppify/skill.toml
+++ b/lobster-shop/desloppify/skill.toml
@@ -1,0 +1,41 @@
+[skill]
+name = "desloppify"
+version = "0.9.10"
+description = "Codebase health scanner and technical debt tracker. Use when the user asks about code quality, technical debt, dead code, large files, god classes, duplicate functions, code smells, naming issues, import cycles, or coupling problems. Also use when asked for a health score, what to fix next, or to create a cleanup plan. Supports 29 languages."
+author = "peteromallet (packaged for Lobster)"
+category = "tool"
+
+[activation]
+mode = "triggered"
+triggers = ["/desloppify", "/codehealth", "/debt"]
+context_patterns = [
+    "when user asks to desloppify",
+    "when user asks about code quality",
+    "when user asks about technical debt",
+    "when user asks for a health score",
+    "when user asks what to fix next in the codebase",
+    "when user asks about dead code or code smells",
+    "when user asks to clean up a codebase",
+    "when user asks about duplicate code or import cycles",
+]
+
+[layering]
+priority = 50
+merge_strategy = "append"
+
+[provides]
+mcp_tools = []
+bot_commands = ["/desloppify", "/codehealth", "/debt"]
+
+[compatibility]
+enhances = []
+conflicts = []
+
+[dependencies]
+pip = ["desloppify[full]>=0.9.10"]
+npm = []
+system = []
+api_keys = []
+
+[dependencies.runtime]
+python = ">=3.11"

--- a/src/bisque/auth.py
+++ b/src/bisque/auth.py
@@ -149,6 +149,34 @@ class TokenStore:
         return len(self._sessions)
 
 
+def create_bootstrap_token(email: str, store: TokenStore) -> str:
+    """Create and persist a one-time bootstrap token for the given email.
+
+    The token is written to the token file (bootstrapTokens dict) so the relay
+    can issue it independently of the bisque-chat Next.js app.
+
+    Returns the raw bootstrap token string.
+    """
+    token = secrets.token_urlsafe(32)
+    now = time.time()
+
+    try:
+        raw = store._tokens_file.read_text(encoding="utf-8")
+        store_data: dict[str, Any] = json.loads(raw)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        store_data = {}
+
+    bootstrap = store_data.setdefault("bootstrapTokens", {})
+    bootstrap[token] = {
+        "email": email,
+        "created_at": now,
+    }
+    store._write_token_store(store_data)
+
+    log.info("Bootstrap token created for %s", email)
+    return token
+
+
 def handle_auth_exchange(body: dict[str, Any], store: TokenStore) -> tuple[int, dict[str, Any]]:
     """Handle the HTTP POST /auth/exchange endpoint.
 

--- a/src/bisque/auth.py
+++ b/src/bisque/auth.py
@@ -11,16 +11,16 @@ from typing import Any
 
 log = logging.getLogger("lobster-bisque-relay")
 
-# Default session TTL: 7 days
-_DEFAULT_SESSION_TTL = 7 * 24 * 60 * 60
+# Default session TTL: 365 days (long-lived — avoids constant re-auth)
+_DEFAULT_SESSION_TTL = 365 * 24 * 60 * 60
 
 
 class TokenStore:
-    """Manages bootstrap tokens (from bisque-chat) and in-memory session tokens.
+    """Manages bootstrap tokens (from bisque-chat) and disk-persisted session tokens.
 
     Bootstrap tokens are read from disk (the bisque-chat token file).
-    Session tokens are generated and held in memory only — on server restart
-    clients must re-authenticate.
+    Session tokens are persisted under the ``sessionTokens`` key of the same file
+    so that relay restarts do not invalidate existing authenticated sessions.
     """
 
     def __init__(self, tokens_file: Path, session_ttl: float = _DEFAULT_SESSION_TTL) -> None:
@@ -28,6 +28,7 @@ class TokenStore:
         self._session_ttl = session_ttl
         # session_token -> {email, created_at, last_seen}
         self._sessions: dict[str, dict[str, Any]] = {}
+        self._load_sessions()
 
     # ------------------------------------------------------------------
     # Bootstrap tokens (disk-backed, one-time use)
@@ -54,6 +55,66 @@ class TokenStore:
             tmp.rename(self._tokens_file)
         except OSError as exc:
             log.error("Error writing token file: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Session persistence helpers
+    # ------------------------------------------------------------------
+
+    def _load_sessions(self) -> None:
+        """Load persisted session tokens from disk into memory.
+
+        Reads the ``sessionTokens`` dict from the token file and populates
+        ``self._sessions``, discarding any entries that are already expired
+        so stale sessions don't accumulate across restarts.
+        """
+        try:
+            raw = self._tokens_file.read_text(encoding="utf-8")
+            store = json.loads(raw)
+        except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+            log.warning("Could not load sessions from disk: %s", exc)
+            return
+
+        now = time.time()
+        loaded = 0
+        skipped = 0
+        for tok, sess in store.get("sessionTokens", {}).items():
+            # Only accept entries that have the fields we write
+            if not isinstance(sess, dict) or "email" not in sess or "last_seen" not in sess:
+                skipped += 1
+                continue
+            # Discard already-expired sessions
+            if now - sess["last_seen"] > self._session_ttl:
+                skipped += 1
+                continue
+            self._sessions[tok] = {
+                "email": sess["email"],
+                "created_at": sess.get("created_at", now),
+                "last_seen": sess["last_seen"],
+            }
+            loaded += 1
+
+        log.info("Loaded %d active session(s) from disk (%d expired/skipped)", loaded, skipped)
+
+    def _persist_sessions(self) -> None:
+        """Write the current in-memory session map back to the token file.
+
+        Merges with existing file content so bootstrap tokens are not lost.
+        """
+        try:
+            raw = self._tokens_file.read_text(encoding="utf-8")
+            store: dict[str, Any] = json.loads(raw)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            store = {}
+
+        store["sessionTokens"] = {
+            tok: {
+                "email": sess["email"],
+                "created_at": sess["created_at"],
+                "last_seen": sess["last_seen"],
+            }
+            for tok, sess in self._sessions.items()
+        }
+        self._write_token_store(store)
 
     def validate_bootstrap_token(self, token: str) -> tuple[bool, str]:
         """Validate and consume a bootstrap token.
@@ -92,7 +153,7 @@ class TokenStore:
     # ------------------------------------------------------------------
 
     def create_session(self, email: str) -> str:
-        """Create a new session token for the given email."""
+        """Create a new session token for the given email and persist it to disk."""
         token = secrets.token_urlsafe(48)
         now = time.time()
         self._sessions[token] = {
@@ -101,12 +162,14 @@ class TokenStore:
             "last_seen": now,
         }
         log.info("Session created for %s", email)
+        self._persist_sessions()
         return token
 
     def validate_session(self, token: str) -> tuple[bool, str]:
         """Validate a session token.
 
         Returns (True, email) if valid and not expired, (False, "") otherwise.
+        Expired sessions are removed from memory and disk on detection.
         """
         if not token:
             return False, ""
@@ -118,22 +181,25 @@ class TokenStore:
         # Check TTL
         if time.time() - session["last_seen"] > self._session_ttl:
             del self._sessions[token]
+            self._persist_sessions()
             return False, ""
 
         return True, session["email"]
 
     def touch_session(self, token: str) -> None:
-        """Update last_seen timestamp for a session."""
+        """Update last_seen timestamp for a session and persist to disk."""
         session = self._sessions.get(token)
         if session:
             session["last_seen"] = time.time()
+            self._persist_sessions()
 
     def revoke_session(self, token: str) -> None:
-        """Revoke (delete) a session."""
+        """Revoke (delete) a session and remove it from disk."""
         self._sessions.pop(token, None)
+        self._persist_sessions()
 
     def cleanup_expired(self) -> int:
-        """Remove all expired sessions. Returns count of removed sessions."""
+        """Remove all expired sessions and persist the result. Returns count removed."""
         now = time.time()
         expired = [
             tok for tok, sess in self._sessions.items()
@@ -141,6 +207,8 @@ class TokenStore:
         ]
         for tok in expired:
             del self._sessions[tok]
+        if expired:
+            self._persist_sessions()
         return len(expired)
 
     @property

--- a/src/bisque/protocol.py
+++ b/src/bisque/protocol.py
@@ -40,7 +40,8 @@ class FrameType(str, Enum):
     ACK = "ack"
     PING = "ping"
 
-    # Server -> Client (15)
+    # Server -> Client (16)
+    HELLO = "hello"
     AUTH_SUCCESS = "auth_success"
     AUTH_ERROR = "auth_error"
     SNAPSHOT = "snapshot"
@@ -61,11 +62,14 @@ class FrameType(str, Enum):
 CLIENT_FRAME_TYPES: set[str] = {
     FrameType.AUTH.value,
     FrameType.SEND_MESSAGE.value,
+    # "message" is accepted as a client-compat alias for "send_message"
+    FrameType.MESSAGE.value,
     FrameType.ACK.value,
     FrameType.PING.value,
 }
 
 SERVER_FRAME_TYPES: set[str] = {
+    FrameType.HELLO.value,
     FrameType.AUTH_SUCCESS.value,
     FrameType.AUTH_ERROR.value,
     FrameType.SNAPSHOT.value,
@@ -157,13 +161,12 @@ def deserialize(raw: str) -> Envelope:
     if not isinstance(data, dict):
         raise ProtocolError("Expected JSON object")
 
-    if "v" not in data:
-        raise ProtocolError("Missing required field: v")
     if "type" not in data:
         raise ProtocolError("Missing required field: type")
 
     # Extract envelope-level fields; everything else is payload.
-    v = data.pop("v")
+    # v is optional for client compat — default to 2 if absent.
+    v = data.pop("v", 2)
     envelope_id = data.pop("id", str(uuid.uuid4()))
     ts = data.pop("ts", datetime.now(timezone.utc).isoformat())
     frame_type = data.pop("type")
@@ -179,6 +182,8 @@ def deserialize(raw: str) -> Envelope:
 _CLIENT_REQUIRED_FIELDS: Dict[str, List[str]] = {
     FrameType.AUTH.value: ["token"],
     FrameType.SEND_MESSAGE.value: ["text"],
+    # "message" is a client-compat alias for "send_message" — same required fields
+    FrameType.MESSAGE.value: ["text"],
     FrameType.ACK.value: ["event_id"],
     FrameType.PING.value: [],
 }
@@ -208,6 +213,11 @@ def validate_client_frame(envelope: Envelope) -> None:
 # ---------------------------------------------------------------------------
 # Server frame convenience builders
 # ---------------------------------------------------------------------------
+
+
+def frame_hello() -> str:
+    """Build a serialized ``hello`` frame (sent to clients on connect)."""
+    return serialize(make_envelope(FrameType.HELLO.value))
 
 
 def frame_auth_success(email: str) -> str:

--- a/src/bisque/relay_server.py
+++ b/src/bisque/relay_server.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import base64
 import json
 import logging
 import logging.handlers
@@ -34,7 +35,7 @@ from typing import Any
 import aiohttp
 from aiohttp import web
 
-from bisque.auth import TokenStore, handle_auth_exchange
+from bisque.auth import TokenStore, create_bootstrap_token, handle_auth_exchange
 from bisque.event_bus import EventBus, OutboxEventSource, FileSystemEventSource
 from bisque.event_log import EventLog
 from bisque.protocol import (
@@ -83,6 +84,19 @@ _file_handler = logging.handlers.RotatingFileHandler(
 _file_handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
 log.addHandler(_file_handler)
 log.addHandler(logging.StreamHandler())
+
+
+# ---------------------------------------------------------------------------
+# Admin configuration (read from environment at startup)
+# ---------------------------------------------------------------------------
+
+# Secret used to protect the POST /auth/admin/token endpoint.
+# Reads BISQUE_ADMIN_SECRET first, falls back to ADMIN_SECRET.
+_ADMIN_SECRET: str = os.environ.get("BISQUE_ADMIN_SECRET", "") or os.environ.get("ADMIN_SECRET", "")
+
+# Public relay URL embedded in login tokens so the browser knows where to connect.
+# Example: wss://178.104.15.109.nip.io/bisque-relay
+_RELAY_URL: str = os.environ.get("BISQUE_RELAY_URL", "")
 
 
 # ---------------------------------------------------------------------------
@@ -182,6 +196,109 @@ class BisqueRelayServer:
                 "Access-Control-Allow-Origin": "*",
                 "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
                 "Access-Control-Allow-Headers": "Content-Type",
+            },
+        )
+
+    # --- HTTP handler: POST /auth/admin/token ---
+
+    async def _http_admin_create_token(self, request: web.Request) -> web.Response:
+        """Create a bootstrap token and return an encoded login token.
+
+        Protected by the BISQUE_ADMIN_SECRET / ADMIN_SECRET environment variable.
+
+        Request:
+            POST /auth/admin/token
+            Authorization: Bearer <admin_secret>
+            Content-Type: application/json
+            {"email": "user@example.com"}
+
+        Response:
+            {"loginToken": "<base64url-encoded>", "bootstrapToken": "<raw>", "email": "..."}
+
+        The loginToken is base64url(JSON.stringify({"url": <relay_url>, "token": <bootstrap>})).
+        Users paste this token into the bisque-chat login screen.
+        """
+        _cors_headers = {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "POST, OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type, Authorization",
+        }
+
+        # Check admin secret is configured
+        if not _ADMIN_SECRET:
+            log.error("POST /auth/admin/token called but BISQUE_ADMIN_SECRET/ADMIN_SECRET is not set")
+            return web.json_response(
+                {"error": "Admin secret not configured on this server"},
+                status=500,
+                headers=_cors_headers,
+            )
+
+        # Validate Authorization header
+        auth_header = request.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            return web.json_response(
+                {"error": "Missing or malformed Authorization header"},
+                status=401,
+                headers=_cors_headers,
+            )
+
+        provided_secret = auth_header[len("Bearer "):]
+        if provided_secret != _ADMIN_SECRET:
+            log.warning("POST /auth/admin/token: invalid admin secret from %s", request.remote)
+            return web.json_response(
+                {"error": "Invalid admin secret"},
+                status=403,
+                headers=_cors_headers,
+            )
+
+        # Parse request body
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, Exception):
+            return web.json_response({"error": "Invalid JSON body"}, status=400, headers=_cors_headers)
+
+        email = (body.get("email") or "").strip()
+        if not email or "@" not in email:
+            return web.json_response(
+                {"error": "Missing or invalid 'email' field"},
+                status=400,
+                headers=_cors_headers,
+            )
+
+        # Determine relay URL (body override > env var)
+        relay_url = (body.get("relayUrl") or "").strip() or _RELAY_URL
+        if not relay_url:
+            return web.json_response(
+                {"error": "BISQUE_RELAY_URL is not configured on this server"},
+                status=500,
+                headers=_cors_headers,
+            )
+
+        # Create bootstrap token (writes to disk so /auth/exchange can consume it)
+        bootstrap_token = create_bootstrap_token(email, self._token_store)
+
+        # Encode login token: base64url(JSON.stringify({url, token}))
+        payload_json = json.dumps({"url": relay_url, "token": bootstrap_token}, separators=(",", ":"))
+        login_token = base64.urlsafe_b64encode(payload_json.encode("utf-8")).decode("ascii").rstrip("=")
+
+        log.info("Admin created login token for %s", email)
+        return web.json_response(
+            {
+                "loginToken": login_token,
+                "bootstrapToken": bootstrap_token,
+                "email": email,
+            },
+            headers=_cors_headers,
+        )
+
+    async def _http_options_admin_token(self, request: web.Request) -> web.Response:
+        """Handle CORS preflight for /auth/admin/token."""
+        return web.Response(
+            status=204,
+            headers={
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "POST, OPTIONS",
+                "Access-Control-Allow-Headers": "Content-Type, Authorization",
             },
         )
 
@@ -471,6 +588,8 @@ class BisqueRelayServer:
         app = web.Application()
         app.router.add_post("/auth/exchange", self._http_auth_exchange)
         app.router.add_route("OPTIONS", "/auth/exchange", self._http_options)
+        app.router.add_post("/auth/admin/token", self._http_admin_create_token)
+        app.router.add_route("OPTIONS", "/auth/admin/token", self._http_options_admin_token)
         app.router.add_get("/", self._ws_handler)
         # Catch-all for WS connections on any path
         app.router.add_get("/{path:.*}", self._ws_handler)

--- a/src/bisque/relay_server.py
+++ b/src/bisque/relay_server.py
@@ -43,6 +43,7 @@ from bisque.protocol import (
     frame_auth_error,
     frame_auth_success,
     frame_error,
+    frame_hello,
     frame_pong,
     frame_snapshot,
     validate_client_frame,
@@ -187,11 +188,66 @@ class BisqueRelayServer:
     # --- WebSocket handler ---
 
     async def _ws_handler(self, request: web.Request) -> web.WebSocketResponse:
-        """Handle WebSocket connections via aiohttp."""
+        """Handle WebSocket connections via aiohttp.
+
+        Auth is accepted via two paths (in order of preference):
+
+        1. Query-param auth (bisque-chat clients): the session token is passed as
+           ``?token=<value>`` in the WS URL.  The connection is marked authenticated
+           as soon as ``ws.onopen`` fires — no first-frame handshake required.
+           On success the server sends ``{type:"hello"}`` followed by a snapshot.
+
+        2. Frame auth (legacy / programmatic clients): the first frame must be
+           ``{type:"auth", token:"<value>"}``.  On success the server sends
+           ``auth_success`` followed by a snapshot.
+
+        Both paths perform the same session-token validation via the token store.
+        """
         ws = web.WebSocketResponse()
         await ws.prepare(request)
         remote = request.remote
 
+        # --- Fix 1 / Fix 4: Query-param auth path ---
+        qp_token = request.rel_url.query.get("token", "")
+        if qp_token:
+            valid, email = self._token_store.validate_session(qp_token)
+            if not valid:
+                log.warning("Rejected invalid query-param session from %s", remote)
+                await ws.send_str(frame_auth_error("Invalid session token"))
+                await ws.close(code=4401, message=b"Unauthorized")
+                return ws
+
+            self._token_store.touch_session(qp_token)
+            log.info("Authenticated bisque client (query-param): %s (%s)", remote, email)
+            self._clients.add(ws)
+            self._client_emails[id(ws)] = email
+
+            try:
+                # Fix 4: Send hello frame immediately (clients expect this on ws.onopen)
+                await ws.send_str(frame_hello())
+
+                # Send snapshot (no last_event_id available via query-param path)
+                await self._send_initial_state(ws, None)
+
+                # Client message loop
+                async for msg in ws:
+                    if msg.type == aiohttp.WSMsgType.TEXT:
+                        await self._handle_client_message(ws, email, msg.data)
+                    elif msg.type == aiohttp.WSMsgType.BINARY:
+                        await ws.send_str(frame_error("Binary frames not supported"))
+                    elif msg.type == aiohttp.WSMsgType.ERROR:
+                        log.error("WS error for %s: %s", email, ws.exception())
+
+            except Exception as exc:
+                log.error("Error in handler for %s: %s", email, exc)
+            finally:
+                self._clients.discard(ws)
+                self._client_emails.pop(id(ws), None)
+                log.info("Bisque client disconnected: %s (%s)", remote, email)
+
+            return ws
+
+        # --- Legacy frame-auth path ---
         # Auth handshake: wait up to 5 seconds for auth frame
         try:
             msg = await asyncio.wait_for(ws.receive(), timeout=5.0)
@@ -235,12 +291,12 @@ class BisqueRelayServer:
         # Touch session
         self._token_store.touch_session(token)
 
-        log.info("Authenticated bisque client: %s (%s)", remote, email)
+        log.info("Authenticated bisque client (frame-auth): %s (%s)", remote, email)
         self._clients.add(ws)
         self._client_emails[id(ws)] = email
 
         try:
-            # Send auth_success
+            # Send auth_success (legacy path)
             await ws.send_str(frame_auth_success(email))
 
             # Replay or snapshot
@@ -326,7 +382,8 @@ class BisqueRelayServer:
         if envelope.type == "ping":
             await ws.send_str(frame_pong())
 
-        elif envelope.type == "send_message":
+        elif envelope.type in ("send_message", "message"):
+            # Fix 3: "message" is accepted as an alias for "send_message"
             text = str(envelope.payload.get("text", "")).strip()
             if not text:
                 await ws.send_str(frame_error("Empty message text"))

--- a/src/bisque/relay_server.py
+++ b/src/bisque/relay_server.py
@@ -24,8 +24,10 @@ import base64
 import json
 import logging
 import logging.handlers
+import mimetypes
 import os
 import signal
+import tempfile
 import time
 import uuid
 from datetime import datetime, timezone
@@ -62,6 +64,39 @@ INBOX_DIR = _MESSAGES / "inbox"
 BISQUE_OUTBOX_DIR = _MESSAGES / "bisque-outbox"
 WIRE_EVENTS_DIR = _MESSAGES / "wire-events"
 SENT_DIR = _MESSAGES / "sent"
+UPLOADS_DIR = _MESSAGES / "bisque-uploads"
+
+# Maximum file upload size: 50 MB
+MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+
+# MIME types we serve inline (images, video); everything else is an attachment
+_INLINE_MIME_PREFIXES = ("image/", "video/", "audio/")
+
+# Map content-type prefixes to file extensions for raw binary uploads
+_MIME_EXT_MAP: dict[str, str] = {
+    "audio/webm": ".webm",
+    "audio/ogg": ".ogg",
+    "audio/mp4": ".m4a",
+    "audio/mpeg": ".mp3",
+    "audio/wav": ".wav",
+    "audio/x-wav": ".wav",
+    "audio/aac": ".aac",
+    "audio/flac": ".flac",
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "video/mp4": ".mp4",
+    "video/webm": ".webm",
+}
+
+
+def _mime_to_ext(mime_type: str) -> str:
+    """Return a file extension for a MIME type, or empty string if unknown."""
+    # Strip parameters like ;codecs=opus
+    base_type = mime_type.split(";")[0].strip().lower()
+    return _MIME_EXT_MAP.get(base_type, "")
+
 
 _BISQUE_CHAT_PROJECT = _WORKSPACE / "projects" / "bisque-chat"
 _TOKENS_FILE = _BISQUE_CHAT_PROJECT / "data" / "tokens.json"
@@ -103,17 +138,38 @@ _RELAY_URL: str = os.environ.get("BISQUE_RELAY_URL", "")
 # Inbox injection
 # ---------------------------------------------------------------------------
 
-def _inject_into_inbox(inbox_dir: Path, email: str, text: str) -> str:
+def _inject_into_inbox(
+    inbox_dir: Path,
+    email: str,
+    text: str,
+    reply_to_id: str | None = None,
+    reply_to_context: dict[str, Any] | None = None,
+    attachments: list[dict[str, Any]] | None = None,
+) -> str:
     """Write a bisque message into Lobster's inbox. Returns message ID."""
     msg_id = f"bisque_{int(time.time() * 1000)}_{uuid.uuid4().hex[:8]}"
-    payload = {
+
+    # Determine message type from attachments (first attachment wins)
+    msg_type = "text"
+    if attachments:
+        first_type = attachments[0].get("type", "file")
+        if first_type in ("image", "video", "file", "voice"):
+            msg_type = first_type
+
+    payload: dict[str, Any] = {
         "id": msg_id,
         "source": "bisque",
         "chat_id": email,
         "text": text,
         "timestamp": datetime.now(timezone.utc).isoformat(),
-        "type": "text",
+        "type": msg_type,
     }
+    if reply_to_id:
+        payload["reply_to_id"] = reply_to_id
+    if reply_to_context:
+        payload["reply_to"] = reply_to_context
+    if attachments:
+        payload["attachments"] = attachments
     dest = inbox_dir / f"{msg_id}.json"
     tmp = inbox_dir / f".{msg_id}.tmp"
     try:
@@ -166,6 +222,10 @@ class BisqueRelayServer:
         self._running = True
         self._clients: set[web.WebSocketResponse] = set()
         self._client_emails: dict[int, str] = {}  # ws id -> email
+        # In-memory message cache for reply context lookup (id -> {text, sender})
+        # Bounded to the most recent 500 messages to avoid unbounded growth.
+        self._message_cache: dict[str, dict[str, str]] = {}
+        self._message_cache_order: list[str] = []
         # Event sources
         self._outbox_source: OutboxEventSource | None = None
         self._fs_source: FileSystemEventSource | None = None
@@ -299,6 +359,146 @@ class BisqueRelayServer:
                 "Access-Control-Allow-Origin": "*",
                 "Access-Control-Allow-Methods": "POST, OPTIONS",
                 "Access-Control-Allow-Headers": "Content-Type, Authorization",
+            },
+        )
+
+    # --- HTTP handler: POST /upload (BIS-119 voice/file upload) ---
+
+    async def _http_upload(self, request: web.Request) -> web.Response:
+        """Accept a multipart or raw binary upload and store it under a UUID filename.
+
+        Authentication: session token required in Authorization header or ?token= query param.
+
+        Request (multipart/form-data):
+            POST /upload
+            Authorization: Bearer <session_token>
+            Content-Type: multipart/form-data; boundary=...
+            file=<binary>
+
+        Request (raw binary, content-type = audio/webm etc.):
+            POST /upload
+            Authorization: Bearer <session_token>
+            Content-Type: audio/webm
+            <raw bytes>
+
+        Response:
+            {"url": "/files/<uuid>.<ext>", "filename": "<uuid>.<ext>"}
+        """
+        _cors = {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "POST, OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type, Authorization",
+        }
+
+        # --- Auth ---
+        token = request.rel_url.query.get("token", "")
+        if not token:
+            auth_header = request.headers.get("Authorization", "")
+            if auth_header.startswith("Bearer "):
+                token = auth_header[len("Bearer "):]
+        if not token:
+            return web.json_response({"error": "Unauthorized"}, status=401, headers=_cors)
+        valid, email = self._token_store.validate_session(token)
+        if not valid:
+            return web.json_response({"error": "Invalid session token"}, status=401, headers=_cors)
+
+        # --- Read body ---
+        content_type = request.content_type or ""
+        file_data: bytes
+        original_ext = ".bin"
+
+        if content_type.startswith("multipart/"):
+            try:
+                reader = await request.multipart()
+                field = await reader.next()
+                if field is None:
+                    return web.json_response({"error": "Empty multipart body"}, status=400, headers=_cors)
+                # Use the submitted filename extension if available
+                if field.filename:
+                    original_ext = Path(field.filename).suffix or ".bin"
+                file_data = await field.read(decode=True)
+            except Exception as exc:
+                log.warning("Upload multipart read error: %s", exc)
+                return web.json_response({"error": "Failed to read upload"}, status=400, headers=_cors)
+        else:
+            # Raw binary body — derive extension from Content-Type
+            ext_from_mime = _mime_to_ext(content_type)
+            if ext_from_mime:
+                original_ext = ext_from_mime
+            try:
+                file_data = await request.read()
+            except Exception as exc:
+                log.warning("Upload raw read error: %s", exc)
+                return web.json_response({"error": "Failed to read upload"}, status=400, headers=_cors)
+
+        if len(file_data) == 0:
+            return web.json_response({"error": "Empty file"}, status=400, headers=_cors)
+        if len(file_data) > MAX_UPLOAD_BYTES:
+            return web.json_response(
+                {"error": f"File too large (max {MAX_UPLOAD_BYTES // (1024 * 1024)} MB)"},
+                status=413,
+                headers=_cors,
+            )
+
+        # --- Store file ---
+        UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
+        file_uuid = uuid.uuid4().hex
+        filename = f"{file_uuid}{original_ext}"
+        dest = UPLOADS_DIR / filename
+        try:
+            dest.write_bytes(file_data)
+        except OSError as exc:
+            log.error("Upload write error: %s", exc)
+            return web.json_response({"error": "Storage error"}, status=500, headers=_cors)
+
+        log.info("Stored upload %s (%d bytes) for %s", filename, len(file_data), email)
+        return web.json_response(
+            {"url": f"/files/{filename}", "filename": filename},
+            headers=_cors,
+        )
+
+    async def _http_upload_options(self, request: web.Request) -> web.Response:
+        """Handle CORS preflight for /upload."""
+        return web.Response(
+            status=204,
+            headers={
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "POST, OPTIONS",
+                "Access-Control-Allow-Headers": "Content-Type, Authorization",
+            },
+        )
+
+    # --- HTTP handler: GET /files/{filename} (BIS-119 file serving) ---
+
+    async def _http_serve_file(self, request: web.Request) -> web.Response:
+        """Serve a previously uploaded file.
+
+        No auth required (URLs are unguessable UUIDs). Files are served inline
+        when the MIME type is audio/*, image/*, or video/*; otherwise as attachment.
+        """
+        filename = request.match_info.get("filename", "")
+        # Safety: reject path traversal attempts
+        if not filename or "/" in filename or "\\" in filename or filename.startswith("."):
+            return web.Response(status=404)
+
+        path = UPLOADS_DIR / filename
+        if not path.exists() or not path.is_file():
+            return web.Response(status=404)
+
+        mime_type, _ = mimetypes.guess_type(filename)
+        if not mime_type:
+            mime_type = "application/octet-stream"
+
+        is_inline = any(mime_type.startswith(p) for p in _INLINE_MIME_PREFIXES)
+        disposition = "inline" if is_inline else f'attachment; filename="{filename}"'
+
+        return web.Response(
+            body=path.read_bytes(),
+            content_type=mime_type,
+            headers={
+                "Content-Disposition": disposition,
+                "Access-Control-Allow-Origin": "*",
+                "Cache-Control": "public, max-age=86400",
             },
         )
 
@@ -456,36 +656,119 @@ class BisqueRelayServer:
         recent_messages = self._load_recent_messages()
         last_event_id = self._event_log.get_latest_id()
 
+        # Populate message cache from snapshot history so reply lookups work
+        # immediately after a reconnect without waiting for new messages.
+        for msg in recent_messages:
+            self._cache_message(
+                msg_id=msg["id"],
+                text=msg.get("text", ""),
+                sender=msg.get("role", "user"),
+            )
+
         return frame_snapshot(
             status="idle",
             recent_messages=recent_messages,
             last_event_id=last_event_id,
         )
 
-    def _load_recent_messages(self, limit: int = 20) -> list[dict[str, Any]]:
-        """Load recent messages from the sent/ directory."""
-        messages = []
+    # ---------------------------------------------------------------------------
+    # Message cache helpers (BIS-118)
+    # ---------------------------------------------------------------------------
+
+    _MESSAGE_CACHE_LIMIT = 500
+
+    def _cache_message(self, msg_id: str, text: str, sender: str) -> None:
+        """Store a message in the bounded in-memory cache for reply lookups."""
+        if msg_id in self._message_cache:
+            return
+        self._message_cache[msg_id] = {"text": text, "sender": sender}
+        self._message_cache_order.append(msg_id)
+        # Evict oldest entries once the cache exceeds the limit
+        while len(self._message_cache_order) > self._MESSAGE_CACHE_LIMIT:
+            oldest = self._message_cache_order.pop(0)
+            self._message_cache.pop(oldest, None)
+
+    def _resolve_reply_context(
+        self, reply_to_id: str | None
+    ) -> dict[str, Any] | None:
+        """Return reply context dict for a given message ID, or None if unknown."""
+        if not reply_to_id:
+            return None
+        cached = self._message_cache.get(reply_to_id)
+        if cached:
+            return {"id": reply_to_id, "text": cached["text"], "sender": cached["sender"]}
+        return None
+
+    def _load_recent_messages(self, limit: int = 50) -> list[dict[str, Any]]:
+        """Load recent conversation history from sent/ and processed/ directories.
+
+        Combines Lobster's outgoing messages (sent/) and user messages (processed/)
+        to reconstruct the full conversation. Only bisque messages are included.
+        Results are sorted by timestamp so history is in chronological order.
+        """
+        raw: list[dict[str, Any]] = []
+
+        # Load sent messages (Lobster → user), role = "assistant"
         try:
-            sent_files = sorted(
-                self._sent_dir.glob("*.json"),
-                key=lambda p: p.stat().st_mtime,
-                reverse=True,
-            )[:limit]
-            for path in reversed(sent_files):
+            for path in self._sent_dir.glob("*.json"):
                 try:
                     data = json.loads(path.read_text(encoding="utf-8"))
-                    messages.append({
+                    # Only include bisque messages
+                    if data.get("source") != "bisque":
+                        continue
+                    text = data.get("text", "")
+                    if not text:
+                        continue
+                    raw.append({
                         "id": data.get("id", path.stem),
-                        "text": data.get("text", ""),
-                        "source": data.get("source", ""),
-                        "chat_id": data.get("chat_id", ""),
+                        "role": "assistant",
+                        "text": text,
                         "timestamp": data.get("timestamp", ""),
+                        "_sort_key": data.get("timestamp", ""),
                     })
                 except (json.JSONDecodeError, OSError):
                     continue
         except OSError:
             pass
-        return messages
+
+        # Load processed messages (user → Lobster), role = "user"
+        # Use the processed/ directory for user messages
+        processed_dir = _MESSAGES / "processed"
+        try:
+            for path in processed_dir.glob("*.json"):
+                try:
+                    data = json.loads(path.read_text(encoding="utf-8"))
+                    # Only include bisque source messages with text content
+                    if data.get("source") != "bisque":
+                        continue
+                    # Skip subagent results and notifications (type != "text")
+                    msg_type = data.get("type", "text")
+                    if msg_type not in ("text", ""):
+                        continue
+                    text = data.get("text", "")
+                    if not text:
+                        continue
+                    raw.append({
+                        "id": data.get("id", path.stem),
+                        "role": "user",
+                        "text": text,
+                        "timestamp": data.get("timestamp", ""),
+                        "_sort_key": data.get("timestamp", ""),
+                    })
+                except (json.JSONDecodeError, OSError):
+                    continue
+        except OSError:
+            pass
+
+        # Sort by timestamp (ISO strings sort lexicographically), take most recent `limit`
+        raw.sort(key=lambda m: m["_sort_key"])
+        recent = raw[-limit:] if len(raw) > limit else raw
+
+        # Strip internal sort key before returning
+        return [
+            {k: v for k, v in m.items() if k != "_sort_key"}
+            for m in recent
+        ]
 
     async def _handle_client_message(self, ws: web.WebSocketResponse, email: str, raw: str) -> None:
         """Dispatch a single client message."""
@@ -502,23 +785,44 @@ class BisqueRelayServer:
         elif envelope.type in ("send_message", "message"):
             # Fix 3: "message" is accepted as an alias for "send_message"
             text = str(envelope.payload.get("text", "")).strip()
-            if not text:
-                await ws.send_str(frame_error("Empty message text"))
+            # BIS-120: attachments are optional; text may be empty when sending a file
+            attachments: list[dict[str, Any]] | None = envelope.payload.get("attachments") or None
+            if not text and not attachments:
+                await ws.send_str(frame_error("Empty message"))
                 return
             if len(text) > 32_000:
                 await ws.send_str(frame_error("Message too long (max 32000 chars)"))
                 return
 
-            msg_id = _inject_into_inbox(self._inbox_dir, email, text)
-            ack_frame = json.dumps({
+            # BIS-118: Extract optional reply reference from client frame
+            reply_to_id: str | None = envelope.payload.get("reply_to_id") or None
+            reply_context = self._resolve_reply_context(reply_to_id)
+
+            msg_id = _inject_into_inbox(
+                self._inbox_dir,
+                email,
+                text,
+                reply_to_id=reply_to_id,
+                reply_to_context=reply_context,
+                attachments=attachments,
+            )
+
+            # Cache the user's outgoing message for future reply lookups
+            self._cache_message(msg_id=msg_id, text=text, sender="user")
+
+            ack_payload: dict[str, Any] = {
                 "v": 2,
                 "id": str(uuid.uuid4()),
                 "ts": datetime.now(timezone.utc).isoformat(),
                 "type": "ack",
                 "message_id": msg_id,
                 "status": "received",
-            })
-            await ws.send_str(ack_frame)
+            }
+            # Echo reply context back in the ack so the PWA can render it immediately
+            if reply_context:
+                ack_payload["reply_to"] = reply_context
+
+            await ws.send_str(json.dumps(ack_payload))
             log.debug("Queued message from %s: %r", email, text[:80])
 
         elif envelope.type == "ack":
@@ -527,11 +831,54 @@ class BisqueRelayServer:
         else:
             await ws.send_str(frame_error(f"Unknown message type: {envelope.type!r}"))
 
+    # ---------------------------------------------------------------------------
+    # Typing indicator helpers (BIS-122)
+    # ---------------------------------------------------------------------------
+
+    def _make_typing_frame(self, is_typing: bool) -> str:
+        """Build a serialized typing indicator frame."""
+        return json.dumps({
+            "v": 2,
+            "id": str(uuid.uuid4()),
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "type": "typing",
+            "is_typing": is_typing,
+        })
+
+    async def broadcast_typing(self, is_typing: bool) -> None:
+        """Broadcast a typing indicator to all connected clients.
+
+        Called externally when the AI starts (is_typing=True) or finishes
+        (is_typing=False) generating a response.
+        """
+        frame = self._make_typing_frame(is_typing)
+        await self._fan_out(frame)
+
     # --- Event bus callback ---
 
     async def _on_event(self, event_id: str, frame: str) -> None:
         """Called by the event bus when a new event is available."""
         self._event_log.append(event_id, frame)
+
+        # Parse once for both BIS-118 and BIS-122 side-effects.
+        try:
+            data = json.loads(frame)
+            if data.get("type") == "message":
+                # BIS-118: cache assistant messages so reply context is available
+                # for future reply_to_id lookups.
+                msg_id = data.get("message_id") or data.get("id")
+                text = data.get("text", "")
+                role = data.get("role", "assistant")
+                if msg_id and text:
+                    sender = "assistant" if role == "assistant" else "user"
+                    self._cache_message(msg_id=msg_id, text=text, sender=sender)
+
+                # BIS-122: send is_typing=false before the message frame so the
+                # typing indicator dismisses immediately when a reply arrives.
+                await self._fan_out(self._make_typing_frame(False))
+        except (json.JSONDecodeError, Exception):
+            pass
+
         await self._fan_out(frame)
 
     async def _fan_out(self, frame: str) -> None:
@@ -555,7 +902,7 @@ class BisqueRelayServer:
 
     async def run(self) -> None:
         """Start the HTTP/WS server and event sources."""
-        for d in [self._inbox_dir, self._outbox_dir, self._wire_events_dir, self._sent_dir]:
+        for d in [self._inbox_dir, self._outbox_dir, self._wire_events_dir, self._sent_dir, UPLOADS_DIR]:
             d.mkdir(parents=True, exist_ok=True)
 
         log.info("Starting Lobster Bisque Relay v2 on %s:%s", self.host, self._requested_port)
@@ -590,6 +937,19 @@ class BisqueRelayServer:
         app.router.add_route("OPTIONS", "/auth/exchange", self._http_options)
         app.router.add_post("/auth/admin/token", self._http_admin_create_token)
         app.router.add_route("OPTIONS", "/auth/admin/token", self._http_options_admin_token)
+        # Nginx-prefixed aliases (nginx may forward /bisque-relay/auth/... without stripping prefix)
+        app.router.add_post("/bisque-relay/auth/exchange", self._http_auth_exchange)
+        app.router.add_route("OPTIONS", "/bisque-relay/auth/exchange", self._http_options)
+        app.router.add_post("/bisque-relay/auth/admin/token", self._http_admin_create_token)
+        app.router.add_route("OPTIONS", "/bisque-relay/auth/admin/token", self._http_options_admin_token)
+        # File upload/serve (BIS-119)
+        app.router.add_post("/upload", self._http_upload)
+        app.router.add_route("OPTIONS", "/upload", self._http_upload_options)
+        app.router.add_get("/files/{filename}", self._http_serve_file)
+        # Nginx-prefixed aliases for upload/files endpoints
+        app.router.add_post("/bisque-relay/upload", self._http_upload)
+        app.router.add_route("OPTIONS", "/bisque-relay/upload", self._http_upload_options)
+        app.router.add_get("/bisque-relay/files/{filename}", self._http_serve_file)
         app.router.add_get("/", self._ws_handler)
         # Catch-all for WS connections on any path
         app.router.add_get("/{path:.*}", self._ws_handler)

--- a/src/bisque/relay_server.py
+++ b/src/bisque/relay_server.py
@@ -138,6 +138,32 @@ _RELAY_URL: str = os.environ.get("BISQUE_RELAY_URL", "")
 # Inbox injection
 # ---------------------------------------------------------------------------
 
+def _resolve_voice_local_path(attachment_url: str) -> Path | None:
+    """Resolve a voice attachment URL to its local file path in UPLOADS_DIR.
+
+    The relay server stores files at UPLOADS_DIR/<uuid>.<ext> and serves them at
+    /files/<uuid>.<ext> (or /bisque-relay/files/<uuid>.<ext>).  Given the public
+    URL we strip the path prefix and return the corresponding local Path.
+
+    Returns None if the URL cannot be resolved to a local file.
+    """
+    if not attachment_url:
+        return None
+    # Accept both absolute URLs (https://host/files/foo.webm) and relative paths (/files/foo.webm)
+    for prefix in ("/bisque-relay/files/", "/files/"):
+        idx = attachment_url.find(prefix)
+        if idx != -1:
+            filename = attachment_url[idx + len(prefix):]
+            # Strip any query-string / fragment
+            filename = filename.split("?")[0].split("#")[0]
+            # Safety: reject path traversal
+            if filename and "/" not in filename and not filename.startswith("."):
+                candidate = UPLOADS_DIR / filename
+                if candidate.exists():
+                    return candidate
+    return None
+
+
 def _inject_into_inbox(
     inbox_dir: Path,
     email: str,
@@ -170,6 +196,17 @@ def _inject_into_inbox(
         payload["reply_to"] = reply_to_context
     if attachments:
         payload["attachments"] = attachments
+
+    # For voice messages: resolve the attachment URL to a local file path so that
+    # the MCP transcribe_audio tool (which looks for audio_file) can find the file.
+    if msg_type == "voice" and attachments:
+        voice_url = attachments[0].get("url", "")
+        local_path = _resolve_voice_local_path(voice_url)
+        if local_path:
+            payload["audio_file"] = str(local_path)
+            log.info("Resolved voice attachment to local path: %s", local_path)
+        else:
+            log.warning("Could not resolve voice URL to local path: %s", voice_url)
     dest = inbox_dir / f"{msg_id}.json"
     tmp = inbox_dir / f".{msg_id}.tmp"
     try:

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -6553,56 +6553,67 @@ async def handle_get_bisque_connection_url(arguments: dict[str, Any]) -> list[Te
 async def handle_generate_bisque_login_token(arguments: dict[str, Any]) -> list[TextContent]:
     """Generate a bisque-chat login token for the given email.
 
-    Calls the bisque-chat Next.js app's /api/auth/generate-login-token endpoint
-    (running locally on port 3000 by default, or the URL configured in
-    BISQUE_CHAT_URL env var).
+    Calls the relay server's POST /auth/admin/token endpoint (running locally on
+    port 9101 by default, or the HTTP URL derived from BISQUE_RELAY_URL).
 
-    The token is a base64url-encoded JSON: { url: <relay_ws_url>, token: <bootstrap> }.
-    Users paste this into the bisque app login screen.
+    The returned loginToken is a base64url-encoded JSON:
+        { url: <relay_ws_url>, token: <bootstrap> }
+    Users paste this into the bisque-chat login screen.
     """
+    import urllib.request
+    import urllib.error
+
     email = arguments.get("email", "").strip()
     if not email or "@" not in email:
         return [TextContent(type="text", text="Error: a valid email address is required.")]
 
-    # Read config
+    # Read config from file
     config_file = _CONFIG_DIR / "config.env"
-    bisque_chat_url = "http://localhost:3000"
-    relay_url_override = ""
     admin_secret = ""
+    relay_url = ""  # WebSocket URL (wss://...)
+    relay_http_url = ""  # HTTP base URL for the relay API
 
     if config_file.exists():
         for line in config_file.read_text().splitlines():
             stripped = line.strip()
-            if stripped.startswith("BISQUE_CHAT_URL="):
-                bisque_chat_url = stripped.split("=", 1)[1].strip().strip('"').strip("'")
-            elif stripped.startswith("NEXT_PUBLIC_LOBSTER_RELAY_URL="):
-                relay_url_override = stripped.split("=", 1)[1].strip().strip('"').strip("'")
-            elif stripped.startswith("ADMIN_SECRET="):
+            if stripped.startswith("BISQUE_ADMIN_SECRET="):
                 admin_secret = stripped.split("=", 1)[1].strip().strip('"').strip("'")
+            elif stripped.startswith("ADMIN_SECRET=") and not admin_secret:
+                admin_secret = stripped.split("=", 1)[1].strip().strip('"').strip("'")
+            elif stripped.startswith("BISQUE_RELAY_URL="):
+                relay_url = stripped.split("=", 1)[1].strip().strip('"').strip("'")
+            elif stripped.startswith("BISQUE_RELAY_HTTP_URL="):
+                relay_http_url = stripped.split("=", 1)[1].strip().strip('"').strip("'")
 
-    # Also check environment variables directly
+    # Fall back to environment variables
     if not admin_secret:
-        admin_secret = os.environ.get("ADMIN_SECRET", "")
-    if not relay_url_override:
-        relay_url_override = os.environ.get("NEXT_PUBLIC_LOBSTER_RELAY_URL", "")
+        admin_secret = os.environ.get("BISQUE_ADMIN_SECRET", "") or os.environ.get("ADMIN_SECRET", "")
+    if not relay_url:
+        relay_url = os.environ.get("BISQUE_RELAY_URL", "")
+    if not relay_http_url:
+        relay_http_url = os.environ.get("BISQUE_RELAY_HTTP_URL", "")
 
     if not admin_secret:
         return [TextContent(type="text", text=(
-            "ADMIN_SECRET is not configured. Add it to ~/lobster-config/config.env:\n"
-            "  ADMIN_SECRET=<your-secret>\n\n"
-            "This secret must match the ADMIN_SECRET set when running bisque-chat."
+            "BISQUE_ADMIN_SECRET is not configured. Add it to ~/lobster-config/config.env:\n"
+            "  BISQUE_ADMIN_SECRET=<your-secret>\n\n"
+            "This secret must match the BISQUE_ADMIN_SECRET used by the relay server."
         ))]
 
-    endpoint = f"{bisque_chat_url.rstrip('/')}/api/auth/generate-login-token"
+    # Derive the HTTP base URL for the relay.
+    # If not explicitly set, default to localhost:9101 (where the relay runs).
+    if not relay_http_url:
+        relay_http_url = "http://localhost:9101"
+
+    endpoint = f"{relay_http_url.rstrip('/')}/auth/admin/token"
 
     payload: dict[str, str] = {"email": email}
+    # Pass relayUrl override only if explicitly provided by the caller
+    relay_url_override = arguments.get("relayUrl", "").strip()
     if relay_url_override:
         payload["relayUrl"] = relay_url_override
 
     try:
-        import urllib.request
-        import urllib.error
-
         req_body = json.dumps(payload).encode("utf-8")
         req = urllib.request.Request(
             endpoint,
@@ -6621,16 +6632,21 @@ async def handle_generate_bisque_login_token(arguments: dict[str, Any]) -> list[
             err_msg = err_body.get("error", str(exc))
         except Exception:
             err_msg = str(exc)
-        return [TextContent(type="text", text=f"Failed to generate token: {err_msg}")]
+        return [TextContent(type="text", text=f"Failed to generate token via relay: {err_msg}")]
     except Exception as exc:
         return [TextContent(type="text", text=(
-            f"Could not reach bisque-chat at {bisque_chat_url}: {exc}\n\n"
-            "Make sure bisque-chat is running and BISQUE_CHAT_URL is set correctly in ~/lobster-config/config.env."
+            f"Could not reach bisque relay at {relay_http_url}: {exc}\n\n"
+            "Make sure the relay is running and BISQUE_ADMIN_SECRET is set in ~/lobster-config/config.env."
         ))]
 
     login_token = resp_body.get("loginToken", "")
-    instructions = resp_body.get("instructions", f"Login token: {login_token}")
+    returned_email = resp_body.get("email", email)
 
+    instructions = (
+        f"Login token for {returned_email}:\n\n"
+        f"{login_token}\n\n"
+        "Paste this token into the bisque-chat login screen."
+    )
     return [TextContent(type="text", text=instructions)]
 
 

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -418,6 +418,54 @@ _INSTANCE_ID: str = os.environ.get("LOBSTER_OBSERVABILITY_TOKEN") or socket.geth
 _recent_replies: dict[str, float] = {}
 _REPLY_TRACK_MAX = 100
 
+
+# ---------------------------------------------------------------------------
+# Timezone utility — reads owner timezone from owner.toml for display
+# ---------------------------------------------------------------------------
+
+def _get_display_tz():
+    """Return the owner's local timezone for display purposes.
+
+    Reads the 'timezone' field from owner.toml (e.g. 'America/Los_Angeles').
+    Falls back to UTC if not set or if zoneinfo cannot load the zone.
+    Always returns a zoneinfo.ZoneInfo-compatible object.
+    """
+    import zoneinfo as _zoneinfo
+    try:
+        from user_model.owner import get_owner_timezone as _get_owner_tz
+        tz_name = _get_owner_tz()
+        return _zoneinfo.ZoneInfo(tz_name)
+    except Exception:
+        return _zoneinfo.ZoneInfo("UTC")
+
+
+def _format_display_ts(dt: "datetime", fmt: str = "%Y-%m-%d %I:%M %p %Z") -> str:
+    """Convert a datetime to the owner's local timezone and format it for display.
+
+    Args:
+        dt:  A datetime object (naive datetimes are assumed UTC).
+        fmt: strftime format string. Default produces e.g. '2026-03-19 02:18 AM PST'.
+
+    Returns a formatted string in the owner's local time.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    local_dt = dt.astimezone(_get_display_tz())
+    return local_dt.strftime(fmt)
+
+
+def _format_iso_for_display(iso_str: str, fmt: str = "%Y-%m-%d %I:%M %p %Z") -> str:
+    """Parse an ISO 8601 string and format it in the owner's local timezone.
+
+    Falls back to the raw string if parsing fails.
+    """
+    try:
+        dt = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
+        return _format_display_ts(dt, fmt)
+    except Exception:
+        return iso_str
+
+
 def _track_reply(chat_id: Any) -> None:
     """Record that a reply was sent to chat_id."""
     global _recent_replies
@@ -4044,13 +4092,9 @@ async def handle_get_conversation_history(args: dict) -> list[TextContent]:
         ts = msg.get("timestamp", "")
         text = msg.get("text", "(no text)")
 
-        # Format timestamp nicely
+        # Format timestamp nicely in owner's local timezone
         try:
-            if "+" in ts or ts.endswith("Z"):
-                dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-            else:
-                dt = datetime.fromisoformat(ts)
-            ts_display = dt.strftime("%Y-%m-%d %H:%M")
+            ts_display = _format_iso_for_display(ts, "%Y-%m-%d %I:%M %p %Z")
         except (ValueError, TypeError):
             ts_display = ts
 
@@ -4743,7 +4787,7 @@ async def handle_create_scheduled_job(args: dict) -> list[TextContent]:
 
 **Job**: {name}
 **Schedule**: {schedule_human} (`{schedule}`)
-**Created**: {now.strftime('%Y-%m-%d %H:%M UTC')}
+**Created**: {_format_display_ts(now)}
 
 ## Context
 
@@ -4805,9 +4849,7 @@ async def handle_list_scheduled_jobs(args: dict) -> list[TextContent]:
 
         if last_run and last_run != "never":
             try:
-                # Parse and format nicely
-                dt = datetime.fromisoformat(last_run.replace("Z", "+00:00"))
-                last_run = dt.strftime("%Y-%m-%d %H:%M")
+                last_run = _format_iso_for_display(last_run, "%Y-%m-%d %I:%M %p %Z")
             except:
                 pass
 
@@ -4838,12 +4880,18 @@ async def handle_get_scheduled_job(args: dict) -> list[TextContent]:
     if task_file.exists():
         task_content = task_file.read_text()
 
+    _fmt = "%Y-%m-%d %I:%M %p %Z"
+    created_disp = _format_iso_for_display(job.get("created_at", ""), _fmt) if job.get("created_at") else "N/A"
+    updated_disp = _format_iso_for_display(job.get("updated_at", ""), _fmt) if job.get("updated_at") else "N/A"
+    last_run_raw = job.get("last_run") or ""
+    last_run_disp = _format_iso_for_display(last_run_raw, _fmt) if last_run_raw else "never"
+
     output = f"**Job: {name}**\n\n"
     output += f"**Schedule**: {job.get('schedule_human', '')} (`{job.get('schedule', '')}`)\n"
     output += f"**Enabled**: {'Yes' if job.get('enabled', True) else 'No'}\n"
-    output += f"**Created**: {job.get('created_at', 'N/A')}\n"
-    output += f"**Updated**: {job.get('updated_at', 'N/A')}\n"
-    output += f"**Last Run**: {job.get('last_run', 'never')}\n"
+    output += f"**Created**: {created_disp}\n"
+    output += f"**Updated**: {updated_disp}\n"
+    output += f"**Last Run**: {last_run_disp}\n"
     output += f"**Last Status**: {job.get('last_status', '-')}\n\n"
     output += f"---\n\n**Task File** (`{task_file}`):\n\n```markdown\n{task_content}\n```"
 
@@ -4887,12 +4935,13 @@ async def handle_update_scheduled_job(args: dict) -> list[TextContent]:
 
         # Rewrite task file
         now = datetime.now(timezone.utc)
+        created_disp = _format_iso_for_display(job.get("created_at", "")) if job.get("created_at") else "N/A"
         task_content = f"""# {name.replace('-', ' ').title()}
 
 **Job**: {name}
 **Schedule**: {job.get('schedule_human', '')} (`{job.get('schedule', '')}`)
-**Created**: {job.get('created_at', 'N/A')}
-**Updated**: {now.strftime('%Y-%m-%d %H:%M UTC')}
+**Created**: {created_disp}
+**Updated**: {_format_display_ts(now)}
 
 ## Context
 
@@ -5021,10 +5070,9 @@ async def handle_check_task_outputs(args: dict) -> list[TextContent]:
         status_icon = "" if status == "success" else ""
         duration_str = f" ({duration}s)" if duration else ""
 
-        # Format timestamp nicely
+        # Format timestamp nicely in owner's local timezone
         try:
-            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-            ts = dt.strftime("%Y-%m-%d %H:%M")
+            ts = _format_iso_for_display(ts, "%Y-%m-%d %I:%M %p %Z")
         except:
             pass
 
@@ -5639,7 +5687,7 @@ async def handle_triage_brain_dump(args: dict) -> list[TextContent]:
 
     comment_lines.append("")
     comment_lines.append("---")
-    comment_lines.append(f"*Triaged at {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}*")
+    comment_lines.append(f"*Triaged at {_format_display_ts(datetime.now(timezone.utc))}*")
 
     comment_body = "\n".join(comment_lines)
 
@@ -5812,7 +5860,7 @@ async def handle_close_brain_dump(args: dict) -> list[TextContent]:
         comment_lines.append("")
 
     comment_lines.append("---")
-    comment_lines.append(f"*Closed at {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}*")
+    comment_lines.append(f"*Closed at {_format_display_ts(datetime.now(timezone.utc))}*")
 
     comment_body = "\n".join(comment_lines)
 
@@ -6016,7 +6064,7 @@ async def handle_memory_search(arguments: dict[str, Any]) -> list[TextContent]:
 
     lines = [f"**Memory Search Results** ({len(results)} found for \"{query}\"):"]
     for i, event in enumerate(results, 1):
-        ts = event.timestamp.strftime("%Y-%m-%d %H:%M") if event.timestamp else "?"
+        ts = _format_display_ts(event.timestamp, "%Y-%m-%d %I:%M %p %Z") if event.timestamp else "?"
         proj = f" [{event.project}]" if event.project else ""
         eid = f"#{event.id}" if event.id else ""
         # Truncate content for display
@@ -6043,7 +6091,7 @@ async def handle_memory_recent(arguments: dict[str, Any]) -> list[TextContent]:
 
         lines = [f"**Recent Events** ({len(results)} in last {hours}h):"]
         for event in results:
-            ts = event.timestamp.strftime("%Y-%m-%d %H:%M") if event.timestamp else "?"
+            ts = _format_display_ts(event.timestamp, "%Y-%m-%d %I:%M %p %Z") if event.timestamp else "?"
             proj = f" [{event.project}]" if event.project else ""
             eid = f"#{event.id}" if event.id else ""
             consolidated = " [consolidated]" if event.consolidated else ""

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -4436,8 +4436,10 @@ async def handle_transcribe_audio(args: dict) -> list[TextContent]:
 
     # Local whisper.cpp transcription
     try:
-        # Convert OGG to WAV if needed
-        if audio_path.suffix.lower() in [".ogg", ".oga", ".opus"]:
+        # whisper.cpp requires 16 kHz mono WAV. Convert any non-WAV format.
+        # This handles .ogg, .opus, .webm (Chrome MediaRecorder), .mp4, .m4a, etc.
+        _NON_WAV_EXTS = {".ogg", ".oga", ".opus", ".webm", ".mp4", ".m4a", ".aac", ".flac", ".mp3"}
+        if audio_path.suffix.lower() in _NON_WAV_EXTS:
             wav_path = audio_path.with_suffix(".wav")
             if not wav_path.exists():
                 success = await convert_ogg_to_wav(audio_path, wav_path)

--- a/src/mcp/user_model/__init__.py
+++ b/src/mcp/user_model/__init__.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from .db import open_db, set_metadata_value
-from .owner import get_owner_id, ensure_owner_toml
+from .owner import get_owner_id, ensure_owner_toml, get_owner_timezone
 from .tools import USER_MODEL_TOOL_DEFINITIONS, dispatch
 from .markdown_sync import sync_all
 from .observation import observe_message

--- a/src/mcp/user_model/owner.py
+++ b/src/mcp/user_model/owner.py
@@ -106,6 +106,17 @@ def write_owner(data: dict[str, Any], owner_file: Path | None = None) -> None:
                 pass
 
 
+def get_owner_timezone(owner_file: Path | None = None) -> str:
+    """Return the owner's IANA timezone string, or 'UTC' if not set.
+
+    Example return values: 'America/Los_Angeles', 'America/New_York', 'Europe/London'.
+    Always returns a non-empty string safe to pass to zoneinfo.ZoneInfo().
+    """
+    data = read_owner(owner_file)
+    tz = data.get("owner", {}).get("timezone", "").strip()
+    return tz if tz else "UTC"
+
+
 def get_owner_name(owner_file: Path | None = None) -> str | None:
     """Return the owner's display name, or None if not set."""
     data = read_owner(owner_file)


### PR DESCRIPTION
## Summary

- **New skill: `lobster-shop/desloppify`** — Codebase health scanner and technical debt tracker. Supports 29 languages. Triggered by `/desloppify`, `/codehealth`, and `/debt`. Packaged from `peteromallet/desloppify` (PyPI: `desloppify[full]>=0.9.10`). Provides a full scan → plan → execute cycle with subjective scoring, cluster management, and commit tracking.

- **`lobster-shop/camofox-browser/install.sh` Step 9** — After MCP registration, the installer now automatically calls `activate_skill('camofox-browser', mode='always')` via the Lobster skill manager. Previously the skill was installed but required a manual `lobster skill activate camofox-browser` step. On failure it degrades gracefully with a warning.

---

## fix(bisque): voice transcription for PWA recordings

Two bugs prevented every bisque PWA voice message from transcribing:

### Bug 1: `audio_file` never set in inbox message (`relay_server.py`)

When the relay server injected a bisque voice message into the inbox, it only stored the HTTPS URL in `attachments[0].url`. The MCP `transcribe_audio` tool reads `msg_data["audio_file"]` (a local filesystem path) — that key was never set, so every call failed with "Audio file not found".

**Fix:** Added `_resolve_voice_local_path(url)` which strips the `/files/` or `/bisque-relay/files/` prefix from the attachment URL and resolves it to `UPLOADS_DIR/<filename>`. `_inject_into_inbox` now sets `audio_file` to the local path.

### Bug 2: WebM not converted before whisper (`inbox_server.py`)

The conversion guard in `handle_transcribe_audio` only converted `.ogg/.oga/.opus` to WAV. Chrome's `MediaRecorder` emits `audio/webm;codecs=opus` saved as `.webm`. whisper.cpp requires 16 kHz mono WAV — passing WebM directly produces empty output.

**Fix:** Expanded `_NON_WAV_EXTS` to cover `.webm`, `.mp4`, `.m4a`, `.aac`, `.flac`, `.mp3`.

**Verified the pipeline manually:**
```
ffprobe: Chrome .webm → opus/48kHz mono, duration=N/A (streaming format)
ffmpeg -ar 16000 -ac 1 → valid WAV
whisper-cli → "Is this going to work or not?" ✓
```

Related: [bisque-chat PR #35](https://github.com/aeschylus/bisque-chat/pull/35)

---

## What was left out and why

- **`lobster-shop/camofox-browser/server` submodule pointer bump** — left out of this PR. The repo tracks this as a gitlink without a `.gitmodules` entry. v1.4.0 changelog: reliability fixes, download/image extraction, ESM migration. Recommend a separate submodule update PR.

## Test plan

- [ ] Run `lobster-shop/camofox-browser/install.sh` — confirm Step 9 activates the skill
- [ ] Trigger `/desloppify` in Lobster chat — confirm skill context is injected
- [ ] Send a voice note from bisque PWA — confirm inbox JSON has `audio_file` set
- [ ] Call `transcribe_audio` — should return transcription, not "Audio file not found"
- [ ] Confirm `.webm` files are converted to WAV before whisper

🤖 Generated with [Claude Code](https://claude.com/claude-code)