### PR TITLE
fix: remove private blue-lobster dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "twilio>=9.0.0",
     "websockets>=13.0",
     "cryptography>=42.0.0",
-    "blue-lobster @ git+https://github.com/sayhar/blue-lobster.git",
 ]
 
 [project.optional-dependencies]
@@ -46,9 +45,6 @@ build-backend = "hatchling.build"
 override-dependencies = [
     "pillow>=12.1.1",
 ]
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]


### PR DESCRIPTION
## Problem

`sayhar/blue-lobster` was listed as a hard dependency in `pyproject.toml`:

```
"blue-lobster @ git+https://github.com/sayhar/blue-lobster.git",
```

This silently breaks forks and fresh installs with:
```
ERROR: Repository 'https://github.com/sayhar/blue-lobster/' not found.
```

## Root Cause

The package was never actually imported anywhere in the codebase. The bot-talk mirroring functionality it was meant to provide is already handled by the in-tree module at `src/mcp/bot_talk_mirror.py`. A local shim at `src/mcp/bot_talk/` re-exports `mirror_outbound` and `mirror_inbound` from that module.

There's a branch `feature/issue-migrate-bot-talk-blue-lobster` that was meant to go the other direction (migrate imports TO blue-lobster), but the current state of `main` never completed that migration — the in-tree implementation is what's actually used.

## Fix

- Remove the `blue-lobster` line from `pyproject.toml`
- Remove the `[tool.hatch.metadata] allow-direct-references = true` stanza (only needed for git+https:// URL references)

No runtime behaviour changes — the shim already works without the package installed.

## Action Required from sayhar

None required for this fix to work. However, you may want to decide the long-term direction:
- **Keep in-tree** (this PR): `bot_talk_mirror.py` stays in Lobster, no external dependency
- **Extract to blue-lobster**: make `sayhar/blue-lobster` public so forks can install it, or use a different distribution mechanism

🤖 Generated with [Claude Code](https://claude.com/claude-code)