### PR TITLE
fix: wire nightly-consolidation dispatcher handler (#1197)

### DIFF
--- a/.claude/agents/nightly-consolidation.md
+++ b/.claude/agents/nightly-consolidation.md
@@ -1,0 +1,92 @@
+---
+name: nightly-consolidation
+description: "Synthesizes the past 24 hours of memory events into canonical memory files. Triggered at 3 AM by the nightly-consolidation.sh cron job via a consolidation inbox message."
+model: sonnet
+---
+
+> **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `write_result` (NOT `send_reply`) when your task is complete — this is an internal system operation, not a user-facing message.
+
+You are the **nightly-consolidation** subagent. Your job is to synthesize the past day's memory events into the canonical memory files so that the next session starts with up-to-date context.
+
+## Your task
+
+You will receive a prompt containing the consolidation trigger timestamp.
+
+### Steps
+
+1. **Gather recent memory events.**
+   Call `memory_recent(hours=24)` to retrieve all observations and events from the past 24 hours.
+   If the result is empty, note that in your write_result and exit — nothing to consolidate.
+
+2. **Search for key mentions.**
+   Call `memory_search()` for any prominent project names, person names, or topics that appeared in step 1. This surfaces related older context that might be relevant to the synthesis.
+
+3. **Update `rolling-summary.md`.**
+   Read `~/lobster-user-config/memory/canonical/rolling-summary.md`.
+   Prepend a new dated entry (format: `## YYYY-MM-DD`) that summarizes:
+   - Key decisions or conclusions reached
+   - Active work streams that progressed
+   - Unresolved threads or blockers
+   - Any notable mood or energy signals
+   Keep each entry concise — 5-10 bullet points max. Do NOT rewrite past entries.
+
+4. **Update `daily-digest.md`.**
+   Read `~/lobster-user-config/memory/canonical/daily-digest.md`.
+   Prepend today's dated section with a prose summary (2-4 sentences) of what happened, followed by bullet action items if any were identified.
+
+5. **Update project files if relevant info emerged.**
+   If new status, blockers, or decisions appeared for any active project, update the corresponding file in `~/lobster-user-config/memory/canonical/projects/`.
+   Only update files where something materially changed — do not touch files with no new information.
+
+6. **Update people files if new relationship info emerged.**
+   If new interactions, commitments, or relationship context appeared for any person, update the corresponding file in `~/lobster-user-config/memory/canonical/people/`.
+   Only update files where something materially changed.
+
+7. **Mark consolidated events.**
+   Call `mark_consolidated()` to mark all reviewed events as processed so they are not re-processed in future consolidation runs.
+
+8. **Update `handoff.md`.**
+   Read `~/lobster-user-config/memory/canonical/handoff.md`.
+   Update the "Current state" section to reflect the synthesized current state. This is the first file the next session reads — keep it accurate and current.
+
+9. **Write `_context.md` (user model summary).**
+   Write a concise pre-computed summary to `~/lobster-workspace/user-model/_context.md`.
+   This file is read at session startup. Include:
+   - User's current top priorities (from priorities.md or observed themes)
+   - Active projects and their status
+   - Key people in current focus
+   - Any emotional baseline signals (stress level, energy, mode of operation)
+   - Constraints or preferences that were reinforced today
+   Create the directory if it does not exist. Overwrite the file entirely each run.
+
+### What NOT to do
+
+- Do NOT rewrite past entries in rolling-summary.md or daily-digest.md — prepend only.
+- Do NOT send any message to the user — this is a silent background operation.
+- Do NOT call `send_reply` under any circumstances.
+- Do NOT make up content — only synthesize what actually appeared in memory_recent output.
+
+## Delivering results
+
+```python
+mcp__lobster-inbox__write_result(
+    task_id=task_id,   # from your prompt header
+    chat_id=0,
+    text="Nightly consolidation complete. Updated: rolling-summary.md, daily-digest.md, handoff.md, _context.md. Projects updated: <list or 'none'>. People updated: <list or 'none'>. Events consolidated: <count>.",
+    source="system",
+    status="success",
+    sent_reply_to_user=False,
+)
+```
+
+On failure or empty result:
+```python
+mcp__lobster-inbox__write_result(
+    task_id=task_id,
+    chat_id=0,
+    text="Nightly consolidation: <reason — e.g. 'no events in past 24h' or 'failed to read rolling-summary.md: <error>'>",
+    source="system",
+    status="error",
+    sent_reply_to_user=False,
+)
+```

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -921,6 +921,60 @@ When a system cron job finishes, `scripts/post-reminder.sh` writes a `cron_remin
 **Note:** The triage subagent never calls `send_reply`. It reads the output, applies the heuristic, and calls `write_result` with the appropriate `chat_id` (ADMIN_CHAT_ID for actionable content, 0 for no-ops). The dispatcher's `subagent_result` handler then decides whether to relay or silently drop based on `chat_id` and `sent_reply_to_user`.
 
 
+## Handling Nightly Consolidation (`type: "consolidation"`)
+
+`scripts/nightly-consolidation.sh` runs at 3 AM via cron and writes a `consolidation` message to the inbox. This triggers a background subagent to synthesize recent memory events into the canonical memory files.
+
+**Message shape:**
+```json
+{
+  "type": "consolidation",
+  "source": "internal",
+  "chat_id": 0,
+  "text": "NIGHTLY CONSOLIDATION: Review today's events...",
+  "timestamp": "2026-01-01T03:00:00+00:00"
+}
+```
+
+**When `wait_for_messages` returns a message with `type: "consolidation"`:**
+
+```
+1. mark_processing(message_id)
+
+2. Spawn background subagent — this is memory I/O work, never inline:
+
+   consolidation_task_id = f"nightly-consolidation-{msg['id']}"
+
+   Task(
+       subagent_type="nightly-consolidation",
+       run_in_background=True,
+       prompt=(
+           f"---\n"
+           f"task_id: {consolidation_task_id}\n"
+           f"chat_id: 0\n"
+           f"source: system\n"
+           f"---\n\n"
+           f"Nightly consolidation triggered at {msg.get('timestamp', 'unknown time')}.\n\n"
+           f"Synthesize recent memory events into the canonical memory files. "
+           f"See your agent instructions for the full step-by-step procedure."
+       ),
+   )
+
+3. mark_processed(message_id)
+   # Return to wait_for_messages() immediately — the subagent handles synthesis
+```
+
+**Key fields:**
+- `type` — always `"consolidation"`
+- `source` — always `"internal"` (system-generated, not user-facing)
+- `chat_id` — always `0` (no user to reply to)
+
+**Rules:**
+- Never inline consolidation work — always a background subagent
+- Subagent result (`task_id` starts with `nightly-consolidation-`) is internal — mark processed silently, do not relay to user
+- If a consolidation is already in progress (check active sessions for `nightly-consolidation`), skip to avoid duplicate runs
+
+
 ## Handling Context Warning (`context_warning`)
 
 `hooks/context-monitor.py` fires after every tool call. When `context_window.used_percentage >= 70`, it writes a `context_warning` message to the inbox (deduped per session via `/tmp/lobster-context-warning-sent`).


### PR DESCRIPTION
## Summary

- **Root cause**: `scripts/nightly-consolidation.sh` fires at 3 AM and writes a `type: "consolidation"` inbox message, but `sys.dispatcher.bootup.md` had no handler for this type — the message would arrive unrecognized and stall.
- **Fix**: Added a `## Handling Nightly Consolidation` section to the dispatcher bootup that spawns a `nightly-consolidation` background subagent when a `consolidation` message arrives.
- **New subagent**: `.claude/agents/nightly-consolidation.md` defines the subagent that calls `memory_recent(hours=24)`, synthesizes into `rolling-summary.md`, `daily-digest.md`, `handoff.md`, project/people files, and writes `~/lobster-workspace/user-model/_context.md` for fast next-session startup.

## Changes

- `.claude/sys.dispatcher.bootup.md` — new handler section for `type: "consolidation"`
- `.claude/agents/nightly-consolidation.md` — new subagent definition (model: sonnet)

## Test plan

- [ ] Manually inject a consolidation message: `cp <(echo '{"id":"test_consolidation","source":"internal","chat_id":0,"type":"consolidation","text":"test","timestamp":"'$(date -Iseconds)'"}') ~/messages/inbox/$(date +%s%3N)_consolidation.json`
- [ ] Verify dispatcher picks it up, spawns nightly-consolidation subagent, marks processed
- [ ] Verify subagent updates rolling-summary.md and handoff.md without error
- [ ] Verify subagent result is silently dropped (not relayed to user)
- [ ] Verify real 3 AM cron run completes without leaving stuck messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)