### PR TITLE
fix: read-merge-write in _write_lobster_state() to prevent field clobber

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -1050,15 +1050,26 @@ def _read_lobster_state(state_file: Path = None) -> str:
 def _write_lobster_state(state_file: Path = None, mode: str = "active") -> None:
     """Atomically write Lobster state to state file.
 
+    Reads existing state first and merges new fields in so that caller-supplied
+    fields (compacted_at, booted_at, last_restart_at, catchup_started_at, etc.)
+    are never clobbered — the bug tracked in #825.  Only ``mode`` and
+    ``updated_at`` are unconditionally overwritten; all other fields survive.
+
     Uses write-to-temp-then-rename so readers never see a partial file.
     """
     if state_file is None:
         state_file = LOBSTER_STATE_FILE
-    data = {
+    # Read existing state so we preserve fields we are not updating (#825).
+    existing: dict = {}
+    try:
+        existing = json.loads(state_file.read_text())
+    except Exception:
+        pass
+    existing.update({
         "mode": mode,
         "updated_at": datetime.now(timezone.utc).isoformat(),
-    }
-    content = json.dumps(data, indent=2)
+    })
+    content = json.dumps(existing, indent=2)
     tmp = state_file.parent / f".lobster-state-{os.getpid()}.tmp"
     try:
         tmp.write_text(content)


### PR DESCRIPTION
## What this fixes

**#825 — _write_lobster_state() clobbered compacted_at, booted_at, last_restart_at on every hibernate/wake**

Every time the dispatcher went to hibernate (or returned from it), `_write_lobster_state()` wrote a fresh dict containing only `{mode, updated_at}`. Any field not in that literal — `compacted_at`, `booted_at`, `catchup_started_at`, `last_restart_at` — was silently deleted.

Downstream impact: the health check uses `compacted_at` for the compaction recency check, `booted_at` for the boot grace period, and `last_restart_at` for the restart cooldown. After any hibernate transition, all three suppression windows were gone, which could trigger false-positive restarts.

The fix reads the existing state file first (best-effort, ignores parse errors), merges in the new `mode` and `updated_at` fields, then writes back atomically via tmp+rename. This is the same read-merge-write pattern already used by `_reset_state_on_startup()` and by `wake_claude_if_hibernating()` in lobster_bot.py (fixed in #927).

## Before / after

```
Before:
  hibernate or wake
    └─ write {mode, updated_at}  ← clobbers compacted_at, booted_at, etc.

After:
  hibernate or wake
    └─ read existing state (best-effort)
    └─ merge {mode, updated_at} into existing
    └─ atomic rename write
```

## Relationship to other PRs

- #927 fixed the same pattern in `wake_claude_if_hibernating()` in `lobster_bot.py`
- This PR fixes the remaining instance: `_write_lobster_state()` in `inbox_server.py`
- Together they close all three known clobber sites (the third, `write_state()` in `claude-persistent.sh`, was tracked separately in #825 as a bash write — that path already reads and merges correctly)

## Functional patterns

The `existing.update(...)` call is the only mutation — it produces the final dict before any I/O. Read and atomic write are the only side effects.

## Tests run
- [ ] `uv run pytest tests/` — skipped: no test harness available in subagent context
- [x] Manual diff review: `existing.update(...)` pattern confirmed; read wrapped in try/except; tmp file uses `os.getpid()` for uniqueness

Closes #825