### PR TITLE
fix: move startup cleanup out of module scope to prevent agent death on HTTP server restart

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -788,31 +788,12 @@ try:
 except Exception as _ss_err:
     log.warning(f"Agent session store init failed (non-fatal): {_ss_err}")
 
-# Startup cleanup: mark stale 'running' rows as 'dead' before reconciler loop begins.
-# After a force-restart, agents killed mid-run leave their output files with
-# stop_reason=tool_use, which the reconciler treats as still-running. We fix this
-# here by checking file existence and mtime against the server start time — any
-# output file that predates this process startup cannot belong to a live agent.
-#
-# Note on asymmetric notification: this sweep intentionally does NOT enqueue user
-# notifications for the sessions it marks dead. This is a bulk-cleanup pass, not a
-# live event. Any sessions that were completed/dead before this restart but not yet
-# notified are handled by the reconciler's _startup_sweep(), which fires immediately
-# after the reconciler loop starts and handles the notification backlog. Separating
-# the two concerns keeps this code path simple and idempotent.
-try:
-    _dead_ids = _session_store.cleanup_stale_running_sessions(
-        server_start_time=_SERVER_START_TIME
-    )
-    if _dead_ids:
-        log.warning(
-            f"[startup] Marked {len(_dead_ids)} stale 'running' session(s) as dead "
-            f"(pre-existing from before this server start): {_dead_ids}"
-        )
-    else:
-        log.info("[startup] No stale 'running' sessions found at startup")
-except Exception as _cleanup_err:
-    log.warning(f"[startup] Stale session cleanup failed (non-fatal): {_cleanup_err}")
+# NOTE: Startup cleanup (cleanup_stale_running_sessions) is intentionally NOT
+# called here at module level. This module is imported by inbox_server_http.py
+# (the HTTP bridge) which may be run as a separate process. Running the cleanup
+# at import time would incorrectly mark running agents as dead every time the
+# HTTP server restarts. The cleanup runs inside main() so it only fires when
+# inbox_server.py is the actual stdio MCP server entry point.
 
 # ---------------------------------------------------------------------------
 # Wire server notification — event-driven SSE push (<40ms latency)
@@ -7335,6 +7316,35 @@ async def main():
     """Run the MCP server."""
     setup_logging()
     _ensure_observation_worker()
+
+    # Startup cleanup: mark stale 'running' rows as 'dead' before reconciler loop begins.
+    # After a force-restart, agents killed mid-run leave their output files with
+    # stop_reason=tool_use, which the reconciler treats as still-running. We fix this
+    # here by checking file existence and stop_reason against the server start time.
+    #
+    # This runs here (inside main) rather than at module level so that importing
+    # this module from inbox_server_http.py does NOT trigger the cleanup.  A
+    # crash-looping HTTP bridge would otherwise incorrectly kill every running
+    # agent on every restart.
+    #
+    # Note on asymmetric notification: this sweep intentionally does NOT enqueue
+    # user notifications for the sessions it marks dead. Any sessions completed or
+    # dead before this restart but not yet notified are handled by the reconciler's
+    # _startup_sweep(), which fires immediately after the reconciler loop starts.
+    try:
+        _dead_ids = _session_store.cleanup_stale_running_sessions(
+            server_start_time=_SERVER_START_TIME
+        )
+        if _dead_ids:
+            log.warning(
+                f"[startup] Marked {len(_dead_ids)} stale 'running' session(s) as dead "
+                f"(pre-existing from before this server start): {_dead_ids}"
+            )
+        else:
+            log.info("[startup] No stale 'running' sessions found at startup")
+    except Exception as _cleanup_err:
+        log.warning(f"[startup] Stale session cleanup failed (non-fatal): {_cleanup_err}")
+
     asyncio.create_task(reconcile_agent_sessions())
     async with stdio_server() as (read_stream, write_stream):
         await server.run(read_stream, write_stream, server.create_initialization_options())


### PR DESCRIPTION
## Summary

- `cleanup_stale_running_sessions` was called at **module level** in `inbox_server.py`, meaning it ran every time the module was imported
- `inbox_server_http.py` (the HTTP MCP bridge) imports `inbox_server` at startup
- `lobster-mcp.service` (which runs the HTTP bridge) crashes on startup when `MCP_HTTP_TOKEN` is unconfigured, then systemd restarts it every ~10 seconds
- Each restart triggered the cleanup, which saw running agents' output symlinks as "missing" (the target JSONL files don't exist yet in the first seconds after spawn) and marked them `dead`
- This made lobster-watcher show all agents as dead/disconnected, even actively-running ones

## Root cause chain

1. `lobster-mcp.service` runs `inbox_server_http.py` (HTTP bridge for remote Claude access)
2. HTTP bridge imports `inbox_server.py` — triggers module-level cleanup
3. Cleanup sees `output_file` symlinks pointing to not-yet-created JSONL files → marks agents `dead`
4. HTTP bridge crashes (no `MCP_HTTP_TOKEN`), systemd restarts in 10s, loop repeats every ~11 seconds
5. Every agent spawned is killed within seconds in the DB, regardless of actual execution state

## Fix

Move `cleanup_stale_running_sessions` from module scope into `main()`, so it only runs when `inbox_server.py` is the actual stdio MCP server entry point — not when imported as a library by the HTTP bridge. Added an explanatory comment at the old call site explaining why the cleanup is intentionally deferred.

## Test plan

- [ ] Verify `lobster-mcp.service` still restarts every ~10s (expected — `MCP_HTTP_TOKEN` still unconfigured) but no longer marks running agents dead
- [ ] Spawn a background agent and confirm it stays `running` in the DB and in lobster-watcher
- [ ] Confirm lobster-watcher at http://eloso.ai/watcher/ shows correct agent state
- [ ] Confirm the stdio MCP server (Claude Code's actual server) still runs the cleanup on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)