### PR TITLE
fix: make WFM Stop hook blocking to eliminate post-batch deliberation stalls

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -359,6 +359,8 @@ REMINDER_ROUTING = {
 > After any `mark_processed` call that is NOT immediately followed by a `Task(...)` subagent spawn, the very next action is `wait_for_messages()`. No exceptions. No state assessment. No "what should I do now?" deliberation. WFM.
 >
 > The most common stall pattern is inline deliberation after processing a batch of system messages. If you find yourself thinking after `mark_processed`, you are violating this rule. Call WFM.
+>
+> **This rule is now enforced by a Stop hook** (`hooks/require-wait-for-messages.py`). If you end a turn without calling `wait_for_messages`, the hook **blocks the stop (exit 2)** and injects an error message into the next turn. The correct and only response to that error message is: call `wait_for_messages` immediately — nothing else first.
 
 **Rules:**
 - Never call `send_reply` for scheduled reminders (chat_id: 0, source: "system")

--- a/hooks/require-wait-for-messages.py
+++ b/hooks/require-wait-for-messages.py
@@ -1,17 +1,30 @@
 #!/usr/bin/env python3
 """
-Stop hook: warn the dispatcher if it ends a turn without calling wait_for_messages.
+Stop hook: block the dispatcher from ending a turn without calling wait_for_messages.
 
 The dispatcher's main loop is: process messages → call wait_for_messages →
 repeat. When the dispatcher stalls — typically after processing a batch of
-subagent results — it can end a turn without calling wait_for_messages. The
-health check catches this after ~12 minutes and restarts, but that is a long
-window with missed messages.
+subagent results or system messages — it can end a turn without calling
+wait_for_messages. The health check catches this after ~12 minutes and
+restarts, causing ~30s of missed messages per incident.
 
-This hook fires on every Stop event (dispatcher or subagent). Subagent sessions
-are immediately exempted via session_role.is_dispatcher(). For the dispatcher,
-the hook scans the transcript: if wait_for_messages was not called, it prints
-a warning to stderr and exits 0 (warn-only — the stop is never blocked).
+This hook fires on every Stop event (dispatcher or subagent). Subagent
+sessions are immediately exempted via session_role.is_dispatcher(). For the
+dispatcher, the hook scans the transcript: if wait_for_messages was not
+called, it exits 2 (blocking) so the dispatcher MUST call wait_for_messages
+before the turn ends.
+
+## Why blocking (exit 2) instead of warn-only (exit 0)
+
+The warn-only version (PR #815) printed to stderr but Claude proceeded with
+the turn ending anyway — 3 restarts occurred tonight after that PR merged.
+The warning fires after the turn is already ending; Claude has no chance to
+act on it in the same turn. Exit 2 injects the error message as a system
+turn and Claude gets a new turn where it must call wait_for_messages before
+stopping again.
+
+This mirrors how require-write-result.py handles subagents: hard-block until
+the required tool is called.
 
 ## Transcript handling
 
@@ -37,6 +50,7 @@ The hook does NOT fire for:
 - Sessions without LOBSTER_MAIN_SESSION=1 (non-Lobster Claude Code sessions)
 - Subagent sessions (is_dispatcher() returns False)
 - Any session where wait_for_messages was called at least once in the transcript
+- Transcript read failures (I/O error → allow stop rather than false-positive block)
 """
 import json
 import os
@@ -54,9 +68,11 @@ _SILENT_OK = json.dumps({"suppressOutput": True})
 
 _WFM_TOOL = "mcp__lobster-inbox__wait_for_messages"
 
-_REMINDER = (
-    "Dispatcher: you ended this turn without calling wait_for_messages. "
-    "Call it now to continue the main loop."
+_BLOCK_MESSAGE = (
+    "STOP: You are the Lobster dispatcher. You ended this turn without calling "
+    "wait_for_messages. The main loop requires wait_for_messages as the very next "
+    "action after mark_processed — no deliberation, no state assessment.\n\n"
+    "Call mcp__lobster-inbox__wait_for_messages NOW. Do not do anything else first."
 )
 
 
@@ -125,7 +141,7 @@ def main() -> None:
     except Exception:
         _exit_ok()  # If we can't read input, don't block.
 
-    # Only warn for the dispatcher session.
+    # Only enforce for the dispatcher session.
     if not is_dispatcher(data):
         _exit_ok()
 
@@ -135,7 +151,8 @@ def main() -> None:
         transcript = _load_transcript_from_jsonl(transcript_path)
         if transcript is None:
             # I/O error reading the transcript — can't determine whether
-            # wait_for_messages was called, so warn and allow stop.
+            # wait_for_messages was called. Allow stop rather than false-positive
+            # block; the health check remains the backstop.
             print(
                 "[require-wait-for-messages] WARNING: could not read transcript "
                 f"at {transcript_path!r} — skipping wait_for_messages check.",
@@ -150,10 +167,11 @@ def main() -> None:
     if _WFM_TOOL in tool_names:
         _exit_ok()
 
-    # wait_for_messages was not called — print a warning and allow the stop.
-    # This is warn-only: exit 0 so the stop is never blocked.
-    print(_REMINDER, file=sys.stderr)
-    _exit_ok()
+    # wait_for_messages was not called — block the stop (exit 2).
+    # Claude gets a new turn with _BLOCK_MESSAGE injected and must call
+    # wait_for_messages before the next stop attempt succeeds.
+    print(_BLOCK_MESSAGE, file=sys.stderr)
+    sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/hooks/require-wait-for-messages.py
+++ b/hooks/require-wait-for-messages.py
@@ -44,6 +44,25 @@ Claude Code injects a "Stop hook feedback: ... No stderr output" system message
 even when the hook exits 0. To prevent this from triggering a new turn,
 the hook outputs JSON with {"suppressOutput": true} on all success paths.
 
+## Graceful exit bypass
+
+Two legitimate cases require the dispatcher to exit without calling
+wait_for_messages again:
+
+1. **Hibernation**: wait_for_messages(hibernate_on_timeout=True) returned a
+   message containing "Hibernating" or "EXIT" — the dispatcher must exit. Calling
+   WFM again would be wrong.
+2. **Context restart**: After writing the handoff and calling `lobster restart`,
+   the dispatcher should exit. It already called WFM earlier in the same session;
+   forcing another call would cause a loop.
+
+In these cases, the dispatcher writes an empty file at /tmp/lobster-graceful-exit
+immediately before exiting. The hook checks for this file: if present, it deletes
+the file and exits 0 (allowing the turn to end). The file is consumed on first use.
+
+The block message itself documents this bypass mechanism so the dispatcher can act
+on it without consulting external docs.
+
 ## Exemptions
 
 The hook does NOT fire for:
@@ -51,6 +70,7 @@ The hook does NOT fire for:
 - Subagent sessions (is_dispatcher() returns False)
 - Any session where wait_for_messages was called at least once in the transcript
 - Transcript read failures (I/O error → allow stop rather than false-positive block)
+- Graceful exit bypass: /tmp/lobster-graceful-exit file present (consumed on use)
 """
 import json
 import os
@@ -68,11 +88,16 @@ _SILENT_OK = json.dumps({"suppressOutput": True})
 
 _WFM_TOOL = "mcp__lobster-inbox__wait_for_messages"
 
+_GRACEFUL_EXIT_FLAG = "/tmp/lobster-graceful-exit"
+
 _BLOCK_MESSAGE = (
-    "STOP: You are the Lobster dispatcher. You ended this turn without calling "
+    "BLOCKED: You are the Lobster dispatcher. You ended this turn without calling "
     "wait_for_messages. The main loop requires wait_for_messages as the very next "
     "action after mark_processed — no deliberation, no state assessment.\n\n"
-    "Call mcp__lobster-inbox__wait_for_messages NOW. Do not do anything else first."
+    "Call mcp__lobster-inbox__wait_for_messages NOW. Do not do anything else first.\n\n"
+    "If this is a legitimate graceful exit (hibernation complete or context restart), "
+    "write the bypass flag and then exit:\n"
+    "    open('/tmp/lobster-graceful-exit', 'w').close()"
 )
 
 
@@ -167,9 +192,20 @@ def main() -> None:
     if _WFM_TOOL in tool_names:
         _exit_ok()
 
-    # wait_for_messages was not called — block the stop (exit 2).
-    # Claude gets a new turn with _BLOCK_MESSAGE injected and must call
-    # wait_for_messages before the next stop attempt succeeds.
+    # wait_for_messages was not called. Check for the graceful exit bypass before
+    # blocking — the dispatcher writes this flag when intentionally exiting without
+    # WFM (hibernation complete, context restart).
+    flag = Path(_GRACEFUL_EXIT_FLAG)
+    if flag.exists():
+        try:
+            flag.unlink()
+        except OSError:
+            pass  # Already deleted by a concurrent process — still honour the bypass.
+        _exit_ok()
+
+    # No bypass flag — block the stop (exit 2). Claude gets a new turn with
+    # _BLOCK_MESSAGE injected and must call wait_for_messages (or write the bypass
+    # flag) before the next stop attempt succeeds.
     print(_BLOCK_MESSAGE, file=sys.stderr)
     sys.exit(2)
 

--- a/hooks/require-wait-for-messages.py
+++ b/hooks/require-wait-for-messages.py
@@ -97,7 +97,7 @@ _BLOCK_MESSAGE = (
     "Call mcp__lobster-inbox__wait_for_messages NOW. Do not do anything else first.\n\n"
     "If this is a legitimate graceful exit (hibernation complete or context restart), "
     "write the bypass flag and then exit:\n"
-    "    open('/tmp/lobster-graceful-exit', 'w').close()"
+    f"    open({_GRACEFUL_EXIT_FLAG!r}, 'w').close()"
 )
 
 

--- a/tests/unit/test_hooks/test_require_wait_for_messages.py
+++ b/tests/unit/test_hooks/test_require_wait_for_messages.py
@@ -1,0 +1,246 @@
+"""
+Unit tests for hooks/require-wait-for-messages.py
+
+Tests cover:
+- Non-Lobster sessions (no LOBSTER_MAIN_SESSION=1) always exit 0
+- Subagent sessions (not dispatcher) always exit 0
+- Dispatcher session with wait_for_messages in transcript: exits 0 (allow)
+- Dispatcher session without wait_for_messages in transcript: exits 2 (block)
+- Missing transcript_path (I/O error): exits 0 to avoid false-positive block
+- Success exit outputs JSON with suppressOutput=true to prevent feedback injection
+- Block message references wait_for_messages to guide dispatcher behavior
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+HOOK_PATH = HOOKS_DIR / "require-wait-for-messages.py"
+
+
+def _load_hook(monkeypatch, tmp_path, is_dispatcher_result: bool = False):
+    """Load require-wait-for-messages.py as a fresh module for each test.
+
+    Patches session_role.is_dispatcher to return is_dispatcher_result so
+    tests don't depend on the live dispatcher marker file.
+    """
+    monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+
+    spec = importlib.util.spec_from_file_location("require_wfm", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    # Insert hooks dir into path so session_role import works.
+    if str(HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(HOOKS_DIR))
+
+    # Patch is_dispatcher before module execution so the module-level import
+    # picks up the mock. We patch the session_role module that is already loaded.
+    import session_role
+    monkeypatch.setattr(session_role, "is_dispatcher", lambda data: is_dispatcher_result)
+
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_jsonl_transcript(tool_names: list[str], tmp_path: Path) -> str:
+    """Write a JSONL transcript file with the given tool_use names and return its path."""
+    content = [
+        {"type": "tool_use", "name": name, "id": f"id_{i}"}
+        for i, name in enumerate(tool_names)
+    ]
+    entry = {
+        "type": "assistant",
+        "message": {"role": "assistant", "content": content},
+    }
+    tf = tmp_path / "transcript.jsonl"
+    tf.write_text(json.dumps(entry) + "\n")
+    return str(tf)
+
+
+def _run_hook(mod, hook_input: dict) -> tuple[int, str, str]:
+    """Run the hook's main() with the given input dict.
+
+    Returns (exit_code, stdout, stderr).
+    """
+    stdout_buf = StringIO()
+    stderr_buf = StringIO()
+    with (
+        patch("sys.stdin", StringIO(json.dumps(hook_input))),
+        patch("sys.stdout", stdout_buf),
+        patch("sys.stderr", stderr_buf),
+    ):
+        try:
+            mod.main()
+            code = 0
+        except SystemExit as e:
+            code = e.code
+    return code, stdout_buf.getvalue(), stderr_buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Tests: session exemptions
+# ---------------------------------------------------------------------------
+
+
+def test_no_lobster_main_session_exits_0(monkeypatch, tmp_path):
+    """Sessions without LOBSTER_MAIN_SESSION=1 are always allowed (exit 0)."""
+    monkeypatch.delenv("LOBSTER_MAIN_SESSION", raising=False)
+
+    spec = importlib.util.spec_from_file_location("require_wfm_noenv", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    if str(HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(HOOKS_DIR))
+    spec.loader.exec_module(mod)
+
+    hook_input = {"hook_event_name": "Stop", "session_id": "some-session"}
+    code, stdout, _ = _run_hook(mod, hook_input)
+    assert code == 0
+    assert json.loads(stdout).get("suppressOutput") is True
+
+
+def test_non_dispatcher_session_exits_0(monkeypatch, tmp_path):
+    """Subagent sessions (is_dispatcher returns False) exit 0."""
+    mod = _load_hook(monkeypatch, tmp_path, is_dispatcher_result=False)
+    hook_input = {
+        "hook_event_name": "Stop",
+        "session_id": "subagent-session",
+    }
+    code, _, _ = _run_hook(mod, hook_input)
+    assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: dispatcher blocking behavior
+# ---------------------------------------------------------------------------
+
+
+def test_dispatcher_with_wfm_exits_0(monkeypatch, tmp_path):
+    """Dispatcher that called wait_for_messages is allowed to stop (exit 0)."""
+    mod = _load_hook(monkeypatch, tmp_path, is_dispatcher_result=True)
+    tf = _make_jsonl_transcript(
+        ["mcp__lobster-inbox__wait_for_messages"], tmp_path
+    )
+    hook_input = {
+        "hook_event_name": "Stop",
+        "session_id": "dispatcher-session",
+        "transcript_path": tf,
+    }
+    code, _, _ = _run_hook(mod, hook_input)
+    assert code == 0
+
+
+def test_dispatcher_without_wfm_exits_2(monkeypatch, tmp_path):
+    """Dispatcher that did NOT call wait_for_messages is blocked (exit 2)."""
+    mod = _load_hook(monkeypatch, tmp_path, is_dispatcher_result=True)
+    tf = _make_jsonl_transcript(
+        ["mcp__lobster-inbox__mark_processed"],
+        tmp_path,
+    )
+    hook_input = {
+        "hook_event_name": "Stop",
+        "session_id": "dispatcher-session",
+        "transcript_path": tf,
+    }
+    code, _, _ = _run_hook(mod, hook_input)
+    assert code == 2
+
+
+def test_block_message_mentions_wfm(monkeypatch, tmp_path):
+    """Block message tells dispatcher to call wait_for_messages."""
+    mod = _load_hook(monkeypatch, tmp_path, is_dispatcher_result=True)
+    tf = _make_jsonl_transcript(
+        ["mcp__lobster-inbox__mark_processed"],
+        tmp_path,
+    )
+    hook_input = {
+        "hook_event_name": "Stop",
+        "session_id": "dispatcher-session",
+        "transcript_path": tf,
+    }
+    _, _, stderr = _run_hook(mod, hook_input)
+    assert "wait_for_messages" in stderr.lower()
+
+
+def test_dispatcher_with_wfm_also_in_transcript_exits_0(monkeypatch, tmp_path):
+    """Dispatcher session with both mark_processed and wait_for_messages exits 0."""
+    mod = _load_hook(monkeypatch, tmp_path, is_dispatcher_result=True)
+    tf = _make_jsonl_transcript(
+        [
+            "mcp__lobster-inbox__mark_processed",
+            "mcp__lobster-inbox__wait_for_messages",
+        ],
+        tmp_path,
+    )
+    hook_input = {
+        "hook_event_name": "Stop",
+        "session_id": "dispatcher-session",
+        "transcript_path": tf,
+    }
+    code, _, _ = _run_hook(mod, hook_input)
+    assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: transcript read failure
+# ---------------------------------------------------------------------------
+
+
+def test_missing_transcript_path_exits_0(monkeypatch, tmp_path):
+    """If transcript_path does not exist, allow stop to avoid false-positive block."""
+    mod = _load_hook(monkeypatch, tmp_path, is_dispatcher_result=True)
+    hook_input = {
+        "hook_event_name": "Stop",
+        "session_id": "dispatcher-session",
+        "transcript_path": str(tmp_path / "nonexistent.jsonl"),
+    }
+    code, _, _ = _run_hook(mod, hook_input)
+    assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: suppressOutput JSON
+# ---------------------------------------------------------------------------
+
+
+def test_success_exit_outputs_suppress_json(monkeypatch, tmp_path):
+    """Successful exit (exit 0) outputs suppressOutput JSON to prevent CC feedback injection."""
+    mod = _load_hook(monkeypatch, tmp_path, is_dispatcher_result=True)
+    tf = _make_jsonl_transcript(
+        ["mcp__lobster-inbox__wait_for_messages"], tmp_path
+    )
+    hook_input = {
+        "hook_event_name": "Stop",
+        "session_id": "dispatcher-session",
+        "transcript_path": tf,
+    }
+    _, stdout, _ = _run_hook(mod, hook_input)
+    output = json.loads(stdout)
+    assert output.get("suppressOutput") is True
+
+
+def test_non_lobster_session_outputs_suppress_json(monkeypatch, tmp_path):
+    """Non-Lobster session also outputs suppressOutput JSON on exit 0."""
+    monkeypatch.delenv("LOBSTER_MAIN_SESSION", raising=False)
+
+    spec = importlib.util.spec_from_file_location("require_wfm_noenv2", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    if str(HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(HOOKS_DIR))
+    spec.loader.exec_module(mod)
+
+    hook_input = {"hook_event_name": "Stop", "session_id": "some-session"}
+    _, stdout, _ = _run_hook(mod, hook_input)
+    output = json.loads(stdout)
+    assert output.get("suppressOutput") is True

--- a/tests/unit/test_hooks/test_require_wait_for_messages.py
+++ b/tests/unit/test_hooks/test_require_wait_for_messages.py
@@ -9,6 +9,9 @@ Tests cover:
 - Missing transcript_path (I/O error): exits 0 to avoid false-positive block
 - Success exit outputs JSON with suppressOutput=true to prevent feedback injection
 - Block message references wait_for_messages to guide dispatcher behavior
+- Graceful exit bypass: /tmp/lobster-graceful-exit flag allows stop without WFM
+- Graceful exit flag is consumed (deleted) on use
+- Block message documents the bypass mechanism
 """
 
 import importlib.util
@@ -244,3 +247,81 @@ def test_non_lobster_session_outputs_suppress_json(monkeypatch, tmp_path):
     _, stdout, _ = _run_hook(mod, hook_input)
     output = json.loads(stdout)
     assert output.get("suppressOutput") is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: graceful exit bypass
+# ---------------------------------------------------------------------------
+
+
+def test_graceful_exit_flag_allows_stop(monkeypatch, tmp_path):
+    """Dispatcher without WFM is allowed to stop when graceful exit flag is present."""
+    mod = _load_hook(monkeypatch, tmp_path, is_dispatcher_result=True)
+    tf = _make_jsonl_transcript(["mcp__lobster-inbox__mark_processed"], tmp_path)
+
+    flag_path = tmp_path / "lobster-graceful-exit"
+    flag_path.touch()
+
+    monkeypatch.setattr(mod, "_GRACEFUL_EXIT_FLAG", str(flag_path))
+
+    hook_input = {
+        "hook_event_name": "Stop",
+        "session_id": "dispatcher-session",
+        "transcript_path": tf,
+    }
+    code, stdout, _ = _run_hook(mod, hook_input)
+    assert code == 0
+    assert json.loads(stdout).get("suppressOutput") is True
+
+
+def test_graceful_exit_flag_is_consumed(monkeypatch, tmp_path):
+    """Graceful exit flag file is deleted after use (single-use bypass)."""
+    mod = _load_hook(monkeypatch, tmp_path, is_dispatcher_result=True)
+    tf = _make_jsonl_transcript(["mcp__lobster-inbox__mark_processed"], tmp_path)
+
+    flag_path = tmp_path / "lobster-graceful-exit"
+    flag_path.touch()
+    assert flag_path.exists()
+
+    monkeypatch.setattr(mod, "_GRACEFUL_EXIT_FLAG", str(flag_path))
+
+    hook_input = {
+        "hook_event_name": "Stop",
+        "session_id": "dispatcher-session",
+        "transcript_path": tf,
+    }
+    _run_hook(mod, hook_input)
+    assert not flag_path.exists(), "Flag file should be deleted after use"
+
+
+def test_no_graceful_exit_flag_still_blocks(monkeypatch, tmp_path):
+    """Without the flag file, dispatcher still gets blocked (exit 2)."""
+    mod = _load_hook(monkeypatch, tmp_path, is_dispatcher_result=True)
+    tf = _make_jsonl_transcript(["mcp__lobster-inbox__mark_processed"], tmp_path)
+
+    # Point at a path that definitely doesn't exist.
+    monkeypatch.setattr(mod, "_GRACEFUL_EXIT_FLAG", str(tmp_path / "no-such-flag"))
+
+    hook_input = {
+        "hook_event_name": "Stop",
+        "session_id": "dispatcher-session",
+        "transcript_path": tf,
+    }
+    code, _, _ = _run_hook(mod, hook_input)
+    assert code == 2
+
+
+def test_block_message_documents_bypass(monkeypatch, tmp_path):
+    """Block message includes instructions for writing the graceful exit flag."""
+    mod = _load_hook(monkeypatch, tmp_path, is_dispatcher_result=True)
+    tf = _make_jsonl_transcript(["mcp__lobster-inbox__mark_processed"], tmp_path)
+
+    monkeypatch.setattr(mod, "_GRACEFUL_EXIT_FLAG", str(tmp_path / "no-such-flag"))
+
+    hook_input = {
+        "hook_event_name": "Stop",
+        "session_id": "dispatcher-session",
+        "transcript_path": tf,
+    }
+    _, _, stderr = _run_hook(mod, hook_input)
+    assert "lobster-graceful-exit" in stderr


### PR DESCRIPTION
## Why this exists

The warn-only Stop hook from PR #815 was insufficient. After that PR merged, 3 more health-check restarts occurred from the same root cause: the dispatcher ending a turn without calling \`wait_for_messages\`.

The failure mode (Failure Mode B from issue #768's audit): after processing a batch of system messages, the dispatcher calls \`mark_processed\` on the last one, then deliberates about "what to do next" instead of immediately calling \`wait_for_messages\`. The health check trips at 600s.

The warn-only hook printed to stderr after the turn was already ending — Claude had no chance to act on it in that turn. Warnings don't prevent deliberation; blocking does.

## What changed

**\`hooks/require-wait-for-messages.py\`**: Changed from warn-only (exit 0) to blocking (exit 2). When the dispatcher ends a turn without calling \`wait_for_messages\`, the hook:
1. Checks for \`/tmp/lobster-graceful-exit\` — if present, deletes it and exits 0 (graceful bypass, see below)
2. Otherwise exits 2, injecting an error message that tells the dispatcher exactly what to do:
   - Call \`wait_for_messages\` now (the normal case), OR
   - Write \`/tmp/lobster-graceful-exit\` and exit (the graceful-exit case)

**\`hooks/require-wait-for-messages.py\` — graceful exit bypass**: Two cases require the dispatcher to exit without calling \`wait_for_messages\` again:
- **Hibernation**: \`wait_for_messages(hibernate_on_timeout=True)\` returned EXIT/Hibernating — calling WFM again would be wrong
- **Context restart**: after \`lobster restart\`, the dispatcher should exit; forcing another WFM call would loop

The bypass: the dispatcher writes an empty file at \`/tmp/lobster-graceful-exit\` immediately before intentionally exiting. The hook consumes the file (deletes it) on first use — single-use, no lingering state.

The block message itself is the instruction manual: it documents the bypass inline, so the dispatcher knows what to do when blocked for a legitimate exit without consulting external docs.

**\`.claude/sys.dispatcher.bootup.md\`**: Added a note to the WFM-always-next rule section that the hook is now enforcing (not just advisory).

**\`tests/unit/test_hooks/test_require_wait_for_messages.py\`**: 13 tests total (9 original + 4 new) covering all behavior paths including the bypass mechanism.

## Flow: before vs after

```
Before (warn-only, PR #815):
  Dispatcher processes batch of system messages
    → mark_processed on last message
    → deliberates (611s) "what should I do now?"
    → turn ends naturally
    → Stop hook fires, prints warning to stderr
    → warning ignored (turn already ended)
    → health check trips at 600s → restart

After (blocking + graceful bypass):
  Normal stall case:
    → mark_processed → deliberates → turn ends without WFM
    → Stop hook fires, exits 2
    → error injected: "Call wait_for_messages NOW (or write bypass flag)"
    → new turn: dispatcher calls wait_for_messages
    → WFM blocks until next message — health check never trips

  Hibernation case:
    → WFM(hibernate_on_timeout=True) returns EXIT/Hibernating
    → dispatcher writes /tmp/lobster-graceful-exit
    → dispatcher exits
    → Stop hook fires, finds flag, deletes it, exits 0
    → turn ends cleanly

  Context restart case:
    → dispatcher writes handoff, calls lobster restart
    → dispatcher writes /tmp/lobster-graceful-exit
    → dispatcher exits
    → Stop hook fires, finds flag, deletes it, exits 0
    → turn ends cleanly
```

## What this does NOT change

- Subagent sessions are still exempt (\`is_dispatcher()\` returns False for subagents)
- Transcript read failures still allow stop (exit 0) — no false-positive blocks
- The health check remains the backstop for genuinely stuck sessions
- No changes to the dispatcher's main loop logic or message routing

## Functional patterns

Pure predicate check: collect all tool names from transcript, test for membership. Graceful bypass is a pure side-effect-isolated check (file presence → read → delete). Single branching function with no retry state.

## Tests run

- [x] \`uv run pytest tests/unit/test_hooks/test_require_wait_for_messages.py -v\` — 13 passed, 0 failed
- [x] \`uv run pytest tests/unit/ -q\` — 1572 passed, 3 failed (all pre-existing on main), 24 skipped, 6 errors (all pre-existing)
- [ ] Live dispatcher test — blocked: requires production behavior to trigger; change is live via symlink once merged

Relates to #771