### PR TITLE
docs(agents): require E2E/manual testing for infrastructure changes

### DIFF
--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -73,6 +73,16 @@ git branch -d feature/issue-42-my-feature
 - Write tests that verify behavior without relying on implementation details
 - **Run tests before opening the PR** — not after. The PR body records what was actually executed, not what you intend to run.
 
+**Manual/E2E testing requirement:** Before opening any PR, assess whether unit tests alone are sufficient. If the change touches any of the following, you MUST run a real integration or manual test and document what you ran and what you observed:
+- systemd units, timers, or service files
+- cron entries or scheduling scripts
+- external service calls (HTTP, SSH, Telegram API, GitHub API, bot-talk)
+- file system operations that affect runtime state (not test fixtures)
+- database schema changes
+- anything that failed in production despite passing unit tests before
+
+"Unit tests pass" is not sufficient evidence that infrastructure changes work. Run the real thing against the real system (or the Docker test instance), document the result, and include it in the PR description under `## Manual test`.
+
 ### 5. Progress Tracking
 - Regularly update the issue with your progress
 - Check off completed items using `gh issue edit` or `gh issue comment --repo <owner/repo>`
@@ -146,6 +156,14 @@ If any tests could not be run (missing Docker, live token, specific env), you **
 2. Call `write_result` with a note to the dispatcher so it can relay the gap to the user before merge is approved
 
 **Never write a forward-looking test plan.** Only record tests you ran and their outcomes.
+
+**Manual test** — required when the change touches systemd, cron, external services, file I/O, or DB schema. Include this section in every PR description:
+
+```
+## Manual test
+<!-- Required for systemd, cron, external services, file I/O, DB changes.
+     Describe what you ran and what you observed. "N/A" only if none of the above apply. -->
+```
 
 ### 7. PR Merge & Completion
 - After PR is approved and merged:


### PR DESCRIPTION
The functional-engineer agent had no mechanism to catch a well-known failure mode: unit tests pass, PR merges, production breaks because the change touched systemd/cron/external services and was never actually run. This PR closes that gap with two enforcements.

## What changed

**Change 1 — Assessment gate in Implementation step:** The agent must now explicitly evaluate whether unit tests are sufficient before opening any PR. If the change touches systemd units, cron entries, external service calls (Telegram, GitHub, HTTP), runtime file I/O, DB schema, or anything that failed in production before, a real integration or manual test is mandatory. The requirement text is explicit: "Unit tests pass is not sufficient evidence that infrastructure changes work."

**Change 2 — `## Manual test` section in PR template:** Every PR description must now include a `## Manual test` section. The comment inside makes the bar clear: describe what you ran and what you observed; "N/A" is only acceptable if none of the trigger categories apply.

These two changes are co-located in `functional-engineer.md`: the assessment rule sits at the end of `### 4. Implementation`, and the template section sits immediately after the existing `## Tests run` block in `### 6. Pull Request Creation`. No other agent files or system code was changed.

## Manual test
N/A — this is a documentation-only change to an agent definition file. No runtime behavior, no systemd, no external services.

## Tests run
- [x] `git diff` reviewed — 18 lines added, 0 removed, both hunks match spec exactly
- [ ] Live agent execution — not applicable; change is prompt text only