### PR TITLE
Fix bot-talk-poller SSL errors: enforce http:// for plain HTTP endpoint

### DIFF
--- a/src/mcp/bot_talk_mirror.py
+++ b/src/mcp/bot_talk_mirror.py
@@ -54,6 +54,11 @@ log = logging.getLogger(__name__)
 # Falls back to reading config.env (same pattern as inbox_server.py / OPENAI_API_KEY).
 # If BOT_TALK_HTTP_URL is empty after all lookups, HTTP mirroring is silently
 # disabled (SSH fallback still applies if sharedLobster is reachable).
+#
+# IMPORTANT: The bot-talk service runs plain HTTP on port 4242 — there is no
+# TLS on this endpoint (TLS was intentionally removed).  Always use http://
+# (never https://) when constructing or configuring BOT_TALK_HTTP_URL.
+# Using https:// causes an SSL handshake failure on every request.
 # ---------------------------------------------------------------------------
 
 def _read_config_env(key: str) -> str:


### PR DESCRIPTION
## What was wrong

The bot-talk-poller task file instructed the subagent to poll the bot-talk API using `https://`, but the service on port 4242 is plain HTTP with no TLS (TLS was intentionally removed in a prior audit). Every poll cycle sent an HTTPS request that failed with an SSL handshake error, followed by a recovery in the next cycle when the poller happened to use HTTP — creating a noisy false-alarm loop of DOWN/UP state changes.

The root cause was a single character sequence in the runtime task definition that the subagent reads as its instructions each cycle.

## What changed

**Runtime fix (immediate):** Corrected `~/lobster-workspace/scheduled-jobs/tasks/bot-talk-poller.md` from `https://` to `http://` in the polling URL. This takes effect on the next 2-minute cron cycle.

**Repo change:** Added a prominent warning comment to the configuration block in `src/mcp/bot_talk_mirror.py` making the HTTP-only requirement explicit. Any future task authoring, config tuning, or `BOT_TALK_HTTP_URL` setup will encounter this comment before writing a URL.

No logic changes — `bot_talk_mirror.py` already reads the URL from env/config with no hardcoded value. The module itself was never at fault; the task instruction was.

## What is not changed

- No changes to connection retry logic, timeout values, or fallback chain
- `bot_talk_mirror.py` HTTP/SSH/local-log fallback behavior is untouched
- No changes to any other scheduled job tasks

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_bot_talk_mirror.py -v` — 33 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)