### PR TITLE
fix: add --system flag to systemd-run in restart command

### DIFF
--- a/src/cli
+++ b/src/cli
@@ -158,7 +158,7 @@ cmd_restart() {
     # cmd_start already removes the flag, but only if it runs; by scheduling
     # start before stop we guarantee it runs even if this process dies.
     echo "Scheduling start via systemd-run in 2s..."
-    if ! sudo systemd-run --on-active=2s --unit=lobster-restart-oneshot \
+    if ! sudo systemd-run --system --on-active=2s --unit=lobster-restart-oneshot \
             /bin/bash -c "rm -f '${MAINTENANCE_FLAG}'; systemctl start lobster-router lobster-claude" \
             2>/dev/null; then
         echo -e "${RED}systemd-run failed — falling back to stop+start${NC}"


### PR DESCRIPTION
`lobster restart` was failing with "Failed to connect to bus: No medium found" because `sudo systemd-run` without `--system` attempts to connect to the calling user's D-Bus session — which doesn't exist under sudo.

## What changed

Added `--system` to the `systemd-run` call in `cmd_restart()` (`src/cli` line 161). This routes the transient oneshot unit through the system D-Bus, which is always available when running as root via sudo. No other behavior changes.

The fallback path (stop+start) is untouched. The unit name, delay, and command being scheduled are all identical.

Functional pattern: pure command substitution — the fix is a single flag addition with no branching or state changes.

## Before / after

```
# Before (fails under sudo — no user bus)
sudo systemd-run --on-active=2s --unit=lobster-restart-oneshot ...

# After (works — uses system bus)
sudo systemd-run --system --on-active=2s --unit=lobster-restart-oneshot ...
```

Closes #696

## Tests run

- [x] `git diff src/cli` — single-line change confirmed correct
- [ ] Live `lobster restart` — not run: would disrupt the running system; safe to merge, change is mechanical