### PR TITLE
fix: restore nightly-consolidation dispatcher handler (lost in 1481a62)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -439,6 +439,43 @@ Triage heuristic: relay failures always; relay successes with actionable finding
 
 ---
 
+### consolidation (`type: "consolidation"`)
+
+`scripts/nightly-consolidation.sh` runs at 3 AM UTC via cron and writes a `consolidation` message to the inbox. This triggers a background subagent to synthesize recent memory events into the canonical memory files.
+
+```
+1. mark_processing(message_id)
+
+2. Spawn nightly-consolidation subagent (run_in_background=True):
+
+   consolidation_task_id = f"nightly-consolidation-{msg['id']}"
+
+   Task(
+       subagent_type="nightly-consolidation",
+       run_in_background=True,
+       prompt=(
+           f"---\n"
+           f"task_id: {consolidation_task_id}\n"
+           f"chat_id: 0\n"
+           f"source: system\n"
+           f"---\n\n"
+           f"Nightly consolidation triggered at {msg.get('timestamp', 'unknown time')}.\n\n"
+           f"Synthesize recent memory events into the canonical memory files. "
+           f"See your agent instructions for the full step-by-step procedure."
+       ),
+   )
+
+3. mark_processed(message_id)
+   # Return to wait_for_messages() immediately -- the subagent handles synthesis
+```
+
+Rules:
+- Never inline consolidation work -- always a background subagent
+- Subagent result (`task_id` starts with `nightly-consolidation-`) is internal -- mark processed silently, do not relay to user
+- `source` is `"internal"`, `chat_id` is `0` -- there is no user to notify
+
+---
+
 ### context_warning (`type: "context_warning"`)
 
 Written by `hooks/context-monitor.py` when context window >= 70%.

--- a/scripts/nightly-consolidation.sh
+++ b/scripts/nightly-consolidation.sh
@@ -20,13 +20,21 @@ LOBSTER_DIR="$(dirname "$SCRIPT_DIR")"
 MESSAGES_DIR="${LOBSTER_MESSAGES:-$HOME/messages}"
 INBOX="$MESSAGES_DIR/inbox"
 TIMESTAMP=$(date +%s%3N)
+LOG_DIR="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}/logs"
+LOG_FILE="$LOG_DIR/nightly-consolidation.log"
 
-# Ensure inbox directory exists
-mkdir -p "$INBOX"
+# Ensure directories exist
+mkdir -p "$INBOX" "$LOG_DIR"
+
+log() {
+    echo "[$(date -Iseconds)] $*" | tee -a "$LOG_FILE"
+}
+
+log "nightly-consolidation.sh started"
 
 # Dedup guard: skip if a consolidation message is already pending
 if ls "$INBOX"/*_consolidation.json 2>/dev/null | grep -q .; then
-    echo "Consolidation message already pending in inbox. Skipping."
+    log "Consolidation message already pending in inbox. Skipping."
     exit 0
 fi
 
@@ -42,4 +50,4 @@ cat > "$INBOX/${TIMESTAMP}_consolidation.json" << EOF
 }
 EOF
 
-echo "Consolidation message injected at $(date -Iseconds)"
+log "Consolidation message injected at $(date -Iseconds)"


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

Nightly consolidation has been silently failing since commit `1481a62` removed the `type: "consolidation"` handler from the dispatcher during an unrelated cleanup. The cron fires, the script writes the inbox message, but the dispatcher encounters the message with no handler and drops it. `daily-digest.md` has been stale for 16 days.

## What broke and why

Commit `1481a62` ("cleanup: remove plans tool") modified `sys.dispatcher.bootup.md` and accidentally deleted the entire `## Handling Nightly Consolidation` section that PR #1199 had added. Nothing in the diff review would have flagged this — it looked like dead space between sections.

The full pipeline was otherwise functional:
- Cron fires at 3 AM UTC
- `nightly-consolidation.sh` writes `type: "consolidation"` to inbox
- `.claude/agents/nightly-consolidation.md` is correctly defined and deployed

Only the dispatcher handler was missing.

## What this PR does

**`sys.dispatcher.bootup.md`** — Restores the `### consolidation (type: "consolidation")` handler section between `cron_reminder` and `context_warning`. Handler: `mark_processing` → spawn `nightly-consolidation` background subagent → `mark_processed`. Subagent results are silently dropped (internal, `chat_id: 0`).

**`scripts/nightly-consolidation.sh`** — Adds logging to `~/lobster-workspace/logs/nightly-consolidation.log` so each cron run attempt is recorded. Previously the script produced no persistent output, making it impossible to tell from logs whether it had fired. The `log()` function tees to both stdout (for cron's mail) and the log file.

## Flow unchanged

The cron → script → inbox → dispatcher → subagent pipeline is identical to what PR #1199 established. This PR only restores the dispatcher handler that was accidentally removed.

No behavior changes to the nightly-consolidation subagent itself (agent definition untouched).

## Tests run

- [x] `grep -n "consolidat" .claude/sys.dispatcher.bootup.md` — confirms handler section present at line 442
- [x] `bash -n scripts/nightly-consolidation.sh` — syntax check passes
- [ ] Live 3 AM cron run — blocked: requires waiting until next cron fire; log file at `~/lobster-workspace/logs/nightly-consolidation.log` will confirm on next run