### PR TITLE
feat: logging Phase 1 — rotation, print→log, agent lifecycle events

### DIFF
--- a/src/bisque/relay_server.py
+++ b/src/bisque/relay_server.py
@@ -165,7 +165,7 @@ log.setLevel(logging.INFO)
 _file_handler = logging.handlers.RotatingFileHandler(
     LOG_DIR / "bisque-relay.log",
     maxBytes=5 * 1024 * 1024,
-    backupCount=3,
+    backupCount=5,
 )
 # P3.12: Use JSON formatter for the file handler so log lines are machine-parseable
 _file_handler.setFormatter(_JsonFormatter())

--- a/src/bisque/relay_server.py
+++ b/src/bisque/relay_server.py
@@ -159,13 +159,23 @@ class _JsonFormatter(logging.Formatter):
 LOG_DIR = _WORKSPACE / "logs"
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 
+# Import GzipRotatingFileHandler from the local src/mcp/log_utils module.
+# We can't use ``from mcp.log_utils import ...`` directly because the external
+# ``mcp`` package (from the MCP SDK) shadows our local src/mcp directory.
+_MCP_SRC = Path(__file__).resolve().parent.parent / "mcp"
+import importlib.util as _ilu
+_lutils_spec = _ilu.spec_from_file_location("lobster_mcp_log_utils", _MCP_SRC / "log_utils.py")
+_lutils_mod = _ilu.module_from_spec(_lutils_spec)  # type: ignore[arg-type]
+_lutils_spec.loader.exec_module(_lutils_mod)  # type: ignore[union-attr]
+GzipRotatingFileHandler = _lutils_mod.GzipRotatingFileHandler
+
 log = logging.getLogger("lobster-bisque-relay")
 log.setLevel(logging.INFO)
 
-_file_handler = logging.handlers.RotatingFileHandler(
+_file_handler = GzipRotatingFileHandler(
     LOG_DIR / "bisque-relay.log",
-    maxBytes=5 * 1024 * 1024,
-    backupCount=5,
+    maxBytes=1 * 1024 * 1024 * 1024,  # 1 GB per file
+    backupCount=5,                      # 5 gzip-compressed backups → ~5 GB history
 )
 # P3.12: Use JSON formatter for the file handler so log lines are machine-parseable
 _file_handler.setFormatter(_JsonFormatter())

--- a/src/bot/sms_router.py
+++ b/src/bot/sms_router.py
@@ -91,11 +91,22 @@ LOG_DIR.mkdir(parents=True, exist_ok=True)
 
 log = logging.getLogger("lobster-sms")
 log.setLevel(logging.INFO)
-from logging.handlers import RotatingFileHandler
-_fh = RotatingFileHandler(
+# Import GzipRotatingFileHandler from the local src/mcp/log_utils module.
+# We can't use ``from mcp.log_utils import ...`` directly because the external
+# ``mcp`` package (from the MCP SDK) shadows our local src/mcp directory
+# when it is installed in the venv.
+import importlib.util as _ilu
+_lutils_spec = _ilu.spec_from_file_location(
+    "lobster_mcp_log_utils",
+    Path(__file__).resolve().parent.parent / "mcp" / "log_utils.py",
+)
+_lutils_mod = _ilu.module_from_spec(_lutils_spec)  # type: ignore[arg-type]
+_lutils_spec.loader.exec_module(_lutils_mod)  # type: ignore[union-attr]
+GzipRotatingFileHandler = _lutils_mod.GzipRotatingFileHandler
+_fh = GzipRotatingFileHandler(
     LOG_DIR / "sms-router.log",
-    maxBytes=5 * 1024 * 1024,
-    backupCount=3,
+    maxBytes=1 * 1024 * 1024 * 1024,  # 1 GB per file
+    backupCount=5,                      # 5 gzip-compressed backups → ~5 GB history
 )
 _fh.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
 log.addHandler(_fh)

--- a/src/mcp/event_bus.py
+++ b/src/mcp/event_bus.py
@@ -16,10 +16,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import threading
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
@@ -168,12 +170,15 @@ class JsonlFileListener:
     """
     Writes every accepted event to ~/lobster-workspace/logs/events.jsonl.
 
-    One JSON object per line. The file is created on first write; intermediate
-    directories are created if absent. Append is atomic at the OS level for
-    lines < PIPE_BUF (~4 KiB on Linux), which is sufficient for structured log lines.
+    One JSON object per line. Uses a RotatingFileHandler (5 MB x 5 backups) so
+    the file never grows unboundedly. The handler is initialised lazily on first
+    deliver() call so that importing this module does not create any files.
     """
 
     name = "jsonl-file"
+
+    _MAX_BYTES = 5 * 1024 * 1024  # 5 MB per file
+    _BACKUP_COUNT = 5              # keep 5 rotated files
 
     def __init__(
         self,
@@ -190,16 +195,40 @@ class JsonlFileListener:
             event_types={"*"},
             require_debug_mode=False,
         )
+        self._handler: RotatingFileHandler | None = None
+        self._handler_lock = threading.Lock()
+
+    def _get_handler(self) -> RotatingFileHandler:
+        """Return (and lazily initialise) the RotatingFileHandler."""
+        if self._handler is None:
+            with self._handler_lock:
+                if self._handler is None:
+                    self._path.parent.mkdir(parents=True, exist_ok=True)
+                    self._handler = RotatingFileHandler(
+                        self._path,
+                        maxBytes=self._MAX_BYTES,
+                        backupCount=self._BACKUP_COUNT,
+                        encoding="utf-8",
+                    )
+        return self._handler
 
     def accepts(self, event: LobsterEvent) -> bool:
         return self._filter.accepts(event)
 
     async def deliver(self, event: LobsterEvent) -> None:
         try:
-            self._path.parent.mkdir(parents=True, exist_ok=True)
-            line = json.dumps(event.to_dict(), ensure_ascii=False)
-            with self._path.open("a", encoding="utf-8") as fh:
-                fh.write(line + "\n")
+            line = json.dumps(event.to_dict(), ensure_ascii=False) + "\n"
+            handler = self._get_handler()
+            handler.acquire()
+            try:
+                if handler.stream is None:
+                    handler.stream = handler._open()  # type: ignore[attr-defined]
+                if handler.shouldRollover(logging.makeLogRecord({"msg": line})):
+                    handler.doRollover()
+                handler.stream.write(line)
+                handler.stream.flush()
+            finally:
+                handler.release()
         except Exception:
             pass  # file listener failures must never propagate
 

--- a/src/mcp/event_bus.py
+++ b/src/mcp/event_bus.py
@@ -21,7 +21,10 @@ import os
 import threading
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
-from logging.handlers import RotatingFileHandler
+try:
+    from .log_utils import GzipRotatingFileHandler
+except ImportError:
+    from log_utils import GzipRotatingFileHandler  # type: ignore[no-redef]
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
@@ -170,15 +173,16 @@ class JsonlFileListener:
     """
     Writes every accepted event to ~/lobster-workspace/logs/events.jsonl.
 
-    One JSON object per line. Uses a RotatingFileHandler (5 MB x 5 backups) so
-    the file never grows unboundedly. The handler is initialised lazily on first
-    deliver() call so that importing this module does not create any files.
+    One JSON object per line. Uses a GzipRotatingFileHandler (1 GB x 5 backups,
+    gzip-compressed) so the file never grows unboundedly while preserving up to
+    ~5 GB of history. The handler is initialised lazily on first deliver() call
+    so that importing this module does not create any files.
     """
 
     name = "jsonl-file"
 
-    _MAX_BYTES = 5 * 1024 * 1024  # 5 MB per file
-    _BACKUP_COUNT = 5              # keep 5 rotated files
+    _MAX_BYTES = 1 * 1024 * 1024 * 1024  # 1 GB per file
+    _BACKUP_COUNT = 5                      # keep 5 gzip-compressed rotated files
 
     def __init__(
         self,
@@ -195,16 +199,16 @@ class JsonlFileListener:
             event_types={"*"},
             require_debug_mode=False,
         )
-        self._handler: RotatingFileHandler | None = None
+        self._handler: GzipRotatingFileHandler | None = None
         self._handler_lock = threading.Lock()
 
-    def _get_handler(self) -> RotatingFileHandler:
-        """Return (and lazily initialise) the RotatingFileHandler."""
+    def _get_handler(self) -> GzipRotatingFileHandler:
+        """Return (and lazily initialise) the GzipRotatingFileHandler."""
         if self._handler is None:
             with self._handler_lock:
                 if self._handler is None:
                     self._path.parent.mkdir(parents=True, exist_ok=True)
-                    self._handler = RotatingFileHandler(
+                    self._handler = GzipRotatingFileHandler(
                         self._path,
                         maxBytes=self._MAX_BYTES,
                         backupCount=self._BACKUP_COUNT,

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -34,6 +34,13 @@ if _MCP_SRC_DIR not in sys.path:
     sys.path.insert(0, _MCP_SRC_DIR)
 from log_utils import JsonFormatter, configure_file_handler
 
+# Early logger — same name as the main `log` object defined after all imports.
+# Python's logging registry is global, so this resolves to the same Logger
+# instance that gets a StreamHandler + RotatingFileHandler during setup_logging().
+# Using it here (before those handlers are attached) sends records to the root
+# logger fallback, which is acceptable for startup diagnostics.
+_startup_log = logging.getLogger("lobster-mcp")
+
 # Event bus — structured observability infrastructure (issue #890).
 # Imported here so callsites can use _emit_event() throughout the module.
 # The singleton is initialised later in main(); events emitted before init
@@ -113,9 +120,9 @@ try:
     _db_count_conversation_history = _db_reader_mod.count_conversation_history
     _db_get_message_by_telegram_id_fn = _db_reader_mod.get_message_by_telegram_id
     _db_get_message_stats = _db_reader_mod.get_message_stats
-    print('[DB] db.reader loaded — DB reads available', file=sys.stderr)
+    _startup_log.info('[DB] db.reader loaded — DB reads available')
 except Exception as _db_reader_import_err:
-    print(f'[WARN] DB reader module unavailable: {_db_reader_import_err}', file=sys.stderr)
+    _startup_log.warning('DB reader module unavailable: %s', _db_reader_import_err)
 
 # BIS-167 Slice 6: Live DB write path — persist messages to messages.db
 _db_persist_inbound = None
@@ -129,10 +136,10 @@ try:
     )
     _db_flag = os.environ.get("LOBSTER_USE_DB", "0")
     _db_status = "ENABLED" if _db_flag == "1" else "DISABLED (set LOBSTER_USE_DB=1 to enable)"
-    print(f"[DB] message_store loaded — DB writes {_db_status}", file=sys.stderr)
+    _startup_log.info('[DB] message_store loaded — DB writes %s', _db_status)
     del _db_flag, _db_status
 except Exception as _db_import_err:
-    print(f"[WARN] messages.db write path unavailable: {_db_import_err}", file=sys.stderr)
+    _startup_log.warning('messages.db write path unavailable: %s', _db_import_err)
 
 
 # Memory system (optional — gracefully degrades to static file search)
@@ -143,7 +150,7 @@ try:
 except Exception as _mem_err:
     # Memory system is optional; log and continue
     import traceback as _tb
-    print(f"[WARN] Memory system unavailable: {_mem_err}", file=sys.stderr)
+    _startup_log.warning('Memory system unavailable: %s', _mem_err)
 
 # User Model subsystem
 _user_model = None
@@ -153,10 +160,10 @@ try:
     from user_model import create_user_model, USER_MODEL_TOOL_DEFINITIONS
     _user_model = create_user_model()
     _user_model_tool_names = _user_model.tool_names
-    print("[INFO] User Model subsystem initialized.", file=sys.stderr)
+    _startup_log.info('User Model subsystem initialized.')
 except Exception as _um_err:
     import traceback as _um_tb
-    print(f"[WARN] User Model subsystem unavailable: {_um_err}", file=sys.stderr)
+    _startup_log.warning('User Model subsystem unavailable: %s', _um_err)
 
 # ---------------------------------------------------------------------------
 # Background observation worker — fire-and-forget, zero main-thread blocking
@@ -6734,6 +6741,13 @@ async def handle_register_agent(args: dict) -> list[TextContent]:
         return [TextContent(type="text", text=f"Error recording agent: {exc}")]
 
     log.info(f"Registered pending agent: agent_id={agent_id!r} chat_id={chat_id_int}")
+    _emit_event(
+        text=f"agent.spawn: agent_id={agent_id!r} description={description!r}",
+        event_type="agent.spawn",
+        severity="info",
+        task_id=task_id,
+        chat_id=chat_id_int,
+    )
     return [TextContent(
         type="text",
         text=f"Agent registered: {agent_id!r} — {description}",
@@ -6757,6 +6771,11 @@ async def handle_unregister_agent(args: dict) -> list[TextContent]:
         return [TextContent(type="text", text=f"Error removing agent: {exc}")]
 
     log.info(f"Unregistered pending agent: agent_id={agent_id!r}")
+    _emit_event(
+        text=f"agent.complete: agent_id={agent_id!r} status=completed",
+        event_type="agent.complete",
+        severity="info",
+    )
     return [TextContent(
         type="text",
         text=f"Agent unregistered: {agent_id!r}",
@@ -6823,6 +6842,13 @@ async def handle_session_start(args: dict) -> list[TextContent]:
         return [TextContent(type="text", text=f"Error starting session: {exc}")]
 
     log.info(f"Session started: agent_id={agent_id!r} agent_type={agent_type!r} chat_id={chat_id}")
+    _emit_event(
+        text=f"agent.spawn: agent_id={agent_id!r} agent_type={agent_type!r} description={description!r}",
+        event_type="agent.spawn",
+        severity="info",
+        task_id=task_id,
+        chat_id=chat_id if isinstance(chat_id, (int, str)) else None,
+    )
 
     # Option B: explicit dispatcher declaration.
     # If the caller declares itself as the dispatcher, tag its MCP session ID
@@ -6869,6 +6895,11 @@ async def handle_session_end(args: dict) -> list[TextContent]:
         return [TextContent(type="text", text=f"Error ending session: {exc}")]
 
     log.info(f"Session ended: agent_id={agent_id!r} status={status!r}")
+    _emit_event(
+        text=f"agent.complete: agent_id={agent_id!r} status={status!r}",
+        event_type="agent.complete",
+        severity="info" if status == "completed" else "warn",
+    )
     # Notify wire server so SSE clients update within 40ms
     asyncio.create_task(_notify_wire_server())
     return [TextContent(

--- a/src/mcp/log_utils.py
+++ b/src/mcp/log_utils.py
@@ -2,7 +2,7 @@
 Shared structured logging utilities for Lobster MCP servers.
 
 Provides a JSON-lines formatter and a factory function for attaching
-RotatingFileHandlers to named loggers. All Python servers should call
+GzipRotatingFileHandlers to named loggers. All Python servers should call
 ``configure_file_handler`` during startup so that log output lands in
 ~/lobster-workspace/logs/ as structured JSON that can be parsed by
 standard log aggregators (jq, Loki, filebeat, etc.).
@@ -16,11 +16,16 @@ Format (one JSON object per line)::
 Required fields: ``ts``, ``level``, ``component``, ``msg``.
 Optional contextual fields forwarded from ``LogRecord.extra`` when present:
 ``message_id``, ``task_id``, ``chat_id``, ``source``, ``duration_ms``.
+
+Rotation: Each log file rotates at 1 GB; 5 backup files are kept (gzip-compressed),
+giving up to ~5 GB of history per logger component.
 """
 
+import gzip
 import json
 import logging
 import os
+import shutil
 from datetime import datetime, timezone
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -78,20 +83,75 @@ class JsonFormatter(logging.Formatter):
         return json.dumps(entry, ensure_ascii=False)
 
 
+class GzipRotatingFileHandler(RotatingFileHandler):
+    """RotatingFileHandler that gzip-compresses rotated backup files.
+
+    When Python's RotatingFileHandler rotates a log file it renames
+    ``foo.log`` → ``foo.log.1`` → ``foo.log.2`` … and so on.  This
+    subclass overrides ``doRollover`` to compress each backup with gzip
+    immediately after rotation, naming them ``foo.log.1.gz``,
+    ``foo.log.2.gz``, etc.
+
+    All constructor arguments are forwarded unchanged to
+    ``RotatingFileHandler``.
+    """
+
+    def doRollover(self) -> None:
+        """Rotate and gzip-compress the rotated backup files."""
+        # Close the current stream before rotating
+        if self.stream:
+            self.stream.close()
+            self.stream = None  # type: ignore[assignment]
+
+        # Shift existing backup files: foo.log.N.gz → foo.log.(N+1).gz
+        for i in range(self.backupCount - 1, 0, -1):
+            src = f"{self.baseFilename}.{i}.gz"
+            dst = f"{self.baseFilename}.{i + 1}.gz"
+            if os.path.exists(src):
+                os.rename(src, dst)
+
+        # Also shift an uncompressed .1 if it exists (left over from a crash
+        # before compression completed on the previous rotation)
+        uncompressed_1 = f"{self.baseFilename}.1"
+        if os.path.exists(uncompressed_1):
+            compressed_1 = f"{self.baseFilename}.1.gz"
+            with open(uncompressed_1, "rb") as f_in, gzip.open(compressed_1, "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out)
+            os.remove(uncompressed_1)
+
+        # Rotate the active log file to .1 and compress it
+        if os.path.exists(self.baseFilename):
+            rotated = f"{self.baseFilename}.1"
+            os.rename(self.baseFilename, rotated)
+            compressed = f"{self.baseFilename}.1.gz"
+            with open(rotated, "rb") as f_in, gzip.open(compressed, "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out)
+            os.remove(rotated)
+
+        # Remove the oldest backup if it exceeds backupCount
+        oldest = f"{self.baseFilename}.{self.backupCount + 1}.gz"
+        if os.path.exists(oldest):
+            os.remove(oldest)
+
+        # Reopen a fresh log file
+        if not self.delay:
+            self.stream = self._open()
+
+
 def configure_file_handler(
     logger: logging.Logger,
     component: str,
     log_dir: Path | None = None,
     filename: str | None = None,
-    max_bytes: int = 5 * 1024 * 1024,
-    backup_count: int = 3,
-) -> RotatingFileHandler:
-    """Attach a JSON-formatted RotatingFileHandler to *logger*.
+    max_bytes: int = 1 * 1024 * 1024 * 1024,  # 1 GB per file
+    backup_count: int = 5,  # 5 compressed backups → up to ~5 GB history
+) -> GzipRotatingFileHandler:
+    """Attach a JSON-formatted GzipRotatingFileHandler to *logger*.
 
-    Idempotent: if a RotatingFileHandler is already attached, returns it
-    without adding a second one.  This prevents duplicate log entries when
-    the function is called more than once (e.g. in tests that import the
-    module multiple times).
+    Idempotent: if a RotatingFileHandler (or subclass) is already attached,
+    returns it without adding a second one.  This prevents duplicate log
+    entries when the function is called more than once (e.g. in tests that
+    import the module multiple times).
 
     Args:
         logger: The logger instance to configure.
@@ -99,22 +159,23 @@ def configure_file_handler(
         log_dir: Directory for the log file.  Defaults to
             ``~/lobster-workspace/logs/``.
         filename: Name of the log file.  Defaults to ``{component}.log``.
-        max_bytes: Rotate when the file reaches this size (default 5 MB).
-        backup_count: Number of rotated backups to keep (default 3).
+        max_bytes: Rotate when the file reaches this size (default 1 GB).
+        backup_count: Number of gzip-compressed rotated backups to keep
+            (default 5, giving up to ~5 GB of history).
 
     Returns:
-        The (possibly pre-existing) RotatingFileHandler attached to *logger*.
+        The (possibly pre-existing) GzipRotatingFileHandler attached to *logger*.
     """
     # Check idempotency
     for handler in logger.handlers:
         if isinstance(handler, RotatingFileHandler):
-            return handler
+            return handler  # type: ignore[return-value]
 
     resolved_log_dir = log_dir if log_dir is not None else _DEFAULT_LOG_DIR
     resolved_log_dir.mkdir(parents=True, exist_ok=True)
 
     log_file = resolved_log_dir / (filename or f"{component}.log")
-    handler = RotatingFileHandler(log_file, maxBytes=max_bytes, backupCount=backup_count)
+    handler = GzipRotatingFileHandler(log_file, maxBytes=max_bytes, backupCount=backup_count)
     handler.setFormatter(JsonFormatter(component))
     logger.addHandler(handler)
     return handler

--- a/src/mcp/reliability.py
+++ b/src/mcp/reliability.py
@@ -18,6 +18,7 @@ import logging
 import sys
 import time
 from datetime import datetime, timezone
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Any
 
@@ -124,13 +125,28 @@ def validate_message_id(message_id: Any) -> str:
 # =============================================================================
 
 _AUDIT_LOG_PATH = None  # Set during init
+_AUDIT_LOG_HANDLER: RotatingFileHandler | None = None  # Rotating handler for audit.jsonl
+
+_AUDIT_MAX_BYTES = 5 * 1024 * 1024  # 5 MB per file
+_AUDIT_BACKUP_COUNT = 5             # keep 5 rotated files
 
 
 def init_audit_log(log_dir: Path) -> None:
-    """Initialize the audit log file path."""
-    global _AUDIT_LOG_PATH
+    """Initialize the audit log file path with rotation.
+
+    Sets up a RotatingFileHandler (5 MB x 5 backups) so audit.jsonl never grows
+    unboundedly. Subsequent calls after the first are no-ops.
+    """
+    global _AUDIT_LOG_PATH, _AUDIT_LOG_HANDLER
     log_dir.mkdir(parents=True, exist_ok=True)
     _AUDIT_LOG_PATH = log_dir / "audit.jsonl"
+    if _AUDIT_LOG_HANDLER is None:
+        _AUDIT_LOG_HANDLER = RotatingFileHandler(
+            _AUDIT_LOG_PATH,
+            maxBytes=_AUDIT_MAX_BYTES,
+            backupCount=_AUDIT_BACKUP_COUNT,
+            encoding="utf-8",
+        )
 
 
 def audit_log(
@@ -187,8 +203,26 @@ def audit_log(
 
     try:
         line = json.dumps(entry, default=str) + "\n"
-        with open(_AUDIT_LOG_PATH, "a") as f:
-            f.write(line)
+        if _AUDIT_LOG_HANDLER is not None:
+            # Write via the RotatingFileHandler so size-based rotation fires.
+            # We bypass the logging.Formatter layer — the handler's stream is
+            # opened lazily on first use and rotated when maxBytes is exceeded.
+            handler = _AUDIT_LOG_HANDLER
+            handler.acquire()
+            try:
+                if handler.stream is None:
+                    handler.stream = handler._open()  # type: ignore[attr-defined]
+                # shouldRollover reads the current file size.
+                if handler.shouldRollover(logging.makeLogRecord({"msg": line})):
+                    handler.doRollover()
+                handler.stream.write(line)
+                handler.stream.flush()
+            finally:
+                handler.release()
+        else:
+            # Fallback for callers that bypass init_audit_log (e.g. tests).
+            with open(_AUDIT_LOG_PATH, "a", encoding="utf-8") as f:  # type: ignore[arg-type]
+                f.write(line)
     except Exception:
         pass  # Audit logging must never crash the main process
 

--- a/src/mcp/reliability.py
+++ b/src/mcp/reliability.py
@@ -18,7 +18,10 @@ import logging
 import sys
 import time
 from datetime import datetime, timezone
-from logging.handlers import RotatingFileHandler
+try:
+    from .log_utils import GzipRotatingFileHandler
+except ImportError:
+    from log_utils import GzipRotatingFileHandler  # type: ignore[no-redef]
 from pathlib import Path
 from typing import Any
 
@@ -125,23 +128,24 @@ def validate_message_id(message_id: Any) -> str:
 # =============================================================================
 
 _AUDIT_LOG_PATH = None  # Set during init
-_AUDIT_LOG_HANDLER: RotatingFileHandler | None = None  # Rotating handler for audit.jsonl
+_AUDIT_LOG_HANDLER: GzipRotatingFileHandler | None = None  # Rotating handler for audit.jsonl
 
-_AUDIT_MAX_BYTES = 5 * 1024 * 1024  # 5 MB per file
-_AUDIT_BACKUP_COUNT = 5             # keep 5 rotated files
+_AUDIT_MAX_BYTES = 1 * 1024 * 1024 * 1024  # 1 GB per file
+_AUDIT_BACKUP_COUNT = 5                     # keep 5 gzip-compressed rotated files
 
 
 def init_audit_log(log_dir: Path) -> None:
     """Initialize the audit log file path with rotation.
 
-    Sets up a RotatingFileHandler (5 MB x 5 backups) so audit.jsonl never grows
-    unboundedly. Subsequent calls after the first are no-ops.
+    Sets up a GzipRotatingFileHandler (1 GB x 5 backups, gzip-compressed) so
+    audit.jsonl never grows unboundedly while preserving up to ~5 GB of history.
+    Subsequent calls after the first are no-ops.
     """
     global _AUDIT_LOG_PATH, _AUDIT_LOG_HANDLER
     log_dir.mkdir(parents=True, exist_ok=True)
     _AUDIT_LOG_PATH = log_dir / "audit.jsonl"
     if _AUDIT_LOG_HANDLER is None:
-        _AUDIT_LOG_HANDLER = RotatingFileHandler(
+        _AUDIT_LOG_HANDLER = GzipRotatingFileHandler(
             _AUDIT_LOG_PATH,
             maxBytes=_AUDIT_MAX_BYTES,
             backupCount=_AUDIT_BACKUP_COUNT,

--- a/tests/unit/test_mcp_server/test_log_utils.py
+++ b/tests/unit/test_mcp_server/test_log_utils.py
@@ -16,7 +16,7 @@ _MCP_SRC = str(Path(__file__).resolve().parents[3] / "src" / "mcp")
 if _MCP_SRC not in sys.path:
     sys.path.insert(0, _MCP_SRC)
 
-from log_utils import JsonFormatter, configure_file_handler
+from log_utils import GzipRotatingFileHandler, JsonFormatter, configure_file_handler
 
 
 # ---------------------------------------------------------------------------
@@ -146,8 +146,8 @@ class TestConfigureFileHandler:
         logger = logging.getLogger(f"test.cfg.{tmp_path.name}")
         logger.handlers.clear()
         handler = configure_file_handler(logger, component="srv", log_dir=tmp_path)
-        assert isinstance(handler, RotatingFileHandler)
-        assert any(isinstance(h, RotatingFileHandler) for h in logger.handlers)
+        assert isinstance(handler, GzipRotatingFileHandler)
+        assert any(isinstance(h, GzipRotatingFileHandler) for h in logger.handlers)
 
     def test_log_file_created(self, tmp_path):
         logger = logging.getLogger(f"test.file.{tmp_path.name}")
@@ -175,7 +175,7 @@ class TestConfigureFileHandler:
         logger.handlers.clear()
         configure_file_handler(logger, component="srv", log_dir=tmp_path)
         configure_file_handler(logger, component="srv", log_dir=tmp_path)
-        rotating_handlers = [h for h in logger.handlers if isinstance(h, RotatingFileHandler)]
+        rotating_handlers = [h for h in logger.handlers if isinstance(h, GzipRotatingFileHandler)]
         assert len(rotating_handlers) == 1
 
     def test_custom_filename(self, tmp_path):


### PR DESCRIPTION
## Why

Part of issue #1167 logging plan — **Phase 1** (rotation + print→log + agent lifecycle events). The issue tracks this PR as "NEEDS-WORK" pending review; the remaining Phase 1 items from the issue (`CriticalAlertListener`, `CRITICAL` severity level) are not included in this PR and remain open in #1167.

`events.jsonl` and `audit.jsonl` were growing unboundedly — no rotation, no compression. Separately, `inbox_server.py` had ~7 bare `print(..., file=sys.stderr)` calls that bypassed the structured log pipeline, and agent spawn/complete lifecycle events were not emitted to the event bus.

## What changed

**Log rotation and compression (`log_utils.py`):**
- Added `GzipRotatingFileHandler` subclass that gzip-compresses each rotated backup (`.log.1.gz`, `.log.2.gz`, etc.)
- Increased rotation threshold from 5 MB to **1 GB per file**, with 5 gzip-compressed backups — ~5 GB total history per logger

**Handlers updated:** `mcp-server.log`, `audit.jsonl`, `events.jsonl`, `bisque-relay.log`, `sms-router.log`

**`inbox_server.py`:** Replaced 7 `print(stderr)` calls with structured `log.warning` / `log.error` calls

**`event_bus.py`:** Added `agent.spawn` and `agent.complete` event emissions to all agent lifecycle handlers

## Design decision: dynamic import workaround

`bisque/relay_server.py` and `bot/sms_router.py` import `GzipRotatingFileHandler` via `importlib.util.spec_from_file_location` rather than a normal import. This is because the external `mcp` package (from the MCP SDK) shadows our local `src/mcp/` directory when installed in the venv, making `from mcp.log_utils import ...` resolve to the SDK package instead of our code. The workaround uses the absolute filesystem path. This is a known import path issue with the package layout; a permanent fix (rename `src/mcp/` or use a namespace package) is out of scope for this PR.

## What is not in this PR (tracked in #1167)

- `CriticalAlertListener` — always forward `severity=critical` events to Telegram (Phase 1 requirement)
- `CRITICAL` severity level added to `LobsterEvent`
- Log streaming to mothership (tracked separately in issue #1232 — requires SSH/rsync architecture decision)

## Test plan

- [ ] Verify `events.jsonl` rotates after 1 GB with `.jsonl.1.gz` produced
- [ ] Verify `audit.jsonl` rotates after 1 GB with `.jsonl.1.gz` produced
- [ ] Verify `mcp-server.log` rotates with `.log.1.gz` produced
- [ ] Verify no bare `print(stderr)` remain in `inbox_server.py`
- [ ] Verify agent lifecycle events appear in `events.jsonl`
- [ ] `uv run pytest tests/unit/test_mcp_server/test_log_utils.py` — all 18 pass

Part of #1167

---
🤖🦞 Lobster (librarian): added missing Phase 1 scope context (CriticalAlertListener not included), noted NEEDS-WORK status from issue, added design decision section explaining the dynamic import workaround, and updated issue link from loose "Part of issue #1167" to a proper `Part of #1167` reference.