### PR TITLE
fix: make sync_crontab async and warn on pre-init audit_log calls

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -5129,22 +5129,29 @@ def validate_job_name(name: str) -> tuple[bool, str]:
     return True, ""
 
 
-def sync_crontab() -> tuple[bool, str]:
-    """Sync jobs.json to crontab. Returns (success, message)."""
+async def sync_crontab() -> tuple[bool, str]:
+    """Sync jobs.json to crontab. Returns (success, message).
+
+    Uses asyncio.create_subprocess_exec so the event loop remains responsive
+    while the crontab subprocess runs (fixes: sync was blocking for up to 10s).
+    """
     sync_script = _REPO_DIR / "scheduled-tasks" / "sync-crontab.sh"
     try:
-        result = subprocess.run(
-            [str(sync_script)],
-            capture_output=True,
-            text=True,
-            timeout=10
+        proc = await asyncio.create_subprocess_exec(
+            str(sync_script),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
-        if result.returncode == 0:
-            return True, result.stdout
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=10)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.communicate()
+            return False, "Sync script timed out"
+        if proc.returncode == 0:
+            return True, stdout.decode()
         else:
-            return False, result.stderr or "Sync failed"
-    except subprocess.TimeoutExpired:
-        return False, "Sync script timed out"
+            return False, stderr.decode() or "Sync failed"
     except Exception as e:
         return False, str(e)
 
@@ -5219,7 +5226,7 @@ Keep output concise. The main Lobster instance will review this later.
     save_scheduled_jobs(data)
 
     # Sync to crontab
-    success, msg = sync_crontab()
+    success, msg = await sync_crontab()
     if not success:
         return [TextContent(type="text", text=f"Job created but crontab sync failed: {msg}")]
 
@@ -5365,7 +5372,7 @@ Keep output concise. The main Lobster instance will review this later.
     save_scheduled_jobs(data)
 
     # Sync to crontab
-    success, msg = sync_crontab()
+    success, msg = await sync_crontab()
     sync_status = "" if success else f"\n(Warning: crontab sync failed: {msg})"
 
     return [TextContent(type="text", text=f"Updated job '{name}':\n- " + "\n- ".join(updated) + sync_status)]
@@ -5392,7 +5399,7 @@ async def handle_delete_scheduled_job(args: dict) -> list[TextContent]:
         task_file.unlink()
 
     # Sync to crontab
-    success, msg = sync_crontab()
+    success, msg = await sync_crontab()
     sync_status = "" if success else f"\n(Warning: crontab sync failed: {msg})"
 
     return [TextContent(type="text", text=f"Deleted job '{name}'" + sync_status)]

--- a/src/mcp/reliability.py
+++ b/src/mcp/reliability.py
@@ -14,11 +14,14 @@ Design principles:
 """
 
 import json
+import logging
 import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Re-export atomic filesystem helpers from the canonical location.
@@ -152,6 +155,9 @@ def audit_log(
         duration_ms: How long the call took.
     """
     if _AUDIT_LOG_PATH is None:
+        log.warning(
+            "audit_log called before init_audit_log() — dropping event: tool=%s", tool
+        )
         return  # Not initialized yet
 
     entry = {


### PR DESCRIPTION
## What this fixes

Two independent reliability gaps in `inbox_server.py` and `reliability.py`, grouped because they are both small and both in the MCP server layer.

**#919 — sync_crontab() blocked the event loop for up to 10 seconds**

Every scheduled-job create, update, or delete called `sync_crontab()`, which internally called `subprocess.run()` — a synchronous blocking call inside an async MCP handler. During those 10 seconds the entire MCP server was unresponsive: `wait_for_messages`, inbox checks, and any other in-flight tool calls were all stalled. The fix replaces `subprocess.run()` with `asyncio.create_subprocess_exec` + `await`, so the subprocess runs concurrently with other event loop work. All three call sites (`handle_create_scheduled_job`, `handle_update_scheduled_job`, `handle_delete_scheduled_job`) are updated to `await sync_crontab()`.

**#921 — audit_log() silently dropped events before init_audit_log() was called**

`audit_log()` returned early with no log output when `_AUDIT_LOG_PATH` was `None`. Any reliability event that fired before `init_audit_log()` completed (early startup, import-time side effects) vanished without a trace. The fix emits a `WARNING` log entry instead, so dropped events are detectable in the server log.

## Functional patterns

Pure functions: `sync_crontab` has no side effects beyond the subprocess it awaits. The warning path in `audit_log` is a single conditional with a single observable output (log line) — no mutation of shared state.

## What is not changed

The three async handler functions themselves are unchanged except for the added `await`. The `sync_crontab` function's external contract (returns `(bool, str)`) is unchanged.

## Tests run
- [ ] `uv run pytest tests/` — skipped: test suite requires a live MCP server environment not available in this subagent context
- [x] Manual diff review: all three `sync_crontab()` call sites confirmed changed to `await sync_crontab()`, return type preserved
- [x] Import check: `asyncio` already imported at line 13 of `inbox_server.py`; `logging` added to `reliability.py`

Closes #919
Closes #921