### PR TITLE
fix: post-compaction reliability improvements

### DIFF
--- a/.claude/agents/compact-catchup.md
+++ b/.claude/agents/compact-catchup.md
@@ -19,16 +19,17 @@ You are the **compact_catchup** subagent. Your job is to:
 3. Call `check_inbox(since_ts=<window_start>, limit=100)` to fetch messages from that window. 100 is a floor -- if the window is large, increase the limit further rather than truncating.
 4. Filter the results -- include only:
    - User messages (source: telegram, slack, sms, etc.)
-   - `subagent_result` messages
+   - `subagent_result` messages (these are recently-returned subagent results — collect their `task_id` values; these represent work that completed and may need dispatcher follow-up)
    - Notable system events: `update_notification`, `consolidation`
    - Exclude: `self_check`, `compact-reminder`, `compact_catchup`, `subagent_notification`, test messages
-5. Read session notes in tiers (see "Session notes reading" below).
-6. Produce a concise structured summary (see output format below).
-7. Update `last_catchup_ts` in `compaction-state.json` to now (prevents duplicate windows on the next compaction).
+5. **Call `get_active_sessions()` now** to retrieve all currently running agent sessions. Filter to `status: "running"` sessions, excluding dispatcher sessions. These are in-flight subagents that were active at compaction time and may still be running. If `get_active_sessions()` errors, note the failure and continue.
+6. Read session notes in tiers (see "Session notes reading" below).
+7. Produce a concise structured summary (see output format below).
+8. Update `last_catchup_ts` in `compaction-state.json` to now (prevents duplicate windows on the next compaction).
 
 ### Phase 2: Populate the session file
 
-8. Locate or create the current session file:
+9. Locate or create the current session file:
    a. Check `/tmp/lobster-current-session-file` -- if it contains a valid path to an existing file, use it.
    b. Otherwise, list `~/lobster-user-config/memory/canonical/sessions/` for files matching `YYYYMMDD-NNN.md` where `YYYYMMDD` is today's UTC date. Pick the highest-sequenced file for today. If today has no file, **create one** (see step c below).
 
@@ -63,9 +64,7 @@ You are the **compact_catchup** subagent. Your job is to:
       5. Write the new file path to `/tmp/lobster-current-session-file` (overwriting any stale value).
       6. Continue with phase 2 population as normal -- the file now exists.
 
-9. Call `get_active_sessions()` to get currently running agents.
-
-10. Build the session file content using the data from phases 1 and 2:
+9. Build the session file content using the data from phases 1 and 2:
 
     - **Summary** (1-3 sentences): Synthesize from the catchup window. What was the user working on? What work completed?
     - **Open Threads**: Carry forward any threads found in the existing session file that are still pending. Add new threads for in-flight requests visible in the catchup window.
@@ -73,7 +72,7 @@ You are the **compact_catchup** subagent. Your job is to:
     - **Open Subagents**: List every agent from `get_active_sessions()` that is still in `running` state. Format: `task_id`, brief description (from the agent name or recent subagent_result), how long running (from the `started_at` field). Exclude dispatcher sessions.
     - **Notable Events**: Restarts, compactions, failed subagents, user decisions, errors -- pulled from the catchup window.
 
-11. Write the populated content to the session file. Preserve the file header (`# Session YYYYMMDD-NNN`, `**Started:**`, `**Ended:**` lines) verbatim -- only overwrite the section bodies below them.
+10. Write the populated content to the session file. Preserve the file header (`# Session YYYYMMDD-NNN`, `**Started:**`, `**Ended:**` lines) verbatim -- only overwrite the section bodies below them.
 
     The sections to populate are the same as the session template:
     ```
@@ -86,7 +85,7 @@ You are the **compact_catchup** subagent. Your job is to:
 
     If a section has nothing to report, write `(nothing to report this session)` rather than leaving it blank.
 
-12. Call `write_result` with the structured summary from Phase 1 plus a note confirming the session file was updated (or why it was skipped).
+11. Call `write_result` with the structured summary from Phase 1 plus a note confirming the session file was updated (or why it was skipped).
 
 ### Phase 3: Update rolling summary
 
@@ -169,6 +168,16 @@ Structure your `write_result` text as follows:
 ### Nothing to report
 (only if all three sections are empty)
 
+## In-flight subagents at compaction time
+- <task_id> (running, <age>) — <brief description from agent name or last known activity>
+- ...
+(or "None." if get_active_sessions() returned no running non-dispatcher sessions)
+
+## Recently-returned subagent results (since compaction)
+- task=<task_id> returned at [HH:MM] — <brief outcome>
+- ...
+(or "None." if no subagent_result messages found in inbox scan)
+
 ## Session context (from session notes)
 - [Latest session: YYYYMMDD-NNN] <one-line summary>
 - Open threads from prior sessions: <list any unresolved threads, or "none">
@@ -194,7 +203,7 @@ Keep each line to one sentence. The dispatcher is on mobile -- brevity matters.
 - If `check_inbox` returns no messages in the window, that is valid -- report "Nothing to report" in the inbox section but still populate the session file.
 - If `compaction-state.json` is missing or corrupt, default to scanning the last 6 hours.
 - Always update `last_catchup_ts` in `compaction-state.json` before calling `write_result`.
-- If `get_active_sessions()` is unavailable or errors, write "Open Subagents: (could not retrieve -- get_active_sessions failed)" in the session file rather than crashing.
+- If `get_active_sessions()` is unavailable or errors, write "Open Subagents: (could not retrieve -- get_active_sessions failed)" in the session file and "None (get_active_sessions failed)" in the in-flight section of write_result rather than crashing.
 - Never truncate Open Threads or Notable Events from the existing session file without good reason -- carry them forward.
 - If the session file cannot be found or written (permissions, path not found), note the failure in `write_result` and continue -- do not crash the entire catchup.
 - If `rolling-summary.md` cannot be read or written, note the failure in `write_result` and continue -- do not abort catchup.

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -171,6 +171,8 @@ After a context compaction you lose situational awareness of the last ~30 minute
 
 > **WARNING: CATCHUP IS ALWAYS A BACKGROUND SUBAGENT — NEVER INLINE.** Catchup involves file I/O, inbox scanning, and summarization — it blocks all new messages for 10–15 minutes if done inline.
 
+> **MANDATORY: You MUST spawn compact-catchup before doing any other work after a compaction. Do not skip compact-catchup even if the in-conversation summary appears sufficient. The summary only covers pre-compaction context; compact-catchup also checks for in-flight subagent state and recently-returned results that the summary cannot know about.**
+
 ```
 1. mark_processing(message_id)
 2. Read the compact-reminder text to re-orient (identity, main loop, key files)
@@ -182,6 +184,7 @@ After a context compaction you lose situational awareness of the last ~30 minute
 5. Spawn compact_catchup subagent (subagent_type: "compact-catchup", run_in_background=True):
    - See .claude/agents/compact-catchup.md for the full prompt
    - Pass task_id: "compact-catchup", chat_id: 0, source: "system"
+   - This step is MANDATORY — never skip it, regardless of how complete the in-conversation summary seems
 6. mark_processed(message_id)
 7. Resume wait_for_messages() loop — do NOT wait for either subagent result inline
 ```

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -251,6 +251,26 @@ Rules: never `send_reply` (chat_id: 0), never add user-created job names to REMI
 
 ---
 
+### reflection_prompt (`type: "reflection_prompt"`)
+
+Debug-mode prompts written by `on-compact.py` and `on-fresh-start.py` when `LOBSTER_DEBUG=true`. They arrive after a compaction or fresh bootup and ask the dispatcher to reflect on the experience while it is fresh.
+
+```
+1. mark_processing(message_id)
+2. Read msg["text"] — the reflection question
+3. Reflect genuinely: were there friction points, gaps, or improvements in the
+   bootup/compaction flow worth capturing?
+4. If there are substantive observations:
+   - File or update GitHub issues in SiderealPress/lobster
+   - Open PRs for straightforward fixes (no need to wait for instruction)
+   - If nothing worth capturing: do nothing — silence is the correct response
+5. mark_processed(message_id)
+```
+
+Rules: never `send_reply` (chat_id: 0). Reflection is optional — only act if there are real observations.
+
+---
+
 ### subagent_result / subagent_error (`type: "subagent_result"`)
 
 Background subagents call `write_result(task_id, chat_id, text, ...)`, which drops a `subagent_result` message into the inbox.

--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -65,6 +65,14 @@ COMPACTION_STATE_FILE = Path(
         os.path.expanduser("~/lobster-workspace/data/compaction-state.json"),
     )
 )
+# Simple timestamp file read by health-check-v3.sh for a 10-minute grace period
+# after compaction (prevents stale-inbox alerts during post-compaction re-orientation).
+LAST_COMPACT_TS_FILE = Path(
+    os.environ.get(
+        "LOBSTER_LAST_COMPACT_TS_FILE_OVERRIDE",
+        os.path.expanduser("~/lobster-workspace/data/last-compact.ts"),
+    )
+)
 
 REMINDER_TEXT = (
     "COMPACT REMINDER \u2014 RE-ORIENT NOW\n\n"
@@ -180,6 +188,27 @@ def write_compaction_state() -> None:
         tmp_path = COMPACTION_STATE_FILE.with_suffix(".tmp")
         tmp_path.write_text(json.dumps(state, indent=2) + "\n")
         tmp_path.replace(COMPACTION_STATE_FILE)  # atomic on Linux (same filesystem)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def write_last_compact_ts() -> None:
+    """
+    Write the current Unix timestamp (integer seconds) to last-compact.ts.
+
+    This simple timestamp file is read by health-check-v3.sh to determine
+    whether a compaction occurred within the last 10 minutes.  If so, the
+    health check skips its inbox staleness alert entirely, giving the dispatcher
+    a grace period to re-read bootup files and drain the inbox backlog before
+    any staleness alert fires.
+
+    Silent on any failure -- must never crash the hook.
+    """
+    try:
+        LAST_COMPACT_TS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = LAST_COMPACT_TS_FILE.with_suffix(".ts.tmp")
+        tmp_path.write_text(str(int(time.time())) + "\n")
+        tmp_path.replace(LAST_COMPACT_TS_FILE)  # atomic on Linux (same filesystem)
     except Exception:  # noqa: BLE001
         pass
 
@@ -378,6 +407,11 @@ def main() -> None:
     # compactions.  The health check reads this to suppress false-positive
     # "stale inbox" restarts during any compaction pause window.
     write_compacted_at()
+
+    # Write simple Unix timestamp for the 10-minute post-compaction grace period.
+    # health-check-v3.sh reads this file and skips staleness alerts for 10 minutes
+    # after a compaction, giving the dispatcher time to re-orient.
+    write_last_compact_ts()
 
     # Always record last_compaction_ts for the catch-up subagent, regardless
     # of whether this is a dispatcher or subagent compaction.  The catch-up

--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -397,6 +397,65 @@ def _is_dispatcher_compact(data: dict) -> bool:
     return True
 
 
+def _schedule_reflection_prompt(trigger: str) -> None:
+    """In debug mode, write a reflection-prompt message to the inbox.
+
+    When LOBSTER_DEBUG=true, drops a message asking the dispatcher to reflect
+    on the bootup/compaction experience and file GitHub issues with observations.
+    Written immediately — the dispatcher processes inbox messages in order so it
+    will reach this after handling the compact-reminder and catching up.
+
+    Silent on any failure — must never crash the hook.
+    """
+    if os.environ.get("LOBSTER_DEBUG", "false").lower() != "true":
+        return
+
+    try:
+        INBOX_DIR.mkdir(parents=True, exist_ok=True)
+
+        ts = time.time()
+        msg_id = f"reflection_{trigger}_{int(ts)}"
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + ".000000"
+
+        content = (
+            f"[Debug] {trigger.capitalize()} reflection prompt:\n\n"
+            "How was the experience? Were there friction points, gaps, or improvements "
+            "worth capturing?\n\n"
+            "If you have observations: file or update GitHub issues in SiderealPress/lobster, "
+            "or open PRs for straightforward fixes. Capture it while it's fresh."
+        )
+
+        msg = {
+            "id": msg_id,
+            "source": "system",
+            "chat_id": 0,
+            "user_id": 0,
+            "username": "lobster-system",
+            "user_name": "System",
+            "type": "reflection_prompt",
+            "trigger": trigger,
+            "text": content,
+            "timestamp": timestamp,
+        }
+
+        # Use current epoch_ms so this sorts after the compact-reminder (ts_ms=0)
+        # and after any queued user messages, but before future messages.
+        ts_ms = int(ts * 1000)
+        msg_path = INBOX_DIR / f"{ts_ms}_reflection_{trigger}.json"
+        tmp_path = msg_path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(msg, indent=2) + "\n")
+        tmp_path.rename(msg_path)
+        print(
+            f"[on-compact] debug: wrote reflection prompt to {msg_path}",
+            file=sys.stderr,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[on-compact] debug: failed to write reflection prompt: {exc}",
+            file=sys.stderr,
+        )
+
+
 def main() -> None:
     try:
         data = json.load(sys.stdin)
@@ -449,6 +508,8 @@ def main() -> None:
         write_reminder()
     except Exception:  # noqa: BLE001
         pass  # Reminder failure is non-fatal — sentinel is the critical artifact
+
+    _schedule_reflection_prompt("compaction")
 
 
 if __name__ == "__main__":

--- a/hooks/on-fresh-start.py
+++ b/hooks/on-fresh-start.py
@@ -263,6 +263,65 @@ def _inject_compact_reminder() -> None:
         )
 
 
+def _schedule_reflection_prompt(trigger: str) -> None:
+    """In debug mode, write a reflection-prompt message to the inbox.
+
+    When LOBSTER_DEBUG=true, drops a message asking the dispatcher to reflect
+    on the bootup/compaction experience and file GitHub issues with observations.
+    Written immediately — the dispatcher processes inbox messages in order so it
+    will reach this after the compact-reminder and catchup handling.
+
+    Silent on any failure — must never crash the hook.
+    """
+    if os.environ.get("LOBSTER_DEBUG", "false").lower() != "true":
+        return
+
+    try:
+        INBOX_DIR.mkdir(parents=True, exist_ok=True)
+
+        ts = time.time()
+        msg_id = f"reflection_{trigger}_{int(ts)}"
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + ".000000"
+
+        content = (
+            f"[Debug] {trigger.capitalize()} reflection prompt:\n\n"
+            "How was the experience? Were there friction points, gaps, or improvements "
+            "worth capturing?\n\n"
+            "If you have observations: file or update GitHub issues in SiderealPress/lobster, "
+            "or open PRs for straightforward fixes. Capture it while it's fresh."
+        )
+
+        msg = {
+            "id": msg_id,
+            "source": "system",
+            "chat_id": 0,
+            "user_id": 0,
+            "username": "lobster-system",
+            "user_name": "System",
+            "type": "reflection_prompt",
+            "trigger": trigger,
+            "text": content,
+            "timestamp": timestamp,
+        }
+
+        # Use current epoch_ms so this sorts after the startup compact-reminder
+        # (ts_ms=0/1) and after any queued user messages.
+        ts_ms = int(ts * 1000)
+        msg_path = INBOX_DIR / f"{ts_ms}_reflection_{trigger}.json"
+        tmp_path = msg_path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(msg, indent=2) + "\n")
+        tmp_path.rename(msg_path)
+        print(
+            f"[on-fresh-start] debug: wrote reflection prompt to {msg_path}",
+            file=sys.stderr,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[on-fresh-start] debug: failed to write reflection prompt: {exc}",
+            file=sys.stderr,
+        )
+
+
 def _mark_all_running_failed() -> None:
     """Run agent-monitor.py --mark-failed via uv.
 
@@ -342,6 +401,8 @@ def main() -> None:
     # compact-reminder without running compact-catchup and then exited.
     if _is_catchup_stale():
         _inject_compact_reminder()
+
+    _schedule_reflection_prompt("bootup")
 
     sys.exit(0)
 

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -79,6 +79,7 @@ RESTART_WINDOW_BUFFER_SECONDS=120    # Pre-mark messages within this window of t
 MAINTENANCE_EXPIRY_SECONDS=3600      # 1 hour - stale maintenance flag is auto-cleared and checks resume
 
 COMPACTION_SUPPRESS_SECONDS=300      # 5 minutes - skip stale-inbox check after a compaction event
+COMPACT_GRACE_SECONDS=600            # 10 minutes - skip stale-inbox check after a compaction (last-compact.ts)
 CATCHUP_SUPPRESS_SECONDS=900         # 15 minutes - skip WFM freshness check while catchup subagent is running
 RESTART_COOLDOWN_SUPPRESS_SECONDS=240 # 4 minutes - suppress stale-inbox RED after a recent restart
 
@@ -401,6 +402,32 @@ except Exception:
     local age=$((now - compacted_epoch))
     if [[ $age -le $COMPACTION_SUPPRESS_SECONDS ]]; then
         log_info "Recent compaction ${age}s ago (threshold: ${COMPACTION_SUPPRESS_SECONDS}s) — stale-inbox check suppressed"
+        return 0
+    fi
+    return 1
+}
+
+# Check if a context compaction occurred within the last COMPACT_GRACE_SECONDS.
+# Returns 0 (true) if inbox staleness checks should be suppressed, 1 otherwise.
+# Reads the Unix timestamp from last-compact.ts (written by hooks/on-compact.py).
+# This provides a 10-minute grace period for post-compaction re-orientation,
+# extending the existing COMPACTION_SUPPRESS_SECONDS (5 min) window by an additional
+# 5 minutes to cover cases where re-orientation takes longer than expected.
+is_compact_grace_period() {
+    local ts_file="$WORKSPACE_DIR/data/last-compact.ts"
+    if [[ ! -f "$ts_file" ]]; then
+        return 1
+    fi
+    local compact_ts
+    compact_ts=$(cat "$ts_file" 2>/dev/null | tr -d '[:space:]')
+    if [[ -z "$compact_ts" ]] || ! [[ "$compact_ts" =~ ^[0-9]+$ ]]; then
+        return 1
+    fi
+    local now
+    now=$(date +%s)
+    local age=$((now - compact_ts))
+    if [[ $age -le $COMPACT_GRACE_SECONDS ]]; then
+        log_info "Post-compaction grace period: compaction ${age}s ago (threshold: ${COMPACT_GRACE_SECONDS}s) — stale-inbox check suppressed"
         return 0
     fi
     return 1
@@ -1536,8 +1563,11 @@ main() {
     # Claude Code pauses tool calls during context compaction for 1-3+ minutes.
     # If on-compact.py recorded a compacted_at within the last
     # COMPACTION_SUPPRESS_SECONDS, skip all stale-inbox checks this run.
+    # Additionally, check last-compact.ts for a 10-minute grace period that
+    # covers the post-compaction re-orientation window (reading bootup files,
+    # processing inbox backlog, waiting for compact-catchup to complete).
     local compaction_recent=false
-    if is_compaction_recent; then
+    if is_compaction_recent || is_compact_grace_period; then
         compaction_recent=true
     fi
 

--- a/tests/unit/test_hooks/test_reflection_prompt.py
+++ b/tests/unit/test_hooks/test_reflection_prompt.py
@@ -1,0 +1,261 @@
+"""
+Unit tests for _schedule_reflection_prompt() in on-compact.py and on-fresh-start.py.
+
+Verifies:
+- In debug mode, writes a well-formed reflection_prompt message to the inbox
+- In non-debug mode, writes nothing
+- Written message has expected fields and content
+- Atomic write (no .tmp file left behind)
+- Silent on filesystem errors (never crashes the hook)
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _PatchEnv:
+    """Context manager to temporarily set / unset environment variables."""
+
+    def __init__(self, env: dict):
+        self._env = env
+        self._saved = {}
+
+    def __enter__(self):
+        for k, v in self._env.items():
+            self._saved[k] = os.environ.get(k)
+            os.environ[k] = v
+        return self
+
+    def __exit__(self, *_):
+        for k, saved_v in self._saved.items():
+            if saved_v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = saved_v
+
+
+def _make_session_role_stub(is_dispatcher: bool = True):
+    stub = types.ModuleType("session_role")
+    stub.is_dispatcher = lambda data: is_dispatcher
+    stub.DISPATCHER_SESSION_FILE = Path("/tmp/lobster-test-dispatcher-session")
+    stub.write_dispatcher_session_id = lambda sid: None
+    stub._read_dispatcher_session_id = lambda: None
+    return stub
+
+
+def _load_on_compact(inbox_dir: str = None, compaction_state_override: str = None):
+    """Load hooks/on-compact.py as a module, with isolated file paths."""
+    env_patch = {}
+    if compaction_state_override:
+        env_patch["LOBSTER_COMPACTION_STATE_FILE_OVERRIDE"] = compaction_state_override
+
+    hook_path = _HOOKS_DIR / "on-compact.py"
+    with _PatchEnv(env_patch):
+        spec = importlib.util.spec_from_file_location("on_compact", hook_path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules.setdefault("session_role", _make_session_role_stub())
+        spec.loader.exec_module(mod)
+
+    if inbox_dir:
+        mod.INBOX_DIR = Path(inbox_dir)
+    if compaction_state_override:
+        mod.COMPACTION_STATE_FILE = Path(compaction_state_override)
+    return mod
+
+
+def _load_on_fresh_start(inbox_dir: str = None, compaction_state_override: str = None):
+    """Load hooks/on-fresh-start.py as a module, with isolated file paths."""
+    env_patch = {}
+    if compaction_state_override:
+        env_patch["LOBSTER_COMPACTION_STATE_FILE_OVERRIDE"] = compaction_state_override
+
+    hook_path = _HOOKS_DIR / "on-fresh-start.py"
+    with _PatchEnv(env_patch):
+        spec = importlib.util.spec_from_file_location("on_fresh_start", hook_path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules.setdefault("session_role", _make_session_role_stub())
+        spec.loader.exec_module(mod)
+
+    if inbox_dir:
+        mod.INBOX_DIR = Path(inbox_dir)
+    if compaction_state_override:
+        mod.COMPACTION_STATE_FILE = Path(compaction_state_override)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Tests: on-compact.py
+# ---------------------------------------------------------------------------
+
+class TestScheduleReflectionPromptCompact:
+    """Tests for _schedule_reflection_prompt() in on-compact.py."""
+
+    def test_writes_inbox_file_in_debug_mode(self, tmp_path):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        mod = _load_on_compact(inbox_dir=str(inbox))
+
+        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
+            mod._schedule_reflection_prompt("compaction")
+
+        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
+        assert len(files) == 1, f"expected 1 file, got {[f.name for f in files]}"
+
+    def test_does_not_write_in_non_debug_mode(self, tmp_path):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        mod = _load_on_compact(inbox_dir=str(inbox))
+
+        with _PatchEnv({"LOBSTER_DEBUG": "false"}):
+            mod._schedule_reflection_prompt("compaction")
+
+        files = list(inbox.iterdir())
+        assert len(files) == 0
+
+    def test_does_not_write_when_debug_env_absent(self, tmp_path):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        mod = _load_on_compact(inbox_dir=str(inbox))
+
+        env_without_debug = {k: v for k, v in os.environ.items() if k != "LOBSTER_DEBUG"}
+        with _PatchEnv({"LOBSTER_DEBUG": ""}):
+            mod._schedule_reflection_prompt("compaction")
+
+        files = list(inbox.iterdir())
+        assert len(files) == 0
+
+    def test_written_message_has_correct_type_and_trigger(self, tmp_path):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        mod = _load_on_compact(inbox_dir=str(inbox))
+
+        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
+            mod._schedule_reflection_prompt("compaction")
+
+        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
+        data = json.loads(files[0].read_text())
+        assert data["type"] == "reflection_prompt"
+        assert data["trigger"] == "compaction"
+        assert data["source"] == "system"
+        assert data["chat_id"] == 0
+
+    def test_written_message_content_contains_key_phrases(self, tmp_path):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        mod = _load_on_compact(inbox_dir=str(inbox))
+
+        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
+            mod._schedule_reflection_prompt("compaction")
+
+        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
+        data = json.loads(files[0].read_text())
+        text = data["text"]
+        assert "friction" in text.lower() or "observations" in text.lower()
+        assert "SiderealPress/lobster" in text
+
+    def test_no_tmp_file_left_behind(self, tmp_path):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        mod = _load_on_compact(inbox_dir=str(inbox))
+
+        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
+            mod._schedule_reflection_prompt("compaction")
+
+        tmp_files = [f for f in inbox.iterdir() if f.suffix == ".tmp"]
+        assert len(tmp_files) == 0, f"tmp files left behind: {tmp_files}"
+
+    def test_creates_inbox_dir_if_absent(self, tmp_path):
+        inbox = tmp_path / "inbox_not_created_yet"
+        mod = _load_on_compact(inbox_dir=str(inbox))
+
+        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
+            mod._schedule_reflection_prompt("compaction")
+
+        assert inbox.exists()
+        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
+        assert len(files) == 1
+
+    def test_silent_on_write_failure(self, tmp_path):
+        """Must not raise when the inbox path is not writable."""
+        mod = _load_on_compact(inbox_dir="/proc/lobster_test_nonexistent/inbox")
+
+        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
+            # Must not raise
+            mod._schedule_reflection_prompt("compaction")
+
+
+# ---------------------------------------------------------------------------
+# Tests: on-fresh-start.py
+# ---------------------------------------------------------------------------
+
+class TestScheduleReflectionPromptFreshStart:
+    """Tests for _schedule_reflection_prompt() in on-fresh-start.py."""
+
+    def test_writes_inbox_file_in_debug_mode(self, tmp_path):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        state_file = tmp_path / "compaction-state.json"
+        mod = _load_on_fresh_start(
+            inbox_dir=str(inbox),
+            compaction_state_override=str(state_file),
+        )
+
+        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
+            mod._schedule_reflection_prompt("bootup")
+
+        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
+        assert len(files) == 1
+
+    def test_does_not_write_in_non_debug_mode(self, tmp_path):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        mod = _load_on_fresh_start(inbox_dir=str(inbox))
+
+        with _PatchEnv({"LOBSTER_DEBUG": "false"}):
+            mod._schedule_reflection_prompt("bootup")
+
+        files = list(inbox.iterdir())
+        assert len(files) == 0
+
+    def test_bootup_trigger_in_message(self, tmp_path):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        mod = _load_on_fresh_start(inbox_dir=str(inbox))
+
+        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
+            mod._schedule_reflection_prompt("bootup")
+
+        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
+        data = json.loads(files[0].read_text())
+        assert data["trigger"] == "bootup"
+        assert data["type"] == "reflection_prompt"
+
+    def test_no_tmp_file_left_behind(self, tmp_path):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        mod = _load_on_fresh_start(inbox_dir=str(inbox))
+
+        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
+            mod._schedule_reflection_prompt("bootup")
+
+        tmp_files = [f for f in inbox.iterdir() if f.suffix == ".tmp"]
+        assert len(tmp_files) == 0
+
+    def test_silent_on_write_failure(self):
+        mod = _load_on_fresh_start(inbox_dir="/proc/lobster_test_nonexistent/inbox")
+
+        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
+            # Must not raise
+            mod._schedule_reflection_prompt("bootup")


### PR DESCRIPTION
Three improvements identified during post-compaction debrief, plus a new debug-mode reflection prompt:

**1. compact-catchup surfaces in-flight subagents**
After compaction, the dispatcher had no visibility into which subagents were running before. compact-catchup now calls `get_active_sessions()` in Phase 1 (moved earlier, before session notes reading) and scans for recently-returned subagent results in the inbox. The `write_result` output now includes two new sections: "In-flight subagents at compaction time" and "Recently-returned subagent results (since compaction)", so the dispatcher resumes with full context on what was running and what just completed.

**2. compact-catchup is now mandatory**
The bootup docs previously implied compact-catchup was optional if the in-conversation summary was "sufficient." Changed to a hard requirement with two explicit callouts: a MANDATORY block before the step list, and a note on step 5 itself. The rationale is in both places: the summary covers pre-compaction content; compact-catchup covers in-flight subagent state and recently-returned results that the summary cannot know about.

**3. Health check grace period after compaction**
The health check's 3-minute staleness threshold was firing during post-compaction re-orientation (reading bootup files, processing inbox backlog, waiting for compact-catchup). The `on-compact.py` hook now writes a Unix timestamp to `~/lobster-workspace/data/last-compact.ts`; `health-check-v3.sh` adds `is_compact_grace_period()` that reads this file and suppresses staleness alerts for 10 minutes. This extends the existing `COMPACTION_SUPPRESS_SECONDS=300` (5 min, reads `compacted_at` from `lobster-state.json`) with an additional 5 minutes via the new file, covering the full re-orientation window.

**4. Debug-mode reflection prompt after compaction/bootup**
When `LOBSTER_DEBUG=true`, `on-compact.py` and `on-fresh-start.py` now write a `reflection_prompt` inbox message after a compaction or fresh bootup. The message asks the dispatcher to reflect on the experience and file GitHub issues or PRs with observations while they are fresh — capturing friction points that would otherwise be lost. The message is written atomically and sorts after compact-reminders in the inbox queue. A new handler in `sys.dispatcher.bootup.md` tells the dispatcher how to process it (reflect genuinely; act only if there are substantive observations; never send_reply). 13 new unit tests cover debug/non-debug mode, message shape, atomic write, and silent failure.

No behavior changes in normal (non-debug, non-compaction) operation.

## Tests run
- [x] `uv run pytest tests/unit/test_hooks/ -v` — 205 passed, 1 failed (pre-existing flaky `test_insert_or_ignore_preserves_existing_row`; confirmed failing on base commit before this change)
- [x] `uv run pytest tests/unit/test_hooks/test_reflection_prompt.py -v` — 13 passed, 0 failed

**Blocked items needing attention before merge:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)