### PR TITLE
feat(dispatcher): expand debug-mode post-bootup status message

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -63,7 +63,28 @@ The symlink `~/.claude/` resolves to `~/lobster/.claude/` on standard installs.
 - New tasks: ack normally and spawn subagent. These are unambiguously new work.
 - Urgent messages: handle them. You have handoff.md for context.
 
-**When the startup catchup result arrives** (`task_id: "startup-catchup"`, `chat_id: 0`): read for situational awareness, update `handoff.md` if anything notable changed (failed subagents, open threads). Run `~/lobster/scripts/record-catchup-state.sh finish`. Do NOT relay to user — except if `LOBSTER_DEBUG=true`, send a brief status to ADMIN_CHAT_ID: `"🔄 Back online. Context recovered from [window_start] to [now]. [N messages] processed, [M subagents] were running."` (Fill in N and M from `msg["text"]`.) **Before composing this message, convert `[window_start]` and `[now]` from UTC ISO timestamps to ET (e.g. "5:29 AM ET"). Rule: EDT (UTC-4) mid-March through early November, EST (UTC-5) otherwise. Never send raw UTC ISO strings to the user.** Then `mark_processed`.
+**When the startup catchup result arrives** (`task_id: "startup-catchup"`, `chat_id: 0`): read for situational awareness, update `handoff.md` if anything notable changed (failed subagents, open threads). Run `~/lobster/scripts/record-catchup-state.sh finish`. Do NOT relay to user — except if `LOBSTER_DEBUG=true`, send the post-bootup status message below. Then `mark_processed`.
+
+**Post-bootup status message (LOBSTER_DEBUG=true only):** Send to ADMIN_CHAT_ID. Keep to 5-8 lines, mobile-friendly. Build it from `handoff.md` (just read for startup) and `msg["text"]` (the catchup summary). Format:
+
+```
+🦞 Back online — [session_id], started [start_time ET]
+Recovery: [clean restart | context gap of ~Xm recovered]
+Catchup window: [window_start ET] → now — [N] msgs, [M] subagents
+
+PRs needing sign-off: [count] ([list first 2-3 PR numbers])
+Open tasks/commitments: [count]
+[If any URGENT/blocked items:] ⚠️ Urgent: [first item, ~60 chars max]
+```
+
+Fill in:
+- `session_id` from `current_session_file` (e.g. `20260331-009`)
+- `start_time ET` from session file or current time
+- `clean restart` if `compaction-state.json` gap was ≤15s; otherwise `context gap of ~Xm recovered` (X = gap in minutes)
+- N and M from `msg["text"]` (the catchup result)
+- PR count and numbers from handoff.md "PRs needing sign-off" section
+- Task/commitment count from handoff or `list_tasks(status="open")`
+- URGENT line only if handoff contains items marked URGENT or blocked — omit entirely if none
 
 ---
 

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -79,11 +79,11 @@ Open tasks/commitments: [count]
 
 Fill in:
 - `session_id` from `current_session_file` (e.g. `20260331-009`)
-- `start_time ET` from session file or current time
+- `start_time ET` from session file — omit the `started [time]` clause entirely if session file is absent
 - `clean restart` if `compaction-state.json` gap was ≤15s; otherwise `context gap of ~Xm recovered` (X = gap in minutes)
 - N and M from `msg["text"]` (the catchup result)
 - PR count and numbers from handoff.md "PRs needing sign-off" section
-- Task/commitment count from handoff or `list_tasks(status="open")`
+- Task/commitment count from handoff.md — omit if handoff is absent; do NOT call `list_tasks` as a fallback
 - URGENT line only if handoff contains items marked URGENT or blocked — omit entirely if none
 
 ---


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

When Lobster restarts or recovers from a compaction, Sahar has no visibility into what the dispatcher actually knows until she asks — and then it's a manual back-and-forth. This PR makes `LOBSTER_DEBUG=true` meaningful at bootup.

## What changed

The `startup-catchup` result handler previously sent a single terse line when `LOBSTER_DEBUG=true`:
> "🔄 Back online. Context recovered from [window_start] to [now]. [N messages] processed, [M subagents] were running."

That line tells Sahar the dispatcher is alive, but nothing about state. It doesn't tell her whether there are PRs waiting for her, whether anything is blocked, or whether the restart was clean.

This PR replaces that one-liner with a structured 5-8 line status block:

```
🦞 Back online — 20260331-009, started 12:46 PM ET
Recovery: context gap of ~14m recovered
Catchup window: 12:32 PM ET → now — 23 msgs, 2 subagents

PRs needing sign-off: 4 (#1246, #1243, #1213, ...)
Open tasks/commitments: 7
⚠️ Urgent: LOBSTER-SELF-CHECK status never answered (critical)
```

All fields come from data the dispatcher has already read during startup: `handoff.md`, `compaction-state.json`, and the catchup result text. No additional tool calls required. The URGENT line is omitted entirely when handoff has no urgent/blocked items.

## What is not changed

- The compact-catchup (post-compaction) handler already had a similar one-liner at line 194-196 — that is left unchanged (a separate PR could expand it symmetrically, but the issue only covers startup-catchup).
- No code changes. This is a behavioral doc update to `sys.dispatcher.bootup.md` only.
- The message is only sent when `LOBSTER_DEBUG=true`. Normal (non-debug) startup remains silent.

## Functional pattern

Pure declarative specification: the format is a template with named slots, each slot has an explicit data source and fallback rule. The dispatcher fills slots from already-loaded state rather than doing new work.

## Tests run

- [ ] Live dispatcher test — not run (requires restarting the live dispatcher, which would interrupt Sahar's session). The change is a documentation/behavioral instruction update with no code; the correct verification is a live bootup observation.

**Blocked items needing attention before merge:** none — doc-only change, safe to merge.

Closes #1263