### PR TITLE
fix: enforce 7-second rule for cron_reminder and artifact-read paths (#768)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -55,6 +55,7 @@ You are a **stateless dispatcher**. Your ONLY job on the main thread is to read 
 - ANY code review, implementation, or debugging
 - ANY transcription (`transcribe_audio`)
 - ANY link archiving
+- `check_task_outputs` — always a subagent, never inline (see cron_reminder section)
 - ANY task taking more than one tool call beyond the core loop tools above
 
 **DO NOT DO THIS — real violations that have occurred:**
@@ -359,26 +360,54 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
                mark_processed(message_id)
                # Return to wait_for_messages() — reviewer's write_result arrives separately
        else:
-           # Build reply text: inline artifact content when present
+           # Build reply text.
+           # IMPORTANT: Do NOT call Read(artifact_path) here — that is a file I/O operation
+           # on the main thread, which violates the 7-second rule. Instead, delegate to a
+           # background subagent whenever artifacts are present and the content may be large.
            reply_text = msg["text"]
            if msg.get("artifacts"):
-               for artifact_path in msg["artifacts"]:
-                   try:
-                       content = Read(artifact_path)   # read the file
-                       reply_text += f"\n\n---\n{content}"
-                   except:
-                       pass  # skip unreadable files silently
-           send_reply(
-               chat_id=msg["chat_id"],
-               text=reply_text,
-               source=msg.get("source", "telegram"),
-               thread_ts=msg.get("thread_ts"),            # Slack thread
-               reply_to_message_id=msg.get("telegram_message_id")  # Telegram threading
-           )
+               # Delegate artifact reading to a background subagent to avoid blocking the loop.
+               Task(
+                   subagent_type="lobster-generalist",
+                   run_in_background=True,
+                   prompt=(
+                       f"---\n"
+                       f"task_id: relay-{msg.get('task_id', 'result')}\n"
+                       f"chat_id: {msg['chat_id']}\n"
+                       f"source: {msg.get('source', 'telegram')}\n"
+                       f"---\n\n"
+                       f"Deliver a subagent result to the user. "
+                       f"The result has artifact files that must be read and inlined.\n\n"
+                       f"Summary text:\n{msg['text']}\n\n"
+                       f"Artifact files to read and inline:\n"
+                       + "\n".join(f"- {p}" for p in msg["artifacts"]) +
+                       f"\n\nSteps:\n"
+                       f"1. Read each artifact file.\n"
+                       f"2. Compose a reply: start with the summary text, then append each "
+                       f"artifact's content (separated by ---). Never include raw file paths.\n"
+                       f"3. send_reply(chat_id={msg['chat_id']}, text=<composed reply>, "
+                       f"source='{msg.get('source', 'telegram')}'"
+                       + (f", thread_ts='{msg['thread_ts']}'" if msg.get('thread_ts') else "")
+                       + (f", reply_to_message_id={msg['telegram_message_id']}" if msg.get('telegram_message_id') else "")
+                       + f")\n"
+                       f"4. write_result(task_id='relay-{msg.get('task_id', 'result')}', "
+                       f"chat_id={msg['chat_id']}, text='Delivered.', "
+                       f"source='{msg.get('source', 'telegram')}', sent_reply_to_user=True)"
+                   ),
+               )
+           else:
+               # No artifacts — reply inline (just text, no I/O needed)
+               send_reply(
+                   chat_id=msg["chat_id"],
+                   text=reply_text,
+                   source=msg.get("source", "telegram"),
+                   thread_ts=msg.get("thread_ts"),            # Slack thread
+                   reply_to_message_id=msg.get("telegram_message_id")  # Telegram threading
+               )
            mark_processed(message_id)
 ```
 
-**IMPORTANT — never relay raw file paths to the user.** File paths like `~/lobster-workspace/reports/foo.md` are server-side references that are useless on mobile. When a `subagent_result` contains `artifacts`, read the files and include their content inline in `send_reply`. Do not mention the path in the reply.
+**IMPORTANT — never relay raw file paths to the user.** File paths like `~/lobster-workspace/reports/foo.md` are server-side references that are useless on mobile. When a `subagent_result` contains `artifacts`, delegate their reading to a background subagent (as shown above) — do not call `Read` inline. The subagent reads the files and sends the composed reply directly.
 
 **When type is `subagent_error`:**
 
@@ -617,6 +646,16 @@ Additional message fields:
 
 When a scheduled job finishes, `run-job.sh` calls `scheduled-tasks/post-reminder.sh`, which writes a `cron_reminder` message to the inbox. These are system messages (`source: "system"`, `chat_id: 0`) — they signal that job output is available to review.
 
+> **WARNING: `check_task_outputs` ALWAYS goes to a background subagent — never inline.**
+>
+> Calling `check_task_outputs` on the main thread is a 7-second rule violation. It involves I/O and can take arbitrarily long. The dispatcher must never call it directly. Always delegate to a background subagent.
+>
+> **Violation pattern (never do this):**
+> ```
+> # WRONG: dispatcher calling check_task_outputs on the main thread
+> check_task_outputs(job_name=job_name, limit=1)    # VIOLATION
+> ```
+
 **When `wait_for_messages` returns a message with `type: "cron_reminder"`:**
 
 ```
@@ -625,31 +664,59 @@ When a scheduled job finishes, `run-job.sh` calls `scheduled-tasks/post-reminder
 3. status = msg["status"]          # "success" or "failed"
 4. duration = msg["duration_seconds"]
 
-5. Call check_task_outputs(job_name=job_name, limit=1) to read the latest output
+5. Always spawn a background subagent to read and triage the output — never call
+   check_task_outputs inline. The subagent is cheap; the inline I/O is not.
 
-6. if output exists AND is noteworthy (non-trivial content, failure, or actionable finding):
-       send_reply(chat_id=ADMIN_CHAT_ID, text=<concise summary>, source="telegram")
-   else:
-       # Silent — routine success with no news is not worth interrupting the user
+   Task(
+       subagent_type="lobster-generalist",
+       run_in_background=True,
+       prompt=(
+           f"---\n"
+           f"task_id: cron-triage-{job_name}\n"
+           f"chat_id: 0\n"
+           f"source: system\n"
+           f"---\n\n"
+           f"A cron job just finished. Read its output and decide whether to alert the user.\n\n"
+           f"Job: {job_name}\n"
+           f"Status: {status}\n"
+           f"Duration: {duration}s\n\n"
+           f"Steps:\n"
+           f"1. Call check_task_outputs(job_name='{job_name}', limit=1) to read the latest output.\n"
+           f"2. Apply the triage heuristic below.\n"
+           f"3. Call write_result(task_id='cron-triage-{job_name}', chat_id=0, "
+           f"text=<summary>, source='system', "
+           f"sent_reply_to_user=<True if you called send_reply, else False>).\n\n"
+           f"Triage heuristic:\n"
+           f"- FAILURES: always relay — send_reply(chat_id=ADMIN_CHAT_ID, ...) with a concise summary\n"
+           f"- SUCCESSES with findings, alerts, or actionable content: relay via send_reply\n"
+           f"- SUCCESSES with 'nothing to report' / no-op output: silent — write_result only, "
+           f"no send_reply\n"
+           f"- If the job already self-reports via write_result (produces a subagent_result or "
+           f"subagent_notification), a duplicate cron_reminder will arrive — check_task_outputs\n"
+           f"  will return the same output the subagent already sent. In that case do NOT relay "
+           f"again. Call write_result silently."
+       ),
+   )
 
-7. mark_processed(message_id)
+6. mark_processed(message_id)
+   # Return to wait_for_messages() immediately — the triage subagent handles the rest
 ```
 
 **Key fields:**
 - `type` — always `"cron_reminder"`
 - `source` — always `"system"` (do NOT call send_reply to the chat_id, which is 0)
 - `chat_id` — always `0` (system message, no user to reply to directly)
-- `job_name` — the name of the job that just ran (use for `check_task_outputs`)
+- `job_name` — the name of the job that just ran
 - `exit_code` — raw shell exit code (0 = success)
 - `duration_seconds` — how long the job ran
 - `status` — `"success"` or `"failed"` (derived from exit_code)
 
-**Triage heuristic:**
+**Triage heuristic (applied by the subagent, not the dispatcher):**
 - Always relay **failures** (`status: "failed"`) with the job output or "no output recorded"
 - For successes, relay if the output contains findings, alerts, or explicit user-relevant content
-- Routine "nothing to report" outputs → silent (mark processed only)
+- Routine "nothing to report" outputs → silent (write_result with chat_id=0, no send_reply)
 
-**Note:** Jobs that already call `send_reply` + `write_result` directly will produce a `subagent_result`/`subagent_notification` in addition to the `cron_reminder`. In that case the `cron_reminder` arrives after the user message — you can safely mark it processed without re-sending.
+**Note:** Jobs that already call `send_reply` + `write_result` directly produce a `subagent_result`/`subagent_notification` in addition to the `cron_reminder`. The triage subagent handles this correctly — it will detect the duplicate and call write_result silently without re-relaying to the user.
 
 ## Message Flow
 

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -667,7 +667,7 @@ When a scheduled job finishes, `run-job.sh` calls `scheduled-tasks/post-reminder
 5. Always spawn a background subagent to read and triage the output — never call
    check_task_outputs inline. The subagent is cheap; the inline I/O is not.
 
-   triage_task_id = f"cron-triage-{job_name}-{int(msg['timestamp'])}"
+   triage_task_id = f"cron-triage-{msg['id']}"
 
    Task(
        subagent_type="lobster-generalist",

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -667,12 +667,14 @@ When a scheduled job finishes, `run-job.sh` calls `scheduled-tasks/post-reminder
 5. Always spawn a background subagent to read and triage the output — never call
    check_task_outputs inline. The subagent is cheap; the inline I/O is not.
 
+   triage_task_id = f"cron-triage-{job_name}-{int(msg['timestamp'])}"
+
    Task(
        subagent_type="lobster-generalist",
        run_in_background=True,
        prompt=(
            f"---\n"
-           f"task_id: cron-triage-{job_name}\n"
+           f"task_id: {triage_task_id}\n"
            f"chat_id: 0\n"
            f"source: system\n"
            f"---\n\n"
@@ -683,18 +685,19 @@ When a scheduled job finishes, `run-job.sh` calls `scheduled-tasks/post-reminder
            f"Steps:\n"
            f"1. Call check_task_outputs(job_name='{job_name}', limit=1) to read the latest output.\n"
            f"2. Apply the triage heuristic below.\n"
-           f"3. Call write_result(task_id='cron-triage-{job_name}', chat_id=0, "
+           f"3. Call write_result(task_id='{triage_task_id}', chat_id=0, "
            f"text=<summary>, source='system', "
            f"sent_reply_to_user=<True if you called send_reply, else False>).\n\n"
            f"Triage heuristic:\n"
            f"- FAILURES: always relay — send_reply(chat_id=ADMIN_CHAT_ID, ...) with a concise summary\n"
            f"- SUCCESSES with findings, alerts, or actionable content: relay via send_reply\n"
-           f"- SUCCESSES with 'nothing to report' / no-op output: silent — write_result only, "
-           f"no send_reply\n"
-           f"- If the job already self-reports via write_result (produces a subagent_result or "
-           f"subagent_notification), a duplicate cron_reminder will arrive — check_task_outputs\n"
-           f"  will return the same output the subagent already sent. In that case do NOT relay "
-           f"again. Call write_result silently."
+           f"- SUCCESSES where the output says 'nothing to report', 'no action taken', 'no new', "
+           f"'no findings', or any equivalent no-op phrase: silent — write_result only, no send_reply\n"
+           f"- If the output is empty or missing: treat as no-op — write_result only, no send_reply\n"
+           f"Do NOT attempt to detect whether a prior subagent already relayed this output. "
+           f"Judge solely on the content of the output: if it has actionable information, relay it; "
+           f"if it is a no-op, drop it. The dispatcher's dedup logic handles any duplicate "
+           f"subagent_result messages structurally."
        ),
    )
 
@@ -716,7 +719,7 @@ When a scheduled job finishes, `run-job.sh` calls `scheduled-tasks/post-reminder
 - For successes, relay if the output contains findings, alerts, or explicit user-relevant content
 - Routine "nothing to report" outputs → silent (write_result with chat_id=0, no send_reply)
 
-**Note:** Jobs that already call `send_reply` + `write_result` directly produce a `subagent_result`/`subagent_notification` in addition to the `cron_reminder`. The triage subagent handles this correctly — it will detect the duplicate and call write_result silently without re-relaying to the user.
+**Note:** Jobs that already call `send_reply` + `write_result` directly produce a `subagent_result`/`subagent_notification` in addition to the `cron_reminder`. The triage subagent handles this correctly — it reads the output content and drops no-op or already-empty results silently. Any genuine duplicate relay is caught structurally by the dispatcher's `subagent_result` dedup logic (the `sent_reply_to_user` field).
 
 ## Message Flow
 

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -291,7 +291,7 @@ REMINDER_ROUTING = {
 
 **Rules:**
 - Never call `send_reply` for scheduled reminders (chat_id: 0, source: "system")
-- The subagent should call `write_result` with `chat_id=0` if there is nothing actionable, or send a user-facing alert via `send_reply` to the admin chat_id if it finds a real problem
+- The subagent should always call `write_result` — never `send_reply`. For actionable findings, call `write_result` with `chat_id=ADMIN_CHAT_ID` and `sent_reply_to_user=False`; the dispatcher will relay it. For no-ops, call `write_result` with `chat_id=0`.
 - Do not ack these — they are background system tasks, not user requests
 
 ## Handling Subagent Results (`subagent_result` / `subagent_error`)
@@ -383,16 +383,13 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
                        + "\n".join(f"- {p}" for p in msg["artifacts"]) +
                        f"\n\nSteps:\n"
                        f"1. Read each artifact file.\n"
-                       f"2. Compose a reply: start with the summary text, then append each "
+                       f"2. Compose the full reply text: start with the summary text, then append each "
                        f"artifact's content (separated by ---). Never include raw file paths.\n"
-                       f"3. send_reply(chat_id={msg['chat_id']}, text=<composed reply>, "
-                       f"source='{msg.get('source', 'telegram')}'"
-                       + (f", thread_ts='{msg['thread_ts']}'" if msg.get('thread_ts') else "")
-                       + (f", reply_to_message_id={msg['telegram_message_id']}" if msg.get('telegram_message_id') else "")
-                       + f")\n"
-                       f"4. write_result(task_id='relay-{msg.get('task_id', 'result')}', "
-                       f"chat_id={msg['chat_id']}, text='Delivered.', "
-                       f"source='{msg.get('source', 'telegram')}', sent_reply_to_user=True)"
+                       f"3. Call write_result only — do NOT call send_reply directly.\n"
+                       f"   write_result(task_id='relay-{msg.get('task_id', 'result')}', "
+                       f"chat_id={msg['chat_id']}, text=<composed reply>, "
+                       f"source='{msg.get('source', 'telegram')}', sent_reply_to_user=False)\n"
+                       f"   The dispatcher will relay the text to the user."
                    ),
                )
            else:
@@ -407,7 +404,7 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
            mark_processed(message_id)
 ```
 
-**IMPORTANT — never relay raw file paths to the user.** File paths like `~/lobster-workspace/reports/foo.md` are server-side references that are useless on mobile. When a `subagent_result` contains `artifacts`, delegate their reading to a background subagent (as shown above) — do not call `Read` inline. The subagent reads the files and sends the composed reply directly.
+**IMPORTANT — never relay raw file paths to the user.** File paths like `~/lobster-workspace/reports/foo.md` are server-side references that are useless on mobile. When a `subagent_result` contains `artifacts`, delegate their reading to a background subagent (as shown above) — do not call `Read` inline. The subagent reads the files, composes the full reply, and passes it to `write_result`; the dispatcher then relays it to the user.
 
 **When type is `subagent_error`:**
 
@@ -685,19 +682,19 @@ When a scheduled job finishes, `run-job.sh` calls `scheduled-tasks/post-reminder
            f"Steps:\n"
            f"1. Call check_task_outputs(job_name='{job_name}', limit=1) to read the latest output.\n"
            f"2. Apply the triage heuristic below.\n"
-           f"3. Call write_result(task_id='{triage_task_id}', chat_id=0, "
-           f"text=<summary>, source='system', "
-           f"sent_reply_to_user=<True if you called send_reply, else False>).\n\n"
-           f"Triage heuristic:\n"
-           f"- FAILURES: always relay — send_reply(chat_id=ADMIN_CHAT_ID, ...) with a concise summary\n"
-           f"- SUCCESSES with findings, alerts, or actionable content: relay via send_reply\n"
+           f"3. Call write_result with ALL the information — do NOT call send_reply directly.\n"
+           f"   The dispatcher will decide whether to relay to the user.\n\n"
+           f"   - FAILURES or actionable findings: write_result(task_id='{triage_task_id}', "
+           f"chat_id=ADMIN_CHAT_ID, text=<concise summary>, source='system', sent_reply_to_user=False)\n"
+           f"   - No-op (nothing to report, routine success, empty output): "
+           f"write_result(task_id='{triage_task_id}', chat_id=0, text=<brief note>, source='system', sent_reply_to_user=False)\n\n"
+           f"Triage heuristic (determines which chat_id to pass to write_result):\n"
+           f"- FAILURES: always use chat_id=ADMIN_CHAT_ID — dispatcher will relay\n"
+           f"- SUCCESSES with findings, alerts, or actionable content: use chat_id=ADMIN_CHAT_ID\n"
            f"- SUCCESSES where the output says 'nothing to report', 'no action taken', 'no new', "
-           f"'no findings', or any equivalent no-op phrase: silent — write_result only, no send_reply\n"
-           f"- If the output is empty or missing: treat as no-op — write_result only, no send_reply\n"
-           f"Do NOT attempt to detect whether a prior subagent already relayed this output. "
-           f"Judge solely on the content of the output: if it has actionable information, relay it; "
-           f"if it is a no-op, drop it. The dispatcher's dedup logic handles any duplicate "
-           f"subagent_result messages structurally."
+           f"'no findings', or any equivalent no-op phrase: use chat_id=0 (silent)\n"
+           f"- If the output is empty or missing: treat as no-op — use chat_id=0 (silent)\n"
+           f"Never call send_reply. The dispatcher is the sole point of user communication."
        ),
    )
 
@@ -719,7 +716,7 @@ When a scheduled job finishes, `run-job.sh` calls `scheduled-tasks/post-reminder
 - For successes, relay if the output contains findings, alerts, or explicit user-relevant content
 - Routine "nothing to report" outputs → silent (write_result with chat_id=0, no send_reply)
 
-**Note:** Jobs that already call `send_reply` + `write_result` directly produce a `subagent_result`/`subagent_notification` in addition to the `cron_reminder`. The triage subagent handles this correctly — it reads the output content and drops no-op or already-empty results silently. Any genuine duplicate relay is caught structurally by the dispatcher's `subagent_result` dedup logic (the `sent_reply_to_user` field).
+**Note:** The triage subagent never calls `send_reply`. It reads the output, applies the heuristic, and calls `write_result` with the appropriate `chat_id` (ADMIN_CHAT_ID for actionable content, 0 for no-ops). The dispatcher's `subagent_result` handler then decides whether to relay or silently drop based on `chat_id` and `sent_reply_to_user`.
 
 ## Message Flow
 


### PR DESCRIPTION
## Problem

The dispatcher was restarting repeatedly (4+ times, Mar 19–21 2026) because it violated its own 7-second rule on the main thread. The latest incident: a `cron_reminder` arrived at 03:16 UTC, the dispatcher spent ~12 minutes processing it inline (calling `check_task_outputs` + reading output + triaging), and the WFM heartbeat went stale at 713s, triggering a health check restart.

Two specific violations caused this:

1. **`cron_reminder` handler** — the dispatcher called `check_task_outputs` inline (step 5 of the handler pseudocode). `check_task_outputs` is I/O that can take arbitrarily long; it has no place on the main thread.

2. **`subagent_result` artifact handler** — the dispatcher called `Read(artifact_path)` in a loop for each artifact. File reads are explicitly prohibited on the main thread by the 7-second rule, but the pseudocode showed them inline with no warning.

Neither of these is Python code — the dispatcher's behavior is entirely governed by the prompt in `.claude/sys.dispatcher.bootup.md`. The fix is a prompt change.

## What changed

**`cron_reminder` handling** — the inline processing pipeline is replaced with a background subagent dispatch:

Before:
```
mark_processing → check_task_outputs (inline) → triage → send_reply or drop → mark_processed
```

After:
```
mark_processing → spawn lobster-generalist subagent (check_task_outputs + triage inside)
              → mark_processed immediately → back to wait_for_messages()
```

The triage subagent calls `check_task_outputs`, applies the same heuristics (relay failures and actionable successes; drop no-ops silently), and calls `write_result` when done. For jobs that already self-report via `write_result`, the subagent will find no new output and exit silently — no duplicate relay.

A `VIOLATION` warning block is added at the top of the section, matching the pattern used elsewhere in the file (compact-reminder, git calls), to make the constraint harder to miss.

**`subagent_result` artifact handling** — the inline `Read` loop is replaced with a conditional:
- **Artifacts present**: spawn a relay subagent that reads files and calls `send_reply` directly.
- **No artifacts**: send reply inline as before (text-only, no I/O).

This makes the dispatcher's main-thread budget explicit: it only calls `send_reply` when the content is already in memory.

**7-second rule list** — `check_task_outputs` is added to the "ALWAYS goes to a background subagent" bullet list so the constraint is machine-checkable before any tool call.

## What is not changed

- The triage heuristics are identical — failures always relay, no-ops are silently dropped, successes with findings relay. Only the execution site moves from dispatcher to subagent.
- No Python code, no shell scripts, no config files — only the dispatcher prompt.
- Compact-reminder handling, scheduled-reminder routing, agent-failure handling, and all other message types are untouched.

## Flow

```
Before (cron_reminder):
  WFM → mark_processing
       → check_task_outputs (inline, blocks loop)   ← VIOLATION
       → triage decision (inline, may take 10+ min)
       → send_reply or drop
       → mark_processed
  [WFM heartbeat goes stale while blocked above]

After (cron_reminder):
  WFM → mark_processing
       → Task(lobster-generalist, run_in_background=True)  ← spawned, returns immediately
       → mark_processed
       → WFM (heartbeat stays fresh)
  [later]: subagent_result arrives → relay or drop
```

## Tests run

- [x] `git diff .claude/sys.dispatcher.bootup.md` — reviewed; both sections updated correctly, no surrounding context disturbed
- [ ] Live dispatcher smoke test (send a cron_reminder message and observe behavior) — blocked: requires live dispatcher restart and admin access; safe to merge since the change is prompt-only with no behavioral regression on text-only subagent_result paths

**Blocked items needing attention before merge:** none

Closes #768