### PR TITLE
fix: replace JSONL-parsing dispatcher detection with MCP state file

### DIFF
--- a/hooks/session_role.py
+++ b/hooks/session_role.py
@@ -8,41 +8,69 @@ dispatcher or a background subagent.
 
 ## Detection strategy (layered)
 
-1. **Marker file (primary)**: At dispatcher startup the session ID is written to
-   `~/messages/config/dispatcher-session-id`. This hook reads that file and
-   compares to the `session_id` field in the hook JSON input.
-   Match → dispatcher.  Mismatch or file absent → try fallback.
+1. **MCP state file (primary)**: The MCP server writes the current dispatcher
+   session ID to `$LOBSTER_WORKSPACE/data/dispatcher-session-id` (defaulting to
+   `~/lobster-workspace/data/dispatcher-session-id`) whenever
+   `_tag_dispatcher_session()` is called (Options A, B, or C).  The file is
+   cleared when the MCP server starts, so a stale ID from a previous run never
+   lingers.  This hook reads that file and compares to the `session_id` field in
+   the hook JSON input.
+   Match → dispatcher.  Mismatch → subagent.  File absent → try fallback.
 
-2. **Transcript fallback (secondary)**: Scan the transcript for tool_use blocks
-   containing the dispatcher-only tools `wait_for_messages` or `check_inbox`.
-   CC 2.1.76+ passes a file path (`transcript_path` for Stop hooks,
-   `agent_transcript_path` for SubagentStop hooks) rather than an inline
-   `transcript` list. Both file-based and inline forms are tried in order.
-   Found → dispatcher.  Not found → subagent.
+2. **Hook marker file (secondary)**: At dispatcher startup the SessionStart hook
+   (`write-dispatcher-session-id.py`) writes the session ID to
+   `~/messages/config/dispatcher-session-id`.  Used as fallback when the MCP
+   state file is absent (e.g. before the first `_tag_dispatcher_session` call
+   after a server restart, or if LOBSTER_WORKSPACE points to a non-standard
+   location).
+   Match → dispatcher.  Mismatch → subagent.  File absent → default.
 
-3. **Default**: If neither signal is available (e.g. a PreToolUse hook with no
-   marker file), return False (treat as subagent = safe/conservative).
+3. **Default**: If neither state file is readable or present, return False
+   (treat as subagent = safe/conservative).
+
+The transcript-scanning fallback that existed in previous versions has been
+removed.  It was fragile (CC JSONL format changes, same-week compaction bug
+tracked in PR #1076) and is now superseded by the MCP state file, which is
+always authoritative when the MCP server is running.
 
 ## Writing the marker file
 
 Call `write_dispatcher_session_id(session_id)` at dispatcher startup.
-Typically invoked from a `SessionStart` hook or from the dispatcher bootup
-script via a small wrapper.
+Typically invoked from the `write-dispatcher-session-id.py` SessionStart hook.
+The MCP server also calls `_write_dispatcher_state_file()` internally; hooks
+do not need to call that path directly.
 """
 
-import json
 import os
 from pathlib import Path
 
+# Secondary: hook marker file (written by write-dispatcher-session-id.py SessionStart hook)
+# Resolved at import time — stable across calls.
 DISPATCHER_SESSION_FILE = Path(
     os.path.expanduser("~/messages/config/dispatcher-session-id")
 )
 
-# Tools that only the dispatcher calls — used as transcript fallback signal.
+# Tools that only the dispatcher calls — kept for reference / external callers.
+# No longer used internally for dispatcher detection (transcript scan removed).
 DISPATCHER_ONLY_TOOLS = {
     "mcp__lobster-inbox__wait_for_messages",
     "mcp__lobster-inbox__check_inbox",
 }
+
+
+def _get_mcp_session_state_file() -> Path:
+    """Return the MCP server state file path, resolved at call time.
+
+    Reads LOBSTER_WORKSPACE on every call so tests can override the env var
+    without having to patch a module-level constant.
+    """
+    workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+    return workspace / "data" / "dispatcher-session-id"
+
+
+# Module-level alias for test patching convenience — tests that set LOBSTER_WORKSPACE
+# can also patch this directly.  Updated lazily if needed.
+MCP_SESSION_STATE_FILE = _get_mcp_session_state_file()
 
 
 # ---------------------------------------------------------------------------
@@ -58,38 +86,32 @@ def get_session_id(hook_input: dict) -> str | None:
 def is_dispatcher(hook_input: dict) -> bool:
     """Return True if the current session is the Lobster dispatcher.
 
-    Checks marker file first; falls back to transcript scan if the marker file
-    is absent or unreadable.  Returns False (subagent) when no signal is found.
+    Checks the MCP state file first (written by the running MCP server and
+    cleared on restart), then falls back to the hook marker file.  Returns
+    False when no state file is present or readable.
+
+    Fail-open behavior: if a file exists but cannot be read due to an OS
+    error, returns True (same conservative fail-open as before) so the
+    dispatcher is never incorrectly blocked by a transient I/O error.
     """
     session_id = get_session_id(hook_input)
 
-    # --- Primary: marker file ---
-    marker_result = _check_marker_file(session_id)
-    if marker_result is not None:
-        return marker_result
+    # --- Primary: MCP state file (re-resolved each call to respect env overrides) ---
+    primary_result = _check_state_file(_get_mcp_session_state_file(), session_id)
+    if primary_result is not None:
+        return primary_result
 
-    # --- Secondary: transcript scan ---
-    # Try inline transcript first (legacy CC < 2.1.76).
-    transcript = hook_input.get("transcript")
-    if transcript is not None:
-        return _transcript_has_dispatcher_tool(transcript)
+    # --- Secondary: hook marker file ---
+    secondary_result = _check_state_file(DISPATCHER_SESSION_FILE, session_id)
+    if secondary_result is not None:
+        return secondary_result
 
-    # Try file-based transcript (CC 2.1.76+):
-    #   Stop hook       → transcript_path
-    #   SubagentStop    → agent_transcript_path
-    for key in ("transcript_path", "agent_transcript_path"):
-        path = hook_input.get(key)
-        if path:
-            transcript = _load_transcript_from_jsonl(path)
-            if transcript:
-                return _transcript_has_dispatcher_tool(transcript)
-
-    # --- Default: no signal → treat as subagent (conservative) ---
+    # --- Default: no state file present → treat as subagent (conservative) ---
     return False
 
 
 def write_dispatcher_session_id(session_id: str) -> None:
-    """Write session_id to the dispatcher marker file.
+    """Write session_id to the hook dispatcher marker file.
 
     Should be called once at dispatcher startup (e.g. from a SessionStart hook
     or a thin wrapper script).  Atomic write via a .tmp rename so concurrent
@@ -111,80 +133,51 @@ def write_dispatcher_session_id(session_id: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _read_dispatcher_session_id() -> str | None:
-    """Return the stored dispatcher session ID, or None on any failure."""
+def _read_session_id_from_file(path: Path) -> "str | None | OSError":
+    """Return the session ID stored in a plain-text state file.
+
+    Returns:
+        str       — the session ID (non-empty string).
+        None      — file absent or empty (no stored ID).
+        OSError   — an I/O error occurred reading the file.
+    """
     try:
-        if not DISPATCHER_SESSION_FILE.exists():
+        if not path.exists():
             return None
-        value = DISPATCHER_SESSION_FILE.read_text().strip()
+        value = path.read_text().strip()
         return value or None
-    except OSError:
-        return None
+    except OSError as exc:
+        return exc
 
 
-def _check_marker_file(session_id: str | None) -> bool | None:
-    """Compare session_id against the marker file.
+def _check_state_file(path: Path, session_id: "str | None") -> "bool | None":
+    """Compare session_id against a plain-text state file.
 
     Returns:
         True   — session_id matches the stored dispatcher ID.
-        False  — marker file exists and session_id does NOT match (→ subagent).
-        None   — marker file absent or unreadable; caller should try fallback.
+        False  — file exists and session_id does NOT match (→ subagent).
+        None   — file absent, empty, or session_id unavailable; caller should
+                 try next fallback.
+
+    Fail-open: if the file exists but reading it raises an OSError (e.g.
+    permissions, concurrent deletion), returns True so the dispatcher is never
+    incorrectly blocked by a transient I/O error.
     """
-    stored = _read_dispatcher_session_id()
+    result = _read_session_id_from_file(path)
+    if isinstance(result, OSError):
+        return True  # fail open — can't read the file, assume dispatcher
+    stored = result
     if stored is None:
-        return None  # No marker file — can't decide; use fallback.
+        return None  # file absent or empty — can't decide; try next fallback
     if session_id is None:
-        return None  # Session ID not in hook input — can't decide; use fallback.
+        return None  # session ID not in hook input — can't decide; try next fallback
     return session_id == stored
 
 
-def _load_transcript_from_jsonl(path: str) -> list:
-    """Load transcript messages from a JSONL file.
-
-    CC 2.1.76+ Stop hooks pass transcript_path (a .jsonl file) rather than an
-    inline transcript list. Each line is a JSON object. Returns [] on any error.
-    """
-    try:
-        messages = []
-        with open(path) as fh:
-            for line in fh:
-                line = line.strip()
-                if line:
-                    try:
-                        messages.append(json.loads(line))
-                    except json.JSONDecodeError:
-                        pass
-        return messages
-    except Exception:
-        return []
-
-
-def _transcript_has_dispatcher_tool(transcript: list) -> bool:
-    """Return True if any tool_use block in transcript calls a dispatcher-only tool.
-
-    Handles both JSONL format (CC 2.1.76+) and legacy inline format:
-
-    JSONL format (each line is a JSONL entry):
-        {"type": "assistant", "message": {"role": "assistant", "content": [...]}, ...}
-
-    Legacy inline format (transcript is a list of messages):
-        {"role": "assistant", "content": [...]}
-    """
-    for msg in transcript:
-        if not isinstance(msg, dict):
-            continue
-        # JSONL format: content is under msg["message"]["content"]
-        # Legacy format: content is directly under msg["content"]
-        nested_msg = msg.get("message")
-        if isinstance(nested_msg, dict):
-            content = nested_msg.get("content", [])
-        else:
-            content = msg.get("content", [])
-        if not isinstance(content, list):
-            continue
-        for item in content:
-            if not isinstance(item, dict):
-                continue
-            if item.get("type") == "tool_use" and item.get("name") in DISPATCHER_ONLY_TOOLS:
-                return True
-    return False
+# Keep for backwards-compat: callers that imported _read_dispatcher_session_id directly.
+def _read_dispatcher_session_id() -> "str | None":
+    """Return the stored dispatcher session ID from the hook marker file, or None."""
+    result = _read_session_id_from_file(DISPATCHER_SESSION_FILE)
+    if isinstance(result, OSError):
+        return None
+    return result

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -787,6 +787,40 @@ _SERVER_START_TIME = datetime.now(timezone.utc)
 _dispatcher_session_id: str | None = None
 _http_session_manager = None  # Set to StreamableHTTPSessionManager in main() when HTTP mode is active
 
+# State file: the dispatcher session ID persisted to disk so hooks can read it
+# without network calls or JSONL parsing.  Written atomically by
+# _tag_dispatcher_session(); cleared at server startup.
+_DISPATCHER_SESSION_STATE_FILE = _WORKSPACE / "data" / "dispatcher-session-id"
+
+
+def _write_dispatcher_state_file(session_id: str) -> None:
+    """Atomically write session_id to the dispatcher state file.
+
+    Uses a temp-file + os.rename() for atomicity so concurrent readers never
+    see a partial write.  Silent on any failure — must never crash the caller.
+    """
+    try:
+        _DISPATCHER_SESSION_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _DISPATCHER_SESSION_STATE_FILE.with_suffix(".tmp")
+        tmp.write_text(session_id.strip())
+        tmp.replace(_DISPATCHER_SESSION_STATE_FILE)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _clear_dispatcher_state_file() -> None:
+    """Remove the dispatcher state file on server startup.
+
+    Prevents a stale session ID from a previous run from being mistaken for
+    the current dispatcher session.  Silent on any failure.
+    """
+    try:
+        if _DISPATCHER_SESSION_STATE_FILE.exists():
+            _DISPATCHER_SESSION_STATE_FILE.unlink()
+            log.info("[session-tag] Cleared stale dispatcher-session-id state file on startup")
+    except Exception:  # noqa: BLE001
+        pass
+
 
 def _get_current_http_session_id() -> str | None:
     """Return the MCP session ID for the current tool call request.
@@ -814,14 +848,20 @@ def _get_current_http_session_id() -> str | None:
 def _tag_dispatcher_session(session_id: str) -> None:
     """Record session_id as the privileged dispatcher session.
 
-    Called by Option A (handle_wait_for_messages) and Option B
-    (handle_session_start with agent_type="dispatcher").  Whichever fires
-    first wins; both paths update on reconnect.
+    Called by Option A (handle_wait_for_messages), Option B
+    (handle_session_start with agent_type="dispatcher"), and Option C
+    (auto-tag on first guarded tool call after server restart).  Whichever
+    fires first wins; both paths update on reconnect.
+
+    Also writes the session_id to the dispatcher state file
+    (_DISPATCHER_SESSION_STATE_FILE) so hooks can read the current dispatcher
+    session without network calls or JSONL parsing.
     """
     global _dispatcher_session_id
     if session_id and session_id != _dispatcher_session_id:
         _dispatcher_session_id = session_id
         log.info(f"[session-tag] Dispatcher session tagged: {session_id}")
+        _write_dispatcher_state_file(session_id)
 
 
 def _is_main_http_session() -> bool:
@@ -8121,6 +8161,12 @@ async def main():
     """Run the MCP server."""
     setup_logging()
     _ensure_observation_worker()
+
+    # Clear the dispatcher state file on startup so a stale session ID from a
+    # previous run cannot linger and mislead hooks into thinking the old session
+    # is still active.  The file is re-written by _tag_dispatcher_session() once
+    # the dispatcher identifies itself via Options A, B, or C.
+    _clear_dispatcher_state_file()
 
     # Initialize the event bus singleton with standard listeners.
     # JsonlFileListener writes all events to logs/events.jsonl.

--- a/tests/unit/test_hooks/test_session_role_state_file.py
+++ b/tests/unit/test_hooks/test_session_role_state_file.py
@@ -1,0 +1,311 @@
+"""
+Unit tests for hooks/session_role.py — state-file-based dispatcher detection.
+
+Covers the new two-layer detection strategy introduced to replace JSONL
+transcript scanning:
+
+1. MCP state file (primary):  $LOBSTER_WORKSPACE/data/dispatcher-session-id
+2. Hook marker file (secondary): ~/messages/config/dispatcher-session-id
+3. Default: False (conservative/subagent)
+
+Also covers:
+- Fail-open: OSError on file read → True (dispatcher)
+- _read_session_id_from_file() contract
+- _check_state_file() contract
+- _read_dispatcher_session_id() backwards-compat shim
+- write_dispatcher_session_id() atomic write
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Make hooks/ importable
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+import importlib
+import session_role as _sr_module  # noqa: E402 — path insert must precede
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reload_session_role(monkeypatch, workspace: Path) -> object:
+    """Reload session_role with LOBSTER_WORKSPACE pointing to workspace."""
+    monkeypatch.setenv("LOBSTER_WORKSPACE", str(workspace))
+    # Force reimport so _get_mcp_session_state_file() picks up the new env.
+    import importlib
+    return importlib.reload(_sr_module)
+
+
+def _hook_input(session_id: str) -> dict:
+    return {"session_id": session_id}
+
+
+# ---------------------------------------------------------------------------
+# _read_session_id_from_file
+# ---------------------------------------------------------------------------
+
+
+class TestReadSessionIdFromFile:
+    def test_absent_file_returns_none(self, tmp_path):
+        path = tmp_path / "no-such-file"
+        result = _sr_module._read_session_id_from_file(path)
+        assert result is None
+
+    def test_empty_file_returns_none(self, tmp_path):
+        path = tmp_path / "empty"
+        path.write_text("")
+        result = _sr_module._read_session_id_from_file(path)
+        assert result is None
+
+    def test_whitespace_only_returns_none(self, tmp_path):
+        path = tmp_path / "whitespace"
+        path.write_text("   \n  ")
+        result = _sr_module._read_session_id_from_file(path)
+        assert result is None
+
+    def test_valid_session_id_returned(self, tmp_path):
+        path = tmp_path / "session-id"
+        path.write_text("abc-123-def")
+        result = _sr_module._read_session_id_from_file(path)
+        assert result == "abc-123-def"
+
+    def test_strips_trailing_newline(self, tmp_path):
+        path = tmp_path / "session-id"
+        path.write_text("abc-123\n")
+        result = _sr_module._read_session_id_from_file(path)
+        assert result == "abc-123"
+
+    def test_os_error_returns_exception(self, tmp_path):
+        path = tmp_path / "unreadable"
+        path.write_text("something")
+        path.chmod(0o000)
+        try:
+            result = _sr_module._read_session_id_from_file(path)
+            assert isinstance(result, OSError)
+        finally:
+            path.chmod(0o644)
+
+
+# ---------------------------------------------------------------------------
+# _check_state_file
+# ---------------------------------------------------------------------------
+
+
+class TestCheckStateFile:
+    def test_absent_file_returns_none(self, tmp_path):
+        path = tmp_path / "no-such-file"
+        result = _sr_module._check_state_file(path, "any-session")
+        assert result is None
+
+    def test_file_match_returns_true(self, tmp_path):
+        path = tmp_path / "state"
+        path.write_text("sess-001")
+        result = _sr_module._check_state_file(path, "sess-001")
+        assert result is True
+
+    def test_file_mismatch_returns_false(self, tmp_path):
+        path = tmp_path / "state"
+        path.write_text("dispatcher-sess")
+        result = _sr_module._check_state_file(path, "subagent-sess")
+        assert result is False
+
+    def test_none_session_id_returns_none(self, tmp_path):
+        path = tmp_path / "state"
+        path.write_text("dispatcher-sess")
+        result = _sr_module._check_state_file(path, None)
+        assert result is None
+
+    def test_os_error_returns_true_fail_open(self, tmp_path):
+        """If the file exists but is unreadable, fail open (return True)."""
+        path = tmp_path / "unreadable"
+        path.write_text("dispatcher-sess")
+        path.chmod(0o000)
+        try:
+            result = _sr_module._check_state_file(path, "any-session")
+            assert result is True
+        finally:
+            path.chmod(0o644)
+
+
+# ---------------------------------------------------------------------------
+# is_dispatcher — MCP state file (primary)
+# ---------------------------------------------------------------------------
+
+
+class TestIsDispatcherMCPStateFile:
+    def test_mcp_file_match_returns_true(self, monkeypatch, tmp_path):
+        """Primary MCP state file matches → dispatcher."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        mcp_dir = tmp_path / "data"
+        mcp_dir.mkdir()
+        (mcp_dir / "dispatcher-session-id").write_text("sess-mcp-001")
+
+        assert sr.is_dispatcher(_hook_input("sess-mcp-001")) is True
+
+    def test_mcp_file_mismatch_returns_false(self, monkeypatch, tmp_path):
+        """Primary MCP state file contains a different session → subagent."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        mcp_dir = tmp_path / "data"
+        mcp_dir.mkdir()
+        (mcp_dir / "dispatcher-session-id").write_text("dispatcher-session")
+
+        assert sr.is_dispatcher(_hook_input("subagent-session")) is False
+
+    def test_mcp_file_absent_falls_through_to_secondary(self, monkeypatch, tmp_path):
+        """Primary absent → falls through to hook marker file."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        # Set HOME so secondary hook marker file resolves under tmp_path.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # Reload to pick up new HOME for DISPATCHER_SESSION_FILE.
+        sr = importlib.reload(sr)
+
+        # Write only the secondary (hook marker) file.
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "dispatcher-session-id").write_text("sess-hook-001")
+
+        assert sr.is_dispatcher(_hook_input("sess-hook-001")) is True
+
+    def test_mcp_file_absent_no_secondary_returns_false(self, monkeypatch, tmp_path):
+        """Both files absent → default False."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(sr)
+
+        assert sr.is_dispatcher(_hook_input("any-session")) is False
+
+
+# ---------------------------------------------------------------------------
+# is_dispatcher — hook marker file (secondary)
+# ---------------------------------------------------------------------------
+
+
+class TestIsDispatcherHookMarkerFile:
+    def test_hook_file_match_when_mcp_absent(self, monkeypatch, tmp_path):
+        """Secondary hook marker file used when primary MCP file is absent."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(sr)
+
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "dispatcher-session-id").write_text("hook-dispatcher-sess")
+
+        assert sr.is_dispatcher(_hook_input("hook-dispatcher-sess")) is True
+
+    def test_hook_file_mismatch_when_mcp_absent(self, monkeypatch, tmp_path):
+        """Hook file present but non-matching → subagent."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(sr)
+
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "dispatcher-session-id").write_text("dispatcher-session")
+
+        assert sr.is_dispatcher(_hook_input("subagent-session")) is False
+
+
+# ---------------------------------------------------------------------------
+# is_dispatcher — default (no files)
+# ---------------------------------------------------------------------------
+
+
+class TestIsDispatcherDefault:
+    def test_no_files_returns_false(self, monkeypatch, tmp_path):
+        """No state files present → default False (conservative)."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(sr)
+
+        assert sr.is_dispatcher(_hook_input("any-session")) is False
+
+    def test_no_session_id_in_hook_input_returns_false(self, monkeypatch, tmp_path):
+        """No session_id in hook input → both file checks return None → False."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(sr)
+
+        # Write both files to ensure it's the missing session_id causing the result.
+        mcp_dir = tmp_path / "data"
+        mcp_dir.mkdir()
+        (mcp_dir / "dispatcher-session-id").write_text("some-dispatcher-sess")
+
+        assert sr.is_dispatcher({}) is False  # no session_id key
+
+
+# ---------------------------------------------------------------------------
+# write_dispatcher_session_id
+# ---------------------------------------------------------------------------
+
+
+class TestWriteDispatcherSessionId:
+    def test_writes_to_hook_marker_file(self, monkeypatch, tmp_path):
+        """write_dispatcher_session_id writes the hook marker file."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(_sr_module)
+
+        sr.write_dispatcher_session_id("my-session-001")
+
+        written = sr.DISPATCHER_SESSION_FILE.read_text().strip()
+        assert written == "my-session-001"
+
+    def test_strips_whitespace_on_write(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(_sr_module)
+
+        sr.write_dispatcher_session_id("  sess-with-spaces  ")
+
+        written = sr.DISPATCHER_SESSION_FILE.read_text().strip()
+        assert written == "sess-with-spaces"
+
+    def test_silent_on_write_failure(self, monkeypatch, tmp_path):
+        """Errors during write are silently swallowed."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(_sr_module)
+
+        # Point to an unwritable directory.
+        unwritable = tmp_path / "readonly"
+        unwritable.mkdir()
+        unwritable.chmod(0o555)
+        try:
+            monkeypatch.setattr(sr, "DISPATCHER_SESSION_FILE",
+                                unwritable / "dispatcher-session-id")
+            # Should not raise.
+            sr.write_dispatcher_session_id("sess-x")
+        finally:
+            unwritable.chmod(0o755)
+
+
+# ---------------------------------------------------------------------------
+# _read_dispatcher_session_id (backwards-compat shim)
+# ---------------------------------------------------------------------------
+
+
+class TestReadDispatcherSessionIdShim:
+    def test_returns_none_when_file_absent(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(_sr_module)
+        assert sr._read_dispatcher_session_id() is None
+
+    def test_returns_session_id_when_file_present(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(_sr_module)
+
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "dispatcher-session-id").write_text("stored-sess-001")
+
+        # Reload again to pick up new DISPATCHER_SESSION_FILE path.
+        sr = importlib.reload(sr)
+        assert sr._read_dispatcher_session_id() == "stored-sess-001"


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What problem this solves

Hook-based dispatcher detection (`session_role.is_dispatcher()`) used JSONL transcript scanning as its fallback signal. This approach is fragile: the CC transcript format changes over time, and the same-week compaction bug (#1076, #1009) caused the detector to misclassify a new dispatcher session as a subagent when the old session's JSONL file still existed on disk. The result was `on-compact.py` skipping the compact-reminder, leaving the dispatcher without situational awareness after compaction.

The MCP server already has authoritative knowledge of which session is the dispatcher — it tracks `_dispatcher_session_id` in memory (set by Options A, B, and C including the Option C auto-tag from PR #1091). This PR makes that state available to hooks via a plain text file, removing any need to scan JSONL transcripts.

## What changed

**`src/mcp/inbox_server.py`**

- Added `_DISPATCHER_SESSION_STATE_FILE` (`$LOBSTER_WORKSPACE/data/dispatcher-session-id`).
- Added `_write_dispatcher_state_file(session_id)`: atomically writes the session ID via temp-file + `os.rename()`. Silent on failure.
- Added `_clear_dispatcher_state_file()`: removes the file on server startup so a stale ID from a previous run never lingers.
- `_tag_dispatcher_session()` now calls `_write_dispatcher_state_file()` after tagging in memory. This covers all three tagging paths (Options A, B, C).
- `main()` calls `_clear_dispatcher_state_file()` before the event bus and reconciler start.

**`hooks/session_role.py`**

- Detection in `is_dispatcher()` now has two layers:
  1. **Primary**: MCP state file (`$LOBSTER_WORKSPACE/data/dispatcher-session-id`) — written by the running server, cleared on restart.
  2. **Secondary**: hook marker file (`~/messages/config/dispatcher-session-id`) — written by the `write-dispatcher-session-id.py` SessionStart hook; used as fallback when the MCP file is absent (e.g. during the brief startup window before Option A/B/C fires).
- The transcript-scanning fallback (JSONL parsing) has been removed entirely.
- `MCP_SESSION_STATE_FILE` is resolved dynamically via `_get_mcp_session_state_file()` so tests can override `LOBSTER_WORKSPACE` without patching a module-level constant.
- `_read_dispatcher_session_id()` and `DISPATCHER_SESSION_FILE` are preserved for backwards compatibility.
- Fail-open behavior retained: `OSError` on file read → `True` (assume dispatcher).

**`tests/unit/test_hooks/test_session_role_state_file.py`** (new)

24 new unit tests covering:
- `_read_session_id_from_file()`: absent, empty, whitespace, valid, OSError
- `_check_state_file()`: match, mismatch, absent, None session_id, OSError fail-open
- `is_dispatcher()`: MCP file match/mismatch, fallthrough to secondary, both absent → False, no session_id → False
- `write_dispatcher_session_id()`: writes, strips whitespace, silent on failure
- `_read_dispatcher_session_id()` shim: absent → None, present → session ID

## Before / after flow

```
Before (session_role.is_dispatcher):
  hook input → check ~/messages/config/dispatcher-session-id
                 ├── match → True
                 ├── mismatch → False
                 └── absent → scan JSONL transcript  ← fragile, compaction bug
                               ├── found dispatcher tool → True
                               └── not found → False

After (session_role.is_dispatcher):
  hook input → check $LOBSTER_WORKSPACE/data/dispatcher-session-id (MCP state file)
                 ├── match → True
                 ├── mismatch → False
                 └── absent → check ~/messages/config/dispatcher-session-id (hook marker)
                               ├── match → True
                               ├── mismatch → False
                               └── absent → False
```

The MCP state file is cleared on every server startup (new) and written atomically by every `_tag_dispatcher_session()` call (new), so it always reflects the current dispatcher or is absent.

## What is out of scope

- `write-dispatcher-session-id.py` is unchanged. Its JSONL-based `_stored_session_is_alive()` still runs to decide whether to write the hook marker file, but is no longer load-bearing for `is_dispatcher()` itself.
- PR #1076 is superseded. See close comment on that PR.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_session_role_state_file.py -v` — 24 passed, 0 failed
- [x] `uv run pytest tests/unit/test_hooks/ -v` — 166 passed, 1 pre-existing failure (`test_insert_or_ignore_preserves_existing_row`, unrelated missing `exist_ok=True`)
- [ ] Live dispatcher restart test — blocked: requires production restart; no change to existing hook marker path

Closes #1009