### PR TITLE
fix(compact-catchup): content-check on /tmp pointer path; guard sessions dir creation

### DIFF
--- a/.claude/agents/compact-catchup.md
+++ b/.claude/agents/compact-catchup.md
@@ -65,14 +65,21 @@ You are the **compact_catchup** subagent. Your job is to:
 ### Phase 2: Populate the session file
 
 9. Locate or create the current session file:
-   a. Check `/tmp/lobster-current-session-file` -- if it contains a valid path to an existing file, use it.
-   b. Otherwise, list `~/lobster-user-config/memory/canonical/sessions/` for files matching `YYYYMMDD-NNN.md` where `YYYYMMDD` is today's UTC date. Pick the highest-sequenced file for today. If today has no file, **create one** (see step c below).
 
-   **Content-check before writing**: Before deciding whether to populate or create a new sequenced file, inspect the candidate file's Summary section:
+   **Content-check definition** (used throughout this step): To assess whether a candidate file has substantial content, inspect its Summary section:
    - Extract the text under `## Summary` in the existing file.
    - Strip any lines that are exactly `(nothing to report this session)` or match the default template placeholder text (e.g. lines starting with `<` and ending with `>`).
    - If the remaining non-whitespace character count exceeds **200 characters**, the file has **substantial content** -- treat it as "content-present".
    - If the file is absent, empty, or has fewer than 200 non-boilerplate characters in Summary, treat it as "stub".
+
+   a. Check `/tmp/lobster-current-session-file` -- if it contains a valid path to an existing file **and** the filename begins with today's UTC date (`YYYYMMDD`):
+      - Apply the content-check to this file.
+      - If stub: use it (proceed to step 9).
+      - If content-present: discard this pointer and fall through to step 8b (today's file needs a new sequence).
+      - If the path does not exist, is stale (not today's date), or the file is unreadable: discard this pointer and fall through to step 8b.
+
+   b. List `~/lobster-user-config/memory/canonical/sessions/` for files matching `YYYYMMDD-NNN.md` where `YYYYMMDD` is today's UTC date. If the directory does not exist, create it (no error -- this is a fresh install or reset), then proceed as if no files exist for today.
+      - Pick the highest-sequenced file for today. If today has no file, **create one** (see step c below).
 
    **Stub fallback**: If the highest-sequenced file for today is a stub, do not immediately write to it. First check earlier session files in order:
    - Check yesterday's most recent session file.
@@ -88,16 +95,17 @@ You are the **compact_catchup** subagent. Your job is to:
    - **Today's highest file is content-present**: create a new sequenced file instead (increment sequence number), populate that, and update `/tmp/lobster-current-session-file` to point to the new file. Do NOT overwrite the existing populated file.
    - **No file for today**: create one (step c).
 
-   c. Creating a new session file (applies when today has no file, or when content-check forces a new sequence):
-      1. Find all files for today to determine the next sequence number. If none exist, start at `001`; otherwise increment the highest by 1 (zero-padded to 3 digits).
-      2. Read the session template from `~/lobster-user-config/memory/canonical/sessions/session.template.md`. If that file does not exist, fall back to `~/lobster/memory/canonical-templates/sessions/session.template.md`. If neither exists, use a minimal inline template (header + empty sections).
-      3. In the template content, make the following literal substitutions:
+   c. Creating a new session file (applies when today has no file, the sessions directory was just created, or when content-check forces a new sequence):
+      1. Ensure `~/lobster-user-config/memory/canonical/sessions/` exists (create it if absent).
+      2. Find all files for today to determine the next sequence number. If none exist, start at `001`; otherwise increment the highest by 1 (zero-padded to 3 digits).
+      3. Read the session template from `~/lobster-user-config/memory/canonical/sessions/session.template.md`. If that file does not exist, fall back to `~/lobster/memory/canonical-templates/sessions/session.template.md`. If neither exists, use a minimal inline template (header + empty sections).
+      4. In the template content, make the following literal substitutions:
          - Replace `# Session YYYYMMDD-NNN` with `# Session <YYYYMMDD>-<NNN>` (e.g. `# Session 20260329-001`)
          - Replace `<ISO timestamp, e.g. 2026-03-25T14:32:00Z>` in the `**Started:**` line with the current UTC ISO timestamp
          - Replace `<ISO timestamp or "active">` in the `**Ended:**` line with `active`
-      4. Write the file to `~/lobster-user-config/memory/canonical/sessions/<YYYYMMDD>-<NNN>.md`.
-      5. Write the new file path to `/tmp/lobster-current-session-file` (overwriting any stale value).
-      6. Continue with phase 2 population as normal -- the file now exists.
+      5. Write the file to `~/lobster-user-config/memory/canonical/sessions/<YYYYMMDD>-<NNN>.md`.
+      6. Write the new file path to `/tmp/lobster-current-session-file` (overwriting any stale value).
+      7. Continue with phase 2 population as normal -- the file now exists.
 
 9. Build the session file content using the data from phases 1 and 2:
 


### PR DESCRIPTION
## What this fixes

Two gaps in the Phase 2 session-file logic shipped in PR #925, surfaced by Sahar's post-merge review:

**Gap 1 — Content-check bypass via /tmp pointer:** The content-check (200-char threshold to distinguish stub from populated files) was only applied when locating a candidate via directory scan (step 8b). When `/tmp/lobster-current-session-file` pointed to an existing file, that file was used directly -- skipping the check entirely. A session file the user had written meaningful content into would be silently overwritten on the next compaction.

**Gap 2 — Sessions directory assumed to exist:** Step 8b listed `~/lobster-user-config/memory/canonical/sessions/` without guarding for the directory being absent. On a fresh install or after a directory reset, this would fail at the listing step. The agent had no self-create path for the directory itself, only for files within it.

## What changed

`compact-catchup.md` Phase 2, step 8 is restructured:

- **Step 8a** now applies the full content-check to the /tmp-pointer path. Stub -> use in-place. Content-present -> discard pointer and fall through to 8b. The pointer is also validated against today's UTC date so stale cross-day pointers are discarded rather than re-used.
- **Step 8b** now explicitly creates the sessions directory if absent before listing, treating a missing directory the same as an empty one.
- **Step c step 1** re-states the mkdir guard so the self-create path is self-contained.

The content-check logic itself (threshold, boilerplate stripping) is unchanged. All other phases are untouched.

## Flow before/after (Phase 2 step 8 only)

```
Before:
  /tmp pointer exists? -> use it (no content-check)
  Otherwise -> scan directory -> content-check -> stub/content-present decision

After:
  /tmp pointer exists AND is today's date? -> content-check
    stub -> use it
    content-present -> discard, fall through to scan
    stale/missing -> discard, fall through to scan
  Scan directory (create dir if absent) -> content-check -> stub/content-present decision
```

## Functional patterns

Pure decision tree: each path through step 8 is a deterministic transformation from (pointer state, directory state, content-check result) to a single outcome (use existing / create new). No shared mutable state between branches.

## Tests run

- [ ] Live end-to-end test -- blocked: agent definition change, requires a running dispatcher session to observe. No executable unit tests apply to LLM instruction files.

**Blocked items needing attention before merge:** none -- all changes are additive guards. Existing behavior on the happy path (pointer present, today's date, stub) is unchanged.

Addresses Sahar's feedback on PR #925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)