### PR TITLE
fix: remove LOBSTER-SELF-CHECK from health-check required cron markers

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -1093,30 +1093,15 @@ check_messages_db() {
     return 0
 }
 
-# Check 10: Required cron entries - auto-restore LOBSTER-SELF-CHECK if missing
+# Check 10: Required cron entries
 check_cron_entries() {
-    local install_dir="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
-    local cron_manage="$install_dir/scripts/cron-manage.sh"
-    local REQUIRED_CRON_MARKERS=("# LOBSTER-SELF-CHECK" "# LOBSTER-HEALTH")
+    local REQUIRED_CRON_MARKERS=("# LOBSTER-HEALTH")
 
     for marker in "${REQUIRED_CRON_MARKERS[@]}"; do
         if ! crontab -l 2>/dev/null | grep -qF "$marker"; then
             log_warn "Missing cron entry: $marker"
-            case "$marker" in
-                "# LOBSTER-SELF-CHECK")
-                    if [[ -x "$cron_manage" ]]; then
-                        "$cron_manage" add "# LOBSTER-SELF-CHECK" \
-                            "*/3 * * * * $install_dir/scripts/periodic-self-check.sh # LOBSTER-SELF-CHECK"
-                        log_info "Auto-restored: $marker"
-                    else
-                        log_warn "cron-manage.sh not found or not executable at $cron_manage — cannot auto-restore $marker"
-                    fi
-                    ;;
-                *)
-                    # LOBSTER-HEALTH checking itself is circular (if we're running, the health cron is working).
-                    # Just warn; do not attempt auto-restore.
-                    ;;
-            esac
+            # LOBSTER-HEALTH checking itself is circular (if we're running, the health cron is working).
+            # Just warn; do not attempt auto-restore.
         else
             log_info "Cron entry present: $marker"
         fi


### PR DESCRIPTION
## What this fixes

Closes #1237.

Migration M25 in `upgrade.sh` deliberately removed the `# LOBSTER-SELF-CHECK` cron entry because it was generating noise (spurious health alerts). However, `health-check-v3.sh` had a `REQUIRED_CRON_MARKERS` array that still listed `LOBSTER-SELF-CHECK` and a `case` block that would silently auto-restore the entry on every health-check run — directly and persistently undoing M25 each time the health check fired.

The fix is a pure removal: `LOBSTER-SELF-CHECK` is taken out of `REQUIRED_CRON_MARKERS` and its associated `case` block is deleted. The `install_dir` and `cron_manage` locals (only used by that restore path) are also removed since nothing else in the function needed them.

## What is not changed

- The `# LOBSTER-HEALTH` marker and its restore logic remain untouched
- The health-check loop and catch-all warn-only path are preserved
- No new logic is introduced — this is purely additive removal

## Why M25 kept being undone

The auto-restore pattern in health-check was originally defensive: if a required cron entry went missing, health-check would put it back. That made sense when the entry was needed. After M25 decided the entry should be gone, the health-check code became a perpetual conflict with the migration. Removing the restore path is the correct resolution — M25's intent now holds permanently.

## Tests run

- [x] `bash -n scripts/health-check-v3.sh` — syntax OK, no errors

---
🤖🦞 Lobster (librarian): fixed "Fixes" → "Closes" for GitHub auto-close, added explanation of why M25 kept being undone (the restore loop conflict), and noted scope boundaries.