### PR TITLE
feat: detect multi-question messages and track unanswered questions

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -768,3 +768,37 @@ update_task(task_id, status="pending", description="<original>\n\n[Stalled: <rea
 
 4. **Handle voice messages** — Voice messages arrive pre-transcribed; read from `msg["transcription"]`.
 5. **Relay short review verdicts only** — When a reviewer's `subagent_result` arrives, relay only the short verdict (1-3 sentences). The full review lives on GitHub as a PR comment.
+
+---
+
+## Multi-Question Handling
+
+When a user message contains **2 or more explicit questions** (sentences ending in `?`), enumerate all questions before composing your reply, then verify each one is addressed.
+
+### Detection rules
+
+Count a sentence as a trackable question if and only if:
+- It ends with `?`
+- It is not inside a code block (fenced with ` ``` ` or indented 4 spaces)
+- It is not a list item (starts with `-`, `*`, or a digit followed by `.`)
+- It does not begin with a rhetorical opener: "I wonder", "Isn't it", "Don't you think", "Wouldn't you say"
+
+If fewer than 2 trackable questions are present, apply no special handling — respond normally.
+
+### When 2+ trackable questions are detected
+
+1. Mentally list every trackable question before writing your reply.
+2. Compose a reply that addresses each question. Questions delegated to a subagent count as addressed ("I'm looking into X now").
+3. Before sending, do a final pass: is every question either answered inline or explicitly delegated? If yes, send normally.
+4. If one or more questions went unanswered and are not delegated, append a single note at the end of your reply:
+
+   > Note: I still need to address: [question text]
+
+   One note, at most, per reply — never one per unanswered question.
+
+### Hard constraints (prevent rogue behavior)
+
+- **No automated follow-up spawning.** Never spawn a subagent or schedule a reminder solely to track unanswered questions. Tracking is mental, not structural.
+- **One note maximum per turn.** If multiple questions are unaddressed, list them all in a single "Note:" line.
+- **No loop behavior.** Never ask "did I answer all your questions?" Do not re-surface unanswered questions on the next turn unless the user brings them up.
+- **Rhetorical questions are not tracked.** Do not append notes for questions that are clearly rhetorical (see detection rules above).


### PR DESCRIPTION
## What this solves

Multi-topic messages often result in partial answers. The first clear question gets handled; bundled questions further in the same message drop silently — as happened with the GSD usage question in issue #1191. This adds an in-context checklist discipline to prevent that pattern without introducing any automated infrastructure.

## What changed

A new **Multi-Question Handling** section in `sys.dispatcher.bootup.md` instructs the dispatcher to:

1. Detect messages with 2+ trackable questions (sentences ending in `?`)
2. Enumerate all questions mentally before composing a reply
3. Verify each question is either answered inline or explicitly delegated to a subagent
4. If any remain unaddressed, append **one** inline note at the end of the reply: "Note: I still need to address: [question]"

This is purely in-context behavioral instruction — no code changes, no DB writes, no new tools.

## Guardrails against rogue behavior

The section Sahar flagged as risky ("could go rogue") is addressed by four hard constraints written directly into the section:

| Risk | Constraint |
|---|---|
| Spam a follow-up for every unanswered question | One note maximum per reply, listing all unaddressed questions together |
| Loop — keep asking "did I answer everything?" | Explicit prohibition: never re-surface unanswered questions on the next turn unless the user raises them |
| Automated follow-up spawning | Explicit prohibition: tracking is mental, never structural (no subagent spawning, no reminder scheduling) |
| False positives on rhetorical questions / code | Detection rules filter: skip questions in code blocks, list items, or beginning with rhetorical openers |

## Functional pattern

The implementation is declarative behavioral specification — enumeration-before-action (map the full question set before dispatching replies), with a final verification pass before sending. No side effects.

## Flow: before vs. after

Before:
```
User: "Q1? Q2? Q3?"
  -> Dispatcher addresses Q1, delegates Q2
  -> Q3 silently dropped
```

After:
```
User: "Q1? Q2? Q3?"
  -> Dispatcher enumerates: [Q1, Q2, Q3]
  -> Addresses Q1, delegates Q2, notices Q3 unaddressed
  -> Reply ends with: "Note: I still need to address: Q3"
```

No behavior change for single-question messages or messages with 0-1 trackable questions.

## Tests run

- [x] Manual read-through of the added section — wording is unambiguous, constraints are explicit
- [ ] Live dispatcher session test — skipped: requires running dispatcher session; the change is behavioral instruction only (no code path), so the effective test is reviewer judgment on whether the wording is clear and the guardrails are sufficient

Closes #1191