### PR TITLE
docs(subagent): add IFTTT behavioral rules section to sys.subagent.bootup.md

### DIFF
--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -344,6 +344,35 @@ Lobster uses a tiered model strategy to balance cost and quality. Each subagent 
   The `patch.multiple` module target for inbox_server tests is always
   `"src.mcp.inbox_server"` (not `"inbox_server"` or `"mcp.inbox_server"`).
 
+## IFTTT Behavioral Rules
+
+Lobster maintains a bounded list of "if X then Y" behavioral rules that encode user preferences and recurring patterns. These rules apply to all roles — the dispatcher loads them at startup, but subagents should also check them when relevant to the task at hand.
+
+**When to check rules as a subagent:**
+
+- You're generating output that affects the user directly (formatting, tone, content decisions)
+- Your task involves a domain where user preferences might apply (coding style, communication style, task prioritization)
+- You're about to make a discretionary choice (e.g., how to structure a report, whether to include details)
+
+You do NOT need to load all rules at the start of every subagent session. Check them when they would plausibly affect your output.
+
+**MCP tools available:**
+
+| Tool | Use |
+|------|-----|
+| `list_rules(enabled_only=true)` | Get all enabled rules (with `resolve=true` to include behavioral content inline) |
+| `get_rule(rule_id, resolve=true)` | Get a single rule with its behavioral content |
+| `add_rule(condition, action_content)` | Add a new rule (stores content to memory DB automatically) |
+| `update_rule(rule_id, ...)` | Update condition, action, or enabled state of an existing rule |
+| `delete_rule(rule_id)` | Remove a rule |
+
+**Key constraints:**
+
+- Do NOT import `src/utils/ifttt_rules` directly — always go through MCP tools
+- Do NOT write to `~/lobster-user-config/memory/canonical/ifttt-rules.yaml` directly — that file is managed by the MCP layer
+- Rules are never surfaced to the user unless the user explicitly asks to see them
+- Add rules only when a genuine recurring pattern exists or the user explicitly establishes a permanent preference — not on a single request
+
 ## PR and Issue Body: Always Canonical
 
 The body of a PR or issue is the canonical state of that work — not just the opening post. As things evolve (reviews, new commits, design changes, resolved concerns, scope changes), update the body to reflect what the thing *is* now, not what it was when opened.


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

Subagents that perform user-facing tasks have no documented awareness of IFTTT-style behavioral rules, despite those rules being relevant to any discretionary output decision. PR #904 added 5 MCP tools for rules management and updated `sys.dispatcher.bootup.md`, but left `sys.subagent.bootup.md` with no mention of the feature.

This PR adds a concise "IFTTT Behavioral Rules" section to `sys.subagent.bootup.md` that tells subagents:
- What the rules system is and when it applies to their work
- The 5 MCP tools (`list_rules`, `get_rule`, `add_rule`, `update_rule`, `delete_rule`) with a compact reference table
- That rules should be checked lazily (when relevant to the task), not loaded unconditionally at session start
- Hard constraints: no direct Python imports of `src/utils/ifttt_rules`, no direct YAML writes

The section is intentionally shorter than the dispatcher version — subagents have no startup loading loop and don't need the cap/LRU enforcement details. The dispatcher version at line 1026 of `sys.dispatcher.bootup.md` remains the authoritative reference for those mechanics.

No behavior changes to any code. Documentation only.

Closes #1155

## Tests run
- [x] `git diff --stat` — 1 file changed, 29 insertions(+), 0 deletions. No unintended modifications.
- [ ] Runtime test (subagent reads file and checks rules) — not applicable: documentation change only, no executable code modified.