### PR TITLE
Artifact-based delivery for large subagent results (supersedes #711)

### DIFF
--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -147,25 +147,31 @@ mcp__lobster-inbox__write_result(
 )
 ```
 
-**Long reports (internal tasks only):**
+**Large results — use artifacts, not inline text:**
 
-If your output exceeds ~500 words, write the full content to a file and return a summary inline:
+If your output exceeds ~4KB or ~500 words, write the full content to a file and pass the path in `artifacts`. This applies to **all tasks** (user-facing and internal):
 
-1. Write the full report to: `~/lobster-workspace/reports/<task_id>.md`
+1. Write the full report to: `~/lobster-workspace/reports/<task_id>-<timestamp>.md`
 2. In `write_result`, set `text` to a concise summary (5–10 lines) + actionable items only. Do NOT include the file path in `text` — file paths are server-side and useless to mobile users.
 3. Pass the file path in `artifacts` — the dispatcher reads the file and sends its content to the user inline.
 
 ```python
+import time
+artifact_path = f"~/lobster-workspace/reports/{task_id}-{int(time.time())}.md"
+# write full content to artifact_path ...
+
 mcp__lobster-inbox__write_result(
     task_id="<task_id>",
     chat_id=<chat_id>,
     text="Summary: ...\n\nActionable items:\n- ...",
     sent_reply_to_user=False,  # dispatcher receives and routes
-    artifacts=["~/lobster-workspace/reports/<task_id>.md"],
+    artifacts=[artifact_path],
 )
 ```
 
 The `artifacts` field is accepted by the inbox server and surfaced in the `subagent_result` message payload. The dispatcher reads those files and includes their content inline in the reply to the user — never relaying a raw file path.
+
+**Never put large content in `text` directly.** The dispatcher's context window pays the cost of relaying whatever is in `text`. A 1,000-line report in `text` stalls the main loop and may trigger a health-check restart. Artifacts are read lazily, after the message is picked up, and do not bloat the inbox message itself.
 
 ## Surfacing Observations (`write_observation`)
 

--- a/install.sh
+++ b/install.sh
@@ -319,6 +319,7 @@ if [ "$CONTAINER_SETUP" = true ]; then
 
     # Create runtime directories (same as full install)
     mkdir -p "$WORKSPACE_DIR"/{logs,data,scheduled-jobs/{logs,tasks}}
+    mkdir -p "$WORKSPACE_DIR/reports"
     mkdir -p "$MESSAGES_DIR"/{inbox,outbox,processed,processing,failed,config,audio,task-outputs}
     mkdir -p "$CONFIG_DIR"
     mkdir -p "$PROJECTS_DIR"
@@ -986,6 +987,7 @@ fi
 step "Creating directories..."
 
 mkdir -p "$WORKSPACE_DIR"/{logs,data,scheduled-jobs/{logs,tasks}}
+mkdir -p "$WORKSPACE_DIR/reports"
 mkdir -p "$MESSAGES_DIR"/{inbox,outbox,processed,processing,failed,config,audio,task-outputs}
 mkdir -p "$CONFIG_DIR"
 mkdir -p "$PROJECTS_DIR"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -634,6 +634,7 @@ create_new_directories() {
         "$WORKSPACE_DIR/scheduled-jobs/tasks"
         "$WORKSPACE_DIR/data"
         "$WORKSPACE_DIR/scheduled-jobs/logs"
+        "$WORKSPACE_DIR/reports"
         "$USER_CONFIG_DIR/memory/canonical/people"
         "$USER_CONFIG_DIR/memory/canonical/projects"
         "$USER_CONFIG_DIR/memory/archive/digests"
@@ -1501,6 +1502,16 @@ with open(path, 'w') as f:
         mkdir -p "$HOME/.config/gws"
         cp "$GWS_SECRET_SRC" "$GWS_SECRET_DEST"
         substep "Restored gws OAuth client secret from lobster-config"
+        migrated=$((migrated + 1))
+    fi
+
+    # Migration 30: Create ~/lobster-workspace/reports/ for artifact-based large result delivery.
+    # Subagents write large outputs (reports, diffs, analysis) to this directory and pass the
+    # path in write_result artifacts=[...]. The dispatcher reads and inlines the content rather
+    # than bloating the inbox message or the dispatcher's context window (see issue #746).
+    if [ ! -d "$WORKSPACE_DIR/reports" ]; then
+        mkdir -p "$WORKSPACE_DIR/reports"
+        substep "Created $WORKSPACE_DIR/reports/ for subagent artifact storage"
         migrated=$((migrated + 1))
     fi
 

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -1700,7 +1700,15 @@ async def list_tools() -> list[Tool]:
                     },
                     "text": {
                         "type": "string",
-                        "description": "The result text to deliver to the user.",
+                        "description": (
+                            "The result text to deliver to the user. "
+                            "Keep this to a concise summary (ideally under ~4KB / ~500 words). "
+                            "For large outputs — reports, diffs, full analysis — write the content "
+                            "to ~/lobster-workspace/reports/<task_id>.md and pass the path in "
+                            "`artifacts` instead. The dispatcher reads artifact files and inlines "
+                            "their content in the reply. Never put raw file paths in text — they "
+                            "are server-side references that are useless to mobile users."
+                        ),
                     },
                     "source": {
                         "type": "string",


### PR DESCRIPTION
## What problem this solves

When a subagent produces a large result — a report, a diff, a full analysis — it calls `write_result` with all that content in `text`. The dispatcher's main loop then has to relay that text to the user by calling `send_reply`, loading the entire payload into its context window. For a 1,000-line result, this stalls the 7-second loop and risks a health-check restart.

PR #711 addressed this by truncating `text` at 2,000 chars server-side. Truncation is data loss. The proper fix is already in the system's design: the `write_result` tool accepts an `artifacts` parameter (file paths), and the dispatcher already reads those files and inlines their content when relaying. The pipeline was complete — but subagents weren't told to use it for user-facing tasks.

## What changed

**`sys.subagent.bootup.md`** — The existing guidance was labeled "Long reports (internal tasks only)." This PR removes that restriction. All subagents, whether handling internal or user-facing tasks, should write large content to `~/lobster-workspace/reports/<task_id>-<timestamp>.md` and pass the path in `artifacts` when output exceeds ~4KB or ~500 words. The `text` field should stay a concise summary. A new note explains why: the dispatcher's context window pays the cost of whatever is in `text`, and large payloads there stall the main loop.

**`src/mcp/inbox_server.py`** — The `text` field description in the `write_result` tool schema now states the ~4KB threshold and directs subagents to use `artifacts` for large content. This is the guidance visible to the model at tool-call time.

**`install.sh` and `scripts/upgrade.sh`** — `~/lobster-workspace/reports/` is now created during install (both full-install and quick-update paths) and in `create_new_directories`. Migration 29 creates the directory on existing installs.

## What was NOT changed

- The `artifacts` schema in `write_result` — already accepted a `list[str]` and was already stored and forwarded correctly in `handle_write_result`
- The dispatcher inlining logic in `sys.dispatcher.bootup.md` — the pseudocode already reads artifact files and inlines content before calling `send_reply`
- `handle_write_result` Python implementation — artifacts already attached to the inbox message payload correctly

## System flow (before and after)

Before this PR, the guidance gap caused subagents to put everything in `text`:

```
Subagent produces 5,000-word report
  → write_result(text="<5,000 words>", artifacts=[])
    → dispatcher picks up subagent_result
      → loads full 5,000 words into context
        → stall / health-check restart risk
```

After this PR, subagents use the artifact path:

```
Subagent produces 5,000-word report
  → writes content to ~/lobster-workspace/reports/<task_id>-<ts>.md
  → write_result(text="Summary: ...", artifacts=["<path>"])
    → dispatcher picks up subagent_result (small inbox message)
      → reads artifact file (lazy, after pickup)
        → inlines content in send_reply to user
```

The inbox message itself stays small. The dispatcher's context window sees only the summary. No size limit, no truncation, no data loss.

## Relationship to PR #711

PR #711 should be closed without merging. This PR supersedes it. A comment has been left on #711 pointing here.

## Functional patterns used

Pure data transformation (summary + artifact path as separate concerns), composition (artifact reading is a separate step from relay, keeping the inbox message format simple), and separation of concerns (subagent writes content; dispatcher reads and inlines).

## Tests run

- [x] `uv run pytest tests/ -q --ignore=tests/integration/test_installation.py` — 27 failed, 1777 passed — identical failure count to main branch. All failures pre-exist and are unrelated to this change (user_model, whatsapp_bridge_adapter, path_guard, skill_manager, auto_register_agent hooks).
- [x] `uv run pytest tests/integration/test_installation.py` — 1 pre-existing failure (`test_bot_module_importable`) also present on main.

Closes #746