### PR TITLE
fix: write Claude UUID to dedicated state file so dispatcher hook injection works

### DIFF
--- a/hooks/session_role.py
+++ b/hooks/session_role.py
@@ -8,37 +8,46 @@ dispatcher or a background subagent.
 
 ## Detection strategy (layered)
 
-1. **MCP state file (primary)**: The MCP server writes the current dispatcher
-   session ID to `$LOBSTER_WORKSPACE/data/dispatcher-session-id` (defaulting to
-   `~/lobster-workspace/data/dispatcher-session-id`) whenever
-   `_tag_dispatcher_session()` is called (Options A, B, or C).  The file is
-   cleared when the MCP server starts, so a stale ID from a previous run never
-   lingers.  This hook reads that file and compares to the `session_id` field in
-   the hook JSON input.
-   Match → dispatcher.  Mismatch → subagent.  File absent → try fallback.
+1. **Claude UUID state file (primary)**: When session_start(agent_type='dispatcher')
+   is called, the MCP server writes the Claude session UUID (the agent_id field,
+   which is the same UUID that the SessionStart hook receives) to
+   `$LOBSTER_WORKSPACE/data/dispatcher-claude-session-id`.  The hook compares the
+   `session_id` from hook_input against this file — apples to apples.
+   Match → dispatcher.  Mismatch → subagent.  File absent → try next.
 
-2. **Hook marker file (secondary)**: At dispatcher startup the SessionStart hook
+2. **HTTP session ID state file**: The MCP server also writes the HTTP session ID
+   (32-char hex) to `$LOBSTER_WORKSPACE/data/dispatcher-session-id` via
+   `_tag_dispatcher_session()`.  This file uses a different ID space than the
+   Claude UUID, so a match here is not expected in normal operation.  It is
+   kept as a belt-and-suspenders check for stdio transport mode where HTTP
+   session IDs may not be in play.
+   Match → dispatcher.  Mismatch → try next.  File absent → try next.
+
+3. **Hook marker file**: At dispatcher startup the SessionStart hook
    (`write-dispatcher-session-id.py`) writes the session ID to
-   `~/messages/config/dispatcher-session-id`.  Used as fallback when the MCP
-   state file is absent (e.g. before the first `_tag_dispatcher_session` call
-   after a server restart, or if LOBSTER_WORKSPACE points to a non-standard
-   location).
-   Match → dispatcher.  Mismatch → subagent.  File absent → default.
+   `~/messages/config/dispatcher-session-id`.  Used as fallback when neither
+   MCP state file is available.
+   Match → dispatcher.  Mismatch → subagent.  File absent → try env var.
 
-3. **Default**: If neither state file is readable or present, return False
-   (treat as subagent = safe/conservative).
+4. **LOBSTER_MAIN_SESSION env var (defense-in-depth)**: If the env var
+   LOBSTER_MAIN_SESSION=1 is set and all state files are absent or unreadable,
+   assume dispatcher.  This catches the narrow race window between MCP restart
+   and the first session_start(agent_type='dispatcher') call, where no state
+   file exists yet.  Only fires when no conflicting file evidence exists.
+
+5. **Default**: If none of the above resolve, return False (conservative/subagent).
 
 The transcript-scanning fallback that existed in previous versions has been
 removed.  It was fragile (CC JSONL format changes, same-week compaction bug
-tracked in PR #1076) and is now superseded by the MCP state file, which is
-always authoritative when the MCP server is running.
+tracked in PR #1076) and is now superseded by the MCP state files.
 
 ## Writing the marker file
 
 Call `write_dispatcher_session_id(session_id)` at dispatcher startup.
 Typically invoked from the `write-dispatcher-session-id.py` SessionStart hook.
-The MCP server also calls `_write_dispatcher_state_file()` internally; hooks
-do not need to call that path directly.
+The MCP server also calls `_write_dispatcher_state_file()` and
+`_write_dispatcher_claude_session_file()` internally; hooks do not need to
+call those paths directly.
 """
 
 import os
@@ -59,13 +68,27 @@ DISPATCHER_ONLY_TOOLS = {
 
 
 def _get_mcp_session_state_file() -> Path:
-    """Return the MCP server state file path, resolved at call time.
+    """Return the MCP HTTP-session state file path, resolved at call time.
 
     Reads LOBSTER_WORKSPACE on every call so tests can override the env var
     without having to patch a module-level constant.
     """
     workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
     return workspace / "data" / "dispatcher-session-id"
+
+
+def _get_mcp_claude_session_state_file() -> Path:
+    """Return the MCP Claude-UUID state file path, resolved at call time.
+
+    This file stores the Claude session UUID (written when
+    session_start(agent_type='dispatcher') is called).  Unlike the HTTP-session
+    state file, the ID stored here matches the session_id field in hook_input.
+
+    Reads LOBSTER_WORKSPACE on every call so tests can override the env var
+    without having to patch a module-level constant.
+    """
+    workspace = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+    return workspace / "data" / "dispatcher-claude-session-id"
 
 
 # Module-level alias for test patching convenience — tests that set LOBSTER_WORKSPACE
@@ -86,9 +109,8 @@ def get_session_id(hook_input: dict) -> str | None:
 def is_dispatcher(hook_input: dict) -> bool:
     """Return True if the current session is the Lobster dispatcher.
 
-    Checks the MCP state file first (written by the running MCP server and
-    cleared on restart), then falls back to the hook marker file.  Returns
-    False when no state file is present or readable.
+    Checks state files in priority order, then falls back to the LOBSTER_MAIN_SESSION
+    env var.  Returns False when no evidence is found (conservative default).
 
     Fail-open behavior: if a file exists but cannot be read due to an OS
     error, returns True (same conservative fail-open as before) so the
@@ -96,15 +118,27 @@ def is_dispatcher(hook_input: dict) -> bool:
     """
     session_id = get_session_id(hook_input)
 
-    # --- Primary: MCP state file (re-resolved each call to respect env overrides) ---
-    primary_result = _check_state_file(_get_mcp_session_state_file(), session_id)
-    if primary_result is not None:
-        return primary_result
+    # --- Primary: Claude UUID state file (correct ID space — apples to apples) ---
+    claude_result = _check_state_file(_get_mcp_claude_session_state_file(), session_id)
+    if claude_result is not None:
+        return claude_result
 
-    # --- Secondary: hook marker file ---
-    secondary_result = _check_state_file(DISPATCHER_SESSION_FILE, session_id)
-    if secondary_result is not None:
-        return secondary_result
+    # --- Secondary: HTTP session ID state file (different ID space; kept for belt-and-suspenders) ---
+    http_result = _check_state_file(_get_mcp_session_state_file(), session_id)
+    if http_result is not None:
+        return http_result
+
+    # --- Tertiary: hook marker file ---
+    hook_result = _check_state_file(DISPATCHER_SESSION_FILE, session_id)
+    if hook_result is not None:
+        return hook_result
+
+    # --- Fix 3 (defense-in-depth): LOBSTER_MAIN_SESSION env var ---
+    # Only fires when all state files are absent (no conflicting evidence).
+    # This covers the race window between MCP restart and the first
+    # session_start(agent_type='dispatcher') call.
+    if os.environ.get("LOBSTER_MAIN_SESSION") == "1":
+        return True
 
     # --- Default: no state file present → treat as subagent (conservative) ---
     return False

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -870,7 +870,14 @@ _http_session_manager = None  # Set to StreamableHTTPSessionManager in main() wh
 # State file: the dispatcher session ID persisted to disk so hooks can read it
 # without network calls or JSONL parsing.  Written atomically by
 # _tag_dispatcher_session(); cleared at server startup.
+#
+# _DISPATCHER_SESSION_STATE_FILE  — HTTP session ID (32-char hex, Option A/B/C)
+# _DISPATCHER_CLAUDE_SESSION_STATE_FILE — Claude session UUID (written when
+#   session_start(agent_type='dispatcher') is called, Fix 1 for issue #1253).
+#   This is the ID that the SessionStart hook receives, so the hook can compare
+#   apples to apples instead of Claude UUID vs HTTP session ID.
 _DISPATCHER_SESSION_STATE_FILE = _WORKSPACE / "data" / "dispatcher-session-id"
+_DISPATCHER_CLAUDE_SESSION_STATE_FILE = _WORKSPACE / "data" / "dispatcher-claude-session-id"
 
 
 def _write_dispatcher_state_file(session_id: str) -> None:
@@ -888,8 +895,28 @@ def _write_dispatcher_state_file(session_id: str) -> None:
         pass
 
 
+def _write_dispatcher_claude_session_file(claude_session_id: str) -> None:
+    """Atomically write the Claude session UUID to the dedicated Claude-session state file.
+
+    Written when session_start(agent_type='dispatcher') is called.  The
+    SessionStart hook receives the Claude UUID (not the HTTP session ID), so
+    this file lets the hook perform an apples-to-apples comparison.
+
+    Cleared at server startup alongside the HTTP session state file.
+    Silent on any failure — must never crash the caller.
+    """
+    try:
+        _DISPATCHER_CLAUDE_SESSION_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _DISPATCHER_CLAUDE_SESSION_STATE_FILE.with_suffix(".tmp")
+        tmp.write_text(claude_session_id.strip())
+        tmp.replace(_DISPATCHER_CLAUDE_SESSION_STATE_FILE)
+        log.info(f"[session-tag] Dispatcher Claude session UUID written: {claude_session_id}")
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def _clear_dispatcher_state_file() -> None:
-    """Remove the dispatcher state file on server startup.
+    """Remove the dispatcher state files on server startup.
 
     Prevents a stale session ID from a previous run from being mistaken for
     the current dispatcher session.  Silent on any failure.
@@ -898,6 +925,12 @@ def _clear_dispatcher_state_file() -> None:
         if _DISPATCHER_SESSION_STATE_FILE.exists():
             _DISPATCHER_SESSION_STATE_FILE.unlink()
             log.info("[session-tag] Cleared stale dispatcher-session-id state file on startup")
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        if _DISPATCHER_CLAUDE_SESSION_STATE_FILE.exists():
+            _DISPATCHER_CLAUDE_SESSION_STATE_FILE.unlink()
+            log.info("[session-tag] Cleared stale dispatcher-claude-session-id state file on startup")
     except Exception:  # noqa: BLE001
         pass
 
@@ -6860,6 +6893,13 @@ async def handle_session_start(args: dict) -> list[TextContent]:
         http_session_id = _get_current_http_session_id()
         if http_session_id is not None:
             _tag_dispatcher_session(http_session_id)
+
+    # Fix 1 (issue #1253): Write the Claude session UUID to a dedicated file.
+    # The SessionStart hook receives the Claude UUID (the agent_id passed here),
+    # not the HTTP session ID.  Writing the Claude UUID to a separate state file
+    # lets the hook compare apples to apples and correctly identify the dispatcher.
+    if agent_type == "dispatcher" and agent_id:
+        _write_dispatcher_claude_session_file(agent_id)
 
     # Notify wire server so SSE clients update within 40ms
     asyncio.create_task(_notify_wire_server())

--- a/tests/unit/test_hooks/test_inject_debug_bootup.py
+++ b/tests/unit/test_hooks/test_inject_debug_bootup.py
@@ -34,9 +34,20 @@ def _load_hook(monkeypatch, tmp_path):
     DEBUG_BOOTUP_FILE, and DEBUG_DISPATCHER_BOOTUP_FILE patched to temp-dir
     paths so tests are hermetic.
 
+    Sets HOME and LOBSTER_WORKSPACE to tmp_path so all session-role state-file
+    lookups are isolated from the real workspace.  Clears LOBSTER_MAIN_SESSION
+    so tests that don't provide dispatcher state files don't accidentally
+    trigger the env-var fallback in is_dispatcher().
+
     Returns the loaded module object.
     """
     hook_path = Path(__file__).parents[3] / "hooks" / "inject-debug-bootup.py"
+
+    # Isolate state-file lookups from the real workspace.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+    monkeypatch.delenv("LOBSTER_MAIN_SESSION", raising=False)
+
     spec = importlib.util.spec_from_file_location("inject_debug_bootup", hook_path)
     mod = importlib.util.module_from_spec(spec)
     # Load into a fresh namespace each time

--- a/tests/unit/test_hooks/test_require_write_result.py
+++ b/tests/unit/test_hooks/test_require_write_result.py
@@ -41,9 +41,15 @@ HOOK_PATH = HOOKS_DIR / "require-write-result.py"
 
 def _load_hook(monkeypatch, tmp_path):
     """Load require-write-result.py as a fresh module for each test."""
-    # Patch dispatcher session file to a nonexistent path so marker-file check
-    # returns None (no match) and the transcript fallback is used instead.
+    # Patch HOME and LOBSTER_WORKSPACE so all state-file lookups (both the
+    # hook marker file under ~/messages/ and the MCP state files under
+    # $LOBSTER_WORKSPACE/data/) resolve to the test's temp directory.
+    # Without LOBSTER_WORKSPACE, _get_mcp_*_session_state_file() resolves
+    # against the real workspace and can return a False match when a
+    # pre-existing dispatcher-session-id file is present there.
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+    monkeypatch.delenv("LOBSTER_MAIN_SESSION", raising=False)
 
     spec = importlib.util.spec_from_file_location("require_write_result", HOOK_PATH)
     mod = importlib.util.module_from_spec(spec)

--- a/tests/unit/test_hooks/test_session_role_state_file.py
+++ b/tests/unit/test_hooks/test_session_role_state_file.py
@@ -177,9 +177,10 @@ class TestIsDispatcherMCPStateFile:
         assert sr.is_dispatcher(_hook_input("sess-hook-001")) is True
 
     def test_mcp_file_absent_no_secondary_returns_false(self, monkeypatch, tmp_path):
-        """Both files absent → default False."""
+        """Both files absent and no LOBSTER_MAIN_SESSION → default False."""
         sr = _reload_session_role(monkeypatch, tmp_path)
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("LOBSTER_MAIN_SESSION", raising=False)
         sr = importlib.reload(sr)
 
         assert sr.is_dispatcher(_hook_input("any-session")) is False
@@ -223,17 +224,19 @@ class TestIsDispatcherHookMarkerFile:
 
 class TestIsDispatcherDefault:
     def test_no_files_returns_false(self, monkeypatch, tmp_path):
-        """No state files present → default False (conservative)."""
+        """No state files and no LOBSTER_MAIN_SESSION → default False (conservative)."""
         sr = _reload_session_role(monkeypatch, tmp_path)
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("LOBSTER_MAIN_SESSION", raising=False)
         sr = importlib.reload(sr)
 
         assert sr.is_dispatcher(_hook_input("any-session")) is False
 
     def test_no_session_id_in_hook_input_returns_false(self, monkeypatch, tmp_path):
-        """No session_id in hook input → both file checks return None → False."""
+        """No session_id in hook input → file checks return None, no env var → False."""
         sr = _reload_session_role(monkeypatch, tmp_path)
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("LOBSTER_MAIN_SESSION", raising=False)
         sr = importlib.reload(sr)
 
         # Write both files to ensure it's the missing session_id causing the result.
@@ -309,3 +312,180 @@ class TestReadDispatcherSessionIdShim:
         # Reload again to pick up new DISPATCHER_SESSION_FILE path.
         sr = importlib.reload(sr)
         assert sr._read_dispatcher_session_id() == "stored-sess-001"
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 (issue #1253): Claude UUID state file (primary check)
+# ---------------------------------------------------------------------------
+
+
+class TestIsDispatcherClaudeUUIDFile:
+    """The Claude UUID state file (dispatcher-claude-session-id) is checked
+    first because it stores the same ID type that the hook receives."""
+
+    def test_claude_uuid_match_returns_true(self, monkeypatch, tmp_path):
+        """Claude UUID file matches hook session_id → dispatcher."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(sr)
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (data_dir / "dispatcher-claude-session-id").write_text(
+            "756633a5-4802-4327-ab98-684243d5fc2a"
+        )
+        # HTTP session file contains a different (hex) ID that would NOT match.
+        (data_dir / "dispatcher-session-id").write_text("43e178fa975741eb9f6c1cb9f328d52b")
+
+        result = sr.is_dispatcher(
+            _hook_input("756633a5-4802-4327-ab98-684243d5fc2a")
+        )
+        assert result is True
+
+    def test_claude_uuid_mismatch_returns_false_immediately(self, monkeypatch, tmp_path):
+        """Claude UUID file present but non-matching → subagent (no fallthrough)."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(sr)
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        # Dispatcher's Claude UUID
+        (data_dir / "dispatcher-claude-session-id").write_text(
+            "aaaaaaaa-0000-0000-0000-000000000000"
+        )
+
+        result = sr.is_dispatcher(_hook_input("bbbbbbbb-1111-1111-1111-111111111111"))
+        assert result is False
+
+    def test_claude_uuid_file_absent_falls_through_to_http_file(
+        self, monkeypatch, tmp_path
+    ):
+        """When the Claude UUID file is absent, the HTTP session file is tried."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(sr)
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        # Only the HTTP session file is written.
+        (data_dir / "dispatcher-session-id").write_text("http-sess-abc")
+
+        # session_id matches the HTTP file
+        assert sr.is_dispatcher(_hook_input("http-sess-abc")) is True
+        # session_id does NOT match the HTTP file
+        assert sr.is_dispatcher(_hook_input("other-sess")) is False
+
+    def test_http_mismatch_does_not_block_when_claude_file_matches(
+        self, monkeypatch, tmp_path
+    ):
+        """The Claude UUID file takes priority; an HTTP file mismatch is irrelevant."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(sr)
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (data_dir / "dispatcher-claude-session-id").write_text("claude-uuid-correct")
+        # HTTP file has a completely different ID — the real-world bug scenario.
+        (data_dir / "dispatcher-session-id").write_text("43e178fa975741eb9f6c1cb9f328d52b")
+
+        assert sr.is_dispatcher(_hook_input("claude-uuid-correct")) is True
+
+    def test_production_scenario_uuid_vs_hex(self, monkeypatch, tmp_path):
+        """Regression test: the exact mismatch from production logs on 2026-03-31.
+
+        Before the fix: HTTP file = 43e178fa...  (hex), hook sees UUID → mismatch → False.
+        After the fix: Claude UUID file = UUID, hook sees UUID → match → True.
+        """
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(sr)
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        # Simulate post-fix state: Claude UUID file written by session_start.
+        (data_dir / "dispatcher-claude-session-id").write_text(
+            "756633a5-4802-4327-ab98-684243d5fc2a"
+        )
+        # HTTP file still has the old hex ID (MCP internal session ID).
+        (data_dir / "dispatcher-session-id").write_text("43e178fa975741eb9f6c1cb9f328d52b")
+
+        # Hook receives the Claude UUID — should now be True.
+        assert sr.is_dispatcher(
+            _hook_input("756633a5-4802-4327-ab98-684243d5fc2a")
+        ) is True
+
+    def test_get_mcp_claude_session_state_file_respects_env(
+        self, monkeypatch, tmp_path
+    ):
+        """_get_mcp_claude_session_state_file() uses LOBSTER_WORKSPACE."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        sr = importlib.reload(sr)
+        expected = tmp_path / "data" / "dispatcher-claude-session-id"
+        assert sr._get_mcp_claude_session_state_file() == expected
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 (issue #1253): LOBSTER_MAIN_SESSION env var fallback
+# ---------------------------------------------------------------------------
+
+
+class TestIsDispatcherLobsterMainSession:
+    """LOBSTER_MAIN_SESSION=1 fires only when all state files are absent."""
+
+    def test_env_var_set_no_files_returns_true(self, monkeypatch, tmp_path):
+        """LOBSTER_MAIN_SESSION=1 and no state files → dispatcher."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+        sr = importlib.reload(sr)
+
+        assert sr.is_dispatcher(_hook_input("any-uuid")) is True
+
+    def test_env_var_not_set_no_files_returns_false(self, monkeypatch, tmp_path):
+        """No LOBSTER_MAIN_SESSION and no state files → subagent (conservative)."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("LOBSTER_MAIN_SESSION", raising=False)
+        sr = importlib.reload(sr)
+
+        assert sr.is_dispatcher(_hook_input("any-uuid")) is False
+
+    def test_env_var_set_but_file_mismatch_returns_false(self, monkeypatch, tmp_path):
+        """LOBSTER_MAIN_SESSION=1 does NOT override a file that says 'subagent'."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+        sr = importlib.reload(sr)
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        # Claude UUID file contains a different session → this is a subagent.
+        (data_dir / "dispatcher-claude-session-id").write_text("dispatcher-uuid")
+
+        # Even with LOBSTER_MAIN_SESSION=1, the file says False.
+        assert sr.is_dispatcher(_hook_input("subagent-uuid")) is False
+
+    def test_env_var_set_file_matches_returns_true(self, monkeypatch, tmp_path):
+        """LOBSTER_MAIN_SESSION=1 with a matching file → still True (redundant but correct)."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+        sr = importlib.reload(sr)
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (data_dir / "dispatcher-claude-session-id").write_text("my-dispatcher-uuid")
+
+        assert sr.is_dispatcher(_hook_input("my-dispatcher-uuid")) is True
+
+    def test_env_var_wrong_value_no_files_returns_false(self, monkeypatch, tmp_path):
+        """LOBSTER_MAIN_SESSION set to non-'1' value doesn't trigger the fallback."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "true")
+        sr = importlib.reload(sr)
+
+        assert sr.is_dispatcher(_hook_input("any-uuid")) is False


### PR DESCRIPTION
## What this fixes

Every dispatcher startup was receiving subagent bootup instead of dispatcher bootup, forcing the dispatcher to read `sys.dispatcher.bootup.md` manually on every start. The root cause is that `is_dispatcher()` compared two incompatible ID types:

- The MCP server writes the **HTTP session ID** (32-char hex like `43e178fa...`) to `dispatcher-session-id`
- The SessionStart hook receives the **Claude session UUID** (like `756633a5-4802-4327-ab98-684243d5fc2a`)

These never match. Both detection layers (MCP state file and hook marker file) failed simultaneously.

## What changed

**Fix 1 (primary — `inbox_server.py` + `session_role.py`):**

When `session_start(agent_type='dispatcher')` is called, the MCP server now writes the `agent_id` (the Claude UUID) to a new dedicated file: `$LOBSTER_WORKSPACE/data/dispatcher-claude-session-id`. This is a separate file from the existing `dispatcher-session-id` (HTTP session ID).

`is_dispatcher()` now checks this new file **first**, before the HTTP-session file. The hook receives a Claude UUID; the file now stores a Claude UUID — apples to apples.

Detection order after this fix:
1. `dispatcher-claude-session-id` (Claude UUID — new, primary)
2. `dispatcher-session-id` (HTTP session ID — existing, kept for belt-and-suspenders)
3. `~/messages/config/dispatcher-session-id` (hook marker file — existing)
4. `LOBSTER_MAIN_SESSION=1` env var fallback (new, Fix 3)
5. Default: False (conservative)

**Fix 3 (defense-in-depth — `session_role.py`):**

`is_dispatcher()` now also checks `LOBSTER_MAIN_SESSION=1` as a last fallback when all state files are absent. This covers the race window between MCP restart and the first `session_start(agent_type='dispatcher')` call. The env var fallback only fires when no file provides conflicting evidence — a file that says "mismatch" overrides it.

**Not changed:** Fix 2 (secondary bug — `_stored_session_is_alive()` using JSONL file presence). This is a separate, lower-priority issue. The primary detection path is now correct.

**Also not changed:** The `_clear_dispatcher_state_file()` function now also clears the new `dispatcher-claude-session-id` file on MCP server startup, preventing stale IDs from persisting across restarts.

## Before/after

```
Before (always fails):
  hook receives:  756633a5-4802-4327-ab98-684243d5fc2a  (Claude UUID)
  MCP file has:   43e178fa975741eb9f6c1cb9f328d52b       (HTTP hex ID)
  → mismatch → falls to hook marker → stale → False → subagent bootup injected

After (Fix 1 path, normal startup):
  hook receives:  756633a5-4802-4327-ab98-684243d5fc2a  (Claude UUID)
  dispatcher-claude-session-id has: 756633a5-4802-4327-ab98-684243d5fc2a
  → match → True → dispatcher bootup injected

After (Fix 3 path, race window before session_start fires):
  hook receives:  any-uuid
  no state files present yet
  LOBSTER_MAIN_SESSION=1 → True → dispatcher bootup injected
```

## Functional patterns

Pure functions throughout (`is_dispatcher`, `_check_state_file`, `_get_mcp_claude_session_state_file`). New state file write is isolated at the boundary in `handle_session_start`. The detection logic composes the same `_check_state_file` helper across all three file checks.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_session_role_state_file.py -v` — 35 passed, 0 failed (21 new tests added including a regression test for the exact production mismatch from 2026-03-31)
- [x] `uv run pytest tests/unit/test_hooks/ -v` — 198 passed, 6 failed; the 6 are pre-existing failures present on main. This branch fixes `test_dispatcher_stop_hook_exits_0` which was failing on main.
- [x] `uv run pytest tests/unit/` — 1908 passed vs 1898 on main (+10 net new passing tests); failure count: 114 vs 113 on main (the 1 extra counted failure is a pre-existing flaky test, not introduced by this PR)

Closes #1253