### PR TITLE
fix: lock _processing_files check-and-add to eliminate outbox TOCTOU race

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -380,6 +380,12 @@ main_loop = None
 # Tracks files currently being processed to prevent duplicate sends
 _processing_files: set[str] = set()
 
+# Lock serialising the _processing_files check-and-add in _schedule_processing.
+# Without this, two watchdog events for the same file (e.g. IN_MOVED_TO and
+# IN_MODIFY arriving close together) could both pass the `not in` guard before
+# either has added the path, causing duplicate Telegram delivery (#922).
+_processing_files_lock = threading.Lock()
+
 # Lock to prevent concurrent wake attempts (race condition: two simultaneous
 # incoming messages while hibernating should only trigger one Claude spawn)
 _wake_lock = threading.Lock()
@@ -1332,12 +1338,17 @@ class OutboxHandler(FileSystemEventHandler):
     def _schedule_processing(self, filepath):
         if filepath.endswith('.json') and not filepath.endswith('.tmp'):
             if bot_app and main_loop and main_loop.is_running():
-                if filepath not in _processing_files:
+                # Hold the lock for the full check-and-add so two watchdog
+                # events for the same file cannot both pass the guard before
+                # either has added the path (TOCTOU — fixes #922).
+                with _processing_files_lock:
+                    if filepath in _processing_files:
+                        return
                     _processing_files.add(filepath)
-                    asyncio.run_coroutine_threadsafe(
-                        self.process_reply(filepath),
-                        main_loop
-                    )
+                asyncio.run_coroutine_threadsafe(
+                    self.process_reply(filepath),
+                    main_loop
+                )
 
     def on_created(self, event):
         if event.is_directory:


### PR DESCRIPTION
## What this fixes

`OutboxHandler._schedule_processing()` was guarding against duplicate file processing with a plain `if filepath not in _processing_files` check followed by `_processing_files.add(filepath)`. These two operations had no lock between them.

When an atomic write (write-to-tmp then rename) lands in the outbox, inotify can fire both `IN_MOVED_TO` (caught as `on_created`) and `IN_MODIFY` for the same file. Both events arrive on the watchdog thread. If both checked `_processing_files` before either had added the path, both would see "not present" and both would schedule `process_reply()` — resulting in two Telegram sends for the same outbox file.

The fix wraps the check and the add in a single `threading.Lock` critical section (`_processing_files_lock`). The asyncio coroutine dispatch is left outside the lock to avoid holding it during I/O scheduling.

## Before / after

```
Before:
  watchdog thread A          watchdog thread B
  if fp not in _pf: True     if fp not in _pf: True   ← both pass
  _pf.add(fp)                _pf.add(fp)
  schedule process_reply()   schedule process_reply()  ← duplicate send

After:
  watchdog thread A                   watchdog thread B
  acquire _processing_files_lock      (blocked)
  if fp in _pf: False
  _pf.add(fp)
  release lock                        acquire lock
                                      if fp in _pf: True → return
```

## Functional patterns

The lock makes the check-and-claim atomic — a single indivisible state transition from "not tracked" to "tracked". No shared mutable state is accessed outside the critical section.

## What is not changed

`process_reply()` itself is unchanged. The `_processing_files.discard()` in the `finally` block remains as-is — it runs from an asyncio coroutine, which is single-threaded, so no locking is needed there.

## Tests run
- [ ] `uv run pytest tests/` — skipped: no test harness available in subagent context
- [x] Manual diff review: lock acquired before check, released before coroutine dispatch; `_processing_files_lock` initialized alongside `_wake_lock`

Closes #922