### PR TITLE
docs: add local-dev deploy convention to boot files

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1120,6 +1120,32 @@ The agent self-detects design-review mode when no PR URL is present. It will:
 - "is this architecture sound?"
 - "what do you think of this design?"
 
+### Local deploy convention (testing PRs before merging)
+
+When Sahar wants to test a PR locally before merging, the deploy target is always the `local-dev` branch — never a dated branch like `local-dev-0325`. This is the branch Lobster actually runs on, so merging into it makes the change live immediately.
+
+**To deploy a PR locally:**
+
+```bash
+cd ~/lobster && git checkout local-dev && git merge origin/<feature-branch> --no-edit
+# Restart if the change requires it (service files, cron, etc.):
+lobster restart
+```
+
+**To restore after testing:**
+
+```bash
+cd ~/lobster && git checkout main
+```
+
+**Rules:**
+- Always use `local-dev` — never create dated variants (local-dev-0325, local-dev-march, etc.)
+- `local-dev` is the running branch — changes land immediately, no separate deploy step needed
+- After testing, always return `~/lobster/` to `main` so the repo's default state stays clean
+- This is a testing convention only — the PR still requires review and a normal merge to main
+
+**Why this matters:** If this convention is not in the boot files, a restarted session will not know it exists and will invent its own branch naming, breaking consistency.
+
 ## Processing Voice Note Brain Dumps
 
 When you receive a **voice message** that appears to be a "brain dump" (unstructured thoughts, ideas, stream of consciousness) rather than a command or question, use the **brain-dumps** agent.


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What problem this solves

Lobster's session context is lost on every restart. If an operational convention isn't written into the boot files, a freshly started session simply doesn't know it exists — and will invent its own behavior. That's what was happening with local deploy branches: the convention was `local-dev`, but nothing documented it, so sessions were creating dated variants like `local-dev-0325`.

## What changed

Added a "Local deploy convention" subsection to the "Working on GitHub Issues" section in `sys.dispatcher.bootup.md`. The new section documents:

- Local PR deploys always target the `local-dev` branch, never dated variants
- `local-dev` is the branch Lobster runs on — changes merged there are live immediately
- The exact commands to deploy a PR locally and restore afterward
- That this is a testing convention only; the PR still follows the normal merge-to-main process

## Why `sys.dispatcher.bootup.md`

The convention governs how the dispatcher responds when asked to "test this PR locally" — it's operational behavior for the main loop, so it belongs alongside the other GitHub issue workflow documentation (PR review flow, design review flow) in the dispatcher boot file. It's placed as a subsection of "Working on GitHub Issues" for logical grouping.

## Scope

No behavior changes — this is documentation only. No code, no services, no configuration files touched.

## Tests run

- [x] Manual diff review — section content matches the spec in the task prompt, no unintended changes to surrounding content
- [ ] Live dispatcher test — not applicable; docs-only change, no behavior to test