### PR TITLE
fix: reset WFM staleness clock on each processed message (#694)

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -828,13 +828,23 @@ check_outbox_drain() {
 }
 
 # Check 6: wait_for_messages freshness
-# Checks the mtime of the claude-heartbeat file, which inbox_server.py touches
-# at the start of every wait_for_messages call. If the file hasn't been updated
-# within WFM_STALE_SECONDS, the main loop is presumed stuck (e.g. infinite
-# loop, hung tool call, or Claude exit without wrapper noticing). Suppressed
-# during hibernation and the compaction window.
+# The dispatcher is considered "fresh" if EITHER:
+#   (a) the claude-heartbeat file was touched recently — inbox_server.py touches
+#       it at the start of every wait_for_messages call, OR
+#   (b) last_processed_at in lobster-state.json was updated recently — written
+#       by inbox_server.py on every successful mark_processed call (issue #694).
+#
+# Using both signals prevents a spurious restart when the dispatcher is actively
+# processing a long batch of messages (e.g. 20 cron pings) without returning to
+# wait_for_messages.  Before this fix, a long batch could exhaust the suppression
+# window mid-batch, triggering a false-positive health-check restart even though
+# the dispatcher was busy and healthy.
+#
+# The effective freshness timestamp is max(wfm_heartbeat_mtime, last_processed_at).
 #
 # Gracefully skips the check if the heartbeat file does not exist (fresh install).
+# Gracefully ignores a missing or unparseable last_processed_at (field absent on
+# older installs before this change was deployed).
 #
 # Returns: 0=GREEN (fresh or skipped), 2=RED (stale)
 check_wfm_freshness() {
@@ -850,16 +860,43 @@ check_wfm_freshness() {
         return 0
     fi
 
+    # Read the per-message heartbeat written by mark_processed (issue #694).
+    # Use whichever signal is more recent as the effective freshness epoch.
+    local last_processed_epoch=0
+    if [[ -f "$LOBSTER_STATE_FILE" ]]; then
+        local last_processed_at
+        last_processed_at=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open('$LOBSTER_STATE_FILE'))
+    print(d.get('last_processed_at', ''))
+except Exception:
+    print('')
+" 2>/dev/null)
+        if [[ -n "$last_processed_at" ]]; then
+            last_processed_epoch=$(date -d "$last_processed_at" +%s 2>/dev/null) || last_processed_epoch=0
+        fi
+    fi
+
+    # Effective freshness = most recent of the two signals
+    local effective_last
+    if [[ "$last_processed_epoch" -gt "$last_heartbeat" ]]; then
+        effective_last="$last_processed_epoch"
+        log_info "WFM freshness: using last_processed_at signal (more recent than WFM heartbeat)"
+    else
+        effective_last="$last_heartbeat"
+    fi
+
     local now age
     now=$(date +%s)
-    age=$(( now - last_heartbeat ))
+    age=$(( now - effective_last ))
 
     if [[ $age -gt $WFM_STALE_SECONDS ]]; then
-        log_error "RED: wait_for_messages stale — heartbeat last updated ${age}s ago (threshold: ${WFM_STALE_SECONDS}s)"
+        log_error "RED: dispatcher stale — last activity ${age}s ago (threshold: ${WFM_STALE_SECONDS}s, wfm=${last_heartbeat}, last_processed=${last_processed_epoch})"
         return 2
     fi
 
-    log_info "WFM freshness OK: last wait_for_messages ${age}s ago"
+    log_info "WFM freshness OK: last dispatcher activity ${age}s ago"
     return 0
 }
 

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -1071,6 +1071,46 @@ def _write_lobster_state(state_file: Path = None, mode: str = "active") -> None:
             pass
 
 
+def _update_lobster_state_fields(fields: dict, state_file: Path = None) -> None:
+    """Atomically merge one or more fields into lobster-state.json.
+
+    Reads the current state, updates the given fields, and writes back via
+    temp-then-rename so readers always see a consistent snapshot.  Other
+    fields (mode, compacted_at, catchup_started_at, etc.) are preserved.
+
+    This is a non-destructive merge — callers supply only the keys they want
+    to update.  Unlike _write_lobster_state, which replaces the entire file,
+    this function is safe to call from any context that must not clobber
+    concurrently-written lifecycle fields.
+
+    Failures are logged but not raised — the caller (mark_processed) must
+    not fail just because the heartbeat write failed.
+    """
+    if state_file is None:
+        state_file = LOBSTER_STATE_FILE
+    try:
+        existing: dict = {}
+        if state_file.exists():
+            try:
+                existing = json.loads(state_file.read_text())
+            except (json.JSONDecodeError, OSError):
+                existing = {}
+        existing.update(fields)
+        content = json.dumps(existing, indent=2) + "\n"
+        tmp = state_file.parent / f".lobster-state-{os.getpid()}.tmp"
+        try:
+            tmp.write_text(content)
+            tmp.rename(state_file)
+        except Exception as e:
+            log.error(f"Failed to update lobster state fields {list(fields)}: {e}")
+            try:
+                tmp.unlink()
+            except Exception:
+                pass
+    except Exception as e:
+        log.error(f"_update_lobster_state_fields unexpected error: {e}")
+
+
 @server.list_tools()
 async def list_tools() -> list[Tool]:
     """List available tools."""
@@ -3615,6 +3655,12 @@ async def handle_send_reply(args: dict) -> list[TextContent]:
                         _db_persist_inbound(json.loads(dest.read_text()))
                     except Exception as _db_exc:
                         log.warning(f"[DB] inbound persist failed for {mid}: {_db_exc}")
+                # Per-message WFM heartbeat: reset the WFM staleness clock so
+                # a long message batch does not exhaust the suppression window
+                # and trigger a spurious health-check restart (issue #694).
+                _update_lobster_state_fields(
+                    {"last_processed_at": datetime.now(timezone.utc).isoformat()}
+                )
             else:
                 mark_info = f" | ⚠️ message {mid} not found for mark_processed"
                 log.warning(f"Atomic mark_processed: message not found: {mid}")
@@ -3803,6 +3849,16 @@ async def handle_mark_processed(args: dict) -> list[TextContent]:
             _db_persist_inbound(json.loads(dest.read_text()))
         except Exception as _db_exc:
             log.warning(f"[DB] inbound persist failed for {message_id}: {_db_exc}")
+
+    # Write a per-message heartbeat so the health check can distinguish a
+    # dispatcher that is actively draining a long message batch from one that
+    # is genuinely stuck.  The WFM freshness check uses the more recent of the
+    # WFM heartbeat file and this timestamp, so a burst of 20+ cron pings
+    # processed without returning to wait_for_messages does not exhaust the
+    # suppression window and trigger a spurious restart (issue #694).
+    _update_lobster_state_fields(
+        {"last_processed_at": datetime.now(timezone.utc).isoformat()}
+    )
 
     log.info(f"Message processed: {message_id}")
     return [TextContent(type="text", text=f"✅ Message marked as processed: {message_id}")]

--- a/tests/smoke/test_health_check.py
+++ b/tests/smoke/test_health_check.py
@@ -344,3 +344,175 @@ def test_maintenance_flag_causes_clean_exit(tmp_path: Path) -> None:
         f"stdout: {result.stdout!r}\n"
         f"stderr: {result.stderr!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# D5 — WFM per-message heartbeat (issue #694)
+# ---------------------------------------------------------------------------
+#
+# The dispatcher is considered "fresh" if EITHER the WFM heartbeat file was
+# touched recently OR last_processed_at in lobster-state.json was updated
+# recently.  These tests verify both signals independently and together.
+
+# How long before a dispatcher is considered stale.
+WFM_STALE_SECONDS = 600
+
+
+def _check_wfm_freshness_script(
+    heartbeat_file: Path,
+    state_file: Path,
+    tmp_path: Path,
+) -> str:
+    """
+    Build a self-contained bash script fragment that:
+    - Sets the minimal variables check_wfm_freshness() reads
+    - Injects stub log functions so logging doesn't fail
+    - Calls check_wfm_freshness()
+    - Exits with the function's return code (0=GREEN, 2=RED)
+    """
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "health-check.log"
+
+    fn_body = _extract_function("check_wfm_freshness")
+
+    return f"""
+#!/bin/bash
+HEARTBEAT_FILE="{heartbeat_file}"
+LOBSTER_STATE_FILE="{state_file}"
+WFM_STALE_SECONDS={WFM_STALE_SECONDS}
+LOG_FILE="{log_file}"
+mkdir -p "$(dirname "$LOG_FILE")"
+log()       {{ echo "[$(date -Iseconds)] [$1] $2" >> "$LOG_FILE"; }}
+log_info()  {{ log "INFO"  "$1"; }}
+log_warn()  {{ log "WARN"  "$1"; }}
+log_error() {{ log "ERROR" "$1"; }}
+
+{fn_body}
+
+check_wfm_freshness
+exit $?
+"""
+
+
+def test_wfm_freshness_green_when_heartbeat_recent(tmp_path: Path) -> None:
+    """
+    D5a: check_wfm_freshness() must return GREEN (0) when the WFM heartbeat
+    file was touched recently, even if last_processed_at is absent.
+
+    This is the pre-existing behaviour: WFM heartbeat alone is sufficient.
+    """
+    heartbeat = tmp_path / "claude-heartbeat"
+    heartbeat.touch()  # mtime = now
+
+    state_file = tmp_path / "lobster-state.json"
+    state_file.write_text(json.dumps({"mode": "active"}))  # no last_processed_at
+
+    fragment = _check_wfm_freshness_script(heartbeat, state_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode == 0, (
+        "check_wfm_freshness() returned RED for a fresh WFM heartbeat. "
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_wfm_freshness_red_when_both_signals_stale(tmp_path: Path) -> None:
+    """
+    D5b: check_wfm_freshness() must return RED (2) when the WFM heartbeat
+    file is stale AND last_processed_at is either absent or also stale.
+
+    Failure mode: if both signals are stale and the function returns GREEN, a
+    genuinely stuck dispatcher goes undetected.
+    """
+    heartbeat = tmp_path / "claude-heartbeat"
+    heartbeat.touch()
+    # Back-date the heartbeat file to well past the stale threshold
+    stale_mtime = time.time() - (WFM_STALE_SECONDS + 120)
+    os.utime(heartbeat, (stale_mtime, stale_mtime))
+
+    # last_processed_at is also stale
+    stale_epoch = time.time() - (WFM_STALE_SECONDS + 120)
+    stale_ts = datetime.fromtimestamp(stale_epoch, tz=timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%S+00:00"
+    )
+    state_file = tmp_path / "lobster-state.json"
+    state_file.write_text(json.dumps({"mode": "active", "last_processed_at": stale_ts}))
+
+    fragment = _check_wfm_freshness_script(heartbeat, state_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode == 2, (
+        "check_wfm_freshness() returned GREEN when both WFM heartbeat and "
+        f"last_processed_at are stale ({WFM_STALE_SECONDS + 120}s old). "
+        "A genuinely stuck dispatcher must trigger RED.\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_wfm_freshness_green_when_last_processed_recent(tmp_path: Path) -> None:
+    """
+    D5c (the issue #694 fix): check_wfm_freshness() must return GREEN (0) when
+    the WFM heartbeat file is stale but last_processed_at is recent.
+
+    This is the core regression test for the fix.  Before this change, a
+    dispatcher actively draining a 20-message batch (without returning to
+    wait_for_messages) could exhaust the suppression window and trigger a
+    spurious health-check restart.  After the fix, any successful mark_processed
+    call resets the clock and keeps the health check GREEN.
+
+    Failure mode: if this returns RED, a busy-but-healthy dispatcher gets
+    restarted mid-batch, losing in-flight work and corrupting dispatcher state.
+    """
+    heartbeat = tmp_path / "claude-heartbeat"
+    heartbeat.touch()
+    # Back-date the WFM heartbeat to well past the stale threshold (simulates
+    # a dispatcher that has been processing a long batch without calling WFM)
+    stale_mtime = time.time() - (WFM_STALE_SECONDS + 300)
+    os.utime(heartbeat, (stale_mtime, stale_mtime))
+
+    # last_processed_at is recent (a few seconds ago) — dispatcher is active
+    recent_ts = datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    state_file = tmp_path / "lobster-state.json"
+    state_file.write_text(
+        json.dumps({"mode": "active", "last_processed_at": recent_ts})
+    )
+
+    fragment = _check_wfm_freshness_script(heartbeat, state_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode == 0, (
+        "check_wfm_freshness() returned RED even though last_processed_at is "
+        "recent. A dispatcher actively draining messages must not be restarted "
+        "just because it hasn't called wait_for_messages recently.\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_wfm_freshness_green_when_last_processed_absent_heartbeat_recent(
+    tmp_path: Path,
+) -> None:
+    """
+    D5d: check_wfm_freshness() must stay GREEN when last_processed_at is
+    absent from the state file but the WFM heartbeat is fresh.
+
+    This covers the upgrade path: before this change is deployed, the state
+    file has no last_processed_at field.  The health check must not break on
+    older state files.
+    """
+    heartbeat = tmp_path / "claude-heartbeat"
+    heartbeat.touch()  # mtime = now
+
+    # State file exists but has no last_processed_at (pre-upgrade format)
+    state_file = tmp_path / "lobster-state.json"
+    state_file.write_text(json.dumps({"mode": "active", "compacted_at": "2026-01-01T00:00:00Z"}))
+
+    fragment = _check_wfm_freshness_script(heartbeat, state_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode == 0, (
+        "check_wfm_freshness() returned RED when last_processed_at is absent "
+        "but WFM heartbeat is recent. Must remain backward-compatible with "
+        "state files that predate issue #694.\n"
+        f"stderr: {result.stderr!r}"
+    )


### PR DESCRIPTION
## What was broken

The health check's WFM freshness check had a single freshness signal: the mtime of the claude-heartbeat file, touched at the start of each `wait_for_messages` call. When the dispatcher processed a long batch of messages — for example, 20 cron pings arriving back-to-back — it would stay busy draining the batch without returning to `wait_for_messages`. If this busy period outlasted the suppression window, the health check would see the WFM heartbeat as stale and trigger a restart, even though the dispatcher was actively working.

This is the "long batch exhausts suppression" failure mode described in issue #694.

## The fix

Add a second freshness signal: `last_processed_at` in `lobster-state.json`, written on every successful `mark_processed` call. The health check now uses `max(wfm_heartbeat_mtime, last_processed_at)` as the effective freshness epoch.

As long as the dispatcher is completing messages (calling `mark_processed`), the health check stays green — regardless of how long since it last called `wait_for_messages`. Only a dispatcher that stops processing AND stops calling WFM triggers a restart.

**Why per-message is better than raising the constant:**
- Raising `COMPACTION_SUPPRESS_SECONDS` provides a fixed window that future workloads can still exceed. Per-message heartbeat is self-scaling: batches of 100 messages keep the clock reset throughout, indefinitely.
- The constant approach is opaque — a reviewer cannot tell from the value alone whether it covers the worst case. Per-message heartbeat makes the invariant explicit: "active processing = not stale."
- A dispatcher that genuinely hangs mid-batch (no `mark_processed` calls) is still caught within `WFM_STALE_SECONDS`, whereas a longer constant would delay detection.

## Flow change

```
Before:
  effective_freshness = mtime(claude-heartbeat)
  if (now - effective_freshness) > WFM_STALE_SECONDS → RED

After:
  effective_freshness = max(mtime(claude-heartbeat), last_processed_at epoch)
  if (now - effective_freshness) > WFM_STALE_SECONDS → RED
```

## What changed

- `src/mcp/inbox_server.py`: new `_update_lobster_state_fields()` helper (merge-write, preserves all other state fields: mode, compacted_at, catchup_started_at, etc.); called from `handle_mark_processed()` and the atomic mark_processed path in `handle_send_reply()`
- `scripts/health-check-v3.sh`: `check_wfm_freshness()` reads `last_processed_at` from `lobster-state.json` and uses the more recent of the two signals
- `tests/smoke/test_health_check.py`: 4 new D5 tests

**What is not changed:** `COMPACTION_SUPPRESS_SECONDS`, `WFM_STALE_SECONDS`, and all other suppression windows are unchanged. The fix is additive — it extends the freshness signal, not the thresholds.

## Functional patterns

`_update_lobster_state_fields` is a pure read-merge-write: reads the existing state dict, updates only the specified keys, atomically replaces the file. Fail-open: errors are logged but never propagate to the caller, so a failed heartbeat write never blocks `mark_processed`.

## Tests run

- [x] `uv run pytest tests/smoke/test_health_check.py -v` — 9 passed (4 new D5 tests + 5 existing), 1 pre-existing failure in `test_maintenance_flag_causes_clean_exit` (FileExistsError unrelated to this change; fails identically on `main`)
- [ ] Full integration test — blocked: requires a running Lobster instance with live Telegram credentials

**Blocked items needing attention before merge:** none — the pre-existing test failure is not caused by this PR.

Closes #694

🤖🦞 Lobster (engineer)