### PR TITLE
feat: expand nightly-consolidation people/projects write protocol

### DIFF
--- a/.claude/agents/nightly-consolidation.md
+++ b/.claude/agents/nightly-consolidation.md
@@ -35,12 +35,58 @@ You will receive a prompt containing the consolidation trigger timestamp.
    Prepend today's dated section with a prose summary (2-4 sentences) of what happened, followed by bullet action items if any were identified.
 
 5. **Update project files if relevant info emerged.**
-   If new status, blockers, or decisions appeared for any active project, update the corresponding file in `~/lobster-user-config/memory/canonical/projects/`.
+   For each project mentioned in today's memory events where new status, blockers, or decisions appeared:
+
+   a. **Match the project name to a file.** List `~/lobster-user-config/memory/canonical/projects/`. Match by partial/fuzzy name — e.g. "Lobster" → `LobsterCore.md`, "MaliniBIS" or "BIS" → `MaliniBIS.md`. If multiple files are plausible, pick the best match. If no file matches and the project appears meaningfully (more than a passing mention), create a new file (see template below).
+
+   b. **Prepend a dated update section.** Do NOT rewrite the file. Prepend a new section immediately after the `# Project: Name` header (before any existing sections), using this format:
+   ```
+   ## YYYY-MM-DD Update
+   - <bullet: new decision, status change, blocker, or notable event>
+   - <bullet: ...>
+   ```
+   Only include bullets for materially new information — not summaries of existing content.
+
+   c. **New project file template** (if no file exists):
+   ```markdown
+   # Project: <Name>
+
+   ## YYYY-MM-DD Update
+   - <initial info from today's memory events>
+
+   **Status**: active
+   **Description**: <one-line description from available context>
+   ```
+
    Only update files where something materially changed — do not touch files with no new information.
 
 6. **Update people files if new relationship info emerged.**
-   If new interactions, commitments, or relationship context appeared for any person, update the corresponding file in `~/lobster-user-config/memory/canonical/people/`.
-   Only update files where something materially changed.
+   For each person mentioned in today's memory events where new interactions, commitments, or relationship context appeared:
+
+   a. **Match the person name to a file.** List `~/lobster-user-config/memory/canonical/people/`. Match by name (fuzzy is fine). If no file matches and the person appears meaningfully, create a new file (see template below).
+
+   b. **Prepend a dated interaction entry.** Do NOT rewrite the file. Prepend a new bullet at the top of the `## Interactions` section (most recent first), using this format:
+   ```
+   - YYYY-MM-DD: <brief description of the interaction or new context>
+   ```
+   Create the `## Interactions` section if it doesn't exist. Only add entries for genuinely new interactions or relationship context — not re-summarized existing content.
+
+   c. **New person file template** (if no file exists):
+   ```markdown
+   # <Name>
+
+   **Role**: <role or relationship from available context>
+
+   ## Context
+
+   <How they appear in today's notes — brief.>
+
+   ## Interactions
+
+   - YYYY-MM-DD: <initial interaction or mention>
+   ```
+
+   Only update files where something materially changed — do not touch files with no new information.
 
 7. **Mark consolidated events.**
    Call `mark_consolidated()` to mark all reviewed events as processed so they are not re-processed in future consolidation runs.
@@ -62,6 +108,7 @@ You will receive a prompt containing the consolidation trigger timestamp.
 ### What NOT to do
 
 - Do NOT rewrite past entries in rolling-summary.md or daily-digest.md — prepend only.
+- Do NOT rewrite project or people files — only prepend/append new dated sections.
 - Do NOT send any message to the user — this is a silent background operation.
 - Do NOT call `send_reply` under any circumstances.
 - Do NOT make up content — only synthesize what actually appeared in memory_recent output.


### PR DESCRIPTION
## What this solves

Steps 5 and 6 of nightly-consolidation previously said "update the corresponding file" with no protocol for *how* — leaving it open to silently rewriting entire files, which would destroy historical entries. This PR makes those steps concrete and enforces append-only semantics.

## What changed

**Steps 5 and 6 now specify:**

- **Fuzzy name matching**: list the `people/` or `projects/` directory and match by partial name (e.g. "Lobster" → `LobsterCore.md`, "BIS" → `MaliniBIS.md`)
- **Append-only for projects**: prepend a `## YYYY-MM-DD Update` section immediately after the file header — never rewrite the file
- **Append-only for people**: prepend a new dated bullet at the top of `## Interactions` — never rewrite the file
- **File creation**: if no matching file exists and the project/person is meaningfully present, create one using a defined template
- **"What NOT to do"** section now explicitly calls out: "Do NOT rewrite project or people files — only prepend/append new dated sections"

This is additive — it does not touch steps 1-4, 7-9, or the `write_result` delivery format. No conflict with the concurrent `fix/nightly-consolidation-handler` branch (that branch doesn't modify this file).

## Functional patterns

Pure declarative instructions: each step is a self-contained rule with explicit inputs (memory events), matching function (fuzzy file lookup), and output (append-only write). No mutable state, no implicit side effects on unrelated files.

## Tests run

- [x] `diff` of new file against main — confirmed only steps 5/6 and the "What NOT to do" list changed; all other steps unchanged
- [ ] Live nightly consolidation run — not run; would require a real memory_recent result and a 3 AM trigger. The change is instructions-only (no executable code), so correctness depends on the LLM following the protocol.

Closes #1209