### PR TITLE
fix: repair two Docker test failures — bot_talk import and mock-telegram startup

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -70,7 +70,7 @@ from reliability import (
 from update_manager import UpdateManager
 
 # Bot-talk mirroring — fire-and-forget relay to the shared SaharLobster/AlbertLobster channel
-from bot_talk.mirror import mirror_outbound as _mirror_outbound, mirror_inbound as _mirror_inbound
+from bot_talk_mirror import mirror_outbound as _mirror_outbound, mirror_inbound as _mirror_inbound
 
 # Pending agent tracker (thin adapter over session_store)
 from agents.tracker import add_pending_agent as _add_pending_agent, remove_pending_agent as _remove_pending_agent

--- a/tests/docker/docker-compose.test.yml
+++ b/tests/docker/docker-compose.test.yml
@@ -21,25 +21,11 @@ services:
     build:
       context: ../..
       dockerfile: tests/docker/Dockerfile.integration
-    command: [".venv/bin/python", "-c", "
-      import asyncio
-      import sys
-      sys.path.insert(0, '/home/testuser/lobster')
-      from tests.mocks.mock_telegram import MockTelegramServer
-
-      async def run():
-          server = MockTelegramServer(port=8081)
-          await server.start()
-          print('Mock Telegram server running on port 8081')
-          while True:
-              await asyncio.sleep(3600)
-
-      asyncio.run(run())
-    "]
+    command: [".venv/bin/python", "/home/testuser/lobster/tests/docker/mock_telegram_runner.py"]
     ports:
       - "8081:8081"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8081/bot_test/getMe"]
+      test: ["CMD", "curl", "-f", "http://localhost:8081/bottest_token/getMe"]
       interval: 5s
       timeout: 3s
       retries: 3

--- a/tests/docker/mock_telegram_runner.py
+++ b/tests/docker/mock_telegram_runner.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Startup script for the mock Telegram API server used in integration tests."""
+import asyncio
+import sys
+
+sys.path.insert(0, '/home/testuser/lobster')
+from tests.mocks.mock_telegram import MockTelegramServer
+
+
+async def run():
+    server = MockTelegramServer(port=8081)
+    await server.start()
+    print('Mock Telegram server running on port 8081')
+    while True:
+        await asyncio.sleep(3600)
+
+
+asyncio.run(run())


### PR DESCRIPTION
## What broke and why

Two independent failures prevented Docker CI from producing useful results.

**Unit-tests: 10 collection errors from `ModuleNotFoundError: No module named 'bot_talk'`**

`inbox_server.py` contained `from bot_talk.mirror import ...` but no `bot_talk` package exists in the codebase — the module is a flat file named `bot_talk_mirror.py` in `src/mcp/`. Any test file that imports `src.mcp.inbox_server` (10 files) failed at collection time before a single test ran. The fix is a one-line correction: `from bot_talk_mirror import ...`.

**Integration-tests: `IndentationError` caused mock-telegram to never start**

The `mock-telegram` service in `docker-compose.test.yml` used a YAML inline string to pass Python source to `python -c "..."`. Because the string was indented 6 spaces inside the YAML structure, Python received every line with 6 spaces of leading whitespace — a syntax error before the server could bind to its port. The integration-test suite depended on mock-telegram being healthy, so it failed immediately at the dependency check.

The fix extracts the startup code into `tests/docker/mock_telegram_runner.py` (a normal Python script) and runs it directly. This also fixes the healthcheck URL, which referenced `/bot_test/getMe` when the server binds to `/bottest_token/getMe` (token = `test_token`).

## After this PR

- `docker compose up unit-tests`: 10 collection errors → 0 (1133 passed before reaching the pre-existing non-bot-talk failures)
- `docker compose up integration-tests`: `IndentationError` + unhealthy dependency → mock-telegram starts cleanly, integration tests reach and run (77 pass, 9 pre-existing failures in unrelated tests remain)

No behavior changes to the running Lobster system — `inbox_server.py` still calls the same `mirror_outbound` and `mirror_inbound` functions, just from the correct module name.

## Functional patterns

Pure import correction — no logic changes. The runner script is a straightforward sequential startup with a `asyncio.run(run())` entry point, same as the original inline code.

## Tests run

- [x] `docker compose -f tests/docker/docker-compose.test.yml up unit-tests --build` — 10 bot_talk collection errors eliminated; 1133 passed, 13 failed (pre-existing), 594 errors (pre-existing, unrelated to this PR)
- [x] `docker compose -f tests/docker/docker-compose.test.yml up integration-tests --build` — mock-telegram starts healthy; integration tests reach execution: 77 passed, 9 failed (pre-existing failures in upgrade_safety, scheduled_execution, telegram_flow)