### PR TITLE
fix: render long URLs as plain text in Telegram (lobstertalk#20)

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -47,12 +47,44 @@ from telegram.ext import Application, CommandHandler, MessageHandler, CallbackQu
 from collections import deque
 
 
+# URLs longer than this are copy-paste targets (e.g. OAuth flows).  Telegram
+# hides the raw URL when it is embedded in an <a> tag, so we render them as
+# plain text instead — label on the first line, URL on the next — so the user
+# can long-press and copy without hunting through a menu.
+_LONG_URL_THRESHOLD = 200
+
+
+def _link_to_html(link_text: str, url: str) -> str:
+    """Convert a single [text](url) Markdown link to HTML.
+
+    Short URLs (≤ _LONG_URL_THRESHOLD chars) become a normal <a> tag so
+    Telegram renders them as a tappable hyperlink.
+
+    Long URLs (> _LONG_URL_THRESHOLD chars) are expanded to two lines of plain
+    text:
+        <b>link_text</b>
+        <pre>url</pre>
+
+    The <pre> wrapper prevents Telegram from collapsing the URL and makes it
+    easy to long-press and copy on mobile.
+    """
+    if len(url) > _LONG_URL_THRESHOLD:
+        # Escape HTML entities in the URL (it may contain & params already escaped)
+        escaped_url = url.replace('&amp;', '&').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+        return f"<b>{link_text}</b>\n<pre>{escaped_url}</pre>"
+    return f'<a href="{url}">{link_text}</a>'
+
+
 def md_to_html(text: str) -> str:
     """Convert Telegram-flavored Markdown to HTML for reliable rendering.
 
     Handles: [text](url) links, `code`, ```code blocks```, **bold**, *bold*, _italic_,
     ## headings, ### headings, --- horizontal rules.
     Escapes &, <, > in non-HTML portions.
+
+    Long URLs (> _LONG_URL_THRESHOLD chars) are rendered as plain text rather
+    than hyperlinks — Telegram hides embedded URLs from users who need to
+    copy-paste them (e.g. OAuth flows).
     """
     # Split on code blocks first to avoid formatting inside them
     parts = re.split(r'(```[\s\S]*?```|`[^`\n]+`)', text)
@@ -79,8 +111,12 @@ def md_to_html(text: str) -> str:
             p = re.sub(r'(?m)^---+\s*$', '', p)
             # Headers: ### or ## or # at start of line → <b>text</b>
             p = re.sub(r'(?m)^#{1,6}\s+(.+)$', r'<b>\1</b>', p)
-            # Links: [text](url)
-            p = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<a href="\2">\1</a>', p)
+            # Links: [text](url) — long URLs rendered as plain text for copy-paste
+            p = re.sub(
+                r'\[([^\]]+)\]\(([^)]+)\)',
+                lambda m: _link_to_html(m.group(1), m.group(2)),
+                p,
+            )
             # Bold: **text**
             p = re.sub(r'\*\*(.+?)\*\*', r'<b>\1</b>', p)
             # Italic: _text_ (single, not double)

--- a/tests/unit/test_bot/test_md_to_html.py
+++ b/tests/unit/test_bot/test_md_to_html.py
@@ -15,26 +15,34 @@ _BOT_PATH = os.path.join(os.path.dirname(__file__), "../../../src/bot/lobster_bo
 
 
 def _load_md_to_html():
-    """Load md_to_html from the bot module without executing module-level side effects."""
+    """Load md_to_html (and its helpers) from the bot module without executing
+    module-level side effects."""
     import re
 
-    spec = importlib.util.spec_from_file_location("lobster_bot_partial", _BOT_PATH)
-    # Read and extract just the function source to avoid import-time side effects
+    # Read and extract just the relevant function definitions and constants
+    # to avoid import-time side effects (Telegram env checks, app start, etc.)
     with open(_BOT_PATH) as f:
         source = f.read()
 
-    # Execute only up to the first non-function/non-import statement
-    # We grab the function by compiling the relevant lines
-    ns: dict = {"re": re}
-    # Extract the md_to_html function definition
     import ast
     tree = ast.parse(source)
-    func_def = next(
-        node for node in tree.body
-        if isinstance(node, ast.FunctionDef) and node.name == "md_to_html"
-    )
-    func_source = ast.get_source_segment(source, func_def)
-    exec(compile(func_source, _BOT_PATH, "exec"), ns)  # noqa: S102
+
+    # Names to extract: the constant, both helper functions
+    _NAMES_TO_EXTRACT = {"_LONG_URL_THRESHOLD", "_link_to_html", "md_to_html"}
+
+    ns: dict = {"re": re}
+    for node in tree.body:
+        name = None
+        if isinstance(node, ast.FunctionDef):
+            name = node.name
+        elif isinstance(node, ast.Assign):
+            # Simple assignment like _LONG_URL_THRESHOLD = 200
+            if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+                name = node.targets[0].id
+        if name in _NAMES_TO_EXTRACT:
+            segment = ast.get_source_segment(source, node)
+            exec(compile(segment, _BOT_PATH, "exec"), ns)  # noqa: S102
+
     return ns["md_to_html"]
 
 
@@ -198,3 +206,70 @@ class TestSnakeCaseNotItalicized:
         result = md_to_html("```\nwrite_result\n```")
         assert "<i>" not in result
         assert "write_result" in result
+
+
+# ---------------------------------------------------------------------------
+# Long URL handling (issue lobstertalk#20)
+# ---------------------------------------------------------------------------
+
+_SHORT_URL = "https://example.com/path"
+_LONG_URL = "https://accounts.google.com/o/oauth2/auth?" + "x" * 180  # > 200 chars
+
+
+class TestLongUrls:
+    """URLs longer than _LONG_URL_THRESHOLD must be rendered as plain text
+    so that users can long-press and copy them on Telegram mobile."""
+
+    def test_short_url_rendered_as_hyperlink(self):
+        result = md_to_html(f"[click]({_SHORT_URL})")
+        assert f'<a href="{_SHORT_URL}">click</a>' in result
+
+    def test_long_url_not_rendered_as_hyperlink(self):
+        result = md_to_html(f"[Authorize]({_LONG_URL})")
+        assert "<a href=" not in result
+
+    def test_long_url_link_text_present_in_bold(self):
+        result = md_to_html(f"[Authorize]({_LONG_URL})")
+        assert "<b>Authorize</b>" in result
+
+    def test_long_url_raw_url_present_in_pre(self):
+        result = md_to_html(f"[Authorize]({_LONG_URL})")
+        assert "<pre>" in result
+        assert _LONG_URL in result
+
+    def test_long_url_threshold_boundary_exactly_200(self):
+        """A URL exactly 200 chars long is NOT long (threshold is > 200)."""
+        url_200 = "https://example.com/" + "a" * 180  # total = 200 chars
+        result = md_to_html(f"[click]({url_200})")
+        assert f'<a href="{url_200}">click</a>' in result
+
+    def test_long_url_threshold_boundary_exactly_201(self):
+        """A URL exactly 201 chars long IS long — rendered as plain text."""
+        url_201 = "https://example.com/" + "a" * 181  # total = 201 chars
+        result = md_to_html(f"[click]({url_201})")
+        assert "<a href=" not in result
+        assert "<pre>" in result
+
+    def test_long_url_mixed_with_short_url(self):
+        """Short and long links can coexist in the same message."""
+        text = f"See [docs]({_SHORT_URL}) and then [auth]({_LONG_URL})."
+        result = md_to_html(text)
+        assert f'<a href="{_SHORT_URL}">docs</a>' in result
+        assert "<a href=" not in result.replace(f'<a href="{_SHORT_URL}">docs</a>', "")
+        assert "<pre>" in result
+        assert _LONG_URL in result
+
+    def test_long_url_ampersand_params_escaped_once(self):
+        """Query string & is escaped exactly once — not double-escaped."""
+        url_with_amp = "https://example.com/auth?client_id=abc&redirect_uri=https%3A%2F%2F" + "x" * 150
+        result = md_to_html(f"[Auth]({url_with_amp})")
+        # Should appear escaped as &amp; (once) inside the <pre>
+        assert "&amp;" in result
+        # Must not be double-escaped to &amp;amp;
+        assert "&amp;amp;" not in result
+
+    def test_long_url_inside_code_block_not_affected(self):
+        """Links inside code blocks are never processed (existing behaviour)."""
+        result = md_to_html(f"```\n[Authorize]({_LONG_URL})\n```")
+        assert "<pre><code>" in result
+        assert "<b>Authorize</b>" not in result


### PR DESCRIPTION
## Summary

Fixes the bug reported in [sayhar/project-lobstertalk#20](https://github.com/sayhar/project-lobstertalk/issues/20): when AlbertLobster (or SaharLobster) sends a very long URL as a Markdown hyperlink, Telegram hides the raw URL — the user sees a tappable label but cannot copy the URL, which is useless for OAuth flows.

**Root cause:** `md_to_html()` was converting all `[text](url)` links to `<a href="url">text</a>`. Telegram renders these as tappable links without displaying the URL.

**Fix:** URLs > 200 chars are now rendered as bold label + `<pre>url</pre>`:
- The label shows what the link was for
- The URL appears in a monospace block that's easy to long-press and copy on mobile

Short URLs (≤ 200 chars) continue to render as tappable `<a>` links — no change in behaviour.

## New helper

`_link_to_html(link_text, url)` — pure function, called by the regex substitution in `md_to_html()`. The threshold constant `_LONG_URL_THRESHOLD = 200` is extractable for testing.

## Before / after

```
# Short URL (no change)
[docs](https://example.com/path)
→ <a href="https://example.com/path">docs</a>

# Long URL (OAuth, etc.) — was broken, now fixed
[Authorize](https://accounts.google.com/...200+ chars...)
→ <b>Authorize</b>
  <pre>https://accounts.google.com/...200+ chars...</pre>
```

## Test plan
- [x] 37 `test_md_to_html.py` tests pass (9 new `TestLongUrls` cases)
- [x] All existing tests pass — no regressions
- [x] Boundary: URL of exactly 200 chars → link; 201 chars → plain text
- [x] Mixed short + long links in one message
- [x] Ampersand query params escaped exactly once (not double-escaped)
- [x] Links inside code blocks are not affected

Addresses: sayhar/project-lobstertalk#20 (SaharLobster side — AlbertLobster to apply same fix independently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)