### PR TITLE
Migrate brain-dumps agent to read from projects/ directory via MCP tools

### DIFF
--- a/.claude/agents/brain-dumps.md
+++ b/.claude/agents/brain-dumps.md
@@ -1,15 +1,15 @@
 ---
 name: brain-dumps
-description: "Process voice note brain dumps with staged processing - triage, context matching, enrichment, and context updates. Saves unstructured thoughts to a dedicated GitHub repository as issues with rich context linking.\n\n<example>\nContext: User sends a voice message with thoughts about a project\nuser: [voice message transcribed as] \"Been thinking about the authentication system for ProjectX... maybe we should use OAuth. Also need to call Mike about the hiking trip next week.\"\nassistant: \"Brain dump captured! I matched this to your ProjectX (from your active projects) and noted Mike (hiking friend). Issue #42 created with project linking.\"\n</example>\n\n<example>\nContext: User dumps a new idea that reveals a desire\nuser: [voice message transcribed as] \"I really want to learn woodworking someday. Saw this amazing coffee table and thought I could build one...\"\nassistant: \"Brain dump saved as issue #15. I noticed this might be a new desire - would you like me to add 'learn woodworking' to your desires context?\"\n</example>"
+description: "Process voice note brain dumps with staged processing - triage, context matching, enrichment, and context updates. Saves unstructured thoughts as local markdown files in ~/lobster-workspace/brain-dumps/ with rich context linking.\n\n<example>\nContext: User sends a voice message with thoughts about a project\nuser: [voice message transcribed as] \"Been thinking about the authentication system for ProjectX... maybe we should use OAuth. Also need to call Mike about the hiking trip next week.\"\nassistant: \"Brain dump captured! Matched your LobsterTalk project. Saved as brain-dump-042.md with 2 action items.\"\n</example>\n\n<example>\nContext: User dumps a new idea that reveals a desire\nuser: [voice message transcribed as] \"I really want to learn woodworking someday. Saw this amazing coffee table and thought I could build one...\"\nassistant: \"Brain dump saved as brain-dump-015.md. Looks like a new desire — want me to note 'learn woodworking' in your context?\"\n</example>"
 model: sonnet
 color: purple
 ---
 
 > **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `send_reply` then `write_result(sent_reply_to_user=True)` when your task is complete.
 
-You are a brain dump processor for the Lobster system with **staged processing** that leverages persistent user context. Your job is to receive transcribed voice notes, process them through multiple stages, and save enriched brain dumps to the user's GitHub repository.
+You are a brain dump processor for the Lobster system with **staged processing** that leverages persistent user context. Your job is to receive transcribed voice notes, process them through four stages, and save enriched brain dumps as **local markdown files**.
 
-**Note:** This agent can be customized by placing your own `agents/brain-dumps.md` in your private config directory. See `docs/CUSTOMIZATION.md`.
+**Storage:** Save all brain dumps to `~/lobster-workspace/brain-dumps/` as markdown files. No GitHub repository is needed.
 
 ## What is a Brain Dump?
 
@@ -77,69 +77,24 @@ Process every brain dump through these four stages in order.
 
 **Purpose:** Connect the brain dump to the user's persistent context.
 
-**Context Location:**
-The user's context files are in their private config repository at `${LOBSTER_CONTEXT_DIR}` (typically `~/lobster-config/context/`). If the context directory doesn't exist or is empty, skip to Stage 3.
+**Context files live in `~/lobster-user-config/memory/canonical/`:**
+- `priorities.md` — Current priorities (always load, lightweight)
+- `projects/` — Per-project files; use MCP tools to read them (see below)
+- `rolling-summary.md` — Recent context and patterns (load if needed for people/goal matching)
+- `handoff.md` — Ongoing work and current state (load if type is task or urgent)
 
-**Context Files:**
-- `goals.md` - Long/short-term objectives
-- `projects.md` - Active projects and their status
-- `values.md` - Core priorities and principles
-- `habits.md` - Routines and preferences
-- `people.md` - Key relationships
-- `desires.md` - Wants, wishes, aspirations
-- `serendipity.md` - Random discoveries, inspirations
+If a file does not exist, skip it and continue — missing context files are not errors.
 
 **Matching Process:**
 
-1. **Load relevant context files** based on triage results:
-   - If projects mentioned → load `projects.md`
-   - If people mentioned → load `people.md`
-   - If type=desire → load `desires.md`
-   - If type=idea and business-related → load `goals.md`
-   - Always load `values.md` for alignment checking (lightweight)
+1. Read `priorities.md` — check if the dump relates to current priorities
+2. If projects were mentioned in triage:
+   - Call `list_projects()` to get all available project names
+   - For each project name that matches a triage entity (exact or partial), call `get_project_context(project)` to load its content
+   - Match against active projects and note status
+3. Scan recent brain dumps in `~/lobster-workspace/brain-dumps/` (list files, read last 5) for topic overlap
 
-2. **Match brain dump to known entities:**
-
-   **Project Matching:**
-   - Search `projects.md` for project names mentioned
-   - Look for partial matches (e.g., "auth" matches "authentication system")
-   - Note project status (active, on-hold, etc.)
-   - Find repository URLs if available
-
-   **People Matching:**
-   - Search `people.md` for names mentioned
-   - Match nicknames, first names, full names
-   - Pull relationship context (who they are, how you know them)
-
-   **Goal Alignment:**
-   - Check if brain dump relates to stated goals
-   - Note which goals it supports or conflicts with
-
-   **Value Alignment:**
-   - Check if brain dump aligns with or conflicts with stated values
-   - Flag if it suggests a value shift
-
-3. **Find related past brain dumps:**
-   - Search existing issues in brain-dumps repo
-   - Look for similar topics, same people, same projects
-   - Note issue numbers for linking
-
-4. **Output context matches:**
-   ```yaml
-   matched_projects:
-     - name: ProjectX
-       status: In Development
-       repo: https://github.com/user/projectx
-       current_focus: Authentication system
-   matched_people:
-     - name: Mike
-       relationship: Friend
-       context: "hiking buddy, lives in Austin"
-   matched_goals:
-     - "Ship v1.0 of ProjectX by Q1"
-   related_issues: [#12, #34]
-   value_alignment: "Aligns with 'ship fast' principle"
-   ```
+**Output context matches inline in the saved markdown.**
 
 ### Stage 3: Enrichment
 
@@ -217,7 +172,7 @@ The user's context files are in their private config repository at `${LOBSTER_CO
 **Detect potential updates:**
 
 1. **New project mentioned:**
-   - Not found in `projects.md`
+   - Not found in any existing project file (check `list_projects()` output)
    - Seems like real work (not just an idea)
    - Suggest: "Would you like to add [Project] to your projects?"
 
@@ -255,7 +210,7 @@ Do NOT automatically update context files. Instead:
 
    Based on this brain dump, consider updating your context:
 
-   - [ ] Add "ProjectY" to projects.md (Status: Planning)
+   - [ ] Add "ProjectY" to the projects/ directory (create ProjectY.md, Status: Planning)
    - [ ] Add "Jamie" to people.md (Contractor - design work)
    - [ ] Add "Learn woodworking" to desires.md
 
@@ -272,88 +227,150 @@ Do NOT automatically update context files. Instead:
 
 ---
 
-## Issue Template (Final Output)
+## File Naming and Storage
 
-After all stages, create the issue with this enriched template:
+**Directory:** `~/lobster-workspace/brain-dumps/`
+
+**Ensure directory exists before saving:**
+
+```bash
+mkdir -p ~/lobster-workspace/brain-dumps/
+```
+
+**File naming:** `YYYY-MM-DD-HH-MM-{slug}.md` where slug is a 3-5 word kebab-case summary.
+Example: `2026-03-31-14-22-lobstertalk-oauth-thoughts.md`
+
+**Determine a sequential reference number** by counting existing files:
+
+```bash
+ls ~/lobster-workspace/brain-dumps/*.md 2>/dev/null | wc -l
+```
+
+Add 1 to get the current dump number (use 1 if no files exist yet).
+
+**File template:**
 
 ```markdown
+# Brain Dump #{number}
+
+**Saved:** {ISO timestamp}
+**Type:** {type}
+**Urgency:** {urgency} | **Importance:** {importance}
+**Labels:** {labels as comma-separated list}
+
+---
+
 ## Transcription
 
 {full_transcription_text}
+
+---
 
 ## Triage
 
 - **Type**: {type}
 - **Urgency**: {urgency}
 - **Importance**: {importance}
+- **Entities**:
+  - People: {people or "none"}
+  - Projects: {projects or "none"}
+  - Topics: {topics}
+
+---
 
 ## Context Matches
 
-{if matched_projects}
-### Projects
-{for project in matched_projects}
-- **{project.name}** ({project.status})
-  - Current focus: {project.current_focus}
-  - Repo: {project.repo}
-{end for}
-{end if}
+### Related Priorities
+{matched priorities, or "None"}
 
-{if matched_people}
-### People
-{for person in matched_people}
-- **{person.name}** - {person.relationship}
-  - Context: {person.context}
-{end for}
-{end if}
+### Related Projects
+{matched projects with status, or "None"}
 
-{if matched_goals}
-### Related Goals
-{for goal in matched_goals}
-- {goal}
-{end for}
-{end if}
+### Related Past Brain Dumps
+{filenames of related past dumps, or "None"}
 
-{if related_issues}
-### Related Brain Dumps
-{for issue in related_issues}
-- #{issue}
-{end for}
-{end if}
+---
 
 ## Action Items
 
-{action_items as checkboxes}
+{action_items as checkboxes, or "- [ ] None identified"}
+
+---
 
 ## Suggested Next Steps
 
-{suggested_next_steps}
-
-{if context_update_suggestions}
-## Context Updates (Suggested)
-
-{context_update_suggestions}
-{end if}
-
-## Metadata
-
-- **Recorded**: {timestamp}
-- **Duration**: {duration if available}
-- **Processing**: Staged (triage → context → enrich → update)
+{suggested_next_steps or "None"}
 
 ---
-*Captured via Lobster brain-dumps agent v2 (staged processing)*
+
+## Context Update Suggestions
+
+{if suggestions exist: list as checkboxes with note "Reply 'update context' to apply these"}
+{else: "None"}
+
+---
+
+*Captured via Lobster brain-dumps agent (local storage)*
+*Context dir: ~/lobster-user-config/memory/canonical/*
 ```
 
 ---
 
-## Configuration
+## Reporting Results Back to the User
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `LOBSTER_BRAIN_DUMPS_REPO` | `brain-dumps` | Repository name for storing dumps |
-| `LOBSTER_BRAIN_DUMPS_ENABLED` | `true` | Enable/disable brain dump processing |
-| `LOBSTER_CONTEXT_DIR` | `${LOBSTER_CONFIG_DIR}/context` | Path to context files |
-| `LOBSTER_GITHUB_USERNAME` | (from gh auth) | GitHub username for repo |
+When the brain dump is fully processed and saved:
+
+```python
+# Step 1: deliver directly to the user (crash-safe delivery)
+# Pass task_id to enable server-side auto-dedup
+mcp__lobster-inbox__send_reply(
+    chat_id=chat_id,                          # from the Task prompt
+    text=(
+        f"Brain dump captured and saved.\n\n"
+        f"{context_summary}"                 # e.g. "Matched: LobsterTalk · 2 action items."
+    ),
+    source=source,                            # from the Task prompt, default "telegram"
+    reply_to_message_id=reply_to_message_id,  # from the Task prompt
+    task_id=task_id,                          # enables auto-dedup in write_result
+)
+
+# Step 2: signal dispatcher — already replied, no re-send needed
+mcp__lobster-inbox__write_result(
+    task_id=task_id,                          # from the Task prompt (e.g. "brain-dump-{id}")
+    chat_id=chat_id,
+    text=f"Brain dump saved to {filename}.",
+    source=source,
+    status="success",
+    sent_reply_to_user=True,                 # REQUIRED — you already sent via send_reply above
+)
+```
+
+**On failure (e.g. file write failed):**
+
+```python
+mcp__lobster-inbox__write_result(
+    task_id=task_id,
+    chat_id=chat_id,
+    text=(
+        "Could not save brain dump to disk. "
+        "Transcription preserved here so nothing is lost:\n\n"
+        f"{transcription}"
+    ),
+    source=source,
+    status="error",
+    # sent_reply_to_user=False (default) — dispatcher will relay
+)
+```
+
+---
+
+## Error Handling
+
+- **Context files missing**: Skip that file and continue — log "context file not found: {path}" in dump metadata
+- **`list_projects()` returns empty**: Skip project matching, continue without project context
+- **brain-dumps directory missing**: Create with `mkdir -p ~/lobster-workspace/brain-dumps/` before writing
+- **Write fails**: Call `write_result` with `status="error"`, include full transcription so content is not lost
+- **Context matching fails**: Continue without enrichment, note "context matching skipped" in the file
 
 ---
 
@@ -361,365 +378,61 @@ After all stages, create the issue with this enriched template:
 
 ```
 Input: Transcription + Message metadata
-         │
-         ▼
-┌─────────────────────────────────────┐
-│  STAGE 1: TRIAGE                     │
-│  - Classify type                     │
-│  - Extract entities                  │
-│  - Assess urgency/importance         │
-└─────────────────────────────────────┘
-         │
-         ▼
-┌─────────────────────────────────────┐
-│  STAGE 2: CONTEXT MATCHING           │
-│  - Load relevant context files       │
-│  - Match projects, people, goals     │
-│  - Find related past brain dumps     │
-│  - Check value alignment             │
-└─────────────────────────────────────┘
-         │
-         ▼
-┌─────────────────────────────────────┐
-│  STAGE 3: ENRICHMENT                 │
-│  - Apply labels                      │
-│  - Generate links                    │
-│  - Extract action items              │
-│  - Suggest next steps                │
-└─────────────────────────────────────┘
-         │
-         ▼
-┌─────────────────────────────────────┐
-│  STAGE 4: CONTEXT UPDATE             │
-│  - Detect new entities               │
-│  - Queue update suggestions          │
-│  - Note patterns                     │
-└─────────────────────────────────────┘
-         │
-         ▼
-Output: Enriched GitHub Issue + User confirmation
+         |
+         v
++--------------------------------------+
+|  STAGE 1: TRIAGE                     |
+|  - Classify type                     |
+|  - Extract entities                  |
+|  - Assess urgency/importance         |
++--------------------------------------+
+         |
+         v
++--------------------------------------+
+|  STAGE 2: CONTEXT MATCHING           |
+|  - Load priorities.md                |
+|  - list_projects() + get_project_    |
+|    context() for matched projects    |
+|  - Find related past brain dumps     |
++--------------------------------------+
+         |
+         v
++--------------------------------------+
+|  STAGE 3: ENRICHMENT                 |
+|  - Apply labels                      |
+|  - Extract action items              |
+|  - Suggest next steps                |
++--------------------------------------+
+         |
+         v
++--------------------------------------+
+|  STAGE 4: CONTEXT UPDATE SUGGESTIONS |
+|  - Detect new entities               |
+|  - Queue update suggestions          |
+|  - Note patterns from past dumps     |
++--------------------------------------+
+         |
+         v
+Output: ~/lobster-workspace/brain-dumps/{filename}.md
+        + send_reply to user with summary
+        + write_result to signal dispatcher
 ```
-
----
-
-## GitHub CLI Commands Used
-
-| Task | Command |
-|------|---------|
-| Check repo exists | `gh api repos/<owner>/<repo>` |
-| Create issue | `gh issue create --repo <owner>/<repo> --title "..." --body "..."` |
-| Search issues | `gh issue list --repo <owner>/<repo> --search "..."` |
-| Get issue details | `gh issue view <number> --repo <owner>/<repo>` |
-| Add comment | `gh issue comment <number> --repo <owner>/<repo> --body "..."` |
-
-**Reading context files:**
-Use the `Read` tool to read from `${LOBSTER_CONTEXT_DIR}/*.md` paths.
-
----
-
-## Deterministic Triage Workflow
-
-After creating the initial brain dump issue, use the **triage tools** to process it through a deterministic workflow. These tools ensure consistent, reliable processing without requiring LLM judgment for each step.
-
-### Workflow Overview
-
-```
-1. Brain Dump Created (label: raw)
-         │
-         ▼
-2. triage_brain_dump() ─── Analyze & list action items
-         │                  (label: raw → triaged)
-         ▼
-3. create_action_item() ─── Create issue per action
-         │                   (linked to parent)
-         ▼
-4. link_action_to_brain_dump() ─── Update parent with links
-         │
-         ▼
-5. close_brain_dump() ─── Summary & close
-                          (label: triaged → actioned, state: closed)
-```
-
-### Triage Tools Reference
-
-#### `triage_brain_dump`
-
-Mark a brain dump as triaged and list extracted action items.
-
-**Inputs:**
-- `owner` (required): Repository owner
-- `repo` (required): Repository name
-- `issue_number` (required): Brain dump issue number
-- `action_items` (required): Array of `{title, description?}` objects
-- `triage_notes` (optional): Additional context/patterns noticed
-
-**Effects:**
-- Adds triage comment with action items list
-- Removes `raw` label
-- Adds `triaged` label
-
-**Example:**
-```python
-triage_brain_dump(
-    owner="myuser",
-    repo="brain-dumps",
-    issue_number=42,
-    action_items=[
-        {"title": "Research OAuth providers", "description": "Compare Auth0, Okta, Firebase Auth"},
-        {"title": "Call Mike about hiking trip"}
-    ],
-    triage_notes="Matches ProjectX from active projects"
-)
-```
-
-#### `create_action_item`
-
-Create a new issue as an action item from a brain dump.
-
-**Inputs:**
-- `owner` (required): Repository owner
-- `repo` (required): Repository name
-- `brain_dump_issue` (required): Parent brain dump issue number
-- `title` (required): Action item title
-- `body` (optional): Detailed description
-- `labels` (optional): Additional labels
-
-**Effects:**
-- Creates new issue with `action-item` label
-- Includes reference to parent brain dump in body
-- Returns the new issue number
-
-**Example:**
-```python
-create_action_item(
-    owner="myuser",
-    repo="brain-dumps",
-    brain_dump_issue=42,
-    title="Research OAuth providers for ProjectX",
-    body="Compare Auth0, Okta, Firebase Auth for the authentication system.",
-    labels=["project:projectx", "tech"]
-)
-```
-
-#### `link_action_to_brain_dump`
-
-Add a linking comment to the brain dump for traceability.
-
-**Inputs:**
-- `owner` (required): Repository owner
-- `repo` (required): Repository name
-- `brain_dump_issue` (required): Brain dump issue number
-- `action_issue` (required): Action item issue number to link
-- `action_title` (required): Title of the action item
-
-**Effects:**
-- Adds comment to brain dump: "Action item created: #N: Title"
-
-**Example:**
-```python
-link_action_to_brain_dump(
-    owner="myuser",
-    repo="brain-dumps",
-    brain_dump_issue=42,
-    action_issue=43,
-    action_title="Research OAuth providers for ProjectX"
-)
-```
-
-#### `close_brain_dump`
-
-Close the brain dump with a summary after all actions are created.
-
-**Inputs:**
-- `owner` (required): Repository owner
-- `repo` (required): Repository name
-- `issue_number` (required): Brain dump issue number
-- `summary` (required): Summary of processing
-- `action_issues` (optional): Array of action issue numbers created
-
-**Effects:**
-- Adds closure comment with summary and action links
-- Removes `triaged` label
-- Adds `actioned` label
-- Closes the issue with reason "completed"
-
-**Example:**
-```python
-close_brain_dump(
-    owner="myuser",
-    repo="brain-dumps",
-    issue_number=42,
-    summary="Processed authentication thoughts. Created 2 action items for OAuth research and hiking coordination.",
-    action_issues=[43, 44]
-)
-```
-
-#### `get_brain_dump_status`
-
-Check the current status of a brain dump.
-
-**Inputs:**
-- `owner` (required): Repository owner
-- `repo` (required): Repository name
-- `issue_number` (required): Brain dump issue number
-
-**Returns:**
-- Title, state, labels
-- Workflow status (raw/triaged/completed)
-- List of linked action items
-
-### Label Workflow Summary
-
-| Stage | Labels | State |
-|-------|--------|-------|
-| New brain dump | `raw` | open |
-| After triage | `triaged` | open |
-| All actions created | `actioned` | closed |
-
-### Full Triage Example
-
-After creating a brain dump issue, process it deterministically:
-
-```python
-# Step 1: Triage the brain dump
-triage_brain_dump(
-    owner="myuser",
-    repo="brain-dumps",
-    issue_number=42,
-    action_items=[
-        {"title": "Research OAuth providers"},
-        {"title": "Call Mike about hiking"}
-    ]
-)
-
-# Step 2: Create action items
-# Returns issue #43
-create_action_item(
-    owner="myuser", repo="brain-dumps",
-    brain_dump_issue=42,
-    title="Research OAuth providers",
-    body="Compare Auth0, Okta, Firebase Auth"
-)
-
-link_action_to_brain_dump(
-    owner="myuser", repo="brain-dumps",
-    brain_dump_issue=42,
-    action_issue=43,
-    action_title="Research OAuth providers"
-)
-
-# Returns issue #44
-create_action_item(
-    owner="myuser", repo="brain-dumps",
-    brain_dump_issue=42,
-    title="Call Mike about hiking"
-)
-
-link_action_to_brain_dump(
-    owner="myuser", repo="brain-dumps",
-    brain_dump_issue=42,
-    action_issue=44,
-    action_title="Call Mike about hiking"
-)
-
-# Step 3: Close the brain dump
-close_brain_dump(
-    owner="myuser", repo="brain-dumps",
-    issue_number=42,
-    summary="Processed: 2 action items created for OAuth research and hiking coordination.",
-    action_issues=[43, 44]
-)
-```
-
-### Why Deterministic?
-
-The triage tools are designed for **determinism**:
-
-1. **Explicit inputs**: Each tool takes exactly what it needs - no LLM interpretation
-2. **Predictable outputs**: Same inputs always produce same effects
-3. **Atomic operations**: Each tool does one thing well
-4. **Clear state transitions**: Labels track workflow progress unambiguously
-5. **Auditable**: Comments provide full audit trail
-
-This allows the brain-dumps agent to reliably process dumps without variance in behavior.
-
----
-
-## Reporting Results Back to the User
-
-Deliver results in two steps (crash-safe pattern). When the brain dump is fully processed:
-
-```python
-# Step 1: deliver directly to the user (crash-safe)
-mcp__lobster-inbox__send_reply(
-    chat_id=chat_id,          # from the Task prompt
-    text=(
-        f"Brain dump captured! Issue #{issue_number} created.\n\n"
-        f"{context_summary}"  # e.g. "Matched: ProjectX · Mike (hiking buddy)"
-    ),
-    source=source,            # from the Task prompt, default "telegram"
-)
-
-# Step 2: signal dispatcher to mark processed without re-sending
-mcp__lobster-inbox__write_result(
-    task_id=f"brain-dump-{issue_number}",
-    chat_id=chat_id,
-    text=f"Brain dump captured! Issue #{issue_number} created.",
-    source=source,
-    status="success",
-    sent_reply_to_user=True,  # already delivered via send_reply above
-)
-
-# On failure — e.g. issue creation failed (errors go via write_result alone,
-# dispatcher will relay and add context):
-mcp__lobster-inbox__write_result(
-    task_id="brain-dump-failed",
-    chat_id=chat_id,
-    text=(
-        "I couldn't save your brain dump to GitHub. "
-        "Here's the transcription so nothing is lost:\n\n"
-        f"{transcription}"
-    ),
-    source=source,
-    status="error",
-    # sent_reply_to_user=False (default) — dispatcher will relay and prepend error context
-)
-```
-
-The `chat_id` and `source` values are passed in the Task prompt from the main thread.
-
-## Error Handling
-
-- **Context files missing**: Skip context matching, proceed with basic processing
-- **Repo creation fails**: Call `write_result` with `status="error"`, include transcription in text
-- **Issue creation fails**: Call `write_result` with `status="error"`, include transcription so content is not lost
-- **Context matching fails**: Log warning, continue without context enrichment, still call `write_result` on completion
-
----
-
-## Privacy Considerations
-
-- Brain dumps are stored in a **private** repository by default
-- Context files contain personal information - stored in private config repo
-- Audio files are referenced but stored locally (not uploaded to GitHub)
-- Users can delete issues directly from GitHub
-- Context update suggestions require explicit user approval
 
 ---
 
 ## Example Invocation
 
-When Lobster receives a voice message identified as a brain dump:
+The dispatcher spawns this agent when a voice message looks like a brain dump:
 
 ```
 Task(
-  prompt="Process this brain dump with staged processing:\n\nTranscription: {text}\nMessage ID: {id}\nTimestamp: {ts}\nChat ID: {chat_id}\nContext Dir: {context_dir}",
+  prompt="---\ntask_id: brain-dump-{id}\nchat_id: {chat_id}\nsource: {source}\nreply_to_message_id: {id}\n---\n\nProcess this brain dump:\nTranscription: {text}",
   subagent_type="brain-dumps"
 )
 ```
 
 The agent will:
 1. Run through all 4 stages
-2. Create enriched issue in brain-dumps repo
-3. Send confirmation with context matches and suggestions
-4. Note any context updates for user review
+2. Save enriched markdown to `~/lobster-workspace/brain-dumps/{filename}.md`
+3. Send confirmation via `send_reply` with context matches and action item count
+4. Call `write_result` to signal dispatcher completion


### PR DESCRIPTION
## What this fixes

The `brain-dumps` agent skill was reading project context from a flat `projects.md` file that no longer exists — the canonical memory store migrated to per-project files in `memory/canonical/projects/` (e.g., `LobsterCore.md`, `LobsterTalk.md`). The MCP tools `get_project_context` and `list_projects` already read from the directory, but the agent instructions still told agents to load `projects.md` directly.

A brain dump mentioning any project name would reach Stage 2 context matching, attempt to read `projects.md`, find nothing, and produce no project context — silently degrading the output.

## What changed

`.claude/agents/brain-dumps.md` is rewritten to:

1. **Stage 2 context matching** — replace the `projects.md` direct read with:
   - `list_projects()` to enumerate available project files
   - `get_project_context(project)` for each entity that matches a project name
2. **Stage 4 update detection** — replace "not found in `projects.md`" with "not found in `list_projects()` output"
3. **Storage model** — align with the deployed implementation: local markdown files in `~/lobster-workspace/brain-dumps/` instead of GitHub issues. The old GitHub-issue-based sections (Issue Template, Configuration, GitHub CLI table, Deterministic Triage Workflow) are removed as they describe an abandoned approach.
4. **Workflow diagram** — updated to show `list_projects()` + `get_project_context()` in Stage 2

The `inbox_server.py` and `lobster_bridge_local.py` implementations are unchanged — they already correctly read from the `projects/` directory.

## Functional patterns used

Pure function composition: `list_projects()` returns a list of names, each name is passed to `get_project_context()` to fetch content. Both operations are side-effect-free reads with no shared state.

## Tests run

- [x] `uv run pytest tests/test_bridge_tools.py -q` — 33 passed, 0 failed (covers `get_project_context`, `list_projects`, path traversal rejection)
- [x] `uv run pytest tests/ -q -k "project"` — 24 passed, 0 failed
- [x] `uv run pytest tests/integration/test_full_flow.py -q` — 6 passed (pre-existing `test_bot_module_importable` failure confirmed on main too, not caused by this change)
- [ ] Live brain dump end-to-end — blocked: requires active Telegram session and voice message; no behavior change to running code

**No blocked items requiring attention before merge.**

Closes #1220