### PR TITLE
fix(tests): reconcile test suite with code drift — batch 1

### DIFF
--- a/tests/unit/test_bisque/test_protocol.py
+++ b/tests/unit/test_bisque/test_protocol.py
@@ -74,8 +74,8 @@ class TestEnvelope:
 
 
 class TestFrameType:
-    def test_all_19_frame_types(self):
-        assert len(FrameType) == 19
+    def test_all_20_frame_types(self):
+        assert len(FrameType) == 20
 
     def test_client_types(self):
         for t in ["auth", "send_message", "ack", "ping"]:
@@ -90,8 +90,13 @@ class TestFrameType:
         ]:
             assert t in SERVER_FRAME_TYPES
 
-    def test_client_server_disjoint(self):
-        assert CLIENT_FRAME_TYPES & SERVER_FRAME_TYPES == set()
+    def test_client_server_disjoint_except_message_alias(self):
+        # "message" is intentionally in both sets as a client-compat alias for
+        # "send_message" (see CLIENT_FRAME_TYPES comment in protocol.py).
+        overlap = CLIENT_FRAME_TYPES & SERVER_FRAME_TYPES
+        assert overlap == {"message"}, (
+            f"Expected only 'message' in the overlap, got: {overlap}"
+        )
 
 
 # =============================================================================
@@ -136,9 +141,11 @@ class TestSerialization:
             deserialize("not json {")
 
     def test_deserialize_missing_v(self):
+        # v is optional for client compat — defaults to 2 if absent, no error raised.
         raw = json.dumps({"type": "pong", "id": "x", "ts": "t"})
-        with pytest.raises(ProtocolError):
-            deserialize(raw)
+        env = deserialize(raw)
+        assert env.v == 2
+        assert env.type == "pong"
 
     def test_deserialize_missing_type(self):
         raw = json.dumps({"v": 2, "id": "x", "ts": "t"})

--- a/tests/unit/test_bisque/test_relay_server.py
+++ b/tests/unit/test_bisque/test_relay_server.py
@@ -57,6 +57,23 @@ async def _close(session, ws):
     await session.close()
 
 
+async def _receive_frame_of_type(ws, frame_type: str, timeout: float = 10) -> Any:
+    """Receive frames until one with the given type is found.
+
+    The relay server may send interstitial frames (e.g. typing indicators) before
+    the expected frame. This helper skips those and returns the first matching frame.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    while True:
+        remaining = deadline - asyncio.get_event_loop().time()
+        if remaining <= 0:
+            raise asyncio.TimeoutError(f"Timed out waiting for frame type '{frame_type}'")
+        msg = await asyncio.wait_for(ws.receive(), timeout=remaining)
+        data = json.loads(msg.data)
+        if data["type"] == frame_type:
+            return data
+
+
 # =============================================================================
 # HTTP auth exchange
 # =============================================================================
@@ -259,9 +276,9 @@ class TestEventDelivery:
             }
             (dirs["bisque_outbox"] / "out-1.json").write_text(json.dumps(msg_data))
 
-            msg = await asyncio.wait_for(ws.receive(), timeout=10)
-            data = json.loads(msg.data)
-            assert data["type"] == "message"
+            # The server sends a typing=false indicator before the message frame
+            # (BIS-122). Skip interstitial frames and wait for the message.
+            data = await _receive_frame_of_type(ws, "message", timeout=10)
             assert data["text"] == "Reply from Lobster"
             assert data["role"] == "assistant"
         finally:
@@ -299,10 +316,12 @@ class TestEventDelivery:
             msg_data = {"id": "fan-1", "text": "Broadcast", "chat_id": "x"}
             (dirs["bisque_outbox"] / "fan-1.json").write_text(json.dumps(msg_data))
 
-            m1 = await asyncio.wait_for(ws1.receive(), timeout=10)
-            m2 = await asyncio.wait_for(ws2.receive(), timeout=10)
-            assert json.loads(m1.data)["type"] == "message"
-            assert json.loads(m2.data)["type"] == "message"
+            # Skip interstitial typing frames (BIS-122) and assert both clients
+            # receive the message frame.
+            d1 = await _receive_frame_of_type(ws1, "message", timeout=10)
+            d2 = await _receive_frame_of_type(ws2, "message", timeout=10)
+            assert d1["type"] == "message"
+            assert d2["type"] == "message"
         finally:
             await _close(s1, ws1)
             await _close(s2, ws2)
@@ -476,7 +495,9 @@ class TestStress:
 
             for _, ws in connections:
                 received = []
-                for _ in range(20):
+                # Each message is now preceded by a typing=false frame (BIS-122),
+                # so double the read budget to collect 20 messages from 40 frames.
+                for _ in range(40):
                     try:
                         msg = await asyncio.wait_for(ws.receive(), timeout=15)
                         data = json.loads(msg.data)

--- a/tests/unit/test_hooks/test_require_write_result.py
+++ b/tests/unit/test_hooks/test_require_write_result.py
@@ -361,7 +361,7 @@ class TestDispatcherExemption:
 
         # Write the dispatcher session marker file.
         config_dir = tmp_path / "messages" / "config"
-        config_dir.mkdir(parents=True)
+        config_dir.mkdir(parents=True, exist_ok=True)
         (config_dir / "dispatcher-session-id").write_text("dispatcher-sess-001")
 
         # Write a transcript file with no write_result (dispatcher never calls it).
@@ -471,7 +471,7 @@ class TestFallbackAfterNFires:
         monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
 
         inbox_dir = tmp_path / "messages" / "inbox"
-        inbox_dir.mkdir(parents=True)
+        inbox_dir.mkdir(parents=True, exist_ok=True)
         monkeypatch.setenv("HOME", str(tmp_path))
 
         # Fire MAX_HOOK_FIRES times — should all block.
@@ -498,7 +498,7 @@ class TestFallbackAfterNFires:
         monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
 
         inbox_dir = tmp_path / "messages" / "inbox"
-        inbox_dir.mkdir(parents=True)
+        inbox_dir.mkdir(parents=True, exist_ok=True)
         monkeypatch.setenv("HOME", str(tmp_path))
 
         for _ in range(mod.MAX_HOOK_FIRES):
@@ -528,7 +528,7 @@ class TestFallbackAfterNFires:
         monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
 
         inbox_dir = tmp_path / "messages" / "inbox"
-        inbox_dir.mkdir(parents=True)
+        inbox_dir.mkdir(parents=True, exist_ok=True)
         monkeypatch.setenv("HOME", str(tmp_path))
 
         for _ in range(mod.MAX_HOOK_FIRES):
@@ -540,7 +540,7 @@ class TestFallbackAfterNFires:
         assert len(inbox_files) == 1, f"Expected 1 inbox file, got {len(inbox_files)}"
 
         msg = json.loads(inbox_files[0].read_text())
-        assert msg["type"] == "subagent_result"
+        assert msg["type"] == "subagent_recovered"
         assert msg["status"] == "recovered"
         assert msg.get("recovered") is True
         assert "write_result" in msg["text"] or "recovered" in msg["text"].lower()
@@ -566,7 +566,7 @@ class TestFallbackAfterNFires:
         monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
 
         inbox_dir = tmp_path / "messages" / "inbox"
-        inbox_dir.mkdir(parents=True)
+        inbox_dir.mkdir(parents=True, exist_ok=True)
         monkeypatch.setenv("HOME", str(tmp_path))
 
         for _ in range(mod.MAX_HOOK_FIRES):
@@ -605,7 +605,7 @@ class TestFallbackAfterNFires:
         monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
 
         inbox_dir = tmp_path / "messages" / "inbox"
-        inbox_dir.mkdir(parents=True)
+        inbox_dir.mkdir(parents=True, exist_ok=True)
         monkeypatch.setenv("HOME", str(tmp_path))
 
         # Simulate first fire at the expected timestamp.
@@ -671,7 +671,7 @@ class TestFallbackAfterNFires:
         monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
 
         inbox_dir = tmp_path / "messages" / "inbox"
-        inbox_dir.mkdir(parents=True)
+        inbox_dir.mkdir(parents=True, exist_ok=True)
         monkeypatch.setenv("HOME", str(tmp_path))
 
         for _ in range(mod.MAX_HOOK_FIRES + 1):

--- a/tests/unit/test_mcp_server/test_agent_failure_recovery.py
+++ b/tests/unit/test_mcp_server/test_agent_failure_recovery.py
@@ -338,7 +338,7 @@ class TestMarkFailedGhostNoUserAlert:
           1. type='agent_failed' to chat_id=0 (dispatcher-internal only)
         """
         inbox_dir = tmp_path / "messages" / "inbox"
-        inbox_dir.mkdir(parents=True)
+        inbox_dir.mkdir(parents=True, exist_ok=True)
 
         # Patch the inbox dir and DB path
         monkeypatch.setattr(_gd, "DB_PATH", tmp_path / "agent_sessions.db")

--- a/tests/unit/test_mcp_server/test_debug_alerts.py
+++ b/tests/unit/test_mcp_server/test_debug_alerts.py
@@ -468,24 +468,19 @@ class TestWriteResultDebugAlert:
         )
         assert "True" in emitted[0]["text"]
 
-    def test_debug_alert_includes_text_preview(self, inbox_dir: Path):
-        """The alert includes a preview of the result text (first 60 chars)."""
+    def test_debug_alert_does_not_include_text_content(self, inbox_dir: Path):
+        """The alert is a compact routing summary — result text is NOT inlined.
+
+        Text preview was removed from the alert format. The full result text
+        appears in the inbox message body, not in the debug alert.
+        """
         _, emitted = self._run(
             {"task_id": "t7", "chat_id": 1, "text": "Short message."},
             inbox_dir,
         )
-        assert "Short message." in emitted[0]["text"]
-
-    def test_text_preview_truncated_at_60_chars(self, inbox_dir: Path):
-        """Text longer than 60 chars is truncated with an ellipsis in the alert."""
-        long_text = "A" * 80
-        _, emitted = self._run(
-            {"task_id": "t8", "chat_id": 1, "text": long_text},
-            inbox_dir,
-        )
-        assert "A" * 60 in emitted[0]["text"]
-        assert "\u2026" in emitted[0]["text"]  # ellipsis
-        assert "A" * 61 not in emitted[0]["text"]
+        # Alert must contain task_id but must NOT inline the payload text.
+        assert "t7" in emitted[0]["text"]
+        assert "Short message." not in emitted[0]["text"]
 
     def test_debug_alert_emitter_includes_task_id(self, inbox_dir: Path):
         """The emitter passed to _emit_debug_observation is task:<task_id>."""
@@ -564,7 +559,7 @@ class TestEmitDebugObservationOutboxDelivery:
         outbox_dir: Path,
         inbox_dir: Path,
         text: str = "debug text",
-        category: str = "system_context",
+        category: str = "system_error",
         visibility: str = "mcp-only",
         emitter: str | None = "test-emitter",
     ) -> None:

--- a/tests/unit/test_mcp_server/test_message_state.py
+++ b/tests/unit/test_mcp_server/test_message_state.py
@@ -12,6 +12,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch
 from datetime import datetime, timezone
+from reliability import ValidationError
 
 
 class TestMarkProcessing:
@@ -64,7 +65,7 @@ class TestMarkProcessing:
             assert "not found" in result[0].text.lower()
 
     def test_requires_message_id(self, setup_dirs):
-        """Test that message_id is required."""
+        """Test that message_id is required — raises ValidationError when absent."""
         inbox, processing = setup_dirs
 
         with patch.multiple(
@@ -75,9 +76,8 @@ class TestMarkProcessing:
             import asyncio
             from src.mcp.inbox_server import handle_mark_processing
 
-            result = asyncio.run(handle_mark_processing({}))
-
-            assert "Error" in result[0].text
+            with pytest.raises(ValidationError):
+                asyncio.run(handle_mark_processing({}))
 
 
 class TestMarkProcessedUpdated:
@@ -305,7 +305,7 @@ class TestMarkFailed:
             assert abs(failed_msg["_retry_at"] - (now + 120)) < 5
 
     def test_requires_message_id(self, setup_dirs):
-        """Test that message_id is required."""
+        """Test that message_id is required — raises ValidationError when absent."""
         inbox, processing, failed = setup_dirs
 
         with patch.multiple(
@@ -317,9 +317,8 @@ class TestMarkFailed:
             import asyncio
             from src.mcp.inbox_server import handle_mark_failed
 
-            result = asyncio.run(handle_mark_failed({}))
-
-            assert "Error" in result[0].text
+            with pytest.raises(ValidationError):
+                asyncio.run(handle_mark_failed({}))
 
     def test_finds_in_inbox_fallback(self, setup_dirs, message_generator):
         """Test that mark_failed can find messages in inbox/ too."""
@@ -377,7 +376,7 @@ class TestStaleRecovery:
         ):
             from src.mcp.inbox_server import _recover_stale_processing
 
-            _recover_stale_processing(max_age_seconds=300)
+            _recover_stale_processing()
 
             assert not (processing / f"{msg_id}.json").exists()
             assert (inbox / f"{msg_id}.json").exists()
@@ -398,7 +397,7 @@ class TestStaleRecovery:
         ):
             from src.mcp.inbox_server import _recover_stale_processing
 
-            _recover_stale_processing(max_age_seconds=300)
+            _recover_stale_processing()
 
             # Should still be in processing
             assert (processing / f"{msg_id}.json").exists()

--- a/tests/unit/test_mcp_server/test_write_observation.py
+++ b/tests/unit/test_mcp_server/test_write_observation.py
@@ -237,58 +237,44 @@ class TestHandleWriteObservation:
     # observation_type parameter (Change 1)
     # ------------------------------------------------------------------
 
-    def test_observation_type_default_is_preference(self, inbox_dir: Path):
-        """When observation_type is omitted, user model dispatch uses 'preference'."""
-        dispatched: list[dict] = []
-
-        class FakeUserModel:
-            def dispatch(self, tool_name: str, args: dict) -> str:
-                dispatched.append({"tool": tool_name, "args": args})
-                return "{}"
-
+    def test_user_context_observation_writes_to_inbox(self, inbox_dir: Path):
+        """user_context observations are written to the inbox regardless of user model state."""
         with patch.multiple(
             "src.mcp.inbox_server",
             INBOX_DIR=inbox_dir,
-            _user_model=FakeUserModel(),
+            _user_model=None,
         ):
             from src.mcp.inbox_server import handle_write_observation
-            asyncio.run(handle_write_observation({
+            result = asyncio.run(handle_write_observation({
                 "chat_id": 123,
                 "text": "User prefers morning meetings.",
                 "category": "user_context",
             }))
 
-        assert len(dispatched) == 1
-        call = dispatched[0]
-        assert call["tool"] == "model_observe"
-        assert call["args"]["observation_type"] == "preference"
-        assert call["args"]["observation"] == "User prefers morning meetings."
-        assert call["args"]["confidence"] == 0.75
+        assert "Observation queued" in result[0].text
+        files = list(inbox_dir.glob("*.json"))
+        assert len(files) == 1
+        msg = json.loads(files[0].read_text())
+        assert msg["category"] == "user_context"
+        assert msg["text"] == "User prefers morning meetings."
 
-    def test_observation_type_explicit_value_forwarded(self, inbox_dir: Path):
-        """When observation_type is supplied, it is forwarded to user model dispatch."""
-        dispatched: list[dict] = []
-
-        class FakeUserModel:
-            def dispatch(self, tool_name: str, args: dict) -> str:
-                dispatched.append({"tool": tool_name, "args": args})
-                return "{}"
-
+    def test_user_context_observation_chat_id_preserved(self, inbox_dir: Path):
+        """The chat_id passed to write_observation is preserved in the inbox message."""
         with patch.multiple(
             "src.mcp.inbox_server",
             INBOX_DIR=inbox_dir,
-            _user_model=FakeUserModel(),
+            _user_model=None,
         ):
             from src.mcp.inbox_server import handle_write_observation
             asyncio.run(handle_write_observation({
                 "chat_id": 123,
                 "text": "User seems energized this morning.",
                 "category": "user_context",
-                "observation_type": "energy",
             }))
 
-        assert len(dispatched) == 1
-        assert dispatched[0]["args"]["observation_type"] == "energy"
+        files = list(inbox_dir.glob("*.json"))
+        msg = json.loads(files[0].read_text())
+        assert msg["chat_id"] == 123
 
     def test_user_context_without_user_model_still_writes_file(self, inbox_dir: Path):
         """When _user_model is None, user_context observation still writes to inbox."""


### PR DESCRIPTION
## What this fixes

20 test failures from issue #739 caused by tests that were never updated after production code changes. No production code is modified.

## Changes by area

**test_hooks/test_require_write_result.py and test_mcp_server/test_agent_failure_recovery.py**
The `_load_hook()` helper sets HOME to `tmp_path`, which triggers inbox/config subdirectory creation as a side effect of earlier assertions in the same test run. Subsequent `mkdir(parents=True)` calls then fail with `FileExistsError`. Fixed by adding `exist_ok=True` throughout. Also: the fallback inbox message type was `subagent_recovered`, not `subagent_result` — test assertion updated.

**test_bisque/test_protocol.py**
Three divergences from the current protocol:
- Frame count was 19, now 20 (TYPING frame added). Updated assertion.
- `MESSAGE` is intentionally in both `CLIENT_FRAME_TYPES` and `SERVER_FRAME_TYPES` as a client-compat alias for `send_message`. The strict disjoint assertion is replaced with a check that the overlap is exactly `{"message"}`.
- `v` is now optional in `deserialize()` and defaults to 2 for client compat. Test updated to assert the default value rather than expecting `ProtocolError`.

**test_bisque/test_relay_server.py**
BIS-122 introduced a `typing=false` frame before every `message` frame to dismiss the typing indicator immediately when a reply arrives. Three tests broke because they assumed the first received frame after triggering outbox delivery would be a `message`:
- Added `_receive_frame_of_type()` helper that skips interstitial frames.
- Updated `test_outbox_file_delivered` and `test_multi_client_fan_out` to use it.
- Doubled the read budget in `test_rapid_events_to_multiple_clients` to collect 20 message frames despite the extra typing frames interspersed.

**test_mcp_server/test_message_state.py**
Two API changes:
- `validate_message_id()` now raises `ValidationError` instead of returning an error `TextContent`. Tests updated to use `pytest.raises(ValidationError)`.
- `_recover_stale_processing()` no longer accepts `max_age_seconds` (now uses type-aware internal thresholds per message type). The kwarg was removed from both call sites.

**test_mcp_server/test_debug_alerts.py**
Two changes:
- Text preview was removed from the `write_result` debug alert format. Replaced the two preview tests with a single test asserting the task_id is present and the payload text is NOT inlined.
- `TestEmitDebugObservationOutboxDelivery._call_emit()` used `category="system_context"` as default, which `_emit_debug_observation` always suppresses (per bootup doc: system_context must never be forwarded). Changed default to `"system_error"` so the outbox write fires.

**test_mcp_server/test_write_observation.py**
`handle_write_observation` no longer calls `_user_model.dispatch()`. The two tests that asserted dispatch behavior were replaced with tests verifying the actual current behavior: inbox file is written with the correct `category` and `chat_id`.

## Tests run
- [x] `uv run python -m pytest tests/unit/test_hooks/ tests/unit/test_bisque/ tests/unit/test_mcp_server/test_message_state.py tests/unit/test_mcp_server/test_agent_failure_recovery.py tests/unit/test_mcp_server/test_debug_alerts.py tests/unit/test_mcp_server/test_write_observation.py` — 186 passed, 0 failed

Closes #739 (partial — batch 1 of the mechanical fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)