### PR TITLE
fix: preserve state fields on wake and seed atomically in install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -343,7 +343,10 @@ if [ "$CONTAINER_SETUP" = true ]; then
     # triggering a restart loop before Claude has had time to initialize.
     state_file="$MESSAGES_DIR/config/lobster-state.json"
     if [ ! -f "$state_file" ]; then
-        echo '{"mode": "active", "booted_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' > "$state_file"
+        # Write atomically via tmp+rename to prevent a truncated file on interrupt (#924)
+        _state_tmp="${state_file}.tmp.$$"
+        printf '{"mode": "active", "booted_at": "%s"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$_state_tmp"
+        mv "$_state_tmp" "$state_file"
         info "  Seeded lobster-state.json with initial booted_at timestamp"
     fi
     success "Directories created"
@@ -1074,7 +1077,10 @@ rm -f "$MESSAGES_DIR/config/agents.db" "$WORKSPACE_DIR/data/agents.db"
 # triggering a restart loop before Claude has had time to initialize.
 STATE_FILE="$MESSAGES_DIR/config/lobster-state.json"
 if [ ! -f "$STATE_FILE" ]; then
-    echo '{"mode": "active", "booted_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' > "$STATE_FILE"
+    # Write atomically via tmp+rename to prevent a truncated file on interrupt (#924)
+    _STATE_TMP="${STATE_FILE}.tmp.$$"
+    printf '{"mode": "active", "booted_at": "%s"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$_STATE_TMP"
+    mv "$_STATE_TMP" "$STATE_FILE"
     info "  Seeded lobster-state.json with initial booted_at timestamp"
 fi
 

--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -579,9 +579,20 @@ def wake_claude_if_hibernating() -> None:
         # This prevents restart storms: even if spawn fails, the state is no longer
         # "hibernate", so the health check won't skip its safety net.
         try:
-            state_data = {"mode": "active", "woke_at": datetime.now(timezone.utc).isoformat()}
+            # Read existing state first so we preserve fields like compacted_at,
+            # booted_at, and last_restart_at — same pattern as _write_lobster_state()
+            # in inbox_server.py. Overwriting with a bare dict was bug #923.
+            existing: dict = {}
+            try:
+                existing = json.loads(LOBSTER_STATE_FILE.read_text())
+            except Exception:
+                pass
+            existing.update({
+                "mode": "active",
+                "woke_at": datetime.now(timezone.utc).isoformat(),
+            })
             tmp = LOBSTER_STATE_FILE.parent / f".lobster-state-wake-{os.getpid()}.tmp"
-            tmp.write_text(json.dumps(state_data, indent=2))
+            tmp.write_text(json.dumps(existing, indent=2))
             tmp.rename(LOBSTER_STATE_FILE)
             log.info("wake_claude: reset state to 'active'")
         except Exception as e:


### PR DESCRIPTION
## What this fixes

Both bugs are instances of the same pattern: `lobster-state.json` written with a bare minimal struct, clobbering existing fields.

**#923 — wake_claude_if_hibernating() wiped compacted_at, booted_at, last_restart_at**

When an incoming Telegram message woke Lobster from hibernation, the bot wrote `{"mode": "active", "woke_at": "..."}` directly to `lobster-state.json`. Any field not in that literal — `compacted_at`, `booted_at`, `last_restart_at` — was silently deleted.

Downstream impact: after a hibernate wake, `is_compaction_recent()` returned false (missing `compacted_at`), which could suppress the post-compact catchup grace period or trigger incorrect restart decisions. `booted_at` being gone meant the boot grace period no longer applied.

The fix reads the existing state file first, merges the wake fields in (`mode` + `woke_at`), then writes back atomically. This is the same read-merge-write pattern already used by `_write_lobster_state()` in `inbox_server.py`.

**#924 — install.sh seeded the state file with a bare `echo >` redirect**

A `>` redirect to the target file directly is not atomic: if the process is interrupted mid-write the file is left truncated. Both seeding sites in `install.sh` are updated to `printf > tmp && mv` (using `$$` in the tmp name to avoid collisions).

## Before / after (wake path)

```
Before:
  wake event
    └─ write {mode, woke_at}  ← clobbers everything else

After:
  wake event
    └─ read existing state (best-effort)
    └─ merge {mode, woke_at} into existing
    └─ atomic rename write
```

## Functional patterns

Immutability at the merge point: `existing.update(...)` produces the final dict before any I/O. The read and write are the only side effects, and the write is atomic.

## What is not changed

The systemd restart path and all process-spawning logic in `wake_claude_if_hibernating()` are untouched. Only the state-file write block changes.

## Tests run
- [ ] `uv run pytest tests/` — skipped: no test harness available in subagent context
- [x] Manual diff review: `existing.update(...)` pattern confirmed; tmp file uses `os.getpid()` for uniqueness; `mv` replaces `>`  in both install.sh sites

Closes #923
Closes #924