### PR TITLE
fix: treat stale JSONL files as dead in _stored_session_is_alive() (#1009)

### DIFF
--- a/hooks/write-dispatcher-session-id.py
+++ b/hooks/write-dispatcher-session-id.py
@@ -44,6 +44,15 @@ exists and correctly classifies the new session as the replacement dispatcher.
 The primary defence against this scenario is `lobster stop` (and `restart`)
 clearing the marker file; this check is a secondary safety net.
 
+## Stale JSONL file fix (issue #1009)
+
+`_stored_session_is_alive()` previously returned True for any existing JSONL
+file, even ones from sessions that ended weeks ago. This caused the hook to
+misclassify a fresh dispatcher restart as a subagent whenever the stale JSONL
+file happened to still exist on disk (Claude Code does not automatically delete
+old session files). The fix adds an age check: JSONL files older than 7 days
+are treated as dead regardless of whether they exist on disk.
+
 ## settings.json configuration
 
 Add this to ~/.claude/settings.json under "hooks" → "SessionStart":
@@ -67,6 +76,7 @@ via a "compact" matcher — the two hooks can coexist safely.
 import json
 import os
 import sys
+import time
 from pathlib import Path
 
 # Allow imports from both the hooks directory (session_role) and src/agents (session_store).
@@ -79,15 +89,27 @@ import session_role  # noqa: E402 — path insert must precede this
 from agents import session_store  # noqa: E402
 
 
+_MAX_SESSION_AGE_DAYS = 7  # JSONL files older than this are treated as dead sessions.
+
+
 def _stored_session_is_alive(stored_session_id: str) -> bool:
-    """Return True if the stored dispatcher session's JSONL file still exists.
+    """Return True if the stored dispatcher session's JSONL file still exists
+    and is recent enough to belong to a live session.
 
     Claude Code stores each session's conversation as
     ~/.claude/projects/<workspace-slug>/<session-id>.jsonl. If the file is
     gone, the session has ended and can no longer be the active dispatcher.
 
+    Age check (fix for issue #1009): JSONL files that exist but are older than
+    _MAX_SESSION_AGE_DAYS are treated as dead. Without this check, stale JSONL
+    files from sessions that ended weeks ago cause _is_dispatcher_session() to
+    misidentify the current session as a subagent — because the stored session
+    ID differs from the new session's ID, and _stored_session_is_alive() returns
+    True (file exists), so the new session is classified as a subagent rather
+    than the replacement dispatcher.
+
     Falls back to True (conservative / assume alive) if the project directory
-    cannot be determined or the JSONL file is not found via glob.
+    cannot be determined or file stat fails.
     """
     try:
         projects_dir = Path(os.path.expanduser("~/.claude/projects"))
@@ -95,6 +117,13 @@ def _stored_session_is_alive(stored_session_id: str) -> bool:
             return True  # can't determine — assume alive (conservative)
         # Search all workspace subdirectories for the session file.
         for jsonl in projects_dir.glob(f"*/{stored_session_id}.jsonl"):
+            # File exists — check its age before declaring it alive.
+            try:
+                age_days = (time.time() - jsonl.stat().st_mtime) / 86400
+                if age_days > _MAX_SESSION_AGE_DAYS:
+                    return False  # stale file — treat stored session as dead
+            except OSError:
+                pass  # stat failed — assume alive (conservative)
             return True
         # No JSONL file found anywhere — the stored session ended.
         return False


### PR DESCRIPTION
## Summary

- Adds a 7-day age threshold to `_stored_session_is_alive()` in `write-dispatcher-session-id.py`
- JSONL session files older than `_MAX_SESSION_AGE_DAYS` are now treated as dead, regardless of whether they exist on disk
- Also adds `import time` (missing) and documents the fix in the module-level docstring

## Root cause

`_stored_session_is_alive()` returned `True` for any existing `.jsonl` file, even ones from sessions that ended weeks ago. Claude Code does not auto-delete old session files, so a stale JSONL caused the hook to classify a fresh dispatcher restart as a subagent:

1. New dispatcher starts with a new `session_id`
2. Stored `dispatcher-session-id` still contains the stale (old) session ID
3. `_stored_session_is_alive(stored_id)` finds the old `.jsonl` on disk → returns `True`
4. `_is_dispatcher_session()` concludes: "stored session is still alive, so this new session must be a subagent"
5. The hook does NOT update `dispatcher-session-id` → compact-reminders never fire → dispatcher loses context after every compaction

This was silently broken from March 17 through March 28 (11 days).

## Fix

```python
_MAX_SESSION_AGE_DAYS = 7

for jsonl in projects_dir.glob(f"*/{stored_session_id}.jsonl"):
    age_days = (time.time() - jsonl.stat().st_mtime) / 86400
    if age_days > _MAX_SESSION_AGE_DAYS:
        return False  # stale file — treat stored session as dead
    return True
```

## Why NOT workdir-based detection

The original issue description explored whether `os.getcwd()` could distinguish dispatcher from subagents. Investigation showed this is NOT reliable:

- The dispatcher runs in `/home/lobster/lobster-workspace/` (set by systemd)
- **Subagents also run in `/home/lobster/lobster-workspace/`** — confirmed by inspecting `.jsonl` session files and by the fact that this investigative subagent itself ran in that directory
- Out of 271 sessions in the `lobster-workspace` project dir: 215 dispatcher, **56 subagents** — all with identical CWDs

The workdir approach would produce false positives (subagents identified as the dispatcher). The stale-file age check is the correct, targeted fix.

## Test plan

- [ ] Verify `_stored_session_is_alive()` returns `False` for a session JSONL older than 7 days
- [ ] Verify `_stored_session_is_alive()` returns `True` for a session JSONL newer than 7 days
- [ ] Verify the hook correctly writes a fresh `dispatcher-session-id` after a crash/restart scenario (old JSONL > 7 days old)
- [ ] Confirm `import time` is present (was missing before this PR)

Closes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)