### PR TITLE
feat(obsidian-km): automatic link capture to vault [BIS-244]

### DIFF
--- a/lobster-shop/obsidian-km/README.md
+++ b/lobster-shop/obsidian-km/README.md
@@ -1,0 +1,76 @@
+# Obsidian KM
+
+**Automatic link capture to your Obsidian vault.**
+
+When Drew sends a URL in Telegram, Lobster automatically saves it to your Obsidian vault with:
+- Page title (fetched automatically)
+- Archive.org backup
+- Original caption
+- Date captured
+- `#link` tag for easy filtering
+
+## Features
+
+- **Automatic capture** — URLs are saved without any extra commands
+- **Duplicate detection** — Skip URLs already captured this month
+- **Page title fetch** — Uses headless browser to get real page titles
+- **Archive integration** — Links are backed up on archive.org
+- **Clean markdown** — Notes use YAML frontmatter for Obsidian compatibility
+
+## Installation
+
+```bash
+bash lobster-shop/obsidian-km/install.sh
+```
+
+Then create your Obsidian vault:
+```bash
+mkdir -p ~/obsidian-vault/Links
+```
+
+## Usage
+
+Just send URLs in Telegram — they're captured automatically.
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `/vault <url>` | Force-capture a URL (bypass duplicate check) |
+| `/vault status` | Show how many links captured this month |
+
+## Configuration
+
+Set preferences via `set_skill_preference`:
+
+| Preference | Default | Description |
+|------------|---------|-------------|
+| `OBSIDIAN_AUTO_CAPTURE_LINKS` | `true` | Enable automatic capture |
+| `OBSIDIAN_VAULT_PATH` | `~/obsidian-vault` | Path to vault |
+| `OBSIDIAN_LINKS_FOLDER` | `Links` | Folder for captured links |
+
+## Note Format
+
+```markdown
+---
+title: "Article Title"
+url: https://example.com/article
+tags: [link]
+captured: 2026-03-30T14:23:00
+archived: https://web.archive.org/web/20260330/https://example.com/article
+---
+
+[https://example.com/article](https://example.com/article)
+
+Saved from Telegram on 2026-03-30.
+```
+
+## Integration
+
+This skill **extends** existing Commonbook behavior:
+
+1. Archive on archive.org (Commonbook)
+2. Comment on brain-dumps issue (Commonbook)
+3. Save to Obsidian vault (this skill)
+
+All three happen for every captured link.

--- a/lobster-shop/obsidian-km/behavior/system.md
+++ b/lobster-shop/obsidian-km/behavior/system.md
@@ -1,0 +1,77 @@
+## Obsidian KM — Dispatcher Behavior
+
+### URL Detection
+
+When processing any message, check if it contains a URL:
+
+```python
+from link_capture import contains_url, extract_urls
+
+if contains_url(message_text):
+    urls = extract_urls(message_text)
+    # Trigger link capture for each URL
+```
+
+### Automatic Link Capture Flow
+
+1. **Detect URL** in incoming message
+2. **Acknowledge immediately**: `send_reply(chat_id, "Link saved.", message_id=message_id)`
+3. **Delegate capture** to background subagent (7-second rule)
+
+The subagent handles:
+- Preference check (`OBSIDIAN_AUTO_CAPTURE_LINKS`)
+- Duplicate detection (skip if captured this month)
+- Page title fetch via `fetch_page` MCP tool
+- Archive.org archival (existing Commonbook)
+- Vault note creation
+- Brain-dumps issue comment (existing Commonbook)
+
+### Subagent Prompt Template
+
+```
+Capture link to Obsidian vault and archive:
+
+URL: {url}
+Caption: {caption}
+Chat ID: {chat_id}
+
+Steps:
+1. Check OBSIDIAN_AUTO_CAPTURE_LINKS preference
+2. Check duplicate (skip if URL captured this month)
+3. Fetch page title: fetch_page(url="{url}")
+4. Archive: curl -s "https://web.archive.org/save/{url}"
+5. Capture to vault using link_capture module
+6. Comment on brain-dumps issue #17 with link + archive URL
+
+Use:
+```python
+import sys, os
+sys.path.insert(0, os.path.expanduser("~/lobster/lobster-shop/obsidian-km/src"))
+from link_capture import capture_link_sync
+
+result = capture_link_sync(
+    url="{url}",
+    caption="{caption}",
+    title=page_title,
+    archived_url=archive_url,
+)
+print(result.message)
+```
+
+Report only on error or skip.
+```
+
+### Manual Commands
+
+| Command | Action |
+|---------|--------|
+| `/vault <url>` | Force-capture URL (bypass duplicate check) |
+| `/vault status` | Show capture stats this month |
+| `/obsidian` | Alias for `/vault` |
+
+### Error Handling
+
+If capture fails:
+- Log error but don't interrupt user flow
+- Report to Drew only on persistent failures
+- Never expose stack traces in Telegram

--- a/lobster-shop/obsidian-km/context/obsidian-km.md
+++ b/lobster-shop/obsidian-km/context/obsidian-km.md
@@ -1,0 +1,128 @@
+## Obsidian KM — Automatic Link Capture
+
+This skill automatically saves URLs that Drew sends to the Obsidian vault at `~/obsidian-vault/Links/`.
+
+### When to capture links
+
+**Trigger:** Any message containing a URL (http:// or https://).
+
+**Before capturing, always check:**
+1. The `OBSIDIAN_AUTO_CAPTURE_LINKS` preference — if false, skip capture
+2. Run duplicate detection — skip if URL already saved this month
+
+### How to capture a link
+
+Delegate to a background subagent — fetching page titles takes > 7 seconds.
+
+**Dispatcher pattern:**
+```
+# 1. Acknowledge immediately
+send_reply(chat_id, "Link saved.", message_id=message_id)
+
+# 2. Delegate to subagent for the actual work
+Task(
+    prompt=f"""
+    Capture this link to Obsidian vault:
+
+    URL: {url}
+    Caption: {caption or "None"}
+
+    Steps:
+    1. Check OBSIDIAN_AUTO_CAPTURE_LINKS preference (skip if false)
+    2. Run duplicate detection for this month
+    3. Fetch page title using fetch_page MCP tool
+    4. Archive on archive.org (existing Commonbook behavior)
+    5. Save note to ~/obsidian-vault/Links/
+    6. Add comment to brain-dumps issue #17 (existing Commonbook behavior)
+
+    Use the link_capture module:
+    ```python
+    import sys, os
+    sys.path.insert(0, os.path.expanduser("~/lobster/lobster-shop/obsidian-km/src"))
+    from link_capture import capture_link
+
+    result = await capture_link(
+        url="{url}",
+        caption="{caption or ''}",
+    )
+    ```
+
+    Report back only if there's an error or if the link was skipped.
+    """,
+    subagent_type="general-purpose",
+    run_in_background=True
+)
+```
+
+### Duplicate detection logic
+
+A link is considered a duplicate if a file already exists in `~/obsidian-vault/Links/` this month with the same URL in its frontmatter. Check by:
+
+1. Glob `~/obsidian-vault/Links/{YYYY-MM}*.md` for current month
+2. Grep for `url: {normalized_url}` in those files
+3. If found, skip capture and log "Duplicate link — already captured this month"
+
+### Note template
+
+Saved to `~/obsidian-vault/Links/{YYYY-MM-DD}-{slug}.md`:
+
+```markdown
+---
+title: "Page Title"
+url: https://example.com/
+tags: [link]
+captured: 2026-03-30T14:23:00
+archived: https://web.archive.org/web/20260330/https://example.com/
+---
+
+[https://example.com/](https://example.com/)
+
+Saved from Telegram on 2026-03-30.
+```
+
+Where:
+- `title` — fetched from page title, or domain if unavailable
+- `url` — the original URL
+- `archived` — the archive.org snapshot URL (after archiving)
+- `slug` — URL-safe version of title (max 50 chars)
+
+### Preference: `OBSIDIAN_AUTO_CAPTURE_LINKS`
+
+| Value | Behavior |
+|-------|----------|
+| `true` (default) | Automatically capture links to vault |
+| `false` | Skip automatic capture; only respond to explicit `/vault` commands |
+
+Check preference using:
+```python
+from mcp.skill_system.skills import get_skill_preference
+
+auto_capture = get_skill_preference("obsidian-km", "OBSIDIAN_AUTO_CAPTURE_LINKS")
+if auto_capture is False:
+    # Skip automatic capture
+    return
+```
+
+### Integration with Commonbook
+
+This skill **extends** existing Commonbook behavior — it does NOT replace it.
+
+When a link is captured:
+1. Archive on archive.org ✓ (Commonbook)
+2. Comment on brain-dumps issue #17 ✓ (Commonbook)
+3. Save note to Obsidian vault ✓ (NEW — this skill)
+
+All three actions should happen for every captured link.
+
+### Vault directory structure
+
+```
+~/obsidian-vault/
+├── Links/
+│   ├── 2026-03-30-example-article.md
+│   ├── 2026-03-30-github-repo.md
+│   └── ...
+└── ...
+```
+
+The `Links/` folder is created automatically if it doesn't exist.

--- a/lobster-shop/obsidian-km/preferences/defaults.toml
+++ b/lobster-shop/obsidian-km/preferences/defaults.toml
@@ -1,0 +1,5 @@
+# Obsidian KM Default Preferences
+
+OBSIDIAN_AUTO_CAPTURE_LINKS = true
+OBSIDIAN_VAULT_PATH = "~/obsidian-vault"
+OBSIDIAN_LINKS_FOLDER = "Links"

--- a/lobster-shop/obsidian-km/preferences/schema.toml
+++ b/lobster-shop/obsidian-km/preferences/schema.toml
@@ -1,0 +1,17 @@
+# Obsidian KM Preference Schema
+# Defines valid preference keys and their types
+
+[OBSIDIAN_AUTO_CAPTURE_LINKS]
+type = "boolean"
+description = "Automatically capture URLs to Obsidian vault when Drew sends them"
+default = true
+
+[OBSIDIAN_VAULT_PATH]
+type = "string"
+description = "Path to Obsidian vault directory"
+default = "~/obsidian-vault"
+
+[OBSIDIAN_LINKS_FOLDER]
+type = "string"
+description = "Folder within vault for captured links"
+default = "Links"

--- a/lobster-shop/obsidian-km/skill.toml
+++ b/lobster-shop/obsidian-km/skill.toml
@@ -1,0 +1,42 @@
+# =============================================================================
+# Obsidian KM — Knowledge Management Skill for Lobster
+# =============================================================================
+# Automatically capture links, notes, and knowledge to your Obsidian vault.
+
+[skill]
+name = "obsidian-km"
+version = "1.0.0"
+description = "Capture links and knowledge to your Obsidian vault — automatically archive URLs Drew sends with metadata and page titles"
+author = "Lobster"
+category = "integration"
+
+[activation]
+mode = "always"
+triggers = ["/vault", "/obsidian", "/note"]
+context_patterns = [
+    "when user sends a URL or link",
+    "when user asks to save a link",
+    "when user asks to capture a note",
+    "when discussing link archival or bookmarks",
+]
+
+[layering]
+priority = 45
+merge_strategy = "append"
+
+[provides]
+mcp_tools = []
+bot_commands = ["/vault", "/obsidian", "/note"]
+
+[compatibility]
+enhances = ["commonbook"]
+conflicts = []
+
+[dependencies]
+pip = []
+npm = []
+system = []
+api_keys = []
+
+[dependencies.runtime]
+python = ">=3.11"

--- a/lobster-shop/obsidian-km/src/__init__.py
+++ b/lobster-shop/obsidian-km/src/__init__.py
@@ -1,0 +1,23 @@
+"""
+Obsidian KM — Knowledge Management for Lobster
+
+Automatic link capture and knowledge archival to Obsidian vault.
+"""
+
+from .link_capture import (
+    capture_link,
+    capture_link_sync,
+    contains_url,
+    extract_urls,
+    CaptureResult,
+    LinkNote,
+)
+
+__all__ = [
+    'capture_link',
+    'capture_link_sync',
+    'contains_url',
+    'extract_urls',
+    'CaptureResult',
+    'LinkNote',
+]

--- a/lobster-shop/obsidian-km/src/link_capture.py
+++ b/lobster-shop/obsidian-km/src/link_capture.py
@@ -1,0 +1,388 @@
+"""
+Obsidian KM — Link Capture Module
+
+Captures URLs to the Obsidian vault with metadata, page titles, and archive URLs.
+Designed for functional composition with clear input/output contracts.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import unicodedata
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+VAULT_PATH = Path(os.path.expanduser("~/obsidian-vault"))
+LINKS_FOLDER = VAULT_PATH / "Links"
+DEFAULT_AUTO_CAPTURE = True
+
+
+# =============================================================================
+# Data Types
+# =============================================================================
+
+@dataclass(frozen=True)
+class LinkNote:
+    """Immutable representation of a captured link note."""
+    title: str
+    url: str
+    tags: tuple[str, ...]
+    captured: datetime
+    archived: Optional[str]
+    caption: Optional[str]
+
+    def to_markdown(self) -> str:
+        """Render note as markdown with YAML frontmatter."""
+        tags_yaml = ", ".join(self.tags)
+        captured_iso = self.captured.strftime("%Y-%m-%dT%H:%M:%S")
+        date_str = self.captured.strftime("%Y-%m-%d")
+
+        archived_line = f'archived: {self.archived}\n' if self.archived else ''
+        caption_line = f'\n{self.caption}\n' if self.caption else ''
+
+        return f"""---
+title: "{escape_yaml_string(self.title)}"
+url: {self.url}
+tags: [{tags_yaml}]
+captured: {captured_iso}
+{archived_line}---
+
+[{self.url}]({self.url})
+{caption_line}
+Saved from Telegram on {date_str}.
+"""
+
+
+@dataclass(frozen=True)
+class CaptureResult:
+    """Result of a link capture operation."""
+    success: bool
+    filepath: Optional[Path]
+    message: str
+    skipped: bool = False
+
+
+# =============================================================================
+# Pure Functions
+# =============================================================================
+
+def escape_yaml_string(s: str) -> str:
+    """Escape special characters for YAML string values."""
+    return s.replace('\\', '\\\\').replace('"', '\\"')
+
+
+def slugify(text: str, max_length: int = 50) -> str:
+    """
+    Convert text to URL-safe slug.
+
+    Pure function: same input always produces same output.
+    """
+    # Normalize unicode characters
+    text = unicodedata.normalize('NFKD', text)
+    text = text.encode('ascii', 'ignore').decode('ascii')
+
+    # Convert to lowercase and replace non-alphanumeric with hyphens
+    text = re.sub(r'[^\w\s-]', '', text.lower())
+    text = re.sub(r'[-\s]+', '-', text).strip('-')
+
+    # Truncate to max length at word boundary
+    if len(text) > max_length:
+        text = text[:max_length].rsplit('-', 1)[0]
+
+    return text or 'untitled'
+
+
+def extract_domain(url: str) -> str:
+    """Extract domain from URL as fallback title."""
+    try:
+        parsed = urlparse(url)
+        domain = parsed.netloc
+        # Remove www. prefix
+        if domain.startswith('www.'):
+            domain = domain[4:]
+        return domain
+    except Exception:
+        return 'unknown'
+
+
+def normalize_url(url: str) -> str:
+    """
+    Normalize URL for duplicate detection.
+
+    Strips trailing slashes, removes www., lowercases domain.
+    """
+    url = url.strip()
+    if not url.startswith(('http://', 'https://')):
+        url = 'https://' + url
+
+    try:
+        parsed = urlparse(url)
+        domain = parsed.netloc.lower()
+        if domain.startswith('www.'):
+            domain = domain[4:]
+
+        path = parsed.path.rstrip('/')
+        query = f'?{parsed.query}' if parsed.query else ''
+
+        return f"{parsed.scheme}://{domain}{path}{query}"
+    except Exception:
+        return url
+
+
+def generate_filename(title: str, captured: datetime) -> str:
+    """Generate filename for link note."""
+    date_prefix = captured.strftime("%Y-%m-%d")
+    slug = slugify(title)
+    return f"{date_prefix}-{slug}.md"
+
+
+def create_link_note(
+    url: str,
+    title: str,
+    archived_url: Optional[str] = None,
+    caption: Optional[str] = None,
+    captured: Optional[datetime] = None,
+) -> LinkNote:
+    """
+    Create an immutable LinkNote from inputs.
+
+    Pure function: no side effects, deterministic output.
+    """
+    return LinkNote(
+        title=title or extract_domain(url),
+        url=normalize_url(url),
+        tags=('link',),
+        captured=captured or datetime.now(timezone.utc),
+        archived=archived_url,
+        caption=caption.strip() if caption else None,
+    )
+
+
+# =============================================================================
+# I/O Functions (side effects isolated here)
+# =============================================================================
+
+def ensure_links_folder() -> Path:
+    """Create Links folder if it doesn't exist."""
+    LINKS_FOLDER.mkdir(parents=True, exist_ok=True)
+    return LINKS_FOLDER
+
+
+def check_duplicate_this_month(url: str, now: Optional[datetime] = None) -> bool:
+    """
+    Check if URL was already captured this month.
+
+    Returns True if duplicate found, False otherwise.
+    """
+    now = now or datetime.now(timezone.utc)
+    month_prefix = now.strftime("%Y-%m")
+    normalized = normalize_url(url)
+
+    if not LINKS_FOLDER.exists():
+        return False
+
+    # Check files from this month
+    for filepath in LINKS_FOLDER.glob(f"{month_prefix}*.md"):
+        try:
+            content = filepath.read_text(encoding='utf-8')
+            # Look for url: in frontmatter
+            if f"url: {normalized}" in content:
+                return True
+        except Exception:
+            continue
+
+    return False
+
+
+def save_note_to_vault(note: LinkNote) -> Path:
+    """
+    Write note to vault. Returns filepath.
+
+    Side effect: writes file to disk.
+    """
+    folder = ensure_links_folder()
+    filename = generate_filename(note.title, note.captured)
+    filepath = folder / filename
+
+    # Handle collision by appending counter
+    counter = 1
+    base_filepath = filepath
+    while filepath.exists():
+        stem = base_filepath.stem
+        filepath = folder / f"{stem}-{counter}.md"
+        counter += 1
+
+    filepath.write_text(note.to_markdown(), encoding='utf-8')
+    return filepath
+
+
+def get_auto_capture_preference() -> bool:
+    """
+    Check OBSIDIAN_AUTO_CAPTURE_LINKS preference.
+
+    Returns True (capture enabled) or False (disabled).
+    """
+    try:
+        import sys
+        sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+        from mcp.skill_system.skills import get_skill_preference
+
+        value = get_skill_preference("obsidian-km", "OBSIDIAN_AUTO_CAPTURE_LINKS")
+        if value is None:
+            return DEFAULT_AUTO_CAPTURE
+        return bool(value)
+    except ImportError:
+        # Skill system not available, use default
+        return DEFAULT_AUTO_CAPTURE
+    except Exception:
+        return DEFAULT_AUTO_CAPTURE
+
+
+# =============================================================================
+# High-Level API
+# =============================================================================
+
+async def capture_link(
+    url: str,
+    caption: Optional[str] = None,
+    title: Optional[str] = None,
+    archived_url: Optional[str] = None,
+    skip_preference_check: bool = False,
+    skip_duplicate_check: bool = False,
+) -> CaptureResult:
+    """
+    Capture a link to the Obsidian vault.
+
+    This is the main entry point for link capture. It:
+    1. Checks OBSIDIAN_AUTO_CAPTURE_LINKS preference
+    2. Checks for duplicates this month
+    3. Creates and saves the note
+
+    Args:
+        url: The URL to capture
+        caption: Optional caption/context from the message
+        title: Optional page title (if already fetched)
+        archived_url: Optional archive.org URL (if already archived)
+        skip_preference_check: Skip the auto-capture preference check
+        skip_duplicate_check: Skip duplicate detection
+
+    Returns:
+        CaptureResult with success status, filepath, and message
+    """
+    # Validate URL
+    url = url.strip()
+    if not url:
+        return CaptureResult(
+            success=False,
+            filepath=None,
+            message="Empty URL provided",
+        )
+
+    if not url.startswith(('http://', 'https://')):
+        url = 'https://' + url
+
+    # Check preference
+    if not skip_preference_check and not get_auto_capture_preference():
+        return CaptureResult(
+            success=False,
+            filepath=None,
+            message="Auto-capture disabled (OBSIDIAN_AUTO_CAPTURE_LINKS=false)",
+            skipped=True,
+        )
+
+    # Check for duplicates
+    if not skip_duplicate_check and check_duplicate_this_month(url):
+        return CaptureResult(
+            success=False,
+            filepath=None,
+            message=f"Duplicate link — already captured this month: {url}",
+            skipped=True,
+        )
+
+    # Create note
+    note = create_link_note(
+        url=url,
+        title=title or extract_domain(url),
+        archived_url=archived_url,
+        caption=caption,
+    )
+
+    # Save to vault
+    try:
+        filepath = save_note_to_vault(note)
+        return CaptureResult(
+            success=True,
+            filepath=filepath,
+            message=f"Link captured: {filepath.name}",
+        )
+    except Exception as e:
+        return CaptureResult(
+            success=False,
+            filepath=None,
+            message=f"Failed to save note: {e}",
+        )
+
+
+def capture_link_sync(
+    url: str,
+    caption: Optional[str] = None,
+    title: Optional[str] = None,
+    archived_url: Optional[str] = None,
+    skip_preference_check: bool = False,
+    skip_duplicate_check: bool = False,
+) -> CaptureResult:
+    """
+    Synchronous version of capture_link for non-async contexts.
+    """
+    import asyncio
+
+    return asyncio.run(capture_link(
+        url=url,
+        caption=caption,
+        title=title,
+        archived_url=archived_url,
+        skip_preference_check=skip_preference_check,
+        skip_duplicate_check=skip_duplicate_check,
+    ))
+
+
+# =============================================================================
+# URL Extraction Helper
+# =============================================================================
+
+URL_PATTERN = re.compile(
+    r'https?://[^\s<>"{}|\\^`\[\]]+',
+    re.IGNORECASE
+)
+
+
+def extract_urls(text: str) -> list[str]:
+    """
+    Extract all URLs from text.
+
+    Returns list of unique URLs in order of first appearance.
+    """
+    matches = URL_PATTERN.findall(text)
+    # Deduplicate while preserving order
+    seen = set()
+    urls = []
+    for url in matches:
+        normalized = normalize_url(url)
+        if normalized not in seen:
+            seen.add(normalized)
+            urls.append(url)
+    return urls
+
+
+def contains_url(text: str) -> bool:
+    """Check if text contains any URLs."""
+    return bool(URL_PATTERN.search(text))


### PR DESCRIPTION
## Summary

- Add new **Obsidian KM** skill for automatic link capture to `~/obsidian-vault/Links/`
- URLs sent in Telegram are automatically saved with: page title, archive.org URL, caption, date, `#link` tag
- Duplicate detection: skip if URL already captured this month
- `OBSIDIAN_AUTO_CAPTURE_LINKS` preference to enable/disable auto-capture
- **Extends** existing Commonbook behavior (archive.org + brain-dumps issue) — does NOT replace it

## Files

| File | Purpose |
|------|---------|
| `lobster-shop/obsidian-km/src/link_capture.py` | Core capture logic (pure functions + isolated I/O) |
| `lobster-shop/obsidian-km/context/obsidian-km.md` | Dispatcher instructions for URL detection & capture |
| `lobster-shop/obsidian-km/behavior/system.md` | Behavioral patterns and subagent prompts |
| `lobster-shop/obsidian-km/skill.toml` | Skill manifest |
| `lobster-shop/obsidian-km/preferences/` | Schema and defaults for preferences |

## Link note format

```markdown
---
title: "Page Title"
url: https://example.com/
tags: [link]
captured: 2026-03-30T14:23:00
archived: https://web.archive.org/web/20260330/https://example.com/
---

[https://example.com/](https://example.com/)

Saved from Telegram on 2026-03-30.
```

## Test plan

- [ ] Send a URL in Telegram → verify note created in `~/obsidian-vault/Links/`
- [ ] Send same URL again → verify duplicate detection skips it
- [ ] Set `OBSIDIAN_AUTO_CAPTURE_LINKS=false` → verify no auto-capture
- [ ] Verify existing Commonbook behavior still works (archive.org + brain-dumps)

Closes BIS-244

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)