### PR TITLE
Fix: Wire code-based polling pre-checks to crontab, remove unified-channel-poller

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1211,6 +1211,12 @@ fi
 # Install dispatch-job.sh (posts scheduled_reminder to inbox; no direct Claude invocation)
 chmod +x "$INSTALL_DIR/scheduled-tasks/dispatch-job.sh" || true
 
+# Install pre-check Layer 1 polling scripts (exit 0 when nothing new; no LLM cost)
+chmod +x "$INSTALL_DIR/scheduled-tasks/bot-talk-check-dispatch.sh" 2>/dev/null || true
+chmod +x "$INSTALL_DIR/scheduled-tasks/lobstertalk-incoming-check.sh" 2>/dev/null || true
+chmod +x "$INSTALL_DIR/scheduled-tasks/lobster-plans-check-dispatch.sh" 2>/dev/null || true
+chmod +x "$INSTALL_DIR/scheduled-tasks/gmail-check-dispatch.sh" 2>/dev/null || true
+
 # Create sync-crontab.sh
 cat > "$INSTALL_DIR/scheduled-tasks/sync-crontab.sh" << 'SYNCCRON'
 #!/bin/bash

--- a/scheduled-tasks/gmail-check-dispatch.sh
+++ b/scheduled-tasks/gmail-check-dispatch.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# gmail-check-dispatch.sh
+# Layer 1 pre-check for gmail-email-pipeline.
+#
+# Rate-limits full pipeline runs to at most once every 6 hours by tracking the
+# last-check timestamp. Within that window, polls Gmail for any unread inbox
+# messages. If none found, logs a no-op and exits 0 (no LLM spawned).
+# If unread messages exist, calls dispatch-job.sh to trigger the full pipeline.
+#
+# Flow:
+#   last check < 6h ago               → exit 0 (rate limit, no query)
+#   last check >= 6h ago, no unread   → log no-op → exit 0
+#   last check >= 6h ago, unread found → dispatch-job.sh gmail-email-pipeline
+#
+# State file: ~/lobster-workspace/data/gmail-last-check.txt
+#   Contains an ISO 8601 timestamp of the last time the pipeline was dispatched.
+#
+# Note: The 6-hour rate limit applies to LLM dispatch only. The cron entry fires
+# this script every 30 minutes, but the script gates on the state file timestamp
+# so the heavy pipeline runs at most 4 times per day.
+
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:$PATH"
+
+JOB_NAME="gmail-email-pipeline"
+REPO_DIR="${REPO_DIR:-$HOME/lobster}"
+WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+STATE_FILE="$WORKSPACE/data/gmail-last-check.txt"
+LOG_PREFIX="[gmail-check]"
+RATE_LIMIT_HOURS=6
+
+# --- Load env ---
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+for _env_file in "$CONFIG_DIR/config.env" "$CONFIG_DIR/global.env"; do
+    if [ -f "$_env_file" ]; then
+        set -a
+        # shellcheck source=/dev/null
+        source "$_env_file"
+        set +a
+    fi
+done
+unset _env_file
+
+# --- Check rate limit ---
+NOW_EPOCH=$(date +%s)
+if [ -f "$STATE_FILE" ]; then
+    LAST_CHECK=$(cat "$STATE_FILE" | tr -d '[:space:]')
+    LAST_EPOCH=$(python3 -c "
+import sys
+from datetime import datetime, timezone
+try:
+    ts = datetime.fromisoformat('$LAST_CHECK'.replace('Z', '+00:00'))
+    print(int(ts.timestamp()))
+except Exception:
+    print(0)
+" 2>/dev/null || echo "0")
+    ELAPSED_SECONDS=$(( NOW_EPOCH - LAST_EPOCH ))
+    RATE_LIMIT_SECONDS=$(( RATE_LIMIT_HOURS * 3600 ))
+    if [ "$ELAPSED_SECONDS" -lt "$RATE_LIMIT_SECONDS" ]; then
+        REMAINING=$(( (RATE_LIMIT_SECONDS - ELAPSED_SECONDS) / 60 ))
+        echo "$LOG_PREFIX Rate limit: last dispatched $ELAPSED_SECONDS seconds ago — next eligible in ~${REMAINING}m"
+        exit 0
+    fi
+fi
+
+echo "$LOG_PREFIX Rate limit cleared — checking Gmail for unread messages"
+
+# --- Query Gmail for unread inbox messages ---
+# Uses gws CLI (Google Workspace CLI). If gws is unavailable, dispatch anyway
+# so the job can report the missing dependency.
+if ! command -v gws &>/dev/null; then
+    echo "$LOG_PREFIX gws not found — dispatching to let job handle missing dependency"
+    exec "$REPO_DIR/scheduled-tasks/dispatch-job.sh" "$JOB_NAME"
+fi
+
+set +e
+UNREAD_COUNT=$(gws gmail users messages list \
+    --params '{"userId":"me","q":"is:unread in:inbox","maxResults":"1"}' \
+    2>/dev/null | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    msgs = data.get('messages', [])
+    print(len(msgs))
+except (json.JSONDecodeError, Exception):
+    sys.exit(2)
+" 2>/dev/null)
+GWS_EXIT=$?
+set -e
+
+if [ "$GWS_EXIT" -ne 0 ]; then
+    echo "$LOG_PREFIX Gmail API query failed — dispatching to let job handle it"
+    exec "$REPO_DIR/scheduled-tasks/dispatch-job.sh" "$JOB_NAME"
+fi
+
+if [ "${UNREAD_COUNT:-0}" -eq 0 ]; then
+    echo "$LOG_PREFIX No unread inbox messages — skipping dispatch"
+    # Update the last-check timestamp so the rate limit window advances
+    date -Iseconds > "$STATE_FILE"
+    exit 0
+fi
+
+echo "$LOG_PREFIX $UNREAD_COUNT unread message(s) found — dispatching to inbox"
+# Update timestamp before dispatch so concurrent runs don't double-dispatch
+date -Iseconds > "$STATE_FILE"
+exec "$REPO_DIR/scheduled-tasks/dispatch-job.sh" "$JOB_NAME"

--- a/scheduled-tasks/lobster-plans-check-dispatch.sh
+++ b/scheduled-tasks/lobster-plans-check-dispatch.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# lobster-plans-check-dispatch.sh
+# Layer 1 pre-check for lobster-plans-poller.
+#
+# Queries the sayhar/lobster-plans GitHub repo for issues with awaiting-decision
+# label updated since the last recorded timestamp. If none have changed, logs a
+# no-op and exits 0 without writing to the inbox (no LLM spawned).
+# If updated issues exist, calls dispatch-job.sh to trigger the full subagent.
+#
+# Flow:
+#   updated issues found  → dispatch-job.sh lobster-plans-poller → inbox → LLM
+#   no updated issues     → log no-op → exit 0 (no inbox write)
+#
+# State file: ~/lobster-workspace/data/lobster-plans-last-seen.txt
+#   Contains an ISO 8601 timestamp of the last time an update was dispatched.
+
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:$PATH"
+
+JOB_NAME="lobster-plans-poller"
+REPO_DIR="${REPO_DIR:-$HOME/lobster}"
+WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+STATE_FILE="$WORKSPACE/data/lobster-plans-last-seen.txt"
+LOG_PREFIX="[lobster-plans-check]"
+
+# --- Load env (for GH_TOKEN if needed) ---
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+for _env_file in "$CONFIG_DIR/config.env" "$CONFIG_DIR/global.env"; do
+    if [ -f "$_env_file" ]; then
+        set -a
+        # shellcheck source=/dev/null
+        source "$_env_file"
+        set +a
+    fi
+done
+unset _env_file
+
+# Export GH_TOKEN so gh CLI works from cron
+if [ -z "${GH_TOKEN:-}" ] && [ -f "$CONFIG_DIR/config.env" ]; then
+    GH_TOKEN=$(grep -E '^GH_TOKEN=' "$CONFIG_DIR/config.env" | cut -d= -f2- | tr -d '"' || true)
+    export GH_TOKEN
+fi
+
+# --- Read last-seen timestamp ---
+if [ -f "$STATE_FILE" ]; then
+    LAST_TS=$(cat "$STATE_FILE" | tr -d '[:space:]')
+else
+    # No state: treat as epoch 0 — process everything on first run
+    LAST_TS="1970-01-01T00:00:00Z"
+fi
+
+echo "$LOG_PREFIX Checking lobster-plans for issues updated since $LAST_TS"
+
+# --- Query GitHub for awaiting-decision issues updated since last_ts ---
+# gh issue list does not support --updated-since directly, so we filter via --json
+# and Python. The --state open filter ensures we only look at active issues.
+set +e
+UPDATED_COUNT=$(gh issue list \
+    --repo sayhar/lobster-plans \
+    --label "awaiting-decision" \
+    --state open \
+    --json number,updatedAt \
+    --limit 50 2>/dev/null | python3 -c "
+import json, sys
+from datetime import datetime, timezone
+
+last_ts_str = '$LAST_TS'
+try:
+    # Parse last timestamp; handle both Z suffix and +00:00
+    last_ts = datetime.fromisoformat(last_ts_str.replace('Z', '+00:00'))
+except ValueError:
+    last_ts = datetime.min.replace(tzinfo=timezone.utc)
+
+try:
+    issues = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(2)
+
+count = sum(
+    1 for i in issues
+    if datetime.fromisoformat(i['updatedAt'].replace('Z', '+00:00')) > last_ts
+)
+print(count)
+" 2>/dev/null)
+QUERY_EXIT=$?
+set -e
+
+if [ "$QUERY_EXIT" -ne 0 ]; then
+    echo "$LOG_PREFIX GitHub query failed or returned invalid JSON — dispatching to let job handle it"
+    exec "$REPO_DIR/scheduled-tasks/dispatch-job.sh" "$JOB_NAME"
+fi
+
+if [ "${UPDATED_COUNT:-0}" -eq 0 ]; then
+    echo "$LOG_PREFIX No awaiting-decision issues updated since $LAST_TS — skipping dispatch"
+    exit 0
+fi
+
+echo "$LOG_PREFIX $UPDATED_COUNT updated issue(s) found — dispatching to inbox"
+exec "$REPO_DIR/scheduled-tasks/dispatch-job.sh" "$JOB_NAME"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1827,6 +1827,132 @@ EOF
         fi
     fi
 
+    # Migration 45: Wire two-layer polling architecture (issue #1059).
+    #
+    # What this does:
+    #   - Removes unified-channel-poller (silently failing, no task file)
+    #   - Re-enables 5 disabled polling jobs with correct schedules and runner fields
+    #   - Sets runner fields so sync-crontab.sh uses pre-check scripts where available
+    #   - Makes new pre-check scripts (lobster-plans-check-dispatch.sh,
+    #     gmail-check-dispatch.sh) executable
+    #   - Re-syncs crontab so all changes take effect
+    #
+    # After this migration:
+    #   bot-talk-poller          → bot-talk-check-dispatch.sh, */5 * * * *
+    #   lobstertalk-incoming-handler → lobstertalk-incoming-check.sh, */2 * * * *
+    #   lobstertalk-poller       → dispatch-job.sh, */30 * * * *
+    #   lobster-plans-poller     → lobster-plans-check-dispatch.sh, */30 * * * *
+    #   gmail-email-pipeline     → gmail-check-dispatch.sh, */30 * * * *
+    local JOBS_FILE_MIG45="$WORKSPACE_DIR/scheduled-jobs/jobs.json"
+    local PLANS_CHECK_SCRIPT="$INSTALL_DIR/scheduled-tasks/lobster-plans-check-dispatch.sh"
+    local GMAIL_CHECK_SCRIPT="$INSTALL_DIR/scheduled-tasks/gmail-check-dispatch.sh"
+    local LBTALK_INCOMING_SCRIPT="$INSTALL_DIR/scheduled-tasks/lobstertalk-incoming-check.sh"
+
+    if [ -f "$JOBS_FILE_MIG45" ]; then
+        local _mig45_needed=0
+        # Check if unified-channel-poller still exists or any of the 5 jobs are disabled
+        if python3 -c "
+import json, sys
+with open('$JOBS_FILE_MIG45') as f:
+    d = json.load(f)
+jobs = d.get('jobs', {})
+needs = (
+    'unified-channel-poller' in jobs or
+    not jobs.get('bot-talk-poller', {}).get('enabled', False) or
+    not jobs.get('lobstertalk-incoming-handler', {}).get('enabled', False) or
+    not jobs.get('lobstertalk-poller', {}).get('enabled', False) or
+    not jobs.get('lobster-plans-poller', {}).get('enabled', False) or
+    not jobs.get('gmail-email-pipeline', {}).get('enabled', False)
+)
+sys.exit(0 if needs else 1)
+" 2>/dev/null; then
+            _mig45_needed=1
+        fi
+
+        if [ "$_mig45_needed" -eq 1 ]; then
+            # Make new pre-check scripts executable if they exist
+            [ -f "$PLANS_CHECK_SCRIPT" ] && chmod +x "$PLANS_CHECK_SCRIPT" 2>/dev/null || true
+            [ -f "$GMAIL_CHECK_SCRIPT" ] && chmod +x "$GMAIL_CHECK_SCRIPT" 2>/dev/null || true
+            [ -f "$LBTALK_INCOMING_SCRIPT" ] && chmod +x "$LBTALK_INCOMING_SCRIPT" 2>/dev/null || true
+
+            python3 - "$JOBS_FILE_MIG45" "$INSTALL_DIR" << 'PYEOF_45'
+import json, os, sys
+
+jobs_file = sys.argv[1]
+install_dir = sys.argv[2]
+
+with open(jobs_file) as f:
+    data = json.load(f)
+
+jobs = data.setdefault('jobs', {})
+
+# Remove unified-channel-poller
+jobs.pop('unified-channel-poller', None)
+
+# Helper to resolve a pre-check script path using $REPO_DIR placeholder
+def runner_path(script_name):
+    return f"$REPO_DIR/scheduled-tasks/{script_name}"
+
+# Re-enable and reconfigure the 5 polling jobs
+updates = {
+    'bot-talk-poller': {
+        'enabled': True,
+        'schedule': '*/5 * * * *',
+        'schedule_human': 'Every 5 minutes',
+        'runner': runner_path('bot-talk-check-dispatch.sh'),
+    },
+    'lobstertalk-incoming-handler': {
+        'enabled': True,
+        'schedule': '*/2 * * * *',
+        'schedule_human': 'Every 2 minutes',
+        'runner': runner_path('lobstertalk-incoming-check.sh'),
+    },
+    'lobstertalk-poller': {
+        'enabled': True,
+        'schedule': '*/30 * * * *',
+        'schedule_human': 'Every 30 minutes',
+        # No runner field: uses default dispatch-job.sh (has internal no-op logic)
+    },
+    'lobster-plans-poller': {
+        'enabled': True,
+        'schedule': '*/30 * * * *',
+        'schedule_human': 'Every 30 minutes',
+        'runner': runner_path('lobster-plans-check-dispatch.sh'),
+    },
+    'gmail-email-pipeline': {
+        'enabled': True,
+        'schedule': '*/30 * * * *',
+        'schedule_human': 'Every 30 minutes',
+        'runner': runner_path('gmail-check-dispatch.sh'),
+    },
+}
+
+for job_name, fields in updates.items():
+    if job_name in jobs:
+        jobs[job_name].update(fields)
+        # Remove runner key for lobstertalk-poller (should use default)
+        if job_name == 'lobstertalk-poller':
+            jobs[job_name].pop('runner', None)
+
+tmp = jobs_file + '.tmp.' + str(os.getpid())
+with open(tmp, 'w') as f:
+    json.dump(data, f, indent=4)
+os.replace(tmp, jobs_file)
+print("jobs.json updated")
+PYEOF_45
+            substep "Migration 45: Re-enabled 5 polling jobs, removed unified-channel-poller, set runner fields"
+
+            # Re-sync crontab so the new schedules and runners take effect
+            if [ -f "$INSTALL_DIR/scheduled-tasks/sync-crontab.sh" ]; then
+                chmod +x "$INSTALL_DIR/scheduled-tasks/sync-crontab.sh" 2>/dev/null || true
+                "$INSTALL_DIR/scheduled-tasks/sync-crontab.sh" 2>/dev/null || true
+                substep "Migration 45: Crontab re-synced with two-layer polling architecture"
+            fi
+
+            migrated=$((migrated + 1))
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What problem this solves

Five polling jobs (`bot-talk-poller`, `lobstertalk-incoming-handler`, `lobstertalk-poller`, `lobster-plans-poller`, `gmail-email-pipeline`) were disabled in `jobs.json`. Before they were disabled, the crontab called `dispatch-job.sh` directly for each one — meaning an LLM subagent was spawned every time the cron fired, regardless of whether there was anything new to process. `unified-channel-poller` existed in `jobs.json` but had no task file, so it was silently failing on every hourly tick.

This PR wires the canonical two-layer polling architecture described in issue #1059: Layer 1 scripts do cheap code-only checks; the LLM is only spawned when there is actually something to process.

## What changed

**New Layer 1 pre-check scripts:**

- `scheduled-tasks/lobster-plans-check-dispatch.sh` — queries `sayhar/lobster-plans` for `awaiting-decision` issues updated since a last-seen timestamp (`~/lobster-workspace/data/lobster-plans-last-seen.txt`). Exits 0 when nothing changed; calls `dispatch-job.sh` only when updated issues are found.
- `scheduled-tasks/gmail-check-dispatch.sh` — rate-limits the Gmail pipeline to at most once per 6 hours (tracked via `~/lobster-workspace/data/gmail-last-check.txt`), then queries Gmail for unread inbox messages. Exits 0 when within the rate-limit window or when no unread messages exist.

Both follow the same fail-safe pattern as the existing `bot-talk-check-dispatch.sh` and `lobstertalk-incoming-check.sh`: on API or parse errors, they fall through to `dispatch-job.sh` rather than silently swallowing events.

**Migration 45 in `scripts/upgrade.sh`:**

On existing installs, running `upgrade.sh` will:
1. Remove `unified-channel-poller` from `jobs.json`
2. Re-enable the 5 polling jobs with updated schedules and `runner` fields:
   - `bot-talk-poller` → `bot-talk-check-dispatch.sh`, `*/5 * * * *`
   - `lobstertalk-incoming-handler` → `lobstertalk-incoming-check.sh`, `*/2 * * * *`
   - `lobstertalk-poller` → `dispatch-job.sh` (has internal no-op logic), `*/30 * * * *`
   - `lobster-plans-poller` → `lobster-plans-check-dispatch.sh`, `*/30 * * * *`
   - `gmail-email-pipeline` → `gmail-check-dispatch.sh`, `*/30 * * * *`
3. Re-run `sync-crontab.sh` so the new schedules and runners take effect immediately

**`install.sh`:** adds `chmod +x` for all four pre-check scripts on fresh installs.

## Polling flow before and after

```
Before (broken):
  cron fires  →  dispatch-job.sh  →  inbox write  →  LLM spawned
  (every tick, even when nothing is new; most runs waste a full subagent)

After:
  cron fires  →  pre-check script  →  nothing new  →  exit 0  (no LLM)
                                   →  new data     →  dispatch-job.sh  →  inbox  →  LLM
```

## Out of scope

- The task files for the re-enabled jobs are unchanged — they already have correct internal logic for the cases they handle.
- The `lobstertalk-poller` job has no pre-check script added in this PR (the issue notes it has internal no-op logic and GitHub polling is cheap enough at 30-minute intervals).
- This PR does not restart any live services or modify the live crontab directly. The migration in `upgrade.sh` handles the live-system update when `upgrade.sh` is next run.

## Tests run

- [x] `bash -n scheduled-tasks/lobster-plans-check-dispatch.sh` — syntax OK
- [x] `bash -n scheduled-tasks/gmail-check-dispatch.sh` — syntax OK
- [x] `bash -n scripts/upgrade.sh` — syntax OK
- [ ] Live upgrade run — not run: requires production environment with `LOBSTER_WORKSPACE` populated. Migration 45 guard condition is safe to verify manually: `python3` block exits 0 only when changes are needed.

Closes #1059