### PR TITLE
🤖🦞 Lobster (engineer): Add IFTTT behavioral rules to CLAUDE.md shared base context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,21 @@ Skills are rich four-dimensional units (behavior + context + preferences + tooli
 
 > **Dispatcher-only:** skill loading at message start and `/shop`/`/skill` command handling are documented in `.claude/sys.dispatcher.bootup.md`.
 
+### IFTTT Behavioral Rules
+
+Lobster maintains a bounded list of "if X then Y" behavioral rules. These are persistent preferences the system has learned — for example, "if the user asks about topic X, always include Y."
+
+**Always access rules through MCP tools. Never import `src/utils/ifttt_rules` directly.**
+
+Available MCP tools:
+- `list_rules(enabled_only?)` — list all rules; pass `enabled_only=true` to get only active rules; pass `resolve=true` to include behavioral content inline
+- `add_rule(condition, action_content)` — create a new rule; stores behavioral content to the memory DB automatically and returns a rule ID
+- `get_rule(rule_id, resolve?)` — fetch a single rule; pass `resolve=true` to include behavioral content
+- `update_rule(rule_id, ...)` — update condition, action content, or enabled state
+- `delete_rule(rule_id)` — remove a rule permanently
+
+Rules are capped at 100 entries. Rules are never surfaced to the user unless explicitly asked. The dispatcher loads enabled rules at startup — see `.claude/sys.dispatcher.bootup.md` for startup loading details.
+
 ## Behavior Guidelines
 
 1. **Be concise** - Users are on mobile


### PR DESCRIPTION
## Problem

IFTTT behavioral rules documentation lived exclusively in `sys.dispatcher.bootup.md`, which is only read by the dispatcher. Any subagent (engineer, ops, etc.) that needs to interact with rules — for example, to list, add, or update a preference rule — had no guidance on which MCP tools to use. The risk: a subagent might try to import `src/utils/ifttt_rules` directly instead of going through MCP, bypassing the memory DB integration.

## What changed

A concise `### IFTTT Behavioral Rules` section is added to `CLAUDE.md`, the shared base context file loaded by all roles. It documents:

- What IFTTT rules are (persistent "if condition → action" behavioral preferences)
- All 5 MCP tools: `list_rules`, `add_rule`, `get_rule`, `update_rule`, `delete_rule` — with the key parameters for each
- The hard constraint: never import `src/utils/ifttt_rules` directly
- The 100-rule cap and the pointer to the dispatcher file for startup loading details

The existing dispatcher section in `sys.dispatcher.bootup.md` is unchanged — the startup loading logic, session-application rules, and autonomous rule-creation behavior remain there. This PR does not touch that file. The new CLAUDE.md section cross-references it for startup details, so there is no duplication of the operational logic.

## What is out of scope

- No changes to `sys.dispatcher.bootup.md` (the optional slim-down was blocked by tool permissions on `.claude/` files; the existing content is not harmful to leave, and the cross-reference in CLAUDE.md is sufficient)
- No changes to runtime behavior — this is documentation only

## Functional patterns

Pure documentation change. No code paths altered.

## Tests run

- [x] `git diff CLAUDE.md` — reviewed diff; section is well-formed Markdown, placed after the Skill System subsection and before Behavior Guidelines
- [ ] Live dispatcher startup test — not applicable; documentation-only change with no code execution path

Closes #1156