### PR TITLE
fix: serialize jobs.json last_run updates with flock and atomic write

### DIFF
--- a/scheduled-tasks/run-job.sh
+++ b/scheduled-tasks/run-job.sh
@@ -126,25 +126,41 @@ PYEOF
 
 echo "[$START_ISO] Reminder posted for job: $JOB_NAME — dispatcher will spawn subagent" | tee -a "$LOG_FILE"
 
-# Update jobs.json last_run to reflect when the job was dispatched
+# Update jobs.json last_run to reflect when the job was dispatched.
+# Uses a lock file to serialise concurrent cron fires and always writes via
+# tmp+rename so an interrupted write never leaves jobs.json truncated (#920).
 if [ -f "$JOBS_FILE" ]; then
-    if command -v jq &> /dev/null; then
-        TMP_FILE=$(mktemp)
-        jq --arg name "$JOB_NAME" \
-           --arg last_run "$START_ISO" \
-           'if .jobs[$name] then .jobs[$name].last_run = $last_run else . end' \
-           "$JOBS_FILE" > "$TMP_FILE" && mv "$TMP_FILE" "$JOBS_FILE"
-    else
-        python3 -c "
-import json
-with open('$JOBS_FILE') as f:
+    JOBS_LOCK="${JOBS_FILE}.lock"
+    (
+        # Acquire exclusive lock (fd 9) — releases automatically when subshell exits
+        flock -x 9
+        if command -v jq &> /dev/null; then
+            TMP_FILE=$(mktemp)
+            jq --arg name "$JOB_NAME" \
+               --arg last_run "$START_ISO" \
+               'if .jobs[$name] then .jobs[$name].last_run = $last_run else . end' \
+               "$JOBS_FILE" > "$TMP_FILE" && mv "$TMP_FILE" "$JOBS_FILE"
+        else
+            uv run - \
+                "$JOBS_FILE" \
+                "$JOB_NAME" \
+                "$START_ISO" \
+                << 'PYEOF'
+import json, os, sys
+jobs_file = sys.argv[1]
+job_name  = sys.argv[2]
+last_run  = sys.argv[3]
+with open(jobs_file) as f:
     data = json.load(f)
-if '$JOB_NAME' in data.get('jobs', {}):
-    data['jobs']['$JOB_NAME']['last_run'] = '$START_ISO'
-    with open('$JOBS_FILE', 'w') as f:
+if job_name in data.get('jobs', {}):
+    data['jobs'][job_name]['last_run'] = last_run
+    tmp = jobs_file + '.tmp.' + str(os.getpid())
+    with open(tmp, 'w') as f:
         json.dump(data, f, indent=2)
-" 2>/dev/null || true
-    fi
+    os.replace(tmp, jobs_file)
+PYEOF
+        fi
+    ) 9>"$JOBS_LOCK" 2>/dev/null || true
 fi
 
 exit 0


### PR DESCRIPTION
## What this fixes

`run-job.sh` updates `jobs.json` to record `last_run` after each job fires, but did so non-atomically with no file locking.

**The race:** two cron jobs firing at the same second both read the same `jobs.json`, each writes back only their own job's `last_run` update, and the second write silently drops the first job's change. In the worst case, an interrupted write leaves `jobs.json` truncated and unreadable, breaking all scheduled job status reads.

**The python fallback was also non-atomic:** the `jq`-absent path used `open('$JOBS_FILE', 'w')` — a direct overwrite with no tmp file, meaning a crash mid-write corrupts the file. It also called bare `python3` rather than `uv run`.

## Fix

Wrap the entire read-modify-write in a `flock -x` exclusive lock on a `.lock` sentinel file using bash's subshell-fd pattern. The lock releases automatically when the subshell exits (whether via success or error). Both paths write via tmp+rename:

- `jq` path: already used `mktemp` + `mv` — no change needed there
- Python fallback: now uses `uv run` and `os.replace(tmp, jobs_file)` with a pid-unique tmp name

The lock file itself is `jobs.json.lock` and persists between runs (this is intentional — `flock` works on the file descriptor, not the file contents).

## Functional patterns

The subshell-fd flock pattern is declarative: the lock scope is defined structurally by the subshell boundary, not by explicit acquire/release calls. The python fallback is a pure transformation (read JSON, update one field, write JSON) with a single atomic side effect.

## What is not changed

The inbox-write section (lines 85–125) and all cron scheduling logic are untouched. Only the `last_run` update block (previously lines 129–148) is replaced.

## Tests run
- [ ] `uv run pytest tests/` — skipped: no test harness available in subagent context
- [x] Manual review: `flock -x 9` + `9>"$JOBS_LOCK"` pattern is standard bash; `os.replace` is atomic on POSIX; `uv run` used in python fallback

Closes #920