### PR TITLE
fix(install): default to git clone, add GitHub token prompt, improve post-install guidance

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,12 +38,21 @@ error() { echo -e "${RED}[ERROR]${NC} $1"; }
 step() { echo -e "\n${CYAN}${BOLD}▶ $1${NC}"; }
 
 # Parse install mode from arguments
-DEV_MODE=false  # accepted for backwards compat; git clone is now the default for all fresh installs
+#
+# Flags:
+#   (default)         git clone from main — always current
+#   --stable          download latest GitHub release tarball (pinned, reproducible)
+#   --dev             git clone from main + write LOBSTER_DEBUG=true to config.env
+#   --non-interactive skip interactive prompts (CI / Docker)
+#   --container-setup implies --non-interactive; for container-specific setup
+DEV_MODE=false
+STABLE_MODE=false
 NON_INTERACTIVE=false
 CONTAINER_SETUP=false
 for arg in "$@"; do
     case "$arg" in
-        --dev) DEV_MODE=true ;;  # no-op: same as default (git clone); kept for script compatibility
+        --dev) DEV_MODE=true ;;
+        --stable) STABLE_MODE=true ;;
         --non-interactive|--skip-config) NON_INTERACTIVE=true ;;
         --container-setup)
             CONTAINER_SETUP=true
@@ -504,9 +513,9 @@ if ! sudo true 2>/dev/null; then
 fi
 success "Sudo access confirmed"
 
-# Check internet (skip when source is already present — dev mode, existing install, or
+# Check internet (skip when source is already present — existing install, or
 # pre-copied source in non-interactive mode, matching the git clone skip condition).
-if [ -d "$INSTALL_DIR/.git" ] || $DEV_MODE || { [ -f "$INSTALL_DIR/install.sh" ] && [ "$NON_INTERACTIVE" = true ]; }; then
+if [ -d "$INSTALL_DIR/.git" ] || { [ -f "$INSTALL_DIR/install.sh" ] && [ "$NON_INTERACTIVE" = true ]; }; then
     info "Skipping internet check (source already present)"
 elif ! curl -s --connect-timeout 5 https://api.github.com >/dev/null; then
     error "No internet connection (required for fresh install)"
@@ -868,18 +877,27 @@ fi
 # Install Lobster Code
 #===============================================================================
 
-# Detect install mode: --dev flag, existing .git, or git clone (default)
-# Tarball is kept as a last-resort fallback only when git is not available.
+# Detect install mode.
+#
+# Priority:
+#   1. Existing .git dir       → git update (always wins; no flag can override an existing repo)
+#   2. --stable flag           → tarball of the latest GitHub release (opt-in, pinned)
+#   3. default / --dev flag    → git clone from main (always current)
+#   4. git not available       → tarball fallback (last resort)
+#
 # See: https://github.com/SiderealPress/lobster/issues/787
 if [ -d "$INSTALL_DIR/.git" ]; then
     INSTALL_MODE="git"
     info "Existing git install detected"
+elif $STABLE_MODE; then
+    INSTALL_MODE="tarball"
+    info "Stable mode: using latest release tarball"
 else
-    # Both --dev mode and fresh installs use git clone when available
+    # Default and --dev: git clone when available
     if command -v git >/dev/null 2>&1; then
         INSTALL_MODE="git"
         if $DEV_MODE; then
-            info "Developer mode: using git clone"
+            info "Developer mode: using git clone (LOBSTER_DEBUG will be enabled)"
         else
             info "Fresh install: using git clone from main (always current)"
         fi
@@ -2143,6 +2161,26 @@ if [ -f "$CONFIG_FILE" ]; then
     else
         success "LOBSTER_INTERNAL_SECRET already set"
     fi
+fi
+
+#===============================================================================
+# Developer Mode: Enable LOBSTER_DEBUG
+#===============================================================================
+
+if $DEV_MODE && [ -f "$CONFIG_FILE" ]; then
+    step "Developer mode: enabling LOBSTER_DEBUG..."
+    # Remove any existing LOBSTER_DEBUG line (set or commented), then append the live value.
+    # This is idempotent — safe to run on reinstall.
+    if grep -q "^#\{0,1\}LOBSTER_DEBUG=" "$CONFIG_FILE" 2>/dev/null; then
+        # Replace in-place using a temp file (sed -i is not portable across macOS/Linux)
+        TMP_CONFIG=$(mktemp)
+        grep -v "^#\{0,1\}LOBSTER_DEBUG=" "$CONFIG_FILE" > "$TMP_CONFIG"
+        mv "$TMP_CONFIG" "$CONFIG_FILE"
+    fi
+    echo "" >> "$CONFIG_FILE"
+    echo "# Enabled by --dev flag at install time" >> "$CONFIG_FILE"
+    echo "LOBSTER_DEBUG=true" >> "$CONFIG_FILE"
+    success "LOBSTER_DEBUG=true written to $CONFIG_FILE"
 fi
 
 #===============================================================================

--- a/install.sh
+++ b/install.sh
@@ -2101,8 +2101,10 @@ if [ -z "${GITHUB_TOKEN:-}" ] || [ "$GITHUB_TOKEN" = "your_github_pat_here" ]; t
         if [ -n "$GH_TOKEN" ]; then
             # Write to global.env, replacing any existing GITHUB_TOKEN line (commented or not)
             if grep -q "^#\? *GITHUB_TOKEN=" "$GLOBAL_ENV_FILE" 2>/dev/null; then
-                awk -v token="$GH_TOKEN" \
-                    '/^#? *GITHUB_TOKEN=/ { print "GITHUB_TOKEN=" token; next } { print }' \
+                # Use ENVIRON to avoid backslash mangling that -v causes with tokens
+                # containing backslash sequences (e.g. \n, \t in a PAT value).
+                GH_TOKEN="$GH_TOKEN" awk \
+                    '/^#? *GITHUB_TOKEN=/ { print "GITHUB_TOKEN=" ENVIRON["GH_TOKEN"]; next } { print }' \
                     "$GLOBAL_ENV_FILE" > "$GLOBAL_ENV_FILE.tmp" && mv "$GLOBAL_ENV_FILE.tmp" "$GLOBAL_ENV_FILE"
             else
                 printf '\nGITHUB_TOKEN=%s\n' "$GH_TOKEN" >> "$GLOBAL_ENV_FILE"

--- a/install.sh
+++ b/install.sh
@@ -38,12 +38,10 @@ error() { echo -e "${RED}[ERROR]${NC} $1"; }
 step() { echo -e "\n${CYAN}${BOLD}▶ $1${NC}"; }
 
 # Parse install mode from arguments
-DEV_MODE=false
 NON_INTERACTIVE=false
 CONTAINER_SETUP=false
 for arg in "$@"; do
     case "$arg" in
-        --dev) DEV_MODE=true ;;
         --non-interactive|--skip-config) NON_INTERACTIVE=true ;;
         --container-setup)
             CONTAINER_SETUP=true
@@ -2089,6 +2087,7 @@ if [ -f "$GLOBAL_ENV_FILE" ]; then
     set +a
 fi
 
+GITHUB_TOKEN_SET=false
 if [ -z "${GITHUB_TOKEN:-}" ] || [ "$GITHUB_TOKEN" = "your_github_pat_here" ]; then
     if [ "$NON_INTERACTIVE" = false ]; then
         echo ""
@@ -2100,15 +2099,15 @@ if [ -z "${GITHUB_TOKEN:-}" ] || [ "$GITHUB_TOKEN" = "your_github_pat_here" ]; t
         echo ""
         read -p "Enter your GitHub PAT (or press Enter to skip): " GH_TOKEN
         if [ -n "$GH_TOKEN" ]; then
-            # Write to global.env, replacing any existing commented-out GITHUB_TOKEN line
-            if grep -q "^# GITHUB_TOKEN=" "$GLOBAL_ENV_FILE" 2>/dev/null; then
-                sed -i "s|^# GITHUB_TOKEN=.*|GITHUB_TOKEN=$GH_TOKEN|" "$GLOBAL_ENV_FILE"
-            elif grep -q "^GITHUB_TOKEN=" "$GLOBAL_ENV_FILE" 2>/dev/null; then
-                sed -i "s|^GITHUB_TOKEN=.*|GITHUB_TOKEN=$GH_TOKEN|" "$GLOBAL_ENV_FILE"
+            # Write to global.env, replacing any existing GITHUB_TOKEN line (commented or not)
+            if grep -q "^#\? *GITHUB_TOKEN=" "$GLOBAL_ENV_FILE" 2>/dev/null; then
+                awk -v token="$GH_TOKEN" \
+                    '/^#? *GITHUB_TOKEN=/ { print "GITHUB_TOKEN=" token; next } { print }' \
+                    "$GLOBAL_ENV_FILE" > "$GLOBAL_ENV_FILE.tmp" && mv "$GLOBAL_ENV_FILE.tmp" "$GLOBAL_ENV_FILE"
             else
-                echo "" >> "$GLOBAL_ENV_FILE"
-                echo "GITHUB_TOKEN=$GH_TOKEN" >> "$GLOBAL_ENV_FILE"
+                printf '\nGITHUB_TOKEN=%s\n' "$GH_TOKEN" >> "$GLOBAL_ENV_FILE"
             fi
+            GITHUB_TOKEN_SET=true
             success "GitHub token saved to $GLOBAL_ENV_FILE"
         else
             warn "Skipped — set GITHUB_TOKEN in $GLOBAL_ENV_FILE later"
@@ -2118,6 +2117,7 @@ if [ -z "${GITHUB_TOKEN:-}" ] || [ "$GITHUB_TOKEN" = "your_github_pat_here" ]; t
         info "Set GITHUB_TOKEN in $GLOBAL_ENV_FILE when ready"
     fi
 else
+    GITHUB_TOKEN_SET=true
     success "GitHub token already configured"
 fi
 
@@ -2825,9 +2825,14 @@ echo -e "${NC}"
 echo "Test it by sending a message to your Telegram bot!"
 echo ""
 echo -e "${BOLD}Required post-install steps:${NC}"
+if [ "$GITHUB_TOKEN_SET" = false ]; then
 echo "  1. Set your GitHub PAT:    lobster env set GITHUB_TOKEN <your-token>"
 echo "  2. Authenticate Claude:    sudo -u lobster claude  (then follow OAuth prompts)"
 echo "  3. Start services:         sudo systemctl start lobster-claude lobster-mcp lobster-router"
+else
+echo "  1. Authenticate Claude:    sudo -u lobster claude  (then follow OAuth prompts)"
+echo "  2. Start services:         sudo systemctl start lobster-claude lobster-mcp lobster-router"
+fi
 echo ""
 echo -e "${BOLD}Commands:${NC}"
 echo "  lobster status    Check service status"

--- a/install.sh
+++ b/install.sh
@@ -869,20 +869,23 @@ fi
 #===============================================================================
 
 # Detect install mode: --dev flag, existing .git, or git clone (default)
-# Tarball mode was removed as the default because the release tarball gets stale
-# (scripts added after the last release tag are missing, causing install failures).
-# All fresh installs now use git clone from main, which is always current.
+# Tarball is kept as a last-resort fallback only when git is not available.
 # See: https://github.com/SiderealPress/lobster/issues/787
 if [ -d "$INSTALL_DIR/.git" ]; then
     INSTALL_MODE="git"
     info "Existing git install detected"
 else
-    # Both --dev mode and fresh installs use git clone
-    INSTALL_MODE="git"
-    if $DEV_MODE; then
-        info "Developer mode: using git clone"
+    # Both --dev mode and fresh installs use git clone when available
+    if command -v git >/dev/null 2>&1; then
+        INSTALL_MODE="git"
+        if $DEV_MODE; then
+            info "Developer mode: using git clone"
+        else
+            info "Fresh install: using git clone from main (always current)"
+        fi
     else
-        info "Fresh install: using git clone from main (always current)"
+        INSTALL_MODE="tarball"
+        warn "git not found — falling back to tarball install"
     fi
 fi
 
@@ -1127,8 +1130,8 @@ done
 
 success "Global env store configured"
 info "  File: $GLOBAL_ENV_FILE"
-info "  Use 'lobster env set KEY VALUE' to store API tokens"
-info "  Use 'lobster env list' to see stored keys"
+info "  Edit directly: $GLOBAL_ENV_FILE"
+info "  (Use 'lobster env set KEY VALUE' after install to update tokens)"
 info "  See docs/GLOBAL-ENV.md for full documentation"
 
 #===============================================================================
@@ -2073,6 +2076,52 @@ EOF
 fi
 
 #===============================================================================
+# GitHub Personal Access Token
+#===============================================================================
+
+step "Checking GitHub Personal Access Token..."
+
+# Load global.env if not already done so we can check for an existing token
+if [ -f "$GLOBAL_ENV_FILE" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    . "$GLOBAL_ENV_FILE"
+    set +a
+fi
+
+if [ -z "${GITHUB_TOKEN:-}" ] || [ "$GITHUB_TOKEN" = "your_github_pat_here" ]; then
+    if [ "$NON_INTERACTIVE" = false ]; then
+        echo ""
+        echo -e "${BOLD}GitHub Personal Access Token${NC}"
+        echo ""
+        echo "Required for: PR creation, issue tracking, repo operations"
+        echo "Create one at: https://github.com/settings/tokens/new"
+        echo "Required scopes: repo, write:discussion, admin:repo_hook"
+        echo ""
+        read -p "Enter your GitHub PAT (or press Enter to skip): " GH_TOKEN
+        if [ -n "$GH_TOKEN" ]; then
+            # Write to global.env, replacing any existing commented-out GITHUB_TOKEN line
+            if grep -q "^# GITHUB_TOKEN=" "$GLOBAL_ENV_FILE" 2>/dev/null; then
+                sed -i "s|^# GITHUB_TOKEN=.*|GITHUB_TOKEN=$GH_TOKEN|" "$GLOBAL_ENV_FILE"
+            elif grep -q "^GITHUB_TOKEN=" "$GLOBAL_ENV_FILE" 2>/dev/null; then
+                sed -i "s|^GITHUB_TOKEN=.*|GITHUB_TOKEN=$GH_TOKEN|" "$GLOBAL_ENV_FILE"
+            else
+                echo "" >> "$GLOBAL_ENV_FILE"
+                echo "GITHUB_TOKEN=$GH_TOKEN" >> "$GLOBAL_ENV_FILE"
+            fi
+            success "GitHub token saved to $GLOBAL_ENV_FILE"
+        else
+            warn "Skipped — set GITHUB_TOKEN in $GLOBAL_ENV_FILE later"
+        fi
+    else
+        info "Skipping GitHub token prompt (non-interactive mode)"
+        info "Set GITHUB_TOKEN in $GLOBAL_ENV_FILE when ready"
+    fi
+else
+    success "GitHub token already configured"
+fi
+
+#===============================================================================
 # Generate LOBSTER_INTERNAL_SECRET (required for Google Calendar token refresh)
 #===============================================================================
 
@@ -2774,6 +2823,11 @@ DONE
 echo -e "${NC}"
 
 echo "Test it by sending a message to your Telegram bot!"
+echo ""
+echo -e "${BOLD}Required post-install steps:${NC}"
+echo "  1. Set your GitHub PAT:    lobster env set GITHUB_TOKEN <your-token>"
+echo "  2. Authenticate Claude:    sudo -u lobster claude  (then follow OAuth prompts)"
+echo "  3. Start services:         sudo systemctl start lobster-claude lobster-mcp lobster-router"
 echo ""
 echo -e "${BOLD}Commands:${NC}"
 echo "  lobster status    Check service status"

--- a/install.sh
+++ b/install.sh
@@ -949,6 +949,10 @@ else
     LATEST_TAG=$(echo "$RELEASE_JSON" | jq -r '.tag_name // empty' 2>/dev/null || true)
 
     if [ -z "$LATEST_TAG" ]; then
+        if ! command -v git >/dev/null 2>&1; then
+            error "No release tag found and git is not available. Cannot install."
+            exit 1
+        fi
         info "No release found, falling back to git clone..."
         git clone --quiet --branch "$REPO_BRANCH" "$REPO_URL" "$INSTALL_DIR"
         cd "$INSTALL_DIR"
@@ -964,6 +968,10 @@ else
         fi
 
         if [ -z "$TARBALL_URL" ]; then
+            if ! command -v git >/dev/null 2>&1; then
+                error "No release tag found and git is not available. Cannot install."
+                exit 1
+            fi
             error "No tarball found in release. Falling back to git clone..."
             git clone --quiet --branch "$REPO_BRANCH" "$REPO_URL" "$INSTALL_DIR"
             cd "$INSTALL_DIR"
@@ -2120,7 +2128,7 @@ if [ -z "${GITHUB_TOKEN:-}" ] || [ "$GITHUB_TOKEN" = "your_github_pat_here" ]; t
         read -p "Enter your GitHub PAT (or press Enter to skip): " GH_TOKEN
         if [ -n "$GH_TOKEN" ]; then
             # Write to global.env, replacing any existing GITHUB_TOKEN line (commented or not)
-            if grep -q "^#\? *GITHUB_TOKEN=" "$GLOBAL_ENV_FILE" 2>/dev/null; then
+            if grep -q "^#\{0,1\} *GITHUB_TOKEN=" "$GLOBAL_ENV_FILE" 2>/dev/null; then
                 # Use ENVIRON to avoid backslash mangling that -v causes with tokens
                 # containing backslash sequences (e.g. \n, \t in a PAT value).
                 GH_TOKEN="$GH_TOKEN" awk \

--- a/install.sh
+++ b/install.sh
@@ -38,10 +38,12 @@ error() { echo -e "${RED}[ERROR]${NC} $1"; }
 step() { echo -e "\n${CYAN}${BOLD}▶ $1${NC}"; }
 
 # Parse install mode from arguments
+DEV_MODE=false  # accepted for backwards compat; git clone is now the default for all fresh installs
 NON_INTERACTIVE=false
 CONTAINER_SETUP=false
 for arg in "$@"; do
     case "$arg" in
+        --dev) DEV_MODE=true ;;  # no-op: same as default (git clone); kept for script compatibility
         --non-interactive|--skip-config) NON_INTERACTIVE=true ;;
         --container-setup)
             CONTAINER_SETUP=true


### PR DESCRIPTION
## Summary

Fresh installs using the tarball path were failing because the tarball was frozen at v0.1.0 (March 15) while scripts referenced by the installer had moved on. This PR fixes the root cause and addresses two gaps that made post-install setup error-prone.

**What was impossible before, is now possible:**
- A fresh install on a machine with \`git\` available would download a stale tarball instead of cloning main — scripts added after March 15 would be missing.
- Users had no guided path to set \`GITHUB_TOKEN\` during install; they'd discover the gap only when a subagent tried to use \`gh\` and failed.
- The final summary showed no mandatory next steps, leaving users without Claude auth or running services.
- \`--dev\` was a no-op; developers could not opt into debug mode at install time.
- There was no way to opt into a pinned tarball install when reproducibility was needed.

## Fix 1 — Default to git clone (Fixes #787)

Install mode detection changed from:
```
.git exists → git update
--dev flag  → git clone
otherwise   → tarball (stale)
```
to:
```
.git exists  → git update (unchanged)
--stable     → tarball of latest release (opt-in, new)
git available → git clone from main (new default)
git missing   → tarball fallback (last resort only)
```

## Fix 2 — \`--stable\` flag (new)

Passing \`--stable\` explicitly routes to the tarball path (latest GitHub release). Use this when you need a pinned, reproducible install — e.g., deploying a known-good version. The tarball path is preserved fully and unchanged; \`--stable\` is the only way to reach it on a machine that has \`git\` installed.

## Fix 3 — \`--dev\` flag now enables \`LOBSTER_DEBUG\`

Previously \`--dev\` was a no-op (kept only for script compatibility). Now:
- Install still uses git clone (same as default)
- After the config file is written, appends \`LOBSTER_DEBUG=true\` to \`~/lobster-config/config.env\`
- Idempotent: any existing \`LOBSTER_DEBUG\` line (active or commented-out) is removed before the new value is written
- The hooks (\`system-file-protect.py\`, \`inject-debug-bootup.py\`) already read \`config.env\` as a fallback for \`LOBSTER_DEBUG\`, so no env var setup is needed at runtime

## Fix 4 — GITHUB_TOKEN prompt during install

After the Telegram token section, a new interactive step prompts for a GitHub PAT. It:
- Skips silently in \`--non-interactive\` mode with a clear "set it later" message
- Checks for an existing token (live or commented-out in \`global.env\`) and skips if already set
- Writes to \`global.env\` using the same upsert pattern as other token writes

## Fix 5 — Post-install instructions

Added a "Required post-install steps" block at the end of the summary output:
1. Set GitHub PAT (\`lobster env set GITHUB_TOKEN ...\`)
2. Authenticate Claude (\`sudo -u lobster claude\`)
3. Start services (\`sudo systemctl start ...\`)

Also fixed the premature \`lobster env set\` instructions at line 1104, which appeared before the CLI was installed — replaced with a direct file path reference so users who read it during install can act on it.

## Functional patterns

Pure conditional logic for mode detection (no side effects in the detection branch), isolated I/O at the token-write and config-write boundaries. The LOBSTER_DEBUG write is idempotent via a read-filter-write pattern (no sed -i portability issues).

## Tests run

- [x] \`bash -n install.sh\` — Syntax OK, no errors
- [x] \`sudo docker compose -f tests/docker/docker-compose.test.yml up install-test --build\` — Installation Test PASSED (exit 0), all 5 post-install checks passed (lobster CLI, help, runtime dirs, MCP import, Telegram import)
- [ ] End-to-end install on a fresh VM — not run; requires a clean machine. The diff is confined to install-time branching and output — no runtime behavior changed.

**Blocked items needing attention before merge:** none