### PR TITLE
feat(obsidian-km): skill preferences system [BIS-245]

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1147,6 +1147,32 @@ for stub_file in "user.base.bootup.md" "user.base.context.md" "user.dispatcher.b
     fi
 done
 
+# Seed skill configuration templates (only files that don't already exist)
+# Skills can have .env.template files in their config/ directory
+for skill_dir in "$INSTALL_DIR"/lobster-shop/*/; do
+    [ -d "$skill_dir" ] || continue
+    skill_name=$(basename "$skill_dir")
+    config_template="$skill_dir/config/${skill_name}.env.template"
+    if [ -f "$config_template" ]; then
+        # Handle special cases: obsidian-km → obsidian.env
+        env_name="${skill_name%.env.template}"
+        env_name="${env_name/-km/}"  # obsidian-km → obsidian
+        dest_file="$CONFIG_DIR/${env_name}.env"
+        if [ ! -f "$dest_file" ]; then
+            cp "$config_template" "$dest_file"
+            info "  Seeded skill config: ${env_name}.env"
+        fi
+    fi
+done
+
+# Also handle obsidian.env.template specifically (named differently from skill)
+OBSIDIAN_TEMPLATE="$INSTALL_DIR/lobster-shop/obsidian-km/config/obsidian.env.template"
+OBSIDIAN_DEST="$CONFIG_DIR/obsidian.env"
+if [ -f "$OBSIDIAN_TEMPLATE" ] && [ ! -f "$OBSIDIAN_DEST" ]; then
+    cp "$OBSIDIAN_TEMPLATE" "$OBSIDIAN_DEST"
+    info "  Seeded skill config: obsidian.env"
+fi
+
 success "Directories created"
 info "  $PROJECTS_DIR - All Lobster-managed projects"
 

--- a/lobster-shop/obsidian-km/behavior/system.md
+++ b/lobster-shop/obsidian-km/behavior/system.md
@@ -1,0 +1,42 @@
+# Obsidian Knowledge Management
+
+You have access to an Obsidian vault for knowledge management. Use these tools to help the user organize and retrieve information.
+
+## Available Tools
+
+- **obsidian_create_note**: Create a new note in the vault with a title, content, optional folder, and tags
+- **obsidian_search**: Search the vault for notes matching a query (searches filenames and content)
+- **obsidian_capture_link**: Archive a URL to the vault with optional title and notes
+- **obsidian_get_preferences**: View current Obsidian KM configuration
+
+## Usage Guidelines
+
+1. **Creating Notes**
+   - Use meaningful titles that describe the content
+   - Default folder is "Inbox" — use this for quick captures
+   - Add relevant tags to improve discoverability
+   - Use markdown formatting for content
+
+2. **Searching**
+   - Search is case-insensitive
+   - Searches both filenames and note content
+   - Results are limited by the max_search_results preference
+
+3. **Capturing Links**
+   - Automatically extracts title from URL if not provided
+   - Links are saved to the "Links" folder by default
+   - Add notes to provide context for why the link was saved
+   - Auto-capture can be disabled via preferences
+
+4. **When to Use Each Tool**
+   - User says "save this", "remember this", "note this down" → create_note
+   - User says "find", "search", "look for" → search
+   - User shares a URL and says "save", "archive", "bookmark" → capture_link
+   - User asks about settings or configuration → get_preferences
+
+## Behavior Notes
+
+- All notes include frontmatter with title, creation date, tags, and source
+- Notes are saved as .md files in the configured vault
+- If a file with the same name exists, a timestamp is appended
+- The vault path must be configured in ~/lobster-config/obsidian.env

--- a/lobster-shop/obsidian-km/config/obsidian.env.template
+++ b/lobster-shop/obsidian-km/config/obsidian.env.template
@@ -1,0 +1,61 @@
+# =============================================================================
+# Obsidian Knowledge Management Skill Configuration
+# =============================================================================
+# Copy this file to ~/lobster-config/obsidian.env and configure as needed.
+# These preferences control Obsidian vault integration behavior.
+#
+# Installation:
+#   cp ~/lobster/lobster-shop/obsidian-km/config/obsidian.env.template ~/lobster-config/obsidian.env
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Vault Configuration
+# -----------------------------------------------------------------------------
+
+# Path to your Obsidian vault directory (required for local vault access)
+# Example: /home/user/Documents/ObsidianVault
+OBSIDIAN_VAULT_PATH=
+
+# -----------------------------------------------------------------------------
+# Default Folder Settings
+# -----------------------------------------------------------------------------
+
+# Default folder for new notes created via Lobster
+# Notes captured without an explicit folder will be placed here.
+# The folder will be created if it doesn't exist.
+# Default: Inbox
+OBSIDIAN_DEFAULT_FOLDER=Inbox
+
+# Folder for archived/saved links
+# When auto-capturing links, they'll be saved here.
+# Default: Links
+OBSIDIAN_LINK_FOLDER=Links
+
+# -----------------------------------------------------------------------------
+# Auto-Capture Behavior
+# -----------------------------------------------------------------------------
+
+# Automatically capture and archive links shared in conversation
+# When true, Lobster will save links to the OBSIDIAN_LINK_FOLDER
+# Set to "false" to disable automatic link capture
+# Default: true
+OBSIDIAN_AUTO_CAPTURE_LINKS=true
+
+# -----------------------------------------------------------------------------
+# Tagging & Organization
+# -----------------------------------------------------------------------------
+
+# Default tags to apply to all new notes (comma-separated)
+# Example: lobster,captured,inbox
+# Leave empty for no default tags
+# Default: (empty)
+OBSIDIAN_DEFAULT_TAGS=
+
+# -----------------------------------------------------------------------------
+# Search Settings
+# -----------------------------------------------------------------------------
+
+# Maximum number of results to return from vault searches
+# Higher values may slow down searches on large vaults
+# Default: 10
+OBSIDIAN_MAX_SEARCH_RESULTS=10

--- a/lobster-shop/obsidian-km/install.sh
+++ b/lobster-shop/obsidian-km/install.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+#===============================================================================
+# Obsidian Knowledge Management Skill Installer for Lobster
+#
+# Sets up the Obsidian KM skill that lets Lobster interact with an Obsidian
+# vault — create notes, search content, and capture links.
+#
+# Usage: bash ~/lobster/lobster-shop/obsidian-km/install.sh
+#===============================================================================
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
+success() { echo -e "${GREEN}[OK]${NC} $1"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error()   { echo -e "${RED}[ERROR]${NC} $1"; }
+step()    { echo -e "\n${CYAN}${BOLD}--- $1${NC}"; }
+
+# Paths
+LOBSTER_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
+SKILL_DIR="$LOBSTER_DIR/lobster-shop/obsidian-km"
+SRC_DIR="$SKILL_DIR/src"
+CONFIG_TEMPLATE="$SKILL_DIR/config/obsidian.env.template"
+VENV_DIR="$LOBSTER_DIR/.venv"
+PYTHON_PATH="$VENV_DIR/bin/python"
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+CONFIG_FILE="$CONFIG_DIR/obsidian.env"
+
+echo ""
+echo -e "${BOLD}Obsidian Knowledge Management Skill Installer${NC}"
+echo "=============================================="
+echo ""
+echo "This installs the Obsidian KM skill for Lobster."
+echo "It adds vault integration tools to Claude."
+echo ""
+
+#===============================================================================
+# Step 1: Check prerequisites
+#===============================================================================
+step "Checking prerequisites"
+
+# Check Python
+if [ -f "$PYTHON_PATH" ]; then
+    success "Lobster Python venv found: $PYTHON_PATH"
+elif command -v python3 &>/dev/null; then
+    PYTHON_PATH="python3"
+    success "Python 3 found: $(python3 --version)"
+else
+    error "Python 3 is required but not installed."
+    exit 1
+fi
+
+# Check Claude CLI
+if ! command -v claude &>/dev/null; then
+    error "Claude CLI is required but not installed."
+    exit 1
+fi
+success "Claude CLI found"
+
+# Check skill directory
+if [ ! -f "$SRC_DIR/obsidian_km_server.py" ]; then
+    error "Skill source not found at $SRC_DIR/obsidian_km_server.py"
+    exit 1
+fi
+success "Skill source found"
+
+#===============================================================================
+# Step 2: Install Python dependencies
+#===============================================================================
+step "Installing Python dependencies (mcp)"
+
+if [ -f "$VENV_DIR/bin/pip" ]; then
+    "$VENV_DIR/bin/pip" install --quiet "mcp>=1.0" 2>&1 || warn "pip install had issues (may already be installed)"
+    success "Python dependencies installed in Lobster venv"
+else
+    pip3 install --quiet "mcp>=1.0" 2>&1 || warn "pip3 install had issues"
+    success "Python dependencies installed"
+fi
+
+#===============================================================================
+# Step 3: Create configuration file
+#===============================================================================
+step "Setting up configuration"
+
+mkdir -p "$CONFIG_DIR"
+
+if [ -f "$CONFIG_FILE" ]; then
+    success "Configuration file already exists: $CONFIG_FILE"
+else
+    if [ -f "$CONFIG_TEMPLATE" ]; then
+        cp "$CONFIG_TEMPLATE" "$CONFIG_FILE"
+        success "Created configuration from template: $CONFIG_FILE"
+        echo ""
+        echo "  Please edit $CONFIG_FILE to set:"
+        echo "    OBSIDIAN_VAULT_PATH=/path/to/your/vault"
+        echo ""
+    else
+        warn "Configuration template not found: $CONFIG_TEMPLATE"
+        echo "  Create $CONFIG_FILE manually with:"
+        echo "    OBSIDIAN_VAULT_PATH=/path/to/your/vault"
+    fi
+fi
+
+# Check if vault path is configured
+VAULT_PATH=""
+if [ -f "$CONFIG_FILE" ]; then
+    VAULT_PATH=$(grep "^OBSIDIAN_VAULT_PATH=" "$CONFIG_FILE" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'" || true)
+fi
+
+if [ -n "$VAULT_PATH" ] && [ -d "$VAULT_PATH" ]; then
+    success "Vault configured and accessible: $VAULT_PATH"
+elif [ -n "$VAULT_PATH" ]; then
+    warn "Vault path configured but directory not found: $VAULT_PATH"
+else
+    warn "OBSIDIAN_VAULT_PATH is not configured."
+    echo ""
+    echo "  To use this skill, edit $CONFIG_FILE and set:"
+    echo "    OBSIDIAN_VAULT_PATH=/path/to/your/obsidian/vault"
+    echo ""
+fi
+
+#===============================================================================
+# Step 4: Register MCP server with Claude
+#===============================================================================
+step "Registering MCP server with Claude"
+
+# Remove old registration if it exists
+claude mcp remove obsidian-km 2>/dev/null || true
+
+# Register the Python MCP server
+if claude mcp add obsidian-km -s user -- "$PYTHON_PATH" "$SRC_DIR/obsidian_km_server.py" 2>/dev/null; then
+    success "MCP server registered: obsidian-km"
+else
+    warn "Could not register MCP server automatically."
+    echo "  Register manually with:"
+    echo "  claude mcp add obsidian-km -s user -- $PYTHON_PATH $SRC_DIR/obsidian_km_server.py"
+fi
+
+#===============================================================================
+# Step 5: Activate the skill
+#===============================================================================
+step "Activating the skill"
+
+# Activate the skill via the skill manager if lobster is available
+ACTIVATE_SCRIPT="$LOBSTER_DIR/src/mcp"
+if [ -f "$ACTIVATE_SCRIPT/skill_manager.py" ]; then
+    "$PYTHON_PATH" -c "
+import sys; sys.path.insert(0, '$ACTIVATE_SCRIPT')
+from skill_manager import activate_skill
+result = activate_skill('obsidian-km')
+print(result)
+" 2>/dev/null && success "Skill activated in Lobster skill manager" || warn "Could not activate via skill manager (will work after restart)"
+fi
+
+#===============================================================================
+# Done
+#===============================================================================
+echo ""
+echo -e "${GREEN}${BOLD}Obsidian KM skill installed!${NC}"
+echo ""
+echo "  Configuration: $CONFIG_FILE"
+echo ""
+echo "  Tools available to Lobster:"
+echo "    obsidian_create_note   - Create a note in the vault"
+echo "    obsidian_search        - Search vault content"
+echo "    obsidian_capture_link  - Archive a link to the vault"
+echo "    obsidian_get_preferences - View current settings"
+echo ""
+echo "  Preferences (edit $CONFIG_FILE):"
+echo "    OBSIDIAN_VAULT_PATH        - Path to your Obsidian vault (required)"
+echo "    OBSIDIAN_DEFAULT_FOLDER    - Default folder for new notes (default: Inbox)"
+echo "    OBSIDIAN_LINK_FOLDER       - Folder for captured links (default: Links)"
+echo "    OBSIDIAN_AUTO_CAPTURE_LINKS - Auto-capture links (default: true)"
+echo "    OBSIDIAN_DEFAULT_TAGS      - Default tags for notes (comma-separated)"
+echo "    OBSIDIAN_MAX_SEARCH_RESULTS - Max search results (default: 10)"
+echo ""
+echo "  Restart Lobster to activate: lobster restart"
+echo "    or: systemctl --user restart lobster-claude"
+echo ""

--- a/lobster-shop/obsidian-km/preferences/defaults.toml
+++ b/lobster-shop/obsidian-km/preferences/defaults.toml
@@ -1,0 +1,5 @@
+default_folder = "Inbox"
+link_folder = "Links"
+auto_capture_links = true
+default_tags = ""
+max_search_results = 10

--- a/lobster-shop/obsidian-km/preferences/schema.toml
+++ b/lobster-shop/obsidian-km/preferences/schema.toml
@@ -1,0 +1,24 @@
+[default_folder]
+type = "string"
+description = "Default folder for new notes created via Lobster. Notes captured without an explicit folder will be placed here."
+required = false
+
+[link_folder]
+type = "string"
+description = "Folder for archived/saved links. When auto-capturing links, they'll be saved here."
+required = false
+
+[auto_capture_links]
+type = "boolean"
+description = "Automatically capture and archive links shared in conversation."
+required = false
+
+[default_tags]
+type = "string"
+description = "Default tags to apply to all new notes (comma-separated). Example: lobster,captured,inbox"
+required = false
+
+[max_search_results]
+type = "integer"
+description = "Maximum number of results to return from vault searches. Higher values may slow down searches on large vaults."
+required = false

--- a/lobster-shop/obsidian-km/skill.toml
+++ b/lobster-shop/obsidian-km/skill.toml
@@ -1,0 +1,38 @@
+[skill]
+name = "obsidian-km"
+version = "1.0.0"
+description = "Obsidian vault integration for knowledge management — create notes, search content, and capture links"
+author = "Lobster"
+category = "integration"
+
+[activation]
+mode = "triggered"
+triggers = ["/obsidian", "/note", "/vault", "/km"]
+context_patterns = [
+    "when user asks to create a note",
+    "when user asks to search their vault",
+    "when user asks to capture or save a link",
+    "when user mentions Obsidian",
+    "when user wants to save something to their knowledge base",
+]
+
+[layering]
+priority = 50
+merge_strategy = "append"
+
+[provides]
+mcp_tools = ["obsidian_create_note", "obsidian_search", "obsidian_capture_link", "obsidian_get_preferences"]
+bot_commands = ["/note", "/vault", "/obsidian"]
+
+[compatibility]
+enhances = []
+conflicts = []
+
+[dependencies]
+pip = ["mcp>=1.0"]
+npm = []
+system = []
+api_keys = []
+
+[dependencies.runtime]
+python = ">=3.11"

--- a/lobster-shop/obsidian-km/src/obsidian_km_server.py
+++ b/lobster-shop/obsidian-km/src/obsidian_km_server.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""
+Obsidian Knowledge Management MCP Server for Lobster
+
+Provides tools for interacting with an Obsidian vault:
+- Create notes in the vault
+- Search vault content
+- Capture and archive links
+- Manage tags and organization
+
+Configuration is loaded from ~/lobster-config/obsidian.env at startup.
+"""
+
+import asyncio
+import json
+import os
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import Tool, TextContent
+
+# ---------------------------------------------------------------------------
+# Configuration Loading
+# ---------------------------------------------------------------------------
+
+def _load_env_file(path: Path) -> dict[str, str]:
+    """Parse a simple KEY=VALUE env file. Ignores comments and blank lines."""
+    result: dict[str, str] = {}
+    if not path.exists():
+        return result
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip()
+        val = val.strip().strip('"').strip("'")
+        if key:
+            result[key] = val
+    return result
+
+
+def _load_obsidian_config() -> dict[str, str]:
+    """Load Obsidian config from ~/lobster-config/obsidian.env.
+
+    Falls back to environment variables if file doesn't exist.
+    """
+    config_file = Path.home() / "lobster-config" / "obsidian.env"
+    return _load_env_file(config_file)
+
+
+# Load configuration at module startup
+_CONFIG = _load_obsidian_config()
+
+# ---------------------------------------------------------------------------
+# Preference Accessors
+# ---------------------------------------------------------------------------
+
+def _get_config(key: str, default: str = "") -> str:
+    """Get config value, checking env vars first, then config file."""
+    return os.getenv(key, _CONFIG.get(key, default))
+
+
+# Preference constants (loaded from obsidian.env with defaults)
+DEFAULT_FOLDER = _get_config("OBSIDIAN_DEFAULT_FOLDER", "Inbox")
+AUTO_CAPTURE_LINKS = _get_config("OBSIDIAN_AUTO_CAPTURE_LINKS", "true").lower() == "true"
+DEFAULT_TAGS = [t.strip() for t in _get_config("OBSIDIAN_DEFAULT_TAGS", "").split(",") if t.strip()]
+LINK_FOLDER = _get_config("OBSIDIAN_LINK_FOLDER", "Links")
+MAX_SEARCH_RESULTS = int(_get_config("OBSIDIAN_MAX_SEARCH_RESULTS", "10"))
+VAULT_PATH = _get_config("OBSIDIAN_VAULT_PATH", "")
+
+# ---------------------------------------------------------------------------
+# Vault Operations
+# ---------------------------------------------------------------------------
+
+def _get_vault_path() -> Path | None:
+    """Get the configured vault path, or None if not configured."""
+    if not VAULT_PATH:
+        return None
+    path = Path(VAULT_PATH).expanduser()
+    if path.exists() and path.is_dir():
+        return path
+    return None
+
+
+def _sanitize_filename(name: str) -> str:
+    """Sanitize a string for use as a filename."""
+    # Remove or replace invalid characters
+    sanitized = re.sub(r'[<>:"/\\|?*]', '', name)
+    # Collapse multiple spaces/underscores
+    sanitized = re.sub(r'[\s_]+', ' ', sanitized)
+    return sanitized.strip()[:200]  # Limit length
+
+
+def _format_tags(tags: list[str]) -> str:
+    """Format tags for Obsidian frontmatter."""
+    if not tags:
+        return ""
+    return ", ".join(f'"{t}"' for t in tags)
+
+
+def _create_note(
+    title: str,
+    content: str,
+    folder: str | None = None,
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    """Create a new note in the Obsidian vault.
+
+    Returns dict with 'path' on success, or 'error' on failure.
+    """
+    vault = _get_vault_path()
+    if not vault:
+        return {"error": "OBSIDIAN_VAULT_PATH not configured. Add it to ~/lobster-config/obsidian.env"}
+
+    # Use default folder if not specified
+    target_folder = folder or DEFAULT_FOLDER
+    folder_path = vault / target_folder
+    folder_path.mkdir(parents=True, exist_ok=True)
+
+    # Combine default tags with any specified tags
+    all_tags = list(DEFAULT_TAGS)
+    if tags:
+        all_tags.extend(t for t in tags if t not in all_tags)
+
+    # Generate filename
+    safe_title = _sanitize_filename(title)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"{safe_title}.md" if safe_title else f"Note_{timestamp}.md"
+    note_path = folder_path / filename
+
+    # Handle existing files
+    if note_path.exists():
+        filename = f"{safe_title}_{timestamp}.md" if safe_title else f"Note_{timestamp}.md"
+        note_path = folder_path / filename
+
+    # Build note content with frontmatter
+    lines = ["---"]
+    lines.append(f'title: "{title}"')
+    lines.append(f"created: {datetime.now(timezone.utc).isoformat()}")
+    if all_tags:
+        lines.append(f"tags: [{_format_tags(all_tags)}]")
+    lines.append("source: lobster")
+    lines.append("---")
+    lines.append("")
+    lines.append(content)
+
+    try:
+        note_path.write_text("\n".join(lines), encoding="utf-8")
+        return {
+            "path": str(note_path),
+            "relative_path": str(note_path.relative_to(vault)),
+            "folder": target_folder,
+            "title": title,
+        }
+    except Exception as e:
+        return {"error": f"Failed to create note: {e}"}
+
+
+def _search_vault(
+    query: str,
+    max_results: int | None = None,
+) -> list[dict[str, Any]]:
+    """Search the vault for notes matching the query.
+
+    Returns a list of matching notes with metadata.
+    """
+    vault = _get_vault_path()
+    if not vault:
+        return [{"error": "OBSIDIAN_VAULT_PATH not configured"}]
+
+    limit = max_results or MAX_SEARCH_RESULTS
+    results: list[dict[str, Any]] = []
+    query_lower = query.lower()
+
+    for md_file in vault.rglob("*.md"):
+        if len(results) >= limit:
+            break
+
+        try:
+            content = md_file.read_text(encoding="utf-8")
+            # Search in filename and content
+            if query_lower in md_file.stem.lower() or query_lower in content.lower():
+                # Extract title from frontmatter or filename
+                title = md_file.stem
+                if match := re.search(r'^title:\s*["\']?([^"\'\n]+)', content, re.MULTILINE):
+                    title = match.group(1).strip()
+
+                results.append({
+                    "path": str(md_file.relative_to(vault)),
+                    "title": title,
+                    "modified": datetime.fromtimestamp(md_file.stat().st_mtime).isoformat(),
+                })
+        except Exception:
+            continue  # Skip unreadable files
+
+    return results
+
+
+def _capture_link(
+    url: str,
+    title: str | None = None,
+    notes: str = "",
+) -> dict[str, Any]:
+    """Capture and archive a link to the vault.
+
+    Creates a note in LINK_FOLDER with the link details.
+    """
+    if not AUTO_CAPTURE_LINKS:
+        return {"skipped": True, "reason": "Auto-capture links is disabled"}
+
+    # Generate title from URL if not provided
+    if not title:
+        # Extract domain or path for title
+        from urllib.parse import urlparse
+        parsed = urlparse(url)
+        title = parsed.netloc or parsed.path or url[:50]
+
+    # Build note content
+    content_lines = [
+        f"# {title}",
+        "",
+        f"**URL:** {url}",
+        f"**Captured:** {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}",
+    ]
+
+    if notes:
+        content_lines.extend(["", "## Notes", "", notes])
+
+    return _create_note(
+        title=f"Link - {title}",
+        content="\n".join(content_lines),
+        folder=LINK_FOLDER,
+        tags=["link", "captured"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# MCP Server
+# ---------------------------------------------------------------------------
+
+server = Server("obsidian-km")
+
+
+def text_result(data: Any) -> list[TextContent]:
+    """Format a result as MCP text content."""
+    if isinstance(data, str):
+        return [TextContent(type="text", text=data)]
+    return [TextContent(type="text", text=json.dumps(data, indent=2))]
+
+
+def error_result(msg: str) -> list[TextContent]:
+    """Format an error as MCP text content."""
+    return [TextContent(type="text", text=f"Error: {msg}")]
+
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    """List available Obsidian KM tools."""
+    return [
+        Tool(
+            name="obsidian_create_note",
+            description=(
+                "Create a new note in the Obsidian vault. "
+                f"Default folder: '{DEFAULT_FOLDER}'. "
+                f"Default tags: {DEFAULT_TAGS or '(none)'}. "
+                "Requires OBSIDIAN_VAULT_PATH in ~/lobster-config/obsidian.env."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": "Title of the note",
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "Content of the note (markdown)",
+                    },
+                    "folder": {
+                        "type": "string",
+                        "description": f"Folder to create the note in (default: {DEFAULT_FOLDER})",
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Additional tags to apply to the note",
+                    },
+                },
+                "required": ["title", "content"],
+            },
+        ),
+        Tool(
+            name="obsidian_search",
+            description=(
+                f"Search the Obsidian vault for notes matching a query. "
+                f"Returns up to {MAX_SEARCH_RESULTS} results by default. "
+                "Searches both filenames and content."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Search query (searches filenames and content)",
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": f"Maximum results to return (default: {MAX_SEARCH_RESULTS})",
+                    },
+                },
+                "required": ["query"],
+            },
+        ),
+        Tool(
+            name="obsidian_capture_link",
+            description=(
+                f"Capture and archive a link to the Obsidian vault in the '{LINK_FOLDER}' folder. "
+                f"Auto-capture is {'enabled' if AUTO_CAPTURE_LINKS else 'disabled'}. "
+                "Creates a note with the URL, title, and optional notes."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "URL to capture",
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Title for the link (extracted from URL if not provided)",
+                    },
+                    "notes": {
+                        "type": "string",
+                        "description": "Optional notes or context about the link",
+                    },
+                },
+                "required": ["url"],
+            },
+        ),
+        Tool(
+            name="obsidian_get_preferences",
+            description="Get current Obsidian KM preferences and configuration.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+            },
+        ),
+    ]
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    """Dispatch tool calls."""
+    try:
+        if name == "obsidian_create_note":
+            return await handle_create_note(arguments)
+        elif name == "obsidian_search":
+            return await handle_search(arguments)
+        elif name == "obsidian_capture_link":
+            return await handle_capture_link(arguments)
+        elif name == "obsidian_get_preferences":
+            return await handle_get_preferences(arguments)
+        else:
+            return error_result(f"Unknown tool: {name}")
+    except Exception as e:
+        return error_result(f"Tool '{name}' failed: {e}")
+
+
+async def handle_create_note(args: dict) -> list[TextContent]:
+    """Handle obsidian_create_note tool call."""
+    title = str(args.get("title", "")).strip()
+    content = str(args.get("content", "")).strip()
+    folder = args.get("folder")
+    tags = args.get("tags", [])
+
+    if not title:
+        return error_result("'title' is required")
+    if not content:
+        return error_result("'content' is required")
+
+    result = _create_note(title=title, content=content, folder=folder, tags=tags)
+
+    if result.get("error"):
+        return error_result(result["error"])
+
+    return text_result({
+        "status": "created",
+        "path": result["relative_path"],
+        "folder": result["folder"],
+        "title": result["title"],
+    })
+
+
+async def handle_search(args: dict) -> list[TextContent]:
+    """Handle obsidian_search tool call."""
+    query = str(args.get("query", "")).strip()
+    max_results = args.get("max_results")
+
+    if not query:
+        return error_result("'query' is required")
+
+    results = _search_vault(query=query, max_results=max_results)
+
+    if results and results[0].get("error"):
+        return error_result(results[0]["error"])
+
+    return text_result({
+        "query": query,
+        "count": len(results),
+        "results": results,
+    })
+
+
+async def handle_capture_link(args: dict) -> list[TextContent]:
+    """Handle obsidian_capture_link tool call."""
+    url = str(args.get("url", "")).strip()
+    title = args.get("title")
+    notes = str(args.get("notes", "")).strip()
+
+    if not url:
+        return error_result("'url' is required")
+
+    result = _capture_link(url=url, title=title, notes=notes)
+
+    if result.get("skipped"):
+        return text_result({"status": "skipped", "reason": result["reason"]})
+
+    if result.get("error"):
+        return error_result(result["error"])
+
+    return text_result({
+        "status": "captured",
+        "path": result["relative_path"],
+        "folder": result["folder"],
+        "title": result["title"],
+    })
+
+
+async def handle_get_preferences(args: dict) -> list[TextContent]:
+    """Handle obsidian_get_preferences tool call."""
+    vault_path = _get_vault_path()
+    return text_result({
+        "vault_configured": vault_path is not None,
+        "vault_path": VAULT_PATH or "(not set)",
+        "default_folder": DEFAULT_FOLDER,
+        "link_folder": LINK_FOLDER,
+        "auto_capture_links": AUTO_CAPTURE_LINKS,
+        "default_tags": DEFAULT_TAGS,
+        "max_search_results": MAX_SEARCH_RESULTS,
+        "config_file": str(Path.home() / "lobster-config" / "obsidian.env"),
+    })
+
+
+# ---------------------------------------------------------------------------
+# Entry Point
+# ---------------------------------------------------------------------------
+
+async def main():
+    """Start the Obsidian KM MCP server."""
+    vault_status = "configured" if _get_vault_path() else "not configured"
+    print(f"[INFO] Obsidian KM MCP Server starting...", file=sys.stderr)
+    print(f"[INFO] Vault: {vault_status} ({VAULT_PATH or 'path not set'})", file=sys.stderr)
+    print(f"[INFO] Default folder: {DEFAULT_FOLDER}", file=sys.stderr)
+    print(f"[INFO] Link folder: {LINK_FOLDER}", file=sys.stderr)
+    print(f"[INFO] Auto-capture links: {AUTO_CAPTURE_LINKS}", file=sys.stderr)
+    print(f"[INFO] Default tags: {DEFAULT_TAGS or '(none)'}", file=sys.stderr)
+    print(f"[INFO] Max search results: {MAX_SEARCH_RESULTS}", file=sys.stderr)
+
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options(),
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- Adds the Obsidian KM skill with configurable preferences stored in `~/lobster-config/obsidian.env`
- MCP server loads preferences at startup with sensible defaults
- Updates `install.sh` to seed `obsidian.env` from template on first install

## Preferences Implemented

| Preference | Default | Description |
|------------|---------|-------------|
| `OBSIDIAN_DEFAULT_FOLDER` | `Inbox` | Default folder for new notes |
| `OBSIDIAN_AUTO_CAPTURE_LINKS` | `true` | Auto-archive links shared in conversation |
| `OBSIDIAN_DEFAULT_TAGS` | `""` | Comma-separated default tags |
| `OBSIDIAN_LINK_FOLDER` | `Links` | Folder for captured links |
| `OBSIDIAN_MAX_SEARCH_RESULTS` | `10` | Max results from vault searches |

## Files Created/Updated

- `lobster-shop/obsidian-km/config/obsidian.env.template` — documented config template
- `lobster-shop/obsidian-km/src/obsidian_km_server.py` — MCP server with preference loading
- `lobster-shop/obsidian-km/skill.toml` — skill manifest
- `lobster-shop/obsidian-km/preferences/schema.toml` — preference schema
- `lobster-shop/obsidian-km/preferences/defaults.toml` — default values
- `lobster-shop/obsidian-km/behavior/system.md` — skill behavior instructions
- `lobster-shop/obsidian-km/install.sh` — skill installer
- `install.sh` — updated to seed obsidian.env from template

## Test plan

- [ ] Run `install.sh` on a fresh system and verify `~/lobster-config/obsidian.env` is created
- [ ] Configure `OBSIDIAN_VAULT_PATH` and verify MCP server starts correctly
- [ ] Test `obsidian_create_note` tool creates notes in the configured default folder
- [ ] Test `obsidian_search` respects `MAX_SEARCH_RESULTS` preference
- [ ] Test `obsidian_capture_link` uses configured `LINK_FOLDER`
- [ ] Test `obsidian_get_preferences` returns current configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)