### PR TITLE
docs: document /report, reactions, and YAML frontmatter pattern (#627)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,20 @@ lobster test       # Create test message
 lobster help       # Show help
 ```
 
+## Telegram Slash Commands
+
+Commands you can send directly in the Telegram chat:
+
+| Command | Description |
+|---------|-------------|
+| `/report <description>` | File a bug report or feedback. Creates a record in Lobster's report store that can be reviewed with `list_reports`. |
+
+## Telegram Reactions
+
+React to any Lobster message with an emoji to send a signal. Reactions are buffered for 5 seconds — removing the reaction within that window cancels it.
+
+Reactions arrive as inbox messages with `type: "reaction"` and include the raw emoji. The dispatcher decides what to do with it.
+
 ## Directory Structure
 
 ```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -105,6 +105,25 @@ After pulling updates on the VPS (`git pull` + `uv pip install -e .`):
 
 ---
 
+## YAML Frontmatter in Subagent Prompts
+
+The `auto-register-agent.py` PostToolUse hook reads structured metadata from subagent prompts using YAML frontmatter. New subagents should use this format instead of the legacy text pattern:
+
+```yaml
+---
+task_id: my-task-123
+chat_id: 8305714125
+source: telegram
+reply_to_message_id: 10924
+---
+```
+
+The hook uses this to register the subagent in `agent_sessions.db` immediately upon spawn. Recognized fields: `task_id`, `chat_id`, `source`, `reply_to_message_id`.
+
+Legacy format (still supported for backward compat): `Your task_id is: my-task-123`
+
+See `hooks/auto-register-agent.py` for full details.
+
 ## Related documentation
 
 - `.claude/sys.dispatcher.bootup.md` — runtime behavior and the worktree constraint from the dispatcher's perspective


### PR DESCRIPTION
🤖🦞 Lobster (engineer): Doc fixes for issue #627 — undocumented features.

## Summary

- Add `Telegram Slash Commands` section to `README.md` documenting `/report <description>`
- Add `Telegram Reactions` section to `README.md` explaining `type:"reaction"` messages and the 5-second undo window
- Add `YAML Frontmatter in Subagent Prompts` section to `docs/DEVELOPMENT.md` documenting the auto-register hook format

Issues 624, 625, 626 are already resolved in main (cron interval fix, global-env path update, claude-wrapper.sh checklist update — all landed in earlier PRs).

Closes #627

## Test plan

- [ ] Verify README renders correctly on GitHub (tables, section headers)
- [ ] Verify DEVELOPMENT.md YAML frontmatter section matches `hooks/auto-register-agent.py` docstring
- [ ] No behavior changes — docs only