### PR TITLE
fix: root install re-execs seamlessly via /tmp copy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -463,20 +463,17 @@ if [ "$(id -u)" = "0" ]; then
     else
         warn "docker group not found — skipping docker group membership (install Docker first)."
     fi
+    # Copy script to /tmp so lobster user can read it regardless of working directory
+    INSTALL_SCRIPT="$(readlink -f "$0")"
+    TMP_SCRIPT="$(mktemp /tmp/lobster-install.XXXXXX.sh)"
+    cp "$INSTALL_SCRIPT" "$TMP_SCRIPT"
+    chmod 755 "$TMP_SCRIPT"
+    LOBSTER_HOME="$(getent passwd lobster | cut -d: -f6)"
+
     echo ""
-    info "User 'lobster' is ready."
+    info "Re-running installer as 'lobster' user..."
     echo ""
-    echo -e "${BOLD}Next step: SSH in as the lobster user and run the installer again:${NC}"
-    echo ""
-    echo -e "  ${CYAN}ssh lobster@$(hostname -f 2>/dev/null || hostname)${NC}"
-    echo -e "  ${CYAN}bash install.sh${NC}"
-    echo ""
-    echo "Or, if install.sh is not present in the lobster home directory, download and run:"
-    echo -e "  ${CYAN}curl -fsSL https://raw.githubusercontent.com/SiderealPress/lobster/main/install.sh | bash${NC}"
-    echo ""
-    echo "Your SSH authorized_keys have been copied to the lobster user."
-    echo "Installation as root is complete. The rest must run as 'lobster'."
-    exit 0
+    exec sudo -u lobster HOME="$LOBSTER_HOME" bash "$TMP_SCRIPT" "$@"
 fi
 
 # Check if running interactively


### PR DESCRIPTION
## Problem

When `install.sh` runs as root, operator experience requires two SSH sessions: one as root to create the lobster user, then a second as lobster to actually install. PR #753 made the failure visible (instead of silent), but the underlying gap remained — the root user couldn't hand off to lobster in-process.

The root cause: `$0` is a relative path (`install.sh`). After `exec sudo -u lobster bash "$0"`, the lobster user looks for `install.sh` relative to root's working directory (`/root/`), which lobster cannot read. The sub-process exits with no output.

## Fix

Before re-execing, copy the script to `/tmp` so lobster can always access it:

```bash
INSTALL_SCRIPT="$(readlink -f "$0")"
TMP_SCRIPT="$(mktemp /tmp/lobster-install.XXXXXX.sh)"
cp "$INSTALL_SCRIPT" "$TMP_SCRIPT"
chmod 755 "$TMP_SCRIPT"
LOBSTER_HOME="$(getent passwd lobster | cut -d: -f6)"

info "Re-running installer as 'lobster' user..."
exec sudo -u lobster HOME="$LOBSTER_HOME" bash "$TMP_SCRIPT" "$@"
```

The rest of the root block (user creation, SSH key copy, docker group add) is unchanged. The `/tmp` file is not explicitly cleaned up — `exec` replaces the process and `/tmp` is ephemeral.

`HOME` is passed explicitly so the lobster user's home directory resolves correctly even when re-execed from root's environment.

## What's not changed

- The lobster user creation, SSH key copy, and docker group membership logic are untouched.
- The interactivity check (below the root block) is untouched — it still guards against non-TTY execution when running as lobster.
- No other install paths are affected.

## Functional pattern

Pure transformation: the root block now has a single exit path (`exec`, which replaces the process). No branching at the end, no `exit 0` instruction-printing that required operator action.

## Tests run

- [x] Manual diff review — change is exactly the 12-line exit+instructions block replaced by 9-line /tmp-copy + re-exec block
- [ ] Live VPS test (root install) — blocked: requires a fresh VPS and root SSH access, not available in this environment. The logic is straightforward: `readlink -f "$0"` → `mktemp` → `cp` → `exec sudo -u lobster`. Each step is standard POSIX shell.

**Blocked items needing attention before merge:** none — the logic is simple enough that live testing is strongly recommended post-merge on a fresh VPS, but the change is low-risk.

Fixes #755
References #752 #753