### PR TITLE
feat: use blue-lobster for bot-talk mirroring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "twilio>=9.0.0",
     "websockets>=13.0",
     "cryptography>=42.0.0",
+    "blue-lobster @ git+https://github.com/sayhar/blue-lobster.git",
 ]
 
 [project.optional-dependencies]

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -60,7 +60,7 @@ from reliability import (
 from update_manager import UpdateManager
 
 # Bot-talk mirroring — fire-and-forget relay to the shared SaharLobster/AlbertLobster channel
-from bot_talk_mirror import mirror_outbound as _mirror_outbound, mirror_inbound as _mirror_inbound
+from bot_talk.mirror import mirror_outbound as _mirror_outbound, mirror_inbound as _mirror_inbound
 
 # Pending agent tracker (thin adapter over session_store)
 from agents.tracker import add_pending_agent as _add_pending_agent, remove_pending_agent as _remove_pending_agent


### PR DESCRIPTION
## Summary

The bot-talk mirror used to import `mirror_outbound` and `mirror_inbound` from an in-tree module (`bot_talk_mirror`). This PR redirects that import to the installable `blue-lobster` package (`bot_talk.mirror`), and registers it as a declared dependency in `pyproject.toml`.

The API is compatible — the two functions have identical signatures in both locations. No call sites change; only the import line changes.

This is step 2 of the migration tracked in sayhar/project-lobstertalk#22. Step 3 (deleting `bot_talk_mirror.py` and its tests) is deferred to a follow-up PR, per the issue plan.

## Functional patterns

Pure function redirect — the import change has no runtime side effects. The public API surface (`mirror_outbound`, `mirror_inbound`) is identical in both locations.

## Before / after

```
Before: inbox_server.py -> bot_talk_mirror  (src/mcp/bot_talk_mirror.py, in-tree)
After:  inbox_server.py -> bot_talk.mirror  (blue-lobster @ git+github.com/sayhar/blue-lobster)
```

The in-tree `bot_talk_mirror.py` and its tests remain untouched in this PR — deletion is a separate follow-up step.

## Tests run
- [x] `uv run python -c "from bot_talk.mirror import mirror_outbound as _mirror_outbound, mirror_inbound as _mirror_inbound; print(...)"` — both symbols resolved correctly
- [x] `uv run pytest tests/unit/test_mcp_server/test_bot_talk_mirror.py -v` — 33 passed, 0 failed
- [x] `uv run pytest tests/unit/ -q --timeout=30` — 1631 passed, 24 skipped; 4 pre-existing failures and 6 pre-existing errors, all unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)