### PR TITLE
fix: MCP deadlock recovery — session-lost-reminder + restart wrapper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,3 +161,15 @@ For changes that affect existing installs (new cron entries, new directories, co
 ## Permissions
 
 This system runs with `--dangerously-skip-permissions`. All tool calls are pre-authorized. Execute tasks directly without asking for permission.
+
+## MCP Service Restart — IMPORTANT
+
+**Never run `sudo systemctl restart lobster-mcp-local` directly.** Doing so invalidates the active MCP session immediately, leaving the dispatcher blocked in `wait_for_messages` with a "Session not found" error and no recovery guidance.
+
+Always use the safe wrapper script instead:
+
+```bash
+~/lobster/scripts/restart-mcp.sh
+```
+
+This script writes a warning to the inbox before restarting, giving the dispatcher a chance to see the notification. Combined with the session-lost-reminder written on server startup (Fix 1), the dispatcher has two opportunities to receive recovery guidance.

--- a/scripts/restart-mcp.sh
+++ b/scripts/restart-mcp.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# restart-mcp.sh — Safe wrapper for restarting the lobster-mcp-local service.
+#
+# USE THIS SCRIPT instead of calling `sudo systemctl restart lobster-mcp-local`
+# directly.  Direct restarts invalidate the active MCP session immediately,
+# leaving the dispatcher blocked in wait_for_messages with a "Session not found"
+# error and no recovery guidance.
+#
+# This script:
+#   1. Writes an mcp-restart warning message to ~/messages/inbox/
+#   2. Waits 2 seconds for the dispatcher to process it
+#   3. Runs `sudo systemctl restart lobster-mcp-local`
+#
+# The inbox message tells the dispatcher the restart is intentional and that
+# it should re-orient after reconnecting.  Combined with Fix 1
+# (session-lost-reminder written on server startup), the dispatcher has two
+# chances to see recovery guidance.
+#
+# Usage:
+#   ~/lobster/scripts/restart-mcp.sh
+#   ~/lobster/scripts/restart-mcp.sh --no-wait   (skip 2s delay, for scripted use)
+
+set -euo pipefail
+
+INBOX_DIR="${LOBSTER_MESSAGES:-${HOME}/messages}/inbox"
+REASON="${1:-manual restart}"
+NO_WAIT=false
+if [[ "${1:-}" == "--no-wait" ]]; then
+    NO_WAIT=true
+fi
+
+# Write the warning message to the inbox
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+MSG_ID="mcp-restart-$(date -u +%s)"
+MSG_FILE="${INBOX_DIR}/${MSG_ID}.json"
+
+mkdir -p "${INBOX_DIR}"
+
+cat > "${MSG_FILE}.tmp" <<EOF
+{
+  "id": "${MSG_ID}",
+  "source": "system",
+  "type": "compact-reminder",
+  "chat_id": 0,
+  "text": "MCP RESTART INCOMING — The lobster-mcp-local service is about to restart. Your MCP session will be invalidated. Re-orient after reconnecting: read sys.dispatcher.bootup.md and resume the main loop.",
+  "timestamp": "${TIMESTAMP}"
+}
+EOF
+mv "${MSG_FILE}.tmp" "${MSG_FILE}"
+
+echo "[restart-mcp] Wrote restart warning to inbox: ${MSG_ID}"
+
+if [[ "${NO_WAIT}" == "false" ]]; then
+    echo "[restart-mcp] Waiting 2s for dispatcher to see the message..."
+    sleep 2
+fi
+
+echo "[restart-mcp] Restarting lobster-mcp-local..."
+sudo systemctl restart lobster-mcp-local
+echo "[restart-mcp] Service restarted."

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -833,6 +833,61 @@ def _clear_dispatcher_state_file() -> None:
         pass
 
 
+def _write_session_lost_reminder() -> None:
+    """Write a compact-reminder to the inbox on MCP server startup.
+
+    When the MCP server restarts (e.g. via systemctl restart lobster-mcp-local),
+    any dispatcher blocked in wait_for_messages receives a "Session not found"
+    error (-32600) at the protocol level with no recovery guidance.  This
+    function writes a synthetic inbox message so that when the dispatcher
+    reconnects and calls wait_for_messages, it immediately receives a prompt
+    to re-orient and resume the main loop.
+
+    Guard: skipped when the lobster-state file indicates a mid-session MCP
+    reconnect (mode=active AND file age < 30 min).  That pattern means Claude
+    Code auto-updated or the HTTP transport briefly cycled — the dispatcher was
+    NOT blocked in a dead session and does not need to re-orient.
+
+    Idempotent: writing an extra compact-reminder during a real restart is
+    harmless; the dispatcher processes it as a routine self-check message.
+    """
+    try:
+        # Same reconnect-detection guard used by _reset_state_on_startup.
+        if LOBSTER_STATE_FILE.exists():
+            try:
+                state_data = json.loads(LOBSTER_STATE_FILE.read_text())
+                mode = state_data.get("mode", "active")
+                file_age = time.time() - LOBSTER_STATE_FILE.stat().st_mtime
+                if mode not in _TRANSIENT_MODES and file_age < _RECONNECT_GRACE_SECONDS:
+                    log.info(
+                        "[session-lost] Skipping session-lost-reminder: mid-session MCP "
+                        f"reconnect detected (mode={mode!r}, age={file_age:.0f}s)"
+                    )
+                    return
+            except Exception:  # noqa: BLE001
+                pass  # Can't read state — fall through and write the reminder
+
+        now_utc = datetime.now(timezone.utc)
+        reminder_id = f"session-lost-{int(now_utc.timestamp())}"
+        reminder = {
+            "id": reminder_id,
+            "source": "system",
+            "type": "compact-reminder",
+            "chat_id": 0,
+            "text": (
+                "SESSION LOST — The MCP server restarted and your previous session was "
+                "invalidated. Re-orient now: read sys.dispatcher.bootup.md and resume "
+                "the main loop."
+            ),
+            "timestamp": now_utc.isoformat(),
+        }
+        inbox_file = INBOX_DIR / f"{reminder_id}.json"
+        atomic_write_json(inbox_file, reminder)
+        log.info(f"[session-lost] Wrote session-lost-reminder to inbox: {reminder_id}")
+    except Exception as exc:  # noqa: BLE001
+        log.warning(f"[session-lost] Failed to write session-lost-reminder: {exc}")
+
+
 def _get_current_http_session_id() -> str | None:
     """Return the MCP session ID for the current tool call request.
 
@@ -8827,6 +8882,11 @@ async def main():
     # is still active.  The file is re-written by _tag_dispatcher_session() once
     # the dispatcher identifies itself via Options A, B, or C.
     _clear_dispatcher_state_file()
+
+    # Write a session-lost-reminder to the inbox so the dispatcher knows to
+    # re-orient after reconnecting.  Skipped for mid-session MCP reconnects.
+    # See _write_session_lost_reminder() for full rationale.
+    _write_session_lost_reminder()
 
     # Initialize the event bus singleton with standard listeners.
     # JsonlFileListener writes all events to logs/events.jsonl.


### PR DESCRIPTION
## Summary

Implements two fixes for the MCP deadlock scenario where `systemctl restart lobster-mcp-local` invalidates the active session, leaving the dispatcher blocked in `wait_for_messages` with an unrecoverable "Session not found" error (-32600).

- **Fix 1**: On `main()` startup in `inbox_server.py`, write a `compact-reminder` to the inbox. When the dispatcher reconnects and calls `wait_for_messages`, it immediately receives re-orient guidance. Guard prevents spurious messages during mid-session MCP reconnects (CC auto-updates).
- **Fix 2**: `scripts/restart-mcp.sh` wrapper that writes an `mcp-restart` inbox message before restarting the service, giving the dispatcher a pre-restart warning. `CLAUDE.md` updated to document that agents must use this script.

Closes #1201, #1202

## Details

### Fix 1 — `_write_session_lost_reminder()` in inbox_server.py

Called from `main()` right after `_clear_dispatcher_state_file()`. Uses the same reconnect-detection guard as `_reset_state_on_startup`: skips the write if `lobster-state.json` shows `mode=active` and file age < 30 minutes (indicating a CC auto-update reconnect, not a true restart).

Message written to inbox:
```json
{
  "id": "session-lost-<timestamp>",
  "source": "system",
  "type": "compact-reminder",
  "chat_id": 0,
  "text": "SESSION LOST — The MCP server restarted...",
  "timestamp": "..."
}
```

### Fix 2 — `scripts/restart-mcp.sh`

Executable shell script. Writes a `compact-reminder` to the inbox, sleeps 2s, then runs `sudo systemctl restart lobster-mcp-local`. Supports `--no-wait` flag for scripted use. `CLAUDE.md` now documents that direct `systemctl restart` is forbidden.

## Test plan

- [ ] Simulate a true restart: run `~/lobster/scripts/restart-mcp.sh` and verify a message appears in `~/messages/inbox/` before the service restarts
- [ ] After restart, verify `wait_for_messages` returns the `session-lost-*` inbox message
- [ ] Simulate a CC reconnect (kill/restart the MCP HTTP server while state is active and fresh): verify no spurious session-lost message is written
- [ ] Verify `scripts/restart-mcp.sh --no-wait` skips the sleep delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)