### PR TITLE
fix: restore gws OAuth client secret from lobster-config on install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1398,6 +1398,19 @@ success "Nightly consolidation configured (runs at 03:00 nightly)"
 
 step "Setting up gws credential sync..."
 
+# Restore gws OAuth client secret from user config if present.
+# The client_secret.json is created once via Google Cloud Console and stored in
+# ~/lobster-config/ so reinstalls automatically restore gws auth capability.
+GWS_CLIENT_SECRET_SRC="$HOME/lobster-config/gws-client-secret.json"
+GWS_CONFIG_DIR="$HOME/.config/gws"
+if [ -f "$GWS_CLIENT_SECRET_SRC" ]; then
+    mkdir -p "$GWS_CONFIG_DIR"
+    cp "$GWS_CLIENT_SECRET_SRC" "$GWS_CONFIG_DIR/client_secret.json"
+    success "gws OAuth client secret restored from lobster-config"
+else
+    warn "No gws-client-secret.json found in ~/lobster-config/ — run 'gws auth setup' or copy client_secret.json manually"
+fi
+
 chmod +x "$INSTALL_DIR/scripts/sync-gws-credentials.py" || true
 
 # Add gws credential sync to crontab (runs daily at 04:00)

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1489,6 +1489,21 @@ with open(path, 'w') as f:
         migrated=$((migrated + 1))
     fi
 
+    # Migration 29: Restore gws OAuth client secret from lobster-config
+    # install.sh previously set up the gws credential sync cron job but did not
+    # restore the client_secret.json. Without it, gws auth login fails with
+    # "No OAuth client configured." on any reinstall.
+    # If the user has stored the secret at ~/lobster-config/gws-client-secret.json
+    # (the canonical location for private credentials), copy it into place now.
+    local GWS_SECRET_SRC="$HOME/lobster-config/gws-client-secret.json"
+    local GWS_SECRET_DEST="$HOME/.config/gws/client_secret.json"
+    if [ -f "$GWS_SECRET_SRC" ] && [ ! -f "$GWS_SECRET_DEST" ]; then
+        mkdir -p "$HOME/.config/gws"
+        cp "$GWS_SECRET_SRC" "$GWS_SECRET_DEST"
+        substep "Restored gws OAuth client secret from lobster-config"
+        migrated=$((migrated + 1))
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What this does

\`install.sh\` now restores the gws OAuth client secret during install/reinstall.

**Background:** \`gws\` is the Google Workspace CLI used for Gmail access. Before it can authenticate, it needs a \`client_secret.json\` file from Google Cloud Console. Previously this file wasn't restored on reinstall, so \`gws auth login\` would fail after any fresh install.

**The fix:** If \`~/lobster-config/gws-client-secret.json\` exists, install.sh copies it to \`~/.config/gws/client_secret.json\`. If it doesn't exist (which is the current state — gws isn't configured yet), install warns and continues. No harm either way.

**Also:** \`scripts/upgrade.sh\` migration 29 does the same copy for existing installs, guarded so it doesn't overwrite an already-working file.

## One-time manual setup still required

To actually use gws, someone needs to:
1. Create a GCP project, enable Gmail API, create OAuth 2.0 credentials (Desktop app type)
2. Download \`client_secret.json\` → place at \`~/lobster-config/gws-client-secret.json\`
3. Run \`gws auth login\` and authorize the target account

After that, future reinstalls automatically restore auth capability.

Closes #750