### PR TITLE
fix: add lobster user to crontab group

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -495,6 +495,13 @@ if [ "$(id -u)" = "0" ]; then
         # Docker not installed — this is the normal case on a fresh machine, not a warning
         info "Docker not installed — skipping docker group setup. Install Docker later to enable Docker features."
     fi
+    # Add lobster user to the crontab group so it can manage cron jobs without sudo
+    if getent group crontab &>/dev/null; then
+        usermod -aG crontab lobster
+        success "Added 'lobster' to the crontab group."
+    else
+        info "crontab group does not exist — skipping. Cron management may require sudo on this system."
+    fi
     # Copy script to /tmp so lobster user can read it regardless of working directory
     INSTALL_SCRIPT="$(readlink -f "$0")"
     TMP_SCRIPT="$(mktemp /tmp/lobster-install.XXXXXX.sh)"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1827,6 +1827,18 @@ EOF
         fi
     fi
 
+    # Migration 45: Add lobster user to the crontab OS group
+    # Required so the lobster user can invoke `crontab` without sudo.
+    # Cron job management (sync-crontab.sh, cron-manage.sh) was silently failing
+    # on systems where the crontab binary is mode 2755 crontab:crontab.
+    if getent group crontab &>/dev/null; then
+        if ! groups lobster 2>/dev/null | grep -q crontab; then
+            usermod -aG crontab lobster
+            substep "Added lobster to the crontab group"
+            migrated=$((migrated + 1))
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## Summary
- Adds `usermod -aG crontab lobster` to `install.sh` alongside the docker group setup
- Adds Migration 41 to `scripts/upgrade.sh` for existing installs
- Applied the fix immediately on the current machine (`groups lobster` now shows `crontab`)

## Why
The `lobster` user could not manage cron jobs without sudo on systems where the `crontab` binary is mode 2755 crontab:crontab. This caused `sync-crontab.sh` and `cron-manage.sh` to fail silently.

## Test plan
- [ ] Fresh install sets crontab group correctly
- [ ] Migration 41 runs cleanly on existing installs (`groups lobster` shows `crontab` after upgrade)
- [ ] `crontab -l` works as the lobster user without sudo

🤖 Generated with [Claude Code](https://claude.com/claude-code)