### PR TITLE
fix: remove dead user-model/_context.md references from bootup files

### DIFF
--- a/.claude/agents/nightly-consolidation.md
+++ b/.claude/agents/nightly-consolidation.md
@@ -96,7 +96,7 @@ You will receive a prompt containing the consolidation trigger timestamp.
    Update the "Current state" section to reflect the synthesized current state. This is the first file the next session reads — keep it accurate and current.
 
 9. **Sync canonical files into the user model DB.**
-   Run the bridge pass to push projects, priorities, and preferences from canonical markdown files into the user model DB. This also generates the pre-computed `_context.md` via `write_context_cache()`:
+   Run the bridge pass to push projects, priorities, and preferences from canonical markdown files into the user model DB:
    ```bash
    cd ~/lobster && uv run python -c "
    import sys; sys.path.insert(0, 'src')
@@ -109,40 +109,8 @@ You will receive a prompt containing the consolidation trigger timestamp.
    print(result)
    "
    ```
-   This syncs `projects/*.md` as narrative arcs and `priorities.md` as attention items, and writes the pre-computed `~/lobster-workspace/user-model/_context.md`.
-   If the script fails (e.g. DB not initialized), continue to step 10.
-
-10. **Write `_context.md` (user model summary).**
-    Call `model_user_context(deep=True)` to retrieve structured user model data from the DB.
-    Combine it with today's synthesized context (from steps 1–8) to write a complete snapshot.
-
-    Create `~/lobster-workspace/user-model/` if it does not exist, then write `_context.md` with this structure:
-
-    ```markdown
-    # User Model Context
-    *Auto-generated YYYY-MM-DD — do not edit manually*
-
-    ## Active Projects
-    <list from model_user_context(deep=True) plus any new project status from today's events>
-
-    ## Top Priorities
-    <from priorities.md or inferred from today's attention>
-
-    ## Key People (Recent Focus)
-    <people who appeared in today's events or model_user_context>
-
-    ## Preferences & Constraints
-    <behavioral rules reinforced today; hard constraints; known preferences>
-
-    ## Emotional Baseline
-    <mood/energy signals from today's events and model baseline>
-
-    ## Open Questions / Pending Decisions
-    <unresolved threads identified in today's synthesis>
-    ```
-
-    If `model_user_context(deep=True)` returns no data (model not yet populated), write the file from today's synthesis alone — do not leave the file empty or skip this step.
-    Overwrite the file entirely each run.
+   This syncs `projects/*.md` as narrative arcs and `priorities.md` as attention items.
+   If the script fails (e.g. DB not initialized), continue.
 
 ### What NOT to do
 
@@ -158,7 +126,7 @@ You will receive a prompt containing the consolidation trigger timestamp.
 mcp__lobster-inbox__write_result(
     task_id=task_id,   # from your prompt header
     chat_id=0,
-    text="Nightly consolidation complete. Updated: rolling-summary.md, daily-digest.md, handoff.md, _context.md. Projects updated: <list or 'none'>. People updated: <list or 'none'>. Events consolidated: <count>.",
+    text="Nightly consolidation complete. Updated: rolling-summary.md, daily-digest.md, handoff.md. Projects updated: <list or 'none'>. People updated: <list or 'none'>. Events consolidated: <count>.",
     source="system",
     status="success",
     sent_reply_to_user=False,

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -24,14 +24,14 @@ When you first start (or after reading this file), follow these steps:
 1. Call `session_start(agent_type='dispatcher', claude_session_id=hook_input["session_id"])` — pass the Claude session UUID injected by the SessionStart hook. This writes the UUID to `$LOBSTER_WORKSPACE/data/dispatcher-claude-session-id`, enabling `inject-bootup-context.py` to identify your session as the dispatcher and inject this file on future restarts. Without this call, the primary detection path is never populated and you will receive the subagent bootup file instead of this one.
 1a. Read `~/lobster-user-config/memory/canonical/handoff.md` — user context, active projects, key people, git rules, available integrations.
 2. Create a new session file inline (see Session File Management). Store its path as `current_session_file`.
-2b. Call `list_rules(enabled_only=true)` to load IFTTT behavioral rules into working context.
-2c. Check `~/lobster-workspace/data/context-handoff.json`:
+2a. Call `list_rules(enabled_only=true)` to load IFTTT behavioral rules into working context.
+2b. Check `~/lobster-workspace/data/context-handoff.json`:
     - If **recent** (< 10 min, based on `triggered_at`): read `context_pct`, `pending_tasks`, `last_user_message`. Notify user: "Restarted — context was at {context_pct}%. Resuming from where we left off." Re-queue any stuck messages from `~/messages/processing/`. Delete the file.
     - If **stale** (>= 10 min) or absent: ignore.
-2d. Check `~/lobster-workspace/data/compaction-state.json` for `last_catchup_ts`:
+2c. Check `~/lobster-workspace/data/compaction-state.json` for `last_catchup_ts`:
     - `gap_seconds > 15`: send `"🦞 Warming up — back in a moment."` to admin chat.
     - `gap_seconds <= 15`: stay silent (health-check restart, not a meaningful gap).
-    - Skip if step 2c already sent a restart notification.
+    - Skip if step 2b already sent a restart notification.
 3. Run `~/lobster/scripts/record-catchup-state.sh start` (suppresses WFM freshness check for 15 min).
 4. Spawn the `compact-catchup` agent in the background with `task_id: startup-catchup` and `chat_id: 0`. See agent definition at `.claude/agents/compact-catchup.md` for the full prompt — pass it with `task_id: startup-catchup` instead of `compact-catchup`. **Never do catchup inline — it violates the 7-second rule.**
 5. Call `wait_for_messages()` to start listening.
@@ -539,7 +539,7 @@ wait_for_messages() ← loop back
 
 ## IFTTT Behavioral Rules
 
-IFTTT rules are loaded at startup (step 2b) and applied throughout the session. They are at `~/lobster-user-config/memory/canonical/ifttt-rules.yaml`. The file is an index only — behavioral content lives in the memory DB, keyed by `action_ref`.
+IFTTT rules are loaded at startup (step 2a) and applied throughout the session. They are at `~/lobster-user-config/memory/canonical/ifttt-rules.yaml`. The file is an index only — behavioral content lives in the memory DB, keyed by `action_ref`.
 
 **Loading:** `list_rules(enabled_only=true)`. If no rules, proceed normally. Load only enabled rules into working context.
 
@@ -553,7 +553,7 @@ IFTTT rules are loaded at startup (step 2b) and applied throughout the session. 
 
 One session note file per session. Lives in `~/lobster-user-config/memory/canonical/sessions/`, named `YYYYMMDD-NNN.md`.
 
-**Creating (startup step 2a):**
+**Creating (startup step 2):**
 1. List the directory, find highest sequence number for today. If none, start at 001.
 2. Copy `session.template.md` to the new path.
 3. Replace `Started` placeholder with current UTC ISO timestamp.

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -23,8 +23,7 @@ When you first start (or after reading this file), follow these steps:
 
 1. Call `session_start(agent_type='dispatcher', claude_session_id=hook_input["session_id"])` — pass the Claude session UUID injected by the SessionStart hook. This writes the UUID to `$LOBSTER_WORKSPACE/data/dispatcher-claude-session-id`, enabling `inject-bootup-context.py` to identify your session as the dispatcher and inject this file on future restarts. Without this call, the primary detection path is never populated and you will receive the subagent bootup file instead of this one.
 1a. Read `~/lobster-user-config/memory/canonical/handoff.md` — user context, active projects, key people, git rules, available integrations.
-2. Read `~/lobster-workspace/user-model/_context.md` if it exists — pre-computed summary of user values, preferences, and active projects. Skip if absent.
-2a. Create a new session file inline (see Session File Management). Store its path as `current_session_file`.
+2. Create a new session file inline (see Session File Management). Store its path as `current_session_file`.
 2b. Call `list_rules(enabled_only=true)` to load IFTTT behavioral rules into working context.
 2c. Check `~/lobster-workspace/data/context-handoff.json`:
     - If **recent** (< 10 min, based on `triggered_at`): read `context_pct`, `pending_tasks`, `last_user_message`. Notify user: "Restarted — context was at {context_pct}%. Resuming from where we left off." Re-queue any stuck messages from `~/messages/processing/`. Delete the file.


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

The dispatcher startup has been reading a file that doesn't exist, and the nightly consolidation agent defined a step to write a file that nothing depends on. Both are dead code in the bootup sequence.

## What changed

`~/lobster-workspace/user-model/_context.md` is referenced in two bootup files as a pre-computed summary the dispatcher should read at startup. No part of the system ever creates this file — `run_bridges()` does not call `write_context_cache()`, and the nightly consolidation step 10 that would have written it was aspirational and never implemented. The dispatcher silently skips the read (the instruction says "skip if absent"), but it's noise in the bootup sequence and confusing for anyone reading the files.

Changes:
- `sys.dispatcher.bootup.md`: removed startup step 2 (read `user-model/_context.md`); renumbered step 2a to 2
- `nightly-consolidation.md`: removed step 10 (write `_context.md`); removed the false claim from step 9 that `run_bridges()` writes `_context.md`; removed `_context.md` from the `write_result` output text

No behavior changes — the dispatcher already skipped this file when absent. This removes dead instructions so the bootup sequence reflects what the system actually does.

## Functional patterns

Pure deletion — no logic added. Changes are confined to markdown instruction files with no code changes.

## Tests run
- [x] `grep -r "user-model/_context" ~/lobster/.claude/` — clean, no remaining references after edit
- [ ] Live dispatcher restart — not run; change only removes a no-op read step, no code path altered

Closes #1264