### PR TITLE
🤖🦞 Lobster (engineer): fix: ghost_detector and oom_check run directly from cron, no LLM

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -170,18 +170,15 @@ Scheduled reminders arrive from two sources:
 
 **Routing table** — maps `reminder_type` to subagent+prompt for system cron jobs. User-created jobs carry `task_content` and are dispatched generically; do NOT add them to REMINDER_ROUTING.
 
+> **Note on ghost_detector and oom_check:** Both run as pure cron scripts — `agent-monitor.py --alert --mark-failed` (every 5 minutes) and `oom-monitor.py --since-minutes 10` (every 10 minutes) — with no inbox message and no LLM involvement. If a `ghost_detector` or `oom_check` scheduled_reminder arrives (e.g. from a legacy install still running `post-reminder.sh`), it will fall through to the unknown-reminder fallback below and be logged and dropped.
+
 ```python
 REMINDER_ROUTING = {
-  "ghost_detector": {
-    "subagent_type": "lobster-generalist",
-    "prompt": "---\ntask_id: agent-monitor\nchat_id: 0\nsource: system\n---\n\n"
-              "Run the agent monitor: uv run ~/lobster/scripts/agent-monitor.py and report findings.",
-  },
-  "oom_check": {
-    "subagent_type": "lobster-generalist",
-    "prompt": "---\ntask_id: oom-check\nchat_id: 0\nsource: system\n---\n\n"
-              "Run the OOM monitor: uv run ~/lobster/scripts/oom-monitor.py --since-minutes 10 and report findings.",
-  },
+  # --- System cron jobs only (no task_content embedded; subagent handles output) ---
+  # Do NOT add user-created jobs here — they are handled generically via task_content.
+  # ghost_detector and oom_check were removed — both scripts now run directly from
+  # cron (LOBSTER-GHOST-DETECTOR and LOBSTER-OOM-CHECK entries) and alert/write
+  # to the inbox themselves. No LLM subagent is needed for either.
 }
 ```
 
@@ -206,10 +203,12 @@ REMINDER_ROUTING = {
                      f"text='Unknown reminder type: {reminder_type}') and return.")
        Spawn lobster-generalist (run_in_background=True) with prompt
    else:
-       Spawn subagent (run_in_background=True) with route["subagent_type"] and route["prompt"]
-
-5. mark_processed(message_id)
-   # THE VERY NEXT ACTION MUST BE wait_for_messages() — see WFM-always-next rule
+       # Known static route (system job with explicit REMINDER_ROUTING entry).
+       Spawn subagent (run_in_background=True):
+       - subagent_type: route["subagent_type"]
+       - prompt: route["prompt"]
+       mark_processed(message_id)
+       # THE VERY NEXT ACTION MUST BE wait_for_messages() — see WFM-always-next rule below
 ```
 
 **WFM-always-next rule:**

--- a/install.sh
+++ b/install.sh
@@ -1386,6 +1386,35 @@ chmod +x "$INSTALL_DIR/scheduled-tasks/export-logs.py" 2>/dev/null || true
 
 success "Log export configured (runs at 03:00 UTC daily)"
 
+#===============================================================================
+# Ghost Detector (agent-monitor)
+#===============================================================================
+
+step "Setting up ghost detector cron..."
+
+# agent-monitor.py runs every 5 minutes, checks for stale/dead agent sessions,
+# sends a Telegram alert if GHOST_CONFIRMED or UNREGISTERED agents are found,
+# and marks ghost sessions as failed in agent_sessions.db. No LLM involved.
+"$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-GHOST-DETECTOR" \
+    "*/5 * * * * cd $HOME && uv run $INSTALL_DIR/scripts/agent-monitor.py --alert --mark-failed >> $HOME/lobster-workspace/logs/agent-monitor.log 2>&1 # LOBSTER-GHOST-DETECTOR"
+
+success "Ghost detector configured (runs every 5 minutes)"
+
+#===============================================================================
+# OOM Monitor
+#===============================================================================
+
+step "Setting up OOM monitor cron..."
+
+# oom-monitor.py runs every 10 minutes, scans the kernel journal for OOM kills
+# affecting Lobster/Claude processes, and writes an inbox message for the
+# dispatcher when new OOM kill events are detected. No LLM involved.
+# Only active when LOBSTER_DEBUG=true (the script is a no-op otherwise).
+"$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-OOM-CHECK" \
+    "*/10 * * * * cd $HOME && uv run $INSTALL_DIR/scripts/oom-monitor.py --since-minutes 10 >> $HOME/lobster-workspace/logs/oom-monitor.log 2>&1 # LOBSTER-OOM-CHECK"
+
+success "OOM monitor configured (runs every 10 minutes, active only when LOBSTER_DEBUG=true)"
+
 # Ensure any lingering self-check cron entry is removed on fresh installs
 { crontab -l 2>/dev/null | grep -v "# LOBSTER-SELF-CHECK" | grep -v "periodic-self-check" || true; } | crontab -
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1847,6 +1847,33 @@ EOF
         fi
     fi
 
+    # Migration 52: Add LOBSTER-GHOST-DETECTOR cron entry.
+    # agent-monitor.py runs every 5 minutes and calls --alert --mark-failed directly,
+    # sending Telegram alerts when ghost agents are found. No LLM subagent is needed.
+    # Previously this was routed through REMINDER_ROUTING in sys.dispatcher.bootup.md
+    # which spawned a lobster-generalist just to run the script and relay its output.
+    # That LLM relay layer has been removed; the script now runs directly from cron.
+    local GHOST_DETECTOR_MARKER="# LOBSTER-GHOST-DETECTOR"
+    if ! crontab -l 2>/dev/null | grep -q "$GHOST_DETECTOR_MARKER"; then
+        "$LOBSTER_DIR/scripts/cron-manage.sh" add "$GHOST_DETECTOR_MARKER" \
+            "*/5 * * * * cd $HOME && uv run $LOBSTER_DIR/scripts/agent-monitor.py --alert --mark-failed >> $WORKSPACE_DIR/logs/agent-monitor.log 2>&1 $GHOST_DETECTOR_MARKER"
+        substep "Added ghost detector cron entry (agent-monitor.py --alert --mark-failed, every 5 min)"
+        migrated=$((migrated + 1))
+    fi
+
+    # Migration 53: Add LOBSTER-OOM-CHECK cron entry.
+    # oom-monitor.py runs every 10 minutes, scans the kernel journal for OOM kills,
+    # and writes inbox messages directly when new events are detected. No LLM needed.
+    # Previously this was routed through REMINDER_ROUTING which spawned a subagent.
+    # Only active when LOBSTER_DEBUG=true (the script exits 0 silently otherwise).
+    local OOM_CHECK_MARKER="# LOBSTER-OOM-CHECK"
+    if ! crontab -l 2>/dev/null | grep -q "$OOM_CHECK_MARKER"; then
+        "$LOBSTER_DIR/scripts/cron-manage.sh" add "$OOM_CHECK_MARKER" \
+            "*/10 * * * * cd $HOME && uv run $LOBSTER_DIR/scripts/oom-monitor.py --since-minutes 10 >> $WORKSPACE_DIR/logs/oom-monitor.log 2>&1 $OOM_CHECK_MARKER"
+        substep "Added OOM monitor cron entry (oom-monitor.py --since-minutes 10, every 10 min)"
+        migrated=$((migrated + 1))
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## What problem this solves

Both `ghost_detector` and `oom_check` were wired through `REMINDER_ROUTING` in `sys.dispatcher.bootup.md`, which caused the dispatcher to spawn a full `lobster-generalist` LLM subagent on each cron tick. The subagent's only job was to call `uv run agent-monitor.py` (or `oom-monitor.py`), read its stdout, and relay the output to `write_result`. No synthesis, no analysis — pure relay of script output through an expensive LLM session.

Both scripts already handle everything themselves:
- `agent-monitor.py --alert --mark-failed`: sends Telegram alerts via `alert.sh`, marks ghost sessions as failed in `agent_sessions.db`, and drops inbox notifications for the dispatcher
- `oom-monitor.py --since-minutes 10`: writes inbox JSON messages directly when OOM kills are detected (already platform-agnostic alerting with dedup state)

## What changed

**`sys.dispatcher.bootup.md`** — `REMINDER_ROUTING` is now empty. The two LLM-dispatch entries for `ghost_detector` and `oom_check` are removed. A note is added explaining both are now pure-cron and that any legacy `post-reminder.sh`-style messages for these types will fall through to the unknown-reminder fallback (logged and dropped harmlessly).

**`install.sh`** — Two new cron sections added:
- `LOBSTER-GHOST-DETECTOR`: `agent-monitor.py --alert --mark-failed` every 5 minutes
- `LOBSTER-OOM-CHECK`: `oom-monitor.py --since-minutes 10` every 10 minutes (no-op unless `LOBSTER_DEBUG=true`, per the script's own debug gate)

**`scripts/upgrade.sh`** — Migrations 52 and 53 add both cron entries to existing installs that predate this change. Idempotent: skips if the marker is already present.

## Flow change

Before:
```
cron -> post-reminder.sh ghost_detector -> inbox JSON -> dispatcher picks up ->
  spawns lobster-generalist ("run agent-monitor.py and report findings") ->
    LLM runs script, reads stdout, calls write_result
```

After:
```
cron -> uv run agent-monitor.py --alert --mark-failed (direct)
         if ghosts found: alert.sh (Telegram) + inbox drop for dispatcher
         else: log only, no inbox write
```

The `oom_check` flow is analogous. The dispatcher is completely removed from both paths.

## What is not changed

- The scripts themselves (`agent-monitor.py`, `oom-monitor.py`) are unchanged
- `alert.sh` is unchanged
- The dispatcher's handling of subagent results and other reminder types is unchanged
- The `REMINDER_ROUTING` dict is now empty but the routing machinery is preserved for future use

## Functional patterns

The scripts already follow the functional pattern — `agent-monitor.py` uses pure classification functions (`classify_agent`, `build_report`) and isolates side effects (`send_alert`, `mark_agent_failed`) at the edges. This PR extends that principle to the scheduling layer: eliminate the LLM relay, let the scripts own their output paths end-to-end.

## Tests run

- [x] `uv run --no-project pytest tests/unit/test_ghost_detector_filesystem.py -x -q` — 36 passed, 0 failed
- [ ] `uv run pytest tests/unit/` — blocked: dependency resolution fails (blue-lobster requires Python >=3.11, project specifies >=3.10; pre-existing issue unrelated to this PR)
- [ ] Live cron validation — skipped: requires production restart; LOBSTER-GHOST-DETECTOR is already present in the live crontab (migration 52 will be a no-op on this machine); LOBSTER-OOM-CHECK will be added by migration 53 on next upgrade run