### PR TITLE
fix(docs): add Telegram threading rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,8 @@ User context files are private and not committed to git. They contain user-speci
 ## Available Tools (MCP)
 
 ### Messaging Tools
-- `send_reply(chat_id, text, source?, thread_ts?, buttons?, message_id?, task_id?)` - Send a reply to a user. **Pass `message_id` to atomically mark the message as processed** (combines send_reply + mark_processed in one call). **Pass `task_id` (subagents only) to auto-suppress duplicate delivery: if write_result is later called with the same task_id, sent_reply_to_user is automatically set to True.** Supports inline keyboard buttons (Telegram) and thread replies (Slack).
+- `send_reply(chat_id, text, source?, thread_ts?, buttons?, message_id?, task_id?, reply_to_message_id?)` - Send a reply to a user. **Pass `message_id` to atomically mark the message as processed** (combines send_reply + mark_processed in one call). **Pass `task_id` (subagents only) to auto-suppress duplicate delivery: if write_result is later called with the same task_id, sent_reply_to_user is automatically set to True.** Supports inline keyboard buttons (Telegram) and thread replies (Slack).
+  > **Telegram threading**: When replying to a Telegram message, always pass `reply_to_message_id` (the integer Telegram message ID shown in `wait_for_messages` output as "pass as reply_to_message_id") in addition to `message_id`. Without `reply_to_message_id`, replies are sent standalone — not threaded to the original message. `message_id` and `reply_to_message_id` serve different purposes: `message_id` marks the internal inbox message as processed; `reply_to_message_id` creates the Telegram thread.
 - `check_inbox(source?, limit?)` - Non-blocking inbox check
 - `list_sources()` - List available channels
 - `get_stats()` - Inbox statistics


### PR DESCRIPTION
Closes #1164

## What this fixes

Agents (both dispatcher and subagents) have been sending Telegram replies as standalone messages rather than threads, because `CLAUDE.md` never mentioned `reply_to_message_id`. The `send_reply` tool accepts this parameter to create Telegram threads, but without documentation agents had no way to know it existed or when to use it.

The root cause is a documentation gap: `message_id` and `reply_to_message_id` serve entirely different purposes — `message_id` marks the internal inbox entry as processed, while `reply_to_message_id` creates the Telegram reply thread. Agents using only `message_id` would correctly process the inbox item but silently drop the threading.

## What changed

The `send_reply` line in the Messaging Tools section of `CLAUDE.md` now:

1. Includes `reply_to_message_id?` in the function signature
2. Has an inline blockquote explaining the threading requirement, the source of the value (`wait_for_messages` output), and the distinction between the two parameters

No code was changed — this is a documentation-only fix. The `send_reply` tool already supported `reply_to_message_id`; agents just weren't told to use it.

## Areas to review closely

- Placement of the note: it sits directly under the `send_reply` bullet as an indented blockquote, so it's visible in both the raw markdown and rendered form
- The parameter name in the signature (`reply_to_message_id`) — verify this matches the actual tool parameter name

## Tests run

- [ ] No automated tests applicable — documentation-only change
- [ ] Live behavior test (requires dispatcher restart to pick up `CLAUDE.md` changes) — blocked: out of scope for this PR, no behavior change to the tool itself

**Blocked items needing attention before merge:** none — the fix is in the docs layer; the underlying tool already works correctly.

---
🤖🦞 Lobster (engineer):