### PR TITLE
fix: silent-drop scheduled job no-op results to prevent dispatcher stall

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -307,6 +307,18 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
        # Subagent already called send_reply — nothing to deliver
        mark_processed(message_id)
    else:
+       # --- SILENT DROP: scheduled job no-op results ---
+       # If task_id starts with "scheduled-job-" AND text signals nothing happened,
+       # drop immediately without relaying. Do not deliberate — if in doubt, drop it.
+       # These are routine background poll results; only relay when there is actionable content.
+       NOOP_PHRASES = ["no action taken", "nothing to do", "no new", "no findings", "nothing to report"]
+       is_scheduled_job = str(msg.get("task_id", "")).startswith("scheduled-job-")
+       text_lower = msg.get("text", "").lower()
+       is_noop = any(phrase in text_lower for phrase in NOOP_PHRASES)
+       if is_scheduled_job and is_noop:
+           mark_processed(message_id)
+           continue  # Return to wait_for_messages() — nothing to relay
+       # --- END SILENT DROP ---
        # Check if this is an engineer briefing (contains a GitHub PR URL)
        pr_url_match = re.search(r"https://github\.com/.*/pull/\d+", msg["text"])
        if pr_url_match and msg.get("sent_reply_to_user") != True:


### PR DESCRIPTION
## Problem

Scheduled job pollers (e.g. `lobster-plans-poller`) periodically return results like "No new comments from sayhar on awaiting-decision issues. No action taken." When nothing actionable was found, these results should be silently discarded — they are routine background noise, not user-relevant events.

Before this fix, no rule in the `subagent_result` handler addressed this case. The dispatcher entered inference deliberation for 611 seconds deciding whether to relay such a result, exceeding the health check's >600s WFM freshness threshold and triggering an unnecessary restart.

## What changed

A silent-drop guard is added at the top of the `subagent_result` handler's `else` branch (before the PR URL check), so it short-circuits immediately:

- If `task_id` starts with `"scheduled-job-"` **and** the result text contains any no-op phrase (`"no action taken"`, `"nothing to do"`, `"no new"`, `"no findings"`, `"nothing to report"`) → `mark_processed` and `continue`. No `send_reply`. No deliberation.
- The rule is explicit: "if in doubt, drop it" — forcing fast exit rather than inference.

Everything else in the handler (PR URL routing, artifact relay, `subagent_error` path) is untouched.

## Flow change

```
Before:
  subagent_result arrives (task_id: scheduled-job-X, text: "No new comments...")
    → sent_reply_to_user? No
    → PR URL? No
    → else: ??? (dispatcher deliberates 600s) → maybe send_reply → restart

After:
  subagent_result arrives (task_id: scheduled-job-X, text: "No new comments...")
    → sent_reply_to_user? No
    → is_scheduled_job AND is_noop? Yes → mark_processed, continue  ← exits here
    → (PR URL check and relay logic never reached)
```

## Functional patterns

Pure predicate logic (`startswith` + `any(phrase in text_lower)`) evaluated as a boolean guard. No side effects in the check; the only action is `mark_processed` + `continue`.

## Tests run

- [ ] Live dispatcher test — blocked: requires production restart (file change is live via symlink once merged, but triggering a no-op poll result requires production environment). No behavior change for actionable results; safe to merge.

Closes #769