### PR TITLE
Add daily log-export job for local archiving (issue #730)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1409,6 +1409,16 @@ chmod +x "$INSTALL_DIR/scripts/sync-gws-credentials.py" || true
 
 success "GWS credential sync configured (runs at 04:00 daily)"
 
+# Add daily log-export to crontab (runs at 03:00 UTC)
+# export-logs.py archives observations.log, lobster.log, and audit.jsonl to a
+# date-stamped directory under ~/lobster-workspace/logs/archive/ and writes a
+# summary to ~/messages/task-outputs/ (readable via check_task_outputs).
+chmod +x "$INSTALL_DIR/scheduled-tasks/export-logs.py" 2>/dev/null || true
+"$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-LOG-EXPORT" \
+    "0 3 * * * cd $INSTALL_DIR && uv run scheduled-tasks/export-logs.py # LOBSTER-LOG-EXPORT"
+
+success "Log export configured (runs at 03:00 UTC daily)"
+
 #===============================================================================
 # Cron-to-Inbox Reminder System (post-reminder.sh)
 #===============================================================================

--- a/scheduled-tasks/export-logs.py
+++ b/scheduled-tasks/export-logs.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+Scheduled job: export recent log entries to ~/lobster-workspace/logs/archive/
+Runs daily. Copies observations.log, lobster.log, and audit.jsonl snapshots
+with date-stamped directory names.
+
+Designed to be the foundation for future remote forwarding once an endpoint
+is chosen (see GitHub issue #730).
+"""
+
+import json
+import os
+import shutil
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — no side effects
+# ---------------------------------------------------------------------------
+
+def resolve_paths() -> dict:
+    """Return all relevant paths as an immutable data structure."""
+    home = Path.home()
+    logs_dir = home / "lobster-workspace" / "logs"
+    archive_base = logs_dir / "archive"
+    messages_dir = Path(os.environ.get("LOBSTER_MESSAGES", home / "messages"))
+    task_outputs_dir = messages_dir / "task-outputs"
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return {
+        "logs_dir": logs_dir,
+        "archive_dir": archive_base / today,
+        "task_outputs_dir": task_outputs_dir,
+        "date_label": today,
+        "source_files": [
+            logs_dir / "observations.log",
+            logs_dir / "lobster.log",
+            logs_dir / "audit.jsonl",
+        ],
+    }
+
+
+def file_stats(path: Path) -> dict:
+    """Return size and line count for a file; empty dict if missing."""
+    if not path.exists():
+        return {"exists": False, "size_bytes": 0, "line_count": 0}
+    size = path.stat().st_size
+    try:
+        with path.open("rb") as fh:
+            line_count = sum(1 for _ in fh)
+    except OSError:
+        line_count = 0
+    return {"exists": True, "size_bytes": size, "line_count": line_count}
+
+
+def count_recent_errors(path: Path, within_hours: int = 24) -> int:
+    """
+    Count ERROR-level entries from the past `within_hours`.
+
+    Handles two formats:
+    - JSON lines (observations.log, audit.jsonl): checks "level", "severity", "lvl" fields.
+    - Plain text: looks for lines containing the literal string "ERROR".
+
+    Returns 0 if the file does not exist or cannot be parsed.
+    """
+    if not path.exists():
+        return 0
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=within_hours)
+    count = 0
+
+    try:
+        with path.open("r", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                    level = (
+                        entry.get("level", "")
+                        or entry.get("severity", "")
+                        or entry.get("lvl", "")
+                    ).upper()
+                    if level != "ERROR":
+                        continue
+                    ts_raw = (
+                        entry.get("timestamp")
+                        or entry.get("ts")
+                        or entry.get("time")
+                    )
+                    if ts_raw:
+                        try:
+                            ts = datetime.fromisoformat(
+                                str(ts_raw).replace("Z", "+00:00")
+                            )
+                            if ts < cutoff:
+                                continue
+                        except (ValueError, TypeError):
+                            pass  # include entry if timestamp is unparseable
+                    count += 1
+                except (json.JSONDecodeError, ValueError):
+                    # Plain-text fallback
+                    if "ERROR" in line:
+                        count += 1
+    except OSError:
+        pass
+
+    return count
+
+
+def copy_to_archive(source: Path, dest_dir: Path) -> dict:
+    """
+    Copy source file to dest_dir and return a structured result dict.
+    Never raises; errors are captured in the result.
+    """
+    if not source.exists():
+        return {
+            "file": source.name,
+            "status": "skipped",
+            "reason": "source not found",
+        }
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / source.name
+    try:
+        shutil.copy2(str(source), str(dest))
+        stats = file_stats(dest)
+        return {
+            "file": source.name,
+            "status": "copied",
+            "dest": str(dest),
+            "size_bytes": stats["size_bytes"],
+            "line_count": stats["line_count"],
+        }
+    except OSError as exc:
+        return {"file": source.name, "status": "error", "reason": str(exc)}
+
+
+def build_summary(paths: dict, copy_results: list, error_counts: dict) -> str:
+    """
+    Compose a human-readable summary string from structured data.
+    Pure function: no I/O.
+    """
+    lines = [
+        f"Log export complete for {paths['date_label']}",
+        f"Archive: {paths['archive_dir']}",
+        "",
+        "Files:",
+    ]
+
+    for result in copy_results:
+        name = result["file"]
+        status = result["status"]
+        if status == "copied":
+            size_kb = result["size_bytes"] / 1024
+            line_count = result["line_count"]
+            errors_24h = error_counts.get(name, 0)
+            error_note = f", {errors_24h} ERROR(s) in past 24h" if errors_24h else ""
+            lines.append(
+                f"  {name}: {line_count} lines, {size_kb:.1f} KB{error_note}"
+            )
+        elif status == "skipped":
+            lines.append(f"  {name}: skipped ({result.get('reason', 'unknown')})")
+        else:
+            lines.append(
+                f"  {name}: FAILED — {result.get('reason', 'unknown')}"
+            )
+
+    total_errors = sum(error_counts.values())
+    lines.append("")
+    if total_errors:
+        lines.append(
+            f"Total ERROR entries in past 24h: {total_errors}"
+        )
+    else:
+        lines.append("No ERROR entries in past 24h.")
+
+    lines.append("")
+    lines.append(
+        "Remote forwarding not yet configured (see issue #730). "
+        "Add an endpoint and extend this script to push archived files."
+    )
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Side-effecting boundary functions
+# ---------------------------------------------------------------------------
+
+def write_task_output(task_outputs_dir: Path, job_name: str, summary: str, status: str) -> None:
+    """
+    Write job output to the task-outputs directory in the same format as the
+    write_task_output MCP tool, so the dispatcher can pick it up via
+    check_task_outputs.
+    """
+    task_outputs_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc)
+    timestamp_str = now.strftime("%Y%m%d-%H%M%S")
+    output_data = {
+        "job_name": job_name,
+        "timestamp": now.isoformat(),
+        "status": status,
+        "output": summary,
+    }
+    output_file = task_outputs_dir / f"{timestamp_str}-{job_name}.json"
+    with open(output_file, "w") as fh:
+        json.dump(output_data, fh, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    paths = resolve_paths()
+
+    copy_results = [
+        copy_to_archive(src, paths["archive_dir"])
+        for src in paths["source_files"]
+    ]
+
+    error_counts = {
+        src.name: count_recent_errors(src)
+        for src in paths["source_files"]
+    }
+
+    any_failure = any(r["status"] == "error" for r in copy_results)
+    status = "failed" if any_failure else "success"
+
+    summary = build_summary(paths, copy_results, error_counts)
+
+    # Write to task-outputs so dispatcher can see it via check_task_outputs
+    write_task_output(
+        paths["task_outputs_dir"],
+        job_name="export-logs",
+        summary=summary,
+        status=status,
+    )
+
+    # Also print to stdout for cron log capture
+    print(summary)
+
+    return 1 if any_failure else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1473,6 +1473,22 @@ with open(path, 'w') as f:
     fi
 
 
+    # Migration 28: Add daily log-export cron entry
+    # export-logs.py copies observations.log, lobster.log, and audit.jsonl to a
+    # date-stamped archive under ~/lobster-workspace/logs/archive/ and writes a
+    # summary to ~/messages/task-outputs/ (readable via check_task_outputs).
+    # Provides an off-process durable copy of high-signal logs and a foundation
+    # for future remote forwarding (see issue #730).
+    local LOG_EXPORT_MARKER="# LOBSTER-LOG-EXPORT"
+    if ! crontab -l 2>/dev/null | grep -q "$LOG_EXPORT_MARKER"; then
+        local log_export_script="$LOBSTER_DIR/scheduled-tasks/export-logs.py"
+        chmod +x "$log_export_script" 2>/dev/null || true
+        "$LOBSTER_DIR/scripts/cron-manage.sh" add "$LOG_EXPORT_MARKER" \
+            "0 3 * * * cd $LOBSTER_DIR && uv run scheduled-tasks/export-logs.py $LOG_EXPORT_MARKER"
+        substep "Added daily log-export cron entry (03:00 UTC, archives observations.log + audit.jsonl)"
+        migrated=$((migrated + 1))
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## Problem

Lobster logs live only on the VPS. If the disk has an issue or the process is killed, there is no forensic record. Issue #730 identified this gap and recommended starting with a local archiving step before making any irreversible decisions about remote endpoints.

## What this changes

Adds `scheduled-tasks/export-logs.py`, a Python script that runs daily via cron and:

1. Copies `observations.log`, `lobster.log`, and `audit.jsonl` from `~/lobster-workspace/logs/` to `~/lobster-workspace/logs/archive/YYYY-MM-DD/` (copy, not move — originals are untouched)
2. Counts ERROR-level entries from the past 24 hours in each file, handling both JSON-lines and plain-text formats
3. Writes a summary to `~/messages/task-outputs/` in the same format as `write_task_output` MCP tool, so the output is visible via `check_task_outputs`

Migration 28 in `scripts/upgrade.sh` registers the `# LOBSTER-LOG-EXPORT` cron entry (daily at 03:00 UTC) on existing installs. New installs pick it up via the same migration path.

## What this does NOT change

- No remote forwarding — the open questions from issue #730 (endpoint choice, data sensitivity) remain open. This PR builds the local infrastructure only.
- No changes to log rotation, log formats, or the MCP server.
- No new daemons or services. This is a cron-invoked Python script with no runtime footprint.

## Design

Pure helpers (`resolve_paths`, `file_stats`, `count_recent_errors`, `build_summary`) do all computation without I/O and are composed in `main()`. Side effects are isolated to `copy_to_archive` and `write_task_output` at the boundary. This makes the script straightforward to extend: adding a remote push step means writing one new boundary function and calling it from `main()`.

## Adding remote forwarding later

Extend `main()` with a call like:

```python
push_to_remote(paths["archive_dir"], endpoint=os.environ["LOG_FORWARD_ENDPOINT"])
```

No structural changes to the existing code are needed.

## Tests run

- [x] `uv run scheduled-tasks/export-logs.py` — ran successfully against live logs; archive directory and task-output JSON created as expected
- [x] `cd ~/lobster && .venv/bin/python -m pytest tests/unit/ -q --timeout=30` — 1203 passed; all failures are pre-existing (test_bisque/test_protocol.py FrameType count, test_bot, test_daemon, test_cli, test_path_guard, test_update_manager) and reproduce identically on main

Closes #730