### PR TITLE
feat: event bus infrastructure — LobsterEvent, EventFilter, EventBus (#890)

### DIFF
--- a/src/mcp/event_bus.py
+++ b/src/mcp/event_bus.py
@@ -1,0 +1,367 @@
+"""
+Lobster Event Bus — structured event infrastructure for observability and routing.
+
+Design: pure dataclasses + a protocol-based listener interface. The EventBus is a
+module-level singleton initialized at server startup. Listeners register against it
+and receive events matching their filter. The JsonlFileListener writes all events to
+~/lobster-workspace/logs/events.jsonl. The TelegramOutboxListener replicates the
+existing _emit_debug_observation outbox-write behaviour.
+
+No existing callsites are changed by this module (Step 1 / issue #890). Step 2
+(#891) migrates _emit_debug_observation callsites; Step 3 (#892) routes
+subagent_observation through the bus.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import threading
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+# ---------------------------------------------------------------------------
+# Core data types
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class LobsterEvent:
+    """An immutable event emitted anywhere in the Lobster system."""
+
+    event_type: str          # e.g. "memory.write", "agent.spawn", "debug.observation"
+    severity: str            # "debug" | "info" | "warn" | "error"
+    source: str              # component that emitted this event
+    payload: dict            # arbitrary structured data; keep serialisable
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    task_id: str | None = None
+    chat_id: int | str | None = None
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serialisable dict representation."""
+        d = asdict(self)
+        d["timestamp"] = self.timestamp.isoformat()
+        return d
+
+
+@dataclass
+class EventFilter:
+    """
+    Declarative filter for deciding which events a listener accepts.
+
+    event_types: set of event_type strings to accept; use {"*"} for wildcard.
+    severity: set of severity strings to accept (e.g. {"warn", "error"}).
+    require_debug_mode: when True, only accept events if LOBSTER_DEBUG=true.
+    """
+
+    severity: set[str] = field(default_factory=lambda: {"debug", "info", "warn", "error"})
+    event_types: set[str] = field(default_factory=lambda: {"*"})
+    require_debug_mode: bool = False
+
+    def accepts(self, event: LobsterEvent) -> bool:
+        """Pure predicate — returns True if this filter passes the event."""
+        if self.require_debug_mode:
+            debug_env = os.environ.get("LOBSTER_DEBUG", "").lower()
+            if debug_env != "true":
+                return False
+
+        if event.severity not in self.severity:
+            return False
+
+        if "*" in self.event_types:
+            return True
+
+        return event.event_type in self.event_types
+
+
+# ---------------------------------------------------------------------------
+# Listener protocol
+# ---------------------------------------------------------------------------
+
+@runtime_checkable
+class EventListener(Protocol):
+    """
+    Protocol every event listener must satisfy.
+
+    Listeners are registered with the EventBus and called for each event that
+    passes their filter. Delivery is async; implementations must not block.
+    """
+
+    name: str
+
+    def accepts(self, event: LobsterEvent) -> bool:
+        """Return True if this listener wants to process the event."""
+        ...
+
+    async def deliver(self, event: LobsterEvent) -> None:
+        """Deliver the event. Must not raise — swallow exceptions internally."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# EventBus
+# ---------------------------------------------------------------------------
+
+class EventBus:
+    """
+    Fanout event bus with registered listeners.
+
+    Thread-safe: emit_sync() can be called from any thread. emit() is a coroutine
+    for use in async contexts. Both fan out to all accepting listeners.
+
+    Listener delivery errors are swallowed individually so one broken listener
+    cannot affect others or the caller.
+    """
+
+    def __init__(self) -> None:
+        self._listeners: list[EventListener] = []
+        self._lock = threading.Lock()
+
+    def register(self, listener: EventListener) -> None:
+        """Register a listener. Safe to call before or after the event loop starts."""
+        with self._lock:
+            self._listeners.append(listener)
+
+    def _accepting_listeners(self, event: LobsterEvent) -> list[EventListener]:
+        with self._lock:
+            return [l for l in self._listeners if l.accepts(event)]
+
+    async def emit(self, event: LobsterEvent) -> None:
+        """
+        Emit an event to all accepting listeners.
+
+        Must be called from within an asyncio event loop. Each listener's
+        deliver() coroutine is awaited in sequence (not gathered) to keep
+        ordering deterministic and simplify error isolation.
+        """
+        for listener in self._accepting_listeners(event):
+            try:
+                await listener.deliver(event)
+            except Exception:
+                pass  # individual listener failures must never propagate
+
+    def emit_sync(self, event: LobsterEvent) -> None:
+        """
+        Thread-safe synchronous emit.
+
+        If a running event loop exists (e.g. we are inside an async server),
+        schedules each listener as a fire-and-forget task. If no loop is
+        running (e.g. tests, scripts), runs the emit coroutine synchronously.
+
+        Never blocks the caller beyond scheduling overhead.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(self.emit(event))
+        except RuntimeError:
+            # No running loop — run synchronously (test / script context)
+            asyncio.run(self.emit(event))
+
+
+# ---------------------------------------------------------------------------
+# Built-in listeners
+# ---------------------------------------------------------------------------
+
+class JsonlFileListener:
+    """
+    Writes every accepted event to ~/lobster-workspace/logs/events.jsonl.
+
+    One JSON object per line. The file is created on first write; intermediate
+    directories are created if absent. Append is atomic at the OS level for
+    lines < PIPE_BUF (~4 KiB on Linux), which is sufficient for structured log lines.
+    """
+
+    name = "jsonl-file"
+
+    def __init__(
+        self,
+        path: Path | None = None,
+        event_filter: EventFilter | None = None,
+    ) -> None:
+        self._path = path or (
+            Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+            / "logs"
+            / "events.jsonl"
+        )
+        self._filter = event_filter or EventFilter(
+            severity={"debug", "info", "warn", "error"},
+            event_types={"*"},
+            require_debug_mode=False,
+        )
+
+    def accepts(self, event: LobsterEvent) -> bool:
+        return self._filter.accepts(event)
+
+    async def deliver(self, event: LobsterEvent) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            line = json.dumps(event.to_dict(), ensure_ascii=False)
+            with self._path.open("a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+        except Exception:
+            pass  # file listener failures must never propagate
+
+
+class TelegramOutboxListener:
+    """
+    Replicates the _emit_debug_observation outbox-write behaviour via the bus.
+
+    Accepts only events with severity in {"warn", "error"} (or "debug" in debug
+    mode) and writes them directly to the bot outbox directory so they are
+    delivered to Telegram without entering the dispatcher inbox.
+
+    This listener mirrors the existing _emit_debug_observation function. The
+    actual migration of callsites to use the bus instead of calling
+    _emit_debug_observation directly is done in issue #891.
+    """
+
+    name = "telegram-outbox"
+
+    def __init__(
+        self,
+        outbox_dir: Path | None = None,
+        event_filter: EventFilter | None = None,
+    ) -> None:
+        self._outbox_dir = outbox_dir  # resolved lazily so it doesn't break imports
+        self._filter = event_filter or EventFilter(
+            # Mirror _emit_debug_observation: only deliver when LOBSTER_DEBUG=true.
+            # The filter is debug-mode-gated; callers do not need to check.
+            severity={"warn", "error", "debug", "info"},
+            event_types={"*"},
+            require_debug_mode=True,
+        )
+
+    def _get_outbox_dir(self) -> Path:
+        if self._outbox_dir is not None:
+            return self._outbox_dir
+        messages_base = Path(
+            os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages")
+        )
+        return messages_base / "outbox"
+
+    def _resolve_owner(self) -> tuple[int | str | None, str]:
+        """Return (chat_id, source) for the configured debug owner."""
+        chat_id: int | str | None = None
+        source = "telegram"
+        try:
+            config_dir = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages")) / "config"
+            config_file = config_dir / "config.env"
+            slack_enabled = False
+            slack_channel: str | None = None
+            telegram_chat_id: int | None = None
+            if config_file.exists():
+                for line in config_file.read_text().splitlines():
+                    stripped = line.strip()
+                    if stripped.startswith("TELEGRAM_ALLOWED_USERS="):
+                        val = stripped.split("=", 1)[1].strip().strip('"').strip("'")
+                        first = val.split(",")[0].strip()
+                        if first.lstrip("-").isdigit():
+                            telegram_chat_id = int(first)
+                    elif stripped.startswith("LOBSTER_ENABLE_SLACK="):
+                        slack_enabled = stripped.split("=", 1)[1].strip().strip('"').strip("'").lower() == "true"
+                    elif stripped.startswith("LOBSTER_SLACK_ALLOWED_CHANNELS="):
+                        val = stripped.split("=", 1)[1].strip().strip('"').strip("'")
+                        first_chan = val.split(",")[0].strip()
+                        if first_chan:
+                            slack_channel = first_chan
+            if slack_enabled and slack_channel:
+                source = "slack"
+                chat_id = slack_channel
+            elif telegram_chat_id is not None:
+                source = "telegram"
+                chat_id = telegram_chat_id
+        except Exception:
+            pass
+        return chat_id, source
+
+    def accepts(self, event: LobsterEvent) -> bool:
+        # system_context events are always suppressed — never forward to Telegram
+        if event.event_type.startswith("system_context"):
+            return False
+        return self._filter.accepts(event)
+
+    async def deliver(self, event: LobsterEvent) -> None:
+        try:
+            chat_id, source = self._resolve_owner()
+            if chat_id is None:
+                return
+
+            outbox_dir = self._get_outbox_dir()
+            outbox_dir.mkdir(parents=True, exist_ok=True)
+
+            ts_ms = int(event.timestamp.timestamp() * 1000)
+            safe_source = "".join(c if c.isalnum() or c in "-_" else "_" for c in event.source)[:40]
+            message_id = f"{ts_ms}_debug_{safe_source}"
+
+            emitter_label = event.task_id or event.source or "unknown"
+            label = f"[debug|event-bus] {event.event_type} from {emitter_label}"
+            full_text = f"{label}\n{event.payload.get('text', json.dumps(event.payload))}"
+
+            message = {
+                "id": message_id,
+                "type": "debug_observation",
+                "source": source,
+                "chat_id": chat_id,
+                "text": full_text,
+                "timestamp": event.timestamp.isoformat(),
+            }
+
+            outbox_file = outbox_dir / f"{message_id}.json"
+            # Atomic write: write to tmp then rename
+            tmp_file = outbox_file.with_suffix(".tmp")
+            tmp_file.write_text(json.dumps(message), encoding="utf-8")
+            tmp_file.rename(outbox_file)
+        except Exception:
+            pass  # telegram listener failures must never propagate
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_EVENT_BUS: EventBus | None = None
+_BUS_LOCK = threading.Lock()
+
+
+def get_event_bus() -> EventBus:
+    """
+    Return the module-level EventBus singleton.
+
+    Thread-safe double-checked locking. The bus is created on first call with
+    no listeners registered. Listeners are added by init_event_bus() at server
+    startup. Calling get_event_bus() before init_event_bus() is safe — events
+    emitted before listeners are registered are silently dropped.
+    """
+    global _EVENT_BUS
+    if _EVENT_BUS is None:
+        with _BUS_LOCK:
+            if _EVENT_BUS is None:
+                _EVENT_BUS = EventBus()
+    return _EVENT_BUS
+
+
+def init_event_bus(
+    jsonl_path: Path | None = None,
+    outbox_dir: Path | None = None,
+) -> EventBus:
+    """
+    Initialize the module-level singleton with standard listeners.
+
+    Called once at server startup (in inbox_server.py main()). Safe to call
+    multiple times — subsequent calls are no-ops that return the existing bus.
+
+    Registers:
+    - JsonlFileListener: writes all events to events.jsonl
+    - TelegramOutboxListener: forwards debug events to Telegram outbox when
+      LOBSTER_DEBUG=true
+    """
+    bus = get_event_bus()
+    # Idempotency guard: check if already initialised
+    with _BUS_LOCK:
+        if any(getattr(l, "name", None) == "jsonl-file" for l in bus._listeners):
+            return bus
+        bus.register(JsonlFileListener(path=jsonl_path))
+        bus.register(TelegramOutboxListener(outbox_dir=outbox_dir))
+    return bus

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -7840,6 +7840,13 @@ async def main():
     setup_logging()
     _ensure_observation_worker()
 
+    # Initialize the event bus singleton with standard listeners.
+    # JsonlFileListener writes all events to logs/events.jsonl.
+    # TelegramOutboxListener delivers debug events to Telegram when LOBSTER_DEBUG=true.
+    # This is a no-op if called more than once (idempotent).
+    from event_bus import init_event_bus
+    init_event_bus()
+
     # Startup cleanup: mark stale 'running' rows as 'dead' before reconciler loop begins.
     # After a force-restart, agents killed mid-run leave their output files with
     # stop_reason=tool_use, which the reconciler treats as still-running. We fix this

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -1,0 +1,299 @@
+"""
+Unit tests for the event bus infrastructure (issue #890).
+
+Covers:
+- EventFilter.accepts() — all cases: severity gate, event_type gate, wildcard,
+  debug-mode gate
+- EventBus.emit() fanout — correct listeners receive events, broken listeners
+  do not affect others
+- JsonlFileListener — writes valid JSONL to the configured path
+- TelegramOutboxListener — rejects system_context events, respects debug gate
+- Module-level singleton — get_event_bus() returns the same instance
+- init_event_bus() idempotency — second call does not double-register listeners
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add src/mcp to path so we can import without installing the package
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src" / "mcp"))
+
+from event_bus import (
+    EventBus,
+    EventFilter,
+    JsonlFileListener,
+    LobsterEvent,
+    TelegramOutboxListener,
+    get_event_bus,
+    init_event_bus,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_event(
+    event_type: str = "test.event",
+    severity: str = "info",
+    source: str = "test",
+    payload: dict | None = None,
+    task_id: str | None = None,
+) -> LobsterEvent:
+    return LobsterEvent(
+        event_type=event_type,
+        severity=severity,
+        source=source,
+        payload=payload or {"msg": "hello"},
+        task_id=task_id,
+    )
+
+
+class _CollectingListener:
+    """Test listener that collects every event it receives."""
+
+    name = "collecting"
+
+    def __init__(self, event_filter: EventFilter | None = None) -> None:
+        self._filter = event_filter or EventFilter()
+        self.received: list[LobsterEvent] = []
+
+    def accepts(self, event: LobsterEvent) -> bool:
+        return self._filter.accepts(event)
+
+    async def deliver(self, event: LobsterEvent) -> None:
+        self.received.append(event)
+
+
+class _BrokenListener:
+    """Test listener that always raises in deliver()."""
+
+    name = "broken"
+
+    def accepts(self, event: LobsterEvent) -> bool:
+        return True
+
+    async def deliver(self, event: LobsterEvent) -> None:
+        raise RuntimeError("broken listener")
+
+
+# ---------------------------------------------------------------------------
+# EventFilter.accepts()
+# ---------------------------------------------------------------------------
+
+class TestEventFilter:
+    def test_wildcard_accepts_any_event_type(self):
+        f = EventFilter(event_types={"*"}, severity={"info"})
+        assert f.accepts(make_event(event_type="anything", severity="info"))
+
+    def test_specific_type_match(self):
+        f = EventFilter(event_types={"agent.spawn"}, severity={"info"})
+        assert f.accepts(make_event(event_type="agent.spawn", severity="info"))
+
+    def test_specific_type_no_match(self):
+        f = EventFilter(event_types={"agent.spawn"}, severity={"info"})
+        assert not f.accepts(make_event(event_type="memory.write", severity="info"))
+
+    def test_severity_gate_blocks_wrong_severity(self):
+        f = EventFilter(event_types={"*"}, severity={"error"})
+        assert not f.accepts(make_event(severity="info"))
+
+    def test_severity_gate_passes_correct_severity(self):
+        f = EventFilter(event_types={"*"}, severity={"error", "warn"})
+        assert f.accepts(make_event(severity="warn"))
+
+    def test_debug_mode_gate_blocks_when_debug_off(self):
+        f = EventFilter(require_debug_mode=True)
+        with patch.dict(os.environ, {"LOBSTER_DEBUG": "false"}):
+            assert not f.accepts(make_event())
+
+    def test_debug_mode_gate_passes_when_debug_on(self):
+        f = EventFilter(require_debug_mode=True)
+        with patch.dict(os.environ, {"LOBSTER_DEBUG": "true"}):
+            assert f.accepts(make_event())
+
+    def test_no_debug_requirement_ignores_env(self):
+        f = EventFilter(require_debug_mode=False)
+        with patch.dict(os.environ, {"LOBSTER_DEBUG": "false"}):
+            assert f.accepts(make_event())
+
+
+# ---------------------------------------------------------------------------
+# EventBus.emit() fanout
+# ---------------------------------------------------------------------------
+
+class TestEventBusFanout:
+    def test_single_listener_receives_matching_event(self):
+        bus = EventBus()
+        listener = _CollectingListener(EventFilter(event_types={"*"}, severity={"info"}))
+        bus.register(listener)
+        event = make_event(severity="info")
+        asyncio.run(bus.emit(event))
+        assert listener.received == [event]
+
+    def test_listener_does_not_receive_filtered_out_event(self):
+        bus = EventBus()
+        listener = _CollectingListener(EventFilter(event_types={"agent.spawn"}, severity={"info"}))
+        bus.register(listener)
+        asyncio.run(bus.emit(make_event(event_type="memory.write", severity="info")))
+        assert listener.received == []
+
+    def test_multiple_listeners_each_receive_matching_events(self):
+        bus = EventBus()
+        l1 = _CollectingListener(EventFilter(event_types={"a"}, severity={"info"}))
+        l2 = _CollectingListener(EventFilter(event_types={"b"}, severity={"info"}))
+        bus.register(l1)
+        bus.register(l2)
+        ev_a = make_event(event_type="a")
+        ev_b = make_event(event_type="b")
+        asyncio.run(bus.emit(ev_a))
+        asyncio.run(bus.emit(ev_b))
+        assert l1.received == [ev_a]
+        assert l2.received == [ev_b]
+
+    def test_broken_listener_does_not_prevent_other_listeners(self):
+        bus = EventBus()
+        broken = _BrokenListener()
+        good = _CollectingListener()
+        bus.register(broken)
+        bus.register(good)
+        event = make_event()
+        asyncio.run(bus.emit(event))
+        assert good.received == [event]
+
+    def test_emit_sync_with_no_running_loop_delivers(self):
+        """emit_sync with no running loop falls back to asyncio.run() and delivers."""
+        bus = EventBus()
+        listener = _CollectingListener()
+        bus.register(listener)
+        event = make_event()
+        bus.emit_sync(event)
+        assert listener.received == [event]
+
+
+# ---------------------------------------------------------------------------
+# JsonlFileListener
+# ---------------------------------------------------------------------------
+
+class TestJsonlFileListener:
+    def test_writes_valid_jsonl(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "events.jsonl"
+            listener = JsonlFileListener(path=path)
+            event = make_event(event_type="test.write", task_id="t1")
+            asyncio.run(listener.deliver(event))
+            lines = path.read_text().strip().splitlines()
+            assert len(lines) == 1
+            obj = json.loads(lines[0])
+            assert obj["event_type"] == "test.write"
+            assert obj["task_id"] == "t1"
+            assert "timestamp" in obj
+
+    def test_appends_multiple_events(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "events.jsonl"
+            listener = JsonlFileListener(path=path)
+            for i in range(3):
+                asyncio.run(listener.deliver(make_event(event_type=f"ev.{i}")))
+            lines = path.read_text().strip().splitlines()
+            assert len(lines) == 3
+            types = [json.loads(l)["event_type"] for l in lines]
+            assert types == ["ev.0", "ev.1", "ev.2"]
+
+    def test_creates_parent_directories(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "nested" / "dir" / "events.jsonl"
+            listener = JsonlFileListener(path=path)
+            asyncio.run(listener.deliver(make_event()))
+            assert path.exists()
+
+    def test_accepts_all_events_by_default(self):
+        listener = JsonlFileListener(path=Path("/dev/null"))
+        assert listener.accepts(make_event(severity="debug", event_type="anything"))
+        assert listener.accepts(make_event(severity="error", event_type="anything"))
+
+    def test_delivery_failure_does_not_raise(self):
+        """Writing to an unwritable path must not propagate an exception."""
+        listener = JsonlFileListener(path=Path("/proc/nonexistent/events.jsonl"))
+        # deliver() must not raise even if the write fails
+        asyncio.run(listener.deliver(make_event()))
+
+
+# ---------------------------------------------------------------------------
+# TelegramOutboxListener
+# ---------------------------------------------------------------------------
+
+class TestTelegramOutboxListener:
+    def test_rejects_system_context_event_type(self):
+        listener = TelegramOutboxListener()
+        event = make_event(event_type="system_context.something")
+        with patch.dict(os.environ, {"LOBSTER_DEBUG": "true"}):
+            assert not listener.accepts(event)
+
+    def test_respects_debug_gate_off(self):
+        listener = TelegramOutboxListener()
+        event = make_event(event_type="agent.spawn")
+        with patch.dict(os.environ, {"LOBSTER_DEBUG": "false"}):
+            assert not listener.accepts(event)
+
+    def test_accepts_non_system_context_in_debug_mode(self):
+        listener = TelegramOutboxListener()
+        event = make_event(event_type="agent.spawn")
+        with patch.dict(os.environ, {"LOBSTER_DEBUG": "true"}):
+            assert listener.accepts(event)
+
+    def test_writes_outbox_file_when_chat_id_configured(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outbox_dir = Path(tmpdir) / "outbox"
+            listener = TelegramOutboxListener(outbox_dir=outbox_dir)
+            with patch.object(listener, "_resolve_owner", return_value=(12345, "telegram")):
+                with patch.dict(os.environ, {"LOBSTER_DEBUG": "true"}):
+                    asyncio.run(listener.deliver(make_event(event_type="test.event")))
+            files = list(outbox_dir.iterdir())
+            assert len(files) == 1
+            content = json.loads(files[0].read_text())
+            assert content["type"] == "debug_observation"
+            assert content["chat_id"] == 12345
+
+    def test_deliver_is_no_op_when_no_chat_id(self):
+        """No outbox file written when owner cannot be resolved."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outbox_dir = Path(tmpdir) / "outbox"
+            listener = TelegramOutboxListener(outbox_dir=outbox_dir)
+            with patch.object(listener, "_resolve_owner", return_value=(None, "telegram")):
+                asyncio.run(listener.deliver(make_event()))
+            assert not outbox_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# Singleton behaviour
+# ---------------------------------------------------------------------------
+
+class TestSingleton:
+    def test_get_event_bus_returns_same_instance(self):
+        import event_bus as _eb
+        _eb._EVENT_BUS = None
+        b1 = get_event_bus()
+        b2 = get_event_bus()
+        assert b1 is b2
+
+    def test_init_event_bus_idempotent(self):
+        """Calling init_event_bus() twice must not double-register listeners."""
+        import event_bus as _eb
+        _eb._EVENT_BUS = None
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "events.jsonl"
+            bus1 = init_event_bus(jsonl_path=path)
+            listener_count_after_first = len(bus1._listeners)
+            bus2 = init_event_bus(jsonl_path=path)
+            assert bus1 is bus2
+            assert len(bus2._listeners) == listener_count_after_first


### PR DESCRIPTION
## What problem does this solve

`_emit_debug_observation` is a point-to-point function that writes directly to the Telegram outbox. There is no way to attach structured logging, additional delivery channels, or per-event routing without duplicating the call at each of its ~10 callsites. Issue #634 calls for replacing this pattern with a composable event bus. This PR delivers Step 1: the infrastructure, with zero behavioral change to existing callsites.

## What changes

**`src/mcp/event_bus.py`** — new file with the full bus implementation:

- `LobsterEvent` — frozen dataclass (immutable after creation). Fields: `event_type`, `severity`, `source`, `payload`, `timestamp`, `task_id`, `chat_id`.
- `EventFilter` — pure predicate dataclass. `accepts(event)` checks severity set, event_type set (with `"*"` wildcard), and optional debug-mode gate. No side effects.
- `EventListener` — `@runtime_checkable` Protocol. Any object with `name`, `accepts()`, and `async deliver()` satisfies it.
- `EventBus` — thread-safe fanout. `emit()` is a coroutine; `emit_sync()` schedules a task if a loop is running, falls back to `asyncio.run()` otherwise. Broken listeners are swallowed individually so one failure cannot affect others.
- `JsonlFileListener` — writes every accepted event to `~/lobster-workspace/logs/events.jsonl` as newline-delimited JSON. Always on (not debug-gated). Creates parent directories on first write.
- `TelegramOutboxListener` — replicates `_emit_debug_observation` outbox-write behaviour via the bus. Only active when `LOBSTER_DEBUG=true`. Suppresses `system_context.*` events (matching existing suppression in `_emit_debug_observation`). Writes atomically (write to `.tmp`, then rename).
- `get_event_bus()` — double-checked locking singleton. Safe to call before `init_event_bus()` — events emitted before listeners register are silently dropped.
- `init_event_bus()` — idempotent; registers both standard listeners at server startup. Second call is a no-op.

**`src/mcp/inbox_server.py`** — one addition: `init_event_bus()` called at the top of `main()`, after `setup_logging()`. No other lines changed.

**`tests/unit/test_event_bus.py`** — 25 unit tests covering all acceptance criteria.

## What is out of scope

- No existing `_emit_debug_observation` callsites are changed (Step 2 / issue #891)
- No `subagent_observation` routing changes (Step 3 / issue #892)
- No config-driven listener registration (Step 4)

## Flow: before and after

This PR adds a parallel path. Existing delivery is unchanged:

```
Before:
  callsite → _emit_debug_observation() → atomic_write_json → OUTBOX_DIR

After (Step 1 only):
  callsite → _emit_debug_observation() → atomic_write_json → OUTBOX_DIR   (unchanged)
                                                                            
  [new, unused until #891]
  callsite → event_bus.emit_sync(LobsterEvent(...)) → JsonlFileListener → events.jsonl
                                                    → TelegramOutboxListener → OUTBOX_DIR
```

## Tests run

- [x] `uv run pytest tests/unit/test_event_bus.py -v` — 25 passed, 0 failed
- [ ] `uv run pytest tests/unit/` (full unit suite) — skipped: not needed for a new isolated module with its own test file; the inbox_server change is a one-line addition to `main()` with no logic
- [ ] Live server start test — blocked: requires production environment; safe to merge since `init_event_bus()` is defensive (no-op if listeners already registered, never raises)

Closes #890