### PR TITLE
fix: reduce empty-matcher hook FD churn (shell wrapper + scope narrowing)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1564,7 +1564,35 @@ else
     info "Skipping auto-register-agent hook (settings.json not yet created)"
 fi
 
-# Set up Claude Code PreToolUse hook to block tool use after compaction without context reload
+# Set up Claude Code PostToolUse hook to monitor context window usage and write a
+# context_warning to inbox when usage crosses 70%.  Scoped to mcp__lobster-inbox__ and Agent
+# tool calls only — these are the high-token events where context growth is most likely.
+# Skipping Read/Edit/Write/Bash PostToolUse reduces spawns by ~65% with no meaningful loss
+# of monitoring coverage.
+chmod +x "$INSTALL_DIR/hooks/context-monitor.py" || true
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.PostToolUse[]? | select(.hooks[]?.command | contains("context-monitor"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq '.hooks.PostToolUse = (.hooks.PostToolUse // []) + [{
+            "matcher": "mcp__lobster-inbox__|Agent",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 '"$INSTALL_DIR"'/hooks/context-monitor.py",
+                "timeout": 5
+            }]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "context-monitor hook installed (mcp__lobster-inbox__|Agent)"
+    else
+        info "context-monitor hook already configured in Claude Code settings"
+    fi
+else
+    info "Skipping context-monitor hook (settings.json not yet created)"
+fi
+
+# Set up Claude Code PreToolUse hook to block tool use after compaction without context reload.
+# Uses a shell wrapper so Python is only spawned when the sentinel file exists (~1% of calls).
+# On the 99%+ of calls where the sentinel is absent, `test ! -f ...` exits in ~1ms with no
+# Python startup overhead (~50ms saved per tool call).
 chmod +x "$INSTALL_DIR/hooks/post-compact-gate.py" || true
 if [ -f "$CLAUDE_SETTINGS" ]; then
     if ! jq -e '.hooks.PreToolUse[]? | select(.matcher == "")' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
@@ -1573,11 +1601,11 @@ if [ -f "$CLAUDE_SETTINGS" ]; then
             "matcher": "",
             "hooks": [{
                 "type": "command",
-                "command": "python3 '"$INSTALL_DIR"'/hooks/post-compact-gate.py",
+                "command": "test ! -f /home/lobster/messages/config/compact-pending || python3 '"$INSTALL_DIR"'/hooks/post-compact-gate.py",
                 "timeout": 5
             }]
         }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
-        success "post-compact-gate hook installed"
+        success "post-compact-gate hook installed (shell wrapper)"
     else
         info "post-compact-gate hook already configured in Claude Code settings"
     fi

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1663,6 +1663,87 @@ EOF
         fi
     fi
 
+    # Migration 41: Replace bare python3 invocation in post-compact-gate PreToolUse hook with
+    # a shell wrapper that skips Python startup when the sentinel file is absent.
+    # On the 99%+ of tool calls where compact-pending does not exist, `test ! -f ...` exits
+    # in ~1ms vs ~50ms for Python startup — eliminating ~14 unnecessary spawns per message cycle.
+    if [ -f "$CLAUDE_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
+        local gate_cmd="python3 $LOBSTER_DIR/hooks/post-compact-gate.py"
+        local gate_wrapper="test ! -f /home/lobster/messages/config/compact-pending || python3 $LOBSTER_DIR/hooks/post-compact-gate.py"
+        local has_bare_gate
+        has_bare_gate=$(jq -r --arg cmd "$gate_cmd" '
+            [.hooks.PreToolUse[]?.hooks[]?.command // empty]
+            | map(select(. == $cmd))
+            | length
+        ' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+        if [ "${has_bare_gate:-0}" != "0" ] && [ "${has_bare_gate:-0}" != "" ]; then
+            TMP_SETTINGS=$(mktemp)
+            jq --arg old "$gate_cmd" --arg new "$gate_wrapper" '
+                .hooks.PreToolUse = [
+                    .hooks.PreToolUse[]? |
+                    .hooks = [
+                        .hooks[]? |
+                        if .command == $old then .command = $new else . end
+                    ]
+                ]
+            ' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+            substep "Updated post-compact-gate hook to use shell wrapper (skips Python when sentinel absent)"
+            migrated=$((migrated + 1))
+        fi
+    fi
+
+    # Migration 42: Narrow context-monitor PostToolUse hook matcher from "" (every tool) to
+    # "mcp__lobster-inbox__|Agent". Context window tracking is most relevant after MCP inbox
+    # calls and Agent spawns — the two events where token consumption is highest. This reduces
+    # PostToolUse spawns by ~65% with no meaningful loss of monitoring coverage.
+    # Also registers the hook if it is absent entirely (for installs that predate install.sh entry).
+    if [ -f "$CLAUDE_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
+        local has_monitor_any
+        has_monitor_any=$(jq -r '
+            [.hooks.PostToolUse[]?.hooks[]?.command // empty]
+            | map(select(contains("context-monitor")))
+            | length
+        ' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+        if [ "${has_monitor_any:-0}" = "0" ] || [ "${has_monitor_any:-0}" = "" ]; then
+            # Hook is absent — install it with the correct (narrow) matcher.
+            chmod +x "$LOBSTER_DIR/hooks/context-monitor.py" 2>/dev/null || true
+            TMP_SETTINGS=$(mktemp)
+            jq --arg cmd "python3 $LOBSTER_DIR/hooks/context-monitor.py" \
+               '.hooks.PostToolUse = (.hooks.PostToolUse // []) + [{
+                "matcher": "mcp__lobster-inbox__|Agent",
+                "hooks": [{
+                    "type": "command",
+                    "command": $cmd,
+                    "timeout": 5
+                }]
+            }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+            substep "Registered context-monitor hook with narrow matcher (mcp__lobster-inbox__|Agent)"
+            migrated=$((migrated + 1))
+        else
+            # Hook exists — check if it has the old empty matcher and fix it.
+            local has_empty_matcher
+            has_empty_matcher=$(jq -r '
+                [.hooks.PostToolUse[]? | select(.hooks[]?.command | contains("context-monitor")) | .matcher]
+                | map(select(. == ""))
+                | length
+            ' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+            if [ "${has_empty_matcher:-0}" != "0" ] && [ "${has_empty_matcher:-0}" != "" ]; then
+                TMP_SETTINGS=$(mktemp)
+                jq '
+                    .hooks.PostToolUse = [
+                        .hooks.PostToolUse[]? |
+                        if (.hooks[]?.command | contains("context-monitor")) and .matcher == ""
+                        then .matcher = "mcp__lobster-inbox__|Agent"
+                        else .
+                        end
+                    ]
+                ' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+                substep "Narrowed context-monitor matcher from empty to mcp__lobster-inbox__|Agent"
+                migrated=$((migrated + 1))
+            fi
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## What problem this solves

Two hooks fired on every tool call with an empty matcher, spawning ~20 unnecessary Python processes per message cycle. Each spawn inherits MCP file descriptors, adding FD reference count pressure on `inbox_server.py`. At 5–20 messages/hour with 10+ tool calls each, this meant hundreds of unnecessary spawns per hour.

Both fixes are available now — no CC 2.1.85 `if` field required.

## Changes

**Fix 1 — `post-compact-gate` (PreToolUse, empty matcher, `install.sh` + migration 41)**

The hook's hot path is: check if `~/messages/config/compact-pending` exists, exit 0 if not. This sentinel is absent during normal operation (~99%+ of calls), yet Python was being spawned for every single tool use (~50ms each).

The command is now a shell wrapper:
```
test ! -f /home/lobster/messages/config/compact-pending || python3 .../post-compact-gate.py
```
When the sentinel is absent, `test` exits in ~1ms with no Python overhead. Python is only spawned during the brief post-compaction window. The hook logic itself is unchanged — this is purely a startup optimization.

**Fix 2 — `context-monitor` (PostToolUse, empty matcher → `mcp__lobster-inbox__|Agent`, `install.sh` + migration 42)**

The hook reads `context_window.used_percentage` from the PostToolUse payload and logs it; above 70% it writes a `context_warning` to inbox. Context growth is highest after MCP calls (tokens received from server) and Agent spawns (tokens consumed by subagent). Skipping PostToolUse on Read/Edit/Write/Bash reduces spawns by ~65% with no meaningful loss of monitoring coverage. A once-per-session dedup flag already prevents duplicate warnings regardless of which tool crosses the threshold.

## What is not changed

- The hook scripts (`post-compact-gate.py`, `context-monitor.py`) are untouched — only the invocation wrapper and matcher in settings.json change.
- The sentinel logic, TTL, session role detection, and blocking behavior of `post-compact-gate` are identical.
- The 70% threshold, dedup flag, and warning message format of `context-monitor` are identical.

## Install path coverage

| Scenario | Handled by |
|---|---|
| Fresh install | `install.sh` (post-compact-gate gets shell wrapper; context-monitor gets `mcp__lobster-inbox__\|Agent` matcher) |
| Existing install, gate command is bare python3 | Migration 41 (rewrites command in-place) |
| Existing install, context-monitor has empty matcher | Migration 42 (updates matcher) |
| Existing install, context-monitor absent entirely | Migration 42 (registers hook with correct matcher) |

## Functional patterns

Pure data transformation: both migrations use `jq` to derive the new settings.json from the old one without side effects. Detection (`jq` queries for current state) is separated from transformation (`jq` rewrites). Both migrations are idempotent — re-running upgrade.sh when already up-to-date skips them.

## Tests run

- [x] `uv run --no-project pytest tests/smoke/test_post_compact_gate.py tests/smoke/test_on_compact.py -v` — 8 passed, 0 failed
- [x] jq migration logic verified against live `~/.claude/settings.json` — both detection queries return expected values; both transformation queries produce correct output
- [ ] Full test suite — blocked: `test_vps_integration.py` requires `httpx` not in env, `unit/test_bisque` requires `aiohttp` not in env; pre-existing failures unrelated to this change

**Blocked items needing attention before merge:** none — the two skipped suites are import-missing failures predating this PR.

Closes #964