### PR TITLE
fix: suppress system_context debug observations from Telegram delivery

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -300,10 +300,13 @@ def _emit_debug_observation(
     never sees these messages and no dispatcher tokens are burned.
 
     When debug mode is off, this function is a no-op.
+    When category is "system_context", this function is always a no-op — per the
+    dispatcher bootup doc, system_context observations must be stored silently and
+    never forwarded to the user, even in debug mode.
 
     Args:
         text: The observation body text.
-        category: "system_context", "system_error", or "user_context".
+        category: "system_context" (always suppressed), "system_error", or "user_context".
         visibility: "mcp-only" if the MCP layer is emitting this directly (dispatcher
             has not seen it yet), or "dispatcher" if the dispatcher's main loop is
             emitting this after processing the message through its inbox.
@@ -311,10 +314,17 @@ def _emit_debug_observation(
             Falls back to "unknown" if not provided.
 
     Label format: [debug|{visibility}] {category} from {emitter}
-    Example: [debug|mcp-only] system_context from task:linear-digest
+    Example: [debug|mcp-only] system_error from task:linear-digest
 
     Never raises — must be safe to call from any context including threads.
     """
+    # system_context observations are internal routing decisions — never forward
+    # to Telegram. The dispatcher bootup doc is explicit: system_context must be
+    # stored silently (memory_store), do NOT send_reply, even in debug mode.
+    # This mirrors the suppression already present in handle_write_observation().
+    if category == "system_context":
+        return
+
     # Fast path: skip I/O if debug alerts have been resolved and are disabled.
     if _DEBUG_RESOLVED and not _DEBUG_ALERTS_ENABLED:
         return


### PR DESCRIPTION
## Summary

Closes #703.

- `_emit_debug_observation()` was sending all debug observations to Telegram, including `system_context` ones (tier-1 signal summaries, memory writes, subagent routing events)
- Per `sys.dispatcher.bootup.md`, `system_context` must be stored silently and **never** forwarded to the user, even in debug mode
- Added an early return in `_emit_debug_observation()` when `category == "system_context"`, consistent with the suppression already present in `handle_write_observation()` (line 5285)

**Before:** With `LOBSTER_DEBUG=true`, users see noisy messages like:
```
[debug|mcp-only] system_context from unknown
🔍 [tier 1 fired] msg=... extracted 1 signal(s): topic='learning' (0.60)
```

**After:** Only `system_error` and `user_context` debug observations reach Telegram. `system_context` is always suppressed.

## Affected call sites (all now suppressed)

| Location | Category | Description |
|---|---|---|
| `_observation_worker()` ~L136 | `system_context` (default) | Tier-1 signal summaries |
| `handle_write_result()` ~L5197 | `system_context` | Subagent→dispatcher routing events |
| `handle_memory_store()` ~L5966 | `system_context` | Memory write debug events |
| `handle_memory_search()` ~L6003 | `system_context` | Memory search debug events |

## Test plan

- [ ] With `LOBSTER_DEBUG=true`, send a message and confirm no `[debug|mcp-only] system_context` messages appear in Telegram
- [ ] Confirm `system_error` debug observations (e.g. from observation worker exceptions) still deliver to Telegram
- [ ] Confirm `user_context` debug observations still deliver to Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)