### PR TITLE
fix: resolve test suite drift (batch 2) — bot, daemon, calendar, reliability, CLI

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -29,7 +29,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Optional
 
-from telegram import Update, InlineKeyboardMarkup, ReplyParameters
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, ReplyParameters
 from telegram.ext import Application, CommandHandler, MessageHandler, CallbackQueryHandler, MessageReactionHandler, filters, ContextTypes
 from collections import deque
 
@@ -1292,6 +1292,29 @@ async def process_reply(chat_id: int, text: str, reply_markup=None, thread_ts=No
                 log.error(f"Plain text fallback also failed: {e2}")
 
 
+def build_inline_keyboard(buttons: list) -> InlineKeyboardMarkup:
+    """Build a Telegram InlineKeyboardMarkup from a nested list of button labels.
+
+    Each inner list represents a row of buttons.  Each element in the row is
+    either a plain string label (callback_data == label) or a [label, data]
+    two-element list where data is the callback_data payload.
+
+    Pure function: no side effects.
+    """
+    keyboard = []
+    for row in buttons:
+        keyboard_row = []
+        for item in row:
+            if isinstance(item, (list, tuple)) and len(item) == 2:
+                label, data = item
+            else:
+                label = str(item)
+                data = str(item)
+            keyboard_row.append(InlineKeyboardButton(text=label, callback_data=data))
+        keyboard.append(keyboard_row)
+    return InlineKeyboardMarkup(keyboard)
+
+
 class OutboxHandler(FileSystemEventHandler):
     """Watches outbox for reply files and sends them via Telegram."""
 
@@ -1318,8 +1341,16 @@ class OutboxHandler(FileSystemEventHandler):
     async def process_reply(self, filepath):
         try:
             await asyncio.sleep(0.5)  # Delay to ensure file write is complete
-            with open(filepath, 'r') as f:
-                reply = json.load(f)
+            try:
+                with open(filepath, 'r') as f:
+                    reply = json.load(f)
+            except (json.JSONDecodeError, OSError) as exc:
+                log.error(f"process_reply: failed to parse {filepath}: {exc}")
+                try:
+                    os.remove(filepath)
+                except OSError:
+                    pass
+                return
 
             chat_id = reply.get('chat_id')
             text = reply.get('text', '')

--- a/tests/unit/test_bot/test_authorization.py
+++ b/tests/unit/test_bot/test_authorization.py
@@ -2,6 +2,12 @@
 Tests for Telegram Bot Authorization
 
 Tests user authorization and access control.
+
+Note: The is_authorized() function was removed from lobster_bot.py — authorization
+is now performed inline via `user.id not in ALLOWED_USERS` in each handler, using
+the module-level ALLOWED_USERS list.  Tests have been updated to:
+  1. Verify the ALLOWED_USERS list is populated correctly from the env var.
+  2. Test handler-level authorization behavior (the end effect is the same).
 """
 
 import pytest
@@ -9,11 +15,11 @@ from unittest.mock import patch, MagicMock, AsyncMock
 import os
 
 
-class TestIsAuthorized:
-    """Tests for is_authorized function."""
+class TestAllowedUsersConfig:
+    """Tests for ALLOWED_USERS configuration from environment."""
 
-    def test_authorized_user_returns_true(self):
-        """Test that authorized user returns True."""
+    def test_allowed_users_populated_from_env(self):
+        """ALLOWED_USERS is built from TELEGRAM_ALLOWED_USERS env var."""
         with patch.dict(
             os.environ,
             {
@@ -21,16 +27,15 @@ class TestIsAuthorized:
                 "TELEGRAM_ALLOWED_USERS": "123456,789012",
             },
         ):
-            # Need to reimport to pick up env change
             import importlib
             import src.bot.lobster_bot as bot_module
             importlib.reload(bot_module)
 
-            assert bot_module.is_authorized(123456) is True
-            assert bot_module.is_authorized(789012) is True
+            assert 123456 in bot_module.ALLOWED_USERS
+            assert 789012 in bot_module.ALLOWED_USERS
 
-    def test_unauthorized_user_returns_false(self):
-        """Test that unauthorized user returns False."""
+    def test_unauthorized_user_not_in_allowed_users(self):
+        """A user not in TELEGRAM_ALLOWED_USERS is absent from ALLOWED_USERS."""
         with patch.dict(
             os.environ,
             {
@@ -42,10 +47,10 @@ class TestIsAuthorized:
             import src.bot.lobster_bot as bot_module
             importlib.reload(bot_module)
 
-            assert bot_module.is_authorized(999999) is False
+            assert 999999 not in bot_module.ALLOWED_USERS
 
-    def test_single_user_authorization(self):
-        """Test authorization with single allowed user."""
+    def test_single_user_in_allowed_users(self):
+        """Single allowed user is correctly parsed."""
         with patch.dict(
             os.environ,
             {
@@ -57,8 +62,8 @@ class TestIsAuthorized:
             import src.bot.lobster_bot as bot_module
             importlib.reload(bot_module)
 
-            assert bot_module.is_authorized(123456) is True
-            assert bot_module.is_authorized(654321) is False
+            assert 123456 in bot_module.ALLOWED_USERS
+            assert 654321 not in bot_module.ALLOWED_USERS
 
 
 class TestStartCommand:
@@ -118,4 +123,5 @@ class TestStartCommand:
 
             mock_update.message.reply_text.assert_called_once()
             call_args = mock_update.message.reply_text.call_args[0][0]
-            assert "Unauthorized" in call_args
+            # The rejection message uses "not authorized" (case-insensitive match)
+            assert "not authorized" in call_args.lower() or "unauthorized" in call_args.lower()

--- a/tests/unit/test_bot/test_message_handling.py
+++ b/tests/unit/test_bot/test_message_handling.py
@@ -1,7 +1,15 @@
 """
 Tests for Telegram Bot Message Handling
 
-Tests text and voice message handling.
+Tests text and audio/voice message handling.
+
+Changes from original:
+- mock_update fixture now explicitly sets message.audio = None and
+  message.photo = None and message.document = None so MagicMock's auto-attribute
+  creation doesn't trick the `audio_obj = message.voice or message.audio` guard.
+- TestHandleVoiceMessage renamed to TestHandleAudioMessage; tests now call
+  handle_audio_message(update, context, msg_id, audio_obj) — the function that
+  replaced handle_voice_message after the audio handling refactor.
 """
 
 import json
@@ -24,7 +32,13 @@ class TestHandleMessage:
         update.message.message_id = 1
         update.message.chat_id = 123456
         update.message.text = "Hello, Lobster!"
+        # Explicitly null out all media fields so the audio/photo/document guards
+        # in handle_message don't fire when testing plain text handling.
         update.message.voice = None
+        update.message.audio = None
+        update.message.photo = None
+        update.message.document = None
+        update.message.reply_to_message = None
         update.message.reply_text = AsyncMock()
         return update
 
@@ -142,8 +156,13 @@ class TestHandleMessage:
                 assert "received" in call_args.lower() or "processing" in call_args.lower()
 
 
-class TestHandleVoiceMessage:
-    """Tests for voice message handling."""
+class TestHandleAudioMessage:
+    """Tests for handle_audio_message function.
+
+    The old handle_voice_message was folded into handle_audio_message, which
+    now accepts both telegram.Voice and telegram.Audio objects via a shared
+    audio_obj parameter.
+    """
 
     @pytest.fixture
     def mock_voice_update(self):
@@ -155,10 +174,17 @@ class TestHandleVoiceMessage:
         update.message.message_id = 1
         update.message.chat_id = 123456
         update.message.text = None
+        update.message.caption = None
+        # voice is non-None so is_voice = True in handle_audio_message
         update.message.voice = MagicMock()
         update.message.voice.file_id = "voice_file_123"
         update.message.voice.duration = 10
         update.message.voice.mime_type = "audio/ogg"
+        # MagicMock.file_name would auto-create a truthy MagicMock (not use the None
+        # default in getattr), making json.dumps fail. Explicitly set to None so that
+        # getattr(audio_obj, "file_name", None) falls through to the .ogg fallback.
+        update.message.voice.file_name = None
+        update.message.audio = None
         update.message.reply_text = AsyncMock()
         # Prevent extract_reply_to_context from generating unserializable MagicMock values
         update.message.reply_to_message = None
@@ -168,12 +194,11 @@ class TestHandleVoiceMessage:
     def mock_context(self):
         """Create mock Context object with bot."""
         context = MagicMock()
-        context.bot.get_file = AsyncMock()
 
         # Create mock file object
         mock_file = MagicMock()
         mock_file.download_to_drive = AsyncMock()
-        context.bot.get_file.return_value = mock_file
+        context.bot.get_file = AsyncMock(return_value=mock_file)
 
         return context
 
@@ -192,6 +217,7 @@ class TestHandleVoiceMessage:
         pending = temp_messages_dir / "pending-transcription"
         pending.mkdir(parents=True, exist_ok=True)
         audio = temp_messages_dir / "audio"
+        audio.mkdir(parents=True, exist_ok=True)
 
         with patch.dict(
             os.environ,
@@ -208,8 +234,10 @@ class TestHandleVoiceMessage:
                 with patch.object(bot_module, "AUDIO_DIR", audio):
                     with patch.object(bot_module, "PENDING_TRANSCRIPTION_DIR", pending):
                         msg_id = "test_123"
-                        await bot_module.handle_voice_message(
-                            mock_voice_update, mock_context, msg_id
+                        # handle_audio_message requires an explicit audio_obj argument
+                        audio_obj = mock_voice_update.message.voice
+                        await bot_module.handle_audio_message(
+                            mock_voice_update, mock_context, msg_id, audio_obj
                         )
 
                         # Voice message must go to pending-transcription/, NOT inbox/
@@ -236,6 +264,7 @@ class TestHandleVoiceMessage:
         pending = temp_messages_dir / "pending-transcription"
         pending.mkdir(parents=True, exist_ok=True)
         audio = temp_messages_dir / "audio"
+        audio.mkdir(parents=True, exist_ok=True)
 
         with patch.dict(
             os.environ,
@@ -251,8 +280,9 @@ class TestHandleVoiceMessage:
             with patch.object(bot_module, "INBOX_DIR", inbox):
                 with patch.object(bot_module, "AUDIO_DIR", audio):
                     with patch.object(bot_module, "PENDING_TRANSCRIPTION_DIR", pending):
-                        await bot_module.handle_voice_message(
-                            mock_voice_update, mock_context, "test_123"
+                        audio_obj = mock_voice_update.message.voice
+                        await bot_module.handle_audio_message(
+                            mock_voice_update, mock_context, "test_123", audio_obj
                         )
 
                         mock_voice_update.message.reply_text.assert_called()

--- a/tests/unit/test_bot/test_onboarding.py
+++ b/tests/unit/test_bot/test_onboarding.py
@@ -161,7 +161,8 @@ class TestOnboardingCommand:
             await bot_module.onboarding_command(mock_update, mock_context)
 
             call_args = mock_update.message.reply_text.call_args[0][0]
-            assert "Unauthorized" in call_args
+            # The rejection message uses "not authorized" rather than "Unauthorized"
+            assert "not authorized" in call_args.lower() or "unauthorized" in call_args.lower()
 
 
 class TestFirstMessageDetection:

--- a/tests/unit/test_cli/test_commands.py
+++ b/tests/unit/test_cli/test_commands.py
@@ -120,6 +120,10 @@ class TestInboxCommand:
 
         env = os.environ.copy()
         env["HOME"] = str(temp_messages_dir.parent)
+        # LOBSTER_MESSAGES overrides $HOME/messages in the CLI.  Unset it so
+        # the CLI falls back to $HOME/messages (our temp dir) rather than
+        # pointing at the live /home/lobster/messages directory.
+        env.pop("LOBSTER_MESSAGES", None)
 
         result = subprocess.run(
             ["bash", str(cli_path), "inbox"],

--- a/tests/unit/test_daemon/test_error_backoff.py
+++ b/tests/unit/test_daemon/test_error_backoff.py
@@ -2,6 +2,10 @@
 Tests for Daemon Error Backoff
 
 Tests error handling and backoff behavior in the daemon loop.
+
+NOTE: The src.daemon.daemon module was removed when the daemon loop was absorbed
+into the MCP inbox_server (src/mcp/inbox_server.py).  These tests are skipped
+until they are rewritten against the new architecture.
 """
 
 import pytest
@@ -9,6 +13,10 @@ import asyncio
 from pathlib import Path
 from unittest.mock import patch, MagicMock, AsyncMock
 import time
+
+pytestmark = pytest.mark.skip(
+    reason="src.daemon.daemon module removed — daemon loop now lives in src.mcp.inbox_server"
+)
 
 
 class TestErrorBackoff:

--- a/tests/unit/test_daemon/test_polling.py
+++ b/tests/unit/test_daemon/test_polling.py
@@ -2,6 +2,10 @@
 Tests for Daemon Polling Behavior
 
 Tests polling intervals and loop behavior.
+
+NOTE: The src.daemon.daemon module was removed when the daemon loop was absorbed
+into the MCP inbox_server (src/mcp/inbox_server.py).  These tests are skipped
+until they are rewritten against the new architecture.
 """
 
 import pytest
@@ -9,6 +13,10 @@ import asyncio
 from pathlib import Path
 from unittest.mock import patch, MagicMock, AsyncMock
 import time
+
+pytestmark = pytest.mark.skip(
+    reason="src.daemon.daemon module removed — daemon loop now lives in src.mcp.inbox_server"
+)
 
 
 class TestPollingIntervals:

--- a/tests/unit/test_daemon/test_session_management.py
+++ b/tests/unit/test_daemon/test_session_management.py
@@ -2,12 +2,20 @@
 Tests for Daemon Session Management
 
 Tests session ID creation, persistence, and resume functionality.
+
+NOTE: The src.daemon.daemon module was removed when the daemon loop was absorbed
+into the MCP inbox_server (src/mcp/inbox_server.py).  These tests are skipped
+until they are rewritten against the new architecture.
 """
 
 import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 import uuid
+
+pytestmark = pytest.mark.skip(
+    reason="src.daemon.daemon module removed — daemon loop now lives in src.mcp.inbox_server"
+)
 
 
 class TestSessionManagement:

--- a/tests/unit/test_integrations/test_google_calendar_token_store.py
+++ b/tests/unit/test_integrations/test_google_calendar_token_store.py
@@ -404,6 +404,14 @@ class TestLoadToken:
 
 # ---------------------------------------------------------------------------
 # get_valid_token
+#
+# NOTE: The token_store module was refactored to use a myownlobster.ai proxy for
+# token refresh instead of calling the Google OAuth API directly.  The old
+# `refresh_access_token` function (from oauth.py) is no longer called from
+# token_store.py.  The internal helper is now `_refresh_token_via_proxy`.
+# Tests that previously patched `refresh_access_token` now patch
+# `_refresh_token_via_proxy` instead.  The `credentials` kwarg to
+# `get_valid_token` is still accepted (for API compatibility) but is ignored.
 # ---------------------------------------------------------------------------
 
 
@@ -423,19 +431,18 @@ class TestGetValidToken:
         expired = _make_expired_token()
         save_token("user1", expired, token_dir=tmp_path)
         new_access = "ya29.refreshed-access-token"
-        refreshed_token = TokenData(
+        # The proxy returns a partial TokenData (no refresh_token, scope="")
+        proxy_result = TokenData(
             access_token=new_access,
             expires_at=_FUTURE_EXPIRES,
-            scope=_FAKE_SCOPE,
-            refresh_token=None,  # Google often omits this
+            scope="",
+            refresh_token=None,
         )
         with patch(
-            "integrations.google_calendar.token_store.refresh_access_token",
-            return_value=refreshed_token,
+            "integrations.google_calendar.token_store._refresh_token_via_proxy",
+            return_value=proxy_result,
         ):
-            result = get_valid_token(
-                "user1", token_dir=tmp_path, credentials=_FAKE_CREDENTIALS
-            )
+            result = get_valid_token("user1", token_dir=tmp_path)
         assert result is not None
         assert result.access_token == new_access
 
@@ -443,17 +450,17 @@ class TestGetValidToken:
         expired = _make_expired_token()
         save_token("user1", expired, token_dir=tmp_path)
         new_access = "ya29.refreshed-token"
-        refreshed_token = TokenData(
+        proxy_result = TokenData(
             access_token=new_access,
             expires_at=_FUTURE_EXPIRES,
-            scope=_FAKE_SCOPE,
+            scope="",
             refresh_token=None,
         )
         with patch(
-            "integrations.google_calendar.token_store.refresh_access_token",
-            return_value=refreshed_token,
+            "integrations.google_calendar.token_store._refresh_token_via_proxy",
+            return_value=proxy_result,
         ):
-            get_valid_token("user1", token_dir=tmp_path, credentials=_FAKE_CREDENTIALS)
+            get_valid_token("user1", token_dir=tmp_path)
         # Now load directly from disk to confirm it was persisted
         stored = load_token("user1", token_dir=tmp_path)
         assert stored is not None
@@ -463,45 +470,30 @@ class TestGetValidToken:
         original_refresh = "1//original-refresh-token"
         expired = _make_expired_token(refresh_token=original_refresh)
         save_token("user1", expired, token_dir=tmp_path)
-        # Refreshed response has no refresh_token
-        refreshed_token = TokenData(
+        # Proxy response has no refresh_token; get_valid_token must preserve the original
+        proxy_result = TokenData(
             access_token="<REDACTED_SECRET>",
             expires_at=_FUTURE_EXPIRES,
-            scope=_FAKE_SCOPE,
+            scope="",
             refresh_token=None,
         )
         with patch(
-            "integrations.google_calendar.token_store.refresh_access_token",
-            return_value=refreshed_token,
+            "integrations.google_calendar.token_store._refresh_token_via_proxy",
+            return_value=proxy_result,
         ):
-            result = get_valid_token(
-                "user1", token_dir=tmp_path, credentials=_FAKE_CREDENTIALS
-            )
+            result = get_valid_token("user1", token_dir=tmp_path)
         assert result is not None
         assert result.refresh_token == original_refresh
 
-    def test_returns_none_when_refresh_fails_with_oauth_error(self, tmp_path: Path) -> None:
+    def test_returns_none_when_refresh_proxy_returns_none(self, tmp_path: Path) -> None:
+        """When the refresh proxy returns None (any failure), get_valid_token returns None."""
         expired = _make_expired_token()
         save_token("user1", expired, token_dir=tmp_path)
         with patch(
-            "integrations.google_calendar.token_store.refresh_access_token",
-            side_effect=OAuthTokenError("invalid_grant", "Token revoked."),
+            "integrations.google_calendar.token_store._refresh_token_via_proxy",
+            return_value=None,
         ):
-            result = get_valid_token(
-                "user1", token_dir=tmp_path, credentials=_FAKE_CREDENTIALS
-            )
-        assert result is None
-
-    def test_returns_none_when_refresh_fails_with_network_error(self, tmp_path: Path) -> None:
-        expired = _make_expired_token()
-        save_token("user1", expired, token_dir=tmp_path)
-        with patch(
-            "integrations.google_calendar.token_store.refresh_access_token",
-            side_effect=OAuthNetworkError("timeout"),
-        ):
-            result = get_valid_token(
-                "user1", token_dir=tmp_path, credentials=_FAKE_CREDENTIALS
-            )
+            result = get_valid_token("user1", token_dir=tmp_path)
         assert result is None
 
     def test_returns_none_when_token_expired_and_no_refresh_token(
@@ -516,25 +508,24 @@ class TestGetValidToken:
         valid = _make_valid_token()
         save_token("user1", valid, token_dir=tmp_path)
         with patch(
-            "integrations.google_calendar.token_store.refresh_access_token",
-        ) as mock_refresh:
+            "integrations.google_calendar.token_store._refresh_token_via_proxy",
+        ) as mock_proxy:
             get_valid_token("user1", token_dir=tmp_path)
-        mock_refresh.assert_not_called()
+        mock_proxy.assert_not_called()
 
-    def test_passes_credentials_to_refresh(self, tmp_path: Path) -> None:
-        expired = _make_expired_token()
+    def test_proxy_called_with_refresh_token(self, tmp_path: Path) -> None:
+        """The proxy is called with the stored refresh_token string."""
+        expired = _make_expired_token(refresh_token=_FAKE_REFRESH_TOKEN)
         save_token("user1", expired, token_dir=tmp_path)
-        refreshed = TokenData(
+        proxy_result = TokenData(
             access_token="<REDACTED_SECRET>",
             expires_at=_FUTURE_EXPIRES,
-            scope=_FAKE_SCOPE,
+            scope="",
+            refresh_token=None,
         )
         with patch(
-            "integrations.google_calendar.token_store.refresh_access_token",
-            return_value=refreshed,
-        ) as mock_refresh:
-            get_valid_token(
-                "user1", token_dir=tmp_path, credentials=_FAKE_CREDENTIALS
-            )
-        _, kwargs = mock_refresh.call_args
-        assert kwargs.get("credentials") == _FAKE_CREDENTIALS
+            "integrations.google_calendar.token_store._refresh_token_via_proxy",
+            return_value=proxy_result,
+        ) as mock_proxy:
+            get_valid_token("user1", token_dir=tmp_path)
+        mock_proxy.assert_called_once_with(_FAKE_REFRESH_TOKEN)

--- a/tests/unit/test_reliability.py
+++ b/tests/unit/test_reliability.py
@@ -60,7 +60,9 @@ class TestAtomicWriteJson:
         path = tmp_path / "test.json"
         atomic_write_json(path, {"clean": True})
 
-        files = list(tmp_path.iterdir())
+        # Filter to non-directory entries only — the autouse isolate_inbox_server_paths
+        # fixture creates messages/ and workspace/ subdirs in tmp_path for every test.
+        files = [f for f in tmp_path.iterdir() if not f.is_dir()]
         assert len(files) == 1
         assert files[0].name == "test.json"
 


### PR DESCRIPTION
## What problem this solves

Six categories of tests in issue #739 were failing because the production code had been refactored without updating the tests. This PR makes each failing test category pass again, and fixes one pre-existing production bug exposed by the process.

## Changes by category

**test_daemon/ (3 files)** — The `src.daemon.daemon` module was removed; the dispatch loop now lives in `src.mcp.inbox_server`. Rather than deleting the tests (they may be revived when the module is rewritten), all three files get a module-level `pytestmark = pytest.mark.skip(reason=...)` so they are collected but not executed.

**test_bot/test_authorization.py** — `is_authorized()` was removed from `lobster_bot.py`; authorization is now inline per-handler (`user.id not in ALLOWED_USERS`). Rewrote `TestIsAuthorized` → `TestAllowedUsersConfig`, which tests the `ALLOWED_USERS` list populated from the env var directly. Fixed a string-match assertion that expected `"Unauthorized"` but the actual message is `"not authorized"`.

**test_bot/test_message_handling.py** — `handle_voice_message` was unified into `handle_audio_message(update, context, msg_id, audio_obj)`. Updated tests to call the new signature. Two MagicMock pitfalls fixed: (1) `message.audio`, `.photo`, `.document`, `.reply_to_message` must be set to `None` explicitly — MagicMock auto-creates truthy attributes on first access, which trips the media-type dispatch guards; (2) `voice.file_name` must also be `None` — `getattr(mock, "file_name", None)` does NOT use the default when the attribute already exists as a MagicMock, causing `json.dumps` to fail with `TypeError: Object of type MagicMock is not JSON serializable`.

**test_integrations/test_google_calendar_token_store.py** — Token refresh was refactored from `refresh_access_token(token, credentials)` (raises `OAuthTokenError`/`OAuthNetworkError` on failure) to `_refresh_token_via_proxy(refresh_token)` (returns `None` on failure, never raises). All `patch(...)` targets updated; exception-based tests replaced with `return_value=None` tests.

**test_reliability.py** — `test_no_temp_files_left_on_success` asserted `len(list(tmp_path.iterdir())) == 1`, but the autouse `isolate_inbox_server_paths` fixture creates `messages/` and `workspace/` subdirs in every test's `tmp_path`. Fixed to count only non-directory entries.

**test_cli/test_commands.py** — `LOBSTER_MESSAGES=/home/lobster/messages` is set in the live process environment. The test set `HOME` to a temp dir but `LOBSTER_MESSAGES` was inherited through `os.environ.copy()`, causing the CLI to read the live inbox (empty) instead of the temp one. Fixed by calling `env.pop("LOBSTER_MESSAGES", None)` before the subprocess call.

## Production bug fixed

`build_inline_keyboard` was called in `OutboxHandler.process_reply` but was never defined, making all inline-keyboard replies crash at runtime. Added the function (pure, no side effects) and the missing `InlineKeyboardButton` import. Also added `try/except (json.JSONDecodeError, OSError)` around `json.load` in `process_reply` so a corrupt outbox file does not crash the watcher loop.

## Functional patterns used

`build_inline_keyboard` is a pure function: takes a nested list, returns an `InlineKeyboardMarkup`, no side effects. The rest of the changes are test infrastructure: patches, fixture nulling, and assertion updates.

## Tests run

- [x] `tests/unit/` — 1307 passed, 16 failed, 24 skipped, 6 errors. All 16 failures and 6 errors are pre-existing on `main` (confirmed by running the same test IDs against `main` before this branch). The previously-failing categories from issue #739 all pass.

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)