### PR TITLE
feat(obsidian-km): note_read MCP tool [BIS-240]

### DIFF
--- a/lobster-shop/obsidian-km/README.md
+++ b/lobster-shop/obsidian-km/README.md
@@ -1,0 +1,148 @@
+# Obsidian KM
+
+**Sync and access your Obsidian vault from anywhere via Telegram.**
+
+Take notes, search your knowledge base, and manage your vault without opening the app. Your notes stay in sync between your devices and are always accessible through Lobster.
+
+## What You Can Do
+
+- **"Create a note about my project ideas"** -- Start a new note instantly
+- **"Search my notes for machine learning"** -- Find notes by keyword
+- **"Read my meeting notes from Monday"** -- Retrieve note content
+- **"Append to my daily log: finished the API integration"** -- Add to existing notes
+- **"List my recent notes"** -- See what you've been working on
+
+## How It Works
+
+Obsidian KM uses CouchDB as a sync backend for your Obsidian vault. Notes are stored as standard Markdown files (compatible with Obsidian) and synced to CouchDB for fast search and access. A TLS proxy (Caddy) provides secure access.
+
+```
+Lobster (Claude Code)
+  |
+  |-- MCP: note_create, note_read, note_search, etc.
+  |
+  v
+obsidian_km_mcp_server.py (Python MCP server)
+  |
+  |-- CouchDB queries / file operations
+  |
+  v
+CouchDB <--sync--> Obsidian Vault (~/*.md files)
+```
+
+## Setup
+
+Run the installer:
+
+```bash
+bash ~/lobster/lobster-shop/obsidian-km/install.sh
+```
+
+The installer will:
+
+1. Install and configure CouchDB
+2. Create an Obsidian vault (or use existing)
+3. Set up database views for fast note lookup
+4. Configure Caddy TLS proxy
+5. Install the MCP server
+6. Register health checks
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OBSIDIAN_VAULT_DIR` | `~/obsidian-vault` | Path to your Obsidian vault |
+| `COUCHDB_PORT` | `5984` | CouchDB port |
+| `COUCHDB_ADMIN_USER` | `admin` | CouchDB admin username |
+| `COUCHDB_ADMIN_PASS` | (generated) | CouchDB admin password |
+| `COUCHDB_DB_NAME` | `obsidian_notes` | Database name for notes |
+| `CADDY_HTTPS_PORT` | `5985` | TLS proxy port |
+
+## Tools
+
+| Tool | What It Does |
+|------|-------------|
+| `note_create` | Create a new note with title and content |
+| `note_read` | Read an existing note by title or path |
+| `note_search` | Search notes by keyword (uses ripgrep) |
+| `note_append` | Append content to an existing note |
+| `note_list` | List recent notes, optionally filtered by tag |
+
+## Commands
+
+| Command | What It Does |
+|---------|-------------|
+| `/note` | Create or manage notes |
+| `/vault` | Vault operations (status, sync, etc.) |
+| `/search` | Search your notes |
+
+## Managing the Services
+
+```bash
+# Check CouchDB status
+sudo systemctl status couchdb
+
+# Check Caddy (TLS proxy) status
+sudo systemctl status caddy
+
+# Run health check
+~/lobster/config/health-checks/obsidian-km.sh
+
+# View CouchDB directly
+curl http://localhost:5984/
+
+# Access via TLS proxy
+curl -k https://localhost:5985/
+```
+
+## Vault Structure
+
+The skill works with standard Obsidian vault structure:
+
+```
+~/obsidian-vault/
+  .obsidian/           # Obsidian settings (preserved)
+  attachments/         # Images and files
+  Welcome.md           # Created by installer
+  *.md                 # Your notes
+```
+
+Notes support YAML frontmatter for metadata:
+
+```yaml
+---
+title: Project Ideas
+tags: [ideas, projects]
+created: 2024-01-15
+---
+
+# Project Ideas
+
+Your note content here...
+```
+
+## Requirements
+
+- CouchDB 3.x
+- Caddy 2.x (for TLS proxy)
+- ripgrep (for fast search)
+- Python 3.11+
+- ~200MB disk space for CouchDB + vault
+
+## Architecture
+
+The skill is split into phases (BIS-228 epic):
+
+| Issue | Component | Status |
+|-------|-----------|--------|
+| BIS-230 | CouchDB installation | In this installer |
+| BIS-231 | CouchDB configuration | In this installer |
+| BIS-232 | TLS proxy setup | In this installer |
+| BIS-233 | Vault creation | In this installer |
+| BIS-235 | Health checks | In this installer |
+| BIS-236 | Master install.sh | This file |
+| BIS-243 | MCP server | Placeholder (coming soon) |
+
+## Status
+
+**In Development** -- Core infrastructure ready, MCP server implementation pending (BIS-243).

--- a/lobster-shop/obsidian-km/install.sh
+++ b/lobster-shop/obsidian-km/install.sh
@@ -1,0 +1,577 @@
+#!/bin/bash
+#===============================================================================
+# Obsidian KM Skill Installer for Lobster
+#
+# Master installer that consolidates all phases of the Obsidian KM skill:
+#   - BIS-230: CouchDB installation
+#   - BIS-233: Obsidian vault creation
+#   - BIS-231: CouchDB configuration
+#   - BIS-232: TLS proxy setup
+#   - BIS-243: MCP server installation (placeholder)
+#   - BIS-235: Health check registration
+#
+# This script is idempotent — safe to run multiple times.
+#
+# Usage: bash ~/lobster/lobster-shop/obsidian-km/install.sh
+#===============================================================================
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+success() { echo -e "${GREEN}[OK]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; }
+step() { echo -e "\n${CYAN}${BOLD}--- $1${NC}"; }
+
+# Paths
+LOBSTER_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
+SKILL_DIR="$LOBSTER_DIR/lobster-shop/obsidian-km"
+CONFIG_DIR="$LOBSTER_DIR/config/obsidian-km"
+VENV_DIR="$LOBSTER_DIR/.venv"
+PYTHON_PATH="$VENV_DIR/bin/python"
+VAULT_DIR="${OBSIDIAN_VAULT_DIR:-$HOME/obsidian-vault}"
+
+# CouchDB settings
+COUCHDB_PORT="${COUCHDB_PORT:-5984}"
+COUCHDB_ADMIN_USER="${COUCHDB_ADMIN_USER:-admin}"
+COUCHDB_ADMIN_PASS="${COUCHDB_ADMIN_PASS:-$(openssl rand -base64 24)}"
+COUCHDB_DB_NAME="${COUCHDB_DB_NAME:-obsidian_notes}"
+
+# TLS proxy settings
+CADDY_PORT="${CADDY_HTTPS_PORT:-5985}"
+
+echo ""
+echo -e "${BOLD}Obsidian KM Skill Installer${NC}"
+echo "============================="
+echo ""
+echo "This will install the Obsidian Knowledge Management skill for Lobster."
+echo "It enables sync and read/write access to an Obsidian vault via Telegram."
+echo ""
+
+#===============================================================================
+# Phase 1: Install CouchDB (BIS-230)
+#===============================================================================
+install_couchdb() {
+    step "Installing CouchDB"
+
+    # Check if CouchDB is already installed and running
+    if systemctl is-active --quiet couchdb 2>/dev/null; then
+        success "CouchDB is already installed and running"
+        return 0
+    fi
+
+    # Check if already installed but not running
+    if command -v couchdb &>/dev/null || [ -f /opt/couchdb/bin/couchdb ]; then
+        info "CouchDB is installed but not running, attempting to start..."
+        sudo systemctl start couchdb 2>/dev/null || true
+        sleep 2
+        if systemctl is-active --quiet couchdb 2>/dev/null; then
+            success "CouchDB started successfully"
+            return 0
+        fi
+    fi
+
+    info "Installing CouchDB from Apache repository..."
+
+    # Add CouchDB repository key
+    if ! [ -f /usr/share/keyrings/couchdb-archive-keyring.gpg ]; then
+        curl -fsSL https://couchdb.apache.org/repo/keys.asc | gpg --dearmor | \
+            sudo tee /usr/share/keyrings/couchdb-archive-keyring.gpg >/dev/null
+    fi
+
+    # Add CouchDB repository
+    DISTRO=$(lsb_release -cs 2>/dev/null || echo "jammy")
+    echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://apache.jfrog.io/artifactory/couchdb-deb/ ${DISTRO} main" | \
+        sudo tee /etc/apt/sources.list.d/couchdb.list >/dev/null
+
+    # Update and install
+    sudo apt-get update -qq
+
+    # Pre-configure CouchDB for unattended install (single-node mode)
+    echo "couchdb couchdb/mode select standalone" | sudo debconf-set-selections
+    echo "couchdb couchdb/bindaddress string 127.0.0.1" | sudo debconf-set-selections
+    echo "couchdb couchdb/cookie string monster" | sudo debconf-set-selections
+    echo "couchdb couchdb/adminpass password ${COUCHDB_ADMIN_PASS}" | sudo debconf-set-selections
+    echo "couchdb couchdb/adminpass_again password ${COUCHDB_ADMIN_PASS}" | sudo debconf-set-selections
+
+    DEBIAN_FRONTEND=noninteractive sudo apt-get install -y couchdb 2>&1 | tail -10
+
+    # Wait for CouchDB to start
+    sleep 3
+
+    if systemctl is-active --quiet couchdb 2>/dev/null; then
+        success "CouchDB installed and running"
+    else
+        sudo systemctl start couchdb 2>/dev/null || true
+        sleep 2
+        if systemctl is-active --quiet couchdb 2>/dev/null; then
+            success "CouchDB installed and started"
+        else
+            error "CouchDB installation failed or could not start"
+            exit 1
+        fi
+    fi
+}
+
+#===============================================================================
+# Phase 2: Create Obsidian Vault (BIS-233)
+#===============================================================================
+create_vault() {
+    step "Creating Obsidian vault"
+
+    if [ -d "$VAULT_DIR" ]; then
+        success "Obsidian vault already exists at $VAULT_DIR"
+        return 0
+    fi
+
+    info "Creating vault directory at $VAULT_DIR..."
+    mkdir -p "$VAULT_DIR"
+    mkdir -p "$VAULT_DIR/.obsidian"
+
+    # Create default vault config
+    cat > "$VAULT_DIR/.obsidian/app.json" << 'EOF'
+{
+  "attachmentFolderPath": "attachments",
+  "newLinkFormat": "relative",
+  "useMarkdownLinks": true,
+  "showUnsupportedFiles": false,
+  "promptDelete": false
+}
+EOF
+
+    # Create welcome note
+    cat > "$VAULT_DIR/Welcome.md" << 'EOF'
+# Welcome to Your Obsidian Vault
+
+This vault is managed by **Lobster** and synced via CouchDB.
+
+## Quick Start
+
+- Create notes by asking Lobster: "Create a note about [topic]"
+- Search notes: "Search my notes for [keyword]"
+- Read notes: "Read my note [title]"
+- List notes: "List my recent notes"
+
+## Organization
+
+Notes are organized by tags and folders. Add tags with `#tag-name` anywhere in your notes.
+
+---
+
+*Created by Lobster Obsidian KM Skill*
+EOF
+
+    # Create attachments directory
+    mkdir -p "$VAULT_DIR/attachments"
+
+    success "Obsidian vault created at $VAULT_DIR"
+}
+
+#===============================================================================
+# Phase 3: Configure CouchDB (BIS-231)
+#===============================================================================
+configure_couchdb() {
+    step "Configuring CouchDB"
+
+    COUCHDB_URL="http://${COUCHDB_ADMIN_USER}:${COUCHDB_ADMIN_PASS}@127.0.0.1:${COUCHDB_PORT}"
+
+    # Wait for CouchDB to be ready
+    for i in $(seq 1 30); do
+        if curl -s "http://127.0.0.1:${COUCHDB_PORT}/" >/dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+    done
+
+    if ! curl -s "http://127.0.0.1:${COUCHDB_PORT}/" >/dev/null 2>&1; then
+        error "CouchDB is not responding on port ${COUCHDB_PORT}"
+        exit 1
+    fi
+
+    # Check if database already exists
+    if curl -s "${COUCHDB_URL}/${COUCHDB_DB_NAME}" 2>/dev/null | grep -q '"db_name"'; then
+        success "Database '${COUCHDB_DB_NAME}' already exists"
+    else
+        info "Creating database '${COUCHDB_DB_NAME}'..."
+        RESULT=$(curl -s -X PUT "${COUCHDB_URL}/${COUCHDB_DB_NAME}" 2>&1)
+        if echo "$RESULT" | grep -q '"ok":true'; then
+            success "Database '${COUCHDB_DB_NAME}' created"
+        elif echo "$RESULT" | grep -q 'file_exists'; then
+            success "Database '${COUCHDB_DB_NAME}' already exists"
+        else
+            warn "Database creation response: $RESULT"
+        fi
+    fi
+
+    # Create design document for views
+    DESIGN_DOC='{
+        "_id": "_design/notes",
+        "views": {
+            "by_title": {
+                "map": "function(doc) { if (doc.type === \"note\") { emit(doc.title, { title: doc.title, updated: doc.updated }); } }"
+            },
+            "by_updated": {
+                "map": "function(doc) { if (doc.type === \"note\") { emit(doc.updated, { title: doc.title, path: doc.path }); } }"
+            },
+            "by_tag": {
+                "map": "function(doc) { if (doc.type === \"note\" && doc.tags) { doc.tags.forEach(function(tag) { emit(tag, { title: doc.title, path: doc.path }); }); } }"
+            }
+        }
+    }'
+
+    # Check if design document exists
+    if curl -s "${COUCHDB_URL}/${COUCHDB_DB_NAME}/_design/notes" 2>/dev/null | grep -q '"_id"'; then
+        success "Design document already exists"
+    else
+        info "Creating design document for note views..."
+        RESULT=$(curl -s -X PUT "${COUCHDB_URL}/${COUCHDB_DB_NAME}/_design/notes" \
+            -H "Content-Type: application/json" \
+            -d "$DESIGN_DOC" 2>&1)
+        if echo "$RESULT" | grep -q '"ok":true'; then
+            success "Design document created"
+        else
+            warn "Design document creation: $RESULT"
+        fi
+    fi
+
+    # Enable CORS for local access
+    info "Configuring CORS..."
+    curl -s -X PUT "${COUCHDB_URL}/_node/_local/_config/httpd/enable_cors" \
+        -d '"true"' >/dev/null 2>&1 || true
+    curl -s -X PUT "${COUCHDB_URL}/_node/_local/_config/cors/origins" \
+        -d '"*"' >/dev/null 2>&1 || true
+    curl -s -X PUT "${COUCHDB_URL}/_node/_local/_config/cors/methods" \
+        -d '"GET, PUT, POST, DELETE, HEAD, OPTIONS"' >/dev/null 2>&1 || true
+    curl -s -X PUT "${COUCHDB_URL}/_node/_local/_config/cors/headers" \
+        -d '"accept, authorization, content-type, origin, referer"' >/dev/null 2>&1 || true
+
+    success "CouchDB configured"
+}
+
+#===============================================================================
+# Phase 4: Setup TLS Proxy (BIS-232)
+#===============================================================================
+setup_tls_proxy() {
+    step "Setting up TLS proxy"
+
+    # Check if Caddy is installed
+    if ! command -v caddy &>/dev/null; then
+        info "Installing Caddy..."
+        sudo apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl 2>&1 | tail -3
+        curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | \
+            sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg 2>/dev/null || true
+        curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | \
+            sudo tee /etc/apt/sources.list.d/caddy-stable.list >/dev/null
+        sudo apt-get update -qq
+        sudo apt-get install -y caddy 2>&1 | tail -3
+    fi
+
+    if command -v caddy &>/dev/null; then
+        success "Caddy is installed: $(caddy version 2>/dev/null || echo 'unknown version')"
+    else
+        warn "Caddy installation may have failed, continuing anyway..."
+    fi
+
+    # Create Caddyfile for CouchDB reverse proxy with TLS
+    CADDYFILE_DIR="/etc/caddy/sites-enabled"
+    sudo mkdir -p "$CADDYFILE_DIR"
+
+    sudo tee "$CADDYFILE_DIR/obsidian-km.caddy" >/dev/null << EOF
+# Obsidian KM - CouchDB TLS Proxy
+# Listens on port $CADDY_PORT with auto-generated self-signed cert
+
+:$CADDY_PORT {
+    # TLS with self-signed cert for local development
+    tls internal
+
+    # Rate limiting
+    @api {
+        path /${COUCHDB_DB_NAME}/*
+    }
+
+    # Reverse proxy to CouchDB
+    reverse_proxy 127.0.0.1:$COUCHDB_PORT {
+        header_up Host {upstream_hostport}
+    }
+
+    # Logging
+    log {
+        output file /var/log/caddy/obsidian-km.log {
+            roll_size 10mb
+            roll_keep 5
+        }
+    }
+}
+EOF
+
+    # Create log directory
+    sudo mkdir -p /var/log/caddy
+    sudo chown caddy:caddy /var/log/caddy 2>/dev/null || true
+
+    # Check if main Caddyfile imports sites-enabled
+    if ! sudo grep -q "sites-enabled" /etc/caddy/Caddyfile 2>/dev/null; then
+        info "Adding sites-enabled import to Caddyfile..."
+        echo "" | sudo tee -a /etc/caddy/Caddyfile >/dev/null
+        echo "import /etc/caddy/sites-enabled/*.caddy" | sudo tee -a /etc/caddy/Caddyfile >/dev/null
+    fi
+
+    # Reload Caddy
+    sudo systemctl reload caddy 2>/dev/null || sudo systemctl restart caddy 2>/dev/null || true
+
+    success "TLS proxy configured on port $CADDY_PORT"
+}
+
+#===============================================================================
+# Phase 5: Install MCP Server (BIS-243 placeholder)
+#===============================================================================
+install_mcp_server() {
+    step "Installing MCP server"
+
+    # Create src directory for MCP server
+    mkdir -p "$SKILL_DIR/src"
+
+    # Check if MCP server file exists
+    if [ -f "$SKILL_DIR/src/obsidian_km_mcp_server.py" ]; then
+        success "MCP server already exists"
+    else
+        info "Creating placeholder MCP server..."
+        cat > "$SKILL_DIR/src/obsidian_km_mcp_server.py" << 'EOF'
+#!/usr/bin/env python3
+"""
+Obsidian KM MCP Server - Placeholder
+
+This MCP server provides tools for reading, writing, and searching
+notes in an Obsidian vault backed by CouchDB.
+
+Tools:
+    - note_create: Create a new note
+    - note_read: Read an existing note
+    - note_search: Search notes by keyword
+    - note_append: Append to an existing note
+    - note_list: List recent notes
+
+Full implementation: BIS-243
+"""
+
+import asyncio
+import os
+import json
+from typing import Any
+
+# Placeholder - full implementation in BIS-243
+# Will integrate with:
+#   - CouchDB for sync
+#   - python-frontmatter for YAML parsing
+#   - ripgrep for fast search
+
+
+def get_config() -> dict[str, Any]:
+    """Load configuration from environment or config file."""
+    config_dir = os.environ.get("LOBSTER_CONFIG_DIR", os.path.expanduser("~/lobster/config"))
+    config_file = os.path.join(config_dir, "obsidian-km", "config.json")
+
+    defaults = {
+        "vault_path": os.environ.get("OBSIDIAN_VAULT_DIR", os.path.expanduser("~/obsidian-vault")),
+        "couchdb_url": os.environ.get("COUCHDB_URL", "http://127.0.0.1:5984"),
+        "couchdb_db": os.environ.get("COUCHDB_DB_NAME", "obsidian_notes"),
+    }
+
+    if os.path.exists(config_file):
+        with open(config_file) as f:
+            defaults.update(json.load(f))
+
+    return defaults
+
+
+async def main():
+    """MCP server entry point - placeholder."""
+    print("Obsidian KM MCP Server - Placeholder")
+    print("Full implementation coming in BIS-243")
+    print(f"Config: {get_config()}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+EOF
+        chmod +x "$SKILL_DIR/src/obsidian_km_mcp_server.py"
+        success "Placeholder MCP server created"
+    fi
+
+    # Install Python dependencies
+    if [ -f "$VENV_DIR/bin/pip" ]; then
+        info "Installing Python dependencies..."
+        "$VENV_DIR/bin/pip" install --quiet python-frontmatter python-dotenv 2>&1 || \
+            warn "Some pip dependencies had issues"
+        success "Python dependencies installed"
+    fi
+
+    warn "MCP server is a placeholder — full implementation in BIS-243"
+}
+
+#===============================================================================
+# Phase 6: Register Health Checks (BIS-235)
+#===============================================================================
+register_health_checks() {
+    step "Registering health checks"
+
+    HEALTH_DIR="$LOBSTER_DIR/config/health-checks"
+    mkdir -p "$HEALTH_DIR"
+
+    # Create health check script
+    cat > "$HEALTH_DIR/obsidian-km.sh" << 'EOF'
+#!/bin/bash
+# Health check for Obsidian KM skill
+# Returns 0 if healthy, 1 if unhealthy
+
+COUCHDB_PORT="${COUCHDB_PORT:-5984}"
+CADDY_PORT="${CADDY_HTTPS_PORT:-5985}"
+
+# Check CouchDB
+if ! curl -s "http://127.0.0.1:${COUCHDB_PORT}/" >/dev/null 2>&1; then
+    echo "CouchDB not responding"
+    exit 1
+fi
+
+# Check TLS proxy (optional, warn only)
+if ! curl -sk "https://127.0.0.1:${CADDY_PORT}/" >/dev/null 2>&1; then
+    echo "Warning: TLS proxy not responding (non-critical)"
+fi
+
+# Check vault exists
+VAULT_DIR="${OBSIDIAN_VAULT_DIR:-$HOME/obsidian-vault}"
+if [ ! -d "$VAULT_DIR" ]; then
+    echo "Vault directory missing: $VAULT_DIR"
+    exit 1
+fi
+
+echo "OK"
+exit 0
+EOF
+    chmod +x "$HEALTH_DIR/obsidian-km.sh"
+
+    # Create health check config
+    cat > "$HEALTH_DIR/obsidian-km.json" << EOF
+{
+    "name": "obsidian-km",
+    "script": "$HEALTH_DIR/obsidian-km.sh",
+    "interval_seconds": 60,
+    "timeout_seconds": 10,
+    "alert_on_failure": true,
+    "dependencies": ["couchdb", "caddy"]
+}
+EOF
+
+    success "Health checks registered"
+}
+
+#===============================================================================
+# Phase 7: Create configuration
+#===============================================================================
+create_config() {
+    step "Creating configuration"
+
+    mkdir -p "$CONFIG_DIR"
+
+    # Write config file
+    cat > "$CONFIG_DIR/config.json" << EOF
+{
+    "vault_path": "$VAULT_DIR",
+    "couchdb_url": "http://127.0.0.1:$COUCHDB_PORT",
+    "couchdb_db": "$COUCHDB_DB_NAME",
+    "caddy_port": $CADDY_PORT,
+    "sync_enabled": true
+}
+EOF
+
+    # Write credentials file (restricted permissions)
+    cat > "$CONFIG_DIR/credentials.env" << EOF
+# Obsidian KM Credentials - DO NOT COMMIT
+COUCHDB_ADMIN_USER=$COUCHDB_ADMIN_USER
+COUCHDB_ADMIN_PASS=$COUCHDB_ADMIN_PASS
+EOF
+    chmod 600 "$CONFIG_DIR/credentials.env"
+
+    success "Configuration saved to $CONFIG_DIR"
+}
+
+#===============================================================================
+# Phase 8: Activate skill
+#===============================================================================
+activate_skill() {
+    step "Activating skill in Lobster"
+
+    ACTIVATE_SCRIPT="
+import sys
+sys.path.insert(0, '$LOBSTER_DIR/src')
+try:
+    from mcp.skill_manager import activate_skill
+    result = activate_skill('obsidian-km', mode='triggered')
+    print(result)
+except ImportError:
+    print('Skill manager not available (not critical)')
+except Exception as e:
+    print(f'Activation note: {e}')
+"
+
+    if [ -f "$PYTHON_PATH" ]; then
+        "$PYTHON_PATH" -c "$ACTIVATE_SCRIPT" 2>/dev/null || \
+            warn "Could not auto-activate skill. Run: lobster skill activate obsidian-km"
+    else
+        warn "Python venv not found. Skill activation skipped."
+    fi
+
+    success "Skill activation complete"
+}
+
+#===============================================================================
+# Main installer
+#===============================================================================
+main() {
+    # Run all phases
+    install_couchdb
+    create_vault
+    configure_couchdb
+    setup_tls_proxy
+    install_mcp_server
+    register_health_checks
+    create_config
+    activate_skill
+
+    echo ""
+    echo -e "${GREEN}${BOLD}Obsidian KM skill installed!${NC}"
+    echo ""
+    echo "  Vault:     $VAULT_DIR"
+    echo "  CouchDB:   http://127.0.0.1:$COUCHDB_PORT"
+    echo "  TLS Proxy: https://127.0.0.1:$CADDY_PORT"
+    echo "  Config:    $CONFIG_DIR"
+    echo ""
+    echo "  Available commands:"
+    echo "    /note  - Create or manage notes"
+    echo "    /vault - Vault operations"
+    echo "    /search - Search notes"
+    echo ""
+    echo "  MCP tools (after BIS-243):"
+    echo "    note_create  - Create a new note"
+    echo "    note_read    - Read an existing note"
+    echo "    note_search  - Search notes by keyword"
+    echo "    note_append  - Append to a note"
+    echo "    note_list    - List recent notes"
+    echo ""
+    echo "  Health check: $LOBSTER_DIR/config/health-checks/obsidian-km.sh"
+    echo ""
+    echo "  Credentials saved to: $CONFIG_DIR/credentials.env"
+    echo ""
+    echo "  To restart Lobster and activate: lobster restart"
+    echo ""
+}
+
+main "$@"

--- a/lobster-shop/obsidian-km/requirements.txt
+++ b/lobster-shop/obsidian-km/requirements.txt
@@ -1,0 +1,4 @@
+# Obsidian KM MCP Server dependencies
+mcp>=1.0.0
+python-frontmatter>=1.0.0
+python-dotenv>=1.0.0

--- a/lobster-shop/obsidian-km/skill.toml
+++ b/lobster-shop/obsidian-km/skill.toml
@@ -1,0 +1,49 @@
+# =============================================================================
+# Lobster Skill Manifest — Obsidian KM
+# =============================================================================
+# Obsidian vault sync and read/write access via Telegram.
+# Part of BIS-228 (Obsidian KM Skill epic)
+
+[skill]
+name = "obsidian-km"
+version = "0.1.0"
+description = "Obsidian vault sync and read/write access via Telegram"
+author = "Lobster"
+category = "tool"
+
+[activation]
+mode = "triggered"
+triggers = ["/note", "/vault", "/search"]
+context_patterns = [
+    "when user asks to create a note",
+    "when user asks to search notes",
+    "when user asks about their vault",
+    "when user wants to read a note",
+]
+
+[layering]
+priority = 50
+merge_strategy = "append"
+
+[provides]
+mcp_tools = [
+    "note_create",
+    "note_read",
+    "note_search",
+    "note_append",
+    "note_list",
+]
+bot_commands = ["/note", "/vault", "/search"]
+
+[compatibility]
+enhances = []
+conflicts = []
+
+[dependencies]
+pip = ["python-frontmatter", "python-dotenv"]
+npm = []
+system = ["couchdb", "caddy", "ripgrep"]
+api_keys = []
+
+[dependencies.runtime]
+python = ">=3.11"

--- a/lobster-shop/obsidian-km/src/__init__.py
+++ b/lobster-shop/obsidian-km/src/__init__.py
@@ -1,0 +1,1 @@
+"""Obsidian KM MCP Server for Lobster."""

--- a/lobster-shop/obsidian-km/src/obsidian_km_server.py
+++ b/lobster-shop/obsidian-km/src/obsidian_km_server.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+Obsidian KM MCP Server for Lobster
+
+Provides note management tools for Obsidian vault access via Telegram.
+
+Tools provided:
+- note_search: Full-text search across vault notes
+- note_read: Read a specific note by title or path
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import Tool, TextContent
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_HOME = Path.home()
+VAULT_DIR = Path(os.environ.get("OBSIDIAN_VAULT_DIR", _HOME / "obsidian-vault"))
+
+
+# ---------------------------------------------------------------------------
+# MCP Server
+# ---------------------------------------------------------------------------
+
+server = Server("obsidian-km")
+
+
+def text_result(data: Any) -> list[TextContent]:
+    """Format a successful result as JSON text content."""
+    if isinstance(data, str):
+        return [TextContent(type="text", text=data)]
+    return [TextContent(type="text", text=json.dumps(data, indent=2))]
+
+
+def error_result(msg: str) -> list[TextContent]:
+    """Format an error message as text content."""
+    return [TextContent(type="text", text=f"Error: {msg}")]
+
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    """List available Obsidian KM tools."""
+    return [
+        Tool(
+            name="note_search",
+            description=(
+                "Search notes in the Obsidian vault using full-text search (ripgrep). "
+                "Returns matching notes with title, path, excerpt, and tags. "
+                "Case-insensitive by default. Optionally restrict search to a subfolder."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Search query. Matches are case-insensitive.",
+                    },
+                    "folder": {
+                        "type": "string",
+                        "description": (
+                            "Optional subfolder to restrict search. "
+                            "Relative to vault root (e.g., 'projects' or 'daily/2024')."
+                        ),
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum number of results to return. Default: 10.",
+                        "default": 10,
+                        "minimum": 1,
+                        "maximum": 100,
+                    },
+                },
+                "required": ["query"],
+            },
+        ),
+        Tool(
+            name="note_read",
+            description=(
+                "Read a specific note by title or path. "
+                "Returns the full note content along with metadata (title, tags, timestamps). "
+                "Supports exact match by path, exact match by title (case-insensitive), "
+                "and fuzzy match (case-insensitive partial title match) as fallback."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "title_or_path": {
+                        "type": "string",
+                        "description": (
+                            "Note title or relative path. "
+                            "Examples: 'My Note', 'projects/project-plan', 'daily/2024-01-15.md'. "
+                            "The .md extension is optional."
+                        ),
+                    },
+                    "folder": {
+                        "type": "string",
+                        "description": (
+                            "Optional subfolder to restrict search. "
+                            "Relative to vault root (e.g., 'projects' or 'daily/2024')."
+                        ),
+                    },
+                },
+                "required": ["title_or_path"],
+            },
+        ),
+    ]
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    """Dispatch tool calls."""
+    try:
+        if name == "note_search":
+            return await handle_note_search(arguments)
+        elif name == "note_read":
+            return await handle_note_read(arguments)
+        else:
+            return error_result(f"Unknown tool: {name}")
+    except Exception as e:
+        return error_result(f"Tool '{name}' failed: {e}")
+
+
+async def handle_note_search(args: dict) -> list[TextContent]:
+    """
+    Search notes in the Obsidian vault.
+
+    Uses ripgrep for fast full-text search. Returns list of matching notes
+    with title, path, excerpt (context around match), and tags.
+    """
+    from vault_ops import search_notes
+
+    query = str(args.get("query", "")).strip()
+    if not query:
+        return error_result("'query' is required")
+
+    folder = args.get("folder")
+    if folder is not None:
+        folder = str(folder).strip() or None
+
+    limit = int(args.get("limit", 10))
+    limit = max(1, min(limit, 100))  # Clamp to 1-100
+
+    # Check vault exists
+    if not VAULT_DIR.exists():
+        return error_result(f"Vault directory not found: {VAULT_DIR}")
+
+    print(f"[INFO] Searching vault for: {query!r} (folder={folder}, limit={limit})", file=sys.stderr)
+
+    # Run search in thread pool to avoid blocking
+    loop = asyncio.get_running_loop()
+    results = await loop.run_in_executor(
+        None,
+        lambda: search_notes(query=query, folder=folder, limit=limit),
+    )
+
+    if not results:
+        return text_result({
+            "query": query,
+            "folder": folder,
+            "count": 0,
+            "results": [],
+        })
+
+    return text_result({
+        "query": query,
+        "folder": folder,
+        "count": len(results),
+        "results": results,
+    })
+
+
+async def handle_note_read(args: dict) -> list[TextContent]:
+    """
+    Read a specific note by title or path.
+
+    Returns the full note content along with metadata:
+    - title: Extracted title (from frontmatter, H1, or filename)
+    - content: Full markdown content
+    - tags: List of tags (from frontmatter and inline)
+    - created: ISO timestamp of file creation
+    - modified: ISO timestamp of last modification
+    - path: Relative path from vault root
+    """
+    from vault_ops import read_note
+
+    title_or_path = str(args.get("title_or_path", "")).strip()
+    if not title_or_path:
+        return error_result("'title_or_path' is required")
+
+    folder = args.get("folder")
+    if folder is not None:
+        folder = str(folder).strip() or None
+
+    # Check vault exists
+    if not VAULT_DIR.exists():
+        return error_result(f"Vault directory not found: {VAULT_DIR}")
+
+    print(f"[INFO] Reading note: {title_or_path!r} (folder={folder})", file=sys.stderr)
+
+    # Run read in thread pool to avoid blocking
+    loop = asyncio.get_running_loop()
+    result = await loop.run_in_executor(
+        None,
+        lambda: read_note(title_or_path=title_or_path, folder=folder),
+    )
+
+    if result is None:
+        # Provide helpful error message
+        search_location = f"folder '{folder}'" if folder else "vault"
+        return error_result(
+            f"Note not found: '{title_or_path}' in {search_location}. "
+            "Try using note_search to find available notes."
+        )
+
+    return text_result(result)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+async def main():
+    print("[INFO] Obsidian KM MCP Server starting...", file=sys.stderr)
+    print(f"[INFO] Vault directory: {VAULT_DIR}", file=sys.stderr)
+    print(f"[INFO] Vault exists: {VAULT_DIR.exists()}", file=sys.stderr)
+
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options(),
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lobster-shop/obsidian-km/src/vault_ops.py
+++ b/lobster-shop/obsidian-km/src/vault_ops.py
@@ -1,0 +1,470 @@
+"""
+Vault operations for Obsidian KM skill.
+
+Pure functions for reading, writing, and searching notes in an Obsidian vault.
+"""
+
+import json
+import os
+import re
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import frontmatter
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+def get_vault_dir() -> Path:
+    """Get the vault directory from environment or default."""
+    vault_path = os.environ.get("OBSIDIAN_VAULT_DIR", str(Path.home() / "obsidian-vault"))
+    return Path(vault_path).expanduser()
+
+
+# ---------------------------------------------------------------------------
+# Note Metadata Extraction
+# ---------------------------------------------------------------------------
+
+def extract_title(path: Path, content: str) -> str:
+    """
+    Extract title from note. Priority:
+    1. YAML frontmatter 'title' field
+    2. First H1 heading (# Title)
+    3. Filename without extension
+    """
+    try:
+        post = frontmatter.loads(content)
+        if post.get("title"):
+            return str(post["title"])
+    except Exception:
+        pass
+
+    # Try to find first H1
+    h1_match = re.search(r"^#\s+(.+)$", content, re.MULTILINE)
+    if h1_match:
+        return h1_match.group(1).strip()
+
+    # Fall back to filename
+    return path.stem
+
+
+def extract_tags(content: str) -> list[str]:
+    """
+    Extract tags from note. Sources:
+    1. YAML frontmatter 'tags' field
+    2. Inline #tags in content
+    """
+    tags: set[str] = set()
+
+    try:
+        post = frontmatter.loads(content)
+        fm_tags = post.get("tags", [])
+        if isinstance(fm_tags, list):
+            tags.update(str(t) for t in fm_tags)
+        elif isinstance(fm_tags, str):
+            # Handle comma-separated string
+            tags.update(t.strip() for t in fm_tags.split(","))
+    except Exception:
+        pass
+
+    # Find inline #tags (but not in code blocks or links)
+    inline_tags = re.findall(r"(?<!\w)#([a-zA-Z][a-zA-Z0-9_-]*)", content)
+    tags.update(inline_tags)
+
+    return sorted(tags)
+
+
+def extract_excerpt(content: str, query: str, context_chars: int = 100) -> str:
+    """
+    Extract an excerpt around the first occurrence of the query.
+    Returns the first context_chars chars if query not found.
+    """
+    # Strip frontmatter for excerpt
+    try:
+        post = frontmatter.loads(content)
+        body = post.content
+    except Exception:
+        body = content
+
+    # Normalize whitespace
+    body = re.sub(r"\s+", " ", body).strip()
+
+    if not body:
+        return ""
+
+    # Find query position (case-insensitive)
+    lower_body = body.lower()
+    lower_query = query.lower()
+    pos = lower_body.find(lower_query)
+
+    if pos == -1:
+        # Query not found in body, return start of content
+        return body[:context_chars] + ("..." if len(body) > context_chars else "")
+
+    # Extract context around the match
+    start = max(0, pos - context_chars // 2)
+    end = min(len(body), pos + len(query) + context_chars // 2)
+
+    excerpt = body[start:end]
+
+    # Add ellipsis if truncated
+    if start > 0:
+        excerpt = "..." + excerpt
+    if end < len(body):
+        excerpt = excerpt + "..."
+
+    return excerpt
+
+
+def get_file_timestamps(path: Path) -> tuple[datetime | None, datetime | None]:
+    """
+    Get created and modified timestamps for a file.
+
+    Returns (created, modified) as datetime objects.
+    Falls back to mtime for created if ctime is not reliable.
+    """
+    try:
+        stat = path.stat()
+        # On Unix, st_ctime is inode change time, not creation.
+        # Use mtime as a reasonable fallback for created.
+        created = datetime.fromtimestamp(stat.st_mtime)  # Fallback
+        modified = datetime.fromtimestamp(stat.st_mtime)
+
+        # Try to get birth time if available (macOS, some Linux)
+        if hasattr(stat, 'st_birthtime'):
+            created = datetime.fromtimestamp(stat.st_birthtime)
+
+        return created, modified
+    except Exception:
+        return None, None
+
+
+# ---------------------------------------------------------------------------
+# Note Reading Functions
+# ---------------------------------------------------------------------------
+
+def read_note(
+    title_or_path: str,
+    folder: str | None = None,
+) -> dict[str, Any] | None:
+    """
+    Read a specific note by title or path.
+
+    Args:
+        title_or_path: Note title or relative path (with or without .md extension)
+        folder: Optional subfolder to restrict search
+
+    Returns:
+        Dict with keys: title, content, tags, created, modified, path
+        None if not found
+
+    Search strategy:
+    1. Exact path match (if title_or_path looks like a path)
+    2. Exact title match (case-insensitive)
+    3. Fuzzy match (case-insensitive partial title match)
+    """
+    vault_dir = get_vault_dir()
+
+    if not vault_dir.exists():
+        return None
+
+    search_dir = vault_dir / folder if folder else vault_dir
+    if not search_dir.exists():
+        return None
+
+    # Normalize the query
+    query = title_or_path.strip()
+    if not query:
+        return None
+
+    # Try exact path match first
+    note_path = _find_by_exact_path(query, search_dir, vault_dir)
+    if note_path:
+        return _read_note_file(note_path, vault_dir)
+
+    # Collect all .md files for title matching
+    candidates = _collect_note_files(search_dir)
+
+    # Try exact title match (case-insensitive)
+    note_path = _find_by_exact_title(query, candidates)
+    if note_path:
+        return _read_note_file(note_path, vault_dir)
+
+    # Fuzzy match: case-insensitive partial title match
+    note_path = _find_by_fuzzy_title(query, candidates)
+    if note_path:
+        return _read_note_file(note_path, vault_dir)
+
+    return None
+
+
+def _find_by_exact_path(
+    query: str,
+    search_dir: Path,
+    vault_dir: Path,
+) -> Path | None:
+    """
+    Find note by exact path match.
+
+    Handles paths with or without .md extension,
+    relative to vault or search_dir.
+    """
+    # Normalize: add .md if missing
+    path_query = query if query.endswith(".md") else f"{query}.md"
+
+    # Try relative to vault
+    full_path = vault_dir / path_query
+    if full_path.is_file() and _is_valid_note(full_path):
+        return full_path
+
+    # Try relative to search_dir (if different from vault)
+    if search_dir != vault_dir:
+        full_path = search_dir / path_query
+        if full_path.is_file() and _is_valid_note(full_path):
+            return full_path
+
+    return None
+
+
+def _collect_note_files(search_dir: Path) -> list[Path]:
+    """
+    Collect all .md files in search_dir, excluding hidden directories.
+    """
+    candidates: list[Path] = []
+
+    for path in search_dir.rglob("*.md"):
+        # Skip hidden directories (like .obsidian)
+        if any(part.startswith(".") for part in path.parts):
+            continue
+        candidates.append(path)
+
+    return candidates
+
+
+def _find_by_exact_title(
+    query: str,
+    candidates: list[Path],
+) -> Path | None:
+    """
+    Find note by exact title match (case-insensitive).
+
+    Checks both:
+    1. Extracted title (from frontmatter/H1/filename)
+    2. Filename stem (without extension)
+    """
+    query_lower = query.lower()
+
+    for path in candidates:
+        # Check filename stem first (fast)
+        if path.stem.lower() == query_lower:
+            return path
+
+        # Check extracted title (requires reading file)
+        try:
+            content = path.read_text(encoding="utf-8")
+            title = extract_title(path, content)
+            if title.lower() == query_lower:
+                return path
+        except Exception:
+            continue
+
+    return None
+
+
+def _find_by_fuzzy_title(
+    query: str,
+    candidates: list[Path],
+) -> Path | None:
+    """
+    Find note by fuzzy title match (case-insensitive partial match).
+
+    Returns the best match based on:
+    1. Shortest title that contains the query (most specific)
+    2. Filename stem matches preferred over extracted title matches
+    """
+    query_lower = query.lower()
+    matches: list[tuple[int, bool, Path]] = []  # (len, is_stem_match, path)
+
+    for path in candidates:
+        stem_lower = path.stem.lower()
+
+        # Check stem match
+        if query_lower in stem_lower:
+            matches.append((len(stem_lower), True, path))
+            continue
+
+        # Check extracted title match (requires reading file)
+        try:
+            content = path.read_text(encoding="utf-8")
+            title = extract_title(path, content)
+            if query_lower in title.lower():
+                matches.append((len(title), False, path))
+        except Exception:
+            continue
+
+    if not matches:
+        return None
+
+    # Sort by: stem match preferred, then shortest title
+    matches.sort(key=lambda x: (not x[1], x[0]))
+    return matches[0][2]
+
+
+def _is_valid_note(path: Path) -> bool:
+    """Check if path is a valid note file."""
+    return (
+        path.is_file()
+        and path.suffix.lower() == ".md"
+        and not any(part.startswith(".") for part in path.parts)
+    )
+
+
+def _read_note_file(path: Path, vault_dir: Path) -> dict[str, Any]:
+    """
+    Read a note file and return structured data.
+
+    Returns dict with: title, content, tags, created, modified, path
+    """
+    content = path.read_text(encoding="utf-8")
+    created, modified = get_file_timestamps(path)
+    rel_path = path.relative_to(vault_dir)
+
+    return {
+        "title": extract_title(path, content),
+        "content": content,
+        "tags": extract_tags(content),
+        "created": created.isoformat() if created else None,
+        "modified": modified.isoformat() if modified else None,
+        "path": str(rel_path),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Search Functions
+# ---------------------------------------------------------------------------
+
+def search_notes(
+    query: str,
+    folder: str | None = None,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """
+    Search notes in the vault using ripgrep.
+
+    Args:
+        query: Search query (case-insensitive by default)
+        folder: Optional subfolder to restrict search
+        limit: Maximum number of results to return
+
+    Returns:
+        List of dicts with keys: title, path, excerpt, tags
+    """
+    vault_dir = get_vault_dir()
+
+    if not vault_dir.exists():
+        return []
+
+    # Determine search path
+    search_path = vault_dir / folder if folder else vault_dir
+    if not search_path.exists():
+        return []
+
+    # Skip hidden directories like .obsidian
+    # Use ripgrep with JSON output for parsing
+    cmd = [
+        "rg",
+        "--json",           # JSON output for structured parsing
+        "-i",               # Case insensitive
+        "--glob", "*.md",   # Only markdown files
+        "--glob", "!.obsidian/**",  # Exclude .obsidian directory
+        "-l",               # List files only (faster initial scan)
+        query,
+        str(search_path),
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=5,  # 5 second timeout
+        )
+    except subprocess.TimeoutExpired:
+        return []
+    except FileNotFoundError:
+        # ripgrep not installed
+        return _fallback_search(query, search_path, limit)
+
+    if result.returncode not in (0, 1):  # 1 = no matches
+        return []
+
+    # Parse JSON lines output
+    matching_files: list[Path] = []
+    for line in result.stdout.strip().split("\n"):
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+            if data.get("type") == "match":
+                file_path = data.get("data", {}).get("path", {}).get("text")
+                if file_path:
+                    matching_files.append(Path(file_path))
+        except json.JSONDecodeError:
+            continue
+
+    # Process results up to limit
+    results: list[dict[str, Any]] = []
+    for path in matching_files[:limit]:
+        try:
+            content = path.read_text(encoding="utf-8")
+            rel_path = path.relative_to(vault_dir)
+            results.append({
+                "title": extract_title(path, content),
+                "path": str(rel_path),
+                "excerpt": extract_excerpt(content, query),
+                "tags": extract_tags(content),
+            })
+        except Exception:
+            continue
+
+    return results
+
+
+def _fallback_search(
+    query: str,
+    search_path: Path,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """
+    Fallback search using pure Python when ripgrep is not available.
+    Slower but functional.
+    """
+    vault_dir = get_vault_dir()
+    query_lower = query.lower()
+    results: list[dict[str, Any]] = []
+
+    for path in search_path.rglob("*.md"):
+        # Skip hidden directories
+        if any(part.startswith(".") for part in path.parts):
+            continue
+
+        try:
+            content = path.read_text(encoding="utf-8")
+            if query_lower in content.lower():
+                rel_path = path.relative_to(vault_dir)
+                results.append({
+                    "title": extract_title(path, content),
+                    "path": str(rel_path),
+                    "excerpt": extract_excerpt(content, query),
+                    "tags": extract_tags(content),
+                })
+                if len(results) >= limit:
+                    break
+        except Exception:
+            continue
+
+    return results

--- a/lobster-shop/obsidian-km/tests/__init__.py
+++ b/lobster-shop/obsidian-km/tests/__init__.py
@@ -1,0 +1,1 @@
+# obsidian-km tests

--- a/lobster-shop/obsidian-km/tests/test_vault_ops.py
+++ b/lobster-shop/obsidian-km/tests/test_vault_ops.py
@@ -1,0 +1,339 @@
+"""
+Tests for vault_ops module.
+
+Tests the read_note function with various matching strategies:
+- Exact path match
+- Exact title match (case-insensitive)
+- Fuzzy title match (partial, case-insensitive)
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Add src to path for imports
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from vault_ops import (
+    read_note,
+    extract_title,
+    extract_tags,
+    get_file_timestamps,
+    _collect_note_files,
+    _find_by_exact_title,
+    _find_by_fuzzy_title,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def temp_vault(tmp_path, monkeypatch):
+    """Create a temporary vault with sample notes."""
+    vault = tmp_path / "test-vault"
+    vault.mkdir()
+
+    # Set env var for vault location
+    monkeypatch.setenv("OBSIDIAN_VAULT_DIR", str(vault))
+
+    # Create sample notes
+    (vault / "Simple Note.md").write_text("# Simple Note\n\nThis is simple content.")
+
+    (vault / "note-with-frontmatter.md").write_text("""---
+title: Frontmatter Title
+tags: [project, planning]
+---
+
+# Heading Title
+
+Content with frontmatter.
+""")
+
+    (vault / "inline-tags.md").write_text("""# Inline Tags Test
+
+This note has #inline and #tags in the content.
+""")
+
+    # Create subfolder with notes
+    projects = vault / "projects"
+    projects.mkdir()
+    (projects / "project-alpha.md").write_text("""---
+title: Project Alpha Plan
+tags: active
+---
+
+# Project Alpha
+
+This is the alpha project plan with #milestone tags.
+""")
+
+    (projects / "project-beta.md").write_text("# Project Beta\n\nBeta project content.")
+
+    # Create .obsidian directory (should be excluded)
+    obsidian = vault / ".obsidian"
+    obsidian.mkdir()
+    (obsidian / "config.md").write_text("# Config\n\nThis should be excluded.")
+
+    return vault
+
+
+# ---------------------------------------------------------------------------
+# Tests: extract_title
+# ---------------------------------------------------------------------------
+
+class TestExtractTitle:
+    def test_title_from_frontmatter(self, tmp_path):
+        """Title in frontmatter takes priority."""
+        path = tmp_path / "test.md"
+        content = "---\ntitle: My Custom Title\n---\n# Heading\nContent"
+        assert extract_title(path, content) == "My Custom Title"
+
+    def test_title_from_h1(self, tmp_path):
+        """H1 heading used when no frontmatter title."""
+        path = tmp_path / "test.md"
+        content = "# First Heading\n\nSome content\n## Second"
+        assert extract_title(path, content) == "First Heading"
+
+    def test_title_from_filename(self, tmp_path):
+        """Filename used as fallback."""
+        path = tmp_path / "My Note Name.md"
+        content = "Just some content without heading"
+        assert extract_title(path, content) == "My Note Name"
+
+
+# ---------------------------------------------------------------------------
+# Tests: extract_tags
+# ---------------------------------------------------------------------------
+
+class TestExtractTags:
+    def test_tags_from_frontmatter_list(self):
+        """Tags from frontmatter list."""
+        content = "---\ntags: [one, two, three]\n---\nContent"
+        assert extract_tags(content) == ["one", "three", "two"]  # sorted
+
+    def test_tags_from_frontmatter_string(self):
+        """Tags from comma-separated string."""
+        content = "---\ntags: alpha, beta, gamma\n---\nContent"
+        assert extract_tags(content) == ["alpha", "beta", "gamma"]
+
+    def test_inline_tags(self):
+        """Inline #tags in content."""
+        content = "Content with #project and #active tags"
+        tags = extract_tags(content)
+        assert "project" in tags
+        assert "active" in tags
+
+    def test_combined_tags(self):
+        """Both frontmatter and inline tags."""
+        content = "---\ntags: [frontmatter]\n---\n#inline tag"
+        tags = extract_tags(content)
+        assert "frontmatter" in tags
+        assert "inline" in tags
+
+
+# ---------------------------------------------------------------------------
+# Tests: read_note - Exact Path Match
+# ---------------------------------------------------------------------------
+
+class TestReadNoteExactPath:
+    def test_exact_path_with_extension(self, temp_vault):
+        """Read note by exact path with .md extension."""
+        result = read_note("Simple Note.md")
+        assert result is not None
+        assert result["title"] == "Simple Note"
+        assert "simple content" in result["content"].lower()
+
+    def test_exact_path_without_extension(self, temp_vault):
+        """Read note by path without .md extension."""
+        result = read_note("Simple Note")
+        assert result is not None
+        assert result["title"] == "Simple Note"
+
+    def test_exact_path_in_subfolder(self, temp_vault):
+        """Read note by path in subfolder."""
+        result = read_note("projects/project-alpha.md")
+        assert result is not None
+        assert result["title"] == "Project Alpha Plan"
+        assert result["path"] == "projects/project-alpha.md"
+
+    def test_path_with_folder_restriction(self, temp_vault):
+        """Read note in specific folder by relative path."""
+        result = read_note("project-alpha", folder="projects")
+        assert result is not None
+        assert "Project Alpha" in result["title"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: read_note - Exact Title Match
+# ---------------------------------------------------------------------------
+
+class TestReadNoteExactTitle:
+    def test_exact_title_match_case_insensitive(self, temp_vault):
+        """Match title case-insensitively."""
+        result = read_note("simple note")
+        assert result is not None
+        assert result["title"] == "Simple Note"
+
+    def test_exact_title_from_frontmatter(self, temp_vault):
+        """Match title from frontmatter."""
+        result = read_note("Frontmatter Title")
+        assert result is not None
+        assert "frontmatter" in result["content"].lower()
+
+    def test_exact_title_match_filename_stem(self, temp_vault):
+        """Match by filename stem exactly."""
+        result = read_note("inline-tags")
+        assert result is not None
+        assert "#inline" in result["content"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: read_note - Fuzzy Title Match
+# ---------------------------------------------------------------------------
+
+class TestReadNoteFuzzyTitle:
+    def test_fuzzy_match_partial_title(self, temp_vault):
+        """Partial title match finds note."""
+        result = read_note("Alpha")
+        assert result is not None
+        assert "alpha" in result["title"].lower()
+
+    def test_fuzzy_match_case_insensitive(self, temp_vault):
+        """Fuzzy match is case-insensitive."""
+        result = read_note("BETA")
+        assert result is not None
+        assert "beta" in result["title"].lower()
+
+    def test_fuzzy_match_prefers_shorter(self, temp_vault):
+        """Fuzzy match prefers shorter (more specific) titles."""
+        # "project" appears in multiple notes, should prefer shortest match
+        result = read_note("project", folder="projects")
+        assert result is not None
+        # Both project-alpha and project-beta match, either is acceptable
+        assert "project" in result["title"].lower()
+
+    def test_fuzzy_match_in_folder(self, temp_vault):
+        """Fuzzy match respects folder restriction."""
+        result = read_note("alpha", folder="projects")
+        assert result is not None
+        assert result["path"].startswith("projects/")
+
+
+# ---------------------------------------------------------------------------
+# Tests: read_note - Metadata
+# ---------------------------------------------------------------------------
+
+class TestReadNoteMetadata:
+    def test_returns_tags(self, temp_vault):
+        """Result includes extracted tags."""
+        result = read_note("project-alpha", folder="projects")
+        assert result is not None
+        assert "active" in result["tags"]
+        assert "milestone" in result["tags"]
+
+    def test_returns_timestamps(self, temp_vault):
+        """Result includes created/modified timestamps."""
+        result = read_note("Simple Note")
+        assert result is not None
+        assert result["created"] is not None
+        assert result["modified"] is not None
+        # Timestamps should be ISO format
+        assert "T" in result["created"]
+
+    def test_returns_relative_path(self, temp_vault):
+        """Result path is relative to vault root."""
+        result = read_note("project-alpha", folder="projects")
+        assert result is not None
+        assert result["path"] == "projects/project-alpha.md"
+
+
+# ---------------------------------------------------------------------------
+# Tests: read_note - Error Cases
+# ---------------------------------------------------------------------------
+
+class TestReadNoteErrors:
+    def test_note_not_found(self, temp_vault):
+        """Returns None when note doesn't exist."""
+        result = read_note("nonexistent-note")
+        assert result is None
+
+    def test_empty_query(self, temp_vault):
+        """Returns None for empty query."""
+        result = read_note("")
+        assert result is None
+        result = read_note("   ")
+        assert result is None
+
+    def test_folder_not_found(self, temp_vault):
+        """Returns None when folder doesn't exist."""
+        result = read_note("anything", folder="nonexistent-folder")
+        assert result is None
+
+    def test_excludes_hidden_directories(self, temp_vault):
+        """Notes in .obsidian are not found."""
+        result = read_note("config")
+        assert result is None
+
+    def test_vault_not_exists(self, tmp_path, monkeypatch):
+        """Returns None when vault doesn't exist."""
+        monkeypatch.setenv("OBSIDIAN_VAULT_DIR", str(tmp_path / "nonexistent"))
+        result = read_note("anything")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: Helper Functions
+# ---------------------------------------------------------------------------
+
+class TestCollectNoteFiles:
+    def test_collects_md_files(self, temp_vault):
+        """Collects all .md files."""
+        files = _collect_note_files(temp_vault)
+        assert len(files) >= 3  # At least the root-level notes
+
+    def test_excludes_hidden_dirs(self, temp_vault):
+        """Excludes files in hidden directories."""
+        files = _collect_note_files(temp_vault)
+        paths = [str(f) for f in files]
+        assert not any(".obsidian" in p for p in paths)
+
+    def test_includes_subfolders(self, temp_vault):
+        """Includes files from subfolders."""
+        files = _collect_note_files(temp_vault)
+        paths = [str(f) for f in files]
+        assert any("projects" in p for p in paths)
+
+
+class TestFindByExactTitle:
+    def test_finds_by_stem(self, temp_vault):
+        """Finds note by filename stem."""
+        candidates = _collect_note_files(temp_vault)
+        result = _find_by_exact_title("inline-tags", candidates)
+        assert result is not None
+        assert result.stem == "inline-tags"
+
+    def test_case_insensitive(self, temp_vault):
+        """Match is case-insensitive."""
+        candidates = _collect_note_files(temp_vault)
+        result = _find_by_exact_title("INLINE-TAGS", candidates)
+        assert result is not None
+
+
+class TestFindByFuzzyTitle:
+    def test_partial_match(self, temp_vault):
+        """Finds note by partial title."""
+        candidates = _collect_note_files(temp_vault)
+        result = _find_by_fuzzy_title("alpha", candidates)
+        assert result is not None
+        assert "alpha" in result.stem.lower()
+
+    def test_no_match_returns_none(self, temp_vault):
+        """Returns None when no partial match."""
+        candidates = _collect_note_files(temp_vault)
+        result = _find_by_fuzzy_title("xyznonexistent", candidates)
+        assert result is None


### PR DESCRIPTION
## Summary

Implements the `note_read` MCP tool for the Obsidian KM skill, allowing users to read specific notes from their vault by title or path.

- **Exact path match** — accepts full or partial paths (with or without `.md` extension)
- **Exact title match** — case-insensitive, checks frontmatter title, H1 heading, and filename
- **Fuzzy match fallback** — case-insensitive partial title matching when no exact match found
- **Rich metadata** — returns title, content, tags, created/modified timestamps, and relative path
- **Folder restriction** — optionally limit search to a specific subfolder

## Implementation

- `read_note()` in `vault_ops.py` — pure function with tiered matching strategy
- `note_read` tool in `obsidian_km_server.py` — async MCP handler with thread pool execution

## Test Plan

- [x] 33 unit tests covering all matching strategies, metadata extraction, and error cases
- [x] Tests pass locally (0.23s execution time)

## Acceptance Criteria

- [x] `note_read(title_or_path, folder=None)` MCP tool exists
- [x] Accepts title or relative path
- [x] Returns: title, content, tags, created, modified, path
- [x] Fuzzy match fallback (case-insensitive partial title match)
- [x] Clear error if not found
- [x] Only returns .md files
- [x] < 500ms (tests complete in 0.23s total)

Closes SiderealPress/bisque#240

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)