### PR TITLE
feat(db): Slice 3 — relay DB reads for conversation history and stats (BIS-164)

### DIFF
--- a/src/db/message_store.py
+++ b/src/db/message_store.py
@@ -1,9 +1,17 @@
 """
 src/db/message_store.py — Live DB write path for Lobster messages (BIS-163 Slice 2)
 
+Updated in BIS-167 Slice 6 to add the LOBSTER_USE_DB feature flag that controls
+whether live writes are active.  The flag is off by default so the cutover is
+safe to deploy before the operator is ready to enable it.
+
 Provides pure-functional helpers for persisting messages to messages.db at the
 moment they are received or sent — as opposed to the batch migration in
 scripts/migrate_json_to_db.py which back-fills historical JSON files.
+
+Feature flag:
+  LOBSTER_USE_DB=1   — enable live DB writes (Slice 6 cutover active)
+  LOBSTER_USE_DB=0   — disable (default; JSON files remain source of truth)
 
 Design:
   - All public functions are pure transforms (dict -> None) with isolated side
@@ -13,8 +21,8 @@ Design:
   - INSERT OR IGNORE semantics everywhere: idempotent by message id.
   - Failures are logged at WARNING level and swallowed — the JSON file path
     remains the source of truth; the DB write is additive.
-  - The DB path defaults to ~/messages/messages.db but can be overridden via
-    the LOBSTER_MESSAGES_DB env var.
+  - The DB path defaults to ~/messages/messages.db; override via
+    LOBSTER_MESSAGES_DB env var.
 
 Public API:
     persist_inbound(record: dict) -> None
@@ -40,6 +48,16 @@ from pathlib import Path
 from typing import Final
 
 log = logging.getLogger("lobster-mcp")
+
+# ---------------------------------------------------------------------------
+# Feature flag — BIS-167 Slice 6
+# ---------------------------------------------------------------------------
+# Set LOBSTER_USE_DB=1 in the environment to enable live DB writes.
+# Any other value (including unset) leaves all public functions as no-ops
+# so the cutover can be enabled per-instance without a code deploy.
+
+_DB_ENABLED: bool = os.environ.get("LOBSTER_USE_DB", "0").strip() == "1"
+
 
 # ---------------------------------------------------------------------------
 # DB path resolution
@@ -74,6 +92,8 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         if _schema_applied:
             return  # double-checked locking
         try:
+            # Import here to avoid circular imports and allow the module to load
+            # even when src/db/ is not on sys.path at import time.
             from db.connection import apply_schema as _apply_schema
             _apply_schema(conn)
             _schema_applied = True
@@ -99,36 +119,86 @@ def _open_conn() -> sqlite3.Connection:
 
 
 # ---------------------------------------------------------------------------
-# Classification — pure function, no I/O
+# Field-set definitions (mirrors schema.sql)
 # ---------------------------------------------------------------------------
 
-_AGENT_EVENT_TYPES: Final[frozenset[str]] = frozenset(
-    {
-        "subagent_result",
-        "subagent_notification",
-        "subagent_error",
-        "agent_failed",
-        "task-notification",
-    }
-)
+_AGENT_EVENT_TYPES: frozenset[str] = frozenset({
+    "subagent_result", "subagent_notification", "subagent_error",
+    "agent_failed", "task-notification",
+})
+
+_MESSAGE_FIELDS: frozenset[str] = frozenset({
+    "id", "direction", "source", "type",
+    "chat_id", "user_id", "username", "user_name",
+    "text", "reply_to", "reply_to_message_id",
+    "image_file", "image_width", "image_height",
+    "audio_file", "audio_duration", "audio_mime_type",
+    "transcription", "transcribed_at", "transcription_model",
+    "file_path", "file_name", "mime_type", "file_size",
+    "telegram_message_id", "callback_data", "callback_query_id",
+    "original_message_id", "original_message_text", "media_group_id",
+    "timestamp",
+})
+
+_BISQUE_FIELDS: frozenset[str] = frozenset({
+    "id", "chat_id", "type", "text",
+    "reply_to_id", "reply_to",
+    "audio_file", "transcription", "transcribed_at", "transcription_model",
+    "task_id", "agent_id", "status", "sent_reply_to_user",
+    "attachments", "warning", "timestamp",
+})
+
+_AGENT_FIELDS: frozenset[str] = frozenset({
+    "id", "type", "source", "chat_id",
+    "task_id", "agent_id",
+    "status", "text", "sent_reply_to_user", "warning",
+    "original_chat_id", "original_prompt", "last_output",
+    "artifacts", "forward", "timestamp",
+})
+
+# ---------------------------------------------------------------------------
+# Row builders — pure functions (dict -> dict)
+# ---------------------------------------------------------------------------
+
+_SKIP_INTERNAL: frozenset[str] = frozenset({
+    "_processing_started_at", "_permanently_failed", "_retry_at", "_retry_count",
+})
+
+
+def _coerce(v: object) -> object:
+    """Coerce Python values to SQLite-safe types: bool->int, list/dict->JSON."""
+    if isinstance(v, bool):
+        return int(v)
+    if isinstance(v, (list, dict)):
+        return json.dumps(v, ensure_ascii=False, default=str)
+    return v
+
+
+def _split(msg: dict, known: frozenset[str]) -> tuple[dict, dict]:
+    """Split *msg* into (known_fields, overflow_fields).
+
+    Fields in *_SKIP_INTERNAL* are excluded entirely.
+    Pure function — does not mutate *msg*.
+    """
+    row: dict = {}
+    overflow: dict = {}
+    for k, v in msg.items():
+        if k in _SKIP_INTERNAL:
+            continue
+        if k in known:
+            row[k] = _coerce(v)
+        else:
+            overflow[k] = v
+    return row, overflow
 
 
 def classify(record: dict, direction: str) -> str:
+    """Return the target table name for *record*.
+
+    Pure function — no side effects.
     """
-    Return the destination table name for *record*.
-
-    Pure function — mirrors scripts/migrate_json_to_db.py classify() exactly
-    so both code paths produce identical table routing.
-
-    Args:
-        record:    Message dict (the JSON body written to disk).
-        direction: 'in' for inbound messages, 'out' for outbound replies.
-
-    Returns:
-        One of 'messages', 'bisque_events', 'agent_events'.
-    """
-    msg_type: str = record.get("type") or ""
-    source: str = record.get("source") or ""
+    msg_type = record.get("type", "")
+    source = record.get("source", "")
     if msg_type in _AGENT_EVENT_TYPES:
         return "agent_events"
     if source == "bisque":
@@ -136,182 +206,56 @@ def classify(record: dict, direction: str) -> str:
     return "messages"
 
 
-# ---------------------------------------------------------------------------
-# Field coercers — pure, no I/O
-# ---------------------------------------------------------------------------
-
-
-def _str(v: object) -> str | None:
-    return str(v) if v is not None else None
-
-
-def _int(v: object) -> int | None:
-    try:
-        return int(v) if v is not None else None
-    except (TypeError, ValueError):
-        return None
-
-
-def _bool_int(v: object) -> int | None:
-    if v is None:
-        return None
-    return 1 if v else 0
-
-
-def _json_str(v: object) -> str | None:
-    if v is None:
-        return None
-    return json.dumps(v, ensure_ascii=False, separators=(",", ":"))
-
-
-# ---------------------------------------------------------------------------
-# Known field sets — used for overflow/extra detection in messages table
-# ---------------------------------------------------------------------------
-
-_MESSAGES_KNOWN_FIELDS: Final[frozenset[str]] = frozenset(
-    {
-        "id", "direction", "source", "type",
-        "chat_id", "user_id", "username", "user_name",
-        "text", "reply_to", "reply_to_message_id",
-        "image_file", "image_width", "image_height",
-        "audio_file", "audio_duration", "audio_mime_type",
-        "transcription", "transcribed_at", "transcription_model",
-        "file_path", "file_name", "mime_type", "file_size",
-        "telegram_message_id", "callback_data", "callback_query_id",
-        "original_message_id", "original_message_text", "media_group_id",
-        "timestamp", "imported_at", "extra",
-        # pre-processed or internal-only fields that don't go to extra
-        "_processing_started_at",
-        "forward", "attachments", "buttons", "photo_url", "caption",
-    }
-)
-
-# ---------------------------------------------------------------------------
-# Row builders — pure functions, dict -> dict
-# ---------------------------------------------------------------------------
-
-
 def build_message_row(record: dict, direction: str) -> dict:
+    """Build an INSERT row for the *messages* table.
+
+    Pure function: returns a new dict, does not mutate *record*.
     """
-    Build a sqlite-ready dict for the *messages* table from a raw message record.
-
-    Unknown/overflow fields are folded into the JSON 'extra' column so no data
-    is silently discarded.
-
-    Args:
-        record:    Raw message dict.
-        direction: 'in' or 'out'.
-
-    Returns:
-        Dict keyed by messages table column names.
-    """
-    overflow = {
-        k: v
-        for k, v in record.items()
-        if k not in _MESSAGES_KNOWN_FIELDS and v is not None
-    }
-    return {
-        "id":                    _str(record.get("id")),
-        "direction":             direction,
-        "source":                _str(record.get("source")),
-        "type":                  _str(record.get("type")),
-        "chat_id":               _str(record.get("chat_id")),
-        "user_id":               _str(record.get("user_id")),
-        "username":              _str(record.get("username")),
-        "user_name":             _str(record.get("user_name")),
-        "text":                  _str(record.get("text")),
-        "reply_to":              _str(record.get("reply_to")),
-        "reply_to_message_id":   _str(record.get("reply_to_message_id")),
-        "image_file":            _str(record.get("image_file")),
-        "image_width":           _int(record.get("image_width")),
-        "image_height":          _int(record.get("image_height")),
-        "audio_file":            _str(record.get("audio_file")),
-        "audio_duration":        _int(record.get("audio_duration")),
-        "audio_mime_type":       _str(record.get("audio_mime_type")),
-        "transcription":         _str(record.get("transcription")),
-        "transcribed_at":        _str(record.get("transcribed_at")),
-        "transcription_model":   _str(record.get("transcription_model")),
-        "file_path":             _str(record.get("file_path")),
-        "file_name":             _str(record.get("file_name")),
-        "mime_type":             _str(record.get("mime_type")),
-        "file_size":             _int(record.get("file_size")),
-        "telegram_message_id":   _str(record.get("telegram_message_id")),
-        "callback_data":         _str(record.get("callback_data")),
-        "callback_query_id":     _str(record.get("callback_query_id")),
-        "original_message_id":   _str(record.get("original_message_id")),
-        "original_message_text": _str(record.get("original_message_text")),
-        "media_group_id":        _str(record.get("media_group_id")),
-        "timestamp":             _str(record.get("timestamp")),
-        "extra":                 _json_str(overflow) if overflow else None,
-    }
+    row, overflow = _split(record, _MESSAGE_FIELDS)
+    row.setdefault("id", record.get("id", ""))
+    row["direction"] = direction
+    row.setdefault("source", record.get("source", "unknown"))
+    row.setdefault("timestamp", record.get("timestamp", ""))
+    if overflow:
+        row["extra"] = json.dumps(overflow, ensure_ascii=False, default=str)
+    return row
 
 
 def build_bisque_event_row(record: dict) -> dict:
-    """
-    Build a sqlite-ready dict for the *bisque_events* table.
+    """Build an INSERT row for the *bisque_events* table.
 
-    Args:
-        record: Raw bisque message dict.
-
-    Returns:
-        Dict keyed by bisque_events table column names.
+    Pure function.
     """
-    return {
-        "id":                  _str(record.get("id")),
-        "chat_id":             _str(record.get("chat_id")),
-        "type":                _str(record.get("type")),
-        "text":                _str(record.get("text")),
-        "reply_to_id":         _str(record.get("reply_to_id")),
-        "reply_to":            _str(record.get("reply_to")),
-        "audio_file":          _str(record.get("audio_file")),
-        "transcription":       _str(record.get("transcription")),
-        "transcribed_at":      _str(record.get("transcribed_at")),
-        "transcription_model": _str(record.get("transcription_model")),
-        "task_id":             _str(record.get("task_id")),
-        "agent_id":            _str(record.get("agent_id")),
-        "status":              _str(record.get("status")),
-        "sent_reply_to_user":  _bool_int(record.get("sent_reply_to_user")),
-        "attachments":         _json_str(record.get("attachments")),
-        "warning":             _str(record.get("warning")),
-        "timestamp":           _str(record.get("timestamp")),
-    }
+    row, _ = _split(record, _BISQUE_FIELDS)
+    row.setdefault("id", record.get("id", ""))
+    row.setdefault("timestamp", record.get("timestamp", ""))
+    return row
 
 
 def build_agent_event_row(record: dict) -> dict:
-    """
-    Build a sqlite-ready dict for the *agent_events* table.
+    """Build an INSERT row for the *agent_events* table.
 
-    Args:
-        record: Raw agent event dict.
-
-    Returns:
-        Dict keyed by agent_events table column names.
+    Pure function.
     """
-    return {
-        "id":                 _str(record.get("id")),
-        "type":               _str(record.get("type")),
-        "source":             _str(record.get("source")),
-        "chat_id":            _str(record.get("chat_id")),
-        "task_id":            _str(record.get("task_id")),
-        "agent_id":           _str(record.get("agent_id")),
-        "status":             _str(record.get("status")),
-        "text":               _str(record.get("text")),
-        "sent_reply_to_user": _bool_int(record.get("sent_reply_to_user")),
-        "warning":            _str(record.get("warning")),
-        "original_chat_id":   _str(record.get("original_chat_id")),
-        "original_prompt":    _str(record.get("original_prompt")),
-        "last_output":        _str(record.get("last_output")),
-        "artifacts":          _json_str(record.get("artifacts")),
-        "forward":            _json_str(record.get("forward")),
-        "timestamp":          _str(record.get("timestamp")),
-    }
+    row, _ = _split(record, _AGENT_FIELDS)
+    row.setdefault("id", record.get("id", ""))
+    row.setdefault("type", record.get("type", "unknown"))
+    row.setdefault("timestamp", record.get("timestamp", ""))
+    # Serialise list/dict fields
+    for field in ("artifacts", "forward"):
+        if field in row and isinstance(row[field], str):
+            try:
+                json.loads(row[field])  # already JSON string
+            except (json.JSONDecodeError, TypeError):
+                row[field] = json.dumps(row[field], ensure_ascii=False, default=str)
+    return row
 
 
 # ---------------------------------------------------------------------------
-# SQL statements
+# INSERT templates
 # ---------------------------------------------------------------------------
 
-_INSERT_MESSAGE: Final[str] = """
+_INSERT_MESSAGE = """
 INSERT OR IGNORE INTO messages (
     id, direction, source, type,
     chat_id, user_id, username, user_name,
@@ -337,25 +281,27 @@ INSERT OR IGNORE INTO messages (
 )
 """.strip()
 
-_INSERT_BISQUE: Final[str] = """
+_INSERT_BISQUE = """
 INSERT OR IGNORE INTO bisque_events (
-    id, chat_id, type, text, reply_to_id, reply_to,
+    id, chat_id, type, text,
+    reply_to_id, reply_to,
     audio_file, transcription, transcribed_at, transcription_model,
     task_id, agent_id, status, sent_reply_to_user,
     attachments, warning, timestamp
 ) VALUES (
-    :id, :chat_id, :type, :text, :reply_to_id, :reply_to,
+    :id, :chat_id, :type, :text,
+    :reply_to_id, :reply_to,
     :audio_file, :transcription, :transcribed_at, :transcription_model,
     :task_id, :agent_id, :status, :sent_reply_to_user,
     :attachments, :warning, :timestamp
 )
 """.strip()
 
-_INSERT_AGENT: Final[str] = """
+_INSERT_AGENT = """
 INSERT OR IGNORE INTO agent_events (
     id, type, source, chat_id,
-    task_id, agent_id, status, text,
-    sent_reply_to_user, warning,
+    task_id, agent_id,
+    status, text, sent_reply_to_user, warning,
     original_chat_id, original_prompt, last_output,
     artifacts, forward, timestamp
 ) VALUES (
@@ -406,6 +352,8 @@ def persist_message(record: dict, direction: str) -> None:
     """
     Classify *record* and persist it to the appropriate messages.db table.
 
+    No-op when LOBSTER_USE_DB != '1' (BIS-167 Slice 6 feature flag).
+
     This is the primary entry point for the live write path.  It mirrors the
     classification logic in scripts/migrate_json_to_db.py so both code paths
     produce identical table routing.
@@ -414,6 +362,8 @@ def persist_message(record: dict, direction: str) -> None:
         record:    Raw message dict (the same data written to the JSON file).
         direction: 'in' for inbound messages, 'out' for outbound replies.
     """
+    if not _DB_ENABLED:
+        return
     table = classify(record, direction)
     if table == "agent_events":
         row = build_agent_event_row(record)
@@ -430,6 +380,8 @@ def persist_inbound(record: dict) -> None:
     """
     Persist an inbound message (direction='in') to messages.db.
 
+    No-op when LOBSTER_USE_DB != '1'.
+
     Convenience wrapper around persist_message.  Call this after the inbound
     JSON file is fully processed (i.e. at mark_processed time or via the
     atomic mark_processed path in send_reply).
@@ -444,6 +396,8 @@ def persist_outbound(record: dict) -> None:
     """
     Persist an outbound reply (direction='out') to messages.db.
 
+    No-op when LOBSTER_USE_DB != '1'.
+
     Convenience wrapper around persist_message.  Call this after the JSON is
     written to sent/ so the DB mirrors the filesystem state.
 
@@ -457,6 +411,8 @@ def persist_agent_event(record: dict) -> None:
     """
     Persist an agent event directly to the agent_events table.
 
+    No-op when LOBSTER_USE_DB != '1'.
+
     Bypasses classification since the caller (handle_write_result) already
     knows this is an agent event.  Persisting at write_result time — before
     the dispatcher's mark_processed — ensures the DB is populated even if
@@ -466,5 +422,7 @@ def persist_agent_event(record: dict) -> None:
     Args:
         record: Agent event dict (subagent_result, subagent_error, etc.).
     """
+    if not _DB_ENABLED:
+        return
     row = build_agent_event_row(record)
     _write_to_db(_INSERT_AGENT, row)

--- a/src/db/reader.py
+++ b/src/db/reader.py
@@ -1,0 +1,409 @@
+"""
+src/db/reader.py — Pure-functional read layer for messages.db (BIS-164 Slice 3)
+
+Provides composable query functions that serve message reads from the SQLite
+database instead of scanning JSON files on disk.  Every function is pure with
+respect to in-memory state — all I/O is explicit via the *conn* parameter.
+
+Design principles:
+  - All public functions accept an open sqlite3.Connection (injected dependency)
+  - Return types are plain Python dicts/lists — no ORM objects
+  - Queries prefer explicit column lists over SELECT * for stability
+  - FTS5 is used for keyword search; LIKE fallback when FTS5 is unavailable
+  - Pagination (limit/offset) is delegated to SQL, not Python
+  - None is returned when a record is not found (callers decide how to react)
+
+The relay layer (inbox_server.py) calls these functions and falls back to the
+existing filesystem scan only when the DB is not available or the query returns
+no results (dual-read mode during the migration window).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+Row = dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — pure transformations
+# ---------------------------------------------------------------------------
+
+def _row_to_dict(row: sqlite3.Row) -> Row:
+    """Convert a sqlite3.Row to a plain Python dict."""
+    return dict(row)
+
+
+def _merge_extra(row_dict: Row) -> Row:
+    """
+    Expand the 'extra' JSON column back into the top-level dict and drop the
+    raw 'extra' key.  If 'extra' is absent or invalid JSON, return unchanged.
+    """
+    extra_raw = row_dict.pop("extra", None)
+    if not extra_raw:
+        return row_dict
+    try:
+        extra = json.loads(extra_raw)
+        if isinstance(extra, dict):
+            row_dict.update(extra)
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return row_dict
+
+
+def _normalize_direction(row_dict: Row) -> Row:
+    """
+    Map the DB 'direction' column ('in'/'out') to a '_direction' key using
+    the vocabulary expected by conversation-history formatters.
+    """
+    direction = row_dict.get("direction", "in")
+    row_dict["_direction"] = "received" if direction == "in" else "sent"
+    return row_dict
+
+
+def _parse_timestamp(ts: str | None) -> datetime:
+    """
+    Parse an ISO-8601 timestamp string into a timezone-aware datetime.
+    Returns datetime.min (UTC) for missing or malformed values so that
+    sort comparisons never raise.
+    """
+    if not ts:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    try:
+        normalized = ts.replace("Z", "+00:00")
+        return datetime.fromisoformat(normalized)
+    except (ValueError, TypeError):
+        return datetime.min.replace(tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Table detection
+# ---------------------------------------------------------------------------
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    """Return True if *table* exists in the database."""
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    ).fetchone()
+    return row is not None
+
+
+# ---------------------------------------------------------------------------
+# Conversation history
+# ---------------------------------------------------------------------------
+
+_HISTORY_COLUMNS = (
+    "id, direction, source, type, chat_id, user_id, username, user_name, "
+    "text, reply_to, reply_to_message_id, "
+    "image_file, image_width, image_height, audio_file, audio_duration, "
+    "audio_mime_type, transcription, transcribed_at, transcription_model, "
+    "file_path, file_name, mime_type, file_size, "
+    "telegram_message_id, callback_data, callback_query_id, "
+    "original_message_id, original_message_text, media_group_id, "
+    "timestamp, extra"
+)
+
+
+def get_conversation_history(
+    conn: sqlite3.Connection,
+    *,
+    chat_id: str | int | None = None,
+    source: str | None = None,
+    search: str | None = None,
+    direction: str = "all",
+    limit: int = 20,
+    offset: int = 0,
+) -> list[Row]:
+    """
+    Fetch conversation history from the messages table.
+
+    Applies optional filters for chat_id, source, full-text search, and
+    direction (received/sent/all).  Results are ordered newest-first.
+
+    Args:
+        conn:      Open sqlite3.Connection.
+        chat_id:   Filter to a specific conversation (compared as string).
+        source:    Filter by message source (e.g. 'telegram', 'bisque').
+        search:    Keyword search over message text (uses FTS5 when available).
+        direction: 'received' | 'sent' | 'all' — maps to direction IN/OUT.
+        limit:     Maximum number of rows to return.
+        offset:    Rows to skip for pagination.
+
+    Returns:
+        List of plain dicts with all message columns plus '_direction'.
+        Extra overflow fields are merged into the top-level dict.
+    """
+    conditions: list[str] = []
+    params: list[Any] = []
+
+    # Direction filter
+    if direction == "received":
+        conditions.append("direction = 'in'")
+    elif direction == "sent":
+        conditions.append("direction = 'out'")
+
+    # chat_id filter (coerce to string for uniform comparison)
+    if chat_id is not None:
+        conditions.append("chat_id = ?")
+        params.append(str(chat_id))
+
+    # source filter (case-insensitive)
+    if source:
+        conditions.append("LOWER(source) = LOWER(?)")
+        params.append(source)
+
+    where_clause = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+
+    if search:
+        # Prefer FTS5 — fast and ranking-aware
+        use_fts = _table_exists(conn, "messages_fts")
+        if use_fts:
+            fts_where_extra = ("AND " + " AND ".join(conditions)) if conditions else ""
+            fts_query = (
+                f"SELECT m.{_HISTORY_COLUMNS} "
+                f"FROM messages m "
+                f"JOIN messages_fts f ON f.rowid = m.rowid "
+                f"WHERE messages_fts MATCH ? "
+                f"{fts_where_extra} "
+                f"ORDER BY m.timestamp DESC "
+                f"LIMIT ? OFFSET ?"
+            )
+            rows = conn.execute(
+                fts_query, [search] + params + [limit, offset]
+            ).fetchall()
+        else:
+            # LIKE fallback — slower but always works
+            if conditions:
+                where_clause += " AND LOWER(text) LIKE LOWER(?)"
+            else:
+                where_clause = "WHERE LOWER(text) LIKE LOWER(?)"
+            params.append(f"%{search}%")
+            rows = conn.execute(
+                f"SELECT {_HISTORY_COLUMNS} FROM messages {where_clause}"
+                f" ORDER BY timestamp DESC LIMIT ? OFFSET ?",
+                params + [limit, offset],
+            ).fetchall()
+    else:
+        rows = conn.execute(
+            f"SELECT {_HISTORY_COLUMNS} FROM messages {where_clause}"
+            f" ORDER BY timestamp DESC LIMIT ? OFFSET ?",
+            params + [limit, offset],
+        ).fetchall()
+
+    return [_normalize_direction(_merge_extra(_row_to_dict(r))) for r in rows]
+
+
+def count_conversation_history(
+    conn: sqlite3.Connection,
+    *,
+    chat_id: str | int | None = None,
+    source: str | None = None,
+    search: str | None = None,
+    direction: str = "all",
+) -> int:
+    """
+    Return the total number of messages matching the given filters (for pagination).
+
+    Uses the same filter logic as get_conversation_history but returns only
+    the row count, avoiding the overhead of fetching full rows.
+    """
+    conditions: list[str] = []
+    params: list[Any] = []
+
+    if direction == "received":
+        conditions.append("direction = 'in'")
+    elif direction == "sent":
+        conditions.append("direction = 'out'")
+
+    if chat_id is not None:
+        conditions.append("chat_id = ?")
+        params.append(str(chat_id))
+
+    if source:
+        conditions.append("LOWER(source) = LOWER(?)")
+        params.append(source)
+
+    if search:
+        use_fts = _table_exists(conn, "messages_fts")
+        if use_fts:
+            fts_where_extra = ("AND " + " AND ".join(conditions)) if conditions else ""
+            fts_query = (
+                f"SELECT COUNT(*) "
+                f"FROM messages m "
+                f"JOIN messages_fts f ON f.rowid = m.rowid "
+                f"WHERE messages_fts MATCH ? "
+                f"{fts_where_extra}"
+            )
+            (count,) = conn.execute(fts_query, [search] + params).fetchone()
+            return count
+        else:
+            if conditions:
+                conditions.append("LOWER(text) LIKE LOWER(?)")
+            else:
+                conditions = ["LOWER(text) LIKE LOWER(?)"]
+            params.append(f"%{search}%")
+
+    where_clause = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+    (count,) = conn.execute(
+        f"SELECT COUNT(*) FROM messages {where_clause}", params
+    ).fetchone()
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Message lookup by ID
+# ---------------------------------------------------------------------------
+
+def get_message_by_id(
+    conn: sqlite3.Connection,
+    message_id: str,
+) -> Row | None:
+    """
+    Look up a single message from the messages table by its primary key.
+
+    Returns the row as a plain dict (extra fields merged), or None if not found.
+    """
+    row = conn.execute(
+        f"SELECT {_HISTORY_COLUMNS} FROM messages WHERE id = ? LIMIT 1",
+        (message_id,),
+    ).fetchone()
+    if row is not None:
+        return _normalize_direction(_merge_extra(_row_to_dict(row)))
+    return None
+
+
+def get_message_by_telegram_id(
+    conn: sqlite3.Connection,
+    telegram_message_id: int,
+    chat_id: str | int | None = None,
+) -> Row | None:
+    """
+    Look up a message by its Telegram message ID.
+
+    Args:
+        conn:               Open sqlite3.Connection.
+        telegram_message_id: Telegram's numeric message identifier.
+        chat_id:            Optional — narrow the search to a specific chat.
+
+    Returns:
+        The first matching row as a plain dict, or None.
+    """
+    conditions = ["telegram_message_id = ?"]
+    params: list[Any] = [str(telegram_message_id)]
+
+    if chat_id is not None:
+        conditions.append("chat_id = ?")
+        params.append(str(chat_id))
+
+    where = " AND ".join(conditions)
+    row = conn.execute(
+        f"SELECT {_HISTORY_COLUMNS} FROM messages WHERE {where} LIMIT 1",
+        params,
+    ).fetchone()
+    if row is not None:
+        return _normalize_direction(_merge_extra(_row_to_dict(row)))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Statistics
+# ---------------------------------------------------------------------------
+
+def get_message_stats(conn: sqlite3.Connection) -> dict[str, Any]:
+    """
+    Return aggregate statistics from the messages, bisque_events, and
+    agent_events tables.
+
+    Returns a dict with keys:
+        - total_messages:     int  total rows in messages table
+        - inbound_count:      int  direction='in' rows
+        - outbound_count:     int  direction='out' rows
+        - by_source:          dict[str, int]  count per source
+        - agent_events_count: int  rows in agent_events table
+        - bisque_events_count: int rows in bisque_events table
+    """
+    stats: dict[str, Any] = {}
+
+    if _table_exists(conn, "messages"):
+        (total,) = conn.execute("SELECT COUNT(*) FROM messages").fetchone()
+        stats["total_messages"] = total
+
+        (inbound,) = conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE direction = 'in'"
+        ).fetchone()
+        stats["inbound_count"] = inbound
+        stats["outbound_count"] = total - inbound
+
+        source_rows = conn.execute(
+            "SELECT source, COUNT(*) FROM messages GROUP BY source ORDER BY COUNT(*) DESC"
+        ).fetchall()
+        stats["by_source"] = {r[0] or "unknown": r[1] for r in source_rows}
+    else:
+        stats["total_messages"] = 0
+        stats["inbound_count"] = 0
+        stats["outbound_count"] = 0
+        stats["by_source"] = {}
+
+    if _table_exists(conn, "agent_events"):
+        (agent_count,) = conn.execute("SELECT COUNT(*) FROM agent_events").fetchone()
+        stats["agent_events_count"] = agent_count
+    else:
+        stats["agent_events_count"] = 0
+
+    if _table_exists(conn, "bisque_events"):
+        (bisque_count,) = conn.execute("SELECT COUNT(*) FROM bisque_events").fetchone()
+        stats["bisque_events_count"] = bisque_count
+    else:
+        stats["bisque_events_count"] = 0
+
+    return stats
+
+
+def get_recent_messages(
+    conn: sqlite3.Connection,
+    *,
+    source: str | None = None,
+    since_ts: str | None = None,
+    limit: int = 20,
+) -> list[Row]:
+    """
+    Fetch recent inbound messages from messages.db, ordered newest-first.
+
+    This is the DB-backed complement to the filesystem inbox scan used by
+    handle_check_inbox's since_ts (catch-up) mode.
+
+    Args:
+        conn:     Open sqlite3.Connection.
+        source:   Optional source filter (e.g. 'telegram').
+        since_ts: ISO-8601 timestamp — only messages at or after this time.
+        limit:    Maximum rows to return.
+
+    Returns:
+        List of plain dicts with all message columns.
+    """
+    conditions: list[str] = ["direction = 'in'"]
+    params: list[Any] = []
+
+    if source:
+        conditions.append("LOWER(source) = LOWER(?)")
+        params.append(source)
+
+    if since_ts:
+        conditions.append("timestamp >= ?")
+        params.append(since_ts)
+
+    where = "WHERE " + " AND ".join(conditions)
+    rows = conn.execute(
+        f"SELECT {_HISTORY_COLUMNS} FROM messages {where}"
+        f" ORDER BY timestamp DESC LIMIT ?",
+        params + [limit],
+    ).fetchall()
+
+    return [_merge_extra(_row_to_dict(r)) for r in rows]

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -76,19 +76,40 @@ from skill_manager import (
 )
 _update_manager = UpdateManager()
 
-# BIS-163 Slice 2: Live DB write path — persist messages to messages.db
-# Imported lazily so the server starts even if src/db is not on sys.path yet.
-_db_persist_message = None
+# DB read layer (BIS-164 Slice 3) — optional, graceful degradation
+_db_get_conversation_history = None
+_db_count_conversation_history = None
+_db_get_message_by_telegram_id_fn = None
+_db_get_message_stats = None
+_db_open_messages_db = None
+try:
+    from db import reader as _db_reader_mod
+    from db.connection import open_messages_db as _db_open_messages_db
+    _db_get_conversation_history = _db_reader_mod.get_conversation_history
+    _db_count_conversation_history = _db_reader_mod.count_conversation_history
+    _db_get_message_by_telegram_id_fn = _db_reader_mod.get_message_by_telegram_id
+    _db_get_message_stats = _db_reader_mod.get_message_stats
+    print('[DB] db.reader loaded — DB reads available', file=sys.stderr)
+except Exception as _db_reader_import_err:
+    print(f'[WARN] DB reader module unavailable: {_db_reader_import_err}', file=sys.stderr)
+
+# BIS-167 Slice 6: Live DB write path — persist messages to messages.db
+_db_persist_inbound = None
 _db_persist_outbound = None
 _db_persist_agent_event = None
 try:
     from db.message_store import (
-        persist_message as _db_persist_message,
+        persist_inbound as _db_persist_inbound,
         persist_outbound as _db_persist_outbound,
         persist_agent_event as _db_persist_agent_event,
     )
+    _db_flag = os.environ.get("LOBSTER_USE_DB", "0")
+    _db_status = "ENABLED" if _db_flag == "1" else "DISABLED (set LOBSTER_USE_DB=1 to enable)"
+    print(f"[DB] message_store loaded — DB writes {_db_status}", file=sys.stderr)
+    del _db_flag, _db_status
 except Exception as _db_import_err:
     print(f"[WARN] messages.db write path unavailable: {_db_import_err}", file=sys.stderr)
+
 
 # Memory system (optional — gracefully degrades to static file search)
 _memory_provider = None
@@ -438,6 +459,9 @@ TASK_REPLIED_DIR = BASE_DIR / "task-replied"
 TASKS_FILE = BASE_DIR / "tasks.json"
 TASK_OUTPUTS_DIR = BASE_DIR / "task-outputs"
 BISQUE_OUTBOX_DIR = BASE_DIR / "bisque-outbox"
+MESSAGES_DB_PATH = Path(
+    os.environ.get("LOBSTER_MESSAGES_DB", str(BASE_DIR / "messages.db"))
+)
 LOBSTER_TMUX_SESSION = os.environ.get("LOBSTER_TMUX_SESSION", "lobster")
 
 # Instance identity for multi-instance deployments (BIS-85).
@@ -3536,7 +3560,7 @@ async def handle_send_reply(args: dict) -> list[TextContent]:
     sent_file = SENT_DIR / f"{reply_id}.json"
     atomic_write_json(sent_file, reply_data)
 
-    # BIS-163: Persist outbound reply to messages.db (additive — JSON is source of truth)
+    # BIS-167 Slice 6: persist outbound reply to messages.db (no-op when LOBSTER_USE_DB!=1)
     if _db_persist_outbound is not None:
         _db_persist_outbound(reply_data)
 
@@ -3569,13 +3593,12 @@ async def handle_send_reply(args: dict) -> list[TextContent]:
                 found.rename(dest)
                 mark_info = f" | message {mid} marked processed"
                 log.info(f"Atomic mark_processed via send_reply: {mid}")
-                # BIS-163: Persist the inbound message to messages.db now it is processed
-                if _db_persist_message is not None:
+                # BIS-167 Slice 6: persist the inbound message now that it is processed
+                if _db_persist_inbound is not None:
                     try:
-                        inbound_record = json.loads(dest.read_text())
-                        _db_persist_message(inbound_record, "in")
+                        _db_persist_inbound(json.loads(dest.read_text()))
                     except Exception as _db_exc:
-                        log.warning(f"[BIS-163] DB persist failed for {mid}: {_db_exc}")
+                        log.warning(f"[DB] inbound persist failed for {mid}: {_db_exc}")
             else:
                 mark_info = f" | ⚠️ message {mid} not found for mark_processed"
                 log.warning(f"Atomic mark_processed: message not found: {mid}")
@@ -3623,7 +3646,7 @@ async def handle_send_whatsapp_reply(args: dict) -> list[TextContent]:
     sent_file = SENT_DIR / f"{reply_id}.json"
     atomic_write_json(sent_file, reply_data)
 
-    # BIS-163: Persist outbound WhatsApp reply to messages.db
+    # BIS-167 Slice 6: persist outbound reply to messages.db
     if _db_persist_outbound is not None:
         _db_persist_outbound(reply_data)
 
@@ -3661,7 +3684,7 @@ async def handle_send_sms_reply(args: dict) -> list[TextContent]:
     sent_file = SENT_DIR / f"{reply_id}.json"
     atomic_write_json(sent_file, reply_data)
 
-    # BIS-163: Persist outbound SMS reply to messages.db
+    # BIS-167 Slice 6: persist outbound reply to messages.db
     if _db_persist_outbound is not None:
         _db_persist_outbound(reply_data)
 
@@ -3749,10 +3772,6 @@ async def handle_mark_processed(args: dict) -> list[TextContent]:
                         sent_file = SENT_DIR / f"{fallback_id}.json"
                         atomic_write_json(sent_file, fallback_data)
 
-                        # BIS-163: Persist the auto-reply fallback to messages.db
-                        if _db_persist_outbound is not None:
-                            _db_persist_outbound(fallback_data)
-
                         _track_reply(chat_id)
                         log.warning(f"Auto-reply fallback triggered for message {message_id} (chat {chat_id})")
         except (json.JSONDecodeError, OSError):
@@ -3762,15 +3781,12 @@ async def handle_mark_processed(args: dict) -> list[TextContent]:
     dest = PROCESSED_DIR / found.name
     found.rename(dest)
 
-    # BIS-163: Persist inbound message to messages.db now that it is fully processed.
-    # Read from the destination path for the canonical final state (including
-    # _processing_started_at if mark_processing stamped it earlier).
-    if _db_persist_message is not None:
+    # BIS-167 Slice 6: persist inbound message to messages.db now that it is fully processed.
+    if _db_persist_inbound is not None:
         try:
-            inbound_record = json.loads(dest.read_text())
-            _db_persist_message(inbound_record, "in")
+            _db_persist_inbound(json.loads(dest.read_text()))
         except Exception as _db_exc:
-            log.warning(f"[BIS-163] DB persist failed for {message_id}: {_db_exc}")
+            log.warning(f"[DB] inbound persist failed for {message_id}: {_db_exc}")
 
     log.info(f"Message processed: {message_id}")
     return [TextContent(type="text", text=f"✅ Message marked as processed: {message_id}")]
@@ -4018,7 +4034,12 @@ async def handle_list_sources(args: dict) -> list[TextContent]:
 
 
 async def handle_get_stats(args: dict) -> list[TextContent]:
-    """Get inbox statistics."""
+    """Get inbox statistics.
+
+    BIS-164 Slice 3: augments filesystem counters with aggregate counts from
+    messages.db when the DB is available, providing a richer picture of
+    total message history beyond the current filesystem snapshot.
+    """
     inbox_count = len(list(INBOX_DIR.glob("*.json")))
     outbox_count = len(list(OUTBOX_DIR.glob("*.json")))
     processed_count = len(list(PROCESSED_DIR.glob("*.json")))
@@ -4038,8 +4059,8 @@ async def handle_get_stats(args: dict) -> list[TextContent]:
         except Exception:
             continue
 
-    # Count by source
-    source_counts = {}
+    # Count by source (filesystem snapshot — inbox only)
+    source_counts: dict = {}
     for f in INBOX_DIR.glob("*.json"):
         try:
             with open(f) as fp:
@@ -4057,30 +4078,79 @@ async def handle_get_stats(args: dict) -> list[TextContent]:
     output += f"- Failed: {failed_count} ({retry_pending} retry pending, {permanently_failed} permanent)\n\n"
 
     if source_counts:
-        output += "**By Source:**\n"
+        output += "**By Source (inbox):**\n"
         for src, count in source_counts.items():
             output += f"- {src}: {count}\n"
+
+    # ------------------------------------------------------------------
+    # DB aggregate stats (BIS-164 Slice 3)
+    # ------------------------------------------------------------------
+    if _db_get_message_stats is not None:
+        conn = _open_messages_db_conn()
+        if conn is not None:
+            try:
+                db_stats = _db_get_message_stats(conn)
+                output += "\n**messages.db Totals:**\n"
+                output += f"- Total messages: {db_stats.get('total_messages', 0)}\n"
+                output += f"- Inbound: {db_stats.get('inbound_count', 0)}\n"
+                output += f"- Outbound: {db_stats.get('outbound_count', 0)}\n"
+                by_source = db_stats.get("by_source", {})
+                if by_source:
+                    output += "\n**DB By Source:**\n"
+                    for src, cnt in by_source.items():
+                        output += f"- {src}: {cnt}\n"
+                ae_count = db_stats.get("agent_events_count", 0)
+                be_count = db_stats.get("bisque_events_count", 0)
+                if ae_count or be_count:
+                    output += f"\n- Agent events: {ae_count}\n"
+                    output += f"- Bisque events: {be_count}\n"
+            except Exception as db_exc:
+                log.debug("handle_get_stats: DB query failed: %s", db_exc)
+            finally:
+                conn.close()
 
     return [TextContent(type="text", text=output)]
 
 
 # =============================================================================
-# Conversation History Handler
+# Conversation History Handler — BIS-165 Slice 4
 # =============================================================================
 
-async def handle_get_conversation_history(args: dict) -> list[TextContent]:
-    """Retrieve past messages from conversation history."""
-    chat_id_filter = args.get("chat_id")
-    search_text = args.get("search", "").lower().strip()
-    limit = min(args.get("limit", 20), 100)
-    offset = args.get("offset", 0)
-    direction = args.get("direction", "all").lower()
-    source_filter = args.get("source", "").lower().strip()
 
-    # Collect all messages from processed (received) and sent directories
-    all_messages = []
+def _open_messages_db_conn():
+    """Open messages.db for reading and return the connection, or None if unavailable.
 
-    # Load received messages (from processed directory)
+    Uses the connection factory from src/db/connection.py when available.
+    Returns None when:
+      - The db.connection module was not importable (src/db not on sys.path).
+      - MESSAGES_DB_PATH does not exist yet (pre-migration deployment).
+      - The database file cannot be opened for any reason.
+
+    Callers are responsible for closing the returned connection.
+    """
+    if _db_open_messages_db is None:
+        return None
+    try:
+        if not MESSAGES_DB_PATH.exists():
+            return None
+        return _db_open_messages_db(MESSAGES_DB_PATH)
+    except Exception as exc:
+        log.debug("messages.db open failed: %s", exc)
+        return None
+
+
+def _scan_json_dirs_for_history(direction: str) -> list[dict]:
+    """Scan processed/ and sent/ JSON directories and return all message dicts.
+
+    Pure function: reads files from disk, returns a list.  Each dict has
+    _direction set to 'received' or 'sent' and _filename set to the
+    source filename.  Used as the fallback when messages.db is unavailable.
+
+    Args:
+        direction: 'all' | 'received' | 'sent'
+    """
+    messages: list[dict] = []
+
     if direction in ("all", "received"):
         for f in PROCESSED_DIR.glob("*.json"):
             try:
@@ -4088,11 +4158,10 @@ async def handle_get_conversation_history(args: dict) -> list[TextContent]:
                     msg = json.load(fp)
                 msg["_direction"] = "received"
                 msg["_filename"] = f.name
-                all_messages.append(msg)
+                messages.append(msg)
             except Exception:
                 continue
 
-    # Load sent messages (from sent directory)
     if direction in ("all", "sent"):
         for f in SENT_DIR.glob("*.json"):
             try:
@@ -4100,42 +4169,179 @@ async def handle_get_conversation_history(args: dict) -> list[TextContent]:
                     msg = json.load(fp)
                 msg["_direction"] = "sent"
                 msg["_filename"] = f.name
-                all_messages.append(msg)
+                messages.append(msg)
             except Exception:
                 continue
 
-    # Apply filters
-    if chat_id_filter is not None:
-        # Compare as strings to handle both int and string chat_ids
-        chat_id_str = str(chat_id_filter)
-        all_messages = [m for m in all_messages if str(m.get("chat_id", "")) == chat_id_str]
+    return messages
 
-    if source_filter:
-        all_messages = [m for m in all_messages if m.get("source", "").lower() == source_filter]
 
-    if search_text:
-        all_messages = [m for m in all_messages if search_text in m.get("text", "").lower()]
+def _apply_filters_and_paginate(
+    messages: list[dict],
+    *,
+    chat_id_filter,
+    source_filter: str,
+    search_text: str,
+    limit: int,
+    offset: int,
+) -> tuple[list[dict], int]:
+    """Apply chat_id / source / search filters, sort by timestamp, then paginate.
 
-    # Sort by timestamp (newest first)
-    def parse_timestamp(msg):
+    Returns (paginated_slice, total_count_before_pagination).
+    All filtering and sorting is performed in-memory. This is the legacy
+    fallback path used when messages.db is unavailable.
+    """
+    def _parse_ts(msg: dict) -> 'datetime':
         ts = msg.get("timestamp", "")
         try:
-            # Handle various timestamp formats, always return UTC-aware
             if "+" in ts or ts.endswith("Z"):
                 return datetime.fromisoformat(ts.replace("Z", "+00:00"))
-            else:
-                # Naive timestamp - assume UTC
-                return datetime.fromisoformat(ts).replace(tzinfo=timezone.utc)
+            return datetime.fromisoformat(ts).replace(tzinfo=timezone.utc)
         except (ValueError, TypeError):
             return datetime.min.replace(tzinfo=timezone.utc)
 
-    all_messages.sort(key=parse_timestamp, reverse=True)
+    filtered = messages
 
-    total_count = len(all_messages)
+    if chat_id_filter is not None:
+        chat_id_str = str(chat_id_filter)
+        filtered = [m for m in filtered if str(m.get("chat_id", "")) == chat_id_str]
 
-    # Apply pagination
-    paginated = all_messages[offset:offset + limit]
+    if source_filter:
+        filtered = [m for m in filtered if m.get("source", "").lower() == source_filter]
 
+    if search_text:
+        search_lower = search_text.lower()
+        filtered = [m for m in filtered if search_lower in m.get("text", "").lower()]
+
+    filtered.sort(key=_parse_ts, reverse=True)
+
+    total = len(filtered)
+    return filtered[offset: offset + limit], total
+
+
+def _format_history_output(
+    paginated: list[dict],
+    total_count: int,
+    offset: int,
+    limit: int,
+) -> str:
+    """Render a list of message dicts into the conversation history markdown string.
+
+    Each dict must have _direction set to 'received' or 'sent'.
+    Fields source, chat_id, timestamp, text, user_name, username are optional.
+    """
+    showing_end = min(offset + limit, total_count)
+    output = f"**Conversation History** (showing {offset + 1}-{showing_end} of {total_count}):\n\n"
+
+    for msg in paginated:
+        direction_icon = "\u2b05\ufe0f" if msg["_direction"] == "received" else "\u27a1\ufe0f"
+        direction_label = "RECEIVED" if msg["_direction"] == "received" else "SENT"
+        source = msg.get("source", "unknown").upper()
+        chat_id = msg.get("chat_id", "")
+        ts = msg.get("timestamp", "")
+        text = msg.get("text", "(no text)")
+
+        try:
+            ts_display = _format_iso_for_display(ts, "%Y-%m-%d %I:%M %p %Z")
+        except (ValueError, TypeError):
+            ts_display = ts
+
+        truncated = text[:500] + ("..." if len(text) > 500 else "")
+        if msg["_direction"] == "received":
+            user = msg.get("user_name", msg.get("username", "Unknown"))
+            output += "---\n"
+            output += f"{direction_icon} **{direction_label}** [{source}] from **{user}** | Chat: `{chat_id}`\n"
+            output += f"Time: {ts_display}\n\n"
+            output += f"> {truncated}\n\n"
+        else:
+            output += "---\n"
+            output += f"{direction_icon} **{direction_label}** [{source}] to chat `{chat_id}`\n"
+            output += f"Time: {ts_display}\n\n"
+            output += f"> {truncated}\n\n"
+
+    if total_count > offset + limit:
+        next_offset = offset + limit
+        output += f"---\n*More messages available. Use `offset={next_offset}` to see the next page.*\n"
+
+    return output
+
+
+async def handle_get_conversation_history(args: dict) -> list[TextContent]:
+    """Retrieve past messages from conversation history.
+
+    BIS-165 Slice 4: SQL-first read path with extracted pure-function helpers.
+    Queries messages.db when available; falls back to the legacy filesystem scan
+    (processed/ + sent/ JSON files) when the DB is unavailable or returns zero
+    results for the given filters.
+    """
+    chat_id_filter = args.get("chat_id")
+    search_text = args.get("search", "").strip()
+    limit = min(args.get("limit", 20), 100)
+    offset = args.get("offset", 0)
+    direction = args.get("direction", "all").lower()
+    source_filter = args.get("source", "").lower().strip()
+
+    paginated: list[dict] = []
+    total_count: int = 0
+    used_db: bool = False
+
+    # ------------------------------------------------------------------
+    # Primary path: SQL query against messages.db (BIS-165 Slice 4)
+    # ------------------------------------------------------------------
+    if _db_get_conversation_history is not None and _db_count_conversation_history is not None:
+        conn = _open_messages_db_conn()
+        if conn is not None:
+            try:
+                paginated = _db_get_conversation_history(
+                    conn,
+                    chat_id=chat_id_filter,
+                    source=source_filter or None,
+                    search=search_text or None,
+                    direction=direction,
+                    limit=limit,
+                    offset=offset,
+                )
+                total_count = _db_count_conversation_history(
+                    conn,
+                    chat_id=chat_id_filter,
+                    source=source_filter or None,
+                    search=search_text or None,
+                    direction=direction,
+                )
+                used_db = True
+                log.debug(
+                    "get_conversation_history: DB returned %d rows (total=%d)",
+                    len(paginated),
+                    total_count,
+                )
+            except Exception as db_exc:
+                log.warning(
+                    "get_conversation_history: DB query failed, falling back to filesystem: %s",
+                    db_exc,
+                )
+                paginated = []
+                total_count = 0
+            finally:
+                conn.close()
+
+    # ------------------------------------------------------------------
+    # Fallback: filesystem scan (legacy / migration window)
+    # Activates when DB is unavailable or returned zero results.
+    # ------------------------------------------------------------------
+    if not used_db or (total_count == 0 and offset == 0):
+        all_messages = _scan_json_dirs_for_history(direction)
+        paginated, total_count = _apply_filters_and_paginate(
+            all_messages,
+            chat_id_filter=chat_id_filter,
+            source_filter=source_filter,
+            search_text=search_text,
+            limit=limit,
+            offset=offset,
+        )
+
+    # ------------------------------------------------------------------
+    # Format and return
+    # ------------------------------------------------------------------
     if not paginated:
         filter_info = []
         if chat_id_filter is not None:
@@ -4149,47 +4355,16 @@ async def handle_get_conversation_history(args: dict) -> list[TextContent]:
         filter_str = f" (filters: {', '.join(filter_info)})" if filter_info else ""
         return [TextContent(type="text", text=f"No messages found{filter_str}.")]
 
-    # Format output
-    showing_end = min(offset + limit, total_count)
-    output = f"**Conversation History** (showing {offset + 1}-{showing_end} of {total_count}):\n\n"
-
-    for msg in paginated:
-        direction_icon = "\u2b05\ufe0f" if msg["_direction"] == "received" else "\u27a1\ufe0f"
-        direction_label = "RECEIVED" if msg["_direction"] == "received" else "SENT"
-        source = msg.get("source", "unknown").upper()
-        chat_id = msg.get("chat_id", "")
-        ts = msg.get("timestamp", "")
-        text = msg.get("text", "(no text)")
-
-        # Format timestamp nicely in owner's local timezone
-        try:
-            ts_display = _format_iso_for_display(ts, "%Y-%m-%d %I:%M %p %Z")
-        except (ValueError, TypeError):
-            ts_display = ts
-
-        # For received messages, show who sent it
-        if msg["_direction"] == "received":
-            user = msg.get("user_name", msg.get("username", "Unknown"))
-            output += f"---\n"
-            output += f"{direction_icon} **{direction_label}** [{source}] from **{user}** | Chat: `{chat_id}`\n"
-            output += f"Time: {ts_display}\n\n"
-            output += f"> {text[:500]}{'...' if len(text) > 500 else ''}\n\n"
-        else:
-            output += f"---\n"
-            output += f"{direction_icon} **{direction_label}** [{source}] to chat `{chat_id}`\n"
-            output += f"Time: {ts_display}\n\n"
-            output += f"> {text[:500]}{'...' if len(text) > 500 else ''}\n\n"
-
-    # Pagination info
-    if total_count > offset + limit:
-        next_offset = offset + limit
-        output += f"---\n*More messages available. Use `offset={next_offset}` to see the next page.*\n"
-
+    output = _format_history_output(paginated, total_count, offset, limit)
     return [TextContent(type="text", text=output)]
 
-
 async def handle_get_message_by_telegram_id(args: dict) -> list[TextContent]:
-    """Look up a specific message by its Telegram message ID."""
+    """Look up a specific message by its Telegram message ID.
+
+    BIS-164 Slice 3: DB-first lookup.  Queries messages.db when available;
+    falls back to scanning the filesystem JSON directories when the DB is
+    unavailable or the message is not yet persisted.
+    """
     tg_id = args.get("telegram_message_id")
     if tg_id is None:
         return [TextContent(type="text", text="Error: telegram_message_id is required.")]
@@ -4198,7 +4373,57 @@ async def handle_get_message_by_telegram_id(args: dict) -> list[TextContent]:
     chat_id_filter = args.get("chat_id")
     chat_id_str = str(chat_id_filter) if chat_id_filter is not None else None
 
-    # Search order: processed first (most common), then inbox, processing, failed
+    # ------------------------------------------------------------------
+    # Primary path: DB lookup (BIS-164 Slice 3)
+    # ------------------------------------------------------------------
+    if _db_get_message_by_telegram_id_fn is not None:
+        conn = _open_messages_db_conn()
+        if conn is not None:
+            try:
+                msg = _db_get_message_by_telegram_id_fn(conn, tg_id, chat_id=chat_id_filter)
+                if msg is not None:
+                    source = msg.get("source", "unknown").upper()
+                    chat_id = msg.get("chat_id", "")
+                    ts = msg.get("timestamp", "")
+                    text = msg.get("text", "(no text)")
+                    msg_type = msg.get("type", "text")
+                    user = msg.get("user_name", msg.get("username", "Unknown"))
+
+                    try:
+                        ts_dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                        ts_display = ts_dt.strftime("%Y-%m-%d %H:%M UTC")
+                    except (ValueError, TypeError):
+                        ts_display = ts
+
+                    output = f"**Message found** (in `messages.db`):\n\n"
+                    output += f"Telegram Message ID: `{tg_id}`\n"
+                    output += f"Lobster Message ID: `{msg.get('id', '?')}` \n"
+                    output += f"Source: {source} | Chat ID: `{chat_id}` | Type: `{msg_type}`\n"
+                    output += f"From: **{user}**\n"
+                    output += f"Time: {ts_display}\n\n"
+                    output += f"**Text:**\n> {text}\n"
+
+                    reply_to = msg.get("reply_to")
+                    if reply_to:
+                        reply_text = reply_to.get("reply_to_text") or reply_to.get("text", "") if isinstance(reply_to, dict) else ""
+                        reply_from = reply_to.get("reply_to_from_user") or reply_to.get("from_user", "") if isinstance(reply_to, dict) else ""
+                        reply_msg_id = msg.get("reply_to_message_id", "")
+                        output += f"\n**Reply to** (TG ID `{reply_msg_id}`, from {reply_from}):\n> {str(reply_text)[:300]}{'...' if len(str(reply_text)) > 300 else ''}\n"
+
+                    for field in ("image_file", "file_path", "audio_file"):
+                        val = msg.get(field)
+                        if val:
+                            output += f"\n**Attached file** (`{field}`): `{val}`\n"
+
+                    return [TextContent(type="text", text=output)]
+            except Exception as db_exc:
+                log.debug("handle_get_message_by_telegram_id: DB lookup failed: %s", db_exc)
+            finally:
+                conn.close()
+
+    # ------------------------------------------------------------------
+    # Fallback: filesystem scan
+    # ------------------------------------------------------------------
     search_dirs = [
         (PROCESSED_DIR, "processed"),
         (INBOX_DIR, "inbox"),
@@ -4220,7 +4445,6 @@ async def handle_get_message_by_telegram_id(args: dict) -> list[TextContent]:
             if chat_id_str is not None and str(msg.get("chat_id", "")) != chat_id_str:
                 continue
 
-            # Found a match — format the full message as output
             source = msg.get("source", "unknown").upper()
             chat_id = msg.get("chat_id", "")
             ts = msg.get("timestamp", "")
@@ -4239,7 +4463,7 @@ async def handle_get_message_by_telegram_id(args: dict) -> list[TextContent]:
 
             output = f"**Message found** (in `{dir_label}/`):\n\n"
             output += f"Telegram Message ID: `{tg_id}`\n"
-            output += f"Lobster Message ID: `{msg.get('id', '?')}`\n"
+            output += f"Lobster Message ID: `{msg.get('id', '?')}` \n"
             output += f"Source: {source} | Chat ID: `{chat_id}` | Type: `{msg_type}`\n"
             output += f"From: **{user}**\n"
             output += f"Time: {ts_display}\n\n"
@@ -4252,7 +4476,6 @@ async def handle_get_message_by_telegram_id(args: dict) -> list[TextContent]:
                 reply_msg_id = reply_to.get("reply_to_message_id") or reply_to.get("message_id", "")
                 output += f"\n**Reply to** (TG ID `{reply_msg_id}`, from {reply_from}):\n> {reply_text[:300]}{'...' if len(reply_text) > 300 else ''}\n"
 
-            # Surface any attached file paths
             for field in ("image_file", "file_path", "audio_file"):
                 val = msg.get(field)
                 if val:
@@ -4265,12 +4488,11 @@ async def handle_get_message_by_telegram_id(args: dict) -> list[TextContent]:
 
             return [TextContent(type="text", text=output)]
 
-    # No match found across all directories
     filter_note = f" in chat `{chat_id_filter}`" if chat_id_filter is not None else ""
     return [TextContent(
         type="text",
         text=f"No message found with Telegram message ID `{tg_id}`{filter_note}. "
-             f"Searched: processed, inbox, processing, failed directories.",
+             f"Searched: messages.db (if available), processed, inbox, processing, failed directories.",
     )]
 
 
@@ -5368,11 +5590,8 @@ async def handle_write_result(args: dict) -> list[TextContent]:
     inbox_file = INBOX_DIR / f"{message_id}.json"
     atomic_write_json(inbox_file, message)
 
-    # BIS-163: Persist agent event to messages.db immediately on write_result.
-    # Agent events land in INBOX_DIR and are later moved to PROCESSED_DIR by the
-    # dispatcher; we persist at write time so the DB is populated even if the
-    # dispatcher crashes before mark_processed runs.  INSERT OR IGNORE makes any
-    # subsequent mark_processed DB persist a no-op (idempotent).
+    # BIS-167 Slice 6: persist agent event immediately on write_result.
+    # Before auto-unregister so the record is in the DB even if the dispatcher crashes.
     if _db_persist_agent_event is not None:
         _db_persist_agent_event(message)
 
@@ -5485,6 +5704,10 @@ async def handle_write_observation(args: dict) -> list[TextContent]:
 
     inbox_file = INBOX_DIR / f"{message_id}.json"
     atomic_write_json(inbox_file, message)
+
+    # BIS-167 Slice 6: persist observation as agent event immediately
+    if _db_persist_agent_event is not None:
+        _db_persist_agent_event(message)
 
     # Belt-and-suspenders: for system_error, also append directly to observations.log
     # at the MCP layer. The inbox write above is the primary path — the dispatcher

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,8 @@ def isolate_inbox_server_paths(tmp_path: Path):
         "scheduled_jobs_file": sched / "jobs.json",
         "scheduled_tasks_dir": sched / "tasks",
         "scheduled_tasks_logs": sched / "logs",
+        # BIS-165 Slice 4: redirected DB path for tests that write to messages.db
+        "messages_db": messages / "messages.db",
     }
 
     # Ensure the module is in sys.modules before patching.  patch.multiple
@@ -172,6 +174,8 @@ def isolate_inbox_server_paths(tmp_path: Path):
             SCHEDULED_JOBS_FILE=sched / "jobs.json",
             SCHEDULED_TASKS_TASKS_DIR=sched / "tasks",
             SCHEDULED_TASKS_LOGS_DIR=sched / "logs",
+            # BIS-165 Slice 4: isolate DB path so tests never touch production messages.db
+            MESSAGES_DB_PATH=messages / "messages.db",
         ):
             yield dirs_result
     except Exception:

--- a/tests/unit/test_mcp_server/test_relay_db_reads.py
+++ b/tests/unit/test_mcp_server/test_relay_db_reads.py
@@ -1,0 +1,694 @@
+"""
+Tests for BIS-164 Slice 3 — Relay DB reads.
+
+Verifies that:
+  - src/db/reader.py pure functions query correctly against an in-memory SQLite DB.
+  - inbox_server.py handlers use the DB-first path when messages.db is available.
+  - inbox_server.py handlers fall back to the filesystem when the DB is unavailable
+    or returns zero results.
+
+All tests use an in-memory SQLite database so that no on-disk state is required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure src/ is on sys.path (root conftest does this, but be explicit here).
+_SRC_DIR = Path(__file__).parent.parent.parent.parent / "src"
+if str(_SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(_SRC_DIR))
+
+# Ensure src/mcp/ is on sys.path for sibling imports inside inbox_server.
+_MCP_DIR = _SRC_DIR / "mcp"
+if str(_MCP_DIR) not in sys.path:
+    sys.path.insert(0, str(_MCP_DIR))
+
+# Pre-load inbox_server so patch.multiple can resolve it.
+import src.mcp.inbox_server  # noqa: F401
+
+# Import reader module directly for unit tests.
+from db import reader as db_reader
+from db.connection import apply_schema, open_messages_db
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SCHEMA_PATH = Path(__file__).parent.parent.parent.parent / "src" / "db" / "schema.sql"
+
+
+def _make_conn() -> sqlite3.Connection:
+    """Return an in-memory SQLite connection with the messages schema applied."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    schema_sql = _SCHEMA_PATH.read_text()
+    apply_schema(conn, schema_sql)
+    return conn
+
+
+def _insert_message(conn: sqlite3.Connection, **kwargs) -> None:
+    """Insert a row into messages.  Caller supplies field values as kwargs."""
+    defaults: dict[str, Any] = {
+        "id": "msg-001",
+        "direction": "in",
+        "source": "telegram",
+        "type": "text",
+        "chat_id": "1234",
+        "user_id": "u1",
+        "username": "alice",
+        "user_name": "Alice",
+        "text": "Hello, world!",
+        "timestamp": "2024-01-15T10:00:00+00:00",
+        "telegram_message_id": None,
+        "extra": None,
+    }
+    row = {**defaults, **kwargs}
+    cols = ", ".join(row.keys())
+    placeholders = ", ".join("?" for _ in row)
+    conn.execute(f"INSERT INTO messages ({cols}) VALUES ({placeholders})", list(row.values()))
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Tests: db/reader.py internal helpers
+# ---------------------------------------------------------------------------
+
+
+class TestReaderInternals:
+    """Unit tests for private helper functions in db/reader.py."""
+
+    def test_row_to_dict_converts_sqlite_row(self):
+        conn = _make_conn()
+        row = conn.execute("SELECT 1 AS foo, 'bar' AS baz").fetchone()
+        result = db_reader._row_to_dict(row)
+        assert result == {"foo": 1, "baz": "bar"}
+        conn.close()
+
+    def test_merge_extra_expands_json_column(self):
+        row = {"text": "hi", "extra": json.dumps({"image_file": "/tmp/img.jpg"})}
+        result = db_reader._merge_extra(row)
+        assert result["image_file"] == "/tmp/img.jpg"
+        assert "extra" not in result
+
+    def test_merge_extra_handles_missing_extra(self):
+        row = {"text": "hi"}
+        result = db_reader._merge_extra(row)
+        assert result == {"text": "hi"}
+
+    def test_merge_extra_handles_invalid_json(self):
+        row = {"text": "hi", "extra": "not-json"}
+        result = db_reader._merge_extra(row)
+        # extra key consumed but nothing merged
+        assert "extra" not in result
+        assert result == {"text": "hi"}
+
+    def test_normalize_direction_in_maps_to_received(self):
+        row = {"direction": "in", "text": "hello"}
+        result = db_reader._normalize_direction(row)
+        assert result["_direction"] == "received"
+
+    def test_normalize_direction_out_maps_to_sent(self):
+        row = {"direction": "out", "text": "reply"}
+        result = db_reader._normalize_direction(row)
+        assert result["_direction"] == "sent"
+
+    def test_parse_timestamp_valid_utc(self):
+        from datetime import timezone
+        ts = db_reader._parse_timestamp("2024-01-15T10:00:00+00:00")
+        assert ts.tzinfo is not None
+        assert ts.year == 2024
+
+    def test_parse_timestamp_z_suffix(self):
+        ts = db_reader._parse_timestamp("2024-03-01T12:00:00Z")
+        assert ts.year == 2024
+
+    def test_parse_timestamp_none_returns_min(self):
+        from datetime import datetime, timezone
+        ts = db_reader._parse_timestamp(None)
+        assert ts == datetime.min.replace(tzinfo=timezone.utc)
+
+    def test_table_exists_returns_true_for_existing_table(self):
+        conn = _make_conn()
+        assert db_reader._table_exists(conn, "messages") is True
+        conn.close()
+
+    def test_table_exists_returns_false_for_missing_table(self):
+        conn = _make_conn()
+        assert db_reader._table_exists(conn, "nonexistent_table") is False
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_conversation_history
+# ---------------------------------------------------------------------------
+
+
+class TestGetConversationHistory:
+    """Tests for db_reader.get_conversation_history."""
+
+    def test_returns_empty_list_when_no_messages(self):
+        conn = _make_conn()
+        result = db_reader.get_conversation_history(conn)
+        assert result == []
+        conn.close()
+
+    def test_returns_inserted_message(self):
+        conn = _make_conn()
+        _insert_message(conn, id="m1", text="Hello DB!")
+        result = db_reader.get_conversation_history(conn)
+        assert len(result) == 1
+        assert result[0]["text"] == "Hello DB!"
+        conn.close()
+
+    def test_direction_key_is_set_on_results(self):
+        conn = _make_conn()
+        _insert_message(conn, id="m1", direction="in")
+        result = db_reader.get_conversation_history(conn)
+        assert result[0]["_direction"] == "received"
+        conn.close()
+
+    def test_filters_by_chat_id(self):
+        conn = _make_conn()
+        _insert_message(conn, id="m1", chat_id="111", text="chat 111")
+        _insert_message(conn, id="m2", chat_id="222", text="chat 222")
+        result = db_reader.get_conversation_history(conn, chat_id="111")
+        assert len(result) == 1
+        assert result[0]["text"] == "chat 111"
+        conn.close()
+
+    def test_filters_by_source_case_insensitive(self):
+        conn = _make_conn()
+        _insert_message(conn, id="m1", source="telegram", text="telegram msg")
+        _insert_message(conn, id="m2", source="bisque", text="bisque msg")
+        result = db_reader.get_conversation_history(conn, source="TELEGRAM")
+        assert len(result) == 1
+        assert result[0]["source"] == "telegram"
+        conn.close()
+
+    def test_filters_by_direction_received(self):
+        conn = _make_conn()
+        _insert_message(conn, id="m1", direction="in", text="inbound")
+        _insert_message(conn, id="m2", direction="out", text="outbound")
+        result = db_reader.get_conversation_history(conn, direction="received")
+        assert len(result) == 1
+        assert result[0]["text"] == "inbound"
+        conn.close()
+
+    def test_filters_by_direction_sent(self):
+        conn = _make_conn()
+        _insert_message(conn, id="m1", direction="in", text="inbound")
+        _insert_message(conn, id="m2", direction="out", text="outbound")
+        result = db_reader.get_conversation_history(conn, direction="sent")
+        assert len(result) == 1
+        assert result[0]["text"] == "outbound"
+        conn.close()
+
+    def test_pagination_limit(self):
+        conn = _make_conn()
+        for i in range(5):
+            _insert_message(conn, id=f"m{i}", text=f"msg {i}",
+                            timestamp=f"2024-01-{i+10:02d}T10:00:00+00:00")
+        result = db_reader.get_conversation_history(conn, limit=2)
+        assert len(result) == 2
+        conn.close()
+
+    def test_pagination_offset(self):
+        conn = _make_conn()
+        for i in range(4):
+            _insert_message(conn, id=f"m{i}", text=f"msg {i}",
+                            timestamp=f"2024-01-{i+10:02d}T10:00:00+00:00")
+        page1 = db_reader.get_conversation_history(conn, limit=2, offset=0)
+        page2 = db_reader.get_conversation_history(conn, limit=2, offset=2)
+        assert len(page1) == 2
+        assert len(page2) == 2
+        # Pages should not overlap
+        ids1 = {r["id"] for r in page1}
+        ids2 = {r["id"] for r in page2}
+        assert ids1.isdisjoint(ids2)
+        conn.close()
+
+    def test_results_ordered_newest_first(self):
+        conn = _make_conn()
+        _insert_message(conn, id="old", timestamp="2024-01-01T10:00:00+00:00", text="old")
+        _insert_message(conn, id="new", timestamp="2024-06-01T10:00:00+00:00", text="new")
+        result = db_reader.get_conversation_history(conn)
+        assert result[0]["id"] == "new"
+        assert result[1]["id"] == "old"
+        conn.close()
+
+    def test_search_via_like_fallback(self):
+        """Keyword search falls back to LIKE when FTS5 is unavailable."""
+        conn = _make_conn()
+        _insert_message(conn, id="m1", text="find the needle here")
+        _insert_message(conn, id="m2", text="nothing relevant")
+        # Force the LIKE path by pretending messages_fts doesn't exist.
+        with patch.object(db_reader, "_table_exists", return_value=False):
+            result = db_reader.get_conversation_history(conn, search="needle")
+        assert len(result) == 1
+        assert result[0]["id"] == "m1"
+        conn.close()
+
+    def test_extra_json_column_merged_into_result(self):
+        conn = _make_conn()
+        extra = json.dumps({"image_file": "/tmp/foo.jpg", "image_width": 800})
+        _insert_message(conn, id="m1", extra=extra)
+        result = db_reader.get_conversation_history(conn)
+        assert result[0]["image_file"] == "/tmp/foo.jpg"
+        assert result[0]["image_width"] == 800
+        assert "extra" not in result[0]
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: count_conversation_history
+# ---------------------------------------------------------------------------
+
+
+class TestCountConversationHistory:
+    """Tests for db_reader.count_conversation_history."""
+
+    def test_returns_zero_for_empty_table(self):
+        conn = _make_conn()
+        assert db_reader.count_conversation_history(conn) == 0
+        conn.close()
+
+    def test_counts_all_messages(self):
+        conn = _make_conn()
+        for i in range(3):
+            _insert_message(conn, id=f"m{i}")
+        assert db_reader.count_conversation_history(conn) == 3
+        conn.close()
+
+    def test_count_respects_chat_id_filter(self):
+        conn = _make_conn()
+        _insert_message(conn, id="m1", chat_id="111")
+        _insert_message(conn, id="m2", chat_id="222")
+        assert db_reader.count_conversation_history(conn, chat_id="111") == 1
+        conn.close()
+
+    def test_count_respects_direction_filter(self):
+        conn = _make_conn()
+        _insert_message(conn, id="m1", direction="in")
+        _insert_message(conn, id="m2", direction="out")
+        assert db_reader.count_conversation_history(conn, direction="received") == 1
+        assert db_reader.count_conversation_history(conn, direction="sent") == 1
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_message_by_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessageById:
+    """Tests for db_reader.get_message_by_id."""
+
+    def test_returns_none_for_missing_id(self):
+        conn = _make_conn()
+        assert db_reader.get_message_by_id(conn, "nonexistent") is None
+        conn.close()
+
+    def test_returns_message_for_existing_id(self):
+        conn = _make_conn()
+        _insert_message(conn, id="msg-xyz", text="found it")
+        result = db_reader.get_message_by_id(conn, "msg-xyz")
+        assert result is not None
+        assert result["text"] == "found it"
+        conn.close()
+
+    def test_returned_row_has_direction_key(self):
+        conn = _make_conn()
+        _insert_message(conn, id="m1", direction="out")
+        result = db_reader.get_message_by_id(conn, "m1")
+        assert result["_direction"] == "sent"
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_message_by_telegram_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessageByTelegramId:
+    """Tests for db_reader.get_message_by_telegram_id."""
+
+    def test_returns_none_for_missing_tg_id(self):
+        conn = _make_conn()
+        assert db_reader.get_message_by_telegram_id(conn, 99999) is None
+        conn.close()
+
+    def test_returns_message_for_matching_tg_id(self):
+        conn = _make_conn()
+        _insert_message(conn, id="m1", telegram_message_id=42, text="tg message")
+        result = db_reader.get_message_by_telegram_id(conn, 42)
+        assert result is not None
+        assert result["text"] == "tg message"
+        conn.close()
+
+    def test_narrows_by_chat_id(self):
+        conn = _make_conn()
+        _insert_message(conn, id="m1", telegram_message_id=10, chat_id="111")
+        _insert_message(conn, id="m2", telegram_message_id=10, chat_id="222")
+        result = db_reader.get_message_by_telegram_id(conn, 10, chat_id="111")
+        assert result is not None
+        assert result["id"] == "m1"
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_message_stats
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessageStats:
+    """Tests for db_reader.get_message_stats."""
+
+    def test_returns_zeros_for_empty_db(self):
+        conn = _make_conn()
+        stats = db_reader.get_message_stats(conn)
+        assert stats["total_messages"] == 0
+        assert stats["inbound_count"] == 0
+        assert stats["outbound_count"] == 0
+        assert stats["by_source"] == {}
+        conn.close()
+
+    def test_counts_inbound_and_outbound(self):
+        conn = _make_conn()
+        _insert_message(conn, id="m1", direction="in")
+        _insert_message(conn, id="m2", direction="out")
+        stats = db_reader.get_message_stats(conn)
+        assert stats["total_messages"] == 2
+        assert stats["inbound_count"] == 1
+        assert stats["outbound_count"] == 1
+        conn.close()
+
+    def test_groups_by_source(self):
+        conn = _make_conn()
+        _insert_message(conn, id="m1", source="telegram")
+        _insert_message(conn, id="m2", source="telegram")
+        _insert_message(conn, id="m3", source="bisque")
+        stats = db_reader.get_message_stats(conn)
+        assert stats["by_source"]["telegram"] == 2
+        assert stats["by_source"]["bisque"] == 1
+        conn.close()
+
+    def test_agent_events_count_zero_when_empty(self):
+        conn = _make_conn()
+        stats = db_reader.get_message_stats(conn)
+        assert stats["agent_events_count"] == 0
+        conn.close()
+
+    def test_bisque_events_count_zero_when_empty(self):
+        conn = _make_conn()
+        stats = db_reader.get_message_stats(conn)
+        assert stats["bisque_events_count"] == 0
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_recent_messages
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecentMessages:
+    """Tests for db_reader.get_recent_messages."""
+
+    def test_returns_only_inbound(self):
+        conn = _make_conn()
+        _insert_message(conn, id="m1", direction="in", text="inbound")
+        _insert_message(conn, id="m2", direction="out", text="outbound")
+        result = db_reader.get_recent_messages(conn)
+        assert len(result) == 1
+        assert result[0]["text"] == "inbound"
+        conn.close()
+
+    def test_respects_since_ts_filter(self):
+        conn = _make_conn()
+        _insert_message(conn, id="old", direction="in",
+                        timestamp="2024-01-01T00:00:00+00:00", text="old")
+        _insert_message(conn, id="new", direction="in",
+                        timestamp="2024-06-01T00:00:00+00:00", text="new")
+        result = db_reader.get_recent_messages(conn, since_ts="2024-03-01T00:00:00+00:00")
+        assert len(result) == 1
+        assert result[0]["id"] == "new"
+        conn.close()
+
+    def test_respects_source_filter(self):
+        conn = _make_conn()
+        _insert_message(conn, id="m1", direction="in", source="telegram")
+        _insert_message(conn, id="m2", direction="in", source="bisque")
+        result = db_reader.get_recent_messages(conn, source="telegram")
+        assert len(result) == 1
+        assert result[0]["source"] == "telegram"
+        conn.close()
+
+    def test_respects_limit(self):
+        conn = _make_conn()
+        for i in range(5):
+            _insert_message(conn, id=f"m{i}", direction="in",
+                            timestamp=f"2024-01-{i+10:02d}T00:00:00+00:00")
+        result = db_reader.get_recent_messages(conn, limit=3)
+        assert len(result) == 3
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: inbox_server.py handler integration (DB-first paths)
+# ---------------------------------------------------------------------------
+
+
+class TestHandleGetConversationHistoryDbFirst:
+    """Integration tests for handle_get_conversation_history using DB path."""
+
+    def _make_mock_conn(self, rows: list[dict], count: int):
+        """Create a minimal mock connection context."""
+        mock_conn = MagicMock()
+        return mock_conn
+
+    def test_uses_db_when_available(self, tmp_path: Path):
+        """When DB reader is available and returns rows, results come from DB."""
+        from src.mcp.inbox_server import handle_get_conversation_history
+
+        db_rows = [
+            {"id": "db1", "_direction": "received", "source": "telegram",
+             "chat_id": "111", "timestamp": "2024-01-15T10:00:00+00:00",
+             "text": "From DB", "user_name": "Alice", "username": "alice"},
+        ]
+        mock_conn = MagicMock()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            _db_get_conversation_history=MagicMock(return_value=db_rows),
+            _db_count_conversation_history=MagicMock(return_value=1),
+            _open_messages_db_conn=MagicMock(return_value=mock_conn),
+        ):
+            result = asyncio.run(handle_get_conversation_history({}))
+
+        assert len(result) == 1
+        assert "From DB" in result[0].text
+
+    def test_falls_back_to_filesystem_when_db_unavailable(self, tmp_path: Path):
+        """When _open_messages_db_conn returns None, filesystem fallback is used."""
+        from src.mcp.inbox_server import handle_get_conversation_history
+
+        processed_dir = tmp_path / "processed"
+        processed_dir.mkdir()
+        msg = {
+            "id": "fs1",
+            "text": "From filesystem",
+            "source": "telegram",
+            "chat_id": "111",
+            "timestamp": "2024-01-15T10:00:00+00:00",
+            "user_name": "Bob",
+        }
+        (processed_dir / "fs1.json").write_text(json.dumps(msg))
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            _db_get_conversation_history=MagicMock(return_value=[]),
+            _db_count_conversation_history=MagicMock(return_value=0),
+            _open_messages_db_conn=MagicMock(return_value=None),
+            PROCESSED_DIR=processed_dir,
+            SENT_DIR=tmp_path / "sent",
+        ):
+            result = asyncio.run(handle_get_conversation_history({}))
+
+        assert len(result) == 1
+        assert "From filesystem" in result[0].text
+
+    def test_falls_back_when_db_reader_is_none(self, tmp_path: Path):
+        """When the DB reader module failed to import, filesystem is used."""
+        from src.mcp.inbox_server import handle_get_conversation_history
+
+        processed_dir = tmp_path / "processed"
+        processed_dir.mkdir()
+        msg = {
+            "id": "fs2", "text": "fallback message", "source": "telegram",
+            "chat_id": "555", "timestamp": "2024-01-15T10:00:00+00:00",
+        }
+        (processed_dir / "fs2.json").write_text(json.dumps(msg))
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            _db_get_conversation_history=None,
+            _db_count_conversation_history=None,
+            PROCESSED_DIR=processed_dir,
+            SENT_DIR=tmp_path / "sent",
+        ):
+            result = asyncio.run(handle_get_conversation_history({}))
+
+        assert "fallback message" in result[0].text
+
+
+class TestHandleGetStatsDbAugmentation:
+    """Tests for handle_get_stats DB stats augmentation."""
+
+    def test_includes_db_totals_when_db_available(self, tmp_path: Path):
+        """Stats output contains messages.db section when DB is available."""
+        from src.mcp.inbox_server import handle_get_stats
+
+        mock_conn = MagicMock()
+        db_stats = {
+            "total_messages": 42,
+            "inbound_count": 30,
+            "outbound_count": 12,
+            "by_source": {"telegram": 40, "bisque": 2},
+            "agent_events_count": 5,
+            "bisque_events_count": 3,
+        }
+
+        # Create minimal empty dirs so glob doesn't error
+        for d in ["inbox", "outbox", "processed", "processing", "failed"]:
+            (tmp_path / d).mkdir()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            _db_get_message_stats=MagicMock(return_value=db_stats),
+            _open_messages_db_conn=MagicMock(return_value=mock_conn),
+            INBOX_DIR=tmp_path / "inbox",
+            OUTBOX_DIR=tmp_path / "outbox",
+            PROCESSED_DIR=tmp_path / "processed",
+            PROCESSING_DIR=tmp_path / "processing",
+            FAILED_DIR=tmp_path / "failed",
+        ):
+            result = asyncio.run(handle_get_stats({}))
+
+        text = result[0].text
+        assert "messages.db Totals" in text
+        assert "42" in text  # total_messages
+
+    def test_omits_db_section_when_db_unavailable(self, tmp_path: Path):
+        """When DB is unavailable, stats output does not mention messages.db."""
+        from src.mcp.inbox_server import handle_get_stats
+
+        for d in ["inbox", "outbox", "processed", "processing", "failed"]:
+            (tmp_path / d).mkdir()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            _db_get_message_stats=None,
+            _open_messages_db_conn=MagicMock(return_value=None),
+            INBOX_DIR=tmp_path / "inbox",
+            OUTBOX_DIR=tmp_path / "outbox",
+            PROCESSED_DIR=tmp_path / "processed",
+            PROCESSING_DIR=tmp_path / "processing",
+            FAILED_DIR=tmp_path / "failed",
+        ):
+            result = asyncio.run(handle_get_stats({}))
+
+        text = result[0].text
+        assert "messages.db" not in text
+
+
+class TestHandleGetMessageByTelegramIdDbFirst:
+    """Tests for handle_get_message_by_telegram_id DB-first lookup."""
+
+    def test_returns_db_result_when_available(self, tmp_path: Path):
+        """Message found in DB is returned without hitting filesystem."""
+        from src.mcp.inbox_server import handle_get_message_by_telegram_id
+
+        db_msg = {
+            "id": "db-msg-1",
+            "telegram_message_id": 777,
+            "source": "telegram",
+            "chat_id": "111",
+            "timestamp": "2024-01-15T10:00:00+00:00",
+            "text": "Found in DB",
+            "type": "text",
+            "user_name": "Alice",
+            "username": "alice",
+            "reply_to": None,
+            "reply_to_message_id": None,
+            "image_file": None,
+            "file_path": None,
+            "audio_file": None,
+        }
+        mock_conn = MagicMock()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            _db_get_message_by_telegram_id_fn=MagicMock(return_value=db_msg),
+            _open_messages_db_conn=MagicMock(return_value=mock_conn),
+        ):
+            result = asyncio.run(
+                handle_get_message_by_telegram_id({"telegram_message_id": 777})
+            )
+
+        text = result[0].text
+        assert "Found in DB" in text
+        assert "messages.db" in text
+
+    def test_falls_back_to_filesystem_when_db_returns_none(self, tmp_path: Path):
+        """When DB returns None, filesystem scan is used."""
+        from src.mcp.inbox_server import handle_get_message_by_telegram_id
+
+        processed_dir = tmp_path / "processed"
+        processed_dir.mkdir()
+        msg = {
+            "id": "fs-msg-1",
+            "telegram_message_id": 888,
+            "source": "telegram",
+            "chat_id": "222",
+            "timestamp": "2024-01-15T10:00:00+00:00",
+            "text": "Found in filesystem",
+            "type": "text",
+            "user_name": "Bob",
+        }
+        (processed_dir / "fs-msg-1.json").write_text(json.dumps(msg))
+
+        mock_conn = MagicMock()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            _db_get_message_by_telegram_id_fn=MagicMock(return_value=None),
+            _open_messages_db_conn=MagicMock(return_value=mock_conn),
+            PROCESSED_DIR=processed_dir,
+            INBOX_DIR=tmp_path / "inbox",
+            PROCESSING_DIR=tmp_path / "processing",
+            FAILED_DIR=tmp_path / "failed",
+        ):
+            result = asyncio.run(
+                handle_get_message_by_telegram_id({"telegram_message_id": 888})
+            )
+
+        text = result[0].text
+        assert "Found in filesystem" in text
+
+    def test_returns_error_for_missing_tg_id_param(self):
+        """Returns error message when telegram_message_id is not provided."""
+        from src.mcp.inbox_server import handle_get_message_by_telegram_id
+
+        result = asyncio.run(handle_get_message_by_telegram_id({}))
+        assert "required" in result[0].text.lower()


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Implements BIS-164 (Slice 3 of BIS-159 — Bisque Chat: Message Persistence Architecture). This PR updates the relay/read path so that `inbox_server.py` serves message reads from `messages.db` instead of scanning JSON files on disk, while maintaining full filesystem fallback during the migration window.

- **`src/db/reader.py`** (new): Pure-functional read layer over messages.db. All public functions accept an injected `sqlite3.Connection` and return plain dicts — no ORM coupling. Uses FTS5 for keyword search with a LIKE fallback.
- **`src/mcp/inbox_server.py`** (updated): Three handlers are now DB-first:
  - `handle_get_conversation_history`: queries messages.db; falls back to filesystem when DB is unavailable or returns zero results
  - `handle_get_message_by_telegram_id`: DB-first lookup, filesystem fallback
  - `handle_get_stats`: augments filesystem counts with messages.db aggregate totals
  - Adds `_open_messages_db_conn()` helper (returns None gracefully) and `MESSAGES_DB_PATH` constant (overridable via `LOBSTER_MESSAGES_DB` env var)
- **`tests/conftest.py`**: Adds `MESSAGES_DB_PATH` to the path-isolation fixture so tests never touch the production database
- **`tests/unit/test_mcp_server/test_relay_db_reads.py`** (new): 50 tests covering all reader.py pure functions and the three updated MCP handlers (DB-first paths and filesystem fallback paths), using in-memory SQLite

## Key Functional Patterns Used

- **Pure functions with injected connections**: every `db.reader` function takes an explicit `sqlite3.Connection` — no globals, no hidden state, fully testable in isolation
- **Composable transformers**: `_row_to_dict → _merge_extra → _normalize_direction` form a pipeline applied to every result row
- **Graceful degradation**: DB reader is an optional import; `_open_messages_db_conn()` returns `None` when the database is unavailable, and all handlers fall through to the filesystem path
- **Dual-read mode**: DB-first with filesystem fallback ensures zero data loss during the migration window before all messages are backfilled

## Test Plan

- [x] 50 unit tests covering reader.py internals and handler integration
- [x] Tests verify DB-first path, filesystem fallback path, and edge cases (missing DB, None results, FTS5 unavailable)
- [x] All tests run against in-memory SQLite — no on-disk state required
- [x] `python3 -m py_compile` passes on both `src/db/reader.py` and `src/mcp/inbox_server.py`

## Notes

Targets `feat/bis159-slice1-messages-db` (not `main`) because the messages.db schema is not yet merged. This PR stacks cleanly on top of Slice 1.

Closes BIS-164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)