### PR TITLE
feat: skip bot-talk-poller dispatch when no new messages

### DIFF
--- a/.githooks/security-allowlist.txt
+++ b/.githooks/security-allowlist.txt
@@ -70,3 +70,8 @@ src/bot/whatsapp_bridge_adapter.py:Email address
 # claude-wrapper.exp reads TELEGRAM_BOT_TOKEN from config.env at runtime using
 # grep — this is a variable reference, not a hardcoded credential value
 scripts/claude-wrapper.exp:Hardcoded token
+
+# bot-talk-check-dispatch.sh uses the same bot-talk API IP that already appears
+# throughout the codebase (scheduled-tasks/tasks/bot-talk-poller*.md). The default
+# value is a fallback when BOT_TALK_API_URL env var is unset — not a secret.
+scheduled-tasks/bot-talk-check-dispatch.sh:IP address

--- a/install.sh
+++ b/install.sh
@@ -1231,10 +1231,14 @@ MARKER="# LOBSTER-SCHEDULED"
 EXISTING=$(crontab -l 2>/dev/null | grep -v "$MARKER" | grep -v "$RUNNER" || true)
 
 if command -v jq &> /dev/null; then
-    CRON_ENTRIES=$(jq -r --arg runner "$RUNNER" --arg marker "$MARKER" '
+    CRON_ENTRIES=$(jq -r --arg runner "$RUNNER" --arg marker "$MARKER" \
+        --arg repo_dir "$REPO_DIR" '
         .jobs | to_entries[] |
         select(.value.enabled == true) |
-        "\(.value.schedule) \($runner) \(.key) \($marker)"
+        (.value.runner // $runner) as $job_runner |
+        # Expand $REPO_DIR placeholder so per-job runners can reference the install dir
+        ($job_runner | gsub("\\$REPO_DIR"; $repo_dir)) as $resolved_runner |
+        "\(.value.schedule) \($resolved_runner) \(.key) \($marker)"
     ' "$JOBS_FILE" 2>/dev/null || echo "")
 else
     CRON_ENTRIES=$(python3 -c "
@@ -1243,11 +1247,15 @@ import sys
 try:
     with open('$JOBS_FILE', 'r') as f:
         data = json.load(f)
+    repo_dir = '$REPO_DIR'
+    default_runner = '$RUNNER'
     for name, job in data.get('jobs', {}).items():
         if job.get('enabled', True):
             schedule = job.get('schedule', '')
             if schedule:
-                print(f\"{schedule} $RUNNER {name} $MARKER\")
+                runner = job.get('runner', default_runner)
+                runner = runner.replace('\$REPO_DIR', repo_dir)
+                print(f\"{schedule} {runner} {name} $MARKER\")
 except Exception as e:
     sys.stderr.write(f'Error: {e}\n')
 " 2>/dev/null || echo "")

--- a/scheduled-tasks/bot-talk-check-dispatch.sh
+++ b/scheduled-tasks/bot-talk-check-dispatch.sh
@@ -81,6 +81,7 @@ BOT_TALK_API_URL="${BOT_TALK_API_URL:-http://46.224.41.108:4242}"
 HAS_NEW_MESSAGES=0
 API_ERROR=0
 
+ENCODED_TS=""
 if [ -n "$LAST_TS" ]; then
     # URL-encode the timestamp for the query string
     ENCODED_TS=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" "$LAST_TS" 2>/dev/null || echo "")
@@ -100,20 +101,32 @@ if [ "$HAS_NEW_MESSAGES" -eq 0 ] && [ -n "$ENCODED_TS" ]; then
         exec "$SCRIPT_DIR/dispatch-job.sh" "$JOB_NAME"
     fi
 
-    # Count messages in the response array
+    # Count messages in the response array.
+    # On JSON parse failure, fall through to dispatch (fail-safe: err on the side of running the job).
+    # set -e is disabled around this call so we can inspect the exit code ourselves.
+    set +e
     MSG_COUNT=$(python3 -c "
 import json, sys
+data_str = sys.argv[1]
 try:
-    data = json.loads(sys.argv[1])
-    # API returns either a list directly or {\"messages\": [...]}
-    if isinstance(data, list):
-        msgs = data
-    else:
-        msgs = data.get('messages', [])
-    print(len(msgs))
-except Exception:
-    print(0)
-" "$RESPONSE" 2>/dev/null || echo "0")
+    data = json.loads(data_str)
+except json.JSONDecodeError:
+    # Invalid JSON from API — signal parse failure so caller falls through to dispatch
+    sys.exit(2)
+# API returns either a list directly or {\"messages\": [...]}
+if isinstance(data, list):
+    msgs = data
+else:
+    msgs = data.get('messages', [])
+print(len(msgs))
+" "$RESPONSE" 2>/dev/null)
+    PARSE_EXIT=$?
+    set -e
+
+    if [ "$PARSE_EXIT" -ne 0 ]; then
+        echo "[$START_ISO] WARNING: bot-talk API returned invalid JSON — dispatching to let job handle it" | tee "$LOG_FILE"
+        exec "$SCRIPT_DIR/dispatch-job.sh" "$JOB_NAME"
+    fi
 
     if [ "$MSG_COUNT" -gt 0 ]; then
         HAS_NEW_MESSAGES=1

--- a/scheduled-tasks/bot-talk-check-dispatch.sh
+++ b/scheduled-tasks/bot-talk-check-dispatch.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Bot-Talk Pre-Check Dispatcher
+#
+# Performs a lightweight HTTP check against the bot-talk API before dispatching
+# the bot-talk-poller job. If there are no new messages since last_message_ts,
+# exits immediately without writing to the inbox (no LLM subagent spawned).
+# If new messages exist, delegates to dispatch-job.sh as normal.
+#
+# Usage: bot-talk-check-dispatch.sh bot-talk-poller
+#
+# Flow:
+#   new messages  → dispatch-job.sh bot-talk-poller → inbox write → LLM
+#   no new msgs   → log no-op → exit 0 (no inbox write)
+
+set -e
+
+export PATH="$HOME/.local/bin:$PATH"
+
+JOB_NAME="${1:-bot-talk-poller}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Load env files (same pattern as dispatch-job.sh)
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+for _env_file in "$CONFIG_DIR/config.env" "$CONFIG_DIR/global.env"; do
+    if [ -f "$_env_file" ]; then
+        # shellcheck source=/dev/null
+        set -a
+        source "$_env_file"
+        set +a
+    fi
+done
+unset _env_file
+
+WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+LOG_DIR="$WORKSPACE/scheduled-jobs/logs"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+START_ISO=$(date -Iseconds)
+
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${JOB_NAME}-precheck-${TIMESTAMP}.log"
+
+# --- Read state file ---
+STATE_FILE="$WORKSPACE/data/bot-talk-state.json"
+LAST_TS=""
+if [ -f "$STATE_FILE" ]; then
+    LAST_TS=$(python3 -c "
+import json
+try:
+    with open('$STATE_FILE') as f:
+        d = json.load(f)
+    print(d.get('last_message_ts', ''))
+except Exception:
+    pass
+" 2>/dev/null || true)
+fi
+
+# Fallback: legacy last-seen file
+if [ -z "$LAST_TS" ] && [ -f "$WORKSPACE/data/bot-talk-last-seen.txt" ]; then
+    LAST_TS=$(python3 -c "
+import sys
+val = open('$WORKSPACE/data/bot-talk-last-seen.txt').read().strip()
+print(val)
+" 2>/dev/null || true)
+fi
+
+# --- Read token ---
+TOKEN_FILE="$WORKSPACE/data/bot-talk-token.txt"
+if [ ! -f "$TOKEN_FILE" ]; then
+    echo "[$START_ISO] ERROR: bot-talk token file missing: $TOKEN_FILE" | tee "$LOG_FILE"
+    # Fall through to dispatch so the job can report the failure properly
+    exec "$SCRIPT_DIR/dispatch-job.sh" "$JOB_NAME"
+fi
+BOT_TOKEN=$(python3 -c "print(open('$TOKEN_FILE').read().strip())" 2>/dev/null)
+
+# --- Determine API URL ---
+BOT_TALK_API_URL="${BOT_TALK_API_URL:-http://46.224.41.108:4242}"
+
+# --- Check for new messages ---
+# A single HTTP request with ?since=<last_ts> returns only messages after that point.
+# If the array is empty (or the field count is 0), nothing is new.
+HAS_NEW_MESSAGES=0
+API_ERROR=0
+
+if [ -n "$LAST_TS" ]; then
+    # URL-encode the timestamp for the query string
+    ENCODED_TS=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" "$LAST_TS" 2>/dev/null || echo "")
+    CHECK_URL="$BOT_TALK_API_URL/messages?since=${ENCODED_TS}"
+else
+    # No known last timestamp — treat as new to be safe
+    HAS_NEW_MESSAGES=1
+fi
+
+if [ "$HAS_NEW_MESSAGES" -eq 0 ] && [ -n "$ENCODED_TS" ]; then
+    RESPONSE=$(curl -sf --max-time 10 \
+        -H "X-Bot-Token: $BOT_TOKEN" \
+        "$CHECK_URL" 2>/dev/null) || API_ERROR=$?
+
+    if [ "$API_ERROR" -ne 0 ]; then
+        echo "[$START_ISO] WARNING: bot-talk API unreachable (curl exit $API_ERROR) — dispatching to let job handle outage logic" | tee "$LOG_FILE"
+        exec "$SCRIPT_DIR/dispatch-job.sh" "$JOB_NAME"
+    fi
+
+    # Count messages in the response array
+    MSG_COUNT=$(python3 -c "
+import json, sys
+try:
+    data = json.loads(sys.argv[1])
+    # API returns either a list directly or {\"messages\": [...]}
+    if isinstance(data, list):
+        msgs = data
+    else:
+        msgs = data.get('messages', [])
+    print(len(msgs))
+except Exception:
+    print(0)
+" "$RESPONSE" 2>/dev/null || echo "0")
+
+    if [ "$MSG_COUNT" -gt 0 ]; then
+        HAS_NEW_MESSAGES=1
+    fi
+fi
+
+# --- Decision ---
+if [ "$HAS_NEW_MESSAGES" -eq 1 ]; then
+    echo "[$START_ISO] New messages found — dispatching $JOB_NAME" | tee "$LOG_FILE"
+    exec "$SCRIPT_DIR/dispatch-job.sh" "$JOB_NAME"
+else
+    echo "[$START_ISO] No new messages since $LAST_TS — skipping dispatch for $JOB_NAME" | tee "$LOG_FILE"
+    exit 0
+fi

--- a/scheduled-tasks/sync-crontab.sh
+++ b/scheduled-tasks/sync-crontab.sh
@@ -28,25 +28,37 @@ MARKER="# LOBSTER-SCHEDULED"
 # Get existing crontab entries (excluding lobster ones)
 EXISTING=$(crontab -l 2>/dev/null | grep -v "$MARKER" | grep -v "$RUNNER" || true)
 
-# Generate new crontab entries from jobs.json
+# Generate new crontab entries from jobs.json.
+# Each job uses its own .runner if set, otherwise falls back to the default RUNNER.
+# This allows specific jobs (e.g. bot-talk-poller) to use a lightweight pre-check
+# wrapper that avoids dispatching to the LLM when there is nothing to process.
 if command -v jq &> /dev/null; then
-    CRON_ENTRIES=$(jq -r --arg runner "$RUNNER" --arg marker "$MARKER" '
+    CRON_ENTRIES=$(jq -r --arg runner "$RUNNER" --arg marker "$MARKER" \
+        --arg repo_dir "$REPO_DIR" '
         .jobs | to_entries[] |
         select(.value.enabled == true) |
-        "\(.value.schedule) \($runner) \(.key) \($marker)"
+        (.value.runner // $runner) as $job_runner |
+        # Expand $REPO_DIR placeholder so per-job runners can reference the install dir
+        ($job_runner | gsub("\\$REPO_DIR"; $repo_dir)) as $resolved_runner |
+        "\(.value.schedule) \($resolved_runner) \(.key) \($marker)"
     ' "$JOBS_FILE" 2>/dev/null || echo "")
 else
     CRON_ENTRIES=$(python3 -c "
 import json
 import sys
+import os
 try:
     with open('$JOBS_FILE', 'r') as f:
         data = json.load(f)
+    repo_dir = '$REPO_DIR'
+    default_runner = '$RUNNER'
     for name, job in data.get('jobs', {}).items():
         if job.get('enabled', True):
             schedule = job.get('schedule', '')
             if schedule:
-                print(f\"{schedule} $RUNNER {name} $MARKER\")
+                runner = job.get('runner', default_runner)
+                runner = runner.replace('\$REPO_DIR', repo_dir)
+                print(f\"{schedule} {runner} {name} $MARKER\")
 except Exception as e:
     sys.stderr.write(f'Error: {e}\n')
 " 2>/dev/null || echo "")

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1744,6 +1744,26 @@ EOF
         fi
     fi
 
+    # Migration 44: Switch bot-talk-poller cron entry to use bot-talk-check-dispatch.sh.
+    # The pre-check wrapper queries the bot-talk API before writing to the inbox,
+    # so no LLM subagent is spawned on empty polls. The runner field in jobs.json
+    # drives this via sync-crontab.sh; this migration re-syncs the crontab so the
+    # change takes effect on existing installs without a manual sync.
+    local BOT_TALK_CHECK_SCRIPT="$INSTALL_DIR/scheduled-tasks/bot-talk-check-dispatch.sh"
+    if [ -f "$BOT_TALK_CHECK_SCRIPT" ]; then
+        if ! crontab -l 2>/dev/null | grep -q "bot-talk-check-dispatch.sh"; then
+            chmod +x "$BOT_TALK_CHECK_SCRIPT" 2>/dev/null || true
+            # Re-run sync-crontab.sh to rebuild the crontab from jobs.json, picking up
+            # the new runner field for bot-talk-poller.
+            if [ -f "$INSTALL_DIR/scheduled-tasks/sync-crontab.sh" ]; then
+                chmod +x "$INSTALL_DIR/scheduled-tasks/sync-crontab.sh" 2>/dev/null || true
+                "$INSTALL_DIR/scheduled-tasks/sync-crontab.sh" 2>/dev/null || true
+                substep "Crontab re-synced: bot-talk-poller now uses bot-talk-check-dispatch.sh"
+                migrated=$((migrated + 1))
+            fi
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## What problem this solves

Every hourly cron tick for `bot-talk-poller` unconditionally writes to the Lobster inbox, spawning a full LLM subagent even when there are zero new messages. The subagent checks the API, finds nothing, and exits — burning tokens and inbox queue slots for a no-op. During quiet periods or API outages, every tick generates a "nothing new" agent invocation.

## What changed

Introduces `bot-talk-check-dispatch.sh`, a lightweight pre-check wrapper that sits in front of `dispatch-job.sh` for the bot-talk-poller cron entry:

```
Before:
  cron tick → dispatch-job.sh → inbox write → LLM subagent → "nothing new" → exit

After (no new messages):
  cron tick → bot-talk-check-dispatch.sh → GET /messages?since=<last_ts> → [] → log no-op → exit 0

After (new messages):
  cron tick → bot-talk-check-dispatch.sh → GET /messages?since=<last_ts> → [...] → dispatch-job.sh → inbox write → LLM
```

The pre-check reads `last_message_ts` from `bot-talk-state.json`, does a single authenticated HTTP request with a `?since=` filter, and only delegates to `dispatch-job.sh` if the response is non-empty. API errors (curl non-zero) fall through to dispatch so the job's existing 30-minute outage-handling logic remains in effect.

## Infrastructure change: per-job runner override

`sync-crontab.sh` and `install.sh` now respect an optional `runner` field in each `jobs.json` job entry. When set, it overrides the default `dispatch-job.sh` runner for that job's cron line. `$REPO_DIR` is expanded in the value so paths stay portable. The `bot-talk-poller` entry in `jobs.json` is updated to use the new wrapper.

This pattern is reusable for other deterministic pollers (e.g. `lobster-plans-poller`) without any further infrastructure changes.

## Migration

Migration 44 in `upgrade.sh` runs `sync-crontab.sh` on existing installs to pick up the new runner. Idempotent: skipped if the crontab already references `bot-talk-check-dispatch.sh`.

## Functional patterns

Pure sequential logic (read state → check API → branch on result), side-effect isolation (HTTP call and crontab I/O at the edges, no mutations until dispatch is confirmed), and fail-safe defaults (API error → dispatch rather than swallow).

## Tests run

- [x] Verified `sync-crontab.sh` jq expression handles `.runner // $runner` fallback correctly: tested manually against `jobs.json` with and without the `runner` field
- [x] Verified `bot-talk-check-dispatch.sh` exits 0 with no dispatch when no messages (manual dry-run against live API with current `last_message_ts`)
- [ ] Full integration test (cron trigger → live dispatch) — blocked: requires merge + `sync-crontab.sh` run on production

Closes #980