### PR TITLE
Fix: Health alert loop — state machine gaps, websockets dep, alert dedup (#40)

### DIFF
--- a/scripts/claude-persistent.sh
+++ b/scripts/claude-persistent.sh
@@ -382,10 +382,13 @@ launch_claude() {
     local claude_exit_code=0
     log "Starting fresh session (attempt $attempt)..."
 
-    # Transition to active BEFORE the blocking claude call.
-    # The "starting" state above covers env cleanup and preflight.
-    # Once we hand off to claude, we're active.
-    write_state "active" "claude running, attempt=$attempt"
+    # Schedule a delayed "active" write ~5 seconds after launch so the health
+    # check sees a live signal once the MCP server has had time to initialise.
+    # This runs in the background so it does not block the claude process launch.
+    # The MCP server's _reset_state_on_startup() and handle_wait_for_messages()
+    # will also write "active" once Claude is truly running, but this belt-and-
+    # suspenders write ensures the state transitions even if those paths are slow.
+    ( sleep 5 && write_state "active" "claude running, attempt=$attempt" ) &
 
     # Write the dispatcher PID file so the health check can target this specific
     # process for cleanup without relying on ambiguous pgrep matches.
@@ -547,7 +550,6 @@ Claude persistent session initializing."
         fi
 
         # Launch Claude
-        write_state "active" "starting claude"
         launch_claude "$attempt"
         local exit_code=$?
 

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -101,6 +101,9 @@ MAX_RESTART_ATTEMPTS=3
 RESTART_COOLDOWN_SECONDS=600         # 10 min window for counting attempts
 RESTART_STATE_FILE="$WORKSPACE_DIR/logs/health-restart-state-v3"
 
+ALERT_DEDUP_COOLDOWN_SECONDS=900     # 15 minutes between alerts for the same issue type
+ALERT_DEDUP_DIR="$WORKSPACE_DIR/logs/health-alert-dedup"
+
 MEMORY_THRESHOLD=90                  # percentage
 DISK_THRESHOLD=95                    # percentage
 
@@ -135,6 +138,7 @@ LOBSTER_ENV="${LOBSTER_ENV:-production}"
 # Ensure log directory exists
 mkdir -p "$(dirname "$LOG_FILE")"
 mkdir -p "$(dirname "$RESTART_STATE_FILE")"
+mkdir -p "$ALERT_DEDUP_DIR"
 
 # Lifecycle gate: skip monitoring and restart loop in non-production environments.
 # Resource checks (disk/memory/auth) do not run either — the service is intentionally
@@ -202,6 +206,46 @@ send_telegram_alert() {
     else
         log_error "Telegram alert failed (curl exit $rc)"
     fi
+}
+
+# send_telegram_alert_deduped — like send_telegram_alert but suppresses repeat
+# alerts for the same issue_key within ALERT_DEDUP_COOLDOWN_SECONDS.
+#
+# Usage:
+#   send_telegram_alert_deduped "issue_key" "message text"
+#
+# The issue_key is a short stable identifier for the problem category
+# (e.g. "stale-inbox", "wrapper-missing", "auth-expired").  Alerts with the
+# same key are suppressed if a previous alert with that key was sent within
+# ALERT_DEDUP_COOLDOWN_SECONDS.  This prevents a restart storm from flooding
+# Telegram with dozens of identical alerts every 4 minutes.
+#
+# BLACK-state alerts and post-restart recovery confirmations should use the
+# raw send_telegram_alert() to guarantee delivery regardless of cooldown.
+send_telegram_alert_deduped() {
+    local issue_key="$1"
+    local message="$2"
+    local now
+    now=$(date +%s)
+
+    # Sanitize the key to a safe filename (alphanumeric + hyphen)
+    local safe_key
+    safe_key=$(echo "$issue_key" | tr -cs 'a-zA-Z0-9-' '-' | sed 's/-\+/-/g; s/^-//; s/-$//')
+    local stamp_file="$ALERT_DEDUP_DIR/${safe_key}"
+
+    if [[ -f "$stamp_file" ]]; then
+        local last_sent
+        last_sent=$(cat "$stamp_file" 2>/dev/null || echo 0)
+        local age=$(( now - last_sent ))
+        if [[ $age -lt $ALERT_DEDUP_COOLDOWN_SECONDS ]]; then
+            log_info "Alert dedup: suppressing '$issue_key' alert (sent ${age}s ago, cooldown ${ALERT_DEDUP_COOLDOWN_SECONDS}s)"
+            return 0
+        fi
+    fi
+
+    # Record send time before the curl call to avoid double-sends on retry
+    echo "$now" > "$stamp_file"
+    send_telegram_alert "$message"
 }
 
 #===============================================================================
@@ -1183,7 +1227,7 @@ do_restart() {
     if [[ "$active_subagents" -gt 0 ]]; then
         log_warn "SUBAGENT GUARD: Skipping restart ($active_subagents active subagent(s) running) — will re-evaluate next check"
         if [[ "$suppress_alert" != "true" ]]; then
-            send_telegram_alert "Health check deferred restart: $active_subagents active subagent(s) in flight.
+            send_telegram_alert_deduped "subagent-guard" "Health check deferred restart: $active_subagents active subagent(s) in flight.
 
 Reason that triggered restart: $reason
 
@@ -1300,7 +1344,7 @@ Manual intervention required:
     # dispatchers running simultaneously.
     if [[ -n "$pre_restart_pid" ]] && kill -0 "$pre_restart_pid" 2>/dev/null; then
         log_error "ABORT: Could not kill pre-restart Claude PID $pre_restart_pid — refusing to start new session to prevent duplicate dispatcher"
-        send_telegram_alert "Restart aborted — could not kill existing Claude process (PID $pre_restart_pid).
+        send_telegram_alert_deduped "restart-aborted-pid" "Restart aborted — could not kill existing Claude process (PID $pre_restart_pid).
 
 Reason: $reason
 
@@ -1399,7 +1443,7 @@ Manual intervention required to kill the process before restarting:
             local post_rc=$?
             if [[ $post_rc -eq 2 ]]; then
                 log_warn "Post-restart: inbox still has NEW stale messages (not same as pre-restart)"
-                send_telegram_alert "System restarted but inbox still has stale messages.
+                send_telegram_alert_deduped "post-restart-stale-inbox" "System restarted but inbox still has stale messages.
 
 Reason: $reason
 Status: Restarted, but new stale messages detected post-restart"
@@ -1410,6 +1454,7 @@ Status: Restarted, but new stale messages detected post-restart"
         log_info "Restart successful"
         write_boot_timestamp
         if [[ "$suppress_alert" != "true" ]]; then
+            # "Recovered" alert: use raw send (important positive signal, not spammy)
             send_telegram_alert "System recovered automatically.
 
 Reason: $reason
@@ -1423,7 +1468,7 @@ Status: Restarted successfully"
         if [[ "$pid_changed" == false ]]; then
             # PID did not change: the old process survived the restart attempt.
             log_error "Restart failed: Claude PID $pre_restart_pid unchanged after 3 checks — old session survived"
-            send_telegram_alert "Restart failed — process still running under original PID $pre_restart_pid.
+            send_telegram_alert_deduped "restart-failed-pid" "Restart failed — process still running under original PID $pre_restart_pid.
 
 Reason: $reason
 Manual intervention may be required: \`lobster restart\`"
@@ -1438,7 +1483,7 @@ Manual intervention may be required: \`lobster restart\`"
                 not_ready_detail="tmux session missing (service is active)"
             fi
             log_warn "Restart confirmed (PID changed) but service/tmux not ready after ${svc_timeout_s}s: $not_ready_detail"
-            send_telegram_alert "Restart confirmed (PID changed) — service/tmux not yet ready after ${svc_timeout_s}s.
+            send_telegram_alert_deduped "restart-not-ready" "Restart confirmed (PID changed) — service/tmux not yet ready after ${svc_timeout_s}s.
 
 Reason: $reason
 Detail: $not_ready_detail

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -28,8 +28,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
-import websockets
-from websockets.asyncio.server import serve
+try:
+    import websockets
+    from websockets.asyncio.server import serve
+    WEBSOCKETS_AVAILABLE = True
+except ImportError:
+    websockets = None  # type: ignore[assignment]
+    serve = None  # type: ignore[assignment]
+    WEBSOCKETS_AVAILABLE = False
 
 from collectors import collect_full_snapshot
 
@@ -231,6 +237,15 @@ class DashboardServer:
 
 
 def main() -> None:
+    if not WEBSOCKETS_AVAILABLE:
+        print(
+            "ERROR: 'websockets' package is not installed. "
+            "Install it with: pip install websockets>=13.0\n"
+            "The dashboard server cannot start without this dependency.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     parser = argparse.ArgumentParser(description="Lobster Dashboard WebSocket Server")
     parser.add_argument("--host", default="0.0.0.0", help="Bind address (default: 0.0.0.0)")
     parser.add_argument("--port", type=int, default=9100, help="Port (default: 9100)")

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -3086,6 +3086,12 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
     # Touch heartbeat at start - signals Claude is alive and waiting for messages
     touch_heartbeat()
 
+    # Write "active" state so the health check always sees a live signal when
+    # wait_for_messages is called.  This is the authoritative steady-state write:
+    # even if claude-persistent.sh left the state in "starting" or another
+    # transient mode, calling wait_for_messages means Claude is up and running.
+    _write_lobster_state(LOBSTER_STATE_FILE, "active")
+
     # Recover stale processing and retryable failed messages
     _recover_stale_processing()
     _recover_retryable_messages()


### PR DESCRIPTION
## Summary

Implements P2–P5 from [SiderealPress/shadowlobster#40](https://github.com/SiderealPress/shadowlobster/issues/40) — the persistent health alert loop caused by state machine gaps and missing websockets dependency.

- **P1** (`_reset_state_on_startup`): Already correctly implemented — `_TRANSIENT_MODES = {"hibernate", "starting", "restarting", "waking"}` covers all cases. Confirmed no change needed.
- **P2** (`handle_wait_for_messages` active write): Add `_write_lobster_state(LOBSTER_STATE_FILE, "active")` at the top of `handle_wait_for_messages()` so the health check sees a live signal on every call to the main loop, regardless of what state the wrapper left behind.
- **P3** (state sequencing in `claude-persistent.sh`): Remove the dead `write_state "active"` in `main()` that was immediately overridden by `launch_claude()`. Replace the synchronous pre-blocking write in `launch_claude()` with a background delayed write (`sleep 5 && write_state "active"`) so the state transitions ~5s after launch once the MCP server has had time to initialize.
- **P4** (dashboard websockets): Make the `websockets` import in `src/dashboard/server.py` conditional (`try/except ImportError`) with `WEBSOCKETS_AVAILABLE` flag. Add a clear error and `sys.exit(1)` in `main()` if the package is absent. Package is already in `pyproject.toml` but the unconditional import was causing crash-loops when missing from the venv.
- **P5** (alert deduplication): Add `send_telegram_alert_deduped(issue_key, message)` to `health-check-v3.sh` with a 15-minute cooldown per issue type using timestamp files in `$WORKSPACE_DIR/logs/health-alert-dedup/`. Applied to repetitive storm alerts (subagent-guard, restart-aborted-pid, post-restart-stale-inbox, restart-failed-pid, restart-not-ready). BLACK-state escalation and recovery-confirmed alerts remain uncooldown'd.

## Test plan

- [ ] Start Lobster fresh; confirm state file transitions from `starting` → `active` within ~5–10s of Claude launching
- [ ] Trigger a hibernate cycle; confirm state resets to `active` when Claude restarts and calls `wait_for_messages`
- [ ] Remove `websockets` from venv, restart dashboard; confirm it exits with a clear error message instead of a crash-loop
- [ ] Simulate a restart storm (manual `do_restart` calls); confirm alert dedup stamps are created in `$WORKSPACE_DIR/logs/health-alert-dedup/` and repeated alerts are suppressed for 15 minutes
- [ ] Confirm BLACK-state alert still fires immediately (no dedup) when max restarts are exceeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)