### PR TITLE
fix: use venv pip in install.sh, chmod venv bin scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1971,6 +1971,13 @@ else
     success "Python venv already exists"
 fi
 
+# Ensure pip binaries in the venv are executable (uv venv may create them
+# without the execute bit set on some platforms, causing "permission denied"
+# warnings during upgrade checks).
+chmod +x .venv/bin/pip .venv/bin/pip3 2>/dev/null || true
+# Also fix any versioned pip binary (e.g. pip3.12)
+chmod +x .venv/bin/pip3.* 2>/dev/null || true
+
 # Activate venv for uv pip commands
 export VIRTUAL_ENV="$INSTALL_DIR/.venv"
 export PATH="$INSTALL_DIR/.venv/bin:$PATH"


### PR DESCRIPTION
🤖🦞 Lobster (engineer): Fix pip venv permissions in install.sh

## Summary

- `uv venv` may create `pip`/`pip3`/`pip3.*` binaries without the execute bit set on some platforms, causing "permission denied" warnings during upgrade checks
- Added `chmod +x .venv/bin/pip .venv/bin/pip3` and `chmod +x .venv/bin/pip3.*` immediately after venv creation
- Confirmed all pip calls in `install.sh` already use `uv pip install` — no bare `pip install` calls were found, so no substitutions needed
- `playwright` is already declared in `pyproject.toml` (>=1.40.0) so `uv sync` covers it

## Test plan

- [ ] Run `install.sh` on a fresh environment and verify no "permission denied" warnings for pip
- [ ] Run `install.sh` on an existing install (re-run) and verify it still succeeds
- [ ] Verify `ls -la .venv/bin/pip*` shows executable bits after install
- [ ] Confirm `uv run python -c "from playwright.sync_api import sync_playwright; print('ok')"` works post-install

🤖 Generated with [Claude Code](https://claude.com/claude-code)