### PR TITLE
fix(lobstertalk): topic-aware Drive search + Google Docs export support

### DIFF
--- a/lobster-shop/lobstertalk-context-handler/README.md
+++ b/lobster-shop/lobstertalk-context-handler/README.md
@@ -1,0 +1,24 @@
+# LobsterTalk Context Handler
+
+Handles incoming context queries from AlbertLobster (or other Lobster instances) via the bot-talk protocol. When Albert asks "what do you know about Person X?", this skill's scheduled job looks up Google Drive, Gmail, and Twenty CRM, then replies with aggregated context.
+
+## What it does
+
+- Polls bot-talk every 5 minutes for incoming queries from AlbertLobster
+- Extracts the person name AND any topic keywords from the query
+- Searches Drive by person name, then runs a second search for topic keywords (deduped)
+- Routes Drive file reads through the correct API: exports native Google Docs as plain text (not `alt=media`), uses `alt=media` for other file types
+- Searches Gmail for threads mentioning the person
+- Queries Twenty CRM for contact records and notes
+- Sends a consolidated reply back to AlbertLobster via bot-talk
+- Notifies Sahar on Telegram when a query is handled
+
+## Scheduled job
+
+**Job name**: `lobstertalk-incoming-handler`
+**Schedule**: `*/5 * * * *`
+
+## Bot commands
+
+- `/lobstertalk` — check handler status, toggle on/off
+- `/botquery` — alias

--- a/lobster-shop/lobstertalk-context-handler/behavior/system.md
+++ b/lobster-shop/lobstertalk-context-handler/behavior/system.md
@@ -1,0 +1,74 @@
+## LobsterTalk Context Handler — Behavior
+
+This skill manages the `lobstertalk-incoming-handler` scheduled job. It runs every 5 minutes and answers context queries from AlbertLobster via bot-talk.
+
+---
+
+### Toggle commands
+
+When the user says "/lobstertalk", "/botquery", or asks about the incoming handler status:
+
+#### Check current status
+
+```python
+# Use get_scheduled_job("lobstertalk-incoming-handler")
+# Report: enabled/disabled, last run time, last status
+```
+
+#### Enable the handler
+
+```python
+# Call update_scheduled_job(name="lobstertalk-incoming-handler", enabled=True)
+reply = "LobsterTalk context handler is now ON. I'll check for incoming queries every 5 minutes."
+```
+
+#### Disable the handler
+
+```python
+# Call update_scheduled_job(name="lobstertalk-incoming-handler", enabled=False)
+reply = "LobsterTalk context handler is now OFF."
+```
+
+---
+
+### Checking recent query results
+
+When the user asks "what did Albert ask?", "show lobstertalk results", "what queries came in":
+
+```
+send_reply(chat_id, "Checking recent LobsterTalk query activity...")
+Task(prompt="Call check_task_outputs with job_name='lobstertalk-incoming-handler', limit=5. Summarize what queries were received and how they were answered. Send to chat_id X.", subagent_type="general-purpose")
+```
+
+---
+
+### Natural language patterns to recognize
+
+| Pattern | Intent |
+|---------|--------|
+| "/lobstertalk", "/botquery" | Show status + toggle options |
+| "what did Albert ask?" | Show recent results |
+| "enable/disable the context handler" | Toggle the job |
+| "is the lobstertalk handler running?" | Status check |
+
+---
+
+### Response format
+
+```
+LobsterTalk context handler: ON
+Last run: 2 minutes ago (success)
+Schedule: every 5 minutes
+
+Commands:
+- Turn off: "disable lobstertalk handler"
+- See results: "what did Albert ask?"
+```
+
+---
+
+### Important rules
+
+- NEVER trigger the context lookup logic directly — it runs as a scheduled job
+- NEVER send bot-talk messages on behalf of the user — the job handles replies
+- NEVER re-enable the job without the user asking

--- a/lobster-shop/lobstertalk-context-handler/context/reference.md
+++ b/lobster-shop/lobstertalk-context-handler/context/reference.md
@@ -1,0 +1,131 @@
+## LobsterTalk Context Handler — Reference
+
+### Scheduled job
+
+- **Job name**: `lobstertalk-incoming-handler`
+- **Schedule**: Every 5 minutes (`*/5 * * * *`)
+- **Account**: robotsquadsm@gmail.com
+- **What it does**: Polls bot-talk for context queries from AlbertLobster, looks up Drive + Gmail + CRM, and replies via bot-talk
+
+### Step 1: Load state and check for new messages
+
+Read state file `~/lobster-workspace/data/lobstertalk-incoming-state.json` (create with `last_processed_ts = "2026-01-01T00:00:00Z"` if not exists).
+
+Poll bot-talk for new messages:
+```
+GET http://46.224.41.108:4242/messages?sender=AlbertLobster&since=<last_processed_ts>&limit=50
+Authorization: X-Bot-Token <token from ~/lobster-workspace/data/bot-talk-token.txt>
+```
+
+Filter for messages containing: "what do you know about", "tell me about", "context on", "who is", "any info on"
+
+### Step 2: Extract subject and person
+
+From each query message, extract:
+1. **Person name** — e.g., "What do you know about Bob Smith re: Pokemon deal?" → "Bob Smith"
+2. **Topic keywords** — additional terms from the message beyond the person name. Strip common stop words and structural phrases ("what do you know about", "tell me about", "re:", etc.). Example: "Pokemon deal" → `["Pokemon", "deal"]`
+
+These topic keywords are used to run a second Drive search (see below).
+
+### Step 3: Query data sources
+
+#### Source 1: Google Drive — name search
+
+```bash
+gws drive files list --params '{"q": "fullText contains \"NAME\" or name contains \"NAME\"", "pageSize": 10}'
+```
+
+#### Source 1b: Google Drive — topic search (NEW)
+
+If topic keywords were extracted, run a second Drive search for those keywords:
+
+```bash
+# For each keyword KW in topic_keywords:
+gws drive files list --params '{"q": "fullText contains \"KW\" or name contains \"KW\"", "pageSize": 5}'
+```
+
+Deduplicate results by fileId across both name and topic searches.
+
+#### Reading Drive file content — mimeType routing (CRITICAL FIX)
+
+Check the `mimeType` field from the files list result. Route accordingly:
+
+**For native Google Docs** (`mimeType = "application/vnd.google-apps.document"`):
+```bash
+gws drive files export --params '{"fileId": "FILE_ID", "mimeType": "text/plain"}'
+```
+
+**For all other file types** (PDFs, plain text uploads, etc.):
+```bash
+gws drive files get --params '{"fileId": "FILE_ID", "alt": "media"}'
+```
+
+Do NOT use `alt=media` on Google Docs — it returns garbled or empty content.
+
+#### Source 2: Gmail
+
+```bash
+gws gmail users.messages list --params '{"userId": "me", "q": "NAME", "maxResults": 5}'
+```
+
+For each message, get subject and snippet.
+
+#### Source 3: Twenty CRM
+
+Check `~/lobster-workspace/data/twenty-api-token.txt`. If present:
+```
+POST https://honest-navy-moose.twenty.com/graphql
+Authorization: Bearer <token>
+{"query": "{ people(filter: {name: {firstName: {like: \"%NAME%\"}}}, first: 5) { edges { node { id name { firstName lastName } emails { primaryEmail } phones { primaryPhoneNumber } notes { edges { node { body } } } } } } }"}
+```
+
+### Step 4: Compose and send reply
+
+Aggregate findings. Format:
+
+```
+Context on Bob Smith:
+
+[Google Drive] Contact Notes - Bob Smith.txt:
+  - Met at Tech Conference 2026-01-15
+  - Budget: $500K
+
+[Google Drive — topic: Pokemon] Pokemon Partnership Deck.gdoc:
+  - Pokemon collab proposal, Q2 2026
+  - Decision maker: Bob Smith
+
+[Gmail] 3 relevant emails found:
+  - 2026-01-20: "Introduction"
+  - 2026-02-05: "Follow-up"
+
+[CRM] Bob Smith @ Acme Corp:
+  - Email: bob@example.com
+```
+
+If nothing found: "No context found for NAME in available data sources (Drive, Gmail, CRM)."
+
+Send reply via bot-talk:
+```
+POST http://46.224.41.108:4242/message
+Authorization: X-Bot-Token <token>
+{"sender": "SaharLobster", "recipient": "AlbertLobster", "content": "<reply>", "genre": "acknowledgment", "tier": "TIER-BOT"}
+```
+
+### Step 5: Update state
+
+Update `last_processed_ts` to the latest processed message timestamp. Write atomically (write .tmp then rename).
+
+Notify Sahar via Telegram (chat_id: 8305714125) if a query was handled:
+"Bot-talk query handled: AlbertLobster asked about NAME. Replied with context from [sources]."
+
+Do NOT notify for heartbeat/status messages or if no new queries.
+
+### Output
+
+Call `write_task_output` with job_name `"lobstertalk-incoming-handler"` and a brief summary.
+
+### Tools used by the job
+
+- `gws` CLI for Drive and Gmail
+- `write_task_output` — log results
+- `send_reply` — notify Sahar on Telegram when a query is handled

--- a/lobster-shop/lobstertalk-context-handler/skill.toml
+++ b/lobster-shop/lobstertalk-context-handler/skill.toml
@@ -1,0 +1,37 @@
+[skill]
+name = "lobstertalk-context-handler"
+version = "1.0.0"
+description = "Handles incoming LobsterTalk context queries from AlbertLobster: looks up Drive, Gmail, and CRM then replies via bot-talk"
+author = "Sahar"
+category = "integration"
+
+[activation]
+mode = "triggered"
+triggers = ["/lobstertalk", "/botquery"]
+context_patterns = [
+    "when user asks about incoming bot-talk queries",
+    "when user wants to check lobstertalk handler status",
+    "when user asks what Albert's lobster asked about",
+    "when user asks about the context handler job",
+]
+
+[layering]
+priority = 50
+merge_strategy = "append"
+
+[provides]
+mcp_tools = []
+bot_commands = ["/lobstertalk", "/botquery"]
+
+[compatibility]
+enhances = []
+conflicts = []
+
+[dependencies]
+pip = []
+npm = []
+system = ["gws"]
+api_keys = []
+
+[dependencies.runtime]
+python = ">=3.11"

--- a/scheduled-tasks/tasks/lobstertalk-incoming-handler.md
+++ b/scheduled-tasks/tasks/lobstertalk-incoming-handler.md
@@ -1,0 +1,190 @@
+# LobsterTalk Incoming Message Handler
+
+**Job**: lobstertalk-incoming-handler
+**Schedule**: `*/5 * * * *` (every 5 minutes)
+**Skill**: `lobstertalk-context-handler` (see `lobster-shop/lobstertalk-context-handler/`)
+
+## Context
+
+You are SaharLobster, handling incoming bot-talk messages from AlbertLobster or other lobsters.
+Your primary function for the LobsterTalk demo: when Albert's lobster asks "what do you know about X?",
+look up X in available data sources and reply with relevant context.
+
+For full instructions, see the skill reference:
+`lobster-shop/lobstertalk-context-handler/context/reference.md`
+
+## Authentication
+
+Read the bot-talk API token:
+```python
+token = open(os.path.expanduser("~/lobster-workspace/data/bot-talk-token.txt")).read().strip()
+headers = {"X-Bot-Token": token}
+```
+
+## State File
+
+Read and write `~/lobster-workspace/data/lobstertalk-incoming-state.json`.
+
+Schema:
+```json
+{
+  "last_processed_ts": "2026-03-27T00:00:00Z"
+}
+```
+
+## Instructions
+
+### Step 1: Load state and check for new messages
+
+Read state file (create if not exists with `last_processed_ts = "2026-01-01T00:00:00Z"`).
+
+Poll bot-talk for new messages from AlbertLobster:
+```
+GET http://46.224.41.108:4242/messages?sender=AlbertLobster&since=<last_processed_ts>&limit=50
+```
+
+Filter for messages containing query patterns:
+- "what do you know about"
+- "tell me about"
+- "context on"
+- "who is"
+- "any info on"
+
+### Step 2: For each query message, extract person and topic keywords
+
+Extract the person name from the message. Common patterns:
+- "What do you know about Bob Smith?" -> "Bob Smith"
+- "What do you know about Bob?" -> "Bob"
+- "Tell me about Bob Smith at Acme" -> "Bob Smith"
+
+Also extract **topic keywords**: additional terms in the query beyond the person name. Strip structural
+phrases ("what do you know about", "tell me about", "re:", etc.) and common stop words. These are used
+to run a second Drive search.
+
+Example: "What do you know about Bob Smith re: Pokemon deal?" → person: "Bob Smith", topics: ["Pokemon", "deal"]
+
+Then query all available data sources:
+
+#### Source 1: Google Drive — name search
+
+Use gws CLI to search Drive files by person name:
+```bash
+gws drive files list --params '{"q": "fullText contains \"NAME\" or name contains \"NAME\"", "pageSize": 10}'
+```
+
+#### Source 1b: Google Drive — topic search
+
+If topic keywords were extracted, run a second Drive search for each keyword:
+```bash
+gws drive files list --params '{"q": "fullText contains \"KEYWORD\" or name contains \"KEYWORD\"", "pageSize": 5}'
+```
+
+Deduplicate results by fileId across name and topic searches before reading content.
+
+#### Reading Drive file content — mimeType routing (CRITICAL)
+
+Check the `mimeType` field from the files list result and route accordingly:
+
+**For native Google Docs** (`mimeType = "application/vnd.google-apps.document"`):
+```bash
+gws drive files export --params '{"fileId": "FILE_ID", "mimeType": "text/plain"}'
+```
+
+**For all other file types** (PDFs, plain text uploads, binary files):
+```bash
+gws drive files get --params '{"fileId": "FILE_ID", "alt": "media"}'
+```
+
+Do NOT use `alt=media` on Google Docs — it returns garbled or empty content.
+
+Note: Use `/usr/local/bin/gws` and `~/.config/gws/credentials.json` for auth.
+The credentials.json has a refresh_token that must be refreshed using:
+- client_id: from credentials.json
+- client_secret: from credentials.json
+- refresh_token: from credentials.json
+- POST https://oauth2.googleapis.com/token
+
+#### Source 2: Google Gmail (robotsquadsm@gmail.com)
+
+Search Gmail for emails mentioning the person:
+```bash
+gws gmail users.messages list --params '{"userId": "me", "q": "NAME", "maxResults": 5}'
+```
+
+For each message, get subject and snippet.
+
+#### Source 3: Conversation/memory history
+
+Search lobster memory for the person:
+- Check `~/lobster-workspace/data/bot-talk-state.json` for any prior context
+- The main lobster memory is in `~/lobster-workspace/data/memory.db` but skip if complex
+
+#### Source 4: Twenty CRM (if API token available)
+
+Check `~/lobster-workspace/data/twenty-api-token.txt`. If it exists, query:
+```
+POST https://honest-navy-moose.twenty.com/graphql
+Authorization: Bearer <token>
+{"query": "{ people(filter: {name: {firstName: {like: \"%NAME%\"}}}, first: 5) { edges { node { id name { firstName lastName } emails { primaryEmail } phones { primaryPhoneNumber } notes { edges { node { body } } } } } } }"}
+```
+
+### Step 3: Compose and send the response
+
+Aggregate all findings into a concise context reply. Format:
+
+```
+Context on Bob Smith:
+
+[Google Drive] Contact Notes - Bob Smith (Acme Corp).txt:
+  - Met at Tech Conference 2026-01-15
+  - Interested in Q2 2026 collaboration proposal
+  - Budget: $500K, decision maker
+
+[Google Drive — topic: Pokemon] Pokemon Partnership Deck.gdoc:
+  - Pokemon collab proposal, Q2 2026
+  - Decision maker: Bob Smith
+
+[Gmail] 3 relevant emails found:
+  - 2026-01-20: "Introduction" - initial intro email exchanged
+  - 2026-02-05: "Follow-up" - proposal timeline discussion
+  - 2026-02-28: "Q2 Timeline" - Bob confirmed Q2 works
+
+[CRM] Bob Smith @ Acme Corp:
+  - Email: bob@example.com
+  - Notes: Met at conference, Q2 proposal follow-up needed
+```
+
+If nothing found: "No context found for NAME in available data sources (Drive, Gmail, CRM)."
+
+Send the reply via bot-talk:
+```
+POST http://46.224.41.108:4242/message
+{
+  "sender": "SaharLobster",
+  "recipient": "AlbertLobster",
+  "content": "<reply>",
+  "genre": "acknowledgment",
+  "tier": "TIER-BOT"
+}
+```
+
+### Step 4: Update state
+
+Update `last_processed_ts` to the timestamp of the latest processed message.
+Write to state file atomically (write .tmp then rename).
+
+Also notify Sahar via Telegram if a context query was received and answered:
+- chat_id: 8305714125
+- Message: "Bot-talk query handled: AlbertLobster asked about NAME. Replied with context from [sources]."
+
+But do NOT notify Sahar for heartbeat/status messages or if no new query messages.
+
+## Output
+
+Call `write_task_output` with:
+- job_name: "lobstertalk-incoming-handler"
+- output: Brief summary (e.g. "No new queries." or "Handled query about Bob Smith, replied with context from Drive + Gmail.")
+- status: "success" or "failed"
+
+If no new queries, call `write_result` with chat_id=0 (silent).
+If a query was handled, call `write_result` with chat_id=8305714125 and sent_reply_to_user=True.


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

The LobsterTalk context handler had two bugs that caused it to silently miss relevant context and return empty file content from Google Drive. Both are fixed here, and the handler is now published as a proper lobster shop skill.

## What was broken

**Drive search was name-only.** When AlbertLobster asks "what do you know about Bob Smith re: Pokemon deal?", the handler only searched Drive for "Bob Smith". Files about the Pokemon deal that don't mention Bob's name were silently excluded. This means topic-specific context — exactly what the query is often signaling — was never surfaced.

**Native Google Docs returned garbled content.** The handler read all Drive files using the `alt=media` endpoint, which works for PDFs and plain text uploads but is wrong for native Google Docs (`application/vnd.google-apps.document`). Google's API returns a garbled MIME envelope or empty bytes for Docs via that endpoint. The correct path for Docs is the export endpoint (`files/export?mimeType=text/plain`).

## What changes

**Topic-aware Drive search:** the handler now extracts topic keywords from the query beyond the person name (stripping structural phrases and stop words) and runs a second Drive search for those keywords. Results are deduplicated by fileId before content is read. Topic-sourced files are labeled in the reply so AlbertLobster knows why they surfaced.

**mimeType routing for file reads:** before reading a file, the handler checks its `mimeType` from the list result. Native Google Docs are exported as plain text; all other types continue to use `alt=media`.

**Skill published to lobster-shop:** the handler's instructions are now a first-class skill at `lobster-shop/lobstertalk-context-handler/`, with `skill.toml`, `behavior/system.md` (toggle commands for the dispatcher), `context/reference.md` (full job instructions), and `README.md`. The canonical task file is added to `scheduled-tasks/tasks/` so it lives in version control.

## What does not change

The bot-talk polling logic, authentication, CRM integration, Gmail search, state file format, Telegram notification, and output format are unchanged.

## Functional patterns

Pure data transformation for keyword extraction (no mutation of the query object). The mimeType routing is expressed as a declarative branch on the file's metadata rather than imperative try/catch on content. Topic and name search results are merged via deduplication on fileId before any I/O for file content.

## Flow change: Drive lookup

```
Before:
  query → extract person name → Drive search(name) → read all via alt=media

After:
  query → extract person name + topic keywords
         → Drive search(name)       ─┐
         → Drive search(keyword…)   ─┴→ dedupe by fileId
                                         → for each file:
                                             mimeType == google-apps.document?
                                               yes → export as text/plain
                                               no  → alt=media
```

## Tests run

- [x] `git diff --stat` — 5 files added, 456 insertions, 0 deletions — no existing files touched
- [ ] Live bot-talk integration test — blocked: requires a running AlbertLobster instance and active bot-talk relay; safe to merge, no behavior change to any other job

Closes #1010