### PR TITLE
fix: mock GitHub API in test_update_manager to prevent rate limit failures

### DIFF
--- a/tests/unit/test_update_manager.py
+++ b/tests/unit/test_update_manager.py
@@ -17,6 +17,9 @@ class TestCheckForUpdates:
 
     def _make_manager(self, tmp_path):
         from src.mcp.update_manager import UpdateManager
+        # Create a .git directory so UpdateManager treats this as a git install,
+        # ensuring the git code path (not the tarball/GitHub API path) is used.
+        (tmp_path / ".git").mkdir()
         return UpdateManager(repo_path=tmp_path)
 
     @patch("src.mcp.update_manager.subprocess.run")
@@ -86,6 +89,7 @@ class TestGenerateChangelog:
 
     def _make_manager(self, tmp_path):
         from src.mcp.update_manager import UpdateManager
+        (tmp_path / ".git").mkdir()
         return UpdateManager(repo_path=tmp_path)
 
     @patch("src.mcp.update_manager.subprocess.run")
@@ -165,6 +169,7 @@ class TestAnalyzeCompatibility:
 
     def _make_manager(self, tmp_path):
         from src.mcp.update_manager import UpdateManager
+        (tmp_path / ".git").mkdir()
         return UpdateManager(repo_path=tmp_path)
 
     @patch("src.mcp.update_manager.subprocess.run")
@@ -322,6 +327,7 @@ class TestCreateUpgradePlan:
 
     def _make_manager(self, tmp_path):
         from src.mcp.update_manager import UpdateManager
+        (tmp_path / ".git").mkdir()
         return UpdateManager(repo_path=tmp_path)
 
     @patch("src.mcp.update_manager.subprocess.run")


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Summary

The `test_update_manager.py` tests were silently routing through the tarball/GitHub Releases code path instead of the mocked git code path, causing them to make real GitHub API calls. This produced flaky failures from rate limits and API contract changes, not from bugs in the code under test.

**Root cause:** `UpdateManager` has two code paths gated by `_is_git_install()`, which checks for a `.git` directory. The `pytest` `tmp_path` fixture creates a plain temporary directory with no `.git`, so `is_git` was `False` for every test. All four test classes patched `subprocess.run` expecting to intercept git commands, but the instance was actually calling `_get_latest_release()` via `httpx` — completely bypassing the mock and hitting the real GitHub API.

**Fix:** Each `_make_manager()` helper now creates a `.git` directory inside `tmp_path` before constructing `UpdateManager`. This is a one-liner per class (`(tmp_path / ".git").mkdir()`), and it correctly activates the git code path so all mocked `subprocess.run` calls are exercised as the test authors intended.

No logic in `update_manager.py` was changed. The tarball code path is untouched.

**Functional patterns used:** Pure function test isolation — each test gets a fresh `tmp_path` with no shared state between runs.

## Tests run

- [x] `uv run pytest tests/unit/test_update_manager.py -v` — 14 passed, 0 failed (was 13 failed before fix)