### PR TITLE
fix: search conversation history before saying 'I don't recognize X'

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -89,6 +89,13 @@ If you find yourself reaching for `Read`, `Bash`, `mcp__github__*`, `WebFetch`, 
 **Code internals questions → delegate, don't speculate**
 When asked how something works internally (a function, a module, a system), spawn a subagent to read the actual code — unless the answer is already present in the current context from a recently returned subagent report. Do not reason from memory or give plausible-sounding explanations without source confirmation.
 
+**Named mode/session/term questions — search first, never say "I don't recognize":**
+When the user asks about a named mode, session, or term you don't immediately recognize
+(e.g. "what did you do during X", "what is X"), do NOT reply "I'm not familiar with X."
+Instead, immediately delegate a subagent to call `get_conversation_history` searching for
+that term. Only after searching (and finding nothing) is it appropriate to say you don't
+recognize it.
+
 **Ack policy — when to send "On it." before delegating:**
 
 **Two-layer ack architecture:** The Telegram bot (`lobster_bot.py`) automatically sends "📨 Message received. Processing..." to the user at the transport layer as soon as it writes a text message to the inbox. This fires for all plain text messages before you ever see the message. Your "On it." is a *second*, dispatcher-level ack — it signals that work is underway, not that the message was received.


### PR DESCRIPTION
## What problem this solves

The dispatcher was admitting ignorance about named modes and sessions without first checking whether conversation history had the answer. A user asking "what did you do during super librarian mode?" would get "I'm not familiar with that" when `get_conversation_history` would have surfaced the answer immediately.

This matters because named-session context is routinely lost. Every context compaction, restart, and long-running session erodes the dispatcher's in-context memory. Absence from the current context window is not evidence that the session never happened — it is evidence only that the dispatcher has forgotten. The user has no way to distinguish "it never happened" from "the system forgot."

## What changed

A new rule is added to `sys.dispatcher.bootup.md`, placed immediately after the existing "Code internals questions → delegate, don't speculate" rule (line 89-90), which it parallels in spirit:

**Named mode/session/term questions — search first, never say "I don't recognize":** When the user asks about a named mode, session, or term the dispatcher doesn't immediately recognize, it must delegate a subagent to call `get_conversation_history` before responding. Only after searching and finding nothing is it appropriate to say the term isn't recognized.

The implementation approach is the same pattern already used for code-internals questions: delegate first, answer from returned evidence, never speculate from absent in-context memory.

## What is not changed

This is a documentation-only change to a bootup prompt. No code is modified. No routing logic, MCP server behavior, or message handling is affected.

## Functional patterns

Pure instruction: the rule is declarative and stateless — it prescribes a deterministic lookup step rather than asking the dispatcher to make a judgment call about whether to search.

## Tests run

- [ ] No automated tests apply — this is a bootup prompt change. Behavior verification requires a live dispatcher session. The rule is verifiable by inspection against the diff.

Closes #845