### PR TITLE
docs(dispatcher): document link-checker hook and upgrade flood behavior

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -161,6 +161,8 @@ To clear the gate: call `mcp__lobster-inbox__wait_for_messages(confirmation='LOB
 - Do NOT call `send_reply` for these — there is no user to reply to
 - `mark_processed` after reading and acting on the content
 
+**Upgrade messages** (`type: "system"`, text starts with "System upgrade:"): these arrive when `git pull` fires the `.githooks/post-merge` hook. A local-dev rebuild merging many PRs can produce 10+ identical messages in rapid succession. Process each one with `mark_processed` silently — no subagent needed, no relay. If you see a burst of identical upgrade messages, that is expected behavior during a local-dev rebuild (rate-limited in PR #1236 but not yet always merged).
+
 ---
 
 ## Message Handlers
@@ -501,6 +503,23 @@ If `reacted_to_text` is empty: use `get_conversation_history` to get context.
 
 - Chat IDs are strings (e.g. `C01ABC123`).
 - Pass `thread_ts` from the original message to reply in a thread.
+
+---
+
+## PreToolUse Hooks (send_reply)
+
+### Link-checker hook (`hooks/link-checker.py`)
+
+A PreToolUse hook fires before every `send_reply` call. It blocks (exit 2) if **both** conditions are true:
+1. The message text references a PR or issue number (e.g. "PR #123", "issue #456")
+2. The message contains no clickable link — no `[text](url)` markdown or bare `https://` URL
+
+**Rule:** When sending a reply that mentions completing work on a PR or issue, always include the full GitHub URL.
+
+- Bad: "Done — opened PR #1236."
+- Good: "Done — opened PR #1236: https://github.com/SiderealPress/lobster/pull/1236"
+
+If a `send_reply` is blocked by this hook, reformulate with a clickable link and retry. The hook does NOT fire for messages that mention PR/issue numbers in passing without completion language.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Link-checker hook**: Added a new `PreToolUse Hooks (send_reply)` section documenting `hooks/link-checker.py`. The hook fires before every `send_reply` and blocks (exit 2) when a message references a PR/issue number but contains no clickable URL. The dispatcher needs to know this to avoid blocked send_reply loops — rule is: always include a full GitHub URL when mentioning PR/issue completion.

- **Upgrade message flood**: Expanded the `System Messages` section with a note about upgrade message floods. When a local-dev rebuild merges multiple PRs, the `.githooks/post-merge` hook fires once per merge, producing 10+ identical system messages in rapid succession. The dispatcher should silently mark_processed each one without spawning subagents.

## Background

Both behaviors were discovered through session notes from today (2026-03-31):
- The link-checker blocking dispatcher send_reply attempts caused a 96-second delay in one incident
- The upgrade flood was documented in PR #1236 description (6 messages in 2 minutes, 10 in under 1 minute)

Neither behavior was documented in the dispatcher bootup context, leaving the dispatcher to rediscover them from scratch each session.

## Test plan

- [ ] Verify added sections are clear and accurate by reading the diff
- [ ] Confirm link-checker hook behavior matches hooks/link-checker.py (checked source)
- [ ] Doc-only change, no code tests needed

## Note on private config fix

Also applied a direct fix to ~/lobster-user-config/agents/user.dispatcher.bootup.md (private, not in repo): the "Post-merge cleanup" section incorrectly said to run `git checkout main && git pull` after a merge. Fixed to only run `git -C ~/lobster fetch origin`, matching existing feedback that switching to main breaks the local-dev soak workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)