### PR TITLE
fix: check_task_outputs returns unknown/no content

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -5607,8 +5607,12 @@ async def handle_check_task_outputs(args: dict) -> list[TextContent]:
     limit = args.get("limit", 10)
     job_name_filter = args.get("job_name", "").strip().lower()
 
-    # Get all output files
-    output_files = sorted(TASK_OUTPUTS_DIR.glob("*.json"), reverse=True)
+    # Get all output files, sorted by mtime descending (newest first).
+    # Sorting by filename is unreliable: non-date-prefixed files (e.g. old
+    # write_result artifacts) sort lexicographically ahead of date-prefixed
+    # write_task_output files and would dominate every result page.
+    all_files = list(TASK_OUTPUTS_DIR.glob("*.json"))
+    output_files = sorted(all_files, key=lambda p: p.stat().st_mtime, reverse=True)
 
     if not output_files:
         return [TextContent(type="text", text="No task outputs yet.\n\nOutputs will appear here when scheduled jobs complete.")]
@@ -5628,6 +5632,13 @@ async def handle_check_task_outputs(args: dict) -> list[TextContent]:
         try:
             with open(f) as fp:
                 data = json.load(fp)
+
+            # Skip files that are not write_task_output records.  The task-outputs
+            # directory may contain stale write_result artifacts (schema: task_id/text)
+            # from an older code path.  These have no job_name or output fields and
+            # would render as "unknown" / "(no output)".  Silently skip them.
+            if "job_name" not in data:
+                continue
 
             # Filter by job name
             if job_name_filter and data.get("job_name", "").lower() != job_name_filter:


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What was broken

`check_task_outputs` was returning all entries as \"unknown\" job / \"(no output)\". The root cause: the `task-outputs/` directory contained ~28 non-date-prefixed files (written by an older `write_result` code path). In reverse lexicographic sort, letter-prefixed names beat `2026...` date-prefixed names (letters > digits in ASCII), so all 10 results came from those stale artifacts — which use the `write_result` schema (`task_id`/`text`) and have no `job_name` or `output` field.

## Fix (two defenses)

**Sort by mtime instead of filename** (`key=lambda p: p.stat().st_mtime`): `write_task_output` files are always the most recently written, so they surface first regardless of filename convention.

**Skip files missing `job_name`**: silently ignores stale `write_result` artifacts. Files without a `job_name` key are not valid `write_task_output` records and would render as \"unknown\" / \"(no output)\".

These two lines are the entire fix. Nothing else in this PR changes.

## What is not changed

This PR touches only `handle_check_task_outputs` in `inbox_server.py`. No schema changes, no API changes, no behavior changes for valid output files.

## Functional patterns

Pure defensive filtering: the `job_name` guard is a predicate applied to each record before aggregation. The mtime sort is a key-function composition passed to `sorted()`. Both are stateless, no side effects.

## Tests run
- [x] Manual: ran `check_task_outputs()` against a workspace with stale artifacts — real job names and output text now surface correctly
- [ ] `uv run pytest tests/` — not run (inbox_server test suite requires MCP server environment not available in this workspace)

Closes #1091 (check_task_outputs shows unknown/no content)