### PR TITLE
fix(run-job): source global.env so GITHUB_TOKEN is available in cron

### DIFF
--- a/scheduled-tasks/run-job.sh
+++ b/scheduled-tasks/run-job.sh
@@ -26,15 +26,21 @@ fi
 
 REPO_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
 
-# Load config.env so env vars like LOBSTER_ADMIN_CHAT_ID are available when
-# running from cron (which does not inherit the systemd EnvironmentFile).
-CONFIG_ENV="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}/config.env"
-if [ -f "$CONFIG_ENV" ]; then
-    # shellcheck source=/dev/null
-    set -a
-    source "$CONFIG_ENV"
-    set +a
-fi
+# Load env files so tokens like LOBSTER_ADMIN_CHAT_ID and GITHUB_TOKEN are
+# available when running from cron (which does not inherit the systemd
+# EnvironmentFile entries). Source both files in the same order as the
+# systemd services: config.env first, then global.env so that global.env
+# values can override config.env when needed.
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+for _env_file in "$CONFIG_DIR/config.env" "$CONFIG_DIR/global.env"; do
+    if [ -f "$_env_file" ]; then
+        # shellcheck source=/dev/null
+        set -a
+        source "$_env_file"
+        set +a
+    fi
+done
+unset _env_file
 WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
 TASK_FILE="$WORKSPACE/scheduled-jobs/tasks/${JOB_NAME}.md"
 OUTPUT_DIR="$HOME/messages/task-outputs"


### PR DESCRIPTION
🤖🦞 Lobster (engineer): Fixes #811

## Problem

Cron strips the process environment entirely. `run-job.sh` compensates by sourcing `config.env` at startup — but `GITHUB_TOKEN` (and other API tokens) live in `global.env`, not `config.env`. The result: every scheduled job that calls `gh` CLI runs unauthenticated and fails silently.

The split between the two files is intentional: `config.env` holds service-level configuration (chat IDs, feature flags, MCP tokens), while `global.env` is the machine-wide API token store managed by `lobster env set`.

## What changed

`run-job.sh` now sources both `config.env` and `global.env` in the same order that the systemd services declare them via `EnvironmentFile`. If `global.env` is absent (e.g. on a fresh install before any tokens are set), the loop skips it gracefully — no behavior change for those installs.

```
Before:
  cron → run-job.sh → sources config.env only → gh CLI unauthenticated

After:
  cron → run-job.sh → sources config.env + global.env → gh CLI authenticated
```

No other scripts or services are touched. The systemd services already source both files correctly and are unaffected.

## Functional patterns

Pure configuration loading — the loop is a straightforward iteration over an ordered list of env file paths, with each file sourced idempotently. No state mutation beyond what `source` already does.

## Tests run

- [x] `bash -n scheduled-tasks/run-job.sh` — syntax check passes
- [x] `git diff` reviewed — change is minimal and matches stated intent
- [ ] End-to-end cron test with a job that calls `gh` — blocked: requires a live cron environment and production restart. Safe to merge; the change is a strict superset of the previous behavior (adds a sourced file, does not remove anything).