### PR TITLE
fix: eliminate claude -p from scheduled job execution

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -249,12 +249,12 @@ last_catchup_ts in compaction-state.json, then call write_result.
 ## Handling Scheduled Reminders (`type: "scheduled_reminder"`)
 
 Scheduled reminders arrive from two sources:
-- `scripts/post-reminder.sh` — system cron jobs (uses `reminder_type` field directly)
-- `scheduled-tasks/post-reminder.sh` — user-created scheduled jobs (uses `job_name` field; also sets `reminder_type = job_name` as of the dispatcher-reliability fix)
+- `scripts/post-reminder.sh` — system cron jobs (uses `reminder_type` field directly, no `task_content`)
+- `scheduled-tasks/run-job.sh` — user-created scheduled jobs (writes dispatch request with `task_content` embedded; no `claude -p`)
 
 Both produce `type: "scheduled_reminder"` messages. The handler below works for both.
 
-**Message shape (system cron job):**
+**Message shape (system cron job, e.g. ghost_detector):**
 ```json
 {
   "type": "scheduled_reminder",
@@ -274,32 +274,43 @@ Both produce `type: "scheduled_reminder"` messages. The handler below works for 
   "job_name": "lobster-plans-poller",
   "source": "system",
   "chat_id": 0,
-  "text": "[Cron] Job 'lobster-plans-poller' finished (success, 42s)",
+  "text": "[Cron] Dispatch job 'lobster-plans-poller'",
+  "task_content": "# Lobster Plans Poller\n\n...full task file contents...",
   "timestamp": "2026-01-01T00:00:00+00:00"
 }
 ```
 
-**Routing table** — maps `reminder_type` to the subagent and prompt to use. A `None` value is a **fast-exit sentinel**: call `mark_processed` immediately, no subagent, no inline work. The concrete fallback for any unknown type is `fallback_lobster_generalist`.
+**Routing table** — maps `reminder_type` to the subagent and prompt to use. A `None` value is a **fast-exit sentinel**: call `mark_processed` immediately, no subagent, no inline work.
 
-> **CRITICAL — read this before adding new entries:**
-> User-created scheduled jobs (those that call `send_reply` + `write_result` directly from `run-job.sh`) already deliver their own results. Their `scheduled_reminder` is a redundant completion signal. Always add them with `None` (fast-exit). Only assign a subagent route for types that do NOT self-deliver results.
+**Generic dispatch (new as of issue #858):** User-created scheduled jobs carry a `task_content` field in the `scheduled_reminder` message — the contents of their task file. The dispatcher reads this field directly from the message (no file I/O on the main thread) and spawns `lobster-generalist` with it as the prompt. No REMINDER_ROUTING entry is needed for user-created jobs. Only add an entry for system jobs that do NOT carry task_content (ghost_detector, oom_check).
 
 ```
-# Concrete fallback — used for any reminder_type not in the table below.
-# Surfaces that an unknown reminder fired; does NOT read output files inline.
-fallback_lobster_generalist = {
+# Generic prompt builder for user-created scheduled jobs.
+# run-job.sh embeds task_content in the scheduled_reminder message.
+def build_generic_job_prompt(msg):
+    job_name = msg.get("reminder_type") or msg.get("job_name", "unknown")
+    task_content = msg.get("task_content", "")
+    return (
+        f"---\ntask_id: scheduled-job-{job_name}\nchat_id: 0\nsource: system\n---\n\n"
+        f"{task_content}"
+    )
+
+# Static fallback for reminder_types that are NOT in REMINDER_ROUTING
+# AND have no task_content (i.e. truly unknown system pings).
+fallback_unknown_reminder = {
   "subagent_type": "lobster-generalist",
   "prompt": (
     "---\ntask_id: unknown-reminder\nchat_id: 0\nsource: system\n---\n\n"
-    "A scheduled_reminder arrived with an unrecognised reminder_type: '{reminder_type}'. "
-    "Do NOT read any output files or check_task_outputs inline. "
+    "A scheduled_reminder arrived with an unrecognised reminder_type: '{reminder_type}' "
+    "and no task_content. "
     "Call write_result(task_id='unknown-reminder', chat_id=0, "
     "text='Unknown reminder type: {reminder_type}') and return immediately."
   ),
 }
 
 REMINDER_ROUTING = {
-  # --- System cron jobs (do NOT self-deliver; subagent handles output) ---
+  # --- System cron jobs only (no task_content embedded; subagent handles output) ---
+  # Do NOT add user-created jobs here — they are handled generically via task_content.
   "ghost_detector": {
     "subagent_type": "lobster-generalist",
     "prompt": "---\ntask_id: agent-monitor\nchat_id: 0\nsource: system\n---\n\n"
@@ -313,25 +324,6 @@ REMINDER_ROUTING = {
               "Run it with uv run ~/lobster/scripts/oom-monitor.py --since-minutes 10 "
               "and report findings.",
   },
-
-  # --- User scheduled jobs (self-deliver via send_reply + write_result) ---
-  # These jobs always deliver their own results directly: they call send_reply to
-  # surface content to the user AND write_result to signal completion. The
-  # scheduled_reminder written by post-reminder.sh is a job-finished ping, NOT
-  # a content delivery — the content was already sent. Fast-exit on the ping.
-  #
-  # NOTE: If a job gains conditional logic where it only writes to the inbox when
-  # it has real content (not always), move it to a subagent dict entry instead.
-  # The contract for None entries: the job unconditionally self-delivers all results;
-  # its scheduled_reminder carries no content the dispatcher needs to act on.
-  "lobster-plans-poller": None,   # always self-delivers via send_reply + write_result
-  "bot-talk-poller": None,        # always self-delivers via send_reply + write_result
-
-  # Add new reminder types here.
-  # Use None for jobs that ALWAYS self-deliver (send_reply + write_result) — their
-  #   scheduled_reminder ping carries no content; drop it immediately.
-  # Use a subagent dict for jobs that do NOT self-deliver and need the dispatcher
-  #   to read output and decide whether to surface it to the user.
 }
 ```
 
@@ -341,24 +333,34 @@ REMINDER_ROUTING = {
 1. mark_processing(message_id)
 
 2. # Field resolution: reminder_type takes precedence; fall back to job_name.
-   # (scheduled-tasks/post-reminder.sh sets both fields; scripts/post-reminder.sh sets reminder_type only.)
    reminder_type = msg.get("reminder_type") or msg.get("job_name")
 
-3. route = REMINDER_ROUTING.get(reminder_type, fallback_lobster_generalist)
+3. route = REMINDER_ROUTING.get(reminder_type)  # returns None if not in table
 
-4. # FAST-EXIT SENTINEL: if route is None, drop immediately — no subagent, no inline work.
-   if route is None:
+4. if route is None:
+       # Check for embedded task_content (user-created job dispatched by run-job.sh)
+       task_content = msg.get("task_content", "").strip()
+       if task_content:
+           # Generic dispatch: pass the embedded task file to a lobster-generalist subagent.
+           prompt = build_generic_job_prompt(msg)
+           Spawn subagent (run_in_background=True):
+           - subagent_type: "lobster-generalist"
+           - prompt: prompt
+       else:
+           # Truly unknown reminder with no task content — log and drop.
+           prompt = fallback_unknown_reminder["prompt"].format(reminder_type=reminder_type)
+           Spawn subagent (run_in_background=True):
+           - subagent_type: "lobster-generalist"
+           - prompt: prompt
        mark_processed(message_id)
        # THE VERY NEXT ACTION MUST BE wait_for_messages() — see WFM-always-next rule below
-       continue
-
-5. # Known route with a subagent.
-   Spawn subagent (run_in_background=True):
-   - subagent_type: route["subagent_type"]
-   - prompt: route["prompt"]
-
-6. mark_processed(message_id)
-   # THE VERY NEXT ACTION MUST BE wait_for_messages() — see WFM-always-next rule below
+   else:
+       # Known static route (system jobs: ghost_detector, oom_check).
+       Spawn subagent (run_in_background=True):
+       - subagent_type: route["subagent_type"]
+       - prompt: route["prompt"]
+       mark_processed(message_id)
+       # THE VERY NEXT ACTION MUST BE wait_for_messages() — see WFM-always-next rule below
 ```
 
 **WFM-always-next rule (applies to ALL message types, not just scheduled reminders):**
@@ -371,7 +373,7 @@ REMINDER_ROUTING = {
 - Never call `send_reply` for scheduled reminders (chat_id: 0, source: "system")
 - The subagent should always call `write_result` — never `send_reply`. For actionable findings, call `write_result` with `chat_id=ADMIN_CHAT_ID` and `sent_reply_to_user=False`; the dispatcher will relay it. For no-ops, call `write_result` with `chat_id=0`.
 - Do not ack these — they are background system tasks, not user requests
-- When in doubt about a new job name, add it to REMINDER_ROUTING as `None` (fast-exit)
+- Do NOT add user-created job names to REMINDER_ROUTING — they are dispatched generically via task_content
 
 ## Handling Subagent Results (`subagent_result` / `subagent_error`)
 

--- a/scheduled-tasks/run-job.sh
+++ b/scheduled-tasks/run-job.sh
@@ -1,21 +1,14 @@
 #!/bin/bash
-# Lobster Scheduled Task Executor
-# Runs a scheduled job in a fresh Claude instance
+# Lobster Scheduled Task Dispatcher
+# Writes a scheduled_reminder to the dispatcher inbox so the dispatcher
+# spawns a subagent for the job. Does NOT call claude -p.
+#
+# Usage: run-job.sh <job-name>
 
 set -e
 
-# Ensure Claude is in PATH (cron doesn't inherit user PATH)
+# Ensure uv and other tools are in PATH (cron doesn't inherit user PATH)
 export PATH="$HOME/.local/bin:$PATH"
-
-# Prevent "cannot launch inside another Claude Code session" error.
-# CLAUDECODE leaks when run-job.sh is manually tested from a Claude session.
-unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
-
-# Allow scheduled jobs to call send_reply and other session-guarded MCP tools.
-# Without this, inbox_server.py's session guard blocks send_reply silently
-# because cron-launched processes are not descendants of the lobster tmux session.
-# See issue #571.
-export LOBSTER_MAIN_SESSION=1
 
 JOB_NAME="$1"
 
@@ -26,11 +19,8 @@ fi
 
 REPO_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
 
-# Load env files so tokens like LOBSTER_ADMIN_CHAT_ID and GITHUB_TOKEN are
-# available when running from cron (which does not inherit the systemd
-# EnvironmentFile entries). Source both files in the same order as the
-# systemd services: config.env first, then global.env so that global.env
-# values can override config.env when needed.
+# Load env files so tokens and config are available when running from cron.
+# Source config.env first, then global.env (global overrides config).
 CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
 for _env_file in "$CONFIG_DIR/config.env" "$CONFIG_DIR/global.env"; do
     if [ -f "$_env_file" ]; then
@@ -41,93 +31,120 @@ for _env_file in "$CONFIG_DIR/config.env" "$CONFIG_DIR/global.env"; do
     fi
 done
 unset _env_file
+
 WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
-TASK_FILE="$WORKSPACE/scheduled-jobs/tasks/${JOB_NAME}.md"
-OUTPUT_DIR="$HOME/messages/task-outputs"
-LOG_DIR="$WORKSPACE/scheduled-jobs/logs"
-TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 JOBS_FILE="$WORKSPACE/scheduled-jobs/jobs.json"
+TASK_FILE="$WORKSPACE/scheduled-jobs/tasks/${JOB_NAME}.md"
+LOG_DIR="$WORKSPACE/scheduled-jobs/logs"
+INBOX_DIR="${LOBSTER_MESSAGES:-$HOME/messages}/inbox"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+START_ISO=$(date -Iseconds)
 
-# Ensure directories exist
-mkdir -p "$OUTPUT_DIR" "$LOG_DIR"
+# Ensure log directory exists
+mkdir -p "$LOG_DIR" "$INBOX_DIR"
 
-# Check task file exists
+LOG_FILE="$LOG_DIR/${JOB_NAME}-${TIMESTAMP}.log"
+
+# --- Check enabled flag ---
+# If the job is marked enabled=false in jobs.json, exit silently.
+# This is the primary guard: when a job is disabled via update_scheduled_job,
+# sync-crontab.sh removes its cron entry. But if an old cron entry fires
+# before the sync takes effect, this check ensures it does nothing.
+if [ -f "$JOBS_FILE" ]; then
+    ENABLED=$(python3 -c "
+import json, sys
+try:
+    with open('$JOBS_FILE') as f:
+        data = json.load(f)
+    job = data.get('jobs', {}).get('$JOB_NAME', {})
+    # Default to true if job exists but has no enabled field
+    print(str(job.get('enabled', True)).lower())
+except Exception:
+    print('true')
+" 2>/dev/null)
+    if [ "$ENABLED" = "false" ]; then
+        echo "[$START_ISO] Job '$JOB_NAME' is disabled — skipping" >> "$LOG_FILE" 2>&1 || true
+        exit 0
+    fi
+fi
+
+echo "[$START_ISO] Posting reminder for job: $JOB_NAME" | tee "$LOG_FILE"
+
+# --- Check task file exists ---
 if [ ! -f "$TASK_FILE" ]; then
-    echo "Error: Task file not found: $TASK_FILE"
+    echo "[$START_ISO] Error: Task file not found: $TASK_FILE" | tee -a "$LOG_FILE"
     exit 1
 fi
 
-# Read task content
-TASK_CONTENT=$(cat "$TASK_FILE")
+# --- Write scheduled_reminder to inbox ---
+# Embed the task content so the dispatcher can pass it directly to the
+# subagent without needing to read the file on the main thread.
+EPOCH_MS=$(date +%s%3N)
+MSG_ID="${EPOCH_MS}_scheduled_${JOB_NAME}"
 
-# Log file for this execution
-LOG_FILE="$LOG_DIR/${JOB_NAME}-${TIMESTAMP}.log"
+uv run - \
+    "${INBOX_DIR}/${MSG_ID}.json" \
+    "${MSG_ID}" \
+    "${START_ISO}" \
+    "${JOB_NAME}" \
+    "${TASK_FILE}" \
+    << 'PYEOF'
+import json, sys, os
 
-# Record start time
-START_TIME=$(date +%s)
-START_ISO=$(date -Iseconds)
+out_path   = sys.argv[1]
+msg_id     = sys.argv[2]
+timestamp  = sys.argv[3]
+job_name   = sys.argv[4]
+task_file  = sys.argv[5]
 
-echo "[$START_ISO] Starting job: $JOB_NAME" | tee "$LOG_FILE"
+with open(task_file) as f:
+    task_content = f.read()
 
-# Run Claude with the task
-# The task instructions tell Claude to deliver results via send_reply + write_result
-claude -p "$TASK_CONTENT
+msg = {
+    "id": msg_id,
+    "source": "system",
+    "type": "scheduled_reminder",
+    "chat_id": 0,
+    "user_id": 0,
+    "username": "lobster-cron",
+    "user_name": "Cron",
+    "text": f"[Cron] Dispatch job '{job_name}'",
+    "reminder_type": job_name,
+    "job_name": job_name,
+    "task_content": task_content,
+    "timestamp": timestamp,
+}
 
----
+tmp_path = out_path + ".tmp"
+with open(tmp_path, "w") as f:
+    json.dump(msg, f, ensure_ascii=False, indent=2)
+    f.flush()
 
-IMPORTANT: You are running as a scheduled task. When you complete your task:
-1. Call send_reply(chat_id=${LOBSTER_ADMIN_CHAT_ID}, text=<your digest>, source=\"telegram\") to deliver results directly to the user
-2. Call write_result(task_id=\"scheduled-job-$JOB_NAME\", chat_id=${LOBSTER_ADMIN_CHAT_ID}, text=<same text>, forward=False) to notify the dispatcher that the job completed
-3. Keep output concise - the user is on mobile
-4. Exit after writing output - do not start a loop
+os.replace(tmp_path, out_path)
+print(f"Reminder posted: {out_path}")
+PYEOF
 
-Both calls are required. send_reply delivers the digest immediately to Telegram; write_result(forward=False) signals the dispatcher that the job is done without double-sending." \
-    --dangerously-skip-permissions \
-    --max-turns 25 \
-    2>&1 | tee -a "$LOG_FILE"
+echo "[$START_ISO] Reminder posted for job: $JOB_NAME — dispatcher will spawn subagent" | tee -a "$LOG_FILE"
 
-EXIT_CODE=$?
-
-# Record end time
-END_TIME=$(date +%s)
-END_ISO=$(date -Iseconds)
-DURATION=$((END_TIME - START_TIME))
-
-echo "" | tee -a "$LOG_FILE"
-echo "[$END_ISO] Job completed in ${DURATION}s with exit code: $EXIT_CODE" | tee -a "$LOG_FILE"
-
-# Update jobs.json with last_run info
+# Update jobs.json last_run to reflect when the job was dispatched
 if [ -f "$JOBS_FILE" ]; then
-    # Use jq if available, otherwise use Python
     if command -v jq &> /dev/null; then
-        STATUS="success"
-        [ $EXIT_CODE -ne 0 ] && STATUS="failed"
-
         TMP_FILE=$(mktemp)
         jq --arg name "$JOB_NAME" \
-           --arg last_run "$END_ISO" \
-           --arg status "$STATUS" \
-           '.jobs[$name].last_run = $last_run | .jobs[$name].last_status = $status' \
+           --arg last_run "$START_ISO" \
+           'if .jobs[$name] then .jobs[$name].last_run = $last_run else . end' \
            "$JOBS_FILE" > "$TMP_FILE" && mv "$TMP_FILE" "$JOBS_FILE"
     else
         python3 -c "
 import json
-import sys
-with open('$JOBS_FILE', 'r') as f:
+with open('$JOBS_FILE') as f:
     data = json.load(f)
 if '$JOB_NAME' in data.get('jobs', {}):
-    data['jobs']['$JOB_NAME']['last_run'] = '$END_ISO'
-    data['jobs']['$JOB_NAME']['last_status'] = 'success' if $EXIT_CODE == 0 else 'failed'
+    data['jobs']['$JOB_NAME']['last_run'] = '$START_ISO'
     with open('$JOBS_FILE', 'w') as f:
         json.dump(data, f, indent=2)
-"
+" 2>/dev/null || true
     fi
 fi
 
-# Post a reminder to the dispatcher inbox so it learns the job completed
-POST_REMINDER="$REPO_DIR/scheduled-tasks/post-reminder.sh"
-if [ -f "$POST_REMINDER" ]; then
-    bash "$POST_REMINDER" "$JOB_NAME" "$EXIT_CODE" "$DURATION" 2>&1 | tee -a "$LOG_FILE" || true
-fi
-
-exit $EXIT_CODE
+exit 0

--- a/tests/unit/test_run_job_sh.py
+++ b/tests/unit/test_run_job_sh.py
@@ -1,0 +1,351 @@
+"""
+Tests for scheduled-tasks/run-job.sh
+
+Verifies:
+1. Disabled jobs exit 0 silently without writing any inbox message
+2. Enabled jobs write a scheduled_reminder to the inbox with task_content embedded
+3. Missing task file exits non-zero
+4. No claude -p invocation under any path
+"""
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_DIR = Path(__file__).parent.parent.parent
+RUN_JOB = REPO_DIR / "scheduled-tasks" / "run-job.sh"
+
+
+def _make_env(workspace: Path, config_dir: Path, messages_dir: Path) -> dict:
+    """Build a minimal environment for run-job.sh."""
+    env = os.environ.copy()
+    env["LOBSTER_WORKSPACE"] = str(workspace)
+    env["LOBSTER_CONFIG_DIR"] = str(config_dir)
+    env["LOBSTER_MESSAGES"] = str(messages_dir)
+    env["LOBSTER_INSTALL_DIR"] = str(REPO_DIR)
+    # Prevent cron PATH issues in CI
+    env["PATH"] = os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin") + ":" + str(Path.home() / ".local" / "bin")
+    return env
+
+
+def _setup_workspace(tmp: Path, job_name: str, enabled: bool, has_task_file: bool = True) -> tuple[Path, Path, Path]:
+    """Create a temporary workspace with jobs.json and optional task file."""
+    workspace = tmp / "lobster-workspace"
+    jobs_dir = workspace / "scheduled-jobs"
+    tasks_dir = jobs_dir / "tasks"
+    logs_dir = jobs_dir / "logs"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    messages_dir = tmp / "messages"
+    inbox_dir = messages_dir / "inbox"
+    inbox_dir.mkdir(parents=True, exist_ok=True)
+
+    config_dir = tmp / "lobster-config"
+    config_dir.mkdir(exist_ok=True)
+
+    jobs_json = {
+        "jobs": {
+            job_name: {
+                "name": job_name,
+                "schedule": "0 * * * *",
+                "enabled": enabled,
+                "last_run": None,
+                "last_status": None,
+            }
+        }
+    }
+    (jobs_dir / "jobs.json").write_text(json.dumps(jobs_json, indent=2))
+
+    if has_task_file:
+        task_content = f"# {job_name}\n\nDo the thing and call write_task_output.\n"
+        (tasks_dir / f"{job_name}.md").write_text(task_content)
+
+    return workspace, messages_dir, config_dir
+
+
+class TestRunJobShDisabledFlag:
+    """Disabled jobs must exit 0 silently without touching the inbox."""
+
+    def test_disabled_job_exits_zero(self, tmp_path):
+        workspace, messages_dir, config_dir = _setup_workspace(
+            tmp_path, "test-job", enabled=False
+        )
+        env = _make_env(workspace, config_dir, messages_dir)
+
+        result = subprocess.run(
+            ["bash", str(RUN_JOB), "test-job"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    def test_disabled_job_writes_no_inbox_message(self, tmp_path):
+        workspace, messages_dir, config_dir = _setup_workspace(
+            tmp_path, "test-job", enabled=False
+        )
+        env = _make_env(workspace, config_dir, messages_dir)
+        inbox_dir = messages_dir / "inbox"
+
+        subprocess.run(
+            ["bash", str(RUN_JOB), "test-job"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        inbox_files = list(inbox_dir.glob("*.json"))
+        assert inbox_files == [], f"Expected no inbox messages for disabled job, got: {inbox_files}"
+
+    def test_disabled_job_logs_skip_message(self, tmp_path):
+        workspace, messages_dir, config_dir = _setup_workspace(
+            tmp_path, "test-job", enabled=False
+        )
+        env = _make_env(workspace, config_dir, messages_dir)
+
+        result = subprocess.run(
+            ["bash", str(RUN_JOB), "test-job"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        log_dir = workspace / "scheduled-jobs" / "logs"
+        log_files = list(log_dir.glob("test-job-*.log"))
+        assert len(log_files) == 1
+        log_content = log_files[0].read_text()
+        assert "disabled" in log_content.lower()
+
+
+class TestRunJobShEnabledDispatch:
+    """Enabled jobs must write a scheduled_reminder to the inbox."""
+
+    def test_enabled_job_exits_zero(self, tmp_path):
+        workspace, messages_dir, config_dir = _setup_workspace(
+            tmp_path, "my-poller", enabled=True
+        )
+        env = _make_env(workspace, config_dir, messages_dir)
+
+        result = subprocess.run(
+            ["bash", str(RUN_JOB), "my-poller"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+
+    def test_enabled_job_writes_inbox_message(self, tmp_path):
+        workspace, messages_dir, config_dir = _setup_workspace(
+            tmp_path, "my-poller", enabled=True
+        )
+        env = _make_env(workspace, config_dir, messages_dir)
+        inbox_dir = messages_dir / "inbox"
+
+        subprocess.run(
+            ["bash", str(RUN_JOB), "my-poller"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        inbox_files = list(inbox_dir.glob("*.json"))
+        assert len(inbox_files) == 1, f"Expected exactly 1 inbox message, got {len(inbox_files)}"
+
+    def test_inbox_message_has_correct_type_and_reminder_type(self, tmp_path):
+        workspace, messages_dir, config_dir = _setup_workspace(
+            tmp_path, "my-poller", enabled=True
+        )
+        env = _make_env(workspace, config_dir, messages_dir)
+        inbox_dir = messages_dir / "inbox"
+
+        subprocess.run(
+            ["bash", str(RUN_JOB), "my-poller"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        inbox_files = list(inbox_dir.glob("*.json"))
+        msg = json.loads(inbox_files[0].read_text())
+
+        assert msg["type"] == "scheduled_reminder"
+        assert msg["reminder_type"] == "my-poller"
+        assert msg["job_name"] == "my-poller"
+
+    def test_inbox_message_embeds_task_content(self, tmp_path):
+        workspace, messages_dir, config_dir = _setup_workspace(
+            tmp_path, "my-poller", enabled=True
+        )
+        env = _make_env(workspace, config_dir, messages_dir)
+        inbox_dir = messages_dir / "inbox"
+
+        subprocess.run(
+            ["bash", str(RUN_JOB), "my-poller"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        inbox_files = list(inbox_dir.glob("*.json"))
+        msg = json.loads(inbox_files[0].read_text())
+
+        assert "task_content" in msg
+        assert "Do the thing" in msg["task_content"]
+
+    def test_inbox_message_has_system_source(self, tmp_path):
+        workspace, messages_dir, config_dir = _setup_workspace(
+            tmp_path, "my-poller", enabled=True
+        )
+        env = _make_env(workspace, config_dir, messages_dir)
+        inbox_dir = messages_dir / "inbox"
+
+        subprocess.run(
+            ["bash", str(RUN_JOB), "my-poller"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        inbox_files = list(inbox_dir.glob("*.json"))
+        msg = json.loads(inbox_files[0].read_text())
+
+        assert msg["source"] == "system"
+        assert msg["chat_id"] == 0
+
+    def test_jobs_json_last_run_updated(self, tmp_path):
+        workspace, messages_dir, config_dir = _setup_workspace(
+            tmp_path, "my-poller", enabled=True
+        )
+        env = _make_env(workspace, config_dir, messages_dir)
+
+        subprocess.run(
+            ["bash", str(RUN_JOB), "my-poller"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        jobs_json_path = workspace / "scheduled-jobs" / "jobs.json"
+        data = json.loads(jobs_json_path.read_text())
+        assert data["jobs"]["my-poller"]["last_run"] is not None
+
+
+class TestRunJobShMissingTaskFile:
+    """Missing task file should produce a non-zero exit."""
+
+    def test_missing_task_file_exits_nonzero(self, tmp_path):
+        workspace, messages_dir, config_dir = _setup_workspace(
+            tmp_path, "no-task-job", enabled=True, has_task_file=False
+        )
+        env = _make_env(workspace, config_dir, messages_dir)
+
+        result = subprocess.run(
+            ["bash", str(RUN_JOB), "no-task-job"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode != 0
+
+    def test_missing_task_file_writes_no_inbox_message(self, tmp_path):
+        workspace, messages_dir, config_dir = _setup_workspace(
+            tmp_path, "no-task-job", enabled=True, has_task_file=False
+        )
+        env = _make_env(workspace, config_dir, messages_dir)
+        inbox_dir = messages_dir / "inbox"
+
+        subprocess.run(
+            ["bash", str(RUN_JOB), "no-task-job"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        inbox_files = list(inbox_dir.glob("*.json"))
+        assert inbox_files == []
+
+
+class TestRunJobShNoClaude:
+    """run-job.sh must never invoke claude -p under any condition."""
+
+    def test_script_does_not_exec_claude(self):
+        """The script source must not exec 'claude' as a subprocess (e.g. claude -p ...)."""
+        content = RUN_JOB.read_text()
+        # Allow the word 'claude' in comments, but not as an executable command.
+        # A call would look like: claude -p or  or `claude ...`
+        import re
+        # Match 'claude' as a command invocation (not preceded by # or / or inside quotes as a string reference)
+        lines = content.splitlines()
+        for line in lines:
+            stripped = line.strip()
+            # Skip comments
+            if stripped.startswith('#'):
+                continue
+            # Check for claude being called as a program
+            if re.search(r'(?<![/#"])claude\s+-', stripped):
+                msg = "run-job.sh invokes claude as a command on line: " + repr(stripped)
+                pytest.fail(msg + " -- jobs must be dispatched via inbox reminders")
+
+    def test_no_claude_invocation_on_enabled_job(self, tmp_path):
+        """Running an enabled job must not spawn any claude process."""
+        workspace, messages_dir, config_dir = _setup_workspace(
+            tmp_path, "my-poller", enabled=True
+        )
+        env = _make_env(workspace, config_dir, messages_dir)
+
+        # Intercept any 'claude' calls by shadowing it with a script that fails loudly
+        fake_claude = tmp_path / "claude"
+        fake_claude.write_text("#!/bin/bash\necho 'ERROR: claude was called from run-job.sh' >&2\nexit 99\n")
+        fake_claude.chmod(0o755)
+        env["PATH"] = str(tmp_path) + ":" + env["PATH"]
+
+        result = subprocess.run(
+            ["bash", str(RUN_JOB), "my-poller"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, f"Expected success, got {result.returncode}. stderr: {result.stderr}"
+        assert "ERROR: claude was called" not in result.stderr
+
+
+class TestRunJobShMissingJobsJson:
+    """When jobs.json is missing, the job should run (default to enabled)."""
+
+    def test_no_jobs_json_runs_as_enabled(self, tmp_path):
+        workspace = tmp_path / "lobster-workspace"
+        jobs_dir = workspace / "scheduled-jobs"
+        tasks_dir = jobs_dir / "tasks"
+        logs_dir = jobs_dir / "logs"
+        tasks_dir.mkdir(parents=True, exist_ok=True)
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        (tasks_dir / "my-poller.md").write_text("# My Poller\n\nDo stuff.\n")
+
+        messages_dir = tmp_path / "messages"
+        inbox_dir = messages_dir / "inbox"
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+
+        config_dir = tmp_path / "lobster-config"
+        config_dir.mkdir(exist_ok=True)
+
+        env = _make_env(workspace, config_dir, messages_dir)
+
+        result = subprocess.run(
+            ["bash", str(RUN_JOB), "my-poller"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0
+        inbox_files = list(inbox_dir.glob("*.json"))
+        assert len(inbox_files) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -991,6 +991,7 @@ name = "lobster"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "cryptography" },
     { name = "fastembed" },
     { name = "httpx" },
     { name = "mcp" },
@@ -1028,6 +1029,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cryptography", specifier = ">=42.0.0" },
     { name = "fastembed", specifier = ">=0.3.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", specifier = ">=1.0.0" },


### PR DESCRIPTION
## What problem this solves

Every scheduled job was calling `claude -p` directly, spawning an independent Claude Code session. Each session creates its own `inbox_server.py` subprocess via MCP stdio. With several jobs on hourly/30-minute schedules — and one (`bot-talk-poller-fast`) mistakenly firing every 2 minutes while disabled in `jobs.json` — the system accumulated 232 inbox_server.py startups in a single day. The MCP stdio reconnection race then caused the dispatcher to permanently lose all tool access mid-session, which is the root cause in issue #858.

A secondary bug made this worse: `run-job.sh` never checked the `enabled` flag, so disabling a job in `jobs.json` had no effect on the cron entry or process spawning.

## Architecture change

**Before (broken):**
```
cron -> run-job.sh -> claude -p   (new MCP session, new inbox_server.py per job)
```

**After:**
```
cron -> run-job.sh -> write scheduled_reminder to inbox
                   -> dispatcher receives reminder
                   -> dispatcher spawns lobster-generalist subagent with task content
```

`run-job.sh` is now a pure inbox writer: it reads the job's task file, embeds the content in a `task_content` field of the `scheduled_reminder` message, and exits. No Claude process, no MCP session, no inbox_server.py spawned.

The dispatcher's `scheduled_reminder` handler checks for `task_content` in the message and uses it to build the subagent prompt — no file I/O on the main thread, no REMINDER_ROUTING entry needed per job.

The `enabled` flag check runs first, before any other action. A disabled job logs one line and exits 0 with no inbox message written.

## Files changed

- **`scheduled-tasks/run-job.sh`**: Replaced `claude -p` with an inline Python inbox write via `uv run`. Added `enabled` check at top. Removed `LOBSTER_MAIN_SESSION` export (no longer needed without a Claude subprocess). Kept `last_run` update, now recording dispatch time.

- **`.claude/sys.dispatcher.bootup.md`**: Removed `lobster-plans-poller: None` and `bot-talk-poller: None` from `REMINDER_ROUTING` (those were the "self-deliver" fast-exit entries; the dispatcher now always handles dispatch). Added `build_generic_job_prompt()` and two-branch routing logic: messages with `task_content` go to `lobster-generalist` generically; messages without `task_content` fall back to the unknown-reminder handler. Updated message shape example to include `task_content`.

- **`tests/unit/test_run_job_sh.py`**: 14 new tests — disabled-job early exit (no inbox message), enabled-job message shape (type, reminder_type, task_content, source, chat_id), last_run update, missing-task-file non-zero exit, absence of `claude` invocation in script source, and absence of any `claude` process when run against a sentinel.

## What is out of scope

`sync-crontab.sh` already skips disabled jobs (`select(.value.enabled == true)`) — no change needed. `scripts/post-reminder.sh` (system cron jobs) is unchanged. `scheduled-tasks/post-reminder.sh` is now dead code but not deleted in this PR to avoid breaking external callers. Existing task `.md` files are unchanged.

## Functional patterns used

Pure functions (the script has no side effects beyond writing one file and updating `last_run`), immutability (message JSON written atomically via `.tmp` → rename), declarative data transformation (`build_generic_job_prompt` composes the prompt from message fields without mutations).

## Tests run

- [x] `uv run pytest tests/unit/test_run_job_sh.py -v` — 14 passed, 0 failed
- [x] `uv run pytest tests/unit/ --ignore=tests/unit/test_bisque --ignore=tests/unit/test_integrations -q` — 1114 passed, 0 new failures (3 pre-existing failures unrelated to this change)
- [x] `bash -n scheduled-tasks/run-job.sh` — bash syntax OK
- [ ] Live cron firing — not testable without deployment; `.claude/` changes are live on merge

Closes #858.