### PR TITLE
feat(obsidian-km): add CouchDB health check monitoring [BIS-235]

### DIFF
--- a/lobster-shop/obsidian-km/README.md
+++ b/lobster-shop/obsidian-km/README.md
@@ -1,0 +1,54 @@
+# Obsidian KM Skill
+
+Knowledge management integration using CouchDB for Lobster.
+
+## Components
+
+### CouchDB Health Check (BIS-235)
+
+Monitors CouchDB service health and alerts via Telegram when unhealthy.
+
+**Files:**
+- `scripts/health-check.sh` - Health check script
+- `services/couchdb-health.service` - systemd oneshot service
+- `services/couchdb-health.timer` - systemd timer (runs every 2 minutes)
+
+**Checks performed:**
+1. CouchDB systemd service is running
+2. Port 5984 is responding
+3. Authentication is working
+
+**Installation:**
+```bash
+bash ~/lobster/lobster-shop/obsidian-km/install.sh
+```
+
+**Prerequisites:**
+- CouchDB running as user service (`couchdb.service`)
+- Config file at `~/lobster-config/obsidian.env` with:
+  ```
+  COUCHDB_USER=admin
+  COUCHDB_PASSWORD=your-secure-password
+  ```
+
+**Logs:**
+- Health check log: `~/lobster-workspace/logs/couchdb-health.log`
+- Alerts log: `~/lobster-workspace/logs/alerts.log`
+
+**Commands:**
+```bash
+# View timer status
+systemctl --user status couchdb-health.timer
+
+# View service logs
+journalctl --user -u couchdb-health.service -f
+
+# Run health check manually
+~/lobster/lobster-shop/obsidian-km/scripts/health-check.sh
+```
+
+## Related Issues
+
+- BIS-228: Obsidian KM Skill (epic)
+- BIS-230: CouchDB installation
+- BIS-235: CouchDB health monitoring (this component)

--- a/lobster-shop/obsidian-km/install.sh
+++ b/lobster-shop/obsidian-km/install.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+#===============================================================================
+# Obsidian KM Skill Installer - CouchDB Health Check Component
+#
+# Installs the CouchDB health check monitoring for the Obsidian KM skill.
+# This sets up:
+#   1. Health check script in ~/lobster/lobster-shop/obsidian-km/scripts/
+#   2. systemd user service and timer for periodic health checks
+#   3. Telegram alerting when CouchDB is unhealthy
+#
+# Prerequisites:
+#   - CouchDB running as a user service (couchdb.service)
+#   - obsidian.env configured with COUCHDB_USER and COUCHDB_PASSWORD
+#
+# Idempotent — safe to re-run for updates.
+#
+# Usage: bash ~/lobster/lobster-shop/obsidian-km/install.sh
+#===============================================================================
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
+success() { echo -e "${GREEN}[OK]${NC} $1"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error()   { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+step()    { echo -e "\n${CYAN}${BOLD}--- $1${NC}"; }
+
+# ---------------------------------------------------------------------------
+# Paths and defaults
+# ---------------------------------------------------------------------------
+LOBSTER_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
+LOBSTER_CONFIG="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+LOBSTER_WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+
+SKILL_DIR="$LOBSTER_DIR/lobster-shop/obsidian-km"
+SCRIPT_SRC="$SKILL_DIR/scripts/health-check.sh"
+SERVICE_SRC="$SKILL_DIR/services/couchdb-health.service"
+TIMER_SRC="$SKILL_DIR/services/couchdb-health.timer"
+SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
+
+OBSIDIAN_ENV="$LOBSTER_CONFIG/obsidian.env"
+
+echo ""
+echo -e "${BOLD}Obsidian KM Skill - CouchDB Health Check Installer${NC}"
+echo "======================================================"
+echo ""
+echo "  Health check script: $SCRIPT_SRC"
+echo "  Timer interval:      every 2 minutes"
+echo "  Config file:         $OBSIDIAN_ENV"
+echo ""
+
+#===============================================================================
+# Step 1: Check prerequisites
+#===============================================================================
+step "Checking prerequisites"
+
+# Check curl
+if ! command -v curl &>/dev/null; then
+    error "curl is required. Install: sudo apt install curl"
+fi
+success "curl available"
+
+# Check systemctl (user mode)
+if ! systemctl --user status >/dev/null 2>&1; then
+    warn "systemd user mode may not be available. Timer installation may fail."
+else
+    success "systemd user mode available"
+fi
+
+# Check for obsidian.env
+if [[ ! -f "$OBSIDIAN_ENV" ]]; then
+    warn "Config file not found: $OBSIDIAN_ENV"
+    warn "You'll need to create it with COUCHDB_USER and COUCHDB_PASSWORD before health checks work."
+    echo ""
+    echo "  Example:"
+    echo "    cat > $OBSIDIAN_ENV << 'EOF'"
+    echo "    COUCHDB_USER=admin"
+    echo "    COUCHDB_PASSWORD=your-secure-password"
+    echo "    EOF"
+    echo ""
+else
+    # Verify credentials are set
+    if grep -q '^COUCHDB_USER=' "$OBSIDIAN_ENV" && grep -q '^COUCHDB_PASSWORD=' "$OBSIDIAN_ENV"; then
+        success "CouchDB credentials configured in $OBSIDIAN_ENV"
+    else
+        warn "COUCHDB_USER and/or COUCHDB_PASSWORD not set in $OBSIDIAN_ENV"
+    fi
+fi
+
+# Check for CouchDB service (optional - might be installed later)
+if systemctl --user is-active --quiet couchdb 2>/dev/null; then
+    success "CouchDB service is running"
+elif systemctl --user list-unit-files couchdb.service >/dev/null 2>&1; then
+    warn "CouchDB service exists but is not running"
+else
+    warn "CouchDB service not found — health check will fail until CouchDB is installed"
+fi
+
+#===============================================================================
+# Step 2: Make scripts executable
+#===============================================================================
+step "Setting up scripts"
+
+if [[ ! -f "$SCRIPT_SRC" ]]; then
+    error "Health check script not found: $SCRIPT_SRC"
+fi
+
+chmod +x "$SCRIPT_SRC"
+success "Made $SCRIPT_SRC executable"
+
+#===============================================================================
+# Step 3: Install systemd service and timer
+#===============================================================================
+step "Installing systemd user service and timer"
+
+mkdir -p "$SYSTEMD_USER_DIR"
+
+# Copy service file
+if [[ ! -f "$SERVICE_SRC" ]]; then
+    error "Service file not found: $SERVICE_SRC"
+fi
+cp "$SERVICE_SRC" "$SYSTEMD_USER_DIR/couchdb-health.service"
+success "Installed couchdb-health.service"
+
+# Copy timer file
+if [[ ! -f "$TIMER_SRC" ]]; then
+    error "Timer file not found: $TIMER_SRC"
+fi
+cp "$TIMER_SRC" "$SYSTEMD_USER_DIR/couchdb-health.timer"
+success "Installed couchdb-health.timer"
+
+# Reload systemd
+systemctl --user daemon-reload
+success "systemd daemon reloaded"
+
+#===============================================================================
+# Step 4: Enable and start the timer
+#===============================================================================
+step "Enabling and starting health check timer"
+
+systemctl --user enable couchdb-health.timer 2>/dev/null
+success "Timer enabled"
+
+# Stop if running, then start fresh
+systemctl --user stop couchdb-health.timer 2>/dev/null || true
+systemctl --user start couchdb-health.timer
+success "Timer started"
+
+# Show timer status
+info "Timer status:"
+systemctl --user list-timers couchdb-health.timer --no-pager 2>/dev/null || true
+
+#===============================================================================
+# Step 5: Run initial health check
+#===============================================================================
+step "Running initial health check"
+
+if "$SCRIPT_SRC"; then
+    success "CouchDB health check passed"
+else
+    exit_code=$?
+    warn "Initial health check returned exit code $exit_code"
+    warn "This is expected if CouchDB is not yet running or configured."
+fi
+
+#===============================================================================
+# Done
+#===============================================================================
+echo ""
+echo -e "${GREEN}${BOLD}CouchDB Health Check installed!${NC}"
+echo ""
+echo "  Health check runs:   every 2 minutes"
+echo "  Logs:                $LOBSTER_WORKSPACE/logs/couchdb-health.log"
+echo "  Alerts log:          $LOBSTER_WORKSPACE/logs/alerts.log"
+echo ""
+echo "  Commands:"
+echo "    View timer:        systemctl --user status couchdb-health.timer"
+echo "    View logs:         journalctl --user -u couchdb-health.service -f"
+echo "    Run manually:      $SCRIPT_SRC"
+echo ""
+echo "  To update later, just re-run this script:"
+echo "    bash $SKILL_DIR/install.sh"
+echo ""

--- a/lobster-shop/obsidian-km/scripts/health-check.sh
+++ b/lobster-shop/obsidian-km/scripts/health-check.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+#===============================================================================
+# CouchDB Health Check for Obsidian KM Skill
+#
+# Verifies:
+#   1. CouchDB systemd service is running
+#   2. Port 5984 is responding
+#   3. HTTP auth is working
+#
+# Exit codes:
+#   0 - CouchDB is healthy
+#   1 - Service not running
+#   2 - HTTP check failed
+#   3 - Auth failed
+#
+# Usage: ~/lobster/lobster-shop/obsidian-km/scripts/health-check.sh
+#===============================================================================
+
+set -o pipefail
+
+#===============================================================================
+# Configuration
+#===============================================================================
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+OBSIDIAN_ENV="$CONFIG_DIR/obsidian.env"
+WORKSPACE_DIR="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+LOG_FILE="$WORKSPACE_DIR/logs/couchdb-health.log"
+ALERT_LOG="$WORKSPACE_DIR/logs/alerts.log"
+COUCHDB_HOST="${COUCHDB_HOST:-127.0.0.1}"
+COUCHDB_PORT="${COUCHDB_PORT:-5984}"
+
+# Ensure log directory exists
+mkdir -p "$(dirname "$LOG_FILE")"
+mkdir -p "$(dirname "$ALERT_LOG")"
+
+#===============================================================================
+# Logging
+#===============================================================================
+log() {
+    echo "[$(date -Iseconds)] [$1] $2" >> "$LOG_FILE"
+}
+log_info()  { log "INFO"  "$1"; }
+log_warn()  { log "WARN"  "$1"; }
+log_error() { log "ERROR" "$1"; }
+
+#===============================================================================
+# Alert function - sends to Telegram via Lobster's outbox
+#===============================================================================
+send_alert() {
+    local message="$1"
+    local timestamp=$(date -Iseconds)
+    local outbox_dir="${LOBSTER_MESSAGES:-$HOME/messages}/outbox"
+
+    # Log alert
+    echo "[$timestamp] ALERT: $message" >> "$ALERT_LOG"
+    log_error "ALERT: $message"
+
+    # Load admin chat ID from config
+    local admin_chat_id=""
+    if [[ -f "$CONFIG_DIR/config.env" ]]; then
+        admin_chat_id=$(grep '^TELEGRAM_ALLOWED_USERS=' "$CONFIG_DIR/config.env" 2>/dev/null | cut -d'=' -f2- | cut -d',' -f1)
+    fi
+
+    # Send via outbox if we have a chat ID
+    if [[ -n "$admin_chat_id" ]]; then
+        mkdir -p "$outbox_dir"
+        local alert_file="$outbox_dir/couchdb_alert_$(date +%s%N).json"
+        cat > "$alert_file" << EOF
+{
+    "chat_id": $admin_chat_id,
+    "text": "CouchDB Health Alert\n\n$message\n\n$(date)",
+    "source": "telegram"
+}
+EOF
+        log_info "Alert sent to Telegram chat $admin_chat_id"
+    fi
+}
+
+#===============================================================================
+# Load credentials
+#===============================================================================
+load_credentials() {
+    if [[ ! -f "$OBSIDIAN_ENV" ]]; then
+        log_error "Config file not found: $OBSIDIAN_ENV"
+        send_alert "CouchDB health check failed: missing config file $OBSIDIAN_ENV"
+        echo "Config file not found: $OBSIDIAN_ENV"
+        exit 1
+    fi
+
+    # shellcheck source=/dev/null
+    source "$OBSIDIAN_ENV"
+
+    if [[ -z "${COUCHDB_USER:-}" || -z "${COUCHDB_PASSWORD:-}" ]]; then
+        log_error "CouchDB credentials not configured in $OBSIDIAN_ENV"
+        send_alert "CouchDB health check failed: credentials not configured"
+        echo "CouchDB credentials not configured"
+        exit 1
+    fi
+}
+
+#===============================================================================
+# Check 1: Is the CouchDB service running?
+#===============================================================================
+check_service() {
+    log_info "Checking CouchDB service status..."
+
+    if ! systemctl --user is-active --quiet couchdb 2>/dev/null; then
+        log_error "CouchDB systemd service is not running"
+        send_alert "CouchDB service is not running. Check: systemctl --user status couchdb"
+        echo "CouchDB service is not running"
+        return 1
+    fi
+
+    log_info "CouchDB service is active"
+    return 0
+}
+
+#===============================================================================
+# Check 2: Is port 5984 responding?
+#===============================================================================
+check_port() {
+    log_info "Checking CouchDB HTTP endpoint..."
+
+    local http_status
+    http_status=$(curl -s -o /dev/null -w "%{http_code}" \
+        --max-time 10 \
+        "http://${COUCHDB_HOST}:${COUCHDB_PORT}/" 2>/dev/null)
+
+    if [[ "$http_status" == "000" ]]; then
+        log_error "CouchDB not responding on port ${COUCHDB_PORT}"
+        send_alert "CouchDB HTTP endpoint not responding on port ${COUCHDB_PORT}"
+        echo "CouchDB HTTP endpoint not responding"
+        return 2
+    fi
+
+    log_info "CouchDB HTTP endpoint responding (status: $http_status)"
+    return 0
+}
+
+#===============================================================================
+# Check 3: Is authentication working?
+#===============================================================================
+check_auth() {
+    log_info "Checking CouchDB authentication..."
+
+    local http_status
+    http_status=$(curl -s -o /dev/null -w "%{http_code}" \
+        --max-time 10 \
+        "http://${COUCHDB_USER}:${COUCHDB_PASSWORD}@${COUCHDB_HOST}:${COUCHDB_PORT}/" 2>/dev/null)
+
+    if [[ "$http_status" != "200" ]]; then
+        log_error "CouchDB auth check failed: status $http_status"
+        send_alert "CouchDB authentication failed (status $http_status). Check credentials in $OBSIDIAN_ENV"
+        echo "CouchDB HTTP check failed: status $http_status"
+        return 3
+    fi
+
+    log_info "CouchDB authentication successful"
+    return 0
+}
+
+#===============================================================================
+# Main
+#===============================================================================
+main() {
+    log_info "Starting CouchDB health check"
+
+    # Load credentials first
+    load_credentials
+
+    # Run checks in order
+    if ! check_service; then
+        exit 1
+    fi
+
+    if ! check_port; then
+        exit 2
+    fi
+
+    if ! check_auth; then
+        exit 3
+    fi
+
+    log_info "CouchDB healthy"
+    echo "CouchDB healthy"
+    exit 0
+}
+
+main "$@"

--- a/lobster-shop/obsidian-km/services/couchdb-health.service
+++ b/lobster-shop/obsidian-km/services/couchdb-health.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=CouchDB Health Check for Obsidian KM Skill
+After=couchdb.service
+Wants=couchdb.service
+
+[Service]
+Type=oneshot
+ExecStart=%h/lobster/lobster-shop/obsidian-km/scripts/health-check.sh
+StandardOutput=journal
+StandardError=journal
+
+# Allow failure — the script handles alerting
+SuccessExitStatus=0 1 2 3
+
+[Install]
+WantedBy=default.target

--- a/lobster-shop/obsidian-km/services/couchdb-health.timer
+++ b/lobster-shop/obsidian-km/services/couchdb-health.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run CouchDB health check every 2 minutes
+After=couchdb.service
+
+[Timer]
+OnBootSec=30
+OnUnitActiveSec=2min
+AccuracySec=10
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Adds health check monitoring for the Obsidian KM skill's CouchDB service.

- **Health check script** (`scripts/health-check.sh`) verifies:
  - CouchDB systemd user service is running
  - Port 5984 is responding
  - HTTP authentication with configured credentials works
- **systemd timer** runs health check every 2 minutes
- **Telegram alerts** sent to admin when CouchDB is unhealthy
- **Installer** sets up the timer and service

## Files Added

| File | Description |
|------|-------------|
| `lobster-shop/obsidian-km/scripts/health-check.sh` | Health check script |
| `lobster-shop/obsidian-km/services/couchdb-health.service` | systemd oneshot service |
| `lobster-shop/obsidian-km/services/couchdb-health.timer` | systemd timer (every 2 min) |
| `lobster-shop/obsidian-km/install.sh` | Installer script |
| `lobster-shop/obsidian-km/README.md` | Documentation |

## Prerequisites

- CouchDB running as user service (`couchdb.service`) - from BIS-230
- Config file at `~/lobster-config/obsidian.env` with `COUCHDB_USER` and `COUCHDB_PASSWORD`

## Test Plan

- [ ] Run `install.sh` on a system with CouchDB running
- [ ] Verify timer is active: `systemctl --user status couchdb-health.timer`
- [ ] Verify health check passes: `~/lobster/lobster-shop/obsidian-km/scripts/health-check.sh`
- [ ] Stop CouchDB and verify alert is sent within 3 minutes
- [ ] Check logs at `~/lobster-workspace/logs/couchdb-health.log`

## Related

- Closes BIS-235
- Part of BIS-228 (Obsidian KM Skill epic)
- Depends on BIS-230 (CouchDB installation)

---
Generated with [Claude Code](https://claude.com/claude-code)