### PR TITLE
feat(db): Slice 1 — messages.db schema + JSON migration script (BIS-162)

### DIFF
--- a/scripts/migrate_json_to_db.py
+++ b/scripts/migrate_json_to_db.py
@@ -1,0 +1,626 @@
+#!/usr/bin/env python3
+"""
+scripts/migrate_json_to_db.py — Migrate processed/ and sent/ JSON files into messages.db
+
+Reads every *.json file from:
+  - ~/messages/processed/   → inbound messages (direction='in')
+  - ~/messages/sent/        → outbound replies  (direction='out')
+
+Classifies each message into one of three tables:
+  - agent_events   — subagent_result | agent_failed | subagent_notification |
+                     subagent_error | task-notification
+  - bisque_events  — source == 'bisque'
+  - messages       — everything else (both inbound and outbound)
+
+Design:
+  - Purely functional transforms: JSON dict → row dict, no mutation of inputs
+  - Idempotent: INSERT OR IGNORE so re-runs are safe
+  - Progress printed to stdout; errors to stderr
+  - Configurable via CLI flags (see --help)
+
+Usage:
+    python scripts/migrate_json_to_db.py
+    python scripts/migrate_json_to_db.py --db ~/messages/messages.db
+    python scripts/migrate_json_to_db.py --processed ~/messages/processed \
+                                          --sent ~/messages/sent \
+                                          --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Iterator
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+_SRC_DB = _REPO_ROOT / "src" / "db"
+
+# Allow running the script from anywhere on the server
+_DEFAULT_DB = Path.home() / "messages" / "messages.db"
+_DEFAULT_PROCESSED = Path.home() / "messages" / "processed"
+_DEFAULT_SENT = Path.home() / "messages" / "sent"
+
+# ---------------------------------------------------------------------------
+# Message classification
+# ---------------------------------------------------------------------------
+
+_AGENT_EVENT_TYPES = frozenset(
+    {
+        "subagent_result",
+        "subagent_notification",
+        "subagent_error",
+        "agent_failed",
+        "task-notification",
+    }
+)
+
+
+def classify(record: dict, direction: str) -> str:
+    """
+    Return the destination table name for *record*.
+
+    Pure function — does not modify *record*.
+
+    Args:
+        record:    Parsed JSON dict from a message file.
+        direction: 'in' (processed/) or 'out' (sent/).
+
+    Returns:
+        One of 'messages', 'bisque_events', 'agent_events'.
+    """
+    msg_type = record.get("type", "")
+    source = record.get("source", "")
+
+    if msg_type in _AGENT_EVENT_TYPES:
+        return "agent_events"
+    if source == "bisque":
+        return "bisque_events"
+    return "messages"
+
+
+# ---------------------------------------------------------------------------
+# Row builders — pure functions, JSON dict → sqlite-ready dict
+# ---------------------------------------------------------------------------
+
+
+def _str(v: object) -> str | None:
+    """Coerce *v* to str, or None if falsy."""
+    return str(v) if v is not None else None
+
+
+def _int(v: object) -> int | None:
+    """Coerce *v* to int, or None."""
+    try:
+        return int(v) if v is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _bool_int(v: object) -> int | None:
+    """Coerce *v* to 0/1 integer for SQLite BOOLEAN storage, or None."""
+    if v is None:
+        return None
+    return 1 if v else 0
+
+
+def _json_str(v: object) -> str | None:
+    """Serialise *v* to a compact JSON string, or None if falsy."""
+    if v is None:
+        return None
+    return json.dumps(v, ensure_ascii=False, separators=(",", ":"))
+
+
+# Known fields on the messages table — used to extract 'extra' overflow
+_MESSAGES_KNOWN_FIELDS = frozenset(
+    {
+        "id",
+        "direction",
+        "source",
+        "type",
+        "chat_id",
+        "user_id",
+        "username",
+        "user_name",
+        "text",
+        "reply_to",
+        "reply_to_message_id",
+        "image_file",
+        "image_width",
+        "image_height",
+        "audio_file",
+        "audio_duration",
+        "audio_mime_type",
+        "transcription",
+        "transcribed_at",
+        "transcription_model",
+        "file_path",
+        "file_name",
+        "mime_type",
+        "file_size",
+        "telegram_message_id",
+        "callback_data",
+        "callback_query_id",
+        "original_message_id",
+        "original_message_text",
+        "media_group_id",
+        "timestamp",
+        "imported_at",
+        "extra",
+        # raw JSON fields that are pre-processed
+        "_processing_started_at",
+        "forward",
+        "attachments",
+        "buttons",
+        "photo_url",
+        "caption",
+    }
+)
+
+
+def build_message_row(record: dict, direction: str) -> dict:
+    """
+    Build a dict suitable for INSERT INTO messages from a raw JSON record.
+
+    Extra/unknown fields are folded into the 'extra' JSON column.
+
+    Args:
+        record:    Raw JSON dict from a processed or sent message file.
+        direction: 'in' or 'out'.
+
+    Returns:
+        A dict whose keys match the messages table columns.
+    """
+    # Gather overflow fields before building the row
+    overflow = {
+        k: v
+        for k, v in record.items()
+        if k not in _MESSAGES_KNOWN_FIELDS and v is not None
+    }
+
+    return {
+        "id": _str(record.get("id")),
+        "direction": direction,
+        "source": _str(record.get("source")),
+        "type": _str(record.get("type")),
+        "chat_id": _str(record.get("chat_id")),
+        "user_id": _str(record.get("user_id")),
+        "username": _str(record.get("username")),
+        "user_name": _str(record.get("user_name")),
+        "text": _str(record.get("text")),
+        "reply_to": _str(record.get("reply_to")),
+        "reply_to_message_id": _str(record.get("reply_to_message_id")),
+        "image_file": _str(record.get("image_file")),
+        "image_width": _int(record.get("image_width")),
+        "image_height": _int(record.get("image_height")),
+        "audio_file": _str(record.get("audio_file")),
+        "audio_duration": _int(record.get("audio_duration")),
+        "audio_mime_type": _str(record.get("audio_mime_type")),
+        "transcription": _str(record.get("transcription")),
+        "transcribed_at": _str(record.get("transcribed_at")),
+        "transcription_model": _str(record.get("transcription_model")),
+        "file_path": _str(record.get("file_path")),
+        "file_name": _str(record.get("file_name")),
+        "mime_type": _str(record.get("mime_type")),
+        "file_size": _int(record.get("file_size")),
+        "telegram_message_id": _str(record.get("telegram_message_id")),
+        "callback_data": _str(record.get("callback_data")),
+        "callback_query_id": _str(record.get("callback_query_id")),
+        "original_message_id": _str(record.get("original_message_id")),
+        "original_message_text": _str(record.get("original_message_text")),
+        "media_group_id": _str(record.get("media_group_id")),
+        "timestamp": _str(record.get("timestamp")),
+        "extra": _json_str(overflow) if overflow else None,
+    }
+
+
+def build_bisque_event_row(record: dict) -> dict:
+    """
+    Build a dict for INSERT INTO bisque_events from a raw JSON record.
+
+    Args:
+        record: Raw JSON dict from a processed bisque message file.
+
+    Returns:
+        A dict whose keys match the bisque_events table columns.
+    """
+    return {
+        "id": _str(record.get("id")),
+        "chat_id": _str(record.get("chat_id")),
+        "type": _str(record.get("type")),
+        "text": _str(record.get("text")),
+        "reply_to_id": _str(record.get("reply_to_id")),
+        "reply_to": _str(record.get("reply_to")),
+        "audio_file": _str(record.get("audio_file")),
+        "transcription": _str(record.get("transcription")),
+        "transcribed_at": _str(record.get("transcribed_at")),
+        "transcription_model": _str(record.get("transcription_model")),
+        "task_id": _str(record.get("task_id")),
+        "agent_id": _str(record.get("agent_id")),
+        "status": _str(record.get("status")),
+        "sent_reply_to_user": _bool_int(record.get("sent_reply_to_user")),
+        "attachments": _json_str(record.get("attachments")),
+        "warning": _str(record.get("warning")),
+        "timestamp": _str(record.get("timestamp")),
+    }
+
+
+def build_agent_event_row(record: dict) -> dict:
+    """
+    Build a dict for INSERT INTO agent_events from a raw JSON record.
+
+    Args:
+        record: Raw JSON dict from a processed agent-event message file.
+
+    Returns:
+        A dict whose keys match the agent_events table columns.
+    """
+    return {
+        "id": _str(record.get("id")),
+        "type": _str(record.get("type")),
+        "source": _str(record.get("source")),
+        "chat_id": _str(record.get("chat_id")),
+        "task_id": _str(record.get("task_id")),
+        "agent_id": _str(record.get("agent_id")),
+        "status": _str(record.get("status")),
+        "text": _str(record.get("text")),
+        "sent_reply_to_user": _bool_int(record.get("sent_reply_to_user")),
+        "warning": _str(record.get("warning")),
+        "original_chat_id": _str(record.get("original_chat_id")),
+        "original_prompt": _str(record.get("original_prompt")),
+        "last_output": _str(record.get("last_output")),
+        "artifacts": _json_str(record.get("artifacts")),
+        "forward": _json_str(record.get("forward")),
+        "timestamp": _str(record.get("timestamp")),
+    }
+
+
+# ---------------------------------------------------------------------------
+# File iteration
+# ---------------------------------------------------------------------------
+
+
+def iter_json_files(directory: Path) -> Iterator[tuple[Path, dict]]:
+    """
+    Yield (path, parsed_dict) for every valid *.json file in *directory*.
+
+    Parsing is attempted in two passes:
+      1. Strict mode (json.loads default) — fastest path.
+      2. Non-strict mode (json.loads strict=False) — handles embedded control
+         characters (U+0000–U+001F) that some messages contain in their text
+         field.  These arise when a task result included raw terminal output.
+
+    Files that cannot be parsed in either pass are skipped with a warning.
+
+    Args:
+        directory: Directory to scan (non-recursive).
+
+    Yields:
+        Tuples of (Path, dict).
+    """
+    for path in sorted(directory.glob("*.json")):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+            try:
+                yield path, json.loads(text)
+            except json.JSONDecodeError:
+                # Retry with strict=False to accept embedded control chars
+                yield path, json.loads(text, strict=False)
+        except json.JSONDecodeError as exc:
+            print(f"WARN  skip {path.name}: JSON error — {exc}", file=sys.stderr)
+        except OSError as exc:
+            print(f"WARN  skip {path.name}: I/O error — {exc}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# INSERT helpers
+# ---------------------------------------------------------------------------
+
+_INSERT_MESSAGE = """
+INSERT OR IGNORE INTO messages (
+    id, direction, source, type,
+    chat_id, user_id, username, user_name,
+    text, reply_to, reply_to_message_id,
+    image_file, image_width, image_height,
+    audio_file, audio_duration, audio_mime_type,
+    transcription, transcribed_at, transcription_model,
+    file_path, file_name, mime_type, file_size,
+    telegram_message_id, callback_data, callback_query_id,
+    original_message_id, original_message_text, media_group_id,
+    timestamp, extra
+) VALUES (
+    :id, :direction, :source, :type,
+    :chat_id, :user_id, :username, :user_name,
+    :text, :reply_to, :reply_to_message_id,
+    :image_file, :image_width, :image_height,
+    :audio_file, :audio_duration, :audio_mime_type,
+    :transcription, :transcribed_at, :transcription_model,
+    :file_path, :file_name, :mime_type, :file_size,
+    :telegram_message_id, :callback_data, :callback_query_id,
+    :original_message_id, :original_message_text, :media_group_id,
+    :timestamp, :extra
+)
+""".strip()
+
+_INSERT_BISQUE = """
+INSERT OR IGNORE INTO bisque_events (
+    id, chat_id, type, text, reply_to_id, reply_to,
+    audio_file, transcription, transcribed_at, transcription_model,
+    task_id, agent_id, status, sent_reply_to_user,
+    attachments, warning, timestamp
+) VALUES (
+    :id, :chat_id, :type, :text, :reply_to_id, :reply_to,
+    :audio_file, :transcription, :transcribed_at, :transcription_model,
+    :task_id, :agent_id, :status, :sent_reply_to_user,
+    :attachments, :warning, :timestamp
+)
+""".strip()
+
+_INSERT_AGENT = """
+INSERT OR IGNORE INTO agent_events (
+    id, type, source, chat_id,
+    task_id, agent_id, status, text,
+    sent_reply_to_user, warning,
+    original_chat_id, original_prompt, last_output,
+    artifacts, forward, timestamp
+) VALUES (
+    :id, :type, :source, :chat_id,
+    :task_id, :agent_id, :status, :text,
+    :sent_reply_to_user, :warning,
+    :original_chat_id, :original_prompt, :last_output,
+    :artifacts, :forward, :timestamp
+)
+""".strip()
+
+
+# ---------------------------------------------------------------------------
+# Core migration logic
+# ---------------------------------------------------------------------------
+
+
+def migrate_directory(
+    conn: sqlite3.Connection,
+    directory: Path,
+    direction: str,
+    batch_size: int = 500,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """
+    Migrate all JSON files in *directory* into the appropriate tables.
+
+    Args:
+        conn:       Open sqlite3 connection with schema already applied.
+        directory:  Folder containing *.json message files.
+        direction:  'in' for processed/, 'out' for sent/.
+        batch_size: Commit every N rows to keep memory usage bounded.
+        dry_run:    If True, parse and classify but do not INSERT.
+
+    Returns:
+        Dict with counts: {'messages': N, 'bisque_events': N, 'agent_events': N,
+                           'skipped': N, 'errors': N}
+    """
+    counts: dict[str, int] = {
+        "messages": 0,
+        "bisque_events": 0,
+        "agent_events": 0,
+        "skipped": 0,
+        "errors": 0,
+    }
+
+    pending = 0
+
+    for path, record in iter_json_files(directory):
+        table = classify(record, direction)
+
+        try:
+            if not dry_run:
+                if table == "agent_events":
+                    row = build_agent_event_row(record)
+                    conn.execute(_INSERT_AGENT, row)
+                elif table == "bisque_events":
+                    row = build_bisque_event_row(record)
+                    conn.execute(_INSERT_BISQUE, row)
+                else:
+                    row = build_message_row(record, direction)
+                    conn.execute(_INSERT_MESSAGE, row)
+
+            counts[table] += 1
+            pending += 1
+
+            if pending >= batch_size:
+                if not dry_run:
+                    conn.commit()
+                pending = 0
+
+        except sqlite3.Error as exc:
+            counts["errors"] += 1
+            print(
+                f"ERROR {path.name}: DB error — {exc}",
+                file=sys.stderr,
+            )
+
+    if not dry_run and pending > 0:
+        conn.commit()
+
+    return counts
+
+
+def migrate_all(
+    db_path: Path,
+    processed_dir: Path,
+    sent_dir: Path,
+    batch_size: int = 500,
+    dry_run: bool = False,
+    verbose: bool = False,
+) -> None:
+    """
+    Full migration: open the DB, apply schema, then migrate processed/ and sent/.
+
+    Args:
+        db_path:       Destination SQLite database file path.
+        processed_dir: ~/messages/processed/ directory.
+        sent_dir:      ~/messages/sent/ directory.
+        batch_size:    Rows per commit.
+        dry_run:       Parse + classify but do not write to DB.
+        verbose:       Print per-directory progress.
+    """
+    # Import here to avoid circular import if running standalone
+    import importlib.util
+    import os
+
+    # Locate src/db/connection.py relative to this script
+    connection_path = Path(__file__).parent.parent / "src" / "db" / "connection.py"
+    schema_path = Path(__file__).parent.parent / "src" / "db" / "schema.sql"
+
+    if connection_path.exists():
+        spec = importlib.util.spec_from_file_location("connection", connection_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        open_db = mod.open_messages_db
+    else:
+        # Fallback: inline open without the module
+        def open_db(path: Path) -> sqlite3.Connection:
+            conn = sqlite3.connect(str(path))
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode = WAL")
+            conn.execute("PRAGMA foreign_keys = ON")
+            if schema_path.exists():
+                conn.executescript(schema_path.read_text(encoding="utf-8"))
+            return conn
+
+    if dry_run:
+        print("DRY RUN — no data will be written to the database.\n")
+        # Use in-memory DB for validation
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        if schema_path.exists():
+            conn.executescript(schema_path.read_text(encoding="utf-8"))
+    else:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = open_db(db_path)
+        print(f"Database: {db_path}\n")
+
+    total: dict[str, int] = {
+        "messages": 0,
+        "bisque_events": 0,
+        "agent_events": 0,
+        "skipped": 0,
+        "errors": 0,
+    }
+
+    for directory, direction, label in [
+        (processed_dir, "in", "processed/"),
+        (sent_dir, "out", "sent/"),
+    ]:
+        if not directory.exists():
+            print(f"WARN  {label} directory not found: {directory}", file=sys.stderr)
+            continue
+
+        file_count = sum(1 for _ in directory.glob("*.json"))
+        if verbose:
+            print(f"Migrating {label} ({file_count} files, direction='{direction}') ...")
+
+        counts = migrate_directory(
+            conn,
+            directory,
+            direction,
+            batch_size=batch_size,
+            dry_run=dry_run,
+        )
+
+        for k, v in counts.items():
+            total[k] = total.get(k, 0) + v
+
+        if verbose:
+            print(
+                f"  -> messages={counts['messages']}  "
+                f"bisque_events={counts['bisque_events']}  "
+                f"agent_events={counts['agent_events']}  "
+                f"errors={counts['errors']}"
+            )
+
+    conn.close()
+
+    # Summary
+    grand = total["messages"] + total["bisque_events"] + total["agent_events"]
+    print(
+        f"\nMigration complete.\n"
+        f"  messages:      {total['messages']:>7,}\n"
+        f"  bisque_events: {total['bisque_events']:>7,}\n"
+        f"  agent_events:  {total['agent_events']:>7,}\n"
+        f"  errors:        {total['errors']:>7,}\n"
+        f"  total rows:    {grand:>7,}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Migrate Lobster JSON message files into messages.db",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--db",
+        metavar="PATH",
+        default=str(_DEFAULT_DB),
+        help=f"Path to the SQLite database file (default: {_DEFAULT_DB})",
+    )
+    parser.add_argument(
+        "--processed",
+        metavar="DIR",
+        default=str(_DEFAULT_PROCESSED),
+        help=f"Directory containing processed inbound JSON files (default: {_DEFAULT_PROCESSED})",
+    )
+    parser.add_argument(
+        "--sent",
+        metavar="DIR",
+        default=str(_DEFAULT_SENT),
+        help=f"Directory containing sent outbound JSON files (default: {_DEFAULT_SENT})",
+    )
+    parser.add_argument(
+        "--batch-size",
+        metavar="N",
+        type=int,
+        default=500,
+        help="Number of rows per transaction commit (default: 500)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse and classify files without writing to the database",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print per-directory progress",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    migrate_all(
+        db_path=Path(args.db),
+        processed_dir=Path(args.processed),
+        sent_dir=Path(args.sent),
+        batch_size=args.batch_size,
+        dry_run=args.dry_run,
+        verbose=args.verbose,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -1,0 +1,1 @@
+# src/db — Lobster message database layer

--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -1,0 +1,88 @@
+"""
+src/db/connection.py — SQLite connection factory for messages.db
+
+Provides a pure-functional approach to database connections:
+  - get_connection(path) returns a configured sqlite3.Connection
+  - apply_schema(conn, schema_sql) applies DDL idempotently
+  - Callers are responsible for committing and closing
+
+WAL mode and foreign_keys are applied at connection time (not stored in schema)
+because they are connection-level PRAGMAs.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+_SCHEMA_PATH = Path(__file__).parent / "schema.sql"
+
+# Reconnection config: row_factory + PRAGMA setup
+_PRAGMAS = [
+    "PRAGMA journal_mode = WAL",
+    "PRAGMA foreign_keys = ON",
+    "PRAGMA synchronous = NORMAL",
+    "PRAGMA temp_store = MEMORY",
+    "PRAGMA mmap_size = 134217728",  # 128 MB memory-mapped I/O
+]
+
+
+def get_connection(db_path: str | Path) -> sqlite3.Connection:
+    """
+    Open (or create) a messages.db SQLite database and return a configured
+    connection.
+
+    The connection uses sqlite3.Row as its row factory so callers can access
+    columns by name.  WAL mode and foreign keys are enabled for every
+    connection.
+
+    Args:
+        db_path: Filesystem path to the .db file.  The parent directory must
+                 already exist.
+
+    Returns:
+        An open sqlite3.Connection.  Callers are responsible for closing it.
+    """
+    db_path = Path(db_path)
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    for pragma in _PRAGMAS:
+        conn.execute(pragma)
+    return conn
+
+
+def apply_schema(conn: sqlite3.Connection, schema_sql: str | None = None) -> None:
+    """
+    Execute the schema DDL against *conn*.
+
+    If *schema_sql* is None, the bundled schema.sql is read from disk.
+    All statements are executed inside a single implicit transaction; if any
+    statement fails the caller should handle the exception.
+
+    Args:
+        conn:       An open sqlite3.Connection.
+        schema_sql: SQL text to execute.  Defaults to the bundled schema.sql.
+    """
+    if schema_sql is None:
+        schema_sql = _SCHEMA_PATH.read_text(encoding="utf-8")
+    conn.executescript(schema_sql)
+
+
+def open_messages_db(db_path: str | Path) -> sqlite3.Connection:
+    """
+    Convenience function: open the database *and* apply the schema.
+
+    Equivalent to:
+        conn = get_connection(db_path)
+        apply_schema(conn)
+        return conn
+
+    Args:
+        db_path: Path to the messages.db file.
+
+    Returns:
+        A fully-initialised, open sqlite3.Connection.
+    """
+    conn = get_connection(db_path)
+    apply_schema(conn)
+    return conn

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -1,0 +1,256 @@
+-- Lobster messages.db schema
+-- BIS-159 Slice 1: messages, bisque_events, agent_events tables + FTS5
+--
+-- Design principles:
+--   - messages:      all inbound user messages (telegram, bisque, self-check, etc.)
+--                    and all outbound sent replies
+--   - bisque_events: bisque-channel-specific messages (superset of bisque rows in messages)
+--   - agent_events:  subagent lifecycle events (results, failures, notifications)
+--   - FTS5 virtual tables index the `text` column of each table for keyword search
+--   - Triggers keep FTS indices in sync with the base tables
+--   - WAL mode, foreign_keys ON — set at connection time, not stored in schema
+
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+
+-- ─── messages ────────────────────────────────────────────────────────────────
+-- One row per processed inbound message or sent outbound reply.
+-- Inbound rows come from ~/messages/processed/*.json.
+-- Outbound rows come from ~/messages/sent/*.json.
+CREATE TABLE IF NOT EXISTS messages (
+    -- Identity
+    id                  TEXT PRIMARY KEY,          -- original file-based id, e.g. "1769219731361_22"
+    direction           TEXT NOT NULL DEFAULT 'in', -- 'in' | 'out'
+    source              TEXT NOT NULL,             -- 'telegram' | 'system' | 'internal' | ...
+    type                TEXT,                      -- 'telegram' | 'text' | 'voice' | 'photo' | 'self_check' | ...
+
+    -- Participants
+    chat_id             TEXT,                      -- telegram chat id or email for bisque
+    user_id             TEXT,
+    username            TEXT,
+    user_name           TEXT,
+
+    -- Content
+    text                TEXT,
+    reply_to            TEXT,                      -- message id this replies to
+    reply_to_message_id TEXT,                      -- outbound: telegram message id of the parent
+
+    -- Media
+    image_file          TEXT,
+    image_width         INTEGER,
+    image_height        INTEGER,
+    audio_file          TEXT,
+    audio_duration      INTEGER,
+    audio_mime_type     TEXT,
+    transcription       TEXT,
+    transcribed_at      TEXT,
+    transcription_model TEXT,
+    file_path           TEXT,
+    file_name           TEXT,
+    mime_type           TEXT,
+    file_size           INTEGER,
+
+    -- Telegram-specific
+    telegram_message_id TEXT,
+    callback_data       TEXT,
+    callback_query_id   TEXT,
+    original_message_id TEXT,
+    original_message_text TEXT,
+    media_group_id      TEXT,
+
+    -- Timestamps
+    timestamp           TEXT NOT NULL,             -- ISO-8601 from the JSON file
+    imported_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+
+    -- Extra fields stored verbatim as JSON (rare/one-off keys)
+    extra               TEXT                       -- JSON blob for overflow fields
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_timestamp  ON messages(timestamp);
+CREATE INDEX IF NOT EXISTS idx_messages_direction  ON messages(direction);
+CREATE INDEX IF NOT EXISTS idx_messages_source     ON messages(source);
+CREATE INDEX IF NOT EXISTS idx_messages_type       ON messages(type);
+CREATE INDEX IF NOT EXISTS idx_messages_chat_id    ON messages(chat_id);
+
+-- FTS5 for keyword search over message text + transcription
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+    text,
+    transcription,
+    user_name,
+    source,
+    type,
+    content='messages',
+    content_rowid='rowid'
+);
+
+CREATE TRIGGER IF NOT EXISTS messages_fts_ai
+    AFTER INSERT ON messages
+BEGIN
+    INSERT INTO messages_fts(rowid, text, transcription, user_name, source, type)
+    VALUES (new.rowid, new.text, new.transcription, new.user_name, new.source, new.type);
+END;
+
+CREATE TRIGGER IF NOT EXISTS messages_fts_ad
+    AFTER DELETE ON messages
+BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, text, transcription, user_name, source, type)
+    VALUES ('delete', old.rowid, old.text, old.transcription, old.user_name, old.source, old.type);
+END;
+
+CREATE TRIGGER IF NOT EXISTS messages_fts_au
+    AFTER UPDATE ON messages
+BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, text, transcription, user_name, source, type)
+    VALUES ('delete', old.rowid, old.text, old.transcription, old.user_name, old.source, old.type);
+    INSERT INTO messages_fts(rowid, text, transcription, user_name, source, type)
+    VALUES (new.rowid, new.text, new.transcription, new.user_name, new.source, new.type);
+END;
+
+-- ─── bisque_events ───────────────────────────────────────────────────────────
+-- Messages originating from the Bisque channel (source = 'bisque').
+-- Contains bisque-specific fields not present on all messages.
+CREATE TABLE IF NOT EXISTS bisque_events (
+    id                  TEXT PRIMARY KEY,
+    chat_id             TEXT,                      -- bisque email address
+    type                TEXT,                      -- 'text' | 'voice' | 'subagent_result' | ...
+    text                TEXT,
+    reply_to_id         TEXT,
+    reply_to            TEXT,
+
+    -- Media (voice)
+    audio_file          TEXT,
+    transcription       TEXT,
+    transcribed_at      TEXT,
+    transcription_model TEXT,
+
+    -- Bisque agent results (when type = subagent_result)
+    task_id             TEXT,
+    agent_id            TEXT,
+    status              TEXT,
+    sent_reply_to_user  INTEGER,                   -- BOOLEAN stored as 0/1
+    attachments         TEXT,                      -- JSON array
+    warning             TEXT,
+
+    -- Timestamps
+    timestamp           TEXT NOT NULL,
+    imported_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_bisque_events_timestamp  ON bisque_events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_bisque_events_type       ON bisque_events(type);
+CREATE INDEX IF NOT EXISTS idx_bisque_events_chat_id    ON bisque_events(chat_id);
+CREATE INDEX IF NOT EXISTS idx_bisque_events_task_id    ON bisque_events(task_id);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS bisque_events_fts USING fts5(
+    text,
+    transcription,
+    type,
+    content='bisque_events',
+    content_rowid='rowid'
+);
+
+CREATE TRIGGER IF NOT EXISTS bisque_events_fts_ai
+    AFTER INSERT ON bisque_events
+BEGIN
+    INSERT INTO bisque_events_fts(rowid, text, transcription, type)
+    VALUES (new.rowid, new.text, new.transcription, new.type);
+END;
+
+CREATE TRIGGER IF NOT EXISTS bisque_events_fts_ad
+    AFTER DELETE ON bisque_events
+BEGIN
+    INSERT INTO bisque_events_fts(bisque_events_fts, rowid, text, transcription, type)
+    VALUES ('delete', old.rowid, old.text, old.transcription, old.type);
+END;
+
+CREATE TRIGGER IF NOT EXISTS bisque_events_fts_au
+    AFTER UPDATE ON bisque_events
+BEGIN
+    INSERT INTO bisque_events_fts(bisque_events_fts, rowid, text, transcription, type)
+    VALUES ('delete', old.rowid, old.text, old.transcription, old.type);
+    INSERT INTO bisque_events_fts(rowid, text, transcription, type)
+    VALUES (new.rowid, new.text, new.transcription, new.type);
+END;
+
+-- ─── agent_events ────────────────────────────────────────────────────────────
+-- Subagent lifecycle events: results, failures, notifications, errors.
+-- Types: subagent_result | agent_failed | subagent_notification | subagent_error
+--        task-notification
+CREATE TABLE IF NOT EXISTS agent_events (
+    id                  TEXT PRIMARY KEY,
+    type                TEXT NOT NULL,             -- 'subagent_result' | 'agent_failed' | ...
+    source              TEXT,                      -- 'telegram' | 'system' | 'internal'
+    chat_id             TEXT,
+
+    -- Task identity
+    task_id             TEXT,
+    agent_id            TEXT,
+
+    -- Outcome
+    status              TEXT,                      -- 'success' | 'error'
+    text                TEXT,                      -- human-readable result summary
+    sent_reply_to_user  INTEGER,                   -- BOOLEAN stored as 0/1
+    warning             TEXT,
+
+    -- Failure details
+    original_chat_id    TEXT,
+    original_prompt     TEXT,
+    last_output         TEXT,
+
+    -- Artifacts / forward
+    artifacts           TEXT,                      -- JSON array of file paths
+    forward             TEXT,                      -- JSON blob
+
+    -- Timestamps
+    timestamp           TEXT NOT NULL,
+    imported_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_events_timestamp  ON agent_events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_agent_events_type       ON agent_events(type);
+CREATE INDEX IF NOT EXISTS idx_agent_events_task_id    ON agent_events(task_id);
+CREATE INDEX IF NOT EXISTS idx_agent_events_agent_id   ON agent_events(agent_id);
+CREATE INDEX IF NOT EXISTS idx_agent_events_status     ON agent_events(status);
+CREATE INDEX IF NOT EXISTS idx_agent_events_chat_id    ON agent_events(chat_id);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS agent_events_fts USING fts5(
+    text,
+    original_prompt,
+    type,
+    content='agent_events',
+    content_rowid='rowid'
+);
+
+CREATE TRIGGER IF NOT EXISTS agent_events_fts_ai
+    AFTER INSERT ON agent_events
+BEGIN
+    INSERT INTO agent_events_fts(rowid, text, original_prompt, type)
+    VALUES (new.rowid, new.text, new.original_prompt, new.type);
+END;
+
+CREATE TRIGGER IF NOT EXISTS agent_events_fts_ad
+    AFTER DELETE ON agent_events
+BEGIN
+    INSERT INTO agent_events_fts(agent_events_fts, rowid, text, original_prompt, type)
+    VALUES ('delete', old.rowid, old.text, old.original_prompt, old.type);
+END;
+
+CREATE TRIGGER IF NOT EXISTS agent_events_fts_au
+    AFTER UPDATE ON agent_events
+BEGIN
+    INSERT INTO agent_events_fts(agent_events_fts, rowid, text, original_prompt, type)
+    VALUES ('delete', old.rowid, old.text, old.original_prompt, old.type);
+    INSERT INTO agent_events_fts(rowid, text, original_prompt, type)
+    VALUES (new.rowid, new.text, new.original_prompt, new.type);
+END;
+
+-- ─── schema_migrations ───────────────────────────────────────────────────────
+-- Simple migration tracking table.
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version     TEXT PRIMARY KEY,
+    applied_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    description TEXT
+);
+
+INSERT OR IGNORE INTO schema_migrations (version, description)
+VALUES ('001', 'Initial schema: messages, bisque_events, agent_events, FTS5');

--- a/tests/test_messages_db.py
+++ b/tests/test_messages_db.py
@@ -1,0 +1,591 @@
+"""
+tests/test_messages_db.py — Unit tests for the messages.db schema and migration.
+
+Tests cover:
+  - Schema creation (all tables, indexes, FTS5 virtual tables)
+  - Row classification (classify function)
+  - Row builders (build_message_row, build_bisque_event_row, build_agent_event_row)
+  - FTS5 full-text search on each table
+  - FTS5 triggers (insert / delete / update)
+  - Idempotent migration (INSERT OR IGNORE)
+  - Malformed JSON recovery (strict=False fallback)
+  - End-to-end migrate_directory with in-memory fixtures
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the modules under test
+# ---------------------------------------------------------------------------
+
+import sys
+
+_REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from src.db.connection import get_connection, apply_schema, open_messages_db
+from scripts.migrate_json_to_db import (
+    classify,
+    build_message_row,
+    build_bisque_event_row,
+    build_agent_event_row,
+    iter_json_files,
+    migrate_directory,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_conn():
+    """In-memory SQLite connection with schema applied."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    apply_schema(conn)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture()
+def tmp_dir(tmp_path):
+    """Return a temporary directory for fake message JSON files."""
+    return tmp_path
+
+
+def write_json(directory: Path, name: str, data: dict) -> Path:
+    """Write *data* as JSON to *directory/name* and return the path."""
+    p = directory / name
+    p.write_text(json.dumps(data), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestSchema:
+    def test_tables_exist(self, db_conn):
+        rows = db_conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        ).fetchall()
+        names = {r["name"] for r in rows}
+        assert "messages" in names
+        assert "bisque_events" in names
+        assert "agent_events" in names
+        assert "schema_migrations" in names
+
+    def test_fts5_virtual_tables_exist(self, db_conn):
+        rows = db_conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        ).fetchall()
+        names = {r["name"] for r in rows}
+        assert "messages_fts" in names
+        assert "bisque_events_fts" in names
+        assert "agent_events_fts" in names
+
+    def test_indexes_exist(self, db_conn):
+        rows = db_conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' ORDER BY name"
+        ).fetchall()
+        names = {r["name"] for r in rows}
+        assert "idx_messages_timestamp" in names
+        assert "idx_bisque_events_timestamp" in names
+        assert "idx_agent_events_timestamp" in names
+        assert "idx_agent_events_task_id" in names
+        assert "idx_messages_chat_id" in names
+
+    def test_migration_version_recorded(self, db_conn):
+        row = db_conn.execute(
+            "SELECT version, description FROM schema_migrations WHERE version = '001'"
+        ).fetchone()
+        assert row is not None
+        assert "messages" in row["description"].lower()
+
+    def test_schema_is_idempotent(self, db_conn):
+        """Applying the schema a second time must not raise."""
+        apply_schema(db_conn)  # already applied by fixture — apply again
+        row = db_conn.execute("SELECT COUNT(*) AS n FROM schema_migrations").fetchone()
+        assert row["n"] == 1  # INSERT OR IGNORE keeps exactly one row
+
+    def test_open_messages_db_creates_file(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        conn = open_messages_db(db_path)
+        conn.close()
+        assert db_path.exists()
+
+    def test_open_messages_db_has_wal_mode(self, tmp_path):
+        db_path = tmp_path / "test_wal.db"
+        conn = open_messages_db(db_path)
+        row = conn.execute("PRAGMA journal_mode").fetchone()
+        conn.close()
+        assert row[0] == "wal"
+
+
+# ---------------------------------------------------------------------------
+# Classification tests
+# ---------------------------------------------------------------------------
+
+
+class TestClassify:
+    @pytest.mark.parametrize(
+        "msg_type,source,direction,expected_table",
+        [
+            # Agent event types always go to agent_events
+            ("subagent_result", "telegram", "in", "agent_events"),
+            ("subagent_notification", "telegram", "in", "agent_events"),
+            ("subagent_error", "telegram", "in", "agent_events"),
+            ("agent_failed", "system", "in", "agent_events"),
+            ("task-notification", "internal", "in", "agent_events"),
+            # Bisque source → bisque_events (unless it is also an agent type)
+            ("text", "bisque", "in", "bisque_events"),
+            ("voice", "bisque", "in", "bisque_events"),
+            (None, "bisque", "in", "bisque_events"),
+            # Everything else → messages
+            ("telegram", "telegram", "in", "messages"),
+            ("self_check", "system", "in", "messages"),
+            (None, "telegram", "out", "messages"),
+            (None, "telegram", "in", "messages"),
+        ],
+    )
+    def test_classify(self, msg_type, source, direction, expected_table):
+        record = {"source": source}
+        if msg_type is not None:
+            record["type"] = msg_type
+        assert classify(record, direction) == expected_table
+
+
+# ---------------------------------------------------------------------------
+# Row builder tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMessageRow:
+    def _minimal(self, direction="in") -> dict:
+        return {
+            "id": "1769219731361_22",
+            "source": "telegram",
+            "chat_id": 6645894734,
+            "text": "Hello",
+            "timestamp": "2026-01-24T01:55:31.361389",
+        }
+
+    def test_basic_fields(self):
+        record = self._minimal()
+        row = build_message_row(record, "in")
+        assert row["id"] == "1769219731361_22"
+        assert row["direction"] == "in"
+        assert row["source"] == "telegram"
+        assert row["text"] == "Hello"
+        assert row["timestamp"] == "2026-01-24T01:55:31.361389"
+
+    def test_chat_id_coerced_to_str(self):
+        record = self._minimal()
+        record["chat_id"] = 6645894734  # int in JSON
+        row = build_message_row(record, "in")
+        assert row["chat_id"] == "6645894734"
+
+    def test_overflow_fields_go_to_extra(self):
+        record = self._minimal()
+        record["unknown_field_xyz"] = "abc"
+        row = build_message_row(record, "in")
+        assert row["extra"] is not None
+        extra = json.loads(row["extra"])
+        assert extra["unknown_field_xyz"] == "abc"
+
+    def test_no_overflow_leaves_extra_null(self):
+        record = self._minimal()
+        row = build_message_row(record, "in")
+        assert row["extra"] is None
+
+    def test_int_fields_coerced(self):
+        record = self._minimal()
+        record["image_width"] = "1920"
+        record["image_height"] = "1080"
+        row = build_message_row(record, "in")
+        assert row["image_width"] == 1920
+        assert row["image_height"] == 1080
+
+    def test_outbound_direction(self):
+        record = self._minimal()
+        row = build_message_row(record, "out")
+        assert row["direction"] == "out"
+
+
+class TestBuildBisqueEventRow:
+    def test_basic_fields(self):
+        record = {
+            "id": "bisque_123",
+            "source": "bisque",
+            "chat_id": "drew@lobster.ai",
+            "type": "text",
+            "text": "Hello from bisque",
+            "timestamp": "2026-03-19T09:33:49.129780+00:00",
+        }
+        row = build_bisque_event_row(record)
+        assert row["id"] == "bisque_123"
+        assert row["chat_id"] == "drew@lobster.ai"
+        assert row["type"] == "text"
+        assert row["text"] == "Hello from bisque"
+
+    def test_sent_reply_to_user_bool_int(self):
+        record = {
+            "id": "bisque_999",
+            "timestamp": "2026-01-01T00:00:00",
+            "sent_reply_to_user": True,
+        }
+        row = build_bisque_event_row(record)
+        assert row["sent_reply_to_user"] == 1
+
+    def test_attachments_serialised_as_json(self):
+        record = {
+            "id": "bisque_attach",
+            "timestamp": "2026-01-01T00:00:00",
+            "attachments": [{"file": "a.txt"}, {"file": "b.txt"}],
+        }
+        row = build_bisque_event_row(record)
+        assert row["attachments"] is not None
+        parsed = json.loads(row["attachments"])
+        assert len(parsed) == 2
+
+
+class TestBuildAgentEventRow:
+    def test_basic_fields(self):
+        record = {
+            "id": "1773682753027_reconciler_abc",
+            "type": "subagent_result",
+            "source": "telegram",
+            "chat_id": "6645894734",
+            "task_id": "abc123",
+            "status": "success",
+            "text": "Done",
+            "timestamp": "2026-03-16T17:39:13.027852+00:00",
+        }
+        row = build_agent_event_row(record)
+        assert row["id"] == "1773682753027_reconciler_abc"
+        assert row["type"] == "subagent_result"
+        assert row["status"] == "success"
+        assert row["task_id"] == "abc123"
+
+    def test_artifacts_serialised_as_json(self):
+        record = {
+            "id": "evt_1",
+            "type": "subagent_notification",
+            "timestamp": "2026-01-01T00:00:00",
+            "artifacts": ["/tmp/report.md"],
+        }
+        row = build_agent_event_row(record)
+        assert row["artifacts"] is not None
+        assert json.loads(row["artifacts"]) == ["/tmp/report.md"]
+
+    def test_sent_reply_false_stored_as_zero(self):
+        record = {
+            "id": "evt_2",
+            "type": "agent_failed",
+            "timestamp": "2026-01-01T00:00:00",
+            "sent_reply_to_user": False,
+        }
+        row = build_agent_event_row(record)
+        assert row["sent_reply_to_user"] == 0
+
+
+# ---------------------------------------------------------------------------
+# iter_json_files tests
+# ---------------------------------------------------------------------------
+
+
+class TestIterJsonFiles:
+    def test_yields_valid_files(self, tmp_dir):
+        write_json(tmp_dir, "msg1.json", {"id": "1", "text": "hello"})
+        write_json(tmp_dir, "msg2.json", {"id": "2", "text": "world"})
+        results = list(iter_json_files(tmp_dir))
+        assert len(results) == 2
+        ids = {r["id"] for _, r in results}
+        assert ids == {"1", "2"}
+
+    def test_skips_invalid_json(self, tmp_dir):
+        (tmp_dir / "bad.json").write_text("{{not valid json}}")
+        write_json(tmp_dir, "good.json", {"id": "ok"})
+        results = list(iter_json_files(tmp_dir))
+        assert len(results) == 1
+        assert results[0][1]["id"] == "ok"
+
+    def test_handles_control_chars_via_non_strict(self, tmp_dir):
+        # Simulate a JSON file with an embedded control character (e.g. \x0b)
+        # inside a string value — which strict json.loads rejects.
+        raw = b'{"id": "ctrl", "text": "hello\x0bworld"}'
+        (tmp_dir / "ctrl.json").write_bytes(raw)
+        results = list(iter_json_files(tmp_dir))
+        assert len(results) == 1
+        assert results[0][1]["id"] == "ctrl"
+
+    def test_empty_directory_yields_nothing(self, tmp_dir):
+        results = list(iter_json_files(tmp_dir))
+        assert results == []
+
+    def test_ignores_non_json_files(self, tmp_dir):
+        (tmp_dir / "readme.txt").write_text("not json")
+        write_json(tmp_dir, "real.json", {"id": "real"})
+        results = list(iter_json_files(tmp_dir))
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# migrate_directory integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateDirectory:
+    def _setup_db(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        apply_schema(conn)
+        return conn
+
+    def test_migrate_plain_messages(self, tmp_dir):
+        write_json(
+            tmp_dir,
+            "msg.json",
+            {
+                "id": "msg001",
+                "source": "telegram",
+                "chat_id": "6645894734",
+                "text": "hi there",
+                "timestamp": "2026-01-01T00:00:00",
+            },
+        )
+        conn = self._setup_db()
+        counts = migrate_directory(conn, tmp_dir, "in")
+        assert counts["messages"] == 1
+        assert counts["agent_events"] == 0
+        assert counts["errors"] == 0
+        row = conn.execute("SELECT * FROM messages WHERE id = 'msg001'").fetchone()
+        assert row is not None
+        assert row["text"] == "hi there"
+        assert row["direction"] == "in"
+
+    def test_migrate_agent_events(self, tmp_dir):
+        write_json(
+            tmp_dir,
+            "agent.json",
+            {
+                "id": "agent001",
+                "type": "subagent_result",
+                "source": "telegram",
+                "chat_id": "6645894734",
+                "task_id": "t001",
+                "status": "success",
+                "text": "Task done",
+                "timestamp": "2026-01-01T00:00:01",
+            },
+        )
+        conn = self._setup_db()
+        counts = migrate_directory(conn, tmp_dir, "in")
+        assert counts["agent_events"] == 1
+        assert counts["messages"] == 0
+        row = conn.execute("SELECT * FROM agent_events WHERE id = 'agent001'").fetchone()
+        assert row is not None
+        assert row["status"] == "success"
+
+    def test_migrate_bisque_events(self, tmp_dir):
+        write_json(
+            tmp_dir,
+            "bisque.json",
+            {
+                "id": "bisque001",
+                "source": "bisque",
+                "chat_id": "drew@lobster.ai",
+                "type": "text",
+                "text": "Bisque message",
+                "timestamp": "2026-01-01T00:00:02",
+            },
+        )
+        conn = self._setup_db()
+        counts = migrate_directory(conn, tmp_dir, "in")
+        assert counts["bisque_events"] == 1
+        assert counts["messages"] == 0
+        row = conn.execute(
+            "SELECT * FROM bisque_events WHERE id = 'bisque001'"
+        ).fetchone()
+        assert row is not None
+        assert row["chat_id"] == "drew@lobster.ai"
+
+    def test_idempotent_migration(self, tmp_dir):
+        write_json(
+            tmp_dir,
+            "dup.json",
+            {
+                "id": "dup001",
+                "source": "telegram",
+                "chat_id": "6645894734",
+                "text": "duplicate",
+                "timestamp": "2026-01-01T00:00:00",
+            },
+        )
+        conn = self._setup_db()
+        migrate_directory(conn, tmp_dir, "in")
+        migrate_directory(conn, tmp_dir, "in")  # second run — should be no-op
+        count = conn.execute(
+            "SELECT COUNT(*) AS n FROM messages WHERE id = 'dup001'"
+        ).fetchone()["n"]
+        assert count == 1
+
+    def test_dry_run_does_not_insert(self, tmp_dir):
+        write_json(
+            tmp_dir,
+            "msg.json",
+            {
+                "id": "dry001",
+                "source": "telegram",
+                "chat_id": "1234",
+                "text": "dry run",
+                "timestamp": "2026-01-01T00:00:00",
+            },
+        )
+        conn = self._setup_db()
+        counts = migrate_directory(conn, tmp_dir, "in", dry_run=True)
+        assert counts["messages"] == 1
+        count = conn.execute("SELECT COUNT(*) AS n FROM messages").fetchone()["n"]
+        assert count == 0  # nothing written
+
+    def test_outbound_direction_stored(self, tmp_dir):
+        write_json(
+            tmp_dir,
+            "sent.json",
+            {
+                "id": "sent001",
+                "source": "telegram",
+                "chat_id": "6645894734",
+                "text": "reply text",
+                "timestamp": "2026-01-01T00:00:00",
+            },
+        )
+        conn = self._setup_db()
+        migrate_directory(conn, tmp_dir, "out")
+        row = conn.execute("SELECT direction FROM messages WHERE id = 'sent001'").fetchone()
+        assert row["direction"] == "out"
+
+
+# ---------------------------------------------------------------------------
+# FTS5 search tests
+# ---------------------------------------------------------------------------
+
+
+class TestFTS5Search:
+    def _insert_message(self, conn, msg_id, text, source="telegram"):
+        conn.execute(
+            """
+            INSERT INTO messages (id, direction, source, text, timestamp)
+            VALUES (?, 'in', ?, ?, '2026-01-01T00:00:00')
+            """,
+            (msg_id, source, text),
+        )
+        conn.commit()
+
+    def _insert_agent_event(self, conn, event_id, text, event_type="subagent_result"):
+        conn.execute(
+            """
+            INSERT INTO agent_events (id, type, source, chat_id, text, timestamp)
+            VALUES (?, ?, 'telegram', '123', ?, '2026-01-01T00:00:00')
+            """,
+            (event_id, event_type, text),
+        )
+        conn.commit()
+
+    def test_messages_fts_basic_search(self, db_conn):
+        self._insert_message(db_conn, "m1", "The quick brown fox jumps")
+        self._insert_message(db_conn, "m2", "The lazy dog sleeps")
+        rows = db_conn.execute(
+            """
+            SELECT m.id FROM messages m
+            JOIN messages_fts ON m.rowid = messages_fts.rowid
+            WHERE messages_fts MATCH 'fox'
+            """
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]["id"] == "m1"
+
+    def test_messages_fts_no_match(self, db_conn):
+        self._insert_message(db_conn, "m1", "Hello world")
+        rows = db_conn.execute(
+            """
+            SELECT m.id FROM messages m
+            JOIN messages_fts ON m.rowid = messages_fts.rowid
+            WHERE messages_fts MATCH 'nonexistent'
+            """
+        ).fetchall()
+        assert rows == []
+
+    def test_agent_events_fts_search(self, db_conn):
+        self._insert_agent_event(db_conn, "a1", "GitHub issue resolved successfully")
+        self._insert_agent_event(db_conn, "a2", "Telegram message delivered")
+        rows = db_conn.execute(
+            """
+            SELECT a.id FROM agent_events a
+            JOIN agent_events_fts ON a.rowid = agent_events_fts.rowid
+            WHERE agent_events_fts MATCH 'github'
+            """
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]["id"] == "a1"
+
+    def test_fts_trigger_on_delete(self, db_conn):
+        """After deleting a row, FTS should no longer find it."""
+        self._insert_message(db_conn, "del1", "deletable content xyz")
+        # Confirm it's findable
+        rows = db_conn.execute(
+            """
+            SELECT m.id FROM messages m
+            JOIN messages_fts ON m.rowid = messages_fts.rowid
+            WHERE messages_fts MATCH 'deletable'
+            """
+        ).fetchall()
+        assert len(rows) == 1
+        # Delete it
+        db_conn.execute("DELETE FROM messages WHERE id = 'del1'")
+        db_conn.commit()
+        # Should be gone from FTS
+        rows = db_conn.execute(
+            """
+            SELECT m.id FROM messages m
+            JOIN messages_fts ON m.rowid = messages_fts.rowid
+            WHERE messages_fts MATCH 'deletable'
+            """
+        ).fetchall()
+        assert rows == []
+
+    def test_fts_trigger_on_update(self, db_conn):
+        """After updating a row, FTS should reflect new content."""
+        self._insert_message(db_conn, "upd1", "original text")
+        db_conn.execute(
+            "UPDATE messages SET text = 'updated content' WHERE id = 'upd1'"
+        )
+        db_conn.commit()
+        # Old text should not match
+        old_rows = db_conn.execute(
+            """
+            SELECT m.id FROM messages m
+            JOIN messages_fts ON m.rowid = messages_fts.rowid
+            WHERE messages_fts MATCH 'original'
+            """
+        ).fetchall()
+        assert old_rows == []
+        # New text should match
+        new_rows = db_conn.execute(
+            """
+            SELECT m.id FROM messages m
+            JOIN messages_fts ON m.rowid = messages_fts.rowid
+            WHERE messages_fts MATCH 'updated'
+            """
+        ).fetchall()
+        assert len(new_rows) == 1


### PR DESCRIPTION
## Summary

BIS-162 — Slice 1 of the BIS-159 message store initiative.

Creates the SQLite `messages.db` schema and a one-shot migration script that backfills 12,400+ processed/ and 2,700+ sent/ JSON message files into three purpose-built tables with FTS5 full-text search.

### New files

**`src/db/schema.sql`** — SQLite DDL for three tables:
- `messages` — all inbound (processed/) and outbound (sent/) messages. Columns cover the full field universe observed across the archive; unknown fields fold into an `extra TEXT` (JSON) column so nothing is lost.
- `bisque_events` — bisque-channel messages with bisque-specific fields (reply_to_id, attachments, etc.).
- `agent_events` — subagent lifecycle events: subagent_result, agent_failed, subagent_notification, subagent_error, task-notification.
- FTS5 virtual table + insert/delete/update triggers for each base table.
- `schema_migrations` version-tracking table.
- WAL mode + NORMAL synchronous mode configured at connection time.

**`src/db/connection.py`** — Pure-functional connection factory:
- `get_connection(path)` — opens a connection with row_factory + PRAGMAs
- `apply_schema(conn)` — applies the bundled DDL idempotently
- `open_messages_db(path)` — convenience: open + schema in one call

**`scripts/migrate_json_to_db.py`** — One-shot JSON-to-SQLite migration:
- Classifies each file via a pure `classify()` function (no mutation of inputs)
- Per-table row builders coerce field types (str, int, bool→0/1, list/dict→JSON)
- Two-pass JSON parser: strict first, `strict=False` fallback for files containing embedded control characters in text fields
- Batch commits (default 500 rows) to keep memory usage bounded
- `INSERT OR IGNORE` makes repeated runs idempotent
- CLI flags: `--db`, `--processed`, `--sent`, `--batch-size`, `--dry-run`, `--verbose`

**`tests/test_messages_db.py`** — 47 tests:
- Schema creation, FTS5 virtual tables, indexes, migration version, WAL mode
- `classify()`, all three row builders, `iter_json_files()` (including control-char recovery)
- `migrate_directory()`: messages, bisque, agent events, dry-run, idempotency, direction
- FTS5 trigger correctness: insert, delete, update all keep the index in sync

## Migration results (dry-run on live data)

```
messages:       14,695  (11,976 inbound + 2,719 outbound)
bisque_events:      71
agent_events:      414
errors:              0  (1 permanently malformed JSON file skipped — truly invalid JSON, not recoverable)
total rows:     15,180
```

## Functional patterns used

- Pure row-builder functions with no side effects
- Immutable input records — builders return new dicts, never modify the source
- Higher-order iteration via `iter_json_files` generator — composable with any consumer
- Explicit error handling at the boundary (file parse errors → stderr, DB errors → counter), not exceptions propagating to callers

## Test plan

- [x] 47 unit + integration tests, all passing (`uv run pytest tests/test_messages_db.py -v`)
- [x] Dry-run on 15,180 live message files — zero errors
- [x] Full migration run into `/tmp/test_messages.db` — verified row counts and FTS5 queries

## Usage

```bash
# Dry run (no writes)
uv run python scripts/migrate_json_to_db.py --dry-run --verbose

# Migrate to default location (~/messages/messages.db)
uv run python scripts/migrate_json_to_db.py --verbose

# Custom paths
uv run python scripts/migrate_json_to_db.py \
    --db ~/messages/messages.db \
    --processed ~/messages/processed \
    --sent ~/messages/sent
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)