### PR TITLE
Harden observation pipeline: direct log write at MCP layer for system_error

### DIFF
--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -197,6 +197,8 @@ mcp__lobster-inbox__write_observation(
 | `system_context` | Internal system info worth storing silently | Stored to memory, no user message |
 | `system_error` | Error or anomaly to log | Written to `observations.log`, no user message |
 
+**`system_error` is durable:** `write_observation(category="system_error")` appends to `observations.log` directly at the MCP layer (belt-and-suspenders), independently of whether the dispatcher processes the inbox message. Use it for unexpected failures — it reaches the operator log even if the dispatcher is restarting or compacting. This is different from `write_result(status="error")`, which delivers the final answer to the user via the dispatcher; both serve different purposes and should both be called on task failure.
+
 **Rules:**
 
 - Call `write_observation` before or after `write_result` — order doesn't matter

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -5431,6 +5431,29 @@ async def handle_write_observation(args: dict) -> list[TextContent]:
     inbox_file = INBOX_DIR / f"{message_id}.json"
     atomic_write_json(inbox_file, message)
 
+    # Belt-and-suspenders: for system_error, also append directly to observations.log
+    # at the MCP layer. The inbox write above is the primary path — the dispatcher
+    # picks it up and writes to the log as part of routing. This direct append is a
+    # durability fallback: if the dispatcher is restarting or compacting at the moment
+    # the observation arrives, the error is still recorded. The source field
+    # "mcp-direct" distinguishes these entries from dispatcher-written ones.
+    # Worst case: two log entries for one event (acceptable — no deduplication needed).
+    if category == "system_error":
+        obs_log = LOG_DIR / "observations.log"
+        log_entry: dict = {
+            "ts": now.isoformat(),
+            "category": category,
+            "content": text,
+            "source": "mcp-direct",
+        }
+        if task_id:
+            log_entry["task_id"] = task_id
+        try:
+            with obs_log.open("a") as f:
+                f.write(json.dumps(log_entry) + "\n")
+        except OSError as exc:
+            log.warning(f"Failed to write observation to {obs_log}: {exc}")
+
     # When LOBSTER_DEBUG=true, also enqueue a debug inbox message so the user
     # sees what the dispatcher sees in real time. This is additive — the inbox
     # write above always happens first regardless of debug mode.

--- a/tests/unit/test_mcp_server/test_write_observation.py
+++ b/tests/unit/test_mcp_server/test_write_observation.py
@@ -538,3 +538,206 @@ class TestHandleWriteObservation:
         assert len(emitted) == 1
         assert emitted[0]["emitter"] == "task:task-42"
         assert emitted[0]["visibility"] == "mcp-only"
+
+    def test_debug_bypass_includes_task_id_in_emitted_text(self, inbox_dir: Path):
+        """In debug mode, system_error emitter contains task_id prefix 'task:'."""
+        emitted: list[dict] = []
+
+        def fake_emit(
+            text: str,
+            category: str = "system_context",
+            visibility: str = "mcp-only",
+            emitter: str | None = None,
+        ) -> None:
+            emitted.append({"text": text, "emitter": emitter})
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox_dir,
+            _DEBUG_MODE=True,
+            _DEBUG_RESOLVED=True,
+            _emit_debug_observation=fake_emit,
+        ):
+            from src.mcp.inbox_server import handle_write_observation
+            asyncio.run(handle_write_observation({
+                "chat_id": 123,
+                "text": "Disk nearly full.",
+                "category": "system_error",
+                "task_id": "disk-check-99",
+            }))
+
+        assert len(emitted) == 1
+        assert emitted[0]["emitter"] == "task:disk-check-99"
+
+
+class TestHandleWriteObservationLogWrite:
+    """Tests for the belt-and-suspenders direct observations.log write."""
+
+    def _run_with_dirs(self, args: dict, inbox_dir: Path, log_dir: Path) -> list:
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox_dir,
+            LOG_DIR=log_dir,
+            _DEBUG_MODE=False,
+            _DEBUG_RESOLVED=True,
+        ):
+            from src.mcp.inbox_server import handle_write_observation
+            return asyncio.run(handle_write_observation(args))
+
+    @pytest.fixture
+    def inbox_dir(self, temp_messages_dir: Path) -> Path:
+        return temp_messages_dir / "inbox"
+
+    @pytest.fixture
+    def log_dir(self, tmp_path: Path) -> Path:
+        d = tmp_path / "logs"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    # ------------------------------------------------------------------
+    # system_error appends to observations.log
+    # ------------------------------------------------------------------
+
+    def test_system_error_appends_json_line_to_observations_log(
+        self, inbox_dir: Path, log_dir: Path
+    ):
+        """system_error observation writes a JSON line directly to observations.log."""
+        self._run_with_dirs(
+            {
+                "chat_id": 123,
+                "text": "API call failed unexpectedly.",
+                "category": "system_error",
+            },
+            inbox_dir,
+            log_dir,
+        )
+
+        obs_log = log_dir / "observations.log"
+        assert obs_log.exists(), "observations.log should be created"
+        lines = [ln for ln in obs_log.read_text().splitlines() if ln.strip()]
+        assert len(lines) == 1
+
+        entry = json.loads(lines[0])
+        assert entry["category"] == "system_error"
+        assert entry["content"] == "API call failed unexpectedly."
+        assert entry["source"] == "mcp-direct"
+        assert "ts" in entry
+
+    def test_system_error_log_entry_includes_task_id_when_provided(
+        self, inbox_dir: Path, log_dir: Path
+    ):
+        """When task_id is supplied, the log entry includes it."""
+        self._run_with_dirs(
+            {
+                "chat_id": 123,
+                "text": "DB connection lost.",
+                "category": "system_error",
+                "task_id": "task-db-99",
+            },
+            inbox_dir,
+            log_dir,
+        )
+
+        obs_log = log_dir / "observations.log"
+        entry = json.loads(obs_log.read_text().strip())
+        assert entry.get("task_id") == "task-db-99"
+
+    def test_system_error_log_entry_omits_task_id_when_absent(
+        self, inbox_dir: Path, log_dir: Path
+    ):
+        """When task_id is not supplied, it is absent from the log entry."""
+        self._run_with_dirs(
+            {
+                "chat_id": 123,
+                "text": "Unexpected state detected.",
+                "category": "system_error",
+            },
+            inbox_dir,
+            log_dir,
+        )
+
+        obs_log = log_dir / "observations.log"
+        entry = json.loads(obs_log.read_text().strip())
+        assert "task_id" not in entry
+
+    def test_multiple_system_errors_append_multiple_lines(
+        self, inbox_dir: Path, log_dir: Path
+    ):
+        """Successive system_error calls each append a new line (not overwrite)."""
+        for i in range(3):
+            self._run_with_dirs(
+                {
+                    "chat_id": 123,
+                    "text": f"Error #{i}",
+                    "category": "system_error",
+                },
+                inbox_dir,
+                log_dir,
+            )
+
+        obs_log = log_dir / "observations.log"
+        lines = [ln for ln in obs_log.read_text().splitlines() if ln.strip()]
+        assert len(lines) == 3
+        texts = [json.loads(ln)["content"] for ln in lines]
+        assert texts == ["Error #0", "Error #1", "Error #2"]
+
+    # ------------------------------------------------------------------
+    # Non-system_error categories do NOT write to observations.log
+    # ------------------------------------------------------------------
+
+    def test_user_context_does_not_write_to_observations_log(
+        self, inbox_dir: Path, log_dir: Path
+    ):
+        """user_context observations skip the direct log write."""
+        self._run_with_dirs(
+            {
+                "chat_id": 123,
+                "text": "User prefers dark mode.",
+                "category": "user_context",
+            },
+            inbox_dir,
+            log_dir,
+        )
+
+        obs_log = log_dir / "observations.log"
+        assert not obs_log.exists(), "observations.log should not be created for user_context"
+
+    def test_system_context_does_not_write_to_observations_log(
+        self, inbox_dir: Path, log_dir: Path
+    ):
+        """system_context observations skip the direct log write."""
+        self._run_with_dirs(
+            {
+                "chat_id": 123,
+                "text": "Config drift detected.",
+                "category": "system_context",
+            },
+            inbox_dir,
+            log_dir,
+        )
+
+        obs_log = log_dir / "observations.log"
+        assert not obs_log.exists(), "observations.log should not be created for system_context"
+
+    def test_system_error_also_writes_inbox_message(
+        self, inbox_dir: Path, log_dir: Path
+    ):
+        """The log write is additive — the inbox message is still written for dispatcher routing."""
+        self._run_with_dirs(
+            {
+                "chat_id": 123,
+                "text": "Service unreachable.",
+                "category": "system_error",
+            },
+            inbox_dir,
+            log_dir,
+        )
+
+        inbox_files = list(inbox_dir.glob("*.json"))
+        assert len(inbox_files) == 1, "Inbox message must still be written"
+        content = json.loads(inbox_files[0].read_text())
+        assert content["type"] == "subagent_observation"
+        assert content["category"] == "system_error"
+
+        obs_log = log_dir / "observations.log"
+        assert obs_log.exists(), "observations.log must also be written"


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

Closes #729

## What this changes

Before this PR, `observations.log` was written exclusively by the dispatcher when it routed a `subagent_observation` inbox message. That made the log write dependent on the dispatcher's session being healthy at the exact moment the observation arrived — a dispatcher restart or context compaction could silently drop `system_error` records.

After this PR, `handle_write_observation` in `inbox_server.py` also appends directly to `observations.log` at the MCP layer for `system_error` observations. The inbox write remains primary (the dispatcher still receives and routes the message). The MCP-layer append is a durability fallback: it happens regardless of dispatcher state. The `source: "mcp-direct"` field distinguishes these entries from dispatcher-written ones.

The two categories unchanged by this PR (`user_context`, `system_context`) do not write to the log — that behavior is correct and unchanged.

## Scope

Three files changed:

- `src/mcp/inbox_server.py` — adds the direct `observations.log` append inside `handle_write_observation`, guarded by `category == "system_error"`. Non-fatal: an `OSError` is logged as a warning, not raised. Pure functional addition — no shared state mutation, no new imports.
- `tests/unit/test_mcp_server/test_write_observation.py` — adds `TestHandleWriteObservationLogWrite` class with 7 tests covering: log entry fields, task_id presence/absence, multiple appends, category filtering (user_context and system_context must not write), and the belt-and-suspenders invariant (inbox message is still written when log write fires).
- `.claude/sys.subagent.bootup.md` — adds a note in the `write_observation` category guide making explicit that `system_error` is durable at the MCP layer, distinct from `write_result(status="error")`.

Out of scope: the `observation_type`/`_user_model.dispatch` path that two pre-existing tests expect (those failures exist on `main` and predate this PR).

## Flow: before vs. after

```
system_error observation arrives
       │
       ▼
handle_write_observation
       │
       ├── [before] inbox write only → dispatcher must be running to reach log
       │
       └── [after]  inbox write
                    + direct append to observations.log (mcp-direct)
                      ↑ happens here, before dispatcher even sees the message
```

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_write_observation.py -v` — 28 passed, 2 pre-existing failures (test_observation_type_default_is_preference, test_observation_type_explicit_value_forwarded — these fail on main too)
- [x] `uv run pytest tests/unit/ -q` — 83 failed, 1249 passed (baseline on main: 83 failed, 1241 passed — net +8 new passing tests, 0 new failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)