### PR TITLE
[Librarian] fix: remove reaction allowlist and add auto-ack for emoji reactions

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -1043,7 +1043,7 @@ async def _emit_reaction_signal(
         try:
             await bot_app.bot.send_message(
                 chat_id=chat_id,
-                text=f"Reaction received: {emoji}",
+                text="📨 Message received. Processing...",
             )
         except Exception as e:
             log.warning(f"Failed to send reaction ack: {e}")


### PR DESCRIPTION
## What this PR does

The REACTION_SIGNALS removal and auto-ack addition were already merged to main via #665 (commit `aeb2b70`). That merged commit used `f"Reaction received: {emoji}"` as the ack text for the final commit in a multi-commit squash.

This PR changes the reaction ack text from the emoji-specific `f"Reaction received: {emoji}"` to the generic `"📨 Message received. Processing..."` — making it consistent with the ack text used for text and image messages.

**Single-line diff:** `src/bot/lobster_bot.py`, line ~1046, in `_emit_reaction_signal`.

## What is NOT in this PR

- REACTION_SIGNALS removal — already on main (`aeb2b70`)
- Auto-ack mechanism — already on main (`aeb2b70`)
- No changes to tests, dispatcher docs, or inbox JSON structure

## Tests run

- [x] `uv run pytest tests/unit/test_bot/test_reaction_handling.py -v` — 13 passed, 0 failed

No test asserts on the ack text string itself, so no test update is needed.

Closes #664 (if not already closed by #665).

🤖 Generated with [Claude Code](https://claude.com/claude-code)