### PR TITLE
Infra: Add scheduling pattern templates and documentation

### DIFF
--- a/scheduled-tasks/README.md
+++ b/scheduled-tasks/README.md
@@ -1,0 +1,87 @@
+# scheduled-tasks/
+
+Scripts in this directory are called **only by cron**. They are never invoked by
+agents directly.
+
+Agents interact with scheduling via MCP tools (`create_scheduled_job`,
+`update_scheduled_job`). Those tools manage `jobs.json` and the task files under
+`scheduled-jobs/tasks/`. This directory holds the shell scripts that cron calls
+to do lightweight pre-checks before (optionally) writing to the inbox.
+
+---
+
+## The Two-Layer Model
+
+```
+Cron
+ │
+ └─ Layer 1: shell script (this directory)
+     │  Lightweight check — HTTP call, file stat, API poll
+     │  If nothing new: log, exit 0 (no LLM cost)
+     │  If new data: call dispatch-job.sh → write to inbox
+     │
+     └─ Layer 2: LLM subagent (spawned by dispatcher)
+         Receives pre-filtered payload
+         Does reasoning, formatting, notifications, GitHub actions
+         Updates state file on success
+```
+
+**Key invariant:** No LLM cost when nothing changed. A polling script that fires
+every 2 minutes and finds nothing new exits 0 and costs nothing.
+
+For full architecture documentation, see issue #1059.
+
+---
+
+## Scripts in This Directory
+
+| Script | Pattern | Description |
+|---|---|---|
+| `dispatch-job.sh` | Non-polling dispatcher | Writes a `scheduled_reminder` to the inbox; called by all Layer 1 scripts and directly by cron for reminder jobs |
+| `bot-talk-check-dispatch.sh` | Poll with state | Polls bot-talk API; skips dispatch if no new messages since last cursor |
+| `lobstertalk-incoming-check.sh` | API poll | Polls bot-talk API for messages addressed to SaharLobster; skips dispatch if none |
+| `sync-crontab.sh` | Local code | Syncs the crontab from a config file; no LLM |
+| `export-logs.py` | Local code | Exports log data; no LLM |
+
+### `dispatch-job.sh`
+
+The core dispatcher. Reads the task file for a job, writes a `scheduled_reminder`
+message to `~/messages/inbox/`, and updates `jobs.json` with the last-run
+timestamp. All Layer 1 polling scripts `exec` into this when they find new data.
+
+For non-polling jobs (reminders, digests, mode-switches), cron calls this
+directly:
+```
+0 8 * * 1-5  ~/lobster/scheduled-tasks/dispatch-job.sh morning-briefing
+```
+
+### `post-reminder.sh` (in `scripts/`)
+
+Purpose-built for **self-reminders** created by the dispatcher itself (e.g.,
+"remind me in 30 minutes"). Has built-in dedup: checks `inbox/` and
+`processing/` for an existing unprocessed message of the same type before
+writing. Safe to call from cron or from `at`.
+
+---
+
+## Adding a New Job
+
+1. Pick a pattern from `templates/README.md`.
+2. Copy the appropriate template, fill in placeholders, save to this directory.
+3. Create `~/lobster-workspace/scheduled-jobs/tasks/<job-name>.md` — this is
+   the task brief passed to the LLM subagent.
+4. Register the job via the `create_scheduled_job` MCP tool (this updates
+   `jobs.json` and the crontab) **or** add an entry to `sync-crontab.sh`.
+
+---
+
+## What Belongs Here vs. Elsewhere
+
+| If you need to... | Do this |
+|---|---|
+| Poll an external source on a schedule | Create a Layer 1 script here |
+| Dispatch a non-polling job on a schedule | Call `dispatch-job.sh` from cron |
+| Schedule a self-reminder from within the dispatcher | Use `post-reminder.sh` |
+| Run something with no LLM involvement | Write a `local-code` script here |
+| Register or configure a scheduled job | Use the `create_scheduled_job` MCP tool |
+| See patterns and conventions | Read `templates/README.md` |

--- a/scheduled-tasks/templates/README.md
+++ b/scheduled-tasks/templates/README.md
@@ -1,0 +1,134 @@
+# Scheduling Pattern Templates
+
+Templates for the five standard Lobster scheduling patterns. Copy the appropriate
+template, fill in the `YOUR_*` placeholders, and wire it into cron.
+
+---
+
+## Choosing a Pattern
+
+```
+Is this a polling job?
+│
+├─ YES: Does it check an external source for new data?
+│   │
+│   ├─ YES: Is the source a REST API with a ?since= timestamp parameter?
+│   │   ├─ YES → api-poll.sh.template     (REST API, bearer token, JSON items)
+│   │   └─ NO  → poll-with-state.sh.template  (generic source, custom check logic)
+│   │
+│   └─ NO, or cadence is slow and LLM decides what's new:
+│       └─ poll-basic.sh.template         (reachability check only, no cursor)
+│
+└─ NO: Does it invoke Claude?
+    ├─ YES → reminder.sh.template         (always dispatch, LLM does the work)
+    └─ NO  → local-code.sh.template       (no dispatch, no LLM, self-contained)
+```
+
+---
+
+## Template Summary
+
+| Template | Polling | State | LLM | When to use |
+|---|---|---|---|---|
+| `poll-with-state.sh.template` | Yes | Yes | Yes (Layer 2) | Frequent polling; you own the cursor |
+| `api-poll.sh.template` | Yes | Yes | Yes (Layer 2) | REST API with `?since=` timestamp support |
+| `poll-basic.sh.template` | Yes | No | Yes (Layer 2) | Slow cadence; LLM handles no-op detection |
+| `reminder.sh.template` | No | No | Yes (Layer 2) | Scheduled jobs that always do work |
+| `local-code.sh.template` | No | No | No | Self-contained maintenance tasks |
+
+---
+
+## How to Instantiate a Template
+
+1. Copy the template to `scheduled-tasks/`:
+   ```bash
+   cp scheduled-tasks/templates/api-poll.sh.template \
+      scheduled-tasks/YOUR_JOB_NAME-check.sh
+   chmod +x scheduled-tasks/YOUR_JOB_NAME-check.sh
+   ```
+
+2. Replace every `YOUR_*` placeholder with your actual values.
+
+3. For polling jobs, create the task file the subagent will receive:
+   ```
+   scheduled-jobs/tasks/YOUR_JOB_NAME.md
+   ```
+   This file is passed verbatim to the LLM subagent by `dispatch-job.sh`.
+
+4. Register the job with the Lobster scheduler (via MCP `create_scheduled_job`)
+   or add a cron entry to `scripts/sync-crontab.sh`.
+
+5. Test the script manually before wiring to cron:
+   ```bash
+   bash -x scheduled-tasks/YOUR_JOB_NAME-check.sh
+   ```
+
+---
+
+## File Conventions
+
+### State files
+Track the last-seen cursor (timestamp, ID, hash) so the script can drop no-ops.
+
+```
+~/lobster-workspace/data/<job-name>-state.json
+```
+
+Format (adapt fields as needed):
+```json
+{
+  "last_seen_ts": "2026-01-15T10:30:00Z",
+  "last_seen_id": "msg-12345"
+}
+```
+
+**Who writes the state file:** the Layer 2 subagent, after successful processing.
+Never advance the cursor in the Layer 1 script — only the subagent knows whether
+processing succeeded.
+
+### Token files
+Store auth tokens as single-line plain text.
+
+```
+~/lobster-workspace/data/<job-name>-token.txt
+```
+
+These files live outside the repo and are never committed.
+
+### Log files
+Each script run writes a timestamped log:
+
+```
+~/lobster-workspace/scheduled-jobs/logs/<job-name>-<YYYYMMDD-HHMMSS>.log
+```
+
+Polling pre-check scripts append `-precheck` to the log name to distinguish them
+from the subagent's own log:
+
+```
+~/lobster-workspace/scheduled-jobs/logs/<job-name>-precheck-<YYYYMMDD-HHMMSS>.log
+```
+
+---
+
+## The Two-Layer Model
+
+Templates enforce the architecture described in `scheduled-tasks/README.md`:
+
+**Layer 1 (scripts, this directory):** Lightweight checks. No LLM. Cost: ~0.
+**Layer 2 (LLM subagent):** Reasoning, formatting, actions. Only spawned when Layer 1 finds new data.
+
+The key invariant: a polling script that fires every 2 minutes and finds nothing
+new costs nothing. LLM invocations are reserved for cases where there is something
+to reason about.
+
+---
+
+## Real Examples
+
+| Script | Template used | Notes |
+|---|---|---|
+| `bot-talk-check-dispatch.sh` | `poll-with-state.sh` | Polls bot-talk API; state in `bot-talk-state.json` |
+| `lobstertalk-incoming-check.sh` | `api-poll.sh` | REST API, `?recipient=` + `?since=` params |
+| `dispatch-job.sh` | (not a template; used by all templates) | Writes to inbox; called by Layer 1 scripts |
+| `post-reminder.sh` | (not a template; purpose-built) | Self-reminders with built-in dedup |

--- a/scheduled-tasks/templates/api-poll.sh.template
+++ b/scheduled-tasks/templates/api-poll.sh.template
@@ -1,0 +1,152 @@
+#!/bin/bash
+# api-poll.sh.template — REST API polling with state (timestamp-based cursor)
+#
+# Pattern: specialization of poll-with-state for REST APIs that support
+# timestamp-based filtering via a ?since= query parameter.
+#
+# This template handles:
+# - Token loading from a file
+# - URL-encoding the since= timestamp
+# - Authorization header injection
+# - JSON response parsing (list or {items:[...]} shape)
+# - Cursor advancement (state file write) in the subagent, not here
+# - Fail-safe dispatch on API error or parse failure
+#
+# The key difference from poll-with-state.sh.template: this template is
+# pre-wired for the REST API + Bearer token + JSON response pattern, so
+# there is less to fill in.
+#
+# Usage: cron calls this script at your desired polling cadence.
+#   Example crontab entry:
+#     */10 * * * * ~/lobster/scheduled-tasks/YOUR_JOB_NAME-check.sh
+#
+# Fill in all variables marked YOUR_* before using.
+#
+# Flow:
+#   API returns items  → dispatch-job.sh YOUR_JOB_NAME → inbox write → LLM
+#   API returns empty  → log no-op → exit 0
+#   API unreachable    → log warning → dispatch (fail-safe, let job handle outage)
+
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:$PATH"
+
+# --- Configuration (fill in these values) ---
+JOB_NAME="YOUR_JOB_NAME"
+# Base URL of the API, no trailing slash
+YOUR_API_BASE_URL="https://YOUR_API_HOST/api/v1"
+# Path to fetch, without the ?since= parameter
+YOUR_API_PATH="/YOUR_RESOURCE"
+# JSON key for the items array in the response (use "." for a top-level array)
+YOUR_ITEMS_KEY="items"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Load env files ---
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+for _env_file in "$CONFIG_DIR/config.env" "$CONFIG_DIR/global.env"; do
+    if [ -f "$_env_file" ]; then
+        # shellcheck source=/dev/null
+        set -a
+        source "$_env_file"
+        set +a
+    fi
+done
+unset _env_file
+
+WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+LOG_DIR="$WORKSPACE/scheduled-jobs/logs"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+START_ISO=$(date -Iseconds)
+
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${JOB_NAME}-precheck-${TIMESTAMP}.log"
+
+# --- Token file ---
+# Convention: ~/lobster-workspace/data/<job-name>-token.txt
+TOKEN_FILE="$WORKSPACE/data/${JOB_NAME}-token.txt"
+if [ ! -f "$TOKEN_FILE" ]; then
+    echo "[$START_ISO] ERROR: token file not found: $TOKEN_FILE — dispatching to let job handle it" | tee "$LOG_FILE"
+    exec "$SCRIPT_DIR/dispatch-job.sh" "$JOB_NAME"
+fi
+TOKEN=$(python3 -c "print(open('$TOKEN_FILE').read().strip())" 2>/dev/null)
+
+# --- State file ---
+# Convention: ~/lobster-workspace/data/<job-name>-state.json
+STATE_FILE="$WORKSPACE/data/${JOB_NAME}-state.json"
+LAST_TS=""
+if [ -f "$STATE_FILE" ]; then
+    LAST_TS=$(python3 -c "
+import json
+try:
+    with open('$STATE_FILE') as f:
+        d = json.load(f)
+    print(d.get('last_seen_ts', ''))
+except Exception:
+    pass
+" 2>/dev/null || true)
+fi
+
+# --- Build URL ---
+if [ -n "$LAST_TS" ]; then
+    ENCODED_TS=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" "$LAST_TS" 2>/dev/null || echo "")
+    CHECK_URL="${YOUR_API_BASE_URL}${YOUR_API_PATH}?since=${ENCODED_TS}"
+else
+    # No cursor — fetch most recent items (API returns its default page size)
+    CHECK_URL="${YOUR_API_BASE_URL}${YOUR_API_PATH}"
+fi
+
+# --- HTTP request ---
+set +e
+RESPONSE=$(curl -sf --max-time 15 \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Accept: application/json" \
+    "$CHECK_URL" 2>/dev/null)
+CURL_EXIT=$?
+set -e
+
+if [ "$CURL_EXIT" -ne 0 ]; then
+    echo "[$START_ISO] WARNING: API unreachable (curl exit $CURL_EXIT) — dispatching to let job handle outage logic" | tee "$LOG_FILE"
+    exec "$SCRIPT_DIR/dispatch-job.sh" "$JOB_NAME"
+fi
+
+# --- Parse response ---
+# Handles two common shapes:
+#   - Top-level array:          [ {...}, {...} ]
+#   - Object with items field:  { "YOUR_ITEMS_KEY": [ {...}, {...} ] }
+set +e
+ITEM_COUNT=$(python3 -c "
+import json, sys
+items_key = sys.argv[1]
+response = sys.argv[2]
+try:
+    data = json.loads(response)
+    if isinstance(data, list):
+        items = data
+    else:
+        items = data.get(items_key, data.get('items', data.get('results', [])))
+    print(len(items))
+except (json.JSONDecodeError, AttributeError):
+    sys.exit(2)
+" "$YOUR_ITEMS_KEY" "$RESPONSE" 2>/dev/null)
+PARSE_EXIT=$?
+set -e
+
+if [ "$PARSE_EXIT" -ne 0 ]; then
+    echo "[$START_ISO] WARNING: unexpected response format — dispatching to let job handle it" | tee "$LOG_FILE"
+    exec "$SCRIPT_DIR/dispatch-job.sh" "$JOB_NAME"
+fi
+
+# --- Decision ---
+if [ "${ITEM_COUNT:-0}" -gt 0 ]; then
+    echo "[$START_ISO] $ITEM_COUNT new item(s) found — dispatching $JOB_NAME" | tee "$LOG_FILE"
+    exec "$SCRIPT_DIR/dispatch-job.sh" "$JOB_NAME"
+else
+    echo "[$START_ISO] No new items since ${LAST_TS:-<no cursor>} — skipping dispatch for $JOB_NAME" | tee "$LOG_FILE"
+    exit 0
+fi
+
+# --- NOTE: Cursor advancement ---
+# The Layer 2 subagent updates the state file after processing. Write to:
+#   ~/lobster-workspace/data/YOUR_JOB_NAME-state.json
+# with the field `last_seen_ts` set to the timestamp of the newest item processed.

--- a/scheduled-tasks/templates/local-code.sh.template
+++ b/scheduled-tasks/templates/local-code.sh.template
@@ -1,0 +1,76 @@
+#!/bin/bash
+# local-code.sh.template — Self-contained scheduled task (no dispatch, no LLM)
+#
+# Pattern: cron fires, runs a local command or script, logs the result.
+# Does NOT write to the inbox. There is no subagent, no LLM invocation.
+#
+# Use this pattern for:
+# - Log rotation and cleanup (rm old files, gzip archives)
+# - Database maintenance (vacuum, backup)
+# - Health checks that write their own output files
+# - Any task where the work is entirely local and deterministic
+#
+# This pattern is appropriate when:
+# - The task requires no intelligence or judgment
+# - Output is a local artifact (file, log entry, DB write)
+# - Failure should alert via exit code (cron mails on nonzero exit)
+#
+# Fill in all variables marked YOUR_* before using.
+#
+# Example crontab entry:
+#   0 3 * * * ~/lobster/scheduled-tasks/YOUR_JOB_NAME.sh >> ~/lobster-workspace/scheduled-jobs/logs/YOUR_JOB_NAME-cron.log 2>&1
+
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:$PATH"
+
+# --- Configuration (fill in these values) ---
+JOB_NAME="YOUR_JOB_NAME"
+
+# --- Load env files ---
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+for _env_file in "$CONFIG_DIR/config.env" "$CONFIG_DIR/global.env"; do
+    if [ -f "$_env_file" ]; then
+        # shellcheck source=/dev/null
+        set -a
+        source "$_env_file"
+        set +a
+    fi
+done
+unset _env_file
+
+WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+LOG_DIR="$WORKSPACE/scheduled-jobs/logs"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+START_ISO=$(date -Iseconds)
+
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${JOB_NAME}-${TIMESTAMP}.log"
+
+echo "[$START_ISO] Starting $JOB_NAME" | tee "$LOG_FILE"
+
+# --- Your task here ---
+# Replace the example below with your actual work.
+#
+# Example: delete log files older than 30 days
+# find "$LOG_DIR" -name "*.log" -mtime +30 -delete
+#
+# Example: backup a SQLite database
+# cp "$WORKSPACE/data/memory.db" "$WORKSPACE/data/memory.db.$(date +%Y%m%d)"
+#
+# Example: rotate a state file
+# if [ -f "$WORKSPACE/data/YOUR_STATE_FILE.json" ]; then
+#     mv "$WORKSPACE/data/YOUR_STATE_FILE.json" "$WORKSPACE/data/YOUR_STATE_FILE-${TIMESTAMP}.json.bak"
+# fi
+
+echo "YOUR TASK COMMAND HERE" | tee -a "$LOG_FILE"
+TASK_EXIT=$?
+
+# --- Result ---
+END_ISO=$(date -Iseconds)
+if [ "$TASK_EXIT" -eq 0 ]; then
+    echo "[$END_ISO] $JOB_NAME completed successfully" | tee -a "$LOG_FILE"
+else
+    echo "[$END_ISO] $JOB_NAME failed with exit code $TASK_EXIT" | tee -a "$LOG_FILE"
+    exit "$TASK_EXIT"
+fi

--- a/scheduled-tasks/templates/poll-basic.sh.template
+++ b/scheduled-tasks/templates/poll-basic.sh.template
@@ -1,0 +1,72 @@
+#!/bin/bash
+# poll-basic.sh.template — Polling without state tracking (always dispatch if reachable)
+#
+# Pattern: cron fires, checks whether the source is reachable and has data,
+# then dispatches unconditionally. No state cursor — the subagent decides
+# whether there is anything new to act on.
+#
+# Use this pattern when:
+# - No-op detection belongs in the LLM layer (e.g., the agent compares against
+#   its own memory rather than a state file)
+# - The source always returns fresh data and the subagent filters it
+# - The cadence is slow enough that LLM invocations are cheap per-call
+#
+# Prefer poll-with-state.sh.template when the job fires frequently (< 15 min)
+# or when the source produces high-volume data with a clear cursor.
+#
+# Usage: cron calls this script directly.
+#   Example crontab entry:
+#     0 * * * * ~/lobster/scheduled-tasks/YOUR_JOB_NAME-check.sh
+#
+# Fill in all variables marked YOUR_* before using.
+#
+# Flow:
+#   source reachable → dispatch-job.sh YOUR_JOB_NAME → inbox write → LLM
+#   source unreachable → log warning → exit 1
+
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:$PATH"
+
+# --- Configuration (fill in these values) ---
+JOB_NAME="YOUR_JOB_NAME"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Load env files ---
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+for _env_file in "$CONFIG_DIR/config.env" "$CONFIG_DIR/global.env"; do
+    if [ -f "$_env_file" ]; then
+        # shellcheck source=/dev/null
+        set -a
+        source "$_env_file"
+        set +a
+    fi
+done
+unset _env_file
+
+WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+LOG_DIR="$WORKSPACE/scheduled-jobs/logs"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+START_ISO=$(date -Iseconds)
+
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${JOB_NAME}-precheck-${TIMESTAMP}.log"
+
+# --- Reachability check (replace with your actual check) ---
+# Keep this minimal: just confirm the source exists and is accessible.
+# The subagent will handle all content inspection.
+YOUR_CHECK_URL="https://YOUR_API_URL/health"
+
+set +e
+curl -sf --max-time 10 "$YOUR_CHECK_URL" > /dev/null 2>&1
+CURL_EXIT=$?
+set -e
+
+if [ "$CURL_EXIT" -ne 0 ]; then
+    echo "[$START_ISO] WARNING: $YOUR_CHECK_URL unreachable (curl exit $CURL_EXIT) — skipping dispatch" | tee "$LOG_FILE"
+    exit 1
+fi
+
+# --- Dispatch unconditionally ---
+echo "[$START_ISO] Source reachable — dispatching $JOB_NAME" | tee "$LOG_FILE"
+exec "$SCRIPT_DIR/dispatch-job.sh" "$JOB_NAME"

--- a/scheduled-tasks/templates/poll-with-state.sh.template
+++ b/scheduled-tasks/templates/poll-with-state.sh.template
@@ -1,0 +1,144 @@
+#!/bin/bash
+# poll-with-state.sh.template — Polling pre-check with state tracking
+#
+# Pattern: cron fires frequently; script checks a source and compares against
+# last-seen state. If nothing new: log a no-op, exit 0 (no LLM spawned).
+# If new data is found: write to inbox and update the state file.
+#
+# This is Layer 1 in the two-layer scheduling model. It must never invoke
+# Claude directly. All LLM work happens in Layer 2 (a subagent spawned by
+# the dispatcher after this script writes to the inbox).
+#
+# Usage: cron calls this script directly at your desired polling cadence.
+#   Example crontab entry:
+#     */5 * * * * ~/lobster/scheduled-tasks/YOUR_JOB_NAME-check.sh
+#
+# Fill in all variables marked YOUR_* before using.
+#
+# Flow:
+#   new data found → dispatch-job.sh YOUR_JOB_NAME → inbox write → LLM
+#   nothing new    → log no-op → exit 0
+
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:$PATH"
+
+# --- Configuration (fill in these values) ---
+JOB_NAME="YOUR_JOB_NAME"                            # matches task file in scheduled-jobs/tasks/
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Load env files (same pattern as dispatch-job.sh) ---
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+for _env_file in "$CONFIG_DIR/config.env" "$CONFIG_DIR/global.env"; do
+    if [ -f "$_env_file" ]; then
+        # shellcheck source=/dev/null
+        set -a
+        source "$_env_file"
+        set +a
+    fi
+done
+unset _env_file
+
+WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+LOG_DIR="$WORKSPACE/scheduled-jobs/logs"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+START_ISO=$(date -Iseconds)
+
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${JOB_NAME}-precheck-${TIMESTAMP}.log"
+
+# --- State file (tracks what was last seen) ---
+# Convention: ~/lobster-workspace/data/<job-name>-state.json
+STATE_FILE="$WORKSPACE/data/${JOB_NAME}-state.json"
+LAST_SEEN=""
+if [ -f "$STATE_FILE" ]; then
+    LAST_SEEN=$(python3 -c "
+import json
+try:
+    with open('$STATE_FILE') as f:
+        d = json.load(f)
+    print(d.get('last_seen', ''))
+except Exception:
+    pass
+" 2>/dev/null || true)
+fi
+
+# --- Token file (if your source requires auth) ---
+# Convention: ~/lobster-workspace/data/<job-name>-token.txt
+TOKEN_FILE="$WORKSPACE/data/${JOB_NAME}-token.txt"
+if [ ! -f "$TOKEN_FILE" ]; then
+    echo "[$START_ISO] ERROR: token file not found: $TOKEN_FILE — dispatching to let job handle it" | tee "$LOG_FILE"
+    exec "$SCRIPT_DIR/dispatch-job.sh" "$JOB_NAME"
+fi
+TOKEN=$(python3 -c "print(open('$TOKEN_FILE').read().strip())" 2>/dev/null)
+
+# --- Check the source (replace with your actual check) ---
+# The goal: determine whether there is new data since LAST_SEEN.
+# Keep this lightweight — a single HTTP call, a file stat, a git rev-parse, etc.
+HAS_NEW_DATA=0
+
+if [ -z "$LAST_SEEN" ]; then
+    # No recorded state — treat as new so the job runs at least once
+    HAS_NEW_DATA=1
+else
+    # Example: HTTP check against YOUR_API_URL with a ?since= parameter
+    YOUR_API_URL="https://YOUR_API_URL/endpoint"
+    ENCODED_SINCE=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" "$LAST_SEEN" 2>/dev/null || echo "")
+    CHECK_URL="${YOUR_API_URL}?since=${ENCODED_SINCE}"
+
+    set +e
+    RESPONSE=$(curl -sf --max-time 10 \
+        -H "Authorization: Bearer $TOKEN" \
+        "$CHECK_URL" 2>/dev/null)
+    CURL_EXIT=$?
+    set -e
+
+    if [ "$CURL_EXIT" -ne 0 ]; then
+        echo "[$START_ISO] WARNING: source unreachable (curl exit $CURL_EXIT) — dispatching to let job handle outage logic" | tee "$LOG_FILE"
+        exec "$SCRIPT_DIR/dispatch-job.sh" "$JOB_NAME"
+    fi
+
+    # Parse the response — count items, or check a version hash, etc.
+    set +e
+    ITEM_COUNT=$(python3 -c "
+import json, sys
+try:
+    data = json.loads(sys.argv[1])
+    # Adjust this for your API's response shape:
+    items = data if isinstance(data, list) else data.get('items', data.get('results', []))
+    print(len(items))
+except (json.JSONDecodeError, KeyError):
+    sys.exit(2)  # parse failure — fall through to dispatch
+" "$RESPONSE" 2>/dev/null)
+    PARSE_EXIT=$?
+    set -e
+
+    if [ "$PARSE_EXIT" -ne 0 ]; then
+        echo "[$START_ISO] WARNING: unexpected response format — dispatching to let job handle it" | tee "$LOG_FILE"
+        exec "$SCRIPT_DIR/dispatch-job.sh" "$JOB_NAME"
+    fi
+
+    if [ "${ITEM_COUNT:-0}" -gt 0 ]; then
+        HAS_NEW_DATA=1
+    fi
+fi
+
+# --- Decision ---
+if [ "$HAS_NEW_DATA" -eq 1 ]; then
+    echo "[$START_ISO] New data found — dispatching $JOB_NAME" | tee "$LOG_FILE"
+    exec "$SCRIPT_DIR/dispatch-job.sh" "$JOB_NAME"
+else
+    echo "[$START_ISO] No new data since $LAST_SEEN — skipping dispatch for $JOB_NAME" | tee "$LOG_FILE"
+    exit 0
+fi
+
+# --- NOTE: State updates ---
+# The Layer 2 subagent (spawned by dispatch-job.sh) is responsible for
+# updating the state file after it processes the data. This keeps state
+# accurate: only advance the cursor after successful processing, not after
+# a successful poll.
+#
+# In the subagent task file (scheduled-jobs/tasks/YOUR_JOB_NAME.md),
+# instruct the agent to write:
+#   ~/lobster-workspace/data/YOUR_JOB_NAME-state.json
+# with the new cursor value (e.g., latest timestamp, last-seen ID).

--- a/scheduled-tasks/templates/reminder.sh.template
+++ b/scheduled-tasks/templates/reminder.sh.template
@@ -1,0 +1,67 @@
+#!/bin/bash
+# reminder.sh.template — Non-polling scheduled task (always dispatch)
+#
+# Pattern: cron fires at a specific time; the script dispatches unconditionally.
+# No source check, no state. The subagent is expected to always have meaningful
+# work to do at this scheduled time.
+#
+# Use this pattern for:
+# - Morning briefings and daily digests
+# - Periodic reminders (check priorities, review queue)
+# - Mode-switches (start work mode, end work mode)
+# - Any job where "nothing new" is not a valid state — the job is the event
+#
+# This pattern is essentially a thin wrapper around dispatch-job.sh.
+# For the simplest cases, call dispatch-job.sh directly from cron instead:
+#   0 8 * * * ~/lobster/scheduled-tasks/dispatch-job.sh YOUR_JOB_NAME
+#
+# Use this script when you need env loading, custom logging, or a pre-check
+# (e.g., confirm a required file exists) before dispatching.
+#
+# Usage: cron calls this script at the desired time.
+#   Example crontab entries:
+#     0 8 * * 1-5  ~/lobster/scheduled-tasks/YOUR_JOB_NAME.sh   # weekdays at 8am
+#     30 22 * * *  ~/lobster/scheduled-tasks/YOUR_JOB_NAME.sh   # nightly at 10:30pm
+#
+# Fill in all variables marked YOUR_* before using.
+
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:$PATH"
+
+# --- Configuration (fill in these values) ---
+JOB_NAME="YOUR_JOB_NAME"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Load env files ---
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+for _env_file in "$CONFIG_DIR/config.env" "$CONFIG_DIR/global.env"; do
+    if [ -f "$_env_file" ]; then
+        # shellcheck source=/dev/null
+        set -a
+        source "$_env_file"
+        set +a
+    fi
+done
+unset _env_file
+
+WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+LOG_DIR="$WORKSPACE/scheduled-jobs/logs"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+START_ISO=$(date -Iseconds)
+
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${JOB_NAME}-${TIMESTAMP}.log"
+
+# --- Optional: pre-condition check ---
+# Uncomment and adapt if you need to verify a precondition before dispatching.
+# If the condition isn't met, exit 0 silently (no dispatch, no error).
+#
+# if [ ! -f "$WORKSPACE/data/YOUR_REQUIRED_FILE" ]; then
+#     echo "[$START_ISO] Pre-condition not met — skipping dispatch for $JOB_NAME" | tee "$LOG_FILE"
+#     exit 0
+# fi
+
+# --- Dispatch ---
+echo "[$START_ISO] Dispatching scheduled job: $JOB_NAME" | tee "$LOG_FILE"
+exec "$SCRIPT_DIR/dispatch-job.sh" "$JOB_NAME"


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

The scheduled-tasks directory had no documentation or templates, making it unclear which pattern to use for a new job and how to implement it correctly. Developers had to read existing scripts (bot-talk-check-dispatch.sh, lobstertalk-incoming-check.sh) and reverse-engineer the conventions. This PR makes the architecture self-describing.

## What this adds

**`scheduled-tasks/README.md`** — Top-level orientation for the directory: what scripts live here, what the two-layer model is, how dispatch-job.sh and post-reminder.sh relate to each other, and a guide to where each kind of task belongs.

**`scheduled-tasks/templates/`** — Five runnable shell script templates, one per scheduling pattern:

| Template | Pattern |
|---|---|
| `poll-with-state.sh.template` | Polling with a state cursor — the general case |
| `api-poll.sh.template` | REST API polling with `?since=` timestamp (specialization) |
| `poll-basic.sh.template` | Polling without a cursor; LLM handles no-op detection |
| `reminder.sh.template` | Unconditional dispatch on schedule |
| `local-code.sh.template` | Self-contained cron task, no LLM |

**`scheduled-tasks/templates/README.md`** — Decision tree for choosing a pattern, table of when to use each, instantiation instructions, file naming conventions (state files, token files, log files), and a mapping of existing scripts to their templates.

Templates are real, runnable shell scripts with `YOUR_*` placeholders — not pseudocode. They use the same env-loading pattern as `dispatch-job.sh` and the same fail-safe dispatch-on-error pattern as `bot-talk-check-dispatch.sh`.

## What this does not change

No existing scripts are modified. No crontab entries are added. No `jobs.json` changes. No upgrade.sh migration needed. This is purely additive documentation and templates — safe to merge at any time.

## Functional patterns used

Each template is a pure transformation: given a cron invocation, it reads state, performs one deterministic check, and either exits 0 (no side effects) or delegates to `dispatch-job.sh` (inbox write). Side effects are isolated to the boundary (the inbox write) and only occur when new data is confirmed.

## Tests run

- [x] `bash -n scheduled-tasks/templates/poll-with-state.sh.template` — syntax OK
- [x] `bash -n scheduled-tasks/templates/api-poll.sh.template` — syntax OK
- [x] `bash -n scheduled-tasks/templates/poll-basic.sh.template` — syntax OK
- [x] `bash -n scheduled-tasks/templates/reminder.sh.template` — syntax OK
- [x] `bash -n scheduled-tasks/templates/local-code.sh.template` — syntax OK
- [x] Pre-push security scanner — all clear, no PII or security issues

Relates to #1059