### PR TITLE
fix(dispatcher): remove dead REMINDER_ROUTING for ghost_detector and oom_check

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -202,50 +202,28 @@ After a context compaction you lose situational awareness of the last ~30 minute
 
 ### scheduled_reminder (`type: "scheduled_reminder"`)
 
-Scheduled reminders arrive from `scripts/post-reminder.sh` (system cron jobs) or `scheduled-tasks/dispatch-job.sh` (user-created jobs). Both produce `type: "scheduled_reminder"`.
+Scheduled reminders arrive from `scheduled-tasks/dispatch-job.sh` (user-created jobs) and produce `type: "scheduled_reminder"`.
 
-**User-created jobs** carry a `task_content` field — the full task file contents. Pass directly to `lobster-generalist` with no REMINDER_ROUTING entry needed.
+**User-created jobs** carry a `task_content` field — the full task file contents. Pass directly to `lobster-generalist`.
 
-**System jobs** (`ghost_detector`, `oom_check`) have static routes in REMINDER_ROUTING.
-
-```python
-REMINDER_ROUTING = {
-  "ghost_detector": {
-    "subagent_type": "lobster-generalist",
-    "prompt": "---\ntask_id: agent-monitor\nchat_id: 0\nsource: system\n---\n\n"
-              "Run the agent monitor check. Script is at ~/lobster/scripts/agent-monitor.py. "
-              "Run it with uv run ~/lobster/scripts/agent-monitor.py and report findings.",
-  },
-  "oom_check": {
-    "subagent_type": "lobster-generalist",
-    "prompt": "---\ntask_id: oom-check\nchat_id: 0\nsource: system\n---\n\n"
-              "Run the OOM monitor check. Script is at ~/lobster/scripts/oom-monitor.py. "
-              "Run it with uv run ~/lobster/scripts/oom-monitor.py --since-minutes 10 "
-              "and report findings.",
-  },
-}
-```
+> **Note:** `ghost_detector` and `oom_check` are NOT dispatched via this path. Both `agent-monitor.py` and `oom-monitor.py` run directly from cron and write to the inbox themselves when they have findings. No LLM layer is involved.
 
 ```
 1. mark_processing(message_id)
 2. reminder_type = msg.get("reminder_type") or msg.get("job_name")
-3. route = REMINDER_ROUTING.get(reminder_type)
+3. task_content = msg.get("task_content", "").strip()
 
-4. if route is None:
-       task_content = msg.get("task_content", "").strip()
-       if task_content:
-           # Generic dispatch: user-created job
-           prompt = f"---\ntask_id: scheduled-job-{reminder_type}\nchat_id: 0\nsource: system\n---\n\n{task_content}"
-       else:
-           # Truly unknown reminder
-           prompt = f"---\ntask_id: unknown-reminder\nchat_id: 0\nsource: system\n---\n\nUnknown reminder_type: '{reminder_type}'. Call write_result and return."
-       Spawn subagent: subagent_type: "lobster-generalist", prompt: prompt
+4. if task_content:
+       # Generic dispatch: user-created job
+       prompt = f"---\ntask_id: scheduled-job-{reminder_type}\nchat_id: 0\nsource: system\n---\n\n{task_content}"
    else:
-       Spawn subagent: subagent_type: route["subagent_type"], prompt: route["prompt"]
+       # Unknown reminder with no task content
+       prompt = f"---\ntask_id: unknown-reminder\nchat_id: 0\nsource: system\n---\n\nUnknown reminder_type: '{reminder_type}'. Call write_result and return."
+   Spawn subagent: subagent_type: "lobster-generalist", prompt: prompt
 5. mark_processed(message_id)
 ```
 
-Rules: never `send_reply` (chat_id: 0), never add user-created job names to REMINDER_ROUTING.
+Rules: never `send_reply` (chat_id: 0).
 
 ---
 


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

The `ghost_detector` and `oom_check` entries in `REMINDER_ROUTING` were never reachable. Both `agent-monitor.py` (ghost detection) and `oom-monitor.py` (OOM monitoring) already run directly from cron and write inbox messages themselves when they detect findings — no `scheduled_reminder` message is ever posted for these types, so the LLM dispatch path was a dead branch that could never execute.

This PR removes both `REMINDER_ROUTING` entries and simplifies the `scheduled_reminder` handler. The handler now has a single code path: dispatch user-created jobs (which carry `task_content`) or drop-with-log for unknown types. The `if route is None / else` branch structure is gone.

## What changed

- Removed `REMINDER_ROUTING` dict and both `ghost_detector`/`oom_check` entries from `sys.dispatcher.bootup.md`
- Simplified `scheduled_reminder` pseudocode: the `route = REMINDER_ROUTING.get(...)` lookup and its `else` branch are replaced with a direct `task_content` check
- Added an explicit callout note explaining that `ghost_detector` and `oom_check` run via cron-direct, not reminder dispatch — so future readers don't wonder what happened to them
- Removed the now-incorrect claim that `post-reminder.sh` feeds this handler (the cron entry for agent-monitor runs the script directly, not via post-reminder.sh)

## Scope

No behavior changes to user-created scheduled jobs. No changes to `agent-monitor.py`, `oom-monitor.py`, `cron-manage.sh`, or any cron entries. The cron jobs that run these scripts directly are already correct and unchanged.

## Flow: before and after

Before:
```
cron: agent-monitor.py --alert --mark-failed  →  writes inbox directly (agent_failed messages)
cron: oom-monitor.py --since-minutes 10       →  writes inbox directly (observation messages)
REMINDER_ROUTING["ghost_detector"] → [DEAD CODE: never triggered]
REMINDER_ROUTING["oom_check"]      → [DEAD CODE: never triggered]
```

After:
```
cron: agent-monitor.py --alert --mark-failed  →  writes inbox directly (unchanged)
cron: oom-monitor.py --since-minutes 10       →  writes inbox directly (unchanged)
(no REMINDER_ROUTING — removed)
```

The `scheduled_reminder` handler itself is unchanged in behavior for user-created jobs. Only the dead `REMINDER_ROUTING` lookup is removed.

## Tests run

- [x] `git diff` reviewed — confirms only `sys.dispatcher.bootup.md` changed, single logical block removed
- [ ] Live dispatcher test — not run; this is a documentation/pseudocode file read at session start, not executed Python. No runtime behavior is affected for the active paths.

Closes #1098