### PR TITLE
feat(obsidian-km): note_search MCP tool [BIS-239]

### DIFF
--- a/lobster-shop/INDEX.md
+++ b/lobster-shop/INDEX.md
@@ -11,6 +11,7 @@ Browse available skills for your Lobster assistant. Install any skill with one c
 | [Camofox Browser](./camofox-browser/) | Browse the real web with anti-detection — search Google, Amazon, LinkedIn without getting blocked | Tool | Available |
 | [GCal Links](./gcal-links/) | Google Calendar integration: read/create events via API when authenticated, or fall back to deep links — all via natural language | Behavioral | Available |
 | [Lobster Watcher](./lobster-watcher/) | Real-time observability dashboard — see all running and recent Lobster agent sessions as a live timeline and 3D view | Tool | Available |
+| [Obsidian KM](./obsidian-km/) | Sync and access your Obsidian vault via Telegram — create, read, search, and manage notes from anywhere | Tool | In Dev |
 
 ## Templates
 

--- a/lobster-shop/obsidian-km/README.md
+++ b/lobster-shop/obsidian-km/README.md
@@ -1,0 +1,148 @@
+# Obsidian KM
+
+**Sync and access your Obsidian vault from anywhere via Telegram.**
+
+Take notes, search your knowledge base, and manage your vault without opening the app. Your notes stay in sync between your devices and are always accessible through Lobster.
+
+## What You Can Do
+
+- **"Create a note about my project ideas"** -- Start a new note instantly
+- **"Search my notes for machine learning"** -- Find notes by keyword
+- **"Read my meeting notes from Monday"** -- Retrieve note content
+- **"Append to my daily log: finished the API integration"** -- Add to existing notes
+- **"List my recent notes"** -- See what you've been working on
+
+## How It Works
+
+Obsidian KM uses CouchDB as a sync backend for your Obsidian vault. Notes are stored as standard Markdown files (compatible with Obsidian) and synced to CouchDB for fast search and access. A TLS proxy (Caddy) provides secure access.
+
+```
+Lobster (Claude Code)
+  |
+  |-- MCP: note_create, note_read, note_search, etc.
+  |
+  v
+obsidian_km_mcp_server.py (Python MCP server)
+  |
+  |-- CouchDB queries / file operations
+  |
+  v
+CouchDB <--sync--> Obsidian Vault (~/*.md files)
+```
+
+## Setup
+
+Run the installer:
+
+```bash
+bash ~/lobster/lobster-shop/obsidian-km/install.sh
+```
+
+The installer will:
+
+1. Install and configure CouchDB
+2. Create an Obsidian vault (or use existing)
+3. Set up database views for fast note lookup
+4. Configure Caddy TLS proxy
+5. Install the MCP server
+6. Register health checks
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OBSIDIAN_VAULT_DIR` | `~/obsidian-vault` | Path to your Obsidian vault |
+| `COUCHDB_PORT` | `5984` | CouchDB port |
+| `COUCHDB_ADMIN_USER` | `admin` | CouchDB admin username |
+| `COUCHDB_ADMIN_PASS` | (generated) | CouchDB admin password |
+| `COUCHDB_DB_NAME` | `obsidian_notes` | Database name for notes |
+| `CADDY_HTTPS_PORT` | `5985` | TLS proxy port |
+
+## Tools
+
+| Tool | What It Does |
+|------|-------------|
+| `note_create` | Create a new note with title and content |
+| `note_read` | Read an existing note by title or path |
+| `note_search` | Search notes by keyword (uses ripgrep) |
+| `note_append` | Append content to an existing note |
+| `note_list` | List recent notes, optionally filtered by tag |
+
+## Commands
+
+| Command | What It Does |
+|---------|-------------|
+| `/note` | Create or manage notes |
+| `/vault` | Vault operations (status, sync, etc.) |
+| `/search` | Search your notes |
+
+## Managing the Services
+
+```bash
+# Check CouchDB status
+sudo systemctl status couchdb
+
+# Check Caddy (TLS proxy) status
+sudo systemctl status caddy
+
+# Run health check
+~/lobster/config/health-checks/obsidian-km.sh
+
+# View CouchDB directly
+curl http://localhost:5984/
+
+# Access via TLS proxy
+curl -k https://localhost:5985/
+```
+
+## Vault Structure
+
+The skill works with standard Obsidian vault structure:
+
+```
+~/obsidian-vault/
+  .obsidian/           # Obsidian settings (preserved)
+  attachments/         # Images and files
+  Welcome.md           # Created by installer
+  *.md                 # Your notes
+```
+
+Notes support YAML frontmatter for metadata:
+
+```yaml
+---
+title: Project Ideas
+tags: [ideas, projects]
+created: 2024-01-15
+---
+
+# Project Ideas
+
+Your note content here...
+```
+
+## Requirements
+
+- CouchDB 3.x
+- Caddy 2.x (for TLS proxy)
+- ripgrep (for fast search)
+- Python 3.11+
+- ~200MB disk space for CouchDB + vault
+
+## Architecture
+
+The skill is split into phases (BIS-228 epic):
+
+| Issue | Component | Status |
+|-------|-----------|--------|
+| BIS-230 | CouchDB installation | In this installer |
+| BIS-231 | CouchDB configuration | In this installer |
+| BIS-232 | TLS proxy setup | In this installer |
+| BIS-233 | Vault creation | In this installer |
+| BIS-235 | Health checks | In this installer |
+| BIS-236 | Master install.sh | This file |
+| BIS-243 | MCP server | Placeholder (coming soon) |
+
+## Status
+
+**In Development** -- Core infrastructure ready, MCP server implementation pending (BIS-243).

--- a/lobster-shop/obsidian-km/install.sh
+++ b/lobster-shop/obsidian-km/install.sh
@@ -1,0 +1,577 @@
+#!/bin/bash
+#===============================================================================
+# Obsidian KM Skill Installer for Lobster
+#
+# Master installer that consolidates all phases of the Obsidian KM skill:
+#   - BIS-230: CouchDB installation
+#   - BIS-233: Obsidian vault creation
+#   - BIS-231: CouchDB configuration
+#   - BIS-232: TLS proxy setup
+#   - BIS-243: MCP server installation (placeholder)
+#   - BIS-235: Health check registration
+#
+# This script is idempotent — safe to run multiple times.
+#
+# Usage: bash ~/lobster/lobster-shop/obsidian-km/install.sh
+#===============================================================================
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+success() { echo -e "${GREEN}[OK]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; }
+step() { echo -e "\n${CYAN}${BOLD}--- $1${NC}"; }
+
+# Paths
+LOBSTER_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
+SKILL_DIR="$LOBSTER_DIR/lobster-shop/obsidian-km"
+CONFIG_DIR="$LOBSTER_DIR/config/obsidian-km"
+VENV_DIR="$LOBSTER_DIR/.venv"
+PYTHON_PATH="$VENV_DIR/bin/python"
+VAULT_DIR="${OBSIDIAN_VAULT_DIR:-$HOME/obsidian-vault}"
+
+# CouchDB settings
+COUCHDB_PORT="${COUCHDB_PORT:-5984}"
+COUCHDB_ADMIN_USER="${COUCHDB_ADMIN_USER:-admin}"
+COUCHDB_ADMIN_PASS="${COUCHDB_ADMIN_PASS:-$(openssl rand -base64 24)}"
+COUCHDB_DB_NAME="${COUCHDB_DB_NAME:-obsidian_notes}"
+
+# TLS proxy settings
+CADDY_PORT="${CADDY_HTTPS_PORT:-5985}"
+
+echo ""
+echo -e "${BOLD}Obsidian KM Skill Installer${NC}"
+echo "============================="
+echo ""
+echo "This will install the Obsidian Knowledge Management skill for Lobster."
+echo "It enables sync and read/write access to an Obsidian vault via Telegram."
+echo ""
+
+#===============================================================================
+# Phase 1: Install CouchDB (BIS-230)
+#===============================================================================
+install_couchdb() {
+    step "Installing CouchDB"
+
+    # Check if CouchDB is already installed and running
+    if systemctl is-active --quiet couchdb 2>/dev/null; then
+        success "CouchDB is already installed and running"
+        return 0
+    fi
+
+    # Check if already installed but not running
+    if command -v couchdb &>/dev/null || [ -f /opt/couchdb/bin/couchdb ]; then
+        info "CouchDB is installed but not running, attempting to start..."
+        sudo systemctl start couchdb 2>/dev/null || true
+        sleep 2
+        if systemctl is-active --quiet couchdb 2>/dev/null; then
+            success "CouchDB started successfully"
+            return 0
+        fi
+    fi
+
+    info "Installing CouchDB from Apache repository..."
+
+    # Add CouchDB repository key
+    if ! [ -f /usr/share/keyrings/couchdb-archive-keyring.gpg ]; then
+        curl -fsSL https://couchdb.apache.org/repo/keys.asc | gpg --dearmor | \
+            sudo tee /usr/share/keyrings/couchdb-archive-keyring.gpg >/dev/null
+    fi
+
+    # Add CouchDB repository
+    DISTRO=$(lsb_release -cs 2>/dev/null || echo "jammy")
+    echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://apache.jfrog.io/artifactory/couchdb-deb/ ${DISTRO} main" | \
+        sudo tee /etc/apt/sources.list.d/couchdb.list >/dev/null
+
+    # Update and install
+    sudo apt-get update -qq
+
+    # Pre-configure CouchDB for unattended install (single-node mode)
+    echo "couchdb couchdb/mode select standalone" | sudo debconf-set-selections
+    echo "couchdb couchdb/bindaddress string 127.0.0.1" | sudo debconf-set-selections
+    echo "couchdb couchdb/cookie string monster" | sudo debconf-set-selections
+    echo "couchdb couchdb/adminpass password ${COUCHDB_ADMIN_PASS}" | sudo debconf-set-selections
+    echo "couchdb couchdb/adminpass_again password ${COUCHDB_ADMIN_PASS}" | sudo debconf-set-selections
+
+    DEBIAN_FRONTEND=noninteractive sudo apt-get install -y couchdb 2>&1 | tail -10
+
+    # Wait for CouchDB to start
+    sleep 3
+
+    if systemctl is-active --quiet couchdb 2>/dev/null; then
+        success "CouchDB installed and running"
+    else
+        sudo systemctl start couchdb 2>/dev/null || true
+        sleep 2
+        if systemctl is-active --quiet couchdb 2>/dev/null; then
+            success "CouchDB installed and started"
+        else
+            error "CouchDB installation failed or could not start"
+            exit 1
+        fi
+    fi
+}
+
+#===============================================================================
+# Phase 2: Create Obsidian Vault (BIS-233)
+#===============================================================================
+create_vault() {
+    step "Creating Obsidian vault"
+
+    if [ -d "$VAULT_DIR" ]; then
+        success "Obsidian vault already exists at $VAULT_DIR"
+        return 0
+    fi
+
+    info "Creating vault directory at $VAULT_DIR..."
+    mkdir -p "$VAULT_DIR"
+    mkdir -p "$VAULT_DIR/.obsidian"
+
+    # Create default vault config
+    cat > "$VAULT_DIR/.obsidian/app.json" << 'EOF'
+{
+  "attachmentFolderPath": "attachments",
+  "newLinkFormat": "relative",
+  "useMarkdownLinks": true,
+  "showUnsupportedFiles": false,
+  "promptDelete": false
+}
+EOF
+
+    # Create welcome note
+    cat > "$VAULT_DIR/Welcome.md" << 'EOF'
+# Welcome to Your Obsidian Vault
+
+This vault is managed by **Lobster** and synced via CouchDB.
+
+## Quick Start
+
+- Create notes by asking Lobster: "Create a note about [topic]"
+- Search notes: "Search my notes for [keyword]"
+- Read notes: "Read my note [title]"
+- List notes: "List my recent notes"
+
+## Organization
+
+Notes are organized by tags and folders. Add tags with `#tag-name` anywhere in your notes.
+
+---
+
+*Created by Lobster Obsidian KM Skill*
+EOF
+
+    # Create attachments directory
+    mkdir -p "$VAULT_DIR/attachments"
+
+    success "Obsidian vault created at $VAULT_DIR"
+}
+
+#===============================================================================
+# Phase 3: Configure CouchDB (BIS-231)
+#===============================================================================
+configure_couchdb() {
+    step "Configuring CouchDB"
+
+    COUCHDB_URL="http://${COUCHDB_ADMIN_USER}:${COUCHDB_ADMIN_PASS}@127.0.0.1:${COUCHDB_PORT}"
+
+    # Wait for CouchDB to be ready
+    for i in $(seq 1 30); do
+        if curl -s "http://127.0.0.1:${COUCHDB_PORT}/" >/dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+    done
+
+    if ! curl -s "http://127.0.0.1:${COUCHDB_PORT}/" >/dev/null 2>&1; then
+        error "CouchDB is not responding on port ${COUCHDB_PORT}"
+        exit 1
+    fi
+
+    # Check if database already exists
+    if curl -s "${COUCHDB_URL}/${COUCHDB_DB_NAME}" 2>/dev/null | grep -q '"db_name"'; then
+        success "Database '${COUCHDB_DB_NAME}' already exists"
+    else
+        info "Creating database '${COUCHDB_DB_NAME}'..."
+        RESULT=$(curl -s -X PUT "${COUCHDB_URL}/${COUCHDB_DB_NAME}" 2>&1)
+        if echo "$RESULT" | grep -q '"ok":true'; then
+            success "Database '${COUCHDB_DB_NAME}' created"
+        elif echo "$RESULT" | grep -q 'file_exists'; then
+            success "Database '${COUCHDB_DB_NAME}' already exists"
+        else
+            warn "Database creation response: $RESULT"
+        fi
+    fi
+
+    # Create design document for views
+    DESIGN_DOC='{
+        "_id": "_design/notes",
+        "views": {
+            "by_title": {
+                "map": "function(doc) { if (doc.type === \"note\") { emit(doc.title, { title: doc.title, updated: doc.updated }); } }"
+            },
+            "by_updated": {
+                "map": "function(doc) { if (doc.type === \"note\") { emit(doc.updated, { title: doc.title, path: doc.path }); } }"
+            },
+            "by_tag": {
+                "map": "function(doc) { if (doc.type === \"note\" && doc.tags) { doc.tags.forEach(function(tag) { emit(tag, { title: doc.title, path: doc.path }); }); } }"
+            }
+        }
+    }'
+
+    # Check if design document exists
+    if curl -s "${COUCHDB_URL}/${COUCHDB_DB_NAME}/_design/notes" 2>/dev/null | grep -q '"_id"'; then
+        success "Design document already exists"
+    else
+        info "Creating design document for note views..."
+        RESULT=$(curl -s -X PUT "${COUCHDB_URL}/${COUCHDB_DB_NAME}/_design/notes" \
+            -H "Content-Type: application/json" \
+            -d "$DESIGN_DOC" 2>&1)
+        if echo "$RESULT" | grep -q '"ok":true'; then
+            success "Design document created"
+        else
+            warn "Design document creation: $RESULT"
+        fi
+    fi
+
+    # Enable CORS for local access
+    info "Configuring CORS..."
+    curl -s -X PUT "${COUCHDB_URL}/_node/_local/_config/httpd/enable_cors" \
+        -d '"true"' >/dev/null 2>&1 || true
+    curl -s -X PUT "${COUCHDB_URL}/_node/_local/_config/cors/origins" \
+        -d '"*"' >/dev/null 2>&1 || true
+    curl -s -X PUT "${COUCHDB_URL}/_node/_local/_config/cors/methods" \
+        -d '"GET, PUT, POST, DELETE, HEAD, OPTIONS"' >/dev/null 2>&1 || true
+    curl -s -X PUT "${COUCHDB_URL}/_node/_local/_config/cors/headers" \
+        -d '"accept, authorization, content-type, origin, referer"' >/dev/null 2>&1 || true
+
+    success "CouchDB configured"
+}
+
+#===============================================================================
+# Phase 4: Setup TLS Proxy (BIS-232)
+#===============================================================================
+setup_tls_proxy() {
+    step "Setting up TLS proxy"
+
+    # Check if Caddy is installed
+    if ! command -v caddy &>/dev/null; then
+        info "Installing Caddy..."
+        sudo apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl 2>&1 | tail -3
+        curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | \
+            sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg 2>/dev/null || true
+        curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | \
+            sudo tee /etc/apt/sources.list.d/caddy-stable.list >/dev/null
+        sudo apt-get update -qq
+        sudo apt-get install -y caddy 2>&1 | tail -3
+    fi
+
+    if command -v caddy &>/dev/null; then
+        success "Caddy is installed: $(caddy version 2>/dev/null || echo 'unknown version')"
+    else
+        warn "Caddy installation may have failed, continuing anyway..."
+    fi
+
+    # Create Caddyfile for CouchDB reverse proxy with TLS
+    CADDYFILE_DIR="/etc/caddy/sites-enabled"
+    sudo mkdir -p "$CADDYFILE_DIR"
+
+    sudo tee "$CADDYFILE_DIR/obsidian-km.caddy" >/dev/null << EOF
+# Obsidian KM - CouchDB TLS Proxy
+# Listens on port $CADDY_PORT with auto-generated self-signed cert
+
+:$CADDY_PORT {
+    # TLS with self-signed cert for local development
+    tls internal
+
+    # Rate limiting
+    @api {
+        path /${COUCHDB_DB_NAME}/*
+    }
+
+    # Reverse proxy to CouchDB
+    reverse_proxy 127.0.0.1:$COUCHDB_PORT {
+        header_up Host {upstream_hostport}
+    }
+
+    # Logging
+    log {
+        output file /var/log/caddy/obsidian-km.log {
+            roll_size 10mb
+            roll_keep 5
+        }
+    }
+}
+EOF
+
+    # Create log directory
+    sudo mkdir -p /var/log/caddy
+    sudo chown caddy:caddy /var/log/caddy 2>/dev/null || true
+
+    # Check if main Caddyfile imports sites-enabled
+    if ! sudo grep -q "sites-enabled" /etc/caddy/Caddyfile 2>/dev/null; then
+        info "Adding sites-enabled import to Caddyfile..."
+        echo "" | sudo tee -a /etc/caddy/Caddyfile >/dev/null
+        echo "import /etc/caddy/sites-enabled/*.caddy" | sudo tee -a /etc/caddy/Caddyfile >/dev/null
+    fi
+
+    # Reload Caddy
+    sudo systemctl reload caddy 2>/dev/null || sudo systemctl restart caddy 2>/dev/null || true
+
+    success "TLS proxy configured on port $CADDY_PORT"
+}
+
+#===============================================================================
+# Phase 5: Install MCP Server (BIS-243 placeholder)
+#===============================================================================
+install_mcp_server() {
+    step "Installing MCP server"
+
+    # Create src directory for MCP server
+    mkdir -p "$SKILL_DIR/src"
+
+    # Check if MCP server file exists
+    if [ -f "$SKILL_DIR/src/obsidian_km_mcp_server.py" ]; then
+        success "MCP server already exists"
+    else
+        info "Creating placeholder MCP server..."
+        cat > "$SKILL_DIR/src/obsidian_km_mcp_server.py" << 'EOF'
+#!/usr/bin/env python3
+"""
+Obsidian KM MCP Server - Placeholder
+
+This MCP server provides tools for reading, writing, and searching
+notes in an Obsidian vault backed by CouchDB.
+
+Tools:
+    - note_create: Create a new note
+    - note_read: Read an existing note
+    - note_search: Search notes by keyword
+    - note_append: Append to an existing note
+    - note_list: List recent notes
+
+Full implementation: BIS-243
+"""
+
+import asyncio
+import os
+import json
+from typing import Any
+
+# Placeholder - full implementation in BIS-243
+# Will integrate with:
+#   - CouchDB for sync
+#   - python-frontmatter for YAML parsing
+#   - ripgrep for fast search
+
+
+def get_config() -> dict[str, Any]:
+    """Load configuration from environment or config file."""
+    config_dir = os.environ.get("LOBSTER_CONFIG_DIR", os.path.expanduser("~/lobster/config"))
+    config_file = os.path.join(config_dir, "obsidian-km", "config.json")
+
+    defaults = {
+        "vault_path": os.environ.get("OBSIDIAN_VAULT_DIR", os.path.expanduser("~/obsidian-vault")),
+        "couchdb_url": os.environ.get("COUCHDB_URL", "http://127.0.0.1:5984"),
+        "couchdb_db": os.environ.get("COUCHDB_DB_NAME", "obsidian_notes"),
+    }
+
+    if os.path.exists(config_file):
+        with open(config_file) as f:
+            defaults.update(json.load(f))
+
+    return defaults
+
+
+async def main():
+    """MCP server entry point - placeholder."""
+    print("Obsidian KM MCP Server - Placeholder")
+    print("Full implementation coming in BIS-243")
+    print(f"Config: {get_config()}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+EOF
+        chmod +x "$SKILL_DIR/src/obsidian_km_mcp_server.py"
+        success "Placeholder MCP server created"
+    fi
+
+    # Install Python dependencies
+    if [ -f "$VENV_DIR/bin/pip" ]; then
+        info "Installing Python dependencies..."
+        "$VENV_DIR/bin/pip" install --quiet python-frontmatter python-dotenv 2>&1 || \
+            warn "Some pip dependencies had issues"
+        success "Python dependencies installed"
+    fi
+
+    warn "MCP server is a placeholder — full implementation in BIS-243"
+}
+
+#===============================================================================
+# Phase 6: Register Health Checks (BIS-235)
+#===============================================================================
+register_health_checks() {
+    step "Registering health checks"
+
+    HEALTH_DIR="$LOBSTER_DIR/config/health-checks"
+    mkdir -p "$HEALTH_DIR"
+
+    # Create health check script
+    cat > "$HEALTH_DIR/obsidian-km.sh" << 'EOF'
+#!/bin/bash
+# Health check for Obsidian KM skill
+# Returns 0 if healthy, 1 if unhealthy
+
+COUCHDB_PORT="${COUCHDB_PORT:-5984}"
+CADDY_PORT="${CADDY_HTTPS_PORT:-5985}"
+
+# Check CouchDB
+if ! curl -s "http://127.0.0.1:${COUCHDB_PORT}/" >/dev/null 2>&1; then
+    echo "CouchDB not responding"
+    exit 1
+fi
+
+# Check TLS proxy (optional, warn only)
+if ! curl -sk "https://127.0.0.1:${CADDY_PORT}/" >/dev/null 2>&1; then
+    echo "Warning: TLS proxy not responding (non-critical)"
+fi
+
+# Check vault exists
+VAULT_DIR="${OBSIDIAN_VAULT_DIR:-$HOME/obsidian-vault}"
+if [ ! -d "$VAULT_DIR" ]; then
+    echo "Vault directory missing: $VAULT_DIR"
+    exit 1
+fi
+
+echo "OK"
+exit 0
+EOF
+    chmod +x "$HEALTH_DIR/obsidian-km.sh"
+
+    # Create health check config
+    cat > "$HEALTH_DIR/obsidian-km.json" << EOF
+{
+    "name": "obsidian-km",
+    "script": "$HEALTH_DIR/obsidian-km.sh",
+    "interval_seconds": 60,
+    "timeout_seconds": 10,
+    "alert_on_failure": true,
+    "dependencies": ["couchdb", "caddy"]
+}
+EOF
+
+    success "Health checks registered"
+}
+
+#===============================================================================
+# Phase 7: Create configuration
+#===============================================================================
+create_config() {
+    step "Creating configuration"
+
+    mkdir -p "$CONFIG_DIR"
+
+    # Write config file
+    cat > "$CONFIG_DIR/config.json" << EOF
+{
+    "vault_path": "$VAULT_DIR",
+    "couchdb_url": "http://127.0.0.1:$COUCHDB_PORT",
+    "couchdb_db": "$COUCHDB_DB_NAME",
+    "caddy_port": $CADDY_PORT,
+    "sync_enabled": true
+}
+EOF
+
+    # Write credentials file (restricted permissions)
+    cat > "$CONFIG_DIR/credentials.env" << EOF
+# Obsidian KM Credentials - DO NOT COMMIT
+COUCHDB_ADMIN_USER=$COUCHDB_ADMIN_USER
+COUCHDB_ADMIN_PASS=$COUCHDB_ADMIN_PASS
+EOF
+    chmod 600 "$CONFIG_DIR/credentials.env"
+
+    success "Configuration saved to $CONFIG_DIR"
+}
+
+#===============================================================================
+# Phase 8: Activate skill
+#===============================================================================
+activate_skill() {
+    step "Activating skill in Lobster"
+
+    ACTIVATE_SCRIPT="
+import sys
+sys.path.insert(0, '$LOBSTER_DIR/src')
+try:
+    from mcp.skill_manager import activate_skill
+    result = activate_skill('obsidian-km', mode='triggered')
+    print(result)
+except ImportError:
+    print('Skill manager not available (not critical)')
+except Exception as e:
+    print(f'Activation note: {e}')
+"
+
+    if [ -f "$PYTHON_PATH" ]; then
+        "$PYTHON_PATH" -c "$ACTIVATE_SCRIPT" 2>/dev/null || \
+            warn "Could not auto-activate skill. Run: lobster skill activate obsidian-km"
+    else
+        warn "Python venv not found. Skill activation skipped."
+    fi
+
+    success "Skill activation complete"
+}
+
+#===============================================================================
+# Main installer
+#===============================================================================
+main() {
+    # Run all phases
+    install_couchdb
+    create_vault
+    configure_couchdb
+    setup_tls_proxy
+    install_mcp_server
+    register_health_checks
+    create_config
+    activate_skill
+
+    echo ""
+    echo -e "${GREEN}${BOLD}Obsidian KM skill installed!${NC}"
+    echo ""
+    echo "  Vault:     $VAULT_DIR"
+    echo "  CouchDB:   http://127.0.0.1:$COUCHDB_PORT"
+    echo "  TLS Proxy: https://127.0.0.1:$CADDY_PORT"
+    echo "  Config:    $CONFIG_DIR"
+    echo ""
+    echo "  Available commands:"
+    echo "    /note  - Create or manage notes"
+    echo "    /vault - Vault operations"
+    echo "    /search - Search notes"
+    echo ""
+    echo "  MCP tools (after BIS-243):"
+    echo "    note_create  - Create a new note"
+    echo "    note_read    - Read an existing note"
+    echo "    note_search  - Search notes by keyword"
+    echo "    note_append  - Append to a note"
+    echo "    note_list    - List recent notes"
+    echo ""
+    echo "  Health check: $LOBSTER_DIR/config/health-checks/obsidian-km.sh"
+    echo ""
+    echo "  Credentials saved to: $CONFIG_DIR/credentials.env"
+    echo ""
+    echo "  To restart Lobster and activate: lobster restart"
+    echo ""
+}
+
+main "$@"

--- a/lobster-shop/obsidian-km/requirements.txt
+++ b/lobster-shop/obsidian-km/requirements.txt
@@ -1,0 +1,4 @@
+# Obsidian KM MCP Server dependencies
+mcp>=1.0.0
+python-frontmatter>=1.0.0
+python-dotenv>=1.0.0

--- a/lobster-shop/obsidian-km/skill.toml
+++ b/lobster-shop/obsidian-km/skill.toml
@@ -1,0 +1,49 @@
+# =============================================================================
+# Lobster Skill Manifest — Obsidian KM
+# =============================================================================
+# Obsidian vault sync and read/write access via Telegram.
+# Part of BIS-228 (Obsidian KM Skill epic)
+
+[skill]
+name = "obsidian-km"
+version = "0.1.0"
+description = "Obsidian vault sync and read/write access via Telegram"
+author = "Lobster"
+category = "tool"
+
+[activation]
+mode = "triggered"
+triggers = ["/note", "/vault", "/search"]
+context_patterns = [
+    "when user asks to create a note",
+    "when user asks to search notes",
+    "when user asks about their vault",
+    "when user wants to read a note",
+]
+
+[layering]
+priority = 50
+merge_strategy = "append"
+
+[provides]
+mcp_tools = [
+    "note_create",
+    "note_read",
+    "note_search",
+    "note_append",
+    "note_list",
+]
+bot_commands = ["/note", "/vault", "/search"]
+
+[compatibility]
+enhances = []
+conflicts = []
+
+[dependencies]
+pip = ["python-frontmatter", "python-dotenv"]
+npm = []
+system = ["couchdb", "caddy", "ripgrep"]
+api_keys = []
+
+[dependencies.runtime]
+python = ">=3.11"

--- a/lobster-shop/obsidian-km/src/__init__.py
+++ b/lobster-shop/obsidian-km/src/__init__.py
@@ -1,0 +1,1 @@
+"""Obsidian KM MCP Server for Lobster."""

--- a/lobster-shop/obsidian-km/src/obsidian_km_server.py
+++ b/lobster-shop/obsidian-km/src/obsidian_km_server.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+Obsidian KM MCP Server for Lobster
+
+Provides note management tools for Obsidian vault access via Telegram.
+
+Tools provided:
+- note_search: Full-text search across vault notes
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import Tool, TextContent
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_HOME = Path.home()
+VAULT_DIR = Path(os.environ.get("OBSIDIAN_VAULT_DIR", _HOME / "obsidian-vault"))
+
+
+# ---------------------------------------------------------------------------
+# MCP Server
+# ---------------------------------------------------------------------------
+
+server = Server("obsidian-km")
+
+
+def text_result(data: Any) -> list[TextContent]:
+    """Format a successful result as JSON text content."""
+    if isinstance(data, str):
+        return [TextContent(type="text", text=data)]
+    return [TextContent(type="text", text=json.dumps(data, indent=2))]
+
+
+def error_result(msg: str) -> list[TextContent]:
+    """Format an error message as text content."""
+    return [TextContent(type="text", text=f"Error: {msg}")]
+
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    """List available Obsidian KM tools."""
+    return [
+        Tool(
+            name="note_search",
+            description=(
+                "Search notes in the Obsidian vault using full-text search (ripgrep). "
+                "Returns matching notes with title, path, excerpt, and tags. "
+                "Case-insensitive by default. Optionally restrict search to a subfolder."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Search query. Matches are case-insensitive.",
+                    },
+                    "folder": {
+                        "type": "string",
+                        "description": (
+                            "Optional subfolder to restrict search. "
+                            "Relative to vault root (e.g., 'projects' or 'daily/2024')."
+                        ),
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum number of results to return. Default: 10.",
+                        "default": 10,
+                        "minimum": 1,
+                        "maximum": 100,
+                    },
+                },
+                "required": ["query"],
+            },
+        ),
+    ]
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    """Dispatch tool calls."""
+    try:
+        if name == "note_search":
+            return await handle_note_search(arguments)
+        else:
+            return error_result(f"Unknown tool: {name}")
+    except Exception as e:
+        return error_result(f"Tool '{name}' failed: {e}")
+
+
+async def handle_note_search(args: dict) -> list[TextContent]:
+    """
+    Search notes in the Obsidian vault.
+
+    Uses ripgrep for fast full-text search. Returns list of matching notes
+    with title, path, excerpt (context around match), and tags.
+    """
+    from vault_ops import search_notes
+
+    query = str(args.get("query", "")).strip()
+    if not query:
+        return error_result("'query' is required")
+
+    folder = args.get("folder")
+    if folder is not None:
+        folder = str(folder).strip() or None
+
+    limit = int(args.get("limit", 10))
+    limit = max(1, min(limit, 100))  # Clamp to 1-100
+
+    # Check vault exists
+    if not VAULT_DIR.exists():
+        return error_result(f"Vault directory not found: {VAULT_DIR}")
+
+    print(f"[INFO] Searching vault for: {query!r} (folder={folder}, limit={limit})", file=sys.stderr)
+
+    # Run search in thread pool to avoid blocking
+    loop = asyncio.get_running_loop()
+    results = await loop.run_in_executor(
+        None,
+        lambda: search_notes(query=query, folder=folder, limit=limit),
+    )
+
+    if not results:
+        return text_result({
+            "query": query,
+            "folder": folder,
+            "count": 0,
+            "results": [],
+        })
+
+    return text_result({
+        "query": query,
+        "folder": folder,
+        "count": len(results),
+        "results": results,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+async def main():
+    print("[INFO] Obsidian KM MCP Server starting...", file=sys.stderr)
+    print(f"[INFO] Vault directory: {VAULT_DIR}", file=sys.stderr)
+    print(f"[INFO] Vault exists: {VAULT_DIR.exists()}", file=sys.stderr)
+
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options(),
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lobster-shop/obsidian-km/src/vault_ops.py
+++ b/lobster-shop/obsidian-km/src/vault_ops.py
@@ -1,0 +1,246 @@
+"""
+Vault operations for Obsidian KM skill.
+
+Pure functions for reading, writing, and searching notes in an Obsidian vault.
+"""
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import frontmatter
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+def get_vault_dir() -> Path:
+    """Get the vault directory from environment or default."""
+    vault_path = os.environ.get("OBSIDIAN_VAULT_DIR", str(Path.home() / "obsidian-vault"))
+    return Path(vault_path).expanduser()
+
+
+# ---------------------------------------------------------------------------
+# Note Metadata Extraction
+# ---------------------------------------------------------------------------
+
+def extract_title(path: Path, content: str) -> str:
+    """
+    Extract title from note. Priority:
+    1. YAML frontmatter 'title' field
+    2. First H1 heading (# Title)
+    3. Filename without extension
+    """
+    try:
+        post = frontmatter.loads(content)
+        if post.get("title"):
+            return str(post["title"])
+    except Exception:
+        pass
+
+    # Try to find first H1
+    h1_match = re.search(r"^#\s+(.+)$", content, re.MULTILINE)
+    if h1_match:
+        return h1_match.group(1).strip()
+
+    # Fall back to filename
+    return path.stem
+
+
+def extract_tags(content: str) -> list[str]:
+    """
+    Extract tags from note. Sources:
+    1. YAML frontmatter 'tags' field
+    2. Inline #tags in content
+    """
+    tags: set[str] = set()
+
+    try:
+        post = frontmatter.loads(content)
+        fm_tags = post.get("tags", [])
+        if isinstance(fm_tags, list):
+            tags.update(str(t) for t in fm_tags)
+        elif isinstance(fm_tags, str):
+            # Handle comma-separated string
+            tags.update(t.strip() for t in fm_tags.split(","))
+    except Exception:
+        pass
+
+    # Find inline #tags (but not in code blocks or links)
+    inline_tags = re.findall(r"(?<!\w)#([a-zA-Z][a-zA-Z0-9_-]*)", content)
+    tags.update(inline_tags)
+
+    return sorted(tags)
+
+
+def extract_excerpt(content: str, query: str, context_chars: int = 100) -> str:
+    """
+    Extract an excerpt around the first occurrence of the query.
+    Returns the first context_chars chars if query not found.
+    """
+    # Strip frontmatter for excerpt
+    try:
+        post = frontmatter.loads(content)
+        body = post.content
+    except Exception:
+        body = content
+
+    # Normalize whitespace
+    body = re.sub(r"\s+", " ", body).strip()
+
+    if not body:
+        return ""
+
+    # Find query position (case-insensitive)
+    lower_body = body.lower()
+    lower_query = query.lower()
+    pos = lower_body.find(lower_query)
+
+    if pos == -1:
+        # Query not found in body, return start of content
+        return body[:context_chars] + ("..." if len(body) > context_chars else "")
+
+    # Extract context around the match
+    start = max(0, pos - context_chars // 2)
+    end = min(len(body), pos + len(query) + context_chars // 2)
+
+    excerpt = body[start:end]
+
+    # Add ellipsis if truncated
+    if start > 0:
+        excerpt = "..." + excerpt
+    if end < len(body):
+        excerpt = excerpt + "..."
+
+    return excerpt
+
+
+# ---------------------------------------------------------------------------
+# Search Functions
+# ---------------------------------------------------------------------------
+
+def search_notes(
+    query: str,
+    folder: str | None = None,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """
+    Search notes in the vault using ripgrep.
+
+    Args:
+        query: Search query (case-insensitive by default)
+        folder: Optional subfolder to restrict search
+        limit: Maximum number of results to return
+
+    Returns:
+        List of dicts with keys: title, path, excerpt, tags
+    """
+    vault_dir = get_vault_dir()
+
+    if not vault_dir.exists():
+        return []
+
+    # Determine search path
+    search_path = vault_dir / folder if folder else vault_dir
+    if not search_path.exists():
+        return []
+
+    # Skip hidden directories like .obsidian
+    # Use ripgrep with JSON output for parsing
+    cmd = [
+        "rg",
+        "--json",           # JSON output for structured parsing
+        "-i",               # Case insensitive
+        "--glob", "*.md",   # Only markdown files
+        "--glob", "!.obsidian/**",  # Exclude .obsidian directory
+        "-l",               # List files only (faster initial scan)
+        query,
+        str(search_path),
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=5,  # 5 second timeout
+        )
+    except subprocess.TimeoutExpired:
+        return []
+    except FileNotFoundError:
+        # ripgrep not installed
+        return _fallback_search(query, search_path, limit)
+
+    if result.returncode not in (0, 1):  # 1 = no matches
+        return []
+
+    # Parse JSON lines output
+    matching_files: list[Path] = []
+    for line in result.stdout.strip().split("\n"):
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+            if data.get("type") == "match":
+                file_path = data.get("data", {}).get("path", {}).get("text")
+                if file_path:
+                    matching_files.append(Path(file_path))
+        except json.JSONDecodeError:
+            continue
+
+    # Process results up to limit
+    results: list[dict[str, Any]] = []
+    for path in matching_files[:limit]:
+        try:
+            content = path.read_text(encoding="utf-8")
+            rel_path = path.relative_to(vault_dir)
+            results.append({
+                "title": extract_title(path, content),
+                "path": str(rel_path),
+                "excerpt": extract_excerpt(content, query),
+                "tags": extract_tags(content),
+            })
+        except Exception:
+            continue
+
+    return results
+
+
+def _fallback_search(
+    query: str,
+    search_path: Path,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """
+    Fallback search using pure Python when ripgrep is not available.
+    Slower but functional.
+    """
+    vault_dir = get_vault_dir()
+    query_lower = query.lower()
+    results: list[dict[str, Any]] = []
+
+    for path in search_path.rglob("*.md"):
+        # Skip hidden directories
+        if any(part.startswith(".") for part in path.parts):
+            continue
+
+        try:
+            content = path.read_text(encoding="utf-8")
+            if query_lower in content.lower():
+                rel_path = path.relative_to(vault_dir)
+                results.append({
+                    "title": extract_title(path, content),
+                    "path": str(rel_path),
+                    "excerpt": extract_excerpt(content, query),
+                    "tags": extract_tags(content),
+                })
+                if len(results) >= limit:
+                    break
+        except Exception:
+            continue
+
+    return results


### PR DESCRIPTION
## Summary

- Add `note_search` MCP tool for full-text search across Obsidian vault
- Uses ripgrep for fast, case-insensitive search
- Returns structured results with title, path, excerpt, and tags
- Includes fallback to pure Python search if `rg` not installed

## Files Changed

- `lobster-shop/obsidian-km/src/vault_ops.py` - Core search logic with ripgrep
- `lobster-shop/obsidian-km/src/obsidian_km_server.py` - MCP server with note_search tool
- `lobster-shop/obsidian-km/requirements.txt` - Dependencies

## Acceptance Criteria

- [x] `note_search(query, folder=None, limit=10)` MCP tool exists
- [x] Returns list: title, path, excerpt, tags
- [x] Case-insensitive by default
- [x] `folder` param restricts search to subfolder
- [x] Empty list (not error) when no results
- [ ] Completes in < 2 seconds for 10,000 notes (requires vault for testing)

## Dependencies

- **Builds on**: BIS-236 (skill structure)
- **Required system package**: `ripgrep` (falls back to Python search if unavailable)

## Test Plan

- [ ] Verify ripgrep is installed: `which rg`
- [ ] Create test vault with sample notes
- [ ] Test basic search: `note_search(query="test")`
- [ ] Test folder restriction: `note_search(query="test", folder="projects")`
- [ ] Test limit: `note_search(query="test", limit=5)`
- [ ] Verify empty results return `[]` not error
- [ ] Test with frontmatter notes (title, tags extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)