### PR TITLE
fix: rebuild better-sqlite3 from source in camofox install.sh

### DIFF
--- a/lobster-shop/camofox-browser/install.sh
+++ b/lobster-shop/camofox-browser/install.sh
@@ -136,6 +136,15 @@ step "Installing Node.js dependencies"
 
 cd "$SERVER_DIR"
 npm install --production 2>&1 | tail -5
+
+# Rebuild native addons (better-sqlite3) from source to match the current Node
+# binary. Pre-built binaries for better-sqlite3 are compiled against the Ubuntu
+# system libnode (libnode.so.109, i.e. Node 18), which does not exist when Node
+# is installed from NodeSource as a static binary. Building from source compiles
+# against the installed node headers with static linkage, so no libnode.so is
+# required at runtime.
+info "Rebuilding native addons from source for Node $(node --version)..."
+npm rebuild better-sqlite3 --build-from-source 2>&1 | tail -5
 success "Node.js dependencies installed"
 
 info "Fetching Camoufox browser engine (this may take a minute on first run)..."


### PR DESCRIPTION
## Problem

After PR #716 upgraded Node to v22 (from NodeSource), the camofox browser pre-warm fails silently at every startup:

```
{"level":"error","msg":"browser pre-warm failed (will retry on first request)","error":"libnode.so.109: cannot open shared object file: No such file or directory"}
```

The server stays up but browserConnected is permanently false, meaning the first actual browser request always pays a cold-start penalty (and may fail).

## Root cause

better-sqlite3 ships pre-built native binaries via prebuild-install. The pre-built binary for linux/arm64 was compiled against Ubuntu's system Node package (libnode109 = Node 18), which installs Node as a shared library (libnode.so.109). NodeSource's Node 22 package installs Node as a monolithic static binary - it does not provide libnode.so at all. So the pre-built addon's dlopen fails.

Verified with ldd before fix:
  libnode.so.109 => not found

After npm rebuild better-sqlite3 --build-from-source, the addon compiles against the current Node headers with static linkage - no libnode.so referenced.

## Fix

Add one line after npm install in install.sh:

  npm rebuild better-sqlite3 --build-from-source

This is idempotent and fast (~30s).

## Verification

- Applied the rebuild manually on the running install
- /health returns {"ok":true} with no libnode error in logs
- New startup log shows no error line (just the expected yt-dlp warning)

Companion to #716 / closes follow-up on #715.

---
🤖🦞 Lobster (ops)