### PR TITLE
docs: update directory structure to reflect current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,10 +235,9 @@ Reactions arrive as inbox messages with `type: "reaction"` and include the raw e
 │   ├── bot/lobster_bot.py     # Telegram bot
 │   ├── mcp/inbox_server.py    # MCP server
 │   └── cli                    # CLI tool
-├── scripts/
+├── scripts/                   # 30+ utility scripts for operations
 │   └── claude-wrapper.exp     # Expect script for Claude startup
 ├── scheduled-tasks/           # Scheduled jobs system
-│   ├── jobs.json              # Job registry
 │   ├── tasks/                 # Task markdown files
 │   ├── logs/                  # Execution logs
 │   ├── run-job.sh             # Task executor
@@ -256,6 +255,8 @@ Reactions arrive as inbox messages with `type: "reaction"` and include the raw e
 
 ~/lobster-workspace/           # Claude workspace (the brain)
 ├── CLAUDE.md                  # System context
+├── scheduled-jobs/            # Scheduled job configuration
+│   └── jobs.json              # Job registry
 ├── projects/                  # All Lobster-managed projects
 │   └── [project-name]/        # Each project in its own directory
 └── logs/                      # Log files
@@ -417,8 +418,8 @@ Manual control:
 sudo systemctl status lobster-router
 sudo systemctl status lobster-slack-router  # if Slack enabled
 sudo systemctl status lobster-claude
-tmux -L lobster list-sessions          # Check tmux session
-lobster attach                          # Attach to Claude session
+tmux -L lobster list-sessions              # Check tmux session
+lobster attach                              # Attach to Claude session
 ```
 
 ## Upgrading
@@ -431,12 +432,9 @@ git pull origin main
 ./install.sh
 ```
 
-The installer is idempotent — it updates scripts and services without touching
-your existing config, tokens, or message history.
+The installer is idempotent — it updates scripts and services without touching your existing config, tokens, or message history.
 
-For a full step-by-step guide including lobster-watcher redeployment, DB
-migration verification, and rollback instructions, see
-[docs/upgrading.md](docs/upgrading.md).
+For a full step-by-step guide including lobster-watcher redeployment, DB migration verification, and rollback instructions, see [docs/upgrading.md](docs/upgrading.md).
 
 ## Slack Integration
 
@@ -444,8 +442,8 @@ To add Slack as a message source, see [docs/SLACK-SETUP.md](docs/SLACK-SETUP.md)
 
 ## Security
 
-- 🔐 Bot restricted to allowed user IDs only
-- 🔒 Credentials stored in config.env (gitignored)
+- 🔒 Bot restricted to allowed user IDs only
+- 🔐 Credentials stored in config.env (gitignored)
 - 🛡️ No hardcoded secrets in code
 - 🦞 Hard shell, soft on the inside
 


### PR DESCRIPTION
## Summary

This PR updates the README directory structure to accurately reflect the current state of the Lobster project.

## Changes

### Repository Structure (`~/lobster/`)

1. **Removed** `scheduled-tasks/jobs.json` 
   - This file does not exist in the repository
   - Only exists in `~/lobster-workspace/scheduled-jobs/jobs.json`

2. **Updated** `scripts/` description
   - Old: Only listed `claude-wrapper.exp`
   - New: Mention "30+ utility scripts for operations"
   - Reflects actual state (37 scripts as of this writing)

### Workspace Structure (`~/lobster-workspace/`)

1. **Added** `scheduled-jobs/jobs.json`
   - Job registry lives in workspace, not repository
   - Matches actual implementation

## Rationale

The README directory tree was outdated and did not reflect the current project structure:

- `jobs.json` is a runtime configuration file that belongs in the workspace, not in version control
- The `scripts/` directory has grown significantly (30+ scripts) but README only mentioned one

## Testing

- ✅ Verified `scheduled-tasks/` contents (no `jobs.json`)
- ✅ Counted `scripts/` files (37 scripts)
- ✅ Reviewed workspace structure documentation

## Related Issue

Fixes #777

## Checklist

- [x] Documentation only change (no code changes)
- [x] Accurately reflects current project structure
- [x] Clear and concise description
- [x] Follows project documentation style