### PR TITLE
feat(compact-catchup): enforce 2-hour minimum lookback window

### DIFF
--- a/.claude/agents/compact-catchup.md
+++ b/.claude/agents/compact-catchup.md
@@ -15,8 +15,11 @@ You are the **compact_catchup** subagent. Your job is to:
 ### Phase 1: Inbox scan and summarization
 
 1. Read `~/lobster-workspace/data/compaction-state.json` to get timestamps.
-2. Compute the catch-up window start: prefer `last_catchup_ts` if present (anchored to last read); otherwise fall back to `min(last_compaction_ts, last_restart_ts)` (use the farther-back timestamp to maximise the window); default to 6 hours ago if none are present.
-3. Call `check_inbox(since_ts=<window_start>, limit=100)` to fetch messages from that window. 100 is a floor -- if the window is large, increase the limit further rather than truncating.
+2. Compute the catch-up window start:
+   a. Derive a candidate from `compaction-state.json`: prefer `last_catchup_ts` if present (anchored to last read); otherwise fall back to `min(last_compaction_ts, last_restart_ts)` (use the farther-back timestamp to maximise the window); default to 6 hours ago if none are present.
+   b. Compute the minimum lookback floor: `min_lookback = now - 2 hours`.
+   c. `window_start = min(candidate, min_lookback)` — always use whichever is farther back. This ensures the catchup window is at least 2 hours even immediately after a compaction or restart.
+3. Call `check_inbox(since_ts=<window_start>, limit=150)` to fetch messages from that window. 150 is a floor -- if the window is large, increase the limit further rather than truncating.
 4. Filter the results -- include only:
    - User messages (source: telegram, slack, sms, etc.)
    - `subagent_result` messages


### PR DESCRIPTION
## Problem

After a compaction, `compact-catchup` used `last_catchup_ts` as the inbox scan start — which is always very recent in a freshly-compacted session. This produced near-empty summaries covering as little as 11 minutes, leaving the dispatcher with almost no context to recover from.

## What changed

Step 2 of the Phase 1 logic now enforces a minimum lookback floor:

```
min_lookback = now - 2 hours
window_start = min(candidate, min_lookback)   # farther-back wins
```

The candidate (`last_catchup_ts` or the compaction/restart timestamps) is preserved — if it reaches further back than 2 hours, the longer window is used as before. The floor only kicks in when the stored timestamp is too recent.

The `check_inbox` limit floor also increases from 100 to 150 messages to match the wider typical window.

## What was not changed

- The 6-hour default when `compaction-state.json` is absent is unchanged.
- The `last_catchup_ts` update logic (step 7) is unchanged — the floor does not affect what gets written back.
- No changes to Phase 2 (session file) or Phase 3 (rolling summary).

## Functional patterns

Pure declarative logic — the window computation is a single `min()` expression with no side effects. No new state is introduced.

## Tests run

- [ ] Live compaction cycle — not triggered; the change is to agent definition text only, verifiable by reading the updated step 2 against the intent.

Closes #1249