### PR TITLE
feat: add sys.debug.dispatcher.bootup.md — branch invariant check on debug startup

### DIFF
--- a/.claude/sys.debug.dispatcher.bootup.md
+++ b/.claude/sys.debug.dispatcher.bootup.md
@@ -1,0 +1,72 @@
+# Debug Mode — Dispatcher Startup Supplement
+
+Loaded when `LOBSTER_DEBUG=true` AND the session is the dispatcher. Extends
+`sys.debug.bootup.md` and `sys.dispatcher.bootup.md` with debug-specific
+startup invariant checks.
+
+## Branch Invariant Check (REQUIRED at startup)
+
+**Before entering your main loop**, spawn a background subagent to verify the
+branch invariant. This must fire before the first `wait_for_messages()` call.
+
+```
+Task(
+    prompt="""
+---
+task_id: debug-branch-check
+chat_id: 8305714125
+source: system
+---
+
+Check the git branch of ~/lobster/ and report the result.
+
+Steps:
+1. Run: git -C ~/lobster branch --show-current
+2. If the branch is NOT 'local-dev':
+   - call send_reply(chat_id=8305714125, text="BRANCH ALERT: ~/lobster/ is on '<branch>' — expected local-dev. Debug mode is active but the local-dev fixes are NOT running. Run: git -C ~/lobster checkout local-dev")
+3. If the branch IS 'local-dev': no action needed (do not send a reply)
+4. call write_result(task_id='debug-branch-check', chat_id=0, source='system', text='Branch check complete. Branch: <branch>. Alert sent: <yes/no>.', status='success')
+""",
+    subagent_type="general-purpose",
+    run_in_background=True,
+)
+```
+
+This check runs in parallel with the startup-catchup subagent and costs
+<1 second on the main thread.
+
+## Startup Invariant Checklist
+
+In debug mode, the dispatcher must verify these invariants on startup. These
+are code-level contracts — treat a failed invariant as an urgent alert, not
+a minor warning.
+
+| Invariant | How to check | Alert if violated |
+|---|---|---|
+| `~/lobster/` is on `local-dev` | `git -C ~/lobster branch --show-current` | Yes — send_reply to Sahar immediately |
+| `LOBSTER_DEBUG=true` in config | Check `~/lobster-config/config.env` | No — you are in debug mode if this file is loaded |
+| No stale sessions from previous run | on-fresh-start.py hook handles this automatically | File bug if sessions persist after 5 min |
+
+## Debug-Mode Startup Sequence
+
+Full startup sequence in debug mode (extends the base startup in
+`sys.dispatcher.bootup.md`):
+
+1. (Base) Read `handoff.md`, `_context.md`, create session file
+2. (Base) Check context-handoff.json, send warming-up notification if stale
+3. **(Debug-only)** Spawn branch-check subagent (parallel with step 4)
+4. (Base) Spawn `compact-catchup` in background
+5. (Base) Call `wait_for_messages()` — enter the main loop
+
+The branch-check result arrives as a `subagent_result` with
+`task_id: "debug-branch-check"` and `chat_id: 0`. Process it silently —
+the subagent already sent the alert if the branch was wrong. Just
+`mark_processed`.
+
+## Debug-Mode Alerting Policy
+
+When an invariant check fails in debug mode, **always alert Sahar immediately**
+via `send_reply(chat_id=8305714125, ...)`. Do not wait for the user to ask.
+
+The branch invariant is critical: if `~/lobster/` is on `main` in debug mode,
+every fix from `local-dev` is absent and the system is silently degraded.

--- a/hooks/inject-debug-bootup.py
+++ b/hooks/inject-debug-bootup.py
@@ -6,6 +6,10 @@ Fires on every SessionStart event. If the LOBSTER_DEBUG environment variable
 is set to 'true' (case-insensitive), reads
 ~/lobster/.claude/sys.debug.bootup.md and prints its contents to stdout.
 
+When the session is the dispatcher, also injects
+~/lobster/.claude/sys.debug.dispatcher.bootup.md — this adds dispatcher-specific
+startup invariant checks (branch check, alerting policy, etc.).
+
 Claude Code SessionStart hooks can inject content into the agent's initial
 context by printing to stdout. This causes the content to appear as a system
 message at the start of the session.
@@ -18,13 +22,21 @@ setting, so developers can set it in config.env instead of the shell
 environment.
 """
 
+import json
 import os
 import sys
 from pathlib import Path
 
+# Allow imports from the hooks directory (session_role).
+sys.path.insert(0, str(Path(__file__).parent))
+
+import session_role  # noqa: E402 — path insert must precede this
 
 CONFIG_ENV = Path(os.path.expanduser("~/lobster-config/config.env"))
 DEBUG_BOOTUP_FILE = Path(os.path.expanduser("~/lobster/.claude/sys.debug.bootup.md"))
+DEBUG_DISPATCHER_BOOTUP_FILE = Path(
+    os.path.expanduser("~/lobster/.claude/sys.debug.dispatcher.bootup.md")
+)
 
 
 def _parse_config_env() -> dict:
@@ -64,31 +76,54 @@ def _is_debug_mode() -> bool:
     return config_val == "true"
 
 
+def _read_file_safe(path: Path, label: str) -> str | None:
+    """Return file contents or None on any error, logging to stderr."""
+    if not path.exists():
+        print(
+            f"[inject-debug-bootup] WARNING: LOBSTER_DEBUG=true but "
+            f"{path} not found; skipping {label} injection.",
+            file=sys.stderr,
+        )
+        return None
+    try:
+        return path.read_text()
+    except OSError as exc:
+        print(
+            f"[inject-debug-bootup] WARNING: could not read {path}: {exc}",
+            file=sys.stderr,
+        )
+        return None
+
+
 def main() -> None:
     if not _is_debug_mode():
         sys.exit(0)
 
-    if not DEBUG_BOOTUP_FILE.exists():
-        # File missing — exit silently rather than crashing the session.
-        print(
-            f"[inject-debug-bootup] WARNING: LOBSTER_DEBUG=true but "
-            f"{DEBUG_BOOTUP_FILE} not found; skipping injection.",
-            file=sys.stderr,
-        )
-        sys.exit(0)
-
+    # Read hook input from stdin to detect dispatcher vs subagent role.
     try:
-        content = DEBUG_BOOTUP_FILE.read_text()
-    except OSError as exc:
-        print(
-            f"[inject-debug-bootup] WARNING: could not read {DEBUG_BOOTUP_FILE}: {exc}",
-            file=sys.stderr,
-        )
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        hook_input = {}
+
+    # Always inject the base debug supplement.
+    content = _read_file_safe(DEBUG_BOOTUP_FILE, "sys.debug.bootup.md")
+    if content is None:
         sys.exit(0)
 
     # Print to stdout — Claude Code injects stdout from SessionStart hooks
     # into the agent's initial context as a system message.
     print(content)
+
+    # Additionally inject the dispatcher-specific supplement when the session
+    # is the Lobster dispatcher. This adds branch-invariant checks and
+    # debug-mode startup sequencing. Silently skipped for subagent sessions.
+    if session_role.is_dispatcher(hook_input):
+        dispatcher_content = _read_file_safe(
+            DEBUG_DISPATCHER_BOOTUP_FILE, "sys.debug.dispatcher.bootup.md"
+        )
+        if dispatcher_content is not None:
+            print(dispatcher_content)
+
     sys.exit(0)
 
 

--- a/tests/unit/test_hooks/test_inject_debug_bootup.py
+++ b/tests/unit/test_hooks/test_inject_debug_bootup.py
@@ -9,9 +9,13 @@ Tests cover:
 - Hook handles case-insensitive LOBSTER_DEBUG values (TRUE, True)
 - Hook exits silently (with stderr warning) when the bootup file is missing
 - Hook exits silently (with stderr warning) when the bootup file is unreadable
+- Hook injects dispatcher supplement when session is the dispatcher
+- Hook does NOT inject dispatcher supplement for subagent sessions
 """
 
 import importlib.util
+import io
+import json
 import os
 import sys
 from pathlib import Path
@@ -26,8 +30,9 @@ import pytest
 
 def _load_hook(monkeypatch, tmp_path):
     """
-    Load hooks/inject-debug-bootup.py as a module, with CONFIG_ENV and
-    DEBUG_BOOTUP_FILE patched to temp-dir paths so tests are hermetic.
+    Load hooks/inject-debug-bootup.py as a module, with CONFIG_ENV,
+    DEBUG_BOOTUP_FILE, and DEBUG_DISPATCHER_BOOTUP_FILE patched to temp-dir
+    paths so tests are hermetic.
 
     Returns the loaded module object.
     """
@@ -40,10 +45,19 @@ def _load_hook(monkeypatch, tmp_path):
     # Patch module-level path constants to point at tmp_path
     config_env = tmp_path / "config.env"
     debug_file = tmp_path / "sys.debug.bootup.md"
+    debug_dispatcher_file = tmp_path / "sys.debug.dispatcher.bootup.md"
     monkeypatch.setattr(mod, "CONFIG_ENV", config_env)
     monkeypatch.setattr(mod, "DEBUG_BOOTUP_FILE", debug_file)
+    monkeypatch.setattr(mod, "DEBUG_DISPATCHER_BOOTUP_FILE", debug_dispatcher_file)
 
-    return mod, config_env, debug_file
+    return mod, config_env, debug_file, debug_dispatcher_file
+
+
+def _run_main_with_stdin(mod, hook_input: dict):
+    """Call mod.main() with hook_input as the stdin JSON payload."""
+    stdin_data = json.dumps(hook_input)
+    with patch("sys.stdin", io.StringIO(stdin_data)):
+        mod.main()
 
 
 # ---------------------------------------------------------------------------
@@ -54,11 +68,11 @@ class TestInjectDebugBootup:
     def test_no_debug_env_exits_silently(self, monkeypatch, tmp_path, capsys):
         """When LOBSTER_DEBUG is not set, hook exits 0 and prints nothing."""
         monkeypatch.delenv("LOBSTER_DEBUG", raising=False)
-        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+        mod, config_env, debug_file, _ = _load_hook(monkeypatch, tmp_path)
         # config.env absent → no fallback
 
         with pytest.raises(SystemExit) as exc_info:
-            mod.main()
+            _run_main_with_stdin(mod, {})
 
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
@@ -68,10 +82,10 @@ class TestInjectDebugBootup:
     def test_debug_false_exits_silently(self, monkeypatch, tmp_path, capsys):
         """When LOBSTER_DEBUG=false, hook exits 0 and prints nothing."""
         monkeypatch.setenv("LOBSTER_DEBUG", "false")
-        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+        mod, config_env, debug_file, _ = _load_hook(monkeypatch, tmp_path)
 
         with pytest.raises(SystemExit) as exc_info:
-            mod.main()
+            _run_main_with_stdin(mod, {})
 
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
@@ -80,13 +94,13 @@ class TestInjectDebugBootup:
     def test_debug_true_env_injects_content(self, monkeypatch, tmp_path, capsys):
         """When LOBSTER_DEBUG=true (env), hook prints bootup file to stdout."""
         monkeypatch.setenv("LOBSTER_DEBUG", "true")
-        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+        mod, config_env, debug_file, _ = _load_hook(monkeypatch, tmp_path)
 
         expected = "# Debug Mode\n\nSome debug instructions here.\n"
         debug_file.write_text(expected)
 
         with pytest.raises(SystemExit) as exc_info:
-            mod.main()
+            _run_main_with_stdin(mod, {})
 
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
@@ -96,12 +110,12 @@ class TestInjectDebugBootup:
     def test_debug_true_case_insensitive(self, monkeypatch, tmp_path, capsys):
         """LOBSTER_DEBUG=TRUE (uppercase) should also trigger injection."""
         monkeypatch.setenv("LOBSTER_DEBUG", "TRUE")
-        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+        mod, config_env, debug_file, _ = _load_hook(monkeypatch, tmp_path)
 
         debug_file.write_text("# Debug content")
 
         with pytest.raises(SystemExit) as exc_info:
-            mod.main()
+            _run_main_with_stdin(mod, {})
 
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
@@ -110,12 +124,12 @@ class TestInjectDebugBootup:
     def test_debug_true_mixed_case(self, monkeypatch, tmp_path, capsys):
         """LOBSTER_DEBUG=True (mixed case) should also trigger injection."""
         monkeypatch.setenv("LOBSTER_DEBUG", "True")
-        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+        mod, config_env, debug_file, _ = _load_hook(monkeypatch, tmp_path)
 
         debug_file.write_text("# Debug content")
 
         with pytest.raises(SystemExit) as exc_info:
-            mod.main()
+            _run_main_with_stdin(mod, {})
 
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
@@ -124,13 +138,13 @@ class TestInjectDebugBootup:
     def test_debug_true_from_config_env(self, monkeypatch, tmp_path, capsys):
         """When LOBSTER_DEBUG is unset but config.env has LOBSTER_DEBUG=true, inject."""
         monkeypatch.delenv("LOBSTER_DEBUG", raising=False)
-        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+        mod, config_env, debug_file, _ = _load_hook(monkeypatch, tmp_path)
 
         config_env.write_text("LOBSTER_DEBUG=true\n")
         debug_file.write_text("# From config.env")
 
         with pytest.raises(SystemExit) as exc_info:
-            mod.main()
+            _run_main_with_stdin(mod, {})
 
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
@@ -139,13 +153,13 @@ class TestInjectDebugBootup:
     def test_debug_true_config_env_quoted(self, monkeypatch, tmp_path, capsys):
         """config.env value with quotes (LOBSTER_DEBUG=\"true\") is handled."""
         monkeypatch.delenv("LOBSTER_DEBUG", raising=False)
-        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+        mod, config_env, debug_file, _ = _load_hook(monkeypatch, tmp_path)
 
         config_env.write_text('LOBSTER_DEBUG="true"\n')
         debug_file.write_text("# Quoted")
 
         with pytest.raises(SystemExit) as exc_info:
-            mod.main()
+            _run_main_with_stdin(mod, {})
 
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
@@ -154,14 +168,14 @@ class TestInjectDebugBootup:
     def test_env_overrides_config_env_false(self, monkeypatch, tmp_path, capsys):
         """Env var LOBSTER_DEBUG=false takes precedence over config.env true."""
         monkeypatch.setenv("LOBSTER_DEBUG", "false")
-        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+        mod, config_env, debug_file, _ = _load_hook(monkeypatch, tmp_path)
 
         # config.env says true, but env var says false — env var wins
         config_env.write_text("LOBSTER_DEBUG=true\n")
         debug_file.write_text("# Should not be injected")
 
         with pytest.raises(SystemExit) as exc_info:
-            mod.main()
+            _run_main_with_stdin(mod, {})
 
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
@@ -170,11 +184,11 @@ class TestInjectDebugBootup:
     def test_missing_bootup_file_exits_with_warning(self, monkeypatch, tmp_path, capsys):
         """When LOBSTER_DEBUG=true but bootup file is missing, exit 0 with stderr warning."""
         monkeypatch.setenv("LOBSTER_DEBUG", "true")
-        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+        mod, config_env, debug_file, _ = _load_hook(monkeypatch, tmp_path)
         # debug_file deliberately not created
 
         with pytest.raises(SystemExit) as exc_info:
-            mod.main()
+            _run_main_with_stdin(mod, {})
 
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
@@ -185,14 +199,14 @@ class TestInjectDebugBootup:
     def test_unreadable_bootup_file_exits_with_warning(self, monkeypatch, tmp_path, capsys):
         """When bootup file exists but is unreadable, exit 0 with stderr warning."""
         monkeypatch.setenv("LOBSTER_DEBUG", "true")
-        mod, config_env, debug_file = _load_hook(monkeypatch, tmp_path)
+        mod, config_env, debug_file, _ = _load_hook(monkeypatch, tmp_path)
 
         debug_file.write_text("content")
         debug_file.chmod(0o000)  # remove read permission
 
         try:
             with pytest.raises(SystemExit) as exc_info:
-                mod.main()
+                _run_main_with_stdin(mod, {})
 
             assert exc_info.value.code == 0
             captured = capsys.readouterr()
@@ -200,3 +214,61 @@ class TestInjectDebugBootup:
             assert "WARNING" in captured.err
         finally:
             debug_file.chmod(0o644)  # restore so tmp_path cleanup works
+
+
+class TestDispatcherSupplementInjection:
+    """Tests for the dispatcher-specific debug supplement injection."""
+
+    def test_dispatcher_session_injects_supplement(self, monkeypatch, tmp_path, capsys):
+        """When session is dispatcher and LOBSTER_DEBUG=true, both files are injected."""
+        monkeypatch.setenv("LOBSTER_DEBUG", "true")
+        mod, config_env, debug_file, debug_dispatcher_file = _load_hook(monkeypatch, tmp_path)
+
+        debug_file.write_text("# Base debug content")
+        debug_dispatcher_file.write_text("# Dispatcher debug content")
+
+        # Simulate dispatcher by patching session_role.is_dispatcher to return True
+        with patch.object(mod.session_role, "is_dispatcher", return_value=True):
+            with pytest.raises(SystemExit) as exc_info:
+                _run_main_with_stdin(mod, {})
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "# Base debug content" in captured.out
+        assert "# Dispatcher debug content" in captured.out
+
+    def test_subagent_session_does_not_inject_supplement(self, monkeypatch, tmp_path, capsys):
+        """When session is a subagent and LOBSTER_DEBUG=true, only base file is injected."""
+        monkeypatch.setenv("LOBSTER_DEBUG", "true")
+        mod, config_env, debug_file, debug_dispatcher_file = _load_hook(monkeypatch, tmp_path)
+
+        debug_file.write_text("# Base debug content")
+        debug_dispatcher_file.write_text("# Dispatcher debug content")
+
+        # Simulate subagent by patching session_role.is_dispatcher to return False
+        with patch.object(mod.session_role, "is_dispatcher", return_value=False):
+            with pytest.raises(SystemExit) as exc_info:
+                _run_main_with_stdin(mod, {})
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "# Base debug content" in captured.out
+        assert "# Dispatcher debug content" not in captured.out
+
+    def test_dispatcher_supplement_missing_does_not_crash(self, monkeypatch, tmp_path, capsys):
+        """When dispatcher supplement file is missing, hook still injects base content."""
+        monkeypatch.setenv("LOBSTER_DEBUG", "true")
+        mod, config_env, debug_file, debug_dispatcher_file = _load_hook(monkeypatch, tmp_path)
+
+        debug_file.write_text("# Base debug content")
+        # debug_dispatcher_file deliberately NOT created
+
+        with patch.object(mod.session_role, "is_dispatcher", return_value=True):
+            with pytest.raises(SystemExit) as exc_info:
+                _run_main_with_stdin(mod, {})
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "# Base debug content" in captured.out
+        # Warning about missing supplement should appear in stderr
+        assert "WARNING" in captured.err


### PR DESCRIPTION
## Problem

When LOBSTER_DEBUG=true, the dispatcher had no instructions to verify that ~/lobster/ is on the expected branch (local-dev) before entering the main loop. On 2026-03-26, this produced a 10-hour production gap: ~/lobster/ silently switched to main at 19:21 EDT, and every subsequent restart confirmed the wrong branch without detecting it. The fixes from local-dev (16 PRs) were idle the entire time.

The existing `sys.debug.bootup.md` covers subagent behavior in debug mode. There was no dispatcher-specific counterpart, so the branch invariant had no code-level enforcement beyond the bootup prose.

## What changed

**New file: `.claude/sys.debug.dispatcher.bootup.md`**

A dispatcher-specific supplement that is injected at startup when LOBSTER_DEBUG=true. It specifies:
- A background branch-check subagent that must be spawned before the first `wait_for_messages()` call
- A startup invariant table (branch, LOBSTER_DEBUG, stale sessions)
- Explicit alerting policy: if the branch is wrong, send_reply to Sahar immediately — do not wait for the user to ask

The subagent checks `git -C ~/lobster branch --show-current`, sends an alert if not `local-dev`, then writes `write_result`. The dispatcher processes the result silently (the subagent already sent the alert).

**Updated: `hooks/inject-debug-bootup.py`**

The hook now:
1. Reads hook input from stdin (needed to call `session_role.is_dispatcher()`)
2. Always injects `sys.debug.bootup.md` (base debug supplement, as before)
3. Additionally injects `sys.debug.dispatcher.bootup.md` when the session is the dispatcher — skipped silently for subagent sessions

Subagent sessions are unaffected: they only receive the base supplement.

**Updated: `tests/unit/test_hooks/test_inject_debug_bootup.py`**

- Updated all existing tests to mock stdin (required by the new `json.load(sys.stdin)` call in `main()`)
- Added 3 new tests: dispatcher supplement injection, subagent non-injection, graceful handling of missing supplement file

## Flow

Before this PR: debug dispatcher starts → reads sys.debug.bootup.md → no branch check → enters main loop blind

After this PR:
```
debug dispatcher starts
  → inject-debug-bootup.py injects sys.debug.bootup.md + sys.debug.dispatcher.bootup.md
  → dispatcher reads bootup files
  → spawns branch-check subagent (background, <1s on main thread)
  → spawns compact-catchup (background)
  → calls wait_for_messages()
  [later] branch-check result arrives
    → branch == local-dev: silent, mark_processed
    → branch != local-dev: alert already sent by subagent, mark_processed
```

No changes to non-debug startup path. No changes to subagent sessions.

## Functional patterns

Pure functions for file reading (`_read_file_safe`), explicit error isolation (OSError caught at the boundary, not propagated), immutable role detection via `session_role.is_dispatcher()`.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_inject_debug_bootup.py -v` — 13 passed, 0 failed
- [x] `uv run pytest tests/unit/ -q --tb=no` — 1599 passed, 3 failed, 9 warnings, 6 errors (all pre-existing on main — verified by running same tests on clean main branch before this change)
- [ ] Live test with LOBSTER_DEBUG=true restart — blocked: requires production restart (safe to merge, the change only affects SessionStart hook behavior)

**Blocked items needing attention before merge:** none

Relates to #933, #934, #935