### PR TITLE
fix: bot-talk-poller skips dispatcher delivery on no-op runs

### DIFF
--- a/scheduled-tasks/tasks/bot-talk-poller-fast.md
+++ b/scheduled-tasks/tasks/bot-talk-poller-fast.md
@@ -92,3 +92,27 @@ When you complete your task, call `write_task_output` with:
 - status: "success" or "failed"
 
 Keep output concise. The main Lobster instance will review this later.
+
+Then call `write_result` to close the subagent task:
+
+**If skipped (hot_mode=false) or no new messages (no-op run):**
+```python
+mcp__lobster-inbox__write_result(
+    task_id="bot-talk-poller-fast",
+    chat_id=0,  # silently dropped by dispatcher — no tokens burned
+    text="no new activity",
+    source="telegram",
+    sent_reply_to_user=True,
+)
+```
+
+**If new messages were found and sent to Sahar:**
+```python
+mcp__lobster-inbox__write_result(
+    task_id="bot-talk-poller-fast",
+    chat_id=8305714125,
+    text="<summary of new messages delivered>",
+    source="telegram",
+    sent_reply_to_user=True,  # already sent via send_reply above
+)
+```

--- a/scheduled-tasks/tasks/bot-talk-poller.md
+++ b/scheduled-tasks/tasks/bot-talk-poller.md
@@ -116,3 +116,27 @@ When you complete your task, call `write_task_output` with:
 - status: "success" or "failed"
 
 Keep output concise. The main Lobster instance will review this later.
+
+Then call `write_result` to close the subagent task:
+
+**If no new messages (no-op run):**
+```python
+mcp__lobster-inbox__write_result(
+    task_id="bot-talk-poller",
+    chat_id=0,  # silently dropped by dispatcher — no tokens burned
+    text="no new activity",
+    source="telegram",
+    sent_reply_to_user=True,
+)
+```
+
+**If new messages were found and sent to Sahar:**
+```python
+mcp__lobster-inbox__write_result(
+    task_id="bot-talk-poller",
+    chat_id=8305714125,
+    text="<summary of new messages delivered>",
+    source="telegram",
+    sent_reply_to_user=True,  # already sent via send_reply above
+)
+```


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

Every scheduled run of the bot-talk-poller (every 5 minutes) and bot-talk-poller-fast (every 2 minutes) spins up a Claude session. Even when there are no new messages, the subagent called `write_result` with Sahar's `chat_id`, causing the dispatcher to receive and process the result — burning ~2–4K tokens per no-op cycle. The fast poller alone runs 720 times per day, meaning the majority of those runs (when Albert is not active) were all burning tokens for nothing.

The fix: both task files now explicitly instruct the subagent to call `write_result(chat_id=0, text='no new activity')` on no-op runs. `chat_id=0` is silently dropped by the dispatcher — no relay, no context window cost. When new messages are found, the subagent continues calling `write_result` with Sahar's `chat_id` as before.

This also covers the fast poller's fast-exit path (when `hot_mode=false`), which was skipping work entirely but still needed a compliant `write_result` call.

**Functional pattern:** the change is pure instruction to the subagent LLM — no code, just conditional branching expressed declaratively in the task file's Output section. The subagent reads the two code blocks and picks the right one based on whether it sent messages.

**What is unchanged:** all polling logic, state file management, Telegram notification formatting, hot-mode activation/cooldown, and the `write_task_output` call. This is strictly a `write_result` routing change.

## Tests run
- [x] `git diff` reviewed manually — changes are additive (new Output section instructions only), no existing behavior removed
- [ ] Live scheduled run — cannot test without a running Lobster instance; the change is a task file instruction with no code path to unit test

Closes #962