### PR TITLE
fix: extract owner/repo dynamically from PR URL in reviewer spawn prompt

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -291,7 +291,9 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
            pr_url = pr_url_match.group(0)
            # Dedup check: skip if a reviewer is already running for this PR.
            # This prevents double-reviews caused by restarts or re-processed results.
-           pr_number = pr_url.rstrip("/").split("/")[-1]
+           pr_url_parts = pr_url.rstrip("/").split("/")
+           pr_number = pr_url_parts[-1]
+           pr_repo = f"{pr_url_parts[-4]}/{pr_url_parts[-3]}"  # owner/repo from URL
            active_sessions = get_active_sessions()
            reviewer_task_id = f"review-{msg.get('task_id', 'unknown')}"
            already_running = any(
@@ -314,7 +316,7 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
                        f"source: {msg.get('source', 'telegram')}\n"
                        f"---\n\n"
                        f"Review PR {pr_url} and post your findings using:\n"
-                       f"  gh pr review <N> --repo SiderealPress/lobster --comment --body \"PASS/NEEDS-WORK/FAIL: ...\"\n"
+                       f"  gh pr review <N> --repo {pr_repo} --comment --body \"PASS/NEEDS-WORK/FAIL: ...\"\n"
                        f"Use --comment only (never --approve or --request-changes — same token = self-review error).\n\n"
                        f"After posting, call write_result with a short verdict summary (1–3 sentences).\n\n"
                        f"Engineer's briefing:\n{msg['text']}"


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What this fixes

PR #692 introduced a regression: the reviewer spawn prompt hardcoded `--repo SiderealPress/lobster`, so any PR from a user project repo would cause the reviewer to run `gh pr review` against the wrong repository — silently reviewing the wrong PR or getting a 404.

The root cause: when extracting `pr_number` from the parsed PR URL, the code stopped there and never extracted `owner/repo`. The hardcoded value was a copy-paste artifact from an earlier version.

## What changed

In the `subagent_result` handler's PR-detection branch (`.claude/sys.dispatcher.bootup.md`), the URL is now split into parts once and both pieces are extracted:

```python
pr_url_parts = pr_url.rstrip("/").split("/")
pr_number = pr_url_parts[-1]
pr_repo = f"{pr_url_parts[-4]}/{pr_url_parts[-3]}"  # owner/repo from URL
```

The reviewer prompt then uses `{pr_repo}` instead of the literal `SiderealPress/lobster`:

```
gh pr review <N> --repo {pr_repo} --comment --body "PASS/NEEDS-WORK/FAIL: ..."
```

The narrative summary section (step 3 in the PR review flow) already documented the correct behavior (`--repo <owner/repo>`). This fix makes the pseudocode match the spec.

Nothing else is changed — dedup logic, session tracking, and all other routing behavior are untouched.

## Functional patterns

Pure extraction: `pr_repo` is computed from the already-parsed URL string with no side effects. The fix is a minimal, local change to two adjacent lines.

## Before / after

**Before (broken):**
```
reviewer prompt → gh pr review <N> --repo SiderealPress/lobster ...
# Any non-lobster PR → wrong repo → wrong review or 404
```

**After (fixed):**
```
pr_url_parts extracted once from URL
reviewer prompt → gh pr review <N> --repo {pr_repo} ...
# PR from any repo → correct review
```

## Tests run

- [x] Manual diff inspection — confirmed `pr_url_parts` extraction yields correct `owner/repo` for a URL of the form `https://github.com/{owner}/{repo}/pull/{N}`: `pr_url_parts[-4]` = owner, `pr_url_parts[-3]` = repo, `pr_url_parts[-1]` = N.
- [ ] Live dispatcher integration test — blocked: requires a running dispatcher session with a cross-repo PR result. No behavior change to the dispatcher's routing logic; only the string value passed to the reviewer changes.

Closes #702