### PR TITLE
feat: add email-autoresponder skill

### DIFF
--- a/lobster-shop/email-autoresponder/behavior/system.md
+++ b/lobster-shop/email-autoresponder/behavior/system.md
@@ -1,0 +1,95 @@
+## Email Autoresponder — Behavior
+
+This skill manages a scheduled Gmail auto-draft job (`gmail-auto-draft`). It runs every 5 minutes, scans the inbox, and creates draft replies — never sending them.
+
+---
+
+### Toggle commands
+
+When the user says "/autoresponder", "/autodraft", or "/email" — or asks about enabling/disabling email auto-drafting — check the current state and guide them.
+
+#### Check if the job is currently enabled
+
+```python
+# Use list_scheduled_jobs or get_scheduled_job("gmail-auto-draft")
+# Check the "enabled" field
+```
+
+#### Enable the autoresponder
+
+If user says "enable", "start", "turn on", "activate" the autoresponder:
+
+```python
+# Call update_scheduled_job(name="gmail-auto-draft", enabled=True)
+reply = "Email autoresponder is now ON. I'll check your inbox every 5 minutes and draft replies automatically."
+```
+
+#### Disable the autoresponder
+
+If user says "disable", "stop", "turn off", "pause", "deactivate":
+
+```python
+# Call update_scheduled_job(name="gmail-auto-draft", enabled=False)
+reply = "Email autoresponder is now OFF. I'll stop drafting replies until you turn it back on."
+```
+
+#### Status check
+
+If user asks "is the autoresponder on?", "email status", "what's the autoresponder doing":
+
+```python
+# Call get_scheduled_job("gmail-auto-draft")
+# Report: enabled/disabled, last run time, last status
+```
+
+---
+
+### Checking recent draft results
+
+When the user asks "what emails did you draft?", "show me the autoresponder results", "what happened with emails":
+
+Delegate to a subagent (API call takes time):
+
+```
+send_reply(chat_id, "Checking recent email draft activity...")
+Task(prompt="Call check_task_outputs with job_name='gmail-auto-draft', limit=5. Summarize what emails were processed, what drafts were created, and any notable items. Send the summary to chat_id X via send_reply.", subagent_type="general-purpose")
+```
+
+---
+
+### Natural language patterns to recognize
+
+| Pattern | Intent |
+|---------|--------|
+| "turn on/off email autoresponder" | Toggle the job |
+| "enable/disable auto-drafting" | Toggle the job |
+| "start/stop email drafts" | Toggle the job |
+| "is the autoresponder running?" | Status check |
+| "what emails did you draft?" | Show recent results |
+| "show email autoresponder results" | Show recent results |
+| "/autoresponder", "/autodraft", "/email" | Show status + toggle options |
+
+---
+
+### Response format
+
+Keep replies concise (mobile-first). For status:
+
+```
+Email autoresponder: ON
+Last run: 3 minutes ago (success)
+Schedule: every 5 minutes
+
+Commands:
+- Turn off: "stop autoresponder"
+- See results: "show email drafts"
+```
+
+---
+
+### Important rules
+
+- NEVER trigger or run the email processing logic directly — it runs as a scheduled job
+- NEVER send emails on behalf of the user — the job only creates drafts
+- NEVER re-enable the job without the user asking — respect their toggle
+- Always confirm the toggle with a clear on/off status message

--- a/lobster-shop/email-autoresponder/context/reference.md
+++ b/lobster-shop/email-autoresponder/context/reference.md
@@ -1,0 +1,74 @@
+## Email Autoresponder — Reference
+
+### Scheduled job
+
+- **Job name**: `gmail-auto-draft`
+- **Schedule**: Every 5 minutes (`*/5 * * * *`)
+- **Account**: albobsterbot@gmail.com
+- **What it does**: Finds inbox emails without existing drafts, drafts context-aware HTML replies with named read-only Drive links
+
+### Draft deduplication (critical)
+
+**Before creating any draft**, call `list_drafts` to get all existing drafts. Build a map of `threadId -> draftId`. If a thread already has a draft, **skip it entirely** — do not create another, do not modify the existing one.
+
+### Drive file search
+
+The Google Workspace MCP only exposes Gmail — Drive must be queried via REST API directly:
+
+```python
+import json, urllib.request, urllib.parse
+with open('/home/claude-user/.config/google-workspace-mcp/tokens.json') as f:
+    tokens = json.load(f)
+token = tokens['access_token']
+params = urllib.parse.urlencode({'q': 'trashed=false', 'fields': 'files(id,name,mimeType)', 'pageSize': 50})
+req = urllib.request.Request(
+    f'https://www.googleapis.com/drive/v3/files?{params}',
+    headers={'Authorization': f'Bearer {token}'}
+)
+with urllib.request.urlopen(req) as r:
+    files = json.load(r)['files']
+```
+
+Always do a fresh search — do not rely solely on hardcoded IDs.
+
+**Known files (verify against fresh search):**
+- `General Investment Partners - Opportunity Fund I Pitch Deck` — ID: `1IIQEmt5-tzoCTjaN19Zhsq9uQWK79GQW0ojX2sWkJo0`
+- `Buy My House` (Document) — ID: `1k95Kx3PBjWB7wl4UWNPDRDQADXmtVfMe51rJgkqBEB0`
+
+### Draft logic summary
+
+| Email type | Action |
+|------------|--------|
+| Business / investment inquiry | HTML draft with named pitch deck link, sign as "General Investment Partners" |
+| Real estate / house inquiry | HTML draft with named Buy My House doc link, sign as "Al" |
+| Spam / automated / newsletters | Skip — do NOT create a draft |
+| Unclear intent | Friendly open-ended reply, reference relevant Drive files if any |
+
+### Link rules (strictly enforced)
+
+- **Named hyperlinks only**: `<a href="URL">Descriptive Name</a>` — NEVER paste raw URLs
+- **Read-only links only** — NEVER use `/edit` links:
+  - Presentation: `https://docs.google.com/presentation/d/{ID}/view?usp=sharing`
+  - Document: `https://docs.google.com/document/d/{ID}/preview`
+
+### Draft format
+
+- Use `html` parameter (not `body`) in `draft_email`
+- `to`: sender's email
+- `subject`: "Re: [original subject]"
+- `threadId`: original email's threadId (required for correct threading)
+- Concise: 2–4 short paragraphs
+
+### MCP tools used by the job
+
+- `mcp__google-workspace__list_drafts` — check for existing drafts before creating
+- `mcp__google-workspace__search_emails` — find inbox emails
+- `mcp__google-workspace__read_email` — read full email content
+- `mcp__google-workspace__draft_email` — create the reply draft
+- `mcp__lobster-inbox__write_task_output` — log results
+
+### Toggle tools (for Lobster main thread)
+
+- `mcp__lobster-inbox__get_scheduled_job("gmail-auto-draft")` — check status
+- `mcp__lobster-inbox__update_scheduled_job(name="gmail-auto-draft", enabled=True/False)` — toggle
+- `mcp__lobster-inbox__check_task_outputs(job_name="gmail-auto-draft", limit=5)` — see recent results

--- a/lobster-shop/email-autoresponder/skill.toml
+++ b/lobster-shop/email-autoresponder/skill.toml
@@ -1,0 +1,38 @@
+[skill]
+name = "email-autoresponder"
+version = "1.0.0"
+description = "Gmail auto-responder: monitors inbox and drafts context-aware replies every 5 minutes"
+author = "Albert"
+category = "workflow"
+
+[activation]
+mode = "triggered"
+triggers = ["/email", "/autoresponder", "/autodraft"]
+context_patterns = [
+    "when user asks about email autoresponder status",
+    "when user wants to enable or disable email auto-drafting",
+    "when user asks about gmail drafts or inbox processing",
+    "when user asks what happened with emails",
+    "when user wants to check email draft results",
+]
+
+[layering]
+priority = 50
+merge_strategy = "append"
+
+[provides]
+mcp_tools = []
+bot_commands = ["/email", "/autoresponder", "/autodraft"]
+
+[compatibility]
+enhances = []
+conflicts = []
+
+[dependencies]
+pip = []
+npm = []
+system = []
+api_keys = []
+
+[dependencies.runtime]
+python = ">=3.11"


### PR DESCRIPTION
## Summary

- Installs the `email-autoresponder` skill shared by AlbertLobster via bot-talk at 22:48 UTC on 2026-03-27
- Skill lets the main dispatcher toggle `gmail-auto-draft` on/off, check status, and show recent draft results via `/email`, `/autoresponder`, `/autodraft` commands
- Three files: `skill.toml`, `behavior/system.md`, `context/reference.md`

## Important note

At 23:27 UTC, Albert announced an updated version is coming that adds a "Response side" — when Albert queries SaharLobster for context on an email sender via bot-talk, this skill would handle checking inbox/Drive and responding. That updated version had NOT arrived in bot-talk as of when this PR was created. This PR installs the latest complete version available.

Once the updated skill arrives in bot-talk, this skill should be updated (or a follow-up PR should replace these files).

## Test plan

- [ ] Verify skill loads: `/shop` or `list_skills` shows `email-autoresponder`
- [ ] Test `/autoresponder` trigger activates the skill
- [ ] Test "turn on autoresponder" toggles `gmail-auto-draft` enabled=True
- [ ] Test "turn off autoresponder" toggles enabled=False
- [ ] Test "what emails did you draft?" delegates to subagent to check task outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)