### PR TITLE
feat: improve post-restart context recovery (session file check, richer snapshots, pre-compaction polish)

### DIFF
--- a/.claude/agents/session-note-appender.md
+++ b/.claude/agents/session-note-appender.md
@@ -19,31 +19,57 @@ You will receive a prompt containing:
 1. Read the session file at the path provided in your prompt.
    - If the file does not exist or the path is missing, note the failure in `write_result` and exit.
 
-2. Build a timestamped snapshot entry:
+2. Call `get_active_sessions()` to retrieve currently running agents.
+
+3. Build a timestamped snapshot entry:
    - Use the current UTC time as the section timestamp, formatted as `YYYY-MM-DDTHH:MMZ`
    - Write a `## Snapshot [timestamp]` heading
-   - Under it, write a bullet list derived from the `activity` context passed in your prompt:
-     - One bullet per user message: `- [HH:MM] User: <brief summary of message>`
-     - One bullet per notable subagent result: `- [HH:MM] <task_id>: <one-line outcome>`
-   - Keep each bullet to one line. No nested bullets. No prose paragraphs.
+   - Under it, write the following subsections:
+
+   **Recent activity (last 30 min)** — derived from the `activity` context passed in your prompt:
+   - One bullet per user message: `- [HH:MM UTC] User: <brief summary of message>`
+   - One bullet per notable subagent result: `- [HH:MM UTC] <task_id>: <one-line outcome>`
+   - Include timestamps on every bullet — they are the primary value of this log.
    - If the activity list is empty, write a single bullet: `- (no notable activity in this window)`
 
-3. Append the snapshot entry to the end of the session file, after all existing content.
+   **In-flight subagents** — from the `get_active_sessions()` result:
+   - One bullet per agent in `running` state: `- <task_id>: <agent name or description>, running ~<N>m`
+     (compute elapsed time from the `started_at` field; round to nearest minute)
+   - Exclude dispatcher sessions.
+   - If no agents are running: `- (none)`
+
+   Keep each bullet to one line. No nested bullets. No prose paragraphs.
+
+4. Append the snapshot entry to the end of the session file, after all existing content.
    - Do NOT overwrite or restructure the existing content.
    - Do NOT modify the header, Summary, Open Threads, Open Tasks, Open Subagents, or Notable Events sections.
    - Simply append the new `## Snapshot [timestamp]` block at the bottom.
 
-4. Write the updated file back to the same path.
+5. Write the updated file back to the same path.
 
-5. Call `write_result` to signal completion.
+6. Call `write_result` to signal completion.
 
 ## Rules
 
 - Do NOT call `send_reply` — this is internal, not a user message.
 - Do NOT rewrite or reformat existing sections — append only.
 - Do NOT truncate the activity list in your prompt — include all items passed to you.
+- If `get_active_sessions()` fails or is unavailable, write `- (get_active_sessions failed)` in the In-flight subagents subsection and continue.
 - If writing fails (permissions, path not found), note it in `write_result` and do not crash.
 - Keep the snapshot compact — the goal is a quick timestamped log, not a full summary.
+
+## Snapshot format
+
+```
+## Snapshot [YYYY-MM-DDTHH:MMZ]
+
+### Recent activity (last 30 min)
+- [HH:MM UTC] User: <brief summary>
+- [HH:MM UTC] <task_id>: <one-line outcome>
+
+### In-flight subagents
+- <task_id>: <description>, running ~Nm
+```
 
 ## Delivering results
 

--- a/.claude/agents/session-note-polish.md
+++ b/.claude/agents/session-note-polish.md
@@ -20,19 +20,29 @@ When summarizing recent activity, cover the last **30 minutes OR 25 messages, wh
    - The path is passed in your prompt as `current_session_file`.
    - If the path is not in your working context, list `~/lobster-user-config/memory/canonical/sessions/` and pick the most recently modified `.md` file (excluding `session.template.md`).
 
-2. Rewrite the file in place as a clean, dense handoff summary:
+2. Call `get_active_sessions()` to get currently running agents.
+
+3. Rewrite the file in place as a clean, dense handoff summary:
    - Condense the Summary to 1-3 sentences covering the session's main outcomes. Synthesize from ALL snapshot blocks, not just the most recent context window.
    - Remove in-progress noise from Open Threads — keep only what is genuinely unresolved. Check snapshot entries for threads that have since resolved.
-   - Consolidate Open Tasks to only what is actually in-flight (not completed). Use snapshot entries to identify tasks that completed mid-session.
-   - List Open Subagents concisely (task_id + one-line description).
+   - Consolidate Open Tasks into two sub-lists:
+     - **Just completed** (finished in the last 30 min): task_id + one-line outcome
+     - **Still in-flight**: task_id + one-line description + how long running
+     Use snapshot entries to distinguish completed from in-flight.
+   - For Open Subagents: list every agent from `get_active_sessions()` still in `running`
+     state. Include: task_id, one-line description, elapsed time (from `started_at`).
+     Write "(none currently running)" if the result is empty.
+   - Add a **Pending user responses** entry if any open thread is waiting for the user to
+     reply or approve something. List each: what is being waited on + which subagent owns it.
+     Write "(none)" if nothing is pending.
    - Trim Notable Events to the 3-5 most significant entries across the whole session.
    - Set the Ended field to the current UTC timestamp.
    - Remove all `## Snapshot [timestamp]` blocks — these are raw log entries that have been incorporated into the polished sections above.
    - Keep all five section headings. Do not delete any section.
 
-3. Write the polished content back to the same file path.
+4. Write the polished content back to the same file path.
 
-4. Call `write_result` to signal completion.
+5. Call `write_result` to signal completion.
 
 ## Rules
 

--- a/hooks/on-fresh-start.py
+++ b/hooks/on-fresh-start.py
@@ -105,6 +105,15 @@ COMPACTION_STATE_FILE = Path(
 
 INBOX_DIR = Path(os.path.expanduser("~/messages/inbox"))
 
+# Pointer to the current session file (written by compact-catchup / session management).
+# If this file exists and was modified recently, there is a prior session worth catching up.
+CURRENT_SESSION_FILE_POINTER = Path(
+    os.environ.get(
+        "LOBSTER_CURRENT_SESSION_FILE_OVERRIDE",
+        "/tmp/lobster-current-session-file",
+    )
+)
+
 # If the compaction state file was written within this window, treat the
 # current SessionStart as a compaction restart rather than a fresh restart.
 COMPACTION_RECENCY_SECONDS = 60
@@ -113,6 +122,13 @@ COMPACTION_RECENCY_SECONDS = 60
 # so the dispatcher is forced to run compact-catchup via its WFM handler.
 # This is the code-level safety net for issue #909.
 STALE_CATCHUP_THRESHOLD_SECONDS = 30 * 60  # 30 minutes
+
+# If a session file exists and was modified within this window, inject a
+# compact-reminder even if last_catchup_ts appears recent. This handles the
+# case where the dispatcher was restarted while actively working — there may
+# be in-flight activity the new session should recover even though catchup
+# ran successfully at the start of the previous session.
+SESSION_FILE_RECENCY_SECONDS = 4 * 60 * 60  # 4 hours
 
 STARTUP_COMPACT_REMINDER_TEXT = (
     "COMPACT REMINDER \u2014 RE-ORIENT NOW (injected by on-fresh-start.py)\n\n"
@@ -184,6 +200,29 @@ def _is_catchup_stale() -> bool:
     except (OSError, KeyError, ValueError, AttributeError):
         # File absent, unreadable, or field missing — treat as stale.
         return True
+
+
+def _has_recent_session_file() -> bool:
+    """Return True if /tmp/lobster-current-session-file points to a session file
+    that was modified within SESSION_FILE_RECENCY_SECONDS.
+
+    This catches the case where the dispatcher was restarted mid-session while
+    actively working. Even if last_catchup_ts is recent, there may be new
+    activity in the session file that the fresh session should catch up on.
+    """
+    try:
+        if not CURRENT_SESSION_FILE_POINTER.exists():
+            return False
+        session_path_str = CURRENT_SESSION_FILE_POINTER.read_text().strip()
+        if not session_path_str:
+            return False
+        session_path = Path(session_path_str)
+        if not session_path.exists():
+            return False
+        age_seconds = time.time() - session_path.stat().st_mtime
+        return age_seconds <= SESSION_FILE_RECENCY_SECONDS
+    except OSError:
+        return False
 
 
 def _compact_reminder_already_queued() -> bool:
@@ -333,7 +372,12 @@ def main() -> None:
     # guarantees the dispatcher will process a compact-reminder via
     # wait_for_messages — even if a previous session consumed the original
     # compact-reminder without running compact-catchup and then exited.
-    if _is_catchup_stale():
+    #
+    # Also inject when a recent session file exists (< 4h old), even if
+    # last_catchup_ts is recent. A mid-session restart can leave in-flight
+    # activity in the session file that the new session needs to recover,
+    # regardless of when catchup last ran.
+    if _is_catchup_stale() or _has_recent_session_file():
         _inject_compact_reminder()
 
     sys.exit(0)

--- a/tests/unit/test_hooks/test_on_fresh_start_catchup.py
+++ b/tests/unit/test_hooks/test_on_fresh_start_catchup.py
@@ -42,13 +42,19 @@ class _PatchEnv:
                 os.environ[k] = saved_v
 
 
-def _load_on_fresh_start(compaction_state_override: str = None, inbox_dir: str = None):
+def _load_on_fresh_start(
+    compaction_state_override: str = None,
+    inbox_dir: str = None,
+    session_file_pointer_override: str = None,
+):
     """Load on-fresh-start.py as a module, overriding file paths for isolation."""
     # We need to patch the module-level constants after load, so we patch env vars
     # that are read at import time and then re-patch constants after import.
     env_patch = {}
     if compaction_state_override:
         env_patch["LOBSTER_COMPACTION_STATE_FILE_OVERRIDE"] = compaction_state_override
+    if session_file_pointer_override:
+        env_patch["LOBSTER_CURRENT_SESSION_FILE_OVERRIDE"] = session_file_pointer_override
 
     with _PatchEnv(env_patch):
         spec = importlib.util.spec_from_file_location("on_fresh_start", _HOOK_PATH)
@@ -62,6 +68,8 @@ def _load_on_fresh_start(compaction_state_override: str = None, inbox_dir: str =
         mod.COMPACTION_STATE_FILE = Path(compaction_state_override)
     if inbox_dir:
         mod.INBOX_DIR = Path(inbox_dir)
+    if session_file_pointer_override:
+        mod.CURRENT_SESSION_FILE_POINTER = Path(session_file_pointer_override)
     return mod
 
 
@@ -133,6 +141,87 @@ class TestIsCatchupStale:
         state_file.write_text(json.dumps({"last_catchup_ts": recent_ts}))
         mod = _load_on_fresh_start(compaction_state_override=str(state_file))
         assert mod._is_catchup_stale() is False
+
+
+
+class TestHasRecentSessionFile:
+    """Tests for _has_recent_session_file()."""
+
+    def test_returns_false_when_pointer_absent(self, tmp_path):
+        """No pointer file → no recent session, return False."""
+        pointer = tmp_path / "nonexistent-pointer"
+        mod = _load_on_fresh_start(session_file_pointer_override=str(pointer))
+        assert mod._has_recent_session_file() is False
+
+    def test_returns_false_when_pointer_empty(self, tmp_path):
+        """Empty pointer file → no session path, return False."""
+        pointer = tmp_path / "pointer"
+        pointer.write_text("")
+        mod = _load_on_fresh_start(session_file_pointer_override=str(pointer))
+        assert mod._has_recent_session_file() is False
+
+    def test_returns_false_when_session_file_absent(self, tmp_path):
+        """Pointer points to nonexistent session file → return False."""
+        pointer = tmp_path / "pointer"
+        pointer.write_text(str(tmp_path / "nonexistent-session.md"))
+        mod = _load_on_fresh_start(session_file_pointer_override=str(pointer))
+        assert mod._has_recent_session_file() is False
+
+    def test_returns_true_when_session_file_recent(self, tmp_path):
+        """Session file modified 5 min ago (within 4h) → return True."""
+        session_file = tmp_path / "20260331-001.md"
+        session_file.write_text("# Session 20260331-001")
+        pointer = tmp_path / "pointer"
+        pointer.write_text(str(session_file))
+        mod = _load_on_fresh_start(session_file_pointer_override=str(pointer))
+        assert mod._has_recent_session_file() is True
+
+    def test_returns_false_when_session_file_old(self, tmp_path):
+        """Session file modified > 4h ago → return False."""
+        import os as _os
+        session_file = tmp_path / "20260330-003.md"
+        session_file.write_text("# Session 20260330-003")
+        # Set mtime to 5 hours ago
+        five_hours_ago = time.time() - (5 * 60 * 60)
+        _os.utime(str(session_file), (five_hours_ago, five_hours_ago))
+        pointer = tmp_path / "pointer"
+        pointer.write_text(str(session_file))
+        mod = _load_on_fresh_start(session_file_pointer_override=str(pointer))
+        assert mod._has_recent_session_file() is False
+
+    def test_boundary_just_within_4h(self, tmp_path):
+        """Session file modified 3h59m ago → return True."""
+        import os as _os
+        session_file = tmp_path / "session.md"
+        session_file.write_text("# Session")
+        just_within = time.time() - (4 * 60 * 60 - 60)  # 3h59m ago
+        _os.utime(str(session_file), (just_within, just_within))
+        pointer = tmp_path / "pointer"
+        pointer.write_text(str(session_file))
+        mod = _load_on_fresh_start(session_file_pointer_override=str(pointer))
+        assert mod._has_recent_session_file() is True
+
+    def test_boundary_just_over_4h(self, tmp_path):
+        """Session file modified 4h1m ago → return False."""
+        import os as _os
+        session_file = tmp_path / "session.md"
+        session_file.write_text("# Session")
+        just_over = time.time() - (4 * 60 * 60 + 60)  # 4h1m ago
+        _os.utime(str(session_file), (just_over, just_over))
+        pointer = tmp_path / "pointer"
+        pointer.write_text(str(session_file))
+        mod = _load_on_fresh_start(session_file_pointer_override=str(pointer))
+        assert mod._has_recent_session_file() is False
+
+    def test_handles_oserror_gracefully(self, tmp_path):
+        """OSError reading pointer → return False without raising."""
+        mod = _load_on_fresh_start()
+        # Point to /proc path that exists but read fails with PermissionError
+        mod.CURRENT_SESSION_FILE_POINTER = Path("/proc/1/mem")
+        # Must not raise
+        result = mod._has_recent_session_file()
+        assert result is False
+
 
 
 class TestCompactReminderAlreadyQueued:


### PR DESCRIPTION
## What problem this solves

After a mid-session restart (OOM, `lobster restart`, systemd kill), the dispatcher can start with stale context even when `last_catchup_ts` looked healthy. The session file on disk contains in-flight activity the new session needs to recover, but the existing 30-minute stale-catchup check doesn't fire because the clock says catchup ran recently. The session snapshots also lacked timestamps and in-flight subagent state, making them poor material for recovery. Pre-compaction polishing wasn't capturing what specifically was done vs. still pending.

## Three fixes

**Fix 1 — `hooks/on-fresh-start.py`:** Add session file recency as a second trigger for compact-reminder injection. If `/tmp/lobster-current-session-file` points to a session file modified within the last 4 hours, a compact-reminder is injected on restart regardless of `last_catchup_ts`. The existing stale-catchup path (>30 min) is unchanged; this adds an `or` condition covering the case where the file exists and is recent. 8 new tests cover boundary conditions (3h59m vs 4h1m), absent pointer, empty pointer, nonexistent session file, and OSError graceful handling.

**Fix 2 — `.claude/agents/session-note-appender.md`:** Snapshot entries now include two structured subsections. "Recent activity (last 30 min)" adds UTC timestamps to every bullet (previously timestamps were absent). "In-flight subagents" is populated from `get_active_sessions()` — the appender calls this directly and records task_id, agent name, and elapsed time (from `started_at`) for every running non-dispatcher agent. Falls back gracefully if `get_active_sessions()` is unavailable.

**Fix 3 — `.claude/sys.dispatcher.bootup.md`:** The pre-compaction session-note-polish prompt now explicitly requires calling `get_active_sessions()` and splitting Open Tasks into "Just completed" (last 30 min) vs "Still in-flight". Open Subagents are populated from live data with elapsed times. A new "Pending user responses" entry captures threads waiting on user approval. Step numbering updated accordingly.

## What is not changed

- The 30-minute stale-catchup threshold in `on-fresh-start.py` is unchanged.
- The compact-reminder message format and injection mechanism are unchanged.
- The `compact-catchup` subagent itself is unchanged.
- No changes to the dispatcher main loop or message handling.
- No migrations needed — these are config/doc-layer changes only.

## Functional patterns

Pure functions (`_has_recent_session_file`, `_is_catchup_stale`) with injectable path constants via environment overrides, making them fully unit-testable without filesystem side effects. The condition in `main()` is a simple boolean composition: `_is_catchup_stale() or _has_recent_session_file()`.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_on_fresh_start_catchup.py -v` — 26 passed, 0 failed (18 pre-existing + 8 new)
- [x] `uv run pytest tests/unit/ -q` — 1908 passed, 109 pre-existing failures (unrelated to this PR, confirmed same failures on main), 6 pre-existing errors
- [x] `uv tool run ruff check hooks/on-fresh-start.py` — clean

Closes #1233