### PR TITLE
ops: add nightly-consolidation migration + document cron/systemd split

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2086,6 +2086,7 @@ PYEOF
             substep "Registered inject-bootup-context SessionStart hook (compact sessions)"
             migrated=$((migrated + 1))
         fi
+    fi
 
     # Migration 61: Add nightly-consolidation crontab entry.
     # install.sh adds this entry but existing installs may be missing it.


### PR DESCRIPTION
Closes #1203

## Summary

- **Migration 55** in `scripts/upgrade.sh`: injects the `LOBSTER-NIGHTLY-CONSOLIDATION` crontab entry (`0 3 * * *`) on existing installs where it is missing. Idempotent — skips if marker already present.
- **CLAUDE.md**: adds a `## Scheduling Architecture` section documenting the two scheduling layers (cron for system-level tasks, systemd MCP tools for user-space jobs) and the rule never to cross them.

## Test plan

- [ ] Run `scripts/upgrade.sh` on a clean install — verify migration 55 fires and crontab entry is added
- [ ] Run `scripts/upgrade.sh` a second time — verify "already present" substep fires, `migrated` counter stays at 0
- [ ] Confirm `crontab -l` shows `LOBSTER-NIGHTLY-CONSOLIDATION` entry after migration
- [ ] Read `CLAUDE.md` Scheduling Architecture section for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)