### PR TITLE
feat(hooks): inject bootup context files on SessionStart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,13 @@ You are **Lobster**, an always-on AI assistant that never exits. You run in a pe
 
 This file provides shared context. Depending on your role, read the appropriate supplement:
 
-**System context** (always read):
-- **If you are the dispatcher (main loop):** read `.claude/sys.dispatcher.bootup.md` — it covers the main loop pseudocode, the 7-second rule, the dispatcher pattern, handling subagent results, message source handling (Telegram/Slack), self-check reminders, message flow diagram, startup behavior, hibernation, context recovery, Google Calendar handling, and voice/brain-dump routing.
-- **If you are a subagent:** read `.claude/sys.subagent.bootup.md` — it covers the `write_result` requirement, identity rules, and the model selection table.
+> **Note:** The system bootup files and user bootup files listed below are pre-injected into context via the `inject-bootup-context.py` SessionStart hook. The content is already present at the start of every session — the file paths are listed here for reference only.
 
-**User context** (read after system files, if the files exist):
+**System context** (pre-injected via hook):
+- **Dispatcher (main loop):** `.claude/sys.dispatcher.bootup.md` — covers the main loop pseudocode, the 7-second rule, the dispatcher pattern, handling subagent results, message source handling (Telegram/Slack), self-check reminders, message flow diagram, startup behavior, hibernation, context recovery, Google Calendar handling, and voice/brain-dump routing.
+- **Subagent:** `.claude/sys.subagent.bootup.md` — covers the `write_result` requirement, identity rules, and the model selection table.
+
+**User context** (pre-injected via hook, if the files exist):
 - Both roles: `~/lobster-user-config/agents/user.base.bootup.md` (behavioral preferences)
 - Both roles: `~/lobster-user-config/agents/user.base.context.md` (personal facts and context)
 - Dispatcher: `~/lobster-user-config/agents/user.dispatcher.bootup.md`

--- a/hooks/inject-bootup-context.py
+++ b/hooks/inject-bootup-context.py
@@ -14,6 +14,14 @@ File injection order:
 2. ~/lobster-user-config/agents/user.base.bootup.md (if exists)
 3. ~/lobster-user-config/agents/user.dispatcher.bootup.md (dispatcher only, if exists)
    OR ~/lobster-user-config/agents/user.subagent.bootup.md (subagent only, if exists)
+
+Hook ordering note:
+This hook calls session_role.write_dispatcher_session_id() when it detects a
+dispatcher session, making it self-sufficient regardless of whether
+write-dispatcher-session-id.py ran first. The write is idempotent: if
+write-dispatcher-session-id.py already ran (position 0 in settings.json),
+the file already has the correct ID and this is a no-op; if this hook runs
+first for any reason, the ID is written here and downstream hooks benefit.
 """
 
 import json
@@ -40,7 +48,7 @@ HOOK_NAME = "inject-bootup-context"
 
 
 def _read_file_safe(path: Path, label: str) -> str | None:
-    """Return file contents or None on any error, logging to stderr."""
+    """Return file contents or None on any error or empty file, logging to stderr."""
     if not path.exists():
         print(
             f"[{HOOK_NAME}] WARNING: {path} not found; skipping {label} injection.",
@@ -48,7 +56,8 @@ def _read_file_safe(path: Path, label: str) -> str | None:
         )
         return None
     try:
-        return path.read_text()
+        content = path.read_text()
+        return content if content.strip() else None
     except OSError as exc:
         print(
             f"[{HOOK_NAME}] WARNING: could not read {path}: {exc}",
@@ -58,12 +67,13 @@ def _read_file_safe(path: Path, label: str) -> str | None:
 
 
 def _inject_if_exists(path: Path, label: str) -> None:
-    """Read and print file contents if the file exists. Silent skip if absent."""
+    """Read and print file contents if the file exists and is non-empty. Silent skip otherwise."""
     if not path.exists():
         return
     try:
         content = path.read_text()
-        print(content)
+        if content.strip():
+            print(content)
     except OSError as exc:
         print(
             f"[{HOOK_NAME}] WARNING: could not read {path} ({label}): {exc}",
@@ -79,6 +89,14 @@ def main() -> None:
         hook_input = {}
 
     is_dispatcher = session_role.is_dispatcher(hook_input)
+
+    # If this is the dispatcher session, write the session ID to the marker file.
+    # This makes the hook self-sufficient regardless of whether
+    # write-dispatcher-session-id.py ran first. The write is idempotent.
+    if is_dispatcher:
+        session_id = session_role.get_session_id(hook_input)
+        if session_id:
+            session_role.write_dispatcher_session_id(session_id)
 
     # 1. Inject system bootup file based on role.
     if is_dispatcher:

--- a/hooks/inject-bootup-context.py
+++ b/hooks/inject-bootup-context.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+SessionStart / compact hook: inject dispatcher or subagent bootup files.
+
+Fires on every SessionStart event (and on compact sessions via the "compact"
+matcher entry in settings.json). Reads the appropriate system bootup file
+and user-specific bootup files, printing their contents to stdout.
+
+Claude Code SessionStart hooks inject stdout as a system message at the start
+of the session, making this content available before the first turn.
+
+File injection order:
+1. sys.dispatcher.bootup.md OR sys.subagent.bootup.md (based on role)
+2. ~/lobster-user-config/agents/user.base.bootup.md (if exists)
+3. ~/lobster-user-config/agents/user.dispatcher.bootup.md (dispatcher only, if exists)
+   OR ~/lobster-user-config/agents/user.subagent.bootup.md (subagent only, if exists)
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Allow imports from the hooks directory (session_role).
+sys.path.insert(0, str(Path(__file__).parent))
+
+import session_role  # noqa: E402 — path insert must precede this
+
+CLAUDE_DIR = Path(os.path.expanduser("~/lobster/.claude"))
+USER_CONFIG_DIR = Path(os.path.expanduser("~/lobster-user-config/agents"))
+
+DISPATCHER_BOOTUP = CLAUDE_DIR / "sys.dispatcher.bootup.md"
+SUBAGENT_BOOTUP = CLAUDE_DIR / "sys.subagent.bootup.md"
+
+USER_BASE_BOOTUP = USER_CONFIG_DIR / "user.base.bootup.md"
+USER_DISPATCHER_BOOTUP = USER_CONFIG_DIR / "user.dispatcher.bootup.md"
+USER_SUBAGENT_BOOTUP = USER_CONFIG_DIR / "user.subagent.bootup.md"
+
+HOOK_NAME = "inject-bootup-context"
+
+
+def _read_file_safe(path: Path, label: str) -> str | None:
+    """Return file contents or None on any error, logging to stderr."""
+    if not path.exists():
+        print(
+            f"[{HOOK_NAME}] WARNING: {path} not found; skipping {label} injection.",
+            file=sys.stderr,
+        )
+        return None
+    try:
+        return path.read_text()
+    except OSError as exc:
+        print(
+            f"[{HOOK_NAME}] WARNING: could not read {path}: {exc}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def _inject_if_exists(path: Path, label: str) -> None:
+    """Read and print file contents if the file exists. Silent skip if absent."""
+    if not path.exists():
+        return
+    try:
+        content = path.read_text()
+        print(content)
+    except OSError as exc:
+        print(
+            f"[{HOOK_NAME}] WARNING: could not read {path} ({label}): {exc}",
+            file=sys.stderr,
+        )
+
+
+def main() -> None:
+    # Read hook input from stdin to detect dispatcher vs subagent role.
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        hook_input = {}
+
+    is_dispatcher = session_role.is_dispatcher(hook_input)
+
+    # 1. Inject system bootup file based on role.
+    if is_dispatcher:
+        content = _read_file_safe(DISPATCHER_BOOTUP, "sys.dispatcher.bootup.md")
+    else:
+        content = _read_file_safe(SUBAGENT_BOOTUP, "sys.subagent.bootup.md")
+
+    if content is None:
+        sys.exit(0)
+
+    print(content)
+
+    # 2. Inject user base bootup (both roles).
+    _inject_if_exists(USER_BASE_BOOTUP, "user.base.bootup.md")
+
+    # 3. Inject role-specific user bootup.
+    if is_dispatcher:
+        _inject_if_exists(USER_DISPATCHER_BOOTUP, "user.dispatcher.bootup.md")
+    else:
+        _inject_if_exists(USER_SUBAGENT_BOOTUP, "user.subagent.bootup.md")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/install.sh
+++ b/install.sh
@@ -1676,6 +1676,30 @@ else
     info "Skipping write-dispatcher-session-id hook (settings.json not yet created)"
 fi
 
+# Set up Claude Code SessionStart hook to inject system and user bootup files into context.
+# Runs after write-dispatcher-session-id so role detection (is_dispatcher) works correctly.
+# Adds two entries: one empty-matcher entry for all fresh sessions, and one compact-matcher
+# entry so bootup content is re-injected after context compaction.
+chmod +x "$INSTALL_DIR/hooks/inject-bootup-context.py" || true
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.SessionStart[]? | select(.hooks[]?.command | contains("inject-bootup-context")) | select(.matcher == "")' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq '.hooks.SessionStart = (.hooks.SessionStart // []) + [{
+            "matcher": "",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 '"$INSTALL_DIR"'/hooks/inject-bootup-context.py",
+                "timeout": 10
+            }]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "inject-bootup-context hook installed (all sessions)"
+    else
+        info "inject-bootup-context hook already configured in Claude Code settings (all sessions)"
+    fi
+else
+    info "Skipping inject-bootup-context hook (settings.json not yet created)"
+fi
+
 # Set up Claude Code SessionStart hook to set compact flag on context compaction
 chmod +x "$INSTALL_DIR/hooks/on-compact.py" || true
 if [ -f "$CLAUDE_SETTINGS" ]; then
@@ -1695,6 +1719,28 @@ if [ -f "$CLAUDE_SETTINGS" ]; then
     fi
 else
     info "Skipping on-compact hook (settings.json not yet created)"
+fi
+
+# Set up Claude Code SessionStart hook to re-inject bootup context after compaction.
+# The compact-matcher entry ensures bootup files are injected into the fresh context
+# that follows a compaction event, just as they are on a fresh session start.
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.SessionStart[]? | select(.hooks[]?.command | contains("inject-bootup-context")) | select(.matcher == "compact")' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq '.hooks.SessionStart = (.hooks.SessionStart // []) + [{
+            "matcher": "compact",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 '"$INSTALL_DIR"'/hooks/inject-bootup-context.py",
+                "timeout": 10
+            }]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "inject-bootup-context hook installed (compact sessions)"
+    else
+        info "inject-bootup-context hook already configured in Claude Code settings (compact sessions)"
+    fi
+else
+    info "Skipping inject-bootup-context compact hook (settings.json not yet created)"
 fi
 
 # Set up Claude Code SessionStart hook to inject sys.debug.bootup.md when LOBSTER_DEBUG=true

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2051,6 +2051,37 @@ print(f"  {migrated} job(s) migrated to systemd timers")
 for sname, reason in skipped:
     print(f"  WARN: '{sname}' skipped — {reason}", file=sys.stderr)
 PYEOF
+
+    # Migration 60: Register inject-bootup-context.py SessionStart hooks in settings.json
+    # Adds two SessionStart entries: one empty-matcher entry for all fresh sessions
+    # (must run after write-dispatcher-session-id so role detection works), and one
+    # compact-matcher entry so bootup content is re-injected after context compaction.
+    if [ -f "$CLAUDE_SETTINGS" ]; then
+        chmod +x "$LOBSTER_DIR/hooks/inject-bootup-context.py" 2>/dev/null || true
+        if ! jq -e '.hooks.SessionStart[]? | select(.hooks[]?.command | contains("inject-bootup-context")) | select(.matcher == "")' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+            TMP_SETTINGS=$(mktemp)
+            jq '.hooks.SessionStart = (.hooks.SessionStart // []) + [{
+                "matcher": "",
+                "hooks": [{
+                    "type": "command",
+                    "command": "python3 '"$LOBSTER_DIR"'/hooks/inject-bootup-context.py",
+                    "timeout": 10
+                }]
+            }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+            substep "Registered inject-bootup-context SessionStart hook (all sessions)"
+            migrated=$((migrated + 1))
+        fi
+        if ! jq -e '.hooks.SessionStart[]? | select(.hooks[]?.command | contains("inject-bootup-context")) | select(.matcher == "compact")' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+            TMP_SETTINGS=$(mktemp)
+            jq '.hooks.SessionStart = (.hooks.SessionStart // []) + [{
+                "matcher": "compact",
+                "hooks": [{
+                    "type": "command",
+                    "command": "python3 '"$LOBSTER_DIR"'/hooks/inject-bootup-context.py",
+                    "timeout": 10
+                }]
+            }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+            substep "Registered inject-bootup-context SessionStart hook (compact sessions)"
             migrated=$((migrated + 1))
         fi
     fi


### PR DESCRIPTION
## Summary

- Adds `hooks/inject-bootup-context.py`: a new SessionStart hook that injects the appropriate system bootup file (`sys.dispatcher.bootup.md` for the dispatcher, `sys.subagent.bootup.md` for subagents) plus user-specific bootup files into Claude Code context via hook stdout before the first turn
- Updates `CLAUDE.md` Role-Specific Context section to note these files are now pre-injected via hook (no manual reads needed)
- Settings.json wiring (two entries) is already live: one empty-matcher entry for all sessions, one compact-matcher entry for post-compact injection

## How it works

1. Hook reads `session_id` from stdin JSON
2. Calls `session_role.is_dispatcher()` to detect role
3. Prints appropriate system bootup file to stdout (injected as system message)
4. Prints user bootup files if they exist

## Test plan

- [x] Manual test as subagent: outputs subagent bootup content correctly
- [x] Manual test as dispatcher: outputs dispatcher bootup content correctly
- [x] Settings.json has 6 SessionStart hooks, inject-bootup-context at positions 1 (all sessions) and 3 (compact sessions)
- [ ] Live verification: start a new session and confirm bootup content in context without manual reads

🤖 Generated with [Claude Code](https://claude.com/claude-code)