### PR TITLE
feat: nightly consolidation generates user-model/_context.md

### DIFF
--- a/.claude/agents/nightly-consolidation.md
+++ b/.claude/agents/nightly-consolidation.md
@@ -52,7 +52,7 @@ You will receive a prompt containing the consolidation trigger timestamp.
 9. **Sync canonical files into the user model DB.**
    Run the bridge pass to push projects, priorities, and preferences from canonical markdown files into the user model DB. This also generates the pre-computed `_context.md` via `write_context_cache()`:
    ```bash
-   cd ~/lobster && uv run -c "
+   cd ~/lobster && uv run python -c "
    import sys; sys.path.insert(0, 'src')
    from mcp.user_model.bridges import run_bridges
    import sqlite3, os

--- a/.claude/agents/nightly-consolidation.md
+++ b/.claude/agents/nightly-consolidation.md
@@ -49,15 +49,54 @@ You will receive a prompt containing the consolidation trigger timestamp.
    Read `~/lobster-user-config/memory/canonical/handoff.md`.
    Update the "Current state" section to reflect the synthesized current state. This is the first file the next session reads — keep it accurate and current.
 
-9. **Write `_context.md` (user model summary).**
-   Write a concise pre-computed summary to `~/lobster-workspace/user-model/_context.md`.
-   This file is read at session startup. Include:
-   - User's current top priorities (from priorities.md or observed themes)
-   - Active projects and their status
-   - Key people in current focus
-   - Any emotional baseline signals (stress level, energy, mode of operation)
-   - Constraints or preferences that were reinforced today
-   Create the directory if it does not exist. Overwrite the file entirely each run.
+9. **Sync canonical files into the user model DB.**
+   Run the bridge pass to push projects, priorities, and preferences from canonical markdown files into the user model DB. This also generates the pre-computed `_context.md` via `write_context_cache()`:
+   ```bash
+   cd ~/lobster && uv run -c "
+   import sys; sys.path.insert(0, 'src')
+   from mcp.user_model.bridges import run_bridges
+   import sqlite3, os
+   db_path = os.path.expanduser('~/lobster-workspace/data/memory.db')
+   conn = sqlite3.connect(db_path)
+   result = run_bridges(conn)
+   conn.close()
+   print(result)
+   "
+   ```
+   This syncs `projects/*.md` as narrative arcs and `priorities.md` as attention items, and writes the pre-computed `~/lobster-workspace/user-model/_context.md`.
+   If the script fails (e.g. DB not initialized), continue to step 10.
+
+10. **Write `_context.md` (user model summary).**
+    Call `model_user_context(deep=True)` to retrieve structured user model data from the DB.
+    Combine it with today's synthesized context (from steps 1–8) to write a complete snapshot.
+
+    Create `~/lobster-workspace/user-model/` if it does not exist, then write `_context.md` with this structure:
+
+    ```markdown
+    # User Model Context
+    *Auto-generated YYYY-MM-DD — do not edit manually*
+
+    ## Active Projects
+    <list from model_user_context(deep=True) plus any new project status from today's events>
+
+    ## Top Priorities
+    <from priorities.md or inferred from today's attention>
+
+    ## Key People (Recent Focus)
+    <people who appeared in today's events or model_user_context>
+
+    ## Preferences & Constraints
+    <behavioral rules reinforced today; hard constraints; known preferences>
+
+    ## Emotional Baseline
+    <mood/energy signals from today's events and model baseline>
+
+    ## Open Questions / Pending Decisions
+    <unresolved threads identified in today's synthesis>
+    ```
+
+    If `model_user_context(deep=True)` returns no data (model not yet populated), write the file from today's synthesis alone — do not leave the file empty or skip this step.
+    Overwrite the file entirely each run.
 
 ### What NOT to do
 


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What this fixes

Every session boots blind on user context because `~/lobster-workspace/user-model/_context.md` never exists. The nightly-consolidation agent had a step 9 that wrote this file, but it wrote a plain LLM text synthesis with no connection to the user model DB. `write_context_cache()` in `bridges.py` — which queries accumulated preferences, narrative arcs, and attention items from the DB — was never called during nightly runs.

## What changed

Step 9 is replaced with two steps:

**Step 9 — DB sync (new):** Run `run_bridges()` via `uv` to push `projects/*.md` as narrative arcs and `priorities.md` as attention items into the user model DB. `run_bridges()` calls `write_context_cache()` internally, which writes `_context.md` from DB state (preferences graph, emotional baseline, attention stack).

**Step 10 — LLM synthesis layer (updated from old step 9):** Call `model_user_context(deep=True)` to read the structured DB output, then merge it with today's synthesized events into a structured `_context.md` template covering: Active Projects, Top Priorities, Key People, Preferences & Constraints, Emotional Baseline, and Open Questions.

The result is a `_context.md` that combines DB-inferred state (accumulated over time, deterministic) with event-driven synthesis from today — rather than pure LLM synthesis with no memory of prior days.

## Functional patterns

Pure function composition: `run_bridges()` → `write_context_cache()` is a pure data transformation (canonical files → DB → markdown snapshot). The agent invokes this as a subprocess to isolate the DB side effects at the boundary, then reads back via `model_user_context(deep=True)` for the synthesis layer.

## What is out of scope

This PR does not fix the separate issue that nightly-consolidation isn't registered as a scheduled job (#1203). The agent change is correct and will take effect once the job is registered and triggering.

## Tests run

- [x] `git diff HEAD~1` — diff reviewed, changes match intent
- [ ] Live nightly run — blocked: requires registered cron job (#1203) and a session running at 3 AM. No behavior change to existing code paths (step 9 was a no-op before; this makes it functional).

Closes #1192