### PR TITLE
Add sender_type filter to get_conversation_history

### DIFF
--- a/src/db/reader.py
+++ b/src/db/reader.py
@@ -22,8 +22,20 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
+
+# Import canonical user types for sender_type filtering.
+# message_types.py lives alongside inbox_server.py in src/mcp/.
+_MCP_DIR = str(Path(__file__).resolve().parent.parent / "mcp")
+if _MCP_DIR not in sys.path:
+    sys.path.insert(0, _MCP_DIR)
+try:
+    from message_types import INBOX_USER_TYPES as _INBOX_USER_TYPES
+except ImportError:  # pragma: no cover — fallback when run outside normal tree
+    _INBOX_USER_TYPES = frozenset()
 
 # ---------------------------------------------------------------------------
 # Type aliases
@@ -84,6 +96,46 @@ def _parse_timestamp(ts: str | None) -> datetime:
 
 
 # ---------------------------------------------------------------------------
+# Sender-type filter helpers — pure functions
+# ---------------------------------------------------------------------------
+
+def _sender_type_sql(sender_type: str | None) -> tuple[list[str], list[Any]]:
+    """
+    Return (conditions, params) for a sender_type filter.
+
+    sender_type semantics:
+      "user"         — inbound messages whose type is a user-initiated type
+                       (text, photo, voice, document, etc. — excludes system noise)
+      "lobster"      — all outbound messages (direction='out')
+      "conversation" — union of user and lobster (real conversation, no cron/system)
+      None / other   — no additional conditions (all messages)
+
+    Returns plain lists so callers can append to their existing conditions/params.
+    This is a pure function with no side effects.
+    """
+    if not sender_type or sender_type == "all":
+        return [], []
+
+    # Build the IN-list for user types once, using positional parameters.
+    user_types = sorted(_INBOX_USER_TYPES)  # sorted for deterministic SQL
+    placeholders = ", ".join("?" * len(user_types))
+    user_clause = f"(direction = 'in' AND type IN ({placeholders}))"
+
+    if sender_type == "user":
+        return [user_clause], list(user_types)
+
+    if sender_type == "lobster":
+        return ["direction = 'out'"], []
+
+    if sender_type == "conversation":
+        # outbound OR inbound-user-type
+        return [f"(direction = 'out' OR {user_clause})"], list(user_types)
+
+    # Unknown value — treat as no filter (safe degradation)
+    return [], []
+
+
+# ---------------------------------------------------------------------------
 # Table detection
 # ---------------------------------------------------------------------------
 
@@ -118,23 +170,30 @@ def get_conversation_history(
     source: str | None = None,
     search: str | None = None,
     direction: str = "all",
+    sender_type: str | None = None,
     limit: int = 20,
     offset: int = 0,
 ) -> list[Row]:
     """
     Fetch conversation history from the messages table.
 
-    Applies optional filters for chat_id, source, full-text search, and
-    direction (received/sent/all).  Results are ordered newest-first.
+    Applies optional filters for chat_id, source, full-text search,
+    direction (received/sent/all), and sender_type.  Results are ordered
+    newest-first.
 
     Args:
-        conn:      Open sqlite3.Connection.
-        chat_id:   Filter to a specific conversation (compared as string).
-        source:    Filter by message source (e.g. 'telegram', 'bisque').
-        search:    Keyword search over message text (uses FTS5 when available).
-        direction: 'received' | 'sent' | 'all' — maps to direction IN/OUT.
-        limit:     Maximum number of rows to return.
-        offset:    Rows to skip for pagination.
+        conn:        Open sqlite3.Connection.
+        chat_id:     Filter to a specific conversation (compared as string).
+        source:      Filter by message source (e.g. 'telegram', 'bisque').
+        search:      Keyword search over message text (uses FTS5 when available).
+        direction:   'received' | 'sent' | 'all' — maps to direction IN/OUT.
+        sender_type: 'user' | 'lobster' | 'conversation' | None
+                     'user'         — inbound user-type messages only (no system/cron)
+                     'lobster'      — outbound messages only
+                     'conversation' — both user and lobster (excludes system noise)
+                     None / omitted — all messages (current default behaviour)
+        limit:       Maximum number of rows to return.
+        offset:      Rows to skip for pagination.
 
     Returns:
         List of plain dicts with all message columns plus '_direction'.
@@ -143,11 +202,19 @@ def get_conversation_history(
     conditions: list[str] = []
     params: list[Any] = []
 
-    # Direction filter
-    if direction == "received":
-        conditions.append("direction = 'in'")
-    elif direction == "sent":
-        conditions.append("direction = 'out'")
+    # sender_type takes precedence over direction when set, because it encodes
+    # its own directionality.  When sender_type is given, the direction param
+    # is ignored to avoid conflicting SQL conditions.
+    if sender_type and sender_type != "all":
+        st_conds, st_params = _sender_type_sql(sender_type)
+        conditions.extend(st_conds)
+        params.extend(st_params)
+    else:
+        # Direction filter (legacy path — only applied when sender_type is absent)
+        if direction == "received":
+            conditions.append("direction = 'in'")
+        elif direction == "sent":
+            conditions.append("direction = 'out'")
 
     # chat_id filter (coerce to string for uniform comparison)
     if chat_id is not None:
@@ -207,20 +274,28 @@ def count_conversation_history(
     source: str | None = None,
     search: str | None = None,
     direction: str = "all",
+    sender_type: str | None = None,
 ) -> int:
     """
     Return the total number of messages matching the given filters (for pagination).
 
     Uses the same filter logic as get_conversation_history but returns only
     the row count, avoiding the overhead of fetching full rows.
+
+    sender_type: see get_conversation_history for semantics.
     """
     conditions: list[str] = []
     params: list[Any] = []
 
-    if direction == "received":
-        conditions.append("direction = 'in'")
-    elif direction == "sent":
-        conditions.append("direction = 'out'")
+    if sender_type and sender_type != "all":
+        st_conds, st_params = _sender_type_sql(sender_type)
+        conditions.extend(st_conds)
+        params.extend(st_params)
+    else:
+        if direction == "received":
+            conditions.append("direction = 'in'")
+        elif direction == "sent":
+            conditions.append("direction = 'out'")
 
     if chat_id is not None:
         conditions.append("chat_id = ?")

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -1362,7 +1362,7 @@ async def list_tools() -> list[Tool]:
         # Conversation History Tool
         Tool(
             name="get_conversation_history",
-            description="Retrieve past messages from conversation history - both received messages and sent replies. Supports pagination, filtering by chat_id, and text search. Use this to scroll back through previous conversations.",
+            description="Retrieve past messages from conversation history - both received messages and sent replies. Supports pagination, filtering by chat_id, text search, and sender_type to isolate real conversation from system/cron noise. Use this to scroll back through previous conversations.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -1389,12 +1389,24 @@ async def list_tools() -> list[Tool]:
                     },
                     "direction": {
                         "type": "string",
-                        "description": "Filter by direction: 'received' for incoming messages only, 'sent' for outgoing replies only, or 'all' for both. Default 'all'.",
+                        "description": "Filter by direction: 'received' for incoming messages only, 'sent' for outgoing replies only, or 'all' for both. Default 'all'. Ignored when sender_type is set.",
                         "default": "all",
                     },
                     "source": {
                         "type": "string",
                         "description": "Filter by source (telegram, slack, etc.). Leave empty for all sources.",
+                    },
+                    "sender_type": {
+                        "type": "string",
+                        "description": (
+                            "Filter by who sent the message. "
+                            "'user' — only messages from the user (inbound Telegram/Slack, excludes system/cron). "
+                            "'lobster' — only messages sent by Lobster/subagents to the user (outbound). "
+                            "'conversation' — both user and lobster messages (real conversation only, no cron/system noise). "
+                            "Omit for all messages including system and cron (current default behaviour). "
+                            "When sender_type is set, the direction parameter is ignored."
+                        ),
+                        "enum": ["user", "lobster", "conversation"],
                     },
                 },
             },
@@ -4192,6 +4204,41 @@ def _scan_json_dirs_for_history(direction: str) -> list[dict]:
     return messages
 
 
+def _apply_sender_type_filter(messages: list[dict], sender_type: str | None) -> list[dict]:
+    """Return only messages matching the given sender_type.
+
+    Pure function: does not mutate the input list.
+
+    sender_type semantics mirror the SQL layer in db/reader.py:
+      'user'         — inbound (_direction='received') messages whose type is in
+                       INBOX_USER_TYPES (real user messages, no system/cron noise)
+      'lobster'      — outbound (_direction='sent') messages
+      'conversation' — union of user and lobster (both, but no system noise)
+      None / other   — all messages unchanged
+    """
+    if not sender_type or sender_type == "all":
+        return messages
+
+    if sender_type == "user":
+        return [
+            m for m in messages
+            if m.get("_direction") == "received" and m.get("type", "text") in INBOX_USER_TYPES
+        ]
+
+    if sender_type == "lobster":
+        return [m for m in messages if m.get("_direction") == "sent"]
+
+    if sender_type == "conversation":
+        return [
+            m for m in messages
+            if m.get("_direction") == "sent"
+            or (m.get("_direction") == "received" and m.get("type", "text") in INBOX_USER_TYPES)
+        ]
+
+    # Unknown value — degrade gracefully
+    return messages
+
+
 def _apply_filters_and_paginate(
     messages: list[dict],
     *,
@@ -4200,8 +4247,9 @@ def _apply_filters_and_paginate(
     search_text: str,
     limit: int,
     offset: int,
+    sender_type: str | None = None,
 ) -> tuple[list[dict], int]:
-    """Apply chat_id / source / search filters, sort by timestamp, then paginate.
+    """Apply chat_id / source / search / sender_type filters, sort by timestamp, then paginate.
 
     Returns (paginated_slice, total_count_before_pagination).
     All filtering and sorting is performed in-memory. This is the legacy
@@ -4217,6 +4265,9 @@ def _apply_filters_and_paginate(
             return datetime.min.replace(tzinfo=timezone.utc)
 
     filtered = messages
+
+    if sender_type:
+        filtered = _apply_sender_type_filter(filtered, sender_type)
 
     if chat_id_filter is not None:
         chat_id_str = str(chat_id_filter)
@@ -4296,6 +4347,7 @@ async def handle_get_conversation_history(args: dict) -> list[TextContent]:
     offset = args.get("offset", 0)
     direction = args.get("direction", "all").lower()
     source_filter = args.get("source", "").lower().strip()
+    sender_type = args.get("sender_type") or None  # None when omitted or empty string
 
     paginated: list[dict] = []
     total_count: int = 0
@@ -4314,6 +4366,7 @@ async def handle_get_conversation_history(args: dict) -> list[TextContent]:
                     source=source_filter or None,
                     search=search_text or None,
                     direction=direction,
+                    sender_type=sender_type,
                     limit=limit,
                     offset=offset,
                 )
@@ -4323,6 +4376,7 @@ async def handle_get_conversation_history(args: dict) -> list[TextContent]:
                     source=source_filter or None,
                     search=search_text or None,
                     direction=direction,
+                    sender_type=sender_type,
                 )
                 used_db = True
                 log.debug(
@@ -4353,6 +4407,7 @@ async def handle_get_conversation_history(args: dict) -> list[TextContent]:
             search_text=search_text,
             limit=limit,
             offset=offset,
+            sender_type=sender_type,
         )
 
     # ------------------------------------------------------------------
@@ -4364,10 +4419,12 @@ async def handle_get_conversation_history(args: dict) -> list[TextContent]:
             filter_info.append(f"chat_id={chat_id_filter}")
         if search_text:
             filter_info.append(f"search='{search_text}'")
-        if direction != "all":
+        if direction != "all" and not sender_type:
             filter_info.append(f"direction={direction}")
         if source_filter:
             filter_info.append(f"source={source_filter}")
+        if sender_type:
+            filter_info.append(f"sender_type={sender_type}")
         filter_str = f" (filters: {', '.join(filter_info)})" if filter_info else ""
         return [TextContent(type="text", text=f"No messages found{filter_str}.")]
 

--- a/tests/unit/test_mcp_server/test_sender_type_filter.py
+++ b/tests/unit/test_mcp_server/test_sender_type_filter.py
@@ -1,0 +1,434 @@
+"""
+Tests for sender_type filter on get_conversation_history (issue #848).
+
+Covers:
+  - _apply_sender_type_filter pure helper in inbox_server.py
+  - _apply_filters_and_paginate with sender_type argument (filesystem fallback path)
+  - db/reader.py get_conversation_history / count_conversation_history with sender_type
+    against an in-memory SQLite DB (SQL path)
+  - handle_get_conversation_history end-to-end: sender_type propagated to DB call
+  - No regression: omitting sender_type still returns all messages
+
+All DB tests use an in-memory SQLite connection — no on-disk state required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure src/ and src/mcp/ are importable.
+_SRC_DIR = Path(__file__).parent.parent.parent.parent / "src"
+_MCP_DIR = _SRC_DIR / "mcp"
+for _d in (_SRC_DIR, _MCP_DIR):
+    if str(_d) not in sys.path:
+        sys.path.insert(0, str(_d))
+
+# Pre-load inbox_server so patch.multiple can resolve it.
+import src.mcp.inbox_server  # noqa: F401
+
+from src.mcp.inbox_server import (
+    _apply_filters_and_paginate,
+    _apply_sender_type_filter,
+    handle_get_conversation_history,
+)
+from db import reader as db_reader
+from db.connection import apply_schema
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_SCHEMA_PATH = Path(__file__).parent.parent.parent.parent / "src" / "db" / "schema.sql"
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    apply_schema(conn, _SCHEMA_PATH.read_text())
+    return conn
+
+
+def _insert(conn: sqlite3.Connection, **kwargs: Any) -> None:
+    defaults: dict[str, Any] = {
+        "id": "m1",
+        "direction": "in",
+        "source": "telegram",
+        "type": "text",
+        "chat_id": "111",
+        "user_id": "u1",
+        "username": "alice",
+        "user_name": "Alice",
+        "text": "hello",
+        "timestamp": "2024-01-15T10:00:00+00:00",
+        "telegram_message_id": None,
+        "extra": None,
+    }
+    row = {**defaults, **kwargs}
+    cols = ", ".join(row.keys())
+    placeholders = ", ".join("?" for _ in row)
+    conn.execute(f"INSERT INTO messages ({cols}) VALUES ({placeholders})", list(row.values()))
+    conn.commit()
+
+
+def _msg(
+    id: str = "m1",
+    direction: str = "received",
+    type_: str = "text",
+    chat_id: str = "111",
+    timestamp: str = "2024-01-15T10:00:00+00:00",
+    text: str = "Hello",
+) -> dict:
+    return {
+        "id": id,
+        "_direction": direction,
+        "type": type_,
+        "source": "telegram",
+        "chat_id": chat_id,
+        "timestamp": timestamp,
+        "text": text,
+        "user_name": "Alice",
+        "username": "alice",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: _apply_sender_type_filter (pure in-memory helper)
+# ---------------------------------------------------------------------------
+
+
+class TestApplySenderTypeFilter:
+    """Unit tests for the pure in-memory sender_type filtering helper."""
+
+    def _sample_messages(self):
+        return [
+            _msg("user-text", direction="received", type_="text"),
+            _msg("user-photo", direction="received", type_="photo"),
+            _msg("user-voice", direction="received", type_="voice"),
+            _msg("sys-result", direction="received", type_="subagent_result"),
+            _msg("sys-cron", direction="received", type_="scheduled_reminder"),
+            _msg("sys-health", direction="received", type_="health_check"),
+            _msg("lobster-out", direction="sent", type_="text"),
+        ]
+
+    def test_none_returns_all_unchanged(self):
+        msgs = self._sample_messages()
+        result = _apply_sender_type_filter(msgs, None)
+        assert len(result) == len(msgs)
+
+    def test_all_returns_all_unchanged(self):
+        msgs = self._sample_messages()
+        result = _apply_sender_type_filter(msgs, "all")
+        assert len(result) == len(msgs)
+
+    def test_user_returns_only_inbound_user_types(self):
+        msgs = self._sample_messages()
+        result = _apply_sender_type_filter(msgs, "user")
+        ids = {m["id"] for m in result}
+        # user-initiated inbound types included
+        assert "user-text" in ids
+        assert "user-photo" in ids
+        assert "user-voice" in ids
+        # system inbound types excluded
+        assert "sys-result" not in ids
+        assert "sys-cron" not in ids
+        assert "sys-health" not in ids
+        # outbound excluded
+        assert "lobster-out" not in ids
+
+    def test_lobster_returns_only_outbound(self):
+        msgs = self._sample_messages()
+        result = _apply_sender_type_filter(msgs, "lobster")
+        assert all(m["_direction"] == "sent" for m in result)
+        assert len(result) == 1
+        assert result[0]["id"] == "lobster-out"
+
+    def test_conversation_excludes_system_noise(self):
+        msgs = self._sample_messages()
+        result = _apply_sender_type_filter(msgs, "conversation")
+        ids = {m["id"] for m in result}
+        # real conversation messages included
+        assert "user-text" in ids
+        assert "user-photo" in ids
+        assert "user-voice" in ids
+        assert "lobster-out" in ids
+        # system noise excluded
+        assert "sys-result" not in ids
+        assert "sys-cron" not in ids
+        assert "sys-health" not in ids
+
+    def test_unknown_value_returns_all(self):
+        msgs = self._sample_messages()
+        result = _apply_sender_type_filter(msgs, "bogus_value")
+        assert len(result) == len(msgs)
+
+    def test_does_not_mutate_input_list(self):
+        msgs = self._sample_messages()
+        original_len = len(msgs)
+        _apply_sender_type_filter(msgs, "user")
+        assert len(msgs) == original_len  # original untouched
+
+
+# ---------------------------------------------------------------------------
+# Tests: _apply_filters_and_paginate with sender_type (filesystem fallback)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyFiltersAndPaginateWithSenderType:
+    """Verify sender_type is applied in the in-memory filter/paginate helper."""
+
+    def _messages(self):
+        return [
+            _msg("u1", direction="received", type_="text"),
+            _msg("u2", direction="received", type_="voice"),
+            _msg("s1", direction="received", type_="subagent_result"),
+            _msg("s2", direction="received", type_="health_check"),
+            _msg("l1", direction="sent", type_="text"),
+        ]
+
+    def test_sender_type_user(self):
+        result, total = _apply_filters_and_paginate(
+            self._messages(),
+            chat_id_filter=None,
+            source_filter="",
+            search_text="",
+            limit=10,
+            offset=0,
+            sender_type="user",
+        )
+        ids = {m["id"] for m in result}
+        assert "u1" in ids
+        assert "u2" in ids
+        assert "s1" not in ids
+        assert "s2" not in ids
+        assert "l1" not in ids
+        assert total == 2
+
+    def test_sender_type_lobster(self):
+        result, total = _apply_filters_and_paginate(
+            self._messages(),
+            chat_id_filter=None,
+            source_filter="",
+            search_text="",
+            limit=10,
+            offset=0,
+            sender_type="lobster",
+        )
+        assert total == 1
+        assert result[0]["id"] == "l1"
+
+    def test_sender_type_conversation(self):
+        result, total = _apply_filters_and_paginate(
+            self._messages(),
+            chat_id_filter=None,
+            source_filter="",
+            search_text="",
+            limit=10,
+            offset=0,
+            sender_type="conversation",
+        )
+        ids = {m["id"] for m in result}
+        assert "u1" in ids
+        assert "u2" in ids
+        assert "l1" in ids
+        assert "s1" not in ids
+        assert "s2" not in ids
+        assert total == 3
+
+    def test_sender_type_none_returns_all(self):
+        result, total = _apply_filters_and_paginate(
+            self._messages(),
+            chat_id_filter=None,
+            source_filter="",
+            search_text="",
+            limit=10,
+            offset=0,
+            sender_type=None,
+        )
+        assert total == 5
+
+    def test_pagination_count_is_post_filter(self):
+        """total count must reflect sender_type-filtered count, not raw count."""
+        result, total = _apply_filters_and_paginate(
+            self._messages(),
+            chat_id_filter=None,
+            source_filter="",
+            search_text="",
+            limit=1,
+            offset=0,
+            sender_type="conversation",
+        )
+        # 3 conversation messages total, only 1 returned due to limit
+        assert total == 3
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: db/reader.py SQL path with sender_type
+# ---------------------------------------------------------------------------
+
+
+class TestDbReaderSenderType:
+    """Verify sender_type filter generates correct SQL against in-memory SQLite."""
+
+    def _setup_db(self):
+        conn = _make_conn()
+        _insert(conn, id="u1", direction="in", type="text", text="user text")
+        _insert(conn, id="u2", direction="in", type="photo", text="user photo")
+        _insert(conn, id="s1", direction="in", type="subagent_result", text="result noise")
+        _insert(conn, id="s2", direction="in", type="scheduled_reminder", text="cron noise")
+        _insert(conn, id="l1", direction="out", type="text", text="lobster reply")
+        return conn
+
+    def test_sender_type_user_sql(self):
+        conn = self._setup_db()
+        rows = db_reader.get_conversation_history(conn, sender_type="user")
+        ids = {r["id"] for r in rows}
+        assert "u1" in ids
+        assert "u2" in ids
+        assert "s1" not in ids
+        assert "s2" not in ids
+        assert "l1" not in ids
+        conn.close()
+
+    def test_sender_type_lobster_sql(self):
+        conn = self._setup_db()
+        rows = db_reader.get_conversation_history(conn, sender_type="lobster")
+        assert len(rows) == 1
+        assert rows[0]["id"] == "l1"
+        conn.close()
+
+    def test_sender_type_conversation_sql(self):
+        conn = self._setup_db()
+        rows = db_reader.get_conversation_history(conn, sender_type="conversation")
+        ids = {r["id"] for r in rows}
+        assert "u1" in ids
+        assert "u2" in ids
+        assert "l1" in ids
+        assert "s1" not in ids
+        assert "s2" not in ids
+        conn.close()
+
+    def test_sender_type_none_returns_all(self):
+        conn = self._setup_db()
+        rows = db_reader.get_conversation_history(conn, sender_type=None)
+        assert len(rows) == 5
+        conn.close()
+
+    def test_count_matches_get_for_user(self):
+        conn = self._setup_db()
+        rows = db_reader.get_conversation_history(conn, sender_type="user")
+        count = db_reader.count_conversation_history(conn, sender_type="user")
+        assert count == len(rows)
+        conn.close()
+
+    def test_count_matches_get_for_conversation(self):
+        conn = self._setup_db()
+        rows = db_reader.get_conversation_history(conn, sender_type="conversation")
+        count = db_reader.count_conversation_history(conn, sender_type="conversation")
+        assert count == len(rows)
+        conn.close()
+
+    def test_sender_type_combined_with_chat_id(self):
+        """sender_type and chat_id filters compose correctly."""
+        conn = _make_conn()
+        _insert(conn, id="a1", direction="in", type="text", chat_id="111", text="chat 111 user")
+        _insert(conn, id="a2", direction="in", type="text", chat_id="222", text="chat 222 user")
+        _insert(conn, id="a3", direction="in", type="subagent_result", chat_id="111", text="noise")
+        rows = db_reader.get_conversation_history(conn, chat_id="111", sender_type="user")
+        ids = {r["id"] for r in rows}
+        assert "a1" in ids
+        assert "a2" not in ids
+        assert "a3" not in ids
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: handle_get_conversation_history propagates sender_type to DB layer
+# ---------------------------------------------------------------------------
+
+
+class TestHandleGetConversationHistorySenderType:
+    """Verify sender_type is threaded through to _db_get_conversation_history."""
+
+    def test_sender_type_propagated_to_db_call(self):
+        mock_get = MagicMock(return_value=[])
+        mock_count = MagicMock(return_value=0)
+        mock_conn = MagicMock()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            _db_get_conversation_history=mock_get,
+            _db_count_conversation_history=mock_count,
+            _open_messages_db_conn=MagicMock(return_value=mock_conn),
+            PROCESSED_DIR=Path("/tmp"),
+            SENT_DIR=Path("/tmp"),
+        ):
+            asyncio.run(handle_get_conversation_history({"sender_type": "conversation"}))
+
+        _, kwargs = mock_get.call_args
+        assert kwargs.get("sender_type") == "conversation"
+
+    def test_sender_type_user_propagated(self):
+        mock_get = MagicMock(return_value=[])
+        mock_count = MagicMock(return_value=0)
+        mock_conn = MagicMock()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            _db_get_conversation_history=mock_get,
+            _db_count_conversation_history=mock_count,
+            _open_messages_db_conn=MagicMock(return_value=mock_conn),
+            PROCESSED_DIR=Path("/tmp"),
+            SENT_DIR=Path("/tmp"),
+        ):
+            asyncio.run(handle_get_conversation_history({"sender_type": "user"}))
+
+        _, kwargs = mock_get.call_args
+        assert kwargs.get("sender_type") == "user"
+
+    def test_omitted_sender_type_is_none(self):
+        """When sender_type is not in args, None is passed to DB layer."""
+        mock_get = MagicMock(return_value=[])
+        mock_count = MagicMock(return_value=0)
+        mock_conn = MagicMock()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            _db_get_conversation_history=mock_get,
+            _db_count_conversation_history=mock_count,
+            _open_messages_db_conn=MagicMock(return_value=mock_conn),
+            PROCESSED_DIR=Path("/tmp"),
+            SENT_DIR=Path("/tmp"),
+        ):
+            asyncio.run(handle_get_conversation_history({}))
+
+        _, kwargs = mock_get.call_args
+        assert kwargs.get("sender_type") is None
+
+    def test_filter_info_includes_sender_type_on_no_results(self, tmp_path: Path):
+        """When no results found, the 'no messages' string mentions sender_type."""
+        processed = tmp_path / "processed"
+        processed.mkdir()
+        (tmp_path / "sent").mkdir()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            _db_get_conversation_history=None,
+            _db_count_conversation_history=None,
+            PROCESSED_DIR=processed,
+            SENT_DIR=tmp_path / "sent",
+        ):
+            result = asyncio.run(
+                handle_get_conversation_history({"sender_type": "user", "chat_id": "999"})
+            )
+
+        text = result[0].text
+        assert "sender_type=user" in text
+        assert "chat_id=999" in text


### PR DESCRIPTION
## Problem

`get_conversation_history` returns everything — cron outputs, `subagent_result` routing messages, `health_check`, `scheduled_reminder`, and other system-generated types all appear alongside genuine user↔Lobster exchanges. When looking up recent conversation context, the system noise drowns the signal.

The existing `direction` filter doesn't help because system messages also arrive as `direction='in'`, so `direction=received` still includes all the noise.

## What this adds

A `sender_type` parameter with four values:

| Value | Effect |
|---|---|
| `"user"` | Inbound messages whose type is in `INBOX_USER_TYPES` (text, photo, voice, document, etc.) — excludes `subagent_result`, `scheduled_reminder`, `health_check`, and all other system-generated types |
| `"lobster"` | Outbound messages only — what Lobster sent back |
| `"conversation"` | Union of the two above — the real back-and-forth with no system noise |
| omitted | Current behavior — all messages, no change |

When `sender_type` is set, the `direction` parameter is ignored (sender_type encodes its own directionality). Omitting `sender_type` is a strict no-op.

## Design

The filter is applied at two layers so it's correct in both read paths:

**SQL path (primary):** `_sender_type_sql()` in `reader.py` is a pure function that returns `(conditions, params)` for a `WHERE` clause. Applied to both `get_conversation_history` and `count_conversation_history` so pagination counts are correct.

- `"user"` → `direction = 'in' AND type IN (text, photo, voice, ...)`
- `"lobster"` → `direction = 'out'`
- `"conversation"` → `(direction = 'out' OR (direction = 'in' AND type IN (...)))`

**Filesystem fallback path (legacy migration window):** `_apply_sender_type_filter()` in `inbox_server.py` is a pure function that applies the same semantics in-memory. Called inside `_apply_filters_and_paginate()` before pagination so the `total` count is also correct.

The canonical type list comes from `INBOX_USER_TYPES` (already imported in both files), so there's one source of truth.

## Functional patterns

Pure functions with no side effects: `_sender_type_sql()` and `_apply_sender_type_filter()` both take data in and return data out. Composed into the existing filter pipelines rather than adding new conditional branches to the handler. The SQL helper returns plain `(list, list)` tuples that callers append to existing conditions/params — composable and testable in isolation.

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_sender_type_filter.py -v` — 23 passed, 0 failed
- [x] `uv run pytest tests/unit/test_mcp_server/test_conversation_history_sql.py -v` — 37 passed, 0 failed (no regression)
- [x] `uv run pytest tests/unit/test_mcp_server/test_relay_db_reads.py -v` — 50 passed, 0 failed (no regression)
- [x] `uv run pytest tests/unit/ -q` — 1582 passed, 3 pre-existing failures (test_auto_register_agent, test_skill_manager ×2), 6 pre-existing errors (test_path_guard)

Closes #848