### PR TITLE
feat: LOBSTER_ENV mode gate + scoped staging credentials

### DIFF
--- a/config/config.staging.env.example
+++ b/config/config.staging.env.example
@@ -1,0 +1,30 @@
+# Lobster Staging Credentials
+#
+# Copy to ~/lobster-config/config.staging.env and fill in values.
+# Used by docker/staging/docker-compose.staging.yml.
+#
+# RULE: Never put production credentials in this file.
+#   - Production TELEGRAM_BOT_TOKEN stays in config.env only.
+#   - Use a dedicated test bot created via @BotFather for staging.
+#   - All other tokens (Linear, Vercel, etc.) should use staging/test equivalents
+#     if they exist, or be omitted entirely if not needed for staging work.
+#
+# LOBSTER_ENV must be set to a non-production value here so that lifecycle
+# automation (health check, auto-restart) does not activate inside the container.
+
+# --- Required for staging Telegram bot ---
+TELEGRAM_BOT_TOKEN=<your-test-bot-token>       # NEVER use production token here
+TELEGRAM_ALLOWED_USERS=<your-chat-id>
+
+# --- Environment mode ---
+LOBSTER_ENV=staging
+
+# --- Logging ---
+LOBSTER_DEBUG=true
+
+# --- GitHub (optional: only if staging work requires gh CLI access) ---
+# GITHUB_TOKEN=<personal-access-token-for-staging>
+
+# --- MCP HTTP auth (regenerate; do not reuse production secret) ---
+# LOBSTER_INTERNAL_SECRET=<new-random-secret>
+# MCP_HTTP_TOKEN=<new-random-token>

--- a/docker/staging/docker-compose.staging.yml
+++ b/docker/staging/docker-compose.staging.yml
@@ -4,6 +4,11 @@
 # dedicated test bot token. Isolated from production via a separate
 # messages volume and workspace.
 #
+# Credential setup (one-time):
+#   cp ~/lobster/config/config.staging.env.example ~/lobster-config/config.staging.env
+#   # Fill in TELEGRAM_BOT_TOKEN (test bot), TELEGRAM_ALLOWED_USERS, etc.
+#   # NEVER put the production TELEGRAM_BOT_TOKEN in config.staging.env.
+#
 # Usage:
 #   cd ~/lobster
 #   sudo docker compose -f docker/staging/docker-compose.staging.yml up -d
@@ -24,11 +29,17 @@ services:
       dockerfile: docker/staging/Dockerfile.staging
     container_name: lobster-staging
     restart: unless-stopped
+    # Scoped credentials: reads ONLY from config.staging.env, never from config.env.
+    # This is the credential boundary that prevents staging from inheriting production
+    # tokens. config.staging.env must NOT contain the production TELEGRAM_BOT_TOKEN.
+    # See config/config.staging.env.example for the template.
+    env_file:
+      - ${LOBSTER_CONFIG_DIR:-/home/lobster/lobster-config}/config.staging.env
     environment:
-      # Test bot token - safe to use in staging
-      TELEGRAM_BOT_TOKEN: "${TELEGRAM_BOT_TOKEN}"
-      TELEGRAM_ALLOWED_USERS: "${TELEGRAM_ALLOWED_USERS}"
-      LOBSTER_DEBUG: "false"
+      # GitHub PAT for gh CLI access inside staging container.
+      # Sourced from the host environment so it doesn't need to live in
+      # config.staging.env (which is committed-adjacent and more exposed).
+      GITHUB_TOKEN: "${GITHUB_TOKEN:-}"
     volumes:
       # Mount host Claude credentials (read-only auth, but settings.json needs write)
       # We mount the whole .claude dir so credentials are available

--- a/docker/staging/docker-compose.staging.yml
+++ b/docker/staging/docker-compose.staging.yml
@@ -34,6 +34,9 @@ services:
     # tokens. config.staging.env must NOT contain the production TELEGRAM_BOT_TOKEN.
     # See config/config.staging.env.example for the template.
     env_file:
+      # LOBSTER_CONFIG_DIR defaults to /home/lobster/lobster-config — the standard
+      # single-user install path. Override this env var before running compose if
+      # your config lives elsewhere (e.g. export LOBSTER_CONFIG_DIR=/custom/path).
       - ${LOBSTER_CONFIG_DIR:-/home/lobster/lobster-config}/config.staging.env
     environment:
       # GitHub PAT for gh CLI access inside staging container.

--- a/install.sh
+++ b/install.sh
@@ -2037,6 +2037,11 @@ TELEGRAM_ALLOWED_USERS=
 # Admin chat ID (Telegram numeric user ID for the primary admin user).
 # Used by run-job.sh (scheduled tasks) and alert.sh to deliver messages.
 LOBSTER_ADMIN_CHAT_ID=
+
+# Environment mode: production | dev | test
+# Set to "dev" to make the persistent session and health check inert while doing
+# interactive SSH work. Revert to "production" (or remove this line) to resume.
+LOBSTER_ENV=production
 EOF
     fi
     NEED_CONFIG=false
@@ -2096,6 +2101,11 @@ TELEGRAM_ALLOWED_USERS=$USER_ID
 # Admin chat ID (Telegram numeric user ID for the primary admin user).
 # Used by run-job.sh (scheduled tasks) and alert.sh to deliver messages.
 LOBSTER_ADMIN_CHAT_ID=$USER_ID
+
+# Environment mode: production | dev | test
+# Set to "dev" to make the persistent session and health check inert while doing
+# interactive SSH work. Revert to "production" (or remove this line) to resume.
+LOBSTER_ENV=production
 EOF
 
     success "Telegram configuration saved"

--- a/scripts/claude-persistent.sh
+++ b/scripts/claude-persistent.sh
@@ -493,6 +493,20 @@ main() {
     log "State file: $STATE_FILE"
     log "================================================================"
 
+    # Lifecycle gate: only run in production mode.
+    # When LOBSTER_ENV is set to anything other than "production" (e.g. "dev" or
+    # "test"), the persistent session exits immediately. This lets Sahar do SSH
+    # dev work without the production session health-checking and auto-restarting
+    # in the background. systemd starts the script but the script exits cleanly
+    # (exit 0), so the service stays in RemainAfterExit=yes without restart loops.
+    # Flip back to production by setting LOBSTER_ENV=production and restarting
+    # the service (or unsetting the var, since "production" is the default).
+    LOBSTER_ENV="${LOBSTER_ENV:-production}"
+    if [[ "$LOBSTER_ENV" != "production" ]]; then
+        log "LOBSTER_ENV=$LOBSTER_ENV — persistent session is disabled in non-production mode. Exiting."
+        exit 0
+    fi
+
     preflight
 
     # Write boot timestamp before the first health-check can fire.

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -141,6 +141,7 @@ mkdir -p "$(dirname "$RESTART_STATE_FILE")"
 # idle and alerting on its resource state would be noise. The cron entry still fires
 # so that flipping back to production takes effect within 4 minutes with no manual step.
 if [[ "$LOBSTER_ENV" != "production" ]]; then
+    mkdir -p "$(dirname "$LOG_FILE")"
     echo "[$(date -Iseconds)] [INFO] LOBSTER_ENV=$LOBSTER_ENV — health check skipped in non-production mode" >> "$LOG_FILE"
     exit 0
 fi

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -126,9 +126,24 @@ if [[ -z "${LOBSTER_DEBUG:-}" && -f "$CONFIG_ENV" ]]; then
 fi
 LOBSTER_DEBUG="${LOBSTER_DEBUG:-false}"
 
+# Read LOBSTER_ENV from config.env (if not already in environment)
+if [[ -z "${LOBSTER_ENV:-}" && -f "$CONFIG_ENV" ]]; then
+    LOBSTER_ENV=$(grep '^LOBSTER_ENV=' "$CONFIG_ENV" 2>/dev/null | cut -d'=' -f2- | tr -d '[:space:]"' || echo "production")
+fi
+LOBSTER_ENV="${LOBSTER_ENV:-production}"
+
 # Ensure log directory exists
 mkdir -p "$(dirname "$LOG_FILE")"
 mkdir -p "$(dirname "$RESTART_STATE_FILE")"
+
+# Lifecycle gate: skip monitoring and restart loop in non-production environments.
+# Resource checks (disk/memory/auth) do not run either — the service is intentionally
+# idle and alerting on its resource state would be noise. The cron entry still fires
+# so that flipping back to production takes effect within 4 minutes with no manual step.
+if [[ "$LOBSTER_ENV" != "production" ]]; then
+    echo "[$(date -Iseconds)] [INFO] LOBSTER_ENV=$LOBSTER_ENV — health check skipped in non-production mode" >> "$LOG_FILE"
+    exit 0
+fi
 
 #===============================================================================
 # Logging

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1536,6 +1536,24 @@ with open(path, 'w') as f:
         migrated=$((migrated + 1))
     fi
 
+    # Migration 32: Add LOBSTER_ENV=production to existing config.env files
+    # New installs write LOBSTER_ENV=production into config.env during setup.
+    # Existing installs that predate this change will not have the variable, which
+    # is safe (both scripts default to "production" when the variable is absent),
+    # but the explicit entry makes the knob discoverable and easy to flip for dev work.
+    # We only append if LOBSTER_ENV is completely absent — no existing line is modified.
+    if [ -f "$CONFIG_FILE" ] && ! grep -q '^LOBSTER_ENV=' "$CONFIG_FILE"; then
+        cat >> "$CONFIG_FILE" << 'EOF'
+
+# Environment mode: production | dev | test
+# Set to "dev" to make the persistent session and health check inert while doing
+# interactive SSH work. Revert to "production" (or remove this line) to resume.
+LOBSTER_ENV=production
+EOF
+        substep "Added LOBSTER_ENV=production to $CONFIG_FILE (existing install backfill)"
+        migrated=$((migrated + 1))
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/services/lobster-claude.service.template
+++ b/services/lobster-claude.service.template
@@ -18,6 +18,9 @@ Environment=LOBSTER_USER_CONFIG={{USER_CONFIG_DIR}}
 EnvironmentFile=-{{INSTALL_DIR}}/config/config.env
 EnvironmentFile={{CONFIG_DIR}}/config.env
 EnvironmentFile=-{{CONFIG_DIR}}/global.env
+# LOBSTER_ENV is read from config.env above (production|dev|test).
+# Set LOBSTER_ENV=dev in config.env to make the session inert during SSH dev work.
+# The script exits cleanly so RemainAfterExit=yes prevents unwanted restart loops.
 UnsetEnvironment=CLAUDECODE CLAUDE_CODE_ENTRYPOINT
 ExecStart=/usr/bin/tmux -L lobster new-session -d -s lobster -c {{WORKSPACE_DIR}} {{INSTALL_DIR}}/scripts/start-claude.sh
 ExecStop=/usr/bin/tmux -L lobster kill-session -t lobster


### PR DESCRIPTION
## What this solves

Two problems caused a Telegram bot conflict: the production persistent session had no way to stand down during SSH dev work, and the staging Docker container inherited production tokens because it read loose env vars sourced from the shared `config.env`.

**Problem 1 — no lifecycle gate:** When doing interactive SSH work, `claude-persistent.sh` kept running and `health-check-v3.sh` kept monitoring and restarting. There was no single switch to make the production session inert without stopping services manually.

**Problem 2 — no credential boundary:** `config.env` is a single file containing all credentials. The staging compose file read `${TELEGRAM_BOT_TOKEN}` from the host environment, which was already sourced from `config.env`. Staging silently got the production token with no enforcement boundary.

## What changed

### LOBSTER_ENV gate

A single `LOBSTER_ENV=production|dev|test` variable (default: `production`) gates both lifecycle components:

- `claude-persistent.sh`: exits cleanly (exit 0) when `LOBSTER_ENV != production`. systemd's `RemainAfterExit=yes` holds the service as "active" so no restart loop fires.
- `health-check-v3.sh`: reads `LOBSTER_ENV` from `config.env` (same pattern as `LOBSTER_DEBUG` already uses) and exits 0 immediately when not `production`. The cron entry keeps firing, so flipping back to production takes effect within 4 minutes with no manual step. Resource checks (disk/memory) also skip — the service is intentionally idle and alerting on it would be noise.

To pause the session for dev work:
```bash
# In ~/lobster-config/config.env:
LOBSTER_ENV=dev
sudo systemctl restart lobster-claude  # script exits cleanly
```

To resume:
```bash
LOBSTER_ENV=production
sudo systemctl restart lobster-claude
```

### Credential boundary

`docker-compose.staging.yml` now uses `env_file:` pointing to `~/lobster-config/config.staging.env` instead of reading loose host env vars that inherited from `config.env`. The staging file is structurally isolated from the production file — there is no code path that causes staging to read `config.env`.

A new repo template `config/config.staging.env.example` documents which credentials belong in staging scope, with an explicit prohibition on the production bot token.

The flow before vs. after:

```
BEFORE:
  host shell → source config.env → TELEGRAM_BOT_TOKEN=<PRODUCTION>
  docker-compose → environment: TELEGRAM_BOT_TOKEN: "${TELEGRAM_BOT_TOKEN}"
  container → gets production token

AFTER:
  docker-compose → env_file: config.staging.env (separate file)
  container → gets only staging-scoped credentials
  config.env → never read by staging container
```

### Migration

`upgrade.sh` Migration 32 appends `LOBSTER_ENV=production` to existing `config.env` files that don't already have it. No behavior change — both scripts already default to `production` when the variable is absent. The migration just makes the knob visible and editable.

`install.sh` writes `LOBSTER_ENV=production` into new config.env files during setup.

## What is NOT changed

- No changes to dispatcher logic, message routing, or any MCP servers
- Slack, SMS, and other router services are unaffected
- The health check's locking, logging, and escalation ladder are unchanged — only the early-exit guard is new
- The `lobster-claude.service.template` comment addition is documentation only; the variable is already loaded via `EnvironmentFile={{CONFIG_DIR}}/config.env`

## Tests run

- [x] `bash -n scripts/claude-persistent.sh` — syntax OK
- [x] `bash -n scripts/health-check-v3.sh` — syntax OK
- [x] `bash -n scripts/upgrade.sh` — syntax OK
- [x] `bash -n install.sh` — syntax OK
- [ ] Live `LOBSTER_ENV=dev` end-to-end (service starts, script exits, health check skips, service resumes on flip back) — blocked: requires production restart; safe to merge as the default is `production` and no existing behavior changes unless the variable is explicitly set