### PR TITLE
docs: add dogfooding gate as Convention 4 in DEVELOPMENT.md

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -124,6 +124,43 @@ Legacy format (still supported for backward compat): `Your task_id is: my-task-1
 
 See `hooks/auto-register-agent.py` for full details.
 
+---
+
+## Convention 4: The Dogfooding Gate
+
+**Every PR that touches runtime code must be cleared through the dogfooding gate before merging to main.** This is a hard prerequisite alongside code review and smoke testing.
+
+### What the gate is
+
+The dogfooding gate is the formal signal that a PR has been running long enough on the local integration branch (`local-dev`) to be trusted. It closes the gap between "merged to local-dev for testing" and "ready to ship to main."
+
+### Soak period
+
+A PR must run on `local-dev` for **at least 2 hours** without incident before it can be cleared. An incident is any error, regression, or behavior change caused by the branch that required action (restart, revert, workaround). Unrelated system failures do not count.
+
+**Exceptions:**
+- Doc/prompt-only PRs (no code changes): soak not required.
+- Infrastructure/install changes tested via Docker: Docker run substitutes for local soak.
+
+### Clearing the gate
+
+After the soak period, the operator clears the PR with `/dogfooded <PR-number>`. This is an explicit human acknowledgment that the branch has been observed in production without incident.
+
+Until the `/dogfooded` command is fully implemented (see [issue #917](https://github.com/SiderealPress/lobster/issues/917)), clearance is handled by the dispatcher as a verbal confirmation from the user, recorded in the PR walkthrough notes.
+
+### Gate status in PR walkthroughs
+
+When presenting a PR for merge consideration, always include dogfooding status:
+- "Not yet deployed to local-dev" — gate is not started
+- "In soak since [time] — [elapsed]h / 2h minimum" — gate is running
+- "Cleared by /dogfooded at [time]" — gate is passed
+
+### Why this gate exists
+
+The informal "used in practice" requirement had no forcing function. There was no moment where anyone consciously declared a PR ready. The dogfooding gate creates that moment.
+
+---
+
 ## Related documentation
 
 - `.claude/sys.dispatcher.bootup.md` — runtime behavior and the worktree constraint from the dispatcher's perspective


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Summary

- Formalizes the local-dev soak requirement that was previously informal ("used in practice")
- Defines a 2-hour minimum soak period and an explicit `/dogfooded <PR-number>` clearance signal
- Documents exception cases (doc-only PRs, Docker-tested infra changes)
- Specifies the dogfooding status format to include in PR walkthroughs

## Background

The development workflow already used `local-dev` for dogfooding PRs before merging to main, but there was no explicit moment where anyone declared a PR "ready." The informal gate was never enforced in practice. This PR documents the formalized gate. Companion tooling tracked in issue #917.

## Judgment calls

- 2-hour minimum was chosen as "substantive but not onerous" — long enough to catch immediate regressions, short enough that it doesn't block hotfixes unreasonably
- `/dogfooded` is defined as a user command (not automated) because this codebase doesn't have production metrics to automate the signal
- No code changes in this PR — the rule lives in `user.dispatcher.bootup.md` (private, live immediately) and in this doc

## Verdict

Rubber-stamp: doc-only, no runtime impact.

## Where to focus

The "Convention 4" section starting at the bottom of `docs/DEVELOPMENT.md`.

Closes #917 (partially — tooling implementation still needed)