### PR TITLE
fix(install): remove local keyword used outside function

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -332,7 +332,7 @@ if [ "$CONTAINER_SETUP" = true ]; then
     # applies immediately on first start. Without this, is_boot_grace_period() returns
     # false (missing field) and the health check fires within seconds of first launch,
     # triggering a restart loop before Claude has had time to initialize.
-    local state_file="$MESSAGES_DIR/config/lobster-state.json"
+    state_file="$MESSAGES_DIR/config/lobster-state.json"
     if [ ! -f "$state_file" ]; then
         echo '{"mode": "active", "booted_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' > "$state_file"
         info "  Seeded lobster-state.json with initial booted_at timestamp"


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Summary

- The `local` keyword on line 335 of `install.sh` was used outside of a function, inside a top-level `if` block (`if [ "$CONTAINER_SETUP" = true ]; then`).
- In bash strict mode (`set -e`/`set -u`) and in some shells (e.g. `dash`), `local` is only valid inside a function body. Using it at the top level is a bash error that causes the script to exit with an error code.
- This was reportedly fixed in a staging container but never committed.

## Fix

Removed the `local` keyword from the variable declaration on line 335, making it a plain assignment (`state_file="..."` instead of `local state_file="..."`). The variable is still correctly scoped within the `if` block for its intended use.

## Test plan

- [ ] Run `bash -n install.sh` to confirm no syntax errors
- [ ] Run `bash --posix install.sh --container-setup` (or equivalent) in a test container to confirm the container setup path executes without errors
- [ ] Verify `lobster-state.json` is still seeded correctly on first run