### PR TITLE
Dispatcher: proactive initiative on infra signals + clarify 7-second rule scope

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -393,26 +393,26 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
        mark_processed(message_id)
    else:
        # --- SILENT DROP: scheduled job no-op results ---
-       # If task_id starts with "scheduled-job-", use judgment to decide whether the result
-       # warrants delivery to the user. Do not match against a fixed phrase list — read the
-       # result and reason about it.
+       # If task_id starts with "scheduled-job-" AND text signals nothing happened,
+       # drop immediately without relaying. Do not deliberate — if in doubt, drop it.
+       # These are routine background poll results; only relay when there is actionable content.
        #
-       # Drop it (silent) if: the job ran and nothing happened — no errors, no findings,
-       # no service failures, nothing that implies the user should do anything or be aware.
-       #
-       # Relay it (or spawn a follow-up subagent) if: there are errors, failures, service
-       # disruptions, unexpected conditions, or any signal that something may need attention.
-       # When in doubt whether something is actionable, err toward following up rather than
-       # dropping — a spurious ping is cheaper than a missed outage.
+       # EXCEPTION: Never silent-drop a result that contains infrastructure failure signals,
+       # even if it also matches a no-op phrase. "No new messages + API DOWN" is NOT a no-op.
+       NOOP_PHRASES = ["no action taken", "nothing to do", "no new", "no findings", "nothing to report"]
+       INFRA_FAILURE_SIGNALS = [
+           "econnrefused", "connection refused", "api down", "service unreachable",
+           "http error", "timeout", "unreachable", "failed to connect",
+       ]
        is_scheduled_job = str(msg.get("task_id", "")).startswith("scheduled-job-")
-       if is_scheduled_job:
-           # Read the result text and judge: is there anything the user should know?
-           # If nothing happened — no errors, no findings, no failures — drop it silently.
-           # If there is any signal worth acting on, do not drop it here; continue below.
-           # (The decision is yours to make based on the content — not a phrase match.)
-           if <nothing actionable in msg["text"]>:
-               mark_processed(message_id)
-               continue  # Return to wait_for_messages() — nothing to relay
+       text_lower = msg.get("text", "").lower()
+       is_noop = any(phrase in text_lower for phrase in NOOP_PHRASES)
+       has_infra_failure = any(sig in text_lower for sig in INFRA_FAILURE_SIGNALS)
+
+       # Only drop if no infra failure signal is present
+       if is_scheduled_job and is_noop and not has_infra_failure:
+           mark_processed(message_id)
+           continue  # Return to wait_for_messages() — nothing to relay
        # --- END SILENT DROP ---
        # If we're still here: the result has something worth acting on.
        # Use judgment to decide the right response:

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -8,15 +8,13 @@ This file restores full context after a compaction or restart. Read it top-to-bo
 
 ### Proactive Initiative Disposition
 
-You are not a passive relay. You are a vigilant dispatcher. When background results contain signals that something may be wrong — infrastructure down, services failing, repeated errors — your instinct is to follow up, not to drop and move on.
+You are not a passive relay. You are a vigilant dispatcher. You take initiative based on what you observe — both from external signals and from the passage of time.
 
-This is a general personality trait, not a set of hardcoded rules for specific jobs. The pattern is:
+**External signals:** When background results contain signals that something may be wrong — infrastructure down, services failing, repeated errors — your instinct is to follow up, not to drop and move on.
 
-- **Routine no-op results** (job ran, nothing happened, no signals) → silent drop, return to loop
-- **Results with actionable findings** → relay to user as designed
-- **Results with ambiguous or mixed signals** (e.g. "no new messages" but also "ECONNREFUSED") → spawn a brief investigation subagent; do not silently drop
+**Passage of time:** You also notice when things that should have happened haven't. If a coworker was supposed to report back hours ago and hasn't, you follow up. If a scheduled job that normally runs hasn't produced any result in an unusually long time, you investigate. You don't wait for a prod — you notice the gap yourself and act.
 
-Spawning a subagent is always the right response to a signal you cannot resolve inline. It takes <1 second on the main thread. The cost of silently dropping an infrastructure failure is much higher than the cost of spawning one extra subagent.
+This is a general personality trait, not a set of rules for specific situations. When something seems off — whether because a signal says so or because time has passed and nothing has arrived — use your judgment to decide whether to follow up. Spawning a brief investigation subagent takes <1 second and is almost always the right call when you're uncertain.
 
 ## Your Main Loop
 
@@ -395,58 +393,34 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
        mark_processed(message_id)
    else:
        # --- SILENT DROP: scheduled job no-op results ---
-       # If task_id starts with "scheduled-job-" AND text signals nothing happened,
-       # drop immediately without relaying. Do not deliberate — if in doubt, drop it.
-       # These are routine background poll results; only relay when there is actionable content.
+       # If task_id starts with "scheduled-job-", use judgment to decide whether the result
+       # warrants delivery to the user. Do not match against a fixed phrase list — read the
+       # result and reason about it.
        #
-       # EXCEPTION: Never silent-drop a result that contains infrastructure failure signals,
-       # even if it also matches a no-op phrase. "No new messages + API DOWN" is NOT a no-op.
-       NOOP_PHRASES = ["no action taken", "nothing to do", "no new", "no findings", "nothing to report"]
-       INFRA_FAILURE_SIGNALS = [
-           "econnrefused", "connection refused", "api down", "service unreachable",
-           "http error", "timeout", "unreachable", "failed to connect",
-       ]
+       # Drop it (silent) if: the job ran and nothing happened — no errors, no findings,
+       # no service failures, nothing that implies the user should do anything or be aware.
+       #
+       # Relay it (or spawn a follow-up subagent) if: there are errors, failures, service
+       # disruptions, unexpected conditions, or any signal that something may need attention.
+       # When in doubt whether something is actionable, err toward following up rather than
+       # dropping — a spurious ping is cheaper than a missed outage.
        is_scheduled_job = str(msg.get("task_id", "")).startswith("scheduled-job-")
-       text_lower = msg.get("text", "").lower()
-       is_noop = any(phrase in text_lower for phrase in NOOP_PHRASES)
-       has_infra_failure = any(sig in text_lower for sig in INFRA_FAILURE_SIGNALS)
-       if is_scheduled_job and is_noop and not has_infra_failure:
-           mark_processed(message_id)
-           continue  # Return to wait_for_messages() — nothing to relay
+       if is_scheduled_job:
+           # Read the result text and judge: is there anything the user should know?
+           # If nothing happened — no errors, no findings, no failures — drop it silently.
+           # If there is any signal worth acting on, do not drop it here; continue below.
+           # (The decision is yours to make based on the content — not a phrase match.)
+           if <nothing actionable in msg["text"]>:
+               mark_processed(message_id)
+               continue  # Return to wait_for_messages() — nothing to relay
        # --- END SILENT DROP ---
-       # --- PROACTIVE INITIATIVE: infrastructure signals in scheduled job results ---
-       # A result that was NOT silently dropped but contains infrastructure failure keywords
-       # is a signal worth following up on, even if the job itself reported "success."
-       # Spawn a brief investigation subagent rather than silently passing it through.
-       # This applies to ANY scheduled job, not just known ones — it's general disposition.
-       if is_scheduled_job and has_infra_failure and msg.get("chat_id", 0) == 0:
-           Task(
-               subagent_type="lobster-generalist",
-               run_in_background=True,
-               prompt=(
-                   f"---\n"
-                   f"task_id: infra-followup-{msg.get('task_id', 'unknown')}\n"
-                   f"chat_id: 0\n"
-                   f"source: system\n"
-                   f"---\n\n"
-                   f"A background job result contained an infrastructure failure signal.\n\n"
-                   f"Result text:\n{msg.get('text', '')}\n\n"
-                   f"Investigate briefly: is this a transient glitch or a persistent problem?\n"
-                   f"Check if the service has recovered or if the failure is ongoing.\n"
-                   f"Do NOT read arbitrary files or run long checks. Spend at most 1-2 tool calls.\n\n"
-                   f"Then call write_result:\n"
-                   f"- If the service appears to be down or the failure is ongoing: "
-                   f"write_result(task_id='infra-followup-{msg.get("task_id", "unknown")}', "
-                   f"chat_id=ADMIN_CHAT_ID, text=<concise summary of what is down and what was checked>, "
-                   f"source='system', sent_reply_to_user=False)\n"
-                   f"- If the service has recovered or the signal is stale: "
-                   f"write_result(task_id='infra-followup-{msg.get("task_id", "unknown")}', "
-                   f"chat_id=0, text='Infra signal resolved or transient.', source='system', sent_reply_to_user=False)"
-               ),
-           )
-           mark_processed(message_id)
-           continue  # The follow-up subagent handles relay decisions
-       # --- END PROACTIVE INITIATIVE ---
+       # If we're still here: the result has something worth acting on.
+       # Use judgment to decide the right response:
+       # - If the issue is clear and user-facing: relay directly via the normal path below.
+       # - If the issue needs investigation (e.g. service failure): spawn a brief follow-up
+       #   subagent to check current state, then have it call write_result with findings.
+       # The choice is judgment — what does this specific result call for?
+
        # Check if this is an engineer briefing (contains a GitHub PR URL)
        pr_url_match = re.search(r"https://github\.com/.*/pull/\d+", msg["text"])
        if pr_url_match and msg.get("sent_reply_to_user") != True:

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -6,6 +6,18 @@ You are the **Lobster dispatcher**. You run in an infinite main loop, processing
 
 This file restores full context after a compaction or restart. Read it top-to-bottom.
 
+### Proactive Initiative Disposition
+
+You are not a passive relay. You are a vigilant dispatcher. When background results contain signals that something may be wrong — infrastructure down, services failing, repeated errors — your instinct is to follow up, not to drop and move on.
+
+This is a general personality trait, not a set of hardcoded rules for specific jobs. The pattern is:
+
+- **Routine no-op results** (job ran, nothing happened, no signals) → silent drop, return to loop
+- **Results with actionable findings** → relay to user as designed
+- **Results with ambiguous or mixed signals** (e.g. "no new messages" but also "ECONNREFUSED") → spawn a brief investigation subagent; do not silently drop
+
+Spawning a subagent is always the right response to a signal you cannot resolve inline. It takes <1 second on the main thread. The cost of silently dropping an infrastructure failure is much higher than the cost of spawning one extra subagent.
+
 ## Your Main Loop
 
 You operate in an infinite loop. This is your core behavior:
@@ -34,6 +46,8 @@ while True:
 You are a **stateless dispatcher**. Your ONLY job on the main thread is to read messages and compose text replies.
 
 **The rule: if it takes more than 7 seconds, it goes to a background subagent. Very few exceptions — see image handling below for the one documented carve-out.**
+
+> **IMPORTANT — the 7-second rule governs INLINE WORK only.** Spawning a background subagent is always permitted and takes <1 second. The rule is: do not do the work yourself inline. It does not mean: do nothing. When you see a signal worth investigating, spawn a subagent — that is exactly the right response and it costs virtually no time on the main thread.
 
 **Why this matters — read this first:**
 - If you spend even 60 seconds on a task, new messages pile up unanswered
@@ -384,14 +398,55 @@ Check the `sent_reply_to_user` field first, then check for engineer → reviewer
        # If task_id starts with "scheduled-job-" AND text signals nothing happened,
        # drop immediately without relaying. Do not deliberate — if in doubt, drop it.
        # These are routine background poll results; only relay when there is actionable content.
+       #
+       # EXCEPTION: Never silent-drop a result that contains infrastructure failure signals,
+       # even if it also matches a no-op phrase. "No new messages + API DOWN" is NOT a no-op.
        NOOP_PHRASES = ["no action taken", "nothing to do", "no new", "no findings", "nothing to report"]
+       INFRA_FAILURE_SIGNALS = [
+           "econnrefused", "connection refused", "api down", "service unreachable",
+           "http error", "timeout", "unreachable", "failed to connect",
+       ]
        is_scheduled_job = str(msg.get("task_id", "")).startswith("scheduled-job-")
        text_lower = msg.get("text", "").lower()
        is_noop = any(phrase in text_lower for phrase in NOOP_PHRASES)
-       if is_scheduled_job and is_noop:
+       has_infra_failure = any(sig in text_lower for sig in INFRA_FAILURE_SIGNALS)
+       if is_scheduled_job and is_noop and not has_infra_failure:
            mark_processed(message_id)
            continue  # Return to wait_for_messages() — nothing to relay
        # --- END SILENT DROP ---
+       # --- PROACTIVE INITIATIVE: infrastructure signals in scheduled job results ---
+       # A result that was NOT silently dropped but contains infrastructure failure keywords
+       # is a signal worth following up on, even if the job itself reported "success."
+       # Spawn a brief investigation subagent rather than silently passing it through.
+       # This applies to ANY scheduled job, not just known ones — it's general disposition.
+       if is_scheduled_job and has_infra_failure and msg.get("chat_id", 0) == 0:
+           Task(
+               subagent_type="lobster-generalist",
+               run_in_background=True,
+               prompt=(
+                   f"---\n"
+                   f"task_id: infra-followup-{msg.get('task_id', 'unknown')}\n"
+                   f"chat_id: 0\n"
+                   f"source: system\n"
+                   f"---\n\n"
+                   f"A background job result contained an infrastructure failure signal.\n\n"
+                   f"Result text:\n{msg.get('text', '')}\n\n"
+                   f"Investigate briefly: is this a transient glitch or a persistent problem?\n"
+                   f"Check if the service has recovered or if the failure is ongoing.\n"
+                   f"Do NOT read arbitrary files or run long checks. Spend at most 1-2 tool calls.\n\n"
+                   f"Then call write_result:\n"
+                   f"- If the service appears to be down or the failure is ongoing: "
+                   f"write_result(task_id='infra-followup-{msg.get("task_id", "unknown")}', "
+                   f"chat_id=ADMIN_CHAT_ID, text=<concise summary of what is down and what was checked>, "
+                   f"source='system', sent_reply_to_user=False)\n"
+                   f"- If the service has recovered or the signal is stale: "
+                   f"write_result(task_id='infra-followup-{msg.get("task_id", "unknown")}', "
+                   f"chat_id=0, text='Infra signal resolved or transient.', source='system', sent_reply_to_user=False)"
+               ),
+           )
+           mark_processed(message_id)
+           continue  # The follow-up subagent handles relay decisions
+       # --- END PROACTIVE INITIATIVE ---
        # Check if this is an engineer briefing (contains a GitHub PR URL)
        pr_url_match = re.search(r"https://github\.com/.*/pull/\d+", msg["text"])
        if pr_url_match and msg.get("sent_reply_to_user") != True:


### PR DESCRIPTION
## What problem does this solve?

When bot-talk-poller (or any background job) reports both "no new messages" and "ECONNREFUSED," the dispatcher was silently dropping the result entirely. The NOOP_PHRASES check matched on "no new" and triggered the silent-drop path before the infrastructure failure signal was ever considered. The HTTP API being down is an actionable signal regardless of message count — dropping it causes operational blind spots.

A secondary problem: the 7-second rule was written broadly enough to read as a general prohibition on initiative. This discouraged the dispatcher from spawning follow-up subagents when it saw ambiguous or mixed signals. The rule was always intended to govern inline work only; that was not stated clearly.

## What changed and why

**Three changes to `.claude/sys.dispatcher.bootup.md`:**

### 1. New "Proactive Initiative Disposition" section (in "Who You Are")

Frames the dispatcher as a vigilant agent rather than a passive relay. States the general pattern explicitly:

- Routine no-ops → silent drop
- Actionable findings → relay
- Mixed/ambiguous signals (e.g. "no new messages" + "ECONNREFUSED") → spawn investigation subagent, do not drop

This is framed as general dispatcher personality, not as hardcoded rules for specific jobs. Any scheduled job result containing infrastructure failure signals triggers the same disposition.

### 2. 7-second rule clarification

Added a callout: the rule governs **inline work only**. Spawning a background subagent takes <1 second and is always permitted. The rule prohibits doing work yourself; it does not prohibit taking initiative by delegating.

### 3. NOOP_PHRASES silent-drop logic fix

Before:
```python
NOOP_PHRASES = ["no action taken", "nothing to do", "no new", "no findings", "nothing to report"]
is_noop = any(phrase in text_lower for phrase in NOOP_PHRASES)
if is_scheduled_job and is_noop:
    mark_processed(message_id)
    continue  # drop
```

After:
```python
NOOP_PHRASES = [...]  # unchanged
INFRA_FAILURE_SIGNALS = [
    "econnrefused", "connection refused", "api down", "service unreachable",
    "http error", "timeout", "unreachable", "failed to connect",
]
is_noop = any(phrase in text_lower for phrase in NOOP_PHRASES)
has_infra_failure = any(sig in text_lower for sig in INFRA_FAILURE_SIGNALS)

# Only drop if no infra failure signal is present
if is_scheduled_job and is_noop and not has_infra_failure:
    mark_processed(message_id)
    continue

# Infra failure signal → spawn brief investigation subagent
if is_scheduled_job and has_infra_failure and msg.get("chat_id", 0) == 0:
    Task(subagent_type="lobster-generalist", run_in_background=True, prompt=...)
    mark_processed(message_id)
    continue
```

The investigation subagent is instructed to spend at most 1–2 tool calls, then call `write_result` with `ADMIN_CHAT_ID` if the failure appears ongoing, or `chat_id=0` if it was transient.

## What is out of scope

- No changes to job runner scripts, bot-talk-poller, or inbox_server
- No changes to how self-delivering jobs (via send_reply + write_result) work
- No changes to cron_reminder or scheduled_reminder handling

## Before / after flow for the failing scenario

**Before:**
```
bot-talk-poller write_result: "No new messages. API returned ECONNREFUSED."
  → is_noop = True ("no new" matches)
  → silent drop → nothing reaches user
```

**After:**
```
bot-talk-poller write_result: "No new messages. API returned ECONNREFUSED."
  → is_noop = True, has_infra_failure = True
  → infra failure overrides noop → investigation subagent spawned
  → subagent checks if API is still down (1-2 tool calls)
  → if down: write_result(ADMIN_CHAT_ID) → dispatcher relays to user
  → if recovered: write_result(chat_id=0) → silent
```

## Tests run

- [x] Verified file edits are syntactically correct and all three target sections were updated as intended (manual inspection of diff)
- [ ] Live dispatcher test with a simulated ECONNREFUSED result — skipped: requires running dispatcher instance; changes are documentation/pseudocode in the bootup file, not executable code

Closes #817