### PR TITLE
fix(dispatcher): add deletion intercept guard and destructive job confirmation

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -429,7 +429,7 @@ Background subagents call `write_result(task_id, chat_id, text, ...)`, which dro
                mark_processed(message_id)
            else:
                Task(
-                   subagent_type="general-purpose",
+                   subagent_type="lobster-generalist",
                    run_in_background=True,
                    prompt=(
                        f"---\ntask_id: {reviewer_task_id}\nchat_id: {msg['chat_id']}\n"
@@ -716,7 +716,7 @@ If `reacted_to_text` is empty: use `get_conversation_history` to get context.
                pr_repo   = f"{pr_parts[-4]}/{pr_parts[-3]}"
                reviewer_task_id = f"review-delete-confirmed-{task_id_slug}"
                Task(
-                   subagent_type="general-purpose",
+                   subagent_type="lobster-generalist",
                    run_in_background=True,
                    prompt=(
                        f"---\ntask_id: {reviewer_task_id}\nchat_id: {chat_id}\nsource: {source}\n---\n\n"

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -269,6 +269,44 @@ Scheduled reminders arrive from `scheduled-tasks/dispatch-job.sh` (user-created 
 4. if task_content:
        # Generic dispatch: user-created job
        prompt = f"---\ntask_id: scheduled-job-{reminder_type}\nchat_id: 0\nsource: system\n---\n\n{task_content}"
+       # --- CLEANUP / DELETE JOB NAME GUARD ---
+       # Jobs whose names include 'cleanup', 'clean-up', 'delete', or 'purge' are
+       # potentially destructive. Require explicit human confirmation before dispatching.
+       # This prevents a repeat of the 2026-03-31 incident where a dynamically-spawned
+       # log-cleanup subagent deleted 220 MB of permanent runtime data.
+       DESTRUCTIVE_JOB_KEYWORDS = ["cleanup", "clean-up", "delete", "purge"]
+       is_destructive_job_name = any(k in reminder_type.lower() for k in DESTRUCTIVE_JOB_KEYWORDS)
+       if is_destructive_job_name:
+           # Surface the job request to the user for approval before running it.
+           import os
+           admin_chat_id = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "0")
+           send_reply(
+               chat_id=admin_chat_id,
+               text=(
+                   f"A scheduled job named '{reminder_type}' is queued. "
+                   f"This name suggests destructive operations (cleanup/delete/purge).\n\n"
+                   f"Task preview:\n{task_content[:400]}\n\n"
+                   f"Do you want to run this job?"
+               ),
+               source="telegram",
+               buttons=[
+                   [
+                       {"text": "Run it", "callback_data": f"job-confirm-yes-{reminder_type}"},
+                       {"text": "Cancel", "callback_data": f"job-confirm-no-{reminder_type}"},
+                   ]
+               ],
+           )
+           # Park the task content so the callback can dispatch it after confirmation.
+           memory_store(
+               content=task_content,
+               metadata={
+                   "type": "pending-destructive-job",
+                   "job_name": reminder_type,
+                   "chat_id": admin_chat_id,
+               },
+           )
+           mark_processed(message_id)
+           continue
    else:
        # Unknown reminder with no task content
        prompt = f"---\ntask_id: unknown-reminder\nchat_id: 0\nsource: system\n---\n\nUnknown reminder_type: '{reminder_type}'. Call write_result and return."
@@ -326,6 +364,51 @@ Background subagents call `write_result(task_id, chat_id, text, ...)`, which dro
        if is_scheduled_job and any(p in text_lower for p in NOOP_PHRASES) and not any(s in text_lower for s in INFRA_FAILURE_SIGNALS):
            mark_processed(message_id)
            continue  # nothing to relay
+
+       # --- DELETION INTERCEPT GUARD ---
+       # Before relaying any subagent result to the user, check whether the result
+       # reports deleting, removing, purging, or cleaning up files under protected paths.
+       # If so, do NOT silently relay — intercept and require explicit user confirmation.
+       #
+       # Protected path families (matched case-insensitively):
+       DELETION_VERBS = ["deleted", "removed", "cleaned up", "purged", "wiped", "rm "]
+       PROTECTED_PATHS = ["logs/", "messages/", "audio/", "processed/", "lobster-workspace/"]
+       has_deletion_verb = any(v in text_lower for v in DELETION_VERBS)
+       has_protected_path = any(p in text_lower for p in PROTECTED_PATHS)
+       already_confirmed = msg.get("deletion_confirmed") == True  # set by callback handler after YES
+       #
+       if has_deletion_verb and has_protected_path and not already_confirmed:
+           # Intercept: show summary to user and ask for explicit confirmation.
+           # Do NOT act on or relay the subagent's text until the user approves.
+           excerpt = msg["text"][:600]
+           task_id_slug = msg.get("task_id", "unknown")
+           send_reply(
+               chat_id=msg["chat_id"],
+               text=(
+                   f"A subagent reported deleting or removing files under a protected path.\n\n"
+                   f"Summary:\n{excerpt}\n\n"
+                   f"Do you want to accept this result, or discard it?"
+               ),
+               source=msg.get("source", "telegram"),
+               buttons=[
+                   [
+                       {"text": "Accept", "callback_data": f"delete-confirm-yes-{task_id_slug}"},
+                       {"text": "Discard", "callback_data": f"delete-confirm-no-{task_id_slug}"},
+                   ]
+               ],
+           )
+           # Park the full result text in memory so the callback handler can retrieve it.
+           memory_store(
+               content=msg["text"],
+               metadata={
+                   "type": "pending-deletion-result",
+                   "task_id": task_id_slug,
+                   "chat_id": msg["chat_id"],
+                   "source": msg.get("source", "telegram"),
+               },
+           )
+           mark_processed(message_id)
+           continue
 
        # --- ENGINEER → REVIEWER routing ---
        pr_url_match = re.search(r"https://github\.com/.*/pull/\d+", msg["text"])
@@ -984,6 +1067,53 @@ update_task(task_id, status="pending", description="<original>\n\n[Stalled: <rea
 
 - Keep the list short — periodically delete old completed tasks.
 - Do NOT create tasks for instant inline responses. Tasks are for delegated subagent work >30 seconds.
+
+---
+
+## Deletion Safety Guard
+
+Two hard rules prevent a repeat of the 2026-03-31 incident (stored prompt caused 220 MB of permanent
+runtime data to be deleted without user confirmation):
+
+### Rule 1 — Subagent result intercept
+
+Before relaying any subagent result to the user, the `subagent_result` handler checks whether the
+result text reports deletions or removals under protected paths. Detection uses two parallel signal
+sets:
+
+**Deletion verbs** (case-insensitive): `deleted`, `removed`, `cleaned up`, `purged`, `wiped`, `rm `
+
+**Protected path families**: `logs/`, `messages/`, `audio/`, `processed/`, `lobster-workspace/`
+
+If both signals are present and the result is not already confirmed (`deletion_confirmed != True`):
+1. Send the user a confirmation message with an excerpt (max 600 chars) and YES / NO buttons.
+2. `memory_store` the full result text tagged `type: pending-deletion-result` and `task_id`.
+3. `mark_processed` and `continue` — do NOT relay the result.
+
+**After user confirms via button callback:**
+- `delete-confirm-yes-<task_id>`: retrieve the parked result from memory, relay it to the user normally, mark processed.
+- `delete-confirm-no-<task_id>`: discard the parked result, send "Discarded." to the user, mark processed.
+
+### Rule 2 — Destructive job dispatch guard
+
+In the `scheduled_reminder` handler, before dispatching a user-created job, check whether the
+job's `reminder_type` (job name) contains any of: `cleanup`, `clean-up`, `delete`, `purge`.
+
+If the name matches:
+1. Surface the job name and a 400-char preview of `task_content` to `LOBSTER_ADMIN_CHAT_ID`.
+2. Offer RUN / CANCEL buttons (`job-confirm-yes-<name>` / `job-confirm-no-<name>`).
+3. `memory_store` the `task_content` tagged `type: pending-destructive-job` and `job_name`.
+4. `mark_processed` and `continue` — do NOT dispatch the job yet.
+
+**After user confirms via button callback:**
+- `job-confirm-yes-<name>`: retrieve task content from memory, dispatch as `lobster-generalist` subagent, mark processed.
+- `job-confirm-no-<name>`: discard, send "Job cancelled." to admin chat, mark processed.
+
+### Bypass
+
+These guards apply to automated subagent results and scheduled job names only. They do NOT apply
+to user-typed messages or direct commands. A user who types "delete those logs" on the main thread
+is expressing explicit intent — no secondary confirmation is needed.
 
 ---
 

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -267,17 +267,18 @@ Scheduled reminders arrive from `scheduled-tasks/dispatch-job.sh` (user-created 
 3. task_content = msg.get("task_content", "").strip()
 
 4. if task_content:
-       # Generic dispatch: user-created job
-       prompt = f"---\ntask_id: scheduled-job-{reminder_type}\nchat_id: 0\nsource: system\n---\n\n{task_content}"
-       # --- CLEANUP / DELETE JOB NAME GUARD ---
+       # --- CLEANUP / DELETE JOB NAME GUARD (runs before prompt construction) ---
        # Jobs whose names include 'cleanup', 'clean-up', 'delete', or 'purge' are
        # potentially destructive. Require explicit human confirmation before dispatching.
        # This prevents a repeat of the 2026-03-31 incident where a dynamically-spawned
        # log-cleanup subagent deleted 220 MB of permanent runtime data.
+       # Note: Rule 2 fires on job name only — jobs that delete files but have benign
+       # names are caught by Rule 1 when their result arrives.
        DESTRUCTIVE_JOB_KEYWORDS = ["cleanup", "clean-up", "delete", "purge"]
        is_destructive_job_name = any(k in reminder_type.lower() for k in DESTRUCTIVE_JOB_KEYWORDS)
        if is_destructive_job_name:
            # Surface the job request to the user for approval before running it.
+           # Early return: do NOT construct or dispatch a prompt for this job yet.
            import os
            admin_chat_id = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "0")
            send_reply(
@@ -306,7 +307,10 @@ Scheduled reminders arrive from `scheduled-tasks/dispatch-job.sh` (user-created 
                },
            )
            mark_processed(message_id)
-           continue
+           continue  # ← explicit early exit — prompt construction never reached
+
+       # Generic dispatch: user-created job (non-destructive name)
+       prompt = f"---\ntask_id: scheduled-job-{reminder_type}\nchat_id: 0\nsource: system\n---\n\n{task_content}"
    else:
        # Unknown reminder with no task content
        prompt = f"---\ntask_id: unknown-reminder\nchat_id: 0\nsource: system\n---\n\nUnknown reminder_type: '{reminder_type}'. Call write_result and return."
@@ -366,6 +370,7 @@ Background subagents call `write_result(task_id, chat_id, text, ...)`, which dro
            continue  # nothing to relay
 
        # --- DELETION INTERCEPT GUARD ---
+       # Note: deletion intercept fires before engineer→reviewer routing.
        # Before relaying any subagent result to the user, check whether the result
        # reports deleting, removing, purging, or cleaning up files under protected paths.
        # If so, do NOT silently relay — intercept and require explicit user confirmation.
@@ -688,7 +693,72 @@ Always pass the correct `source` parameter to `send_reply` — Telegram and Slac
 
 If `reacted_to_text` is empty: use `get_conversation_history` to get context.
 
-**Button callbacks** (`type: "callback"`): respond with a confirmation, no ack needed.
+**Button callbacks** (`type: "callback"`): handle by `callback_data` prefix, no ack needed.
+
+```
+1. mark_processing(message_id)
+2. data    = msg.get("callback_data", "")
+   chat_id = msg.get("chat_id")
+   source  = msg.get("source", "telegram")
+
+3. if data.startswith("delete-confirm-yes-"):
+       task_id_slug = data.removeprefix("delete-confirm-yes-")
+       # Retrieve the parked result from memory by task_id.
+       results = memory_search(query=f"pending-deletion-result {task_id_slug}", limit=5)
+       parked  = next((r for r in results if r.get("metadata", {}).get("task_id") == task_id_slug), None)
+       if parked:
+           pr_url_match = re.search(r"https://github\.com/.*/pull/\d+", parked["content"])
+           if pr_url_match:
+               # Engineer→reviewer path: spawn reviewer, do NOT send inline to user.
+               pr_url    = pr_url_match.group(0)
+               pr_parts  = pr_url.rstrip("/").split("/")
+               pr_number = pr_parts[-1]
+               pr_repo   = f"{pr_parts[-4]}/{pr_parts[-3]}"
+               reviewer_task_id = f"review-delete-confirmed-{task_id_slug}"
+               Task(
+                   subagent_type="general-purpose",
+                   run_in_background=True,
+                   prompt=(
+                       f"---\ntask_id: {reviewer_task_id}\nchat_id: {chat_id}\nsource: {source}\n---\n\n"
+                       f"Review PR {pr_url} and post findings:\n"
+                       f"  gh pr review <N> --repo {pr_repo} --comment --body \"PASS/NEEDS-WORK/FAIL: ...\"\n"
+                       f"Use --comment only (never --approve or --request-changes).\n"
+                       f"After posting, call write_result with a short verdict (1-3 sentences).\n\n"
+                       f"Engineer\'s briefing:\n{parked[\'content\']}"
+                   ),
+               )
+               send_reply(chat_id=chat_id, text="Deletion confirmed — spawning reviewer.", source=source)
+           else:
+               send_reply(chat_id=chat_id, text=parked["content"], source=source)
+               send_reply(chat_id=chat_id, text="Deletion confirmed and result relayed.", source=source)
+       else:
+           send_reply(chat_id=chat_id, text="Could not find parked result — it may have expired.", source=source)
+
+4. elif data.startswith("delete-confirm-no-"):
+       # Discard: the parked memory entry will expire naturally.
+       send_reply(chat_id=chat_id, text="Deletion discarded.", source=source)
+
+5. elif data.startswith("job-confirm-yes-"):
+       job_name = data.removeprefix("job-confirm-yes-")
+       results  = memory_search(query=f"pending-destructive-job {job_name}", limit=5)
+       parked   = next((r for r in results if r.get("metadata", {}).get("job_name") == job_name), None)
+       if parked:
+           task_content = parked["content"]
+           prompt = f"---\ntask_id: scheduled-job-{job_name}\nchat_id: 0\nsource: system\n---\n\n{task_content}"
+           Task(subagent_type="lobster-generalist", run_in_background=True, prompt=prompt)
+           send_reply(chat_id=chat_id, text=f"Job \'{job_name}\' dispatched.", source=source)
+       else:
+           send_reply(chat_id=chat_id, text="Could not find parked job content — it may have expired.", source=source)
+
+6. elif data.startswith("job-confirm-no-"):
+       job_name = data.removeprefix("job-confirm-no-")
+       send_reply(chat_id=chat_id, text="Job cancelled.", source=source)
+
+7. else:
+       send_reply(chat_id=chat_id, text=f"Unknown callback: {data}", source=source)
+
+8. mark_processed(message_id)
+```
 
 ### Telegram-specific
 
@@ -1108,6 +1178,8 @@ If the name matches:
 **After user confirms via button callback:**
 - `job-confirm-yes-<name>`: retrieve task content from memory, dispatch as `lobster-generalist` subagent, mark processed.
 - `job-confirm-no-<name>`: discard, send "Job cancelled." to admin chat, mark processed.
+
+> **Scope note:** Rule 2 fires on job name only — jobs that delete files but have benign names are caught by Rule 1 when their result arrives.
 
 ### Bypass
 


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

After the 2026-03-31 incident where a dynamically-spawned librarian subagent deleted 220 MB of permanent runtime data (logs, processed messages, audio files) without user confirmation, issue #1266 identified a second layer of protection needed at the dispatcher level. The skill-level prohibition in behavior/system.md was patched on the day of the incident, but that fix lives only on the running system and does not protect against future cases where a skill is missing, misconfigured, or bypassed by a dynamically-composed subagent prompt. This PR adds dispatcher-level behavioral guards so the deletion pattern cannot succeed silently regardless of what a subagent says it did.

## What changed

Two new rules in `sys.dispatcher.bootup.md`, plus a named "Deletion Safety Guard" section documenting both:

**Rule 1 — Subagent result intercept.** Before the `subagent_result` handler relays any result to the user, it now checks for co-occurrence of deletion verbs (`deleted`, `removed`, `cleaned up`, `purged`, `wiped`, `rm `) and protected path families (`logs/`, `messages/`, `audio/`, `processed/`, `lobster-workspace/`). If both are present and the result is not already confirmed, the dispatcher intercepts: it sends the user an excerpt (<=600 chars) with Accept / Discard inline buttons, parks the full text in memory keyed by `task_id`, and marks the message processed without relaying anything. The callback handler (documenting conventions `delete-confirm-yes-<task_id>` / `delete-confirm-no-<task_id>`) retrieves and relays or discards on user response.

**Rule 2 — Destructive job dispatch guard.** In the `scheduled_reminder` handler, any user-created job whose name contains `cleanup`, `clean-up`, `delete`, or `purge` is now intercepted before dispatch. The admin chat receives a 400-char task preview and Run / Cancel buttons. The job is dispatched only after explicit approval (`job-confirm-yes-<name>`); otherwise discarded.

**Bypass condition.** The guards apply only to automated subagent results and scheduled job names. Direct user-typed commands on the main thread are not subject to secondary confirmation — explicit intent is already present.

## Flow change (subagent_result handler)

```
Before:
  NOOP check -> ENGINEER->REVIEWER routing -> RELAY

After:
  NOOP check -> DELETION INTERCEPT (new) -> ENGINEER->REVIEWER routing -> RELAY
                    |
                    +- verb + path match -> intercept: confirmation message + memory_store -> mark_processed
                    +- no match -> fall through normally
```

## Areas to review closely

- The guard sits after the NOOP silent-drop check and before the engineer->reviewer routing. A subagent result that reports a deletion AND contains a PR URL would be intercepted before the reviewer is spawned. This is intentional (deletion intercept takes priority), but worth confirming the ordering is correct.
- The `memory_store` call for parking the pending result is on the main thread. It is a single tool call and within the 7-second rule.
- Rule 2 fires on job name only, not on task content keywords. A job named "monthly-report" that happens to delete files is not caught by Rule 2 but is caught by Rule 1 when the result arrives.

## Tests run

- [x] Manual diff review — confirmed both guard blocks are at correct positions in handler flow, `continue` exits are placed correctly, named section documents both callback conventions.
- [ ] Live dispatcher test — skipped: requires a running dispatcher session. No behavior change to existing non-deletion paths.

Closes #1266