### PR TITLE
feat: inbox-staleness early warning script (3-min cron)

### DIFF
--- a/scripts/inbox-staleness-warn.sh
+++ b/scripts/inbox-staleness-warn.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# inbox-staleness-warn.sh — Inject an inbox-staleness warning when the oldest
+# unprocessed user message has been waiting for 3+ minutes.
+#
+# Design: pure shell, no Python, no Claude. Safe to call from cron every minute.
+#
+# Filtering logic mirrors health-check-v3.sh lines ~107-114:
+#   - Only user-facing sources (telegram, sms, signal, slack) are counted.
+#   - Only genuine user-originated message types (message, photo, image, voice,
+#     audio, callback, text, document) are counted.
+#   - Internal queue messages (subagent_result, subagent_error, scheduled_reminder,
+#     system, compact, etc.) are excluded even when they carry source="telegram".
+#
+# Dedup logic mirrors post-reminder.sh:
+#   - Check both inbox/ and processing/ for an existing message with the same
+#     reminder_type. If found, exit silently without injecting a duplicate.
+
+set -euo pipefail
+
+INBOX_DIR="${HOME}/messages/inbox"
+PROCESSING_DIR="${HOME}/messages/processing"
+
+REMINDER_TYPE="inbox_staleness_warn"
+STALE_THRESHOLD_SECONDS=180   # 3 minutes
+
+# User-facing sources — matches health-check-v3.sh line ~108
+USER_FACING_SOURCES="telegram sms signal slack"
+
+# Genuine user-originated message types — matches health-check-v3.sh line ~114
+USER_FACING_TYPES="message photo image voice audio callback text document"
+
+mkdir -p "$INBOX_DIR"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+is_user_facing_source() {
+    local source="$1"
+    local s
+    for s in $USER_FACING_SOURCES; do
+        [[ "$source" == "$s" ]] && return 0
+    done
+    return 1
+}
+
+is_user_facing_type() {
+    local type="$1"
+    local t
+    for t in $USER_FACING_TYPES; do
+        [[ "$type" == "$t" ]] && return 0
+    done
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Dedup: skip if a staleness warning is already pending (inbox or processing).
+# ---------------------------------------------------------------------------
+if grep -rl "\"reminder_type\": \"${REMINDER_TYPE}\"" "$INBOX_DIR" "$PROCESSING_DIR" 2>/dev/null | grep -q .; then
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Scan inbox for user-facing messages and find the oldest.
+# ---------------------------------------------------------------------------
+now=$(date +%s)
+oldest_age=0
+
+while IFS= read -r -d '' f; do
+    # Parse source and type via jq; skip if missing or unparseable.
+    source=$(jq -r '.source // empty' "$f" 2>/dev/null)
+    type=$(jq -r '.type // empty' "$f" 2>/dev/null)
+
+    [[ -z "$source" ]] && continue
+    is_user_facing_source "$source" || continue
+    if [[ -n "$type" ]] && ! is_user_facing_type "$type"; then
+        continue
+    fi
+
+    file_time=$(stat -c %Y "$f" 2>/dev/null) || continue
+    [[ -z "$file_time" ]] && continue
+
+    age=$(( now - file_time ))
+    [[ $age -gt $oldest_age ]] && oldest_age=$age
+done < <(find "$INBOX_DIR" -maxdepth 1 -name "*.json" -print0 2>/dev/null)
+
+# No user-facing messages, or none old enough — nothing to warn about.
+[[ $oldest_age -lt $STALE_THRESHOLD_SECONDS ]] && exit 0
+
+# ---------------------------------------------------------------------------
+# Inject the warning message.
+# ---------------------------------------------------------------------------
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%S+00:00)"
+MILLIS="$(date +%s%3N)"
+FILENAME="${INBOX_DIR}/${MILLIS}_reminder_${REMINDER_TYPE}.json"
+
+cat > "$FILENAME" <<EOF
+{
+  "type": "scheduled_reminder",
+  "reminder_type": "${REMINDER_TYPE}",
+  "source": "system",
+  "chat_id": 0,
+  "text": "Inbox stale for 3 minutes — call wait_for_messages now, or delegate to a subagent. Do not continue inline work.",
+  "timestamp": "${TIMESTAMP}"
+}
+EOF

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1874,6 +1874,21 @@ EOF
         migrated=$((migrated + 1))
     fi
 
+    # Migration 54: Add inbox-staleness-warn.sh cron entry
+    # Injects a scheduled_reminder into the inbox when the oldest unprocessed
+    # user message has been waiting for 3+ minutes. Gives the dispatcher an
+    # in-band nudge to call wait_for_messages or delegate, complementing the
+    # health-check restart path (which only fires at 8+ minutes). Dedup prevents
+    # multiple warnings per staleness event.
+    local STALENESS_WARN_MARKER="# LOBSTER-INBOX-STALENESS-WARN"
+    if ! crontab -l 2>/dev/null | grep -q "$STALENESS_WARN_MARKER"; then
+        chmod +x "$LOBSTER_DIR/scripts/inbox-staleness-warn.sh" 2>/dev/null || true
+        "$LOBSTER_DIR/scripts/cron-manage.sh" add "$STALENESS_WARN_MARKER" \
+            "*/1 * * * * $LOBSTER_DIR/scripts/inbox-staleness-warn.sh $STALENESS_WARN_MARKER"
+        substep "Added inbox-staleness-warn.sh cron entry (runs every minute, warns at 3-minute staleness)"
+        migrated=$((migrated + 1))
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## Summary

The dispatcher sometimes gets stuck doing inline work instead of calling `wait_for_messages`. The existing health check catches this at 8+ minutes, but by then a restart is required. This adds an in-band warning that fires at 3 minutes — giving the dispatcher a chance to self-correct without a restart.

- New script: `scripts/inbox-staleness-warn.sh` — runs every minute via cron, injects a `scheduled_reminder` into the inbox when the oldest unprocessed user message is 3+ minutes old
- Dedup: mirrors `post-reminder.sh` pattern (checks both inbox/ and processing/ before injecting)
- Source/type filtering: mirrors `health-check-v3.sh` exactly — only genuine user-originated messages count (telegram/sms/signal/slack sources + message/photo/voice/etc types); subagent results, system messages, and existing reminders are excluded
- `scripts/upgrade.sh` migration 37: registers the cron entry idempotently on existing installs

The dispatcher already handles `scheduled_reminder` type as a context warning. No dispatcher changes needed.

## What to review closely

- `is_user_facing_source` and `is_user_facing_type` filter logic (lines 31-51) — must match health-check-v3.sh exactly or it will fire on non-user messages
- Dedup grep pattern — same pattern as `post-reminder.sh`; verify the field name `reminder_type` matches what the dispatcher expects
- Cron frequency: `*/1 * * * *` (every minute) — intentional; the 3-minute threshold is enforced by the script, not the cron schedule

## Concerns / known gaps

None — pure shell, no new dependencies, no behavior change to the dispatcher.

## Tests run

- [x] `bash -n scripts/inbox-staleness-warn.sh` — syntax OK
- [ ] Live cron test — blocked: requires production install with running Lobster instance

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)