### PR TITLE
fix: Docker test build — whisper examples target + add psutil test dep

### DIFF
--- a/tests/docker/Dockerfile.integration
+++ b/tests/docker/Dockerfile.integration
@@ -58,7 +58,8 @@ RUN git clone --depth 1 https://github.com/ggml-org/whisper.cpp.git \
           -S /home/testuser/lobster-workspace/whisper.cpp \
           -DBUILD_SHARED_LIBS=OFF \
           -DWHISPER_BUILD_TESTS=OFF \
-          -DWHISPER_BUILD_EXAMPLES=OFF && \
+          -DWHISPER_BUILD_EXAMPLES=ON \
+          -DWHISPER_BUILD_SERVER=OFF && \
     cmake --build /home/testuser/lobster-workspace/whisper.cpp/build \
           --config Release -j$(nproc) --target whisper-cli && \
     curl -L --retry 3 \

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -17,6 +17,9 @@ docker>=7.0.0
 aioresponses>=0.7.6
 responses>=0.24.0
 
+# System utilities (required by test_memory.py)
+psutil>=5.9.0
+
 # General utilities
 faker>=22.0.0
 freezegun>=1.2.0


### PR DESCRIPTION
## What this fixes

The Docker integration test build was failing at the whisper.cpp cmake step. The root cause: `-DWHISPER_BUILD_EXAMPLES=OFF` suppresses the `whisper-cli` target entirely, so `cmake --build --target whisper-cli` has nothing to build and exits with an error.

The fix builds examples but skips the HTTP server, which is the only binary we don't need in CI:

```
-DWHISPER_BUILD_EXAMPLES=ON \
-DWHISPER_BUILD_SERVER=OFF
```

This produces `whisper-cli` (required by the transcription tests) without pulling in the server binary.

## Second change: psutil in test requirements

`test_memory.py` does a top-level `import psutil`. The package was not listed in `tests/requirements-test.txt`, so the Docker test container failed on import with `ModuleNotFoundError: No module named 'psutil'`. Added `psutil>=5.9.0` under a "System utilities" comment.

## Scope

No behavior changes to production code. Both changes are test infrastructure only.

## Tests run

- [ ] `docker compose -f tests/docker/docker-compose.test.yml up --build` — not run locally; this PR exists precisely to unblock that build

**Blocked items needing attention before merge:** none — the changes are mechanical and verifiable from the diff.

Relates to #738 (test suite drift tracking issue)