### PR TITLE
feat: send warming-up notification on startup when gap > 15s

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -929,6 +929,12 @@ When you first start (or after reading this file), immediately begin your main l
           the dispatcher re-queues the message and lets normal processing handle it.
         - Delete the file after reading it
     - If the file is **stale** (>= 10 minutes old) or absent: normal startup, ignore it.
+2c. Check `~/lobster-workspace/data/compaction-state.json` to decide whether to send a warming-up notification:
+    - Read the file. If it does not exist, treat `last_catchup_ts` as absent.
+    - Compute `gap_seconds = now - last_catchup_ts` (or treat as infinite if absent).
+    - If `gap_seconds > 15`: send `"🦞 Warming up — back in a moment."` to the default chat (chat_id: 8305714125).
+    - If `gap_seconds <= 15`: stay silent — this is a health-check restart, not a meaningful gap.
+    - **Do NOT send this notification if step 2b already sent a context-at-X%-restart message** — one startup message is enough. If step 2b sent a notification, skip this step.
 3. Run: `~/lobster/scripts/record-catchup-state.sh start`
    (tells health check a catchup is starting — suppresses WFM freshness check for 15 min)
 4. Spawn the `compact-catchup` agent in the background to recover recent activity from the message gap (see prompt below). Like the post-compaction handler, the startup version is internal-only — the dispatcher reads the result to update context and handoff, not relay to the user.


### PR DESCRIPTION
🤖🦞 Lobster (engineer): 

## What problem does this solve?

When Lobster restarts after a genuine gap (crash, deliberate restart, hibernation), the user had no signal that the system was back and catching up. They had to wait silently, not knowing whether their messages were being received. This PR adds a brief "Warming up" notification at startup so the user immediately knows the system is active.

## What changed

Step 2c is added to the dispatcher startup sequence in `sys.dispatcher.bootup.md`, positioned between the context-handoff check (2b) and the `record-catchup-state.sh start` call (3):

- At startup, read `compaction-state.json` and extract `last_catchup_ts`
- If the gap since `last_catchup_ts` exceeds 15 seconds (or the file is absent), send `"🦞 Warming up — back in a moment."` to the default chat (chat_id: 8305714125)
- If the gap is <= 15 seconds, stay silent — this is a health-check restart, not a meaningful gap
- If step 2b already sent a "context at X% — restarting" notification, skip this one — one startup message is sufficient

## What is out of scope

No code changes — this is purely a prompt/doc update to `sys.dispatcher.bootup.md`. No new scripts, no new state, no changes to `record-catchup-state.sh` or `compaction-state.json` schema. The file is read-only from the dispatcher's perspective; the catchup subagent continues to update `last_catchup_ts` as it does today.

No "ready" message after catchup completes — the next reply to the user implicitly signals readiness.

## Startup sequence (before/after)

```
Before:                               After:
1. Read handoff.md                    1. Read handoff.md
2. Read user-model/_context.md        2. Read user-model/_context.md
2b. Check context-handoff.json        2b. Check context-handoff.json
                                      2c. [NEW] Check compaction-state.json
                                          gap > 15s -> send "lobster Warming up"
                                          gap <= 15s -> silent
3. record-catchup-state.sh start      3. record-catchup-state.sh start
4. Spawn compact-catchup subagent     4. Spawn compact-catchup subagent
5. wait_for_messages()                5. wait_for_messages()
```

## Functional patterns

Pure declarative logic: the new step is a conditional check with no side effects beyond the `send_reply` call. The decision function is `gap_seconds > 15` applied to an immutable snapshot of `compaction-state.json`.

## Tests run

- [ ] Live smoke test — blocked: requires a real restart with a >15s gap. This is a doc-only change (no code modified); behavior depends on the dispatcher reading and following the updated instructions. Safe to merge; dogfooding will validate on the next genuine restart.

**Blocked items:** the smoke test requires a live dispatcher restart, which the engineer subagent cannot trigger without disrupting the running system. The reviewer should note this gap — the change is simple enough that a single live restart observation constitutes a sufficient smoke test.

Closes #864