### PR TITLE
fix: crontab sync fails with Permission denied under NoNewPrivs (issue #985)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -495,6 +495,20 @@ if [ "$(id -u)" = "0" ]; then
         # Docker not installed — this is the normal case on a fresh machine, not a warning
         info "Docker not installed — skipping docker group setup. Install Docker later to enable Docker features."
     fi
+    # Add lobster user to the crontab group so sync-crontab.sh works under NoNewPrivs.
+    # Claude Code sets PR_SET_NO_NEW_PRIVS on the MCP server process, which propagates to
+    # child processes and suppresses setgid bits. The `crontab` binary is setgid-crontab —
+    # that privilege is what lets it write to /var/spool/cron/crontabs/. Without it,
+    # `crontab -` fails with "mkstemp: Permission denied". Group membership lets the
+    # lobster user write directly to /var/spool/cron/crontabs/ (group-writable) without
+    # needing the setgid bit.
+    if getent group crontab &>/dev/null; then
+        usermod -aG crontab lobster
+        success "Added 'lobster' to the crontab group (fixes NoNewPrivs crontab permission error)."
+        warn "Group membership takes effect at next login. Run 'newgrp crontab' or restart after install to apply."
+    else
+        warn "The 'crontab' group does not exist — scheduled job syncing may fail. Run: sudo groupadd crontab && sudo usermod -aG crontab lobster"
+    fi
     # Copy script to /tmp so lobster user can read it regardless of working directory
     INSTALL_SCRIPT="$(readlink -f "$0")"
     TMP_SCRIPT="$(mktemp /tmp/lobster-install.XXXXXX.sh)"

--- a/scheduled-tasks/sync-crontab.sh
+++ b/scheduled-tasks/sync-crontab.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 # Lobster Crontab Synchronizer
-# Syncs jobs.json to system crontab
+# Syncs jobs.json to the user's crontab.
+#
+# This script runs as a subprocess of the MCP server, which sets
+# PR_SET_NO_NEW_PRIVS (NoNewPrivs=1).  That flag suppresses setgid bits,
+# so `crontab -` fails with "mkstemp: Permission denied" even though the
+# crontab binary is setgid-crontab.
+#
+# Primary path: write directly to /var/spool/cron/crontabs/$USER (requires
+# the lobster user to be in the `crontab` group — see upgrade.sh Migration 41).
+# Fallback path: use `crontab -` for systems where the user is not yet in the
+# crontab group (e.g. before the migration runs or on non-Debian systems).
 
 set -e
 
@@ -8,9 +18,10 @@ WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
 REPO_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
 JOBS_FILE="$WORKSPACE/scheduled-jobs/jobs.json"
 RUNNER="$REPO_DIR/scheduled-tasks/dispatch-job.sh"
+CRONTAB_FILE="/var/spool/cron/crontabs/$(whoami)"
 
-# Check if crontab is available
-if ! command -v crontab &> /dev/null; then
+# Check if cron is available at all
+if ! command -v crontab &> /dev/null && [ ! -d "/var/spool/cron/crontabs" ]; then
     echo "Warning: crontab command not found. Install cron to enable scheduled tasks."
     echo "On Debian/Ubuntu: sudo apt-get install cron"
     echo "Jobs are saved and will be synced when cron is available."
@@ -25,8 +36,18 @@ fi
 # Marker for lobster-managed cron entries
 MARKER="# LOBSTER-SCHEDULED"
 
-# Get existing crontab entries (excluding lobster ones)
-EXISTING=$(crontab -l 2>/dev/null | grep -v "$MARKER" | grep -v "$RUNNER" || true)
+# Read existing crontab entries, stripping any lobster-managed lines.
+# Try direct file read first (available when user is in the crontab group),
+# then fall back to `crontab -l` (requires setgid to work).
+read_existing_crontab() {
+    if [ -f "$CRONTAB_FILE" ] && [ -r "$CRONTAB_FILE" ]; then
+        cat "$CRONTAB_FILE"
+    elif command -v crontab &> /dev/null; then
+        crontab -l 2>/dev/null || true
+    fi
+}
+
+EXISTING=$(read_existing_crontab | grep -v "$MARKER" | grep -v "$RUNNER" || true)
 
 # Generate new crontab entries from jobs.json.
 # Each job uses its own .runner if set, otherwise falls back to the default RUNNER.
@@ -64,16 +85,48 @@ except Exception as e:
 " 2>/dev/null || echo "")
 fi
 
-# Build new crontab
-{
-    if [ -n "$EXISTING" ]; then
-        echo "$EXISTING"
+# Build the new crontab content
+NEW_CRONTAB=""
+if [ -n "$EXISTING" ]; then
+    NEW_CRONTAB="$EXISTING"
+fi
+if [ -n "$CRON_ENTRIES" ]; then
+    if [ -n "$NEW_CRONTAB" ]; then
+        NEW_CRONTAB="$NEW_CRONTAB
+$CRON_ENTRIES"
+    else
+        NEW_CRONTAB="$CRON_ENTRIES"
     fi
-    if [ -n "$CRON_ENTRIES" ]; then
-        echo "$CRON_ENTRIES"
+fi
+
+# Write the crontab.
+# Primary: write directly to the crontab file (works under NoNewPrivs=1 when
+# the user is in the crontab group, because the directory is group-writable).
+# Fallback: pipe through `crontab -` (works in regular shell sessions where
+# the crontab setgid bit is effective).
+write_crontab() {
+    local content="$1"
+    # Direct write: requires crontab group membership (upgrade.sh Migration 41).
+    if [ -d "/var/spool/cron/crontabs" ] && [ -w "/var/spool/cron/crontabs" ]; then
+        # Write atomically: temp file in same directory, then rename.
+        local tmpfile
+        tmpfile=$(mktemp "/var/spool/cron/crontabs/.tmp.XXXXXX")
+        chmod 0600 "$tmpfile"
+        printf '%s\n' "$content" > "$tmpfile"
+        mv "$tmpfile" "$CRONTAB_FILE"
+        return 0
     fi
-} | crontab -
+    # Fallback: crontab binary (requires setgid, blocked under NoNewPrivs=1).
+    if command -v crontab &> /dev/null; then
+        printf '%s\n' "$content" | crontab -
+        return $?
+    fi
+    echo "Error: cannot write crontab — not in crontab group and crontab binary unavailable" >&2
+    return 1
+}
+
+write_crontab "$NEW_CRONTAB"
 
 # Show result
 echo "Crontab synchronized:"
-crontab -l 2>/dev/null | grep "$MARKER" || echo "(no lobster jobs)"
+read_existing_crontab | grep "$MARKER" || echo "(no lobster jobs)"

--- a/scripts/local-setup-helper.sh
+++ b/scripts/local-setup-helper.sh
@@ -103,7 +103,13 @@ echo ""
 step "Step 1/4: Installing system dependencies"
 #-------------------------------------------------------------------------------
 sudo apt update
-sudo apt install -y curl git
+sudo apt install -y curl git cron
+# Add the current user to the crontab group so sync-crontab.sh can write
+# directly to /var/spool/cron/crontabs/ under NoNewPrivs=1 (set by Claude Code).
+if [ -d "/var/spool/cron/crontabs" ] && ! id -nG "$USER" | grep -qw "crontab"; then
+    sudo usermod -aG crontab "$USER"
+    info "Added $USER to the crontab group (required for scheduled job sync under Claude Code)"
+fi
 success "Dependencies installed"
 
 #-------------------------------------------------------------------------------

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1827,6 +1827,27 @@ EOF
         fi
     fi
 
+    # Migration 46: Add lobster user to the `crontab` group.
+    # The MCP server process runs under PR_SET_NO_NEW_PRIVS (NoNewPrivs=1), which
+    # suppresses setgid bits on child processes. The `crontab` binary is setgid-crontab,
+    # so `crontab -` fails with "mkstemp: Permission denied" when called from the MCP
+    # server. Fix: add the lobster user to the crontab group so sync-crontab.sh can
+    # write directly to /var/spool/cron/crontabs/$USER (group-writable directory) without
+    # needing the setgid bit. Requires sudo; warns and skips if sudo is unavailable.
+    local CRONTAB_DIR="/var/spool/cron/crontabs"
+    if [ -d "$CRONTAB_DIR" ] && ! id -nG "$USER" | grep -qw "crontab"; then
+        if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo usermod -aG crontab "$USER" 2>/dev/null && {
+                substep "Added $USER to the crontab group (fixes NoNewPrivs crontab permission error)"
+                migrated=$((migrated + 1))
+                warn "Group membership change takes effect at next login. Run 'newgrp crontab' or restart the Lobster service to apply immediately."
+            } || warn "Failed to add $USER to crontab group — run: sudo usermod -aG crontab $USER"
+        else
+            warn "Cannot add $USER to crontab group (sudo unavailable). Run manually: sudo usermod -aG crontab $USER"
+            warn "Until this is done, create_scheduled_job/update_scheduled_job/delete_scheduled_job will fail to sync crontab."
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## Summary

Every call to `create_scheduled_job`, `update_scheduled_job`, and `delete_scheduled_job` silently fails to sync the crontab, leaving jobs in `jobs.json` but never actually scheduled.

The root cause: Claude Code sets `PR_SET_NO_NEW_PRIVS` on the MCP server process (`NoNewPrivs: 1`), which propagates to all child processes and suppresses setgid bits. The `crontab` binary is setgid-crontab — that privilege is exactly what lets it write to `/var/spool/cron/crontabs/`. Without it, the `crontab -` call fails with `/var/spool/cron/: mkstemp: Permission denied`.

Verified with `strace`: `crontab -` does `chdir("/var/spool/cron")` then `openat(AT_FDCWD, "crontabs/tmp.XXXXXX", O_RDWR|O_CREAT|O_EXCL)` → `EACCES`. The binary works fine in a regular shell session (`NoNewPrivs: 0`) but always fails when spawned from the MCP server process tree.

## Changes

**`sync-crontab.sh`**: adds a primary path that writes directly to `/var/spool/cron/crontabs/$USER` using an atomic temp-file rename. This works under `NoNewPrivs=1` because the `crontab` group has `-wx` (write+execute) on the directory — group membership alone is sufficient, no setgid needed. The `crontab -` path is kept as a fallback for systems where the user hasn't joined the group yet.

**`upgrade.sh` Migration 41**: runs `sudo usermod -aG crontab $USER` on existing installs (if sudo is available passwordlessly). Warns and skips if sudo is not available.

**`local-setup-helper.sh`**: adds the user to the `crontab` group during fresh setup, alongside the other `apt install` dependencies.

## What is not changed

The Python `sync_crontab()` function in `inbox_server.py` is unchanged — it already calls `sync-crontab.sh` correctly as an async subprocess. No logic changes to the MCP tool handlers.

## Before / after

```
Before:
  MCP server (NoNewPrivs=1)
    → sync-crontab.sh
      → crontab - [FAILS: setgid suppressed, mkstemp: Permission denied]
      → job written to jobs.json but never in crontab

After (user in crontab group):
  MCP server (NoNewPrivs=1)
    → sync-crontab.sh
      → write directly to /var/spool/cron/crontabs/lobster [OK: group membership]
      → job written to jobs.json AND appears in crontab

After (user NOT yet in crontab group — fallback):
  MCP server (NoNewPrivs=1)
    → sync-crontab.sh
      → direct write fails (directory not writable)
      → crontab - [FAILS same as before — until migration 41 runs]
```

## Functional patterns

Idempotency: `write_crontab()` in the shell script produces the same result for the same input regardless of prior crontab state. The two-path design (direct write first, `crontab -` fallback) degrades gracefully without requiring the caller to know which path succeeded.

## Tests run

- [x] `bash -n scheduled-tasks/sync-crontab.sh` — syntax OK
- [x] `bash -n scripts/upgrade.sh` — syntax OK
- [x] `bash -n scripts/local-setup-helper.sh` — syntax OK
- [x] `~/lobster/.venv/bin/pytest tests/unit/test_mcp_server/test_scheduled_jobs.py` — 23 errors, all pre-existing (`_DEBUG_RESOLVED` AttributeError; same failure on `main` before this change, unrelated to this PR)
- [ ] Live test: add user to crontab group and verify `create_scheduled_job` syncs crontab correctly — blocked: `usermod` requires sudo/root in this environment; needs manual verification before merge

**Blocked item needing attention before merge:** the live end-to-end test (`usermod -aG crontab lobster` + create_scheduled_job) could not be run because `sudo` requires a password in this environment. The logic is straightforward (if directory is writable, write directly; else fall back), but a smoke test after adding the user to the crontab group would be prudent.

Closes #985