### PR TITLE
fix: allow hatchling direct references for blue-lobster git dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ override-dependencies = [
     "pillow>=12.1.1",
 ]
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
 


### PR DESCRIPTION
## What problem this solves

`uv pip install -e .` fails after upgrades with:
```
ValueError: Dependency #14 of field `project.dependencies` cannot be a direct reference
unless field `tool.hatch.metadata.allow-direct-references` is set to `true`
```

The `blue-lobster` dependency uses a git direct reference (`@ git+https://github.com/sayhar/blue-lobster.git`). Hatchling requires explicit opt-in via `[tool.hatch.metadata] allow-direct-references = true` — without it, installs fail at the metadata validation step, blocking the full upgrade path.

## What changed

Added a `[tool.hatch.metadata]` section with `allow-direct-references = true` immediately before `[tool.hatch.build.targets.wheel]` in `pyproject.toml`. This is a three-line addition with no behavior change to the package itself — only the build backend's validation step is affected.

## Functional patterns

Pure config change — no code logic involved. No state transitions or sequencing altered.

## Tests run

- [x] `uv pip install -e .` — succeeds after this change (was failing before with the ValueError above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)