### PR TITLE
fix: per-session HTTP dispatcher guard (Options A + B)

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -11,7 +11,6 @@ Provides tools for Claude Code to interact with the message queue:
 """
 
 import asyncio
-import contextvars
 import json
 import logging
 from logging.handlers import RotatingFileHandler
@@ -718,32 +717,100 @@ if not SCHEDULED_JOBS_FILE.exists():
 _SERVER_START_TIME = datetime.now(timezone.utc)
 
 # ---------------------------------------------------------------------------
-# HTTP session identity — dispatcher session tagging (Option A)
+# HTTP session identity — dispatcher session tagging (Options A and B)
 # ---------------------------------------------------------------------------
 #
 # When running in HTTP transport mode, multiple Claude Code sessions can
 # connect simultaneously (dispatcher + subagents). The server needs to know
-# which session is the dispatcher so health checks and the reconciler can
-# verify the dispatcher is alive.
+# which session is the dispatcher so that:
+#   - guarded tools (wait_for_messages, send_reply, etc.) are allowed only
+#     for the dispatcher session
+#   - health checks and the reconciler can verify the dispatcher is connected
 #
-# Strategy: tag-on-first-use. When wait_for_messages is called (a
-# dispatcher-exclusive tool), the current MCP session ID is recorded as the
-# dispatcher session. The session ID is propagated to tool handlers via a
-# contextvars.ContextVar set in the ASGI request handler before dispatching
-# to session_manager.handle_request.
+# Session ID propagation:
+#   Each HTTP request carries an "mcp-session-id" header (set by the MCP
+#   client after the initial handshake).  The MCP library stores the raw
+#   Starlette Request object in the per-request RequestContext
+#   (request_ctx.get().request).  Tool handlers running inside the session
+#   task can retrieve the session ID by reading that header:
 #
-# _current_http_session_id: ContextVar populated per-request in _mcp_handler
-# _dispatcher_session_id: module-level str, set on first wait_for_messages call
-# _http_session_manager: reference to the StreamableHTTPSessionManager instance
-#   (set in main() when HTTP mode is active), used by /dispatcher-session to
-#   check whether the tagged session is still alive in _server_instances.
+#     _get_current_http_session_id()  →  request_ctx.get().request.headers[...]
+#
+#   This works because request_ctx is a ContextVar set in the session task
+#   itself (by mcp.server.lowlevel.server._handle_request) before the tool
+#   handler is called.
+#
+# Option A — tag-on-first-use:
+#   The first call to wait_for_messages (dispatcher-exclusive) records the
+#   current session ID as the dispatcher session.  On CC reconnect after a
+#   restart, the tag is updated automatically so the new session is tracked.
+#
+# Option B — explicit declaration:
+#   When a session calls session_start(agent_type="dispatcher", ...) the
+#   current session ID is immediately recorded.  This is explicit and robust
+#   — it fires before any guarded tool is needed.
+#
+# Both layers coexist; whichever fires first wins.  A subsequent call from
+# either path updates the tag (CC restart recovery).
+#
+# _dispatcher_session_id: module-level str, set by Option A or B
+# _http_session_manager: reference to the StreamableHTTPSessionManager
+#   instance (set in main() when HTTP mode is active).  Non-None iff in HTTP
+#   mode.  Used by /dispatcher-session endpoint and by _dispatch_tool to
+#   select the correct guard path.
 # ---------------------------------------------------------------------------
 
-_current_http_session_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-    "_current_http_session_id", default=None
-)
 _dispatcher_session_id: str | None = None
 _http_session_manager = None  # Set to StreamableHTTPSessionManager in main() when HTTP mode is active
+
+
+def _get_current_http_session_id() -> str | None:
+    """Return the MCP session ID for the current tool call request.
+
+    Reads the 'mcp-session-id' header from the Starlette Request object
+    stored in the MCP request context.  Returns None if:
+      - not running in HTTP mode
+      - called outside of an active MCP request (e.g. during startup)
+      - the header is absent (first initialise request has no session ID)
+    """
+    try:
+        from mcp.server.lowlevel.server import request_ctx
+        req_ctx = request_ctx.get()
+        raw_request = req_ctx.request  # Starlette Request or None
+        if raw_request is None:
+            return None
+        return raw_request.headers.get("mcp-session-id")
+    except LookupError:
+        # request_ctx not set — called outside a request context
+        return None
+    except Exception:
+        return None
+
+
+def _tag_dispatcher_session(session_id: str) -> None:
+    """Record session_id as the privileged dispatcher session.
+
+    Called by Option A (handle_wait_for_messages) and Option B
+    (handle_session_start with agent_type="dispatcher").  Whichever fires
+    first wins; both paths update on reconnect.
+    """
+    global _dispatcher_session_id
+    if session_id and session_id != _dispatcher_session_id:
+        _dispatcher_session_id = session_id
+        log.info(f"[session-tag] Dispatcher session tagged: {session_id}")
+
+
+def _is_main_http_session() -> bool:
+    """Return True if the current HTTP session is the tagged dispatcher session.
+
+    Only meaningful when running in HTTP transport mode (_http_session_manager
+    is not None).  Fails closed: returns False if no session is tagged or if
+    the current session ID cannot be determined.
+    """
+    if _dispatcher_session_id is None:
+        return False
+    current = _get_current_http_session_id()
+    return current is not None and current == _dispatcher_session_id
 
 # Initialize SQLite agent session store (idempotent, runs JSON migration on first boot)
 try:
@@ -2593,12 +2660,31 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
 
 async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
     """Dispatch tool calls to handlers."""
-    # Session guard: block inbox-monitoring and outbox-write tools for any
-    # Claude process that is not a descendant of the lobster tmux session
-    # (primary check) or does not have LOBSTER_MAIN_SESSION=1 (fallback).
-    if name in _SESSION_GUARDED_TOOLS and not _is_main_session():
-        log.warning(f"Session guard blocked '{name}' — not in lobster tmux session")
-        return _session_guard_error(name)
+    # Session guard: block inbox-monitoring and outbox-write tools for
+    # any session that is not the designated dispatcher session.
+    #
+    # In HTTP transport mode: use per-session tagging (_is_main_http_session).
+    #   - A session becomes the dispatcher by calling wait_for_messages (Option A)
+    #     or session_start(agent_type="dispatcher") (Option B).
+    #   - All other sessions are blocked from guarded tools.
+    #
+    # In stdio transport mode: use the legacy tmux ancestry / env-var check
+    #   (_is_main_session).  This path is unchanged.
+    if name in _SESSION_GUARDED_TOOLS:
+        if _http_session_manager is not None:
+            # HTTP mode: per-session guard.  wait_for_messages is exempted from
+            # the guard check because it IS the tagging call (Option A) — the
+            # session won't be tagged yet when the first WFM call arrives.
+            if name != "wait_for_messages" and not _is_main_http_session():
+                log.warning(
+                    f"Session guard blocked '{name}' — HTTP session "
+                    f"{_get_current_http_session_id()!r} is not the dispatcher "
+                    f"(dispatcher={_dispatcher_session_id!r})"
+                )
+                return _session_guard_error(name)
+        elif not _is_main_session():
+            log.warning(f"Session guard blocked '{name}' — not in lobster tmux session")
+            return _session_guard_error(name)
 
     if name == "wait_for_messages":
         return await handle_wait_for_messages(arguments)
@@ -2850,19 +2936,16 @@ def _prepend_sessions_prefix(prefix: str, results: list[TextContent]) -> list[Te
 
 async def handle_wait_for_messages(args: dict) -> list[TextContent]:
     """Block until new messages arrive in inbox, or return immediately if messages exist."""
-    global _dispatcher_session_id
     timeout = args.get("timeout", 72000)
     hibernate_on_timeout = args.get("hibernate_on_timeout", False)
 
-    # Tag the calling HTTP session as the dispatcher session (Option A).
-    # wait_for_messages is dispatcher-exclusive, so the first caller that reaches
-    # this point owns the dispatcher role for this server lifetime.  We only set
-    # the tag once: if the dispatcher reconnects with a new session ID after a CC
-    # restart, subsequent calls will update the tag so the new session is tracked.
-    session_id = _current_http_session_id.get()
-    if session_id is not None and session_id != _dispatcher_session_id:
-        _dispatcher_session_id = session_id
-        log.info(f"[session-tag] Dispatcher session tagged: {session_id}")
+    # Option A: tag-on-first-use.  wait_for_messages is dispatcher-exclusive,
+    # so the session calling it is the dispatcher.  Tag it now so subsequent
+    # guarded tool calls from this same session are allowed.
+    if _http_session_manager is not None:
+        session_id = _get_current_http_session_id()
+        if session_id is not None:
+            _tag_dispatcher_session(session_id)
 
     # Touch heartbeat at start - signals Claude is alive and waiting for messages
     touch_heartbeat()
@@ -5840,6 +5923,17 @@ async def handle_session_start(args: dict) -> list[TextContent]:
         return [TextContent(type="text", text=f"Error starting session: {exc}")]
 
     log.info(f"Session started: agent_id={agent_id!r} agent_type={agent_type!r} chat_id={chat_id}")
+
+    # Option B: explicit dispatcher declaration.
+    # If the caller declares itself as the dispatcher, tag its MCP session ID
+    # immediately.  This is more robust than Option A (tag-on-first-use via
+    # wait_for_messages) because it fires during session_start, before any
+    # guarded tools are called.  Both options coexist; whichever fires first wins.
+    if agent_type == "dispatcher" and _http_session_manager is not None:
+        http_session_id = _get_current_http_session_id()
+        if http_session_id is not None:
+            _tag_dispatcher_session(http_session_id)
+
     # Notify wire server so SSE clients update within 40ms
     asyncio.create_task(_notify_wire_server())
     return [TextContent(
@@ -7860,17 +7954,7 @@ async def main():
                 response = Response('{"ok":true}', status_code=200, media_type="application/json")
                 await response(scope, receive, send)
             elif path == "/mcp":
-                # Propagate the MCP session ID into the per-request context so
-                # tool handlers can read it via _current_http_session_id.get().
-                # The header is set by the client on all requests after the
-                # initial handshake (the first request has no session ID yet,
-                # which is fine — wait_for_messages is never the first call).
-                incoming_session_id = request.headers.get("mcp-session-id")
-                token = _current_http_session_id.set(incoming_session_id)
-                try:
-                    await session_manager.handle_request(scope, receive, send)
-                finally:
-                    _current_http_session_id.reset(token)
+                await session_manager.handle_request(scope, receive, send)
             elif path == "/dispatcher-session":
                 # Returns the currently tagged dispatcher session ID and whether
                 # that session is still active in the session manager.
@@ -7882,8 +7966,7 @@ async def main():
                     dsid is not None
                     and dsid in getattr(session_manager, "_server_instances", {})
                 )
-                import json as _json
-                payload = _json.dumps({"session_id": dsid, "active": active})
+                payload = json.dumps({"session_id": dsid, "active": active})
                 response = Response(payload, status_code=200, media_type="application/json")
                 await response(scope, receive, send)
             else:

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -11,6 +11,7 @@ Provides tools for Claude Code to interact with the message queue:
 """
 
 import asyncio
+import contextvars
 import json
 import logging
 from logging.handlers import RotatingFileHandler
@@ -715,6 +716,34 @@ if not SCHEDULED_JOBS_FILE.exists():
 # Record the moment this server process started. Used by stale-session cleanup
 # to distinguish output files from the current run vs a previous (dead) run.
 _SERVER_START_TIME = datetime.now(timezone.utc)
+
+# ---------------------------------------------------------------------------
+# HTTP session identity — dispatcher session tagging (Option A)
+# ---------------------------------------------------------------------------
+#
+# When running in HTTP transport mode, multiple Claude Code sessions can
+# connect simultaneously (dispatcher + subagents). The server needs to know
+# which session is the dispatcher so health checks and the reconciler can
+# verify the dispatcher is alive.
+#
+# Strategy: tag-on-first-use. When wait_for_messages is called (a
+# dispatcher-exclusive tool), the current MCP session ID is recorded as the
+# dispatcher session. The session ID is propagated to tool handlers via a
+# contextvars.ContextVar set in the ASGI request handler before dispatching
+# to session_manager.handle_request.
+#
+# _current_http_session_id: ContextVar populated per-request in _mcp_handler
+# _dispatcher_session_id: module-level str, set on first wait_for_messages call
+# _http_session_manager: reference to the StreamableHTTPSessionManager instance
+#   (set in main() when HTTP mode is active), used by /dispatcher-session to
+#   check whether the tagged session is still alive in _server_instances.
+# ---------------------------------------------------------------------------
+
+_current_http_session_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "_current_http_session_id", default=None
+)
+_dispatcher_session_id: str | None = None
+_http_session_manager = None  # Set to StreamableHTTPSessionManager in main() when HTTP mode is active
 
 # Initialize SQLite agent session store (idempotent, runs JSON migration on first boot)
 try:
@@ -2821,8 +2850,19 @@ def _prepend_sessions_prefix(prefix: str, results: list[TextContent]) -> list[Te
 
 async def handle_wait_for_messages(args: dict) -> list[TextContent]:
     """Block until new messages arrive in inbox, or return immediately if messages exist."""
+    global _dispatcher_session_id
     timeout = args.get("timeout", 72000)
     hibernate_on_timeout = args.get("hibernate_on_timeout", False)
+
+    # Tag the calling HTTP session as the dispatcher session (Option A).
+    # wait_for_messages is dispatcher-exclusive, so the first caller that reaches
+    # this point owns the dispatcher role for this server lifetime.  We only set
+    # the tag once: if the dispatcher reconnects with a new session ID after a CC
+    # restart, subsequent calls will update the tag so the new session is tracked.
+    session_id = _current_http_session_id.get()
+    if session_id is not None and session_id != _dispatcher_session_id:
+        _dispatcher_session_id = session_id
+        log.info(f"[session-tag] Dispatcher session tagged: {session_id}")
 
     # Touch heartbeat at start - signals Claude is alive and waiting for messages
     touch_heartbeat()
@@ -7802,6 +7842,11 @@ async def main():
 
         session_manager = StreamableHTTPSessionManager(app=server, stateless=False)
 
+        # Publish the session_manager reference so tool handlers (and /dispatcher-session)
+        # can inspect live session state without importing from main().
+        global _http_session_manager
+        _http_session_manager = session_manager
+
         @contextlib.asynccontextmanager
         async def _lifespan(app: Starlette):
             async with session_manager.run():
@@ -7815,7 +7860,32 @@ async def main():
                 response = Response('{"ok":true}', status_code=200, media_type="application/json")
                 await response(scope, receive, send)
             elif path == "/mcp":
-                await session_manager.handle_request(scope, receive, send)
+                # Propagate the MCP session ID into the per-request context so
+                # tool handlers can read it via _current_http_session_id.get().
+                # The header is set by the client on all requests after the
+                # initial handshake (the first request has no session ID yet,
+                # which is fine — wait_for_messages is never the first call).
+                incoming_session_id = request.headers.get("mcp-session-id")
+                token = _current_http_session_id.set(incoming_session_id)
+                try:
+                    await session_manager.handle_request(scope, receive, send)
+                finally:
+                    _current_http_session_id.reset(token)
+            elif path == "/dispatcher-session":
+                # Returns the currently tagged dispatcher session ID and whether
+                # that session is still active in the session manager.
+                # Used by health checks and the reconciler to verify the dispatcher
+                # is connected.  Returns 200 with JSON payload in all cases;
+                # callers should check the "active" field.
+                dsid = _dispatcher_session_id
+                active = (
+                    dsid is not None
+                    and dsid in getattr(session_manager, "_server_instances", {})
+                )
+                import json as _json
+                payload = _json.dumps({"session_id": dsid, "active": active})
+                response = Response(payload, status_code=200, media_type="application/json")
+                await response(scope, receive, send)
             else:
                 response = Response("Not Found", status_code=404)
                 await response(scope, receive, send)


### PR DESCRIPTION
## What this fixes

With HTTP transport (#961), the MCP server runs as a systemd service completely detached from tmux. The old session guard (tmux ancestry walk + \`LOBSTER_MAIN_SESSION\` env var) fails for every connection, so the dispatcher cannot call \`wait_for_messages\` at all. This unblocks it.

The root cause: the guard was server-level (one binary = one identity). HTTP changes the model: multiple Claude Code sessions connect to the same server simultaneously. The fix moves the guard to **per-connection-level** — only the session that declares itself the dispatcher is allowed to use guarded tools.

## How it works

**Session ID propagation**: Each HTTP request carries an \`mcp-session-id\` header. The MCP library stores the raw Starlette \`Request\` object in its own \`request_ctx\` ContextVar before calling each tool handler. \`_get_current_http_session_id()\` reads \`server.request_context.request.headers["mcp-session-id"]\` and is always available from within a tool call.

**Option A — tag-on-first-use**: \`wait_for_messages\` is dispatcher-exclusive. The first call to it tags that session ID as the dispatcher. Subsequent calls update the tag, so CC reconnect after a restart self-heals automatically. \`wait_for_messages\` itself is exempt from the guard check — it IS the tagging action.

**Option B — explicit declaration**: \`session_start(agent_type="dispatcher", ...)\` immediately tags the calling session. This is more robust: it fires before any other guarded tool is needed.

Both layers coexist in \`_dispatch_tool\`. In HTTP mode:
- \`wait_for_messages\`: always allowed (triggers Option A tagging)
- all other guarded tools: blocked unless \`_is_main_http_session()\` → True

**Stdio unchanged**: the tmux ancestry / env-var path is untouched. The new code only activates when \`_http_session_manager is not None\`.

**Note on the first commit on this branch**: it used a \`contextvars.ContextVar\` set in the ASGI request handler. This doesn't work — tool handlers run in the session task (a separate task created at connection time), which doesn't inherit context set in later ASGI request coroutines. The second commit (this fix) removes the ContextVar and reads the session ID from the MCP library's own \`request_ctx\` instead.

## Session flow

```
Before (HTTP mode):
  Dispatcher CC  → wait_for_messages
                     → SESSION GUARD BLOCKED (tmux check fails, env var not set)

After (HTTP mode):
  Dispatcher CC  → session_start(agent_type="dispatcher")
                     → _tag_dispatcher_session(session_id)   [Option B]
               OR
  Dispatcher CC  → wait_for_messages
                     → _tag_dispatcher_session(session_id)   [Option A, exempt from guard]
                     → proceeds normally

  Dispatcher CC  → send_reply / mark_processed / etc.
                     → _is_main_http_session() → True → allowed

  Subagent CC    → send_reply / etc.
                     → _is_main_http_session() → False → SESSION GUARD BLOCKED

  /dispatcher-session endpoint → {"session_id": "<uuid>", "active": true|false}
    active=true: tagged session is still present in session_manager._server_instances
```

## What this does NOT change

- stdio mode — existing tmux ancestry / env-var path untouched
- Any tool handler behavior
- \`StreamableHTTPSessionManager\` internals — only reads \`_server_instances\`, never writes it
- Existing \`/health\` endpoint

## Functional patterns used

Pure functions with no shared mutable state in the hot path: \`_get_current_http_session_id()\`, \`_is_main_http_session()\` are stateless reads. The only mutation is \`_tag_dispatcher_session()\` writing one module-level string, called at most once per dispatcher reconnect.

Relates to #961

## Tests run
- [x] `python3 -c "import ast; ast.parse(open('src/mcp/inbox_server.py').read()); print('OK')"` — syntax clean
- [ ] Live end-to-end (dispatcher calls WFM successfully post HTTP restart) — requires service restart in live env; no correctness regression possible since the old code blocked 100% of calls
- [ ] Subagent isolation test — same environment dependency

**Blocked items needing attention before merge:** live smoke test post-deploy. Restart \`lobster-mcp-local.service\`, confirm dispatcher gets through WFM.