### PR TITLE
fix: auditor hook zombie loop — ISO-8601 timestamp parsing and stderr routing

### DIFF
--- a/hooks/require-auditor-context-update.py
+++ b/hooks/require-auditor-context-update.py
@@ -157,15 +157,17 @@ def _safe_word_in_transcript(tool_calls: list[dict]) -> bool:
     return False
 
 
-def _parse_timestamp(t) -> float | None:
+def _parse_timestamp(t: str | int | float | None) -> float | None:
     """Parse a timestamp value to a Unix float.
 
     Accepts:
       - int/float: returned as float directly
       - str: tried as ISO-8601 first (CC 2.1.76+ format), then as a numeric string
 
-    Returns None if the value cannot be parsed.
+    Returns None if the value cannot be parsed or if t is None.
     """
+    if t is None:
+        return None
     if isinstance(t, (int, float)):
         return float(t)
     if isinstance(t, str):

--- a/hooks/require-auditor-context-update.py
+++ b/hooks/require-auditor-context-update.py
@@ -51,10 +51,21 @@ SAFE_WORD = "AUDIT_CONTEXT_UNCHANGED"
 # Path fragment used to detect auditor sessions in the transcript.
 AUDIT_CONTEXT_FILENAME = "system-audit.context.md"
 
+# JSON to emit on every successful (allow) exit — suppresses the
+# "Stop hook feedback: No stderr output" injection that CC 2.1.76+
+# produces even when the hook exits 0 with no output.
+_SILENT_OK = json.dumps({"suppressOutput": True})
+
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _exit_ok() -> None:
+    """Exit 0 with JSON that suppresses CC feedback injection."""
+    print(_SILENT_OK)
+    sys.exit(0)
 
 
 def _load_transcript_from_jsonl(path: str) -> list:
@@ -227,7 +238,7 @@ def main() -> None:
     try:
         hook_input = json.load(sys.stdin)
     except Exception:
-        sys.exit(0)  # Unreadable input — never block
+        _exit_ok()  # Unreadable input — never block
 
     # CC 2.1.76+: SubagentStop passes the transcript as a JSONL file at
     # agent_transcript_path rather than inline. Load from the file path,
@@ -242,18 +253,18 @@ def main() -> None:
 
     # Fast path: not an auditor session — pass through.
     if not _is_auditor_session(tool_calls):
-        sys.exit(0)
+        _exit_ok()
 
     # --- Auditor session detected ---
 
     # Condition 1: context file was updated during this session.
     session_start = _session_start_time(hook_input, transcript)
     if _context_file_updated_since(session_start):
-        sys.exit(0)
+        _exit_ok()
 
     # Condition 2: transcript contains the explicit safe word.
     if _safe_word_in_transcript(tool_calls):
-        sys.exit(0)
+        _exit_ok()
 
     # Neither condition met — block exit.
     print(

--- a/hooks/require-auditor-context-update.py
+++ b/hooks/require-auditor-context-update.py
@@ -39,6 +39,7 @@ import json
 import os
 import sys
 import time
+from datetime import datetime
 from pathlib import Path
 
 CONTEXT_FILE = Path(os.path.expanduser(
@@ -145,6 +146,31 @@ def _safe_word_in_transcript(tool_calls: list[dict]) -> bool:
     return False
 
 
+def _parse_timestamp(t) -> float | None:
+    """Parse a timestamp value to a Unix float.
+
+    Accepts:
+      - int/float: returned as float directly
+      - str: tried as ISO-8601 first (CC 2.1.76+ format), then as a numeric string
+
+    Returns None if the value cannot be parsed.
+    """
+    if isinstance(t, (int, float)):
+        return float(t)
+    if isinstance(t, str):
+        # ISO-8601 (CC 2.1.76+): e.g. "2026-03-19T16:52:01.657Z"
+        try:
+            return datetime.fromisoformat(t.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            pass
+        # Numeric string fallback (older CC versions)
+        try:
+            return float(t)
+        except ValueError:
+            pass
+    return None
+
+
 def _session_start_time(hook_input: dict, transcript: list) -> float | None:
     """Estimate session start time from the transcript's first message timestamp.
 
@@ -157,10 +183,9 @@ def _session_start_time(hook_input: dict, transcript: list) -> float | None:
     # Claude Code hook input may carry a top-level timestamp.
     ts = hook_input.get("session_start_time") or hook_input.get("timestamp")
     if ts:
-        try:
-            return float(ts)
-        except (TypeError, ValueError):
-            pass
+        parsed = _parse_timestamp(ts)
+        if parsed is not None:
+            return parsed
 
     # Try to find the minimum timestamp inside transcript messages.
     min_ts = None
@@ -169,12 +194,10 @@ def _session_start_time(hook_input: dict, transcript: list) -> float | None:
             continue
         t = msg.get("timestamp")
         if t:
-            try:
-                t_float = float(t)
+            t_float = _parse_timestamp(t)
+            if t_float is not None:
                 if min_ts is None or t_float < min_ts:
                     min_ts = t_float
-            except (TypeError, ValueError):
-                continue
     return min_ts
 
 
@@ -238,7 +261,8 @@ def main() -> None:
         "system-audit.context.md. "
         "Either update the file with your findings, or include "
         f"{SAFE_WORD!r} as the first line of your write_result call "
-        "if nothing new was found."
+        "if nothing new was found.",
+        file=sys.stderr,
     )
     sys.exit(2)
 


### PR DESCRIPTION
## What problem this solves

The auditor hook (`require-auditor-context-update.py`) had three bugs:

**Bug 1 — Timestamp parsing (root cause of zombie loop)**

\`_session_start_time()\` called \`float(t)\` on transcript timestamps. In CC 2.1.76+, timestamps are ISO-8601 strings (\`"2026-03-19T16:52:01.657Z"\`), not Unix floats. \`float(...)\` throws \`ValueError\`, which is silently caught, returning \`None\`. With \`since=None\`, \`_context_file_updated_since()\` always returns \`False\` — condition 1 could never be satisfied. The hook blocked on every auditor session exit regardless of whether the agent had done the right thing.

**Bug 2 — Block message written to stdout instead of stderr**

When the hook blocks (exits 2), the diagnostic message went to stdout. Claude Code reads only stderr for hook feedback. The agent always saw "Stop hook feedback: No stderr output" — no actionable information.

**Bug 3 — Spurious feedback injection on clean exits**

CC 2.1.76+ injects a "Stop hook feedback: No stderr output" system message into the agent even when a hook exits 0 cleanly, triggering a spurious extra turn on every auditor session exit.

## What changed

**\`_parse_timestamp()\` helper (new pure function):** Accepts \`int\`/\`float\`/\`str\`. For strings, tries \`datetime.fromisoformat()\` with \`Z\` → \`+00:00\` substitution first, then falls back to \`float()\`. Returns \`None\` on failure. Pattern matches \`_entry_timestamp()\` in \`require-write-result.py\`.

**\`_session_start_time()\` updated:** Delegates timestamp parsing to \`_parse_timestamp()\` for both the top-level hook input field and each transcript message scan.

**Blocking \`print()\` updated:** Added \`file=sys.stderr\` so the diagnostic is visible to Claude Code when the hook blocks.

**\`_SILENT_OK\` / \`_exit_ok()\` added:** All \`sys.exit(0)\` paths now emit \`{"suppressOutput": true}\` to stdout before exiting, suppressing the CC feedback injection. Identical pattern to \`require-write-result.py\`.

## What is NOT in this PR

- The circuit breaker (\`MAX_HOOK_FIRES\`) from PR #720 — not duplicated here
- Any change to the mtime comparison logic or the safe word check
- Any change to other hooks

## Flow: before vs after

Before (CC 2.1.76+):
```
SubagentStop fires
  → _session_start_time() calls float("2026-...Z") → ValueError → returns None
  → _context_file_updated_since(None) → False (always)
  → safe word not present → block with exit 2
  → agent sees "No stderr output" — no actionable info → loop forever

Clean exit:
  → sys.exit(0) with no stdout → CC injects "Stop hook feedback" → spurious turn
```

After:
```
SubagentStop fires (auditor updated the file)
  → _parse_timestamp("2026-...Z") → valid Unix float
  → _context_file_updated_since(t) → True → _exit_ok() → suppressOutput emitted
  → CC does not inject feedback → session ends cleanly

If not updated, block fires:
  → diagnostic written to stderr → agent sees the error message
```

## Functional patterns used

Pure function (\`_parse_timestamp\`) with explicit return type and no side effects. Fallback chain expressed as sequential \`try/except\` blocks with early returns rather than nested conditionals. \`_exit_ok()\` as a named exit point consistent across all success paths.

## Tests run

- [x] \`python3 -c "import ast; ast.parse(...)"\` — syntax clean after each commit
- [x] Inline smoke test of \`_parse_timestamp\` with ISO-8601 (Z suffix), ISO-8601 (offset), float, int, numeric string, invalid string, None — all 7 cases pass
- [ ] Live auditor session end-to-end — blocked: requires a running CC instance

**Blocked items needing attention before merge:** none

---
🤖🦞 Lobster (engineer): fixes zombie loop root cause (ISO-8601 timestamps), stderr routing for block messages, and spurious feedback injection on clean exits