### PR TITLE
feat: add get_person_context and list_people MCP tools

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -2642,6 +2642,28 @@ async def list_tools() -> list[Tool]:
                 "properties": {},
             },
         ),
+        Tool(
+            name="get_person_context",
+            description="Fetch context for a specific person. Returns role, contact info, and interaction history from the canonical people file.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "person": {
+                        "type": "string",
+                        "description": "Person name matching the file stem in people/ (e.g., 'Alice', 'Bob')",
+                    },
+                },
+                "required": ["person"],
+            },
+        ),
+        Tool(
+            name="list_people",
+            description="List all people tracked in Lobster's canonical memory. Returns person names for use with get_person_context().",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+            },
+        ),
         # Local Sync Awareness Tools
         Tool(
             name="check_local_sync",
@@ -3199,6 +3221,10 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[TextConte
         return await handle_get_daily_digest(arguments)
     elif name == "list_projects":
         return await handle_list_projects(arguments)
+    elif name == "get_person_context":
+        return await handle_get_person_context(arguments)
+    elif name == "list_people":
+        return await handle_list_people(arguments)
     # Local Sync Awareness Tools
     elif name == "check_local_sync":
         return await handle_check_local_sync(arguments)
@@ -7663,6 +7689,17 @@ def _list_project_names() -> list[dict]:
     ]
 
 
+def _list_person_names() -> list[dict]:
+    """Pure helper: list person markdown files under CANONICAL_DIR/people/."""
+    people_dir = CANONICAL_DIR / "people"
+    if not people_dir.exists():
+        return []
+    return [
+        {"name": f.stem, "path": str(f)}
+        for f in sorted(people_dir.glob("*.md"))
+    ]
+
+
 async def handle_get_priorities(arguments: dict[str, Any]) -> list[TextContent]:
     """Return the canonical priorities.md content."""
     try:
@@ -7723,6 +7760,42 @@ async def handle_list_projects(arguments: dict[str, Any]) -> list[TextContent]:
     except Exception as e:
         log.error(f"list_projects failed: {e}", exc_info=True)
         return [TextContent(type="text", text=f"Error listing projects: {e}")]
+
+
+async def handle_get_person_context(arguments: dict[str, Any]) -> list[TextContent]:
+    """Return a specific person's canonical markdown content."""
+    person = arguments.get("person", "")
+    if not person:
+        return [TextContent(type="text", text="Error: person name is required.")]
+
+    # Sanitize: reject path traversal attempts
+    if "/" in person or "\\" in person or ".." in person:
+        return [TextContent(type="text", text="Error: invalid person name.")]
+
+    try:
+        path = CANONICAL_DIR / "people" / f"{person}.md"
+        if path.exists():
+            return [TextContent(type="text", text=path.read_text())]
+        available = [f.stem for f in (CANONICAL_DIR / "people").glob("*.md")] if (CANONICAL_DIR / "people").exists() else []
+        return [TextContent(
+            type="text",
+            text=f"No person file for '{person}'. Available: {', '.join(available) or 'none'}",
+        )]
+    except Exception as e:
+        log.error(f"get_person_context failed: {e}", exc_info=True)
+        return [TextContent(type="text", text=f"Error reading person context: {e}")]
+
+
+async def handle_list_people(arguments: dict[str, Any]) -> list[TextContent]:
+    """List all person files in canonical memory."""
+    try:
+        people = _list_person_names()
+        if not people:
+            return [TextContent(type="text", text="No person files found in canonical memory.")]
+        return [TextContent(type="text", text=json.dumps(people, indent=2))]
+    except Exception as e:
+        log.error(f"list_people failed: {e}", exc_info=True)
+        return [TextContent(type="text", text=f"Error listing people: {e}")]
 
 
 # =============================================================================

--- a/src/mcp/inbox_server_http.py
+++ b/src/mcp/inbox_server_http.py
@@ -97,6 +97,8 @@ READONLY_TOOLS = frozenset({
     "get_project_context",
     "get_daily_digest",
     "list_projects",
+    "get_person_context",
+    "list_people",
     # Utilities (read-only)
     "fetch_page",
     "transcribe_audio",

--- a/src/mcp/lobster_bridge_local.py
+++ b/src/mcp/lobster_bridge_local.py
@@ -98,6 +98,34 @@ def _get_project_context(canonical_dir: Path, project: str) -> str:
     return f"No project file for '{project}'. Available: {', '.join(available) or 'none'}"
 
 
+def _list_person_names(canonical_dir: Path) -> list[dict]:
+    """List person markdown files under canonical_dir/people/."""
+    people_dir = canonical_dir / "people"
+    if not people_dir.exists():
+        return []
+    return [
+        {"name": f.stem, "path": str(f)}
+        for f in sorted(people_dir.glob("*.md"))
+    ]
+
+
+def _get_person_context(canonical_dir: Path, person: str) -> str:
+    """Read a person file or return available people as a fallback."""
+    if "/" in person or "\\" in person or ".." in person:
+        return "Error: invalid person name."
+
+    path = canonical_dir / "people" / f"{person}.md"
+    if path.exists():
+        return path.read_text()
+
+    available = (
+        [f.stem for f in (canonical_dir / "people").glob("*.md")]
+        if (canonical_dir / "people").exists()
+        else []
+    )
+    return f"No person file for '{person}'. Available: {', '.join(available) or 'none'}"
+
+
 # ---------------------------------------------------------------------------
 # MCP Server
 # ---------------------------------------------------------------------------
@@ -155,6 +183,28 @@ async def list_tools() -> list[Tool]:
                 "properties": {},
             },
         ),
+        Tool(
+            name="get_person_context",
+            description="Fetch context for a specific person. Returns role, contact info, and interaction history from the canonical people file.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "person": {
+                        "type": "string",
+                        "description": "Person name matching the file stem in people/ (e.g., 'Alice', 'Bob')",
+                    },
+                },
+                "required": ["person"],
+            },
+        ),
+        Tool(
+            name="list_people",
+            description="List all people tracked in Lobster's canonical memory. Returns person names for use with get_person_context().",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+            },
+        ),
     ]
 
 
@@ -184,6 +234,13 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         "list_projects": lambda args: json.dumps(_list_project_names(CANONICAL_DIR), indent=2)
         if _list_project_names(CANONICAL_DIR)
         else "No project files found in canonical memory.",
+        "get_person_context": lambda args: _get_person_context(
+            CANONICAL_DIR,
+            args.get("person", ""),
+        ),
+        "list_people": lambda args: json.dumps(_list_person_names(CANONICAL_DIR), indent=2)
+        if _list_person_names(CANONICAL_DIR)
+        else "No person files found in canonical memory.",
     }
 
     handler = dispatch.get(name)


### PR DESCRIPTION
## Summary

- Adds `get_person_context(person)` and `list_people()` MCP tools, mirroring the existing `get_project_context`/`list_projects` pattern
- Reads from `~/lobster-user-config/memory/canonical/people/*.md` (same base dir as projects/)
- Adds helpers in both `inbox_server.py` and `lobster_bridge_local.py`; registers in HTTP whitelist

## What this enables

Agents can now look up people context programmatically via MCP rather than reading files directly. Closes #1198.

Note: The actual `people/*.md` files are private data in `lobster-user-config/` — not in this PR. They are already populated locally.

## Test plan

- [ ] `list_people()` returns names from `people/` directory
- [ ] `get_person_context("Alice")` returns matching .md content
- [ ] `get_person_context("nobody")` returns a helpful "available: ..." error
- [ ] Invalid names with `/` or `..` are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)