### PR TITLE
fix: add SSH pre-check guard to lobstertalk-incoming-handler

### DIFF
--- a/.githooks/security-allowlist.txt
+++ b/.githooks/security-allowlist.txt
@@ -71,11 +71,16 @@ src/bot/whatsapp_bridge_adapter.py:Email address
 # grep — this is a variable reference, not a hardcoded credential value
 scripts/claude-wrapper.exp:Hardcoded token
 
-# bot-talk-check-dispatch.sh uses the same bot-talk API IP that already appears
-# throughout the codebase (scheduled-tasks/tasks/bot-talk-poller*.md). The default
-# value is a fallback when BOT_TALK_API_URL env var is unset — not a secret.
+# bot-talk-check-dispatch.sh and lobstertalk-incoming-check-dispatch.sh use the same
+# bot-talk API IP that already appears throughout the codebase (scheduled-tasks/tasks/).
+# The default value is a fallback when BOT_TALK_HOST/BOT_TALK_API_URL env var is unset — not a secret.
 scheduled-tasks/bot-talk-check-dispatch.sh:IP address
+scheduled-tasks/lobstertalk-incoming-check-dispatch.sh:IP address
 
 # scripts/upgrade.sh contains pre-existing migration comments written before the
 # name-block hook was added. These are historical references, not new additions.
 scripts/upgrade.sh:Personal name (sahar)
+
+# upgrade.sh migration M60 comment references the bot-talk host IP for clarity.
+# Same IP already appears in bot-talk-check-dispatch.sh (allowlisted above).
+scripts/upgrade.sh:IP address

--- a/scheduled-tasks/lobstertalk-incoming-check-dispatch.sh
+++ b/scheduled-tasks/lobstertalk-incoming-check-dispatch.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# LobsterTalk Incoming Handler Pre-Check Dispatcher
+#
+# Tests SSH connectivity to the bot-talk host before dispatching the
+# lobstertalk-incoming-handler job. If the host is unreachable, logs a
+# brief "host unreachable, skipping" message and exits cleanly — no LLM
+# subagent is spawned, no error is escalated.
+#
+# If the host is reachable, delegates to dispatch-job.sh as normal.
+#
+# Usage: lobstertalk-incoming-check-dispatch.sh lobstertalk-incoming-handler
+#
+# Flow:
+#   host reachable   → dispatch-job.sh lobstertalk-incoming-handler → inbox write → LLM
+#   host unreachable → log skip → exit 0 (no inbox write)
+
+set -e
+
+export PATH="$HOME/.local/bin:$PATH"
+
+JOB_NAME="${1:-lobstertalk-incoming-handler}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Load env files (same pattern as dispatch-job.sh)
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+for _env_file in "$CONFIG_DIR/config.env" "$CONFIG_DIR/global.env"; do
+    if [ -f "$_env_file" ]; then
+        # shellcheck source=/dev/null
+        set -a
+        source "$_env_file"
+        set +a
+    fi
+done
+unset _env_file
+
+WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+LOG_DIR="$WORKSPACE/scheduled-jobs/logs"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+START_ISO=$(date -Iseconds)
+
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${JOB_NAME}-precheck-${TIMESTAMP}.log"
+
+# --- SSH connectivity pre-check ---
+# The bot-talk host. Can be overridden via BOT_TALK_HOST in config.env.
+BOT_TALK_HOST="${BOT_TALK_HOST:-46.224.41.108}"
+BOT_TALK_USER="${BOT_TALK_USER:-shared}"
+
+# Test SSH connectivity with a short timeout. BatchMode=yes prevents interactive
+# prompts; StrictHostKeyChecking=no avoids blocking on first-connect key checks.
+# We only test connectivity (ssh ... exit) — no actual work is performed here.
+if ! ssh \
+    -o ConnectTimeout=5 \
+    -o BatchMode=yes \
+    -o StrictHostKeyChecking=no \
+    "${BOT_TALK_USER}@${BOT_TALK_HOST}" exit 2>/dev/null; then
+    echo "[$START_ISO] Host ${BOT_TALK_HOST} unreachable — skipping dispatch for $JOB_NAME" | tee "$LOG_FILE"
+    exit 0
+fi
+
+# Host is reachable — delegate to standard dispatcher
+echo "[$START_ISO] Host ${BOT_TALK_HOST} reachable — dispatching $JOB_NAME" | tee "$LOG_FILE"
+exec "$SCRIPT_DIR/dispatch-job.sh" "$JOB_NAME"

--- a/scheduled-tasks/run-lobstertalk-incoming-handler.sh
+++ b/scheduled-tasks/run-lobstertalk-incoming-handler.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Wrapper for systemd: runs SSH pre-check then dispatches lobstertalk-incoming-handler
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/lobstertalk-incoming-check-dispatch.sh" lobstertalk-incoming-handler

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2264,7 +2264,7 @@ PYEOF
         migrated=$((migrated + 1))
     fi
 
-    # Migration 60: Wire lobstertalk-incoming-handler service to use the SSH pre-check wrapper.
+    # Migration 62: Wire lobstertalk-incoming-handler service to use the SSH pre-check wrapper.
     # The service was created calling dispatch-job.sh directly, which means it spawns
     # a Claude subagent even when the bot-talk host (46.224.41.108) is unreachable and
     # fails noisily. The pre-check wrapper (lobstertalk-incoming-check-dispatch.sh) tests
@@ -2279,8 +2279,8 @@ PYEOF
             sudo sed -i \
                 "s|ExecStart=.*/dispatch-job.sh lobstertalk-incoming-handler|ExecStart=$LOBSTER_DIR/scheduled-tasks/run-lobstertalk-incoming-handler.sh|" \
                 "$LOBSTERTALK_SERVICE"
-            sudo systemctl daemon-reload 2>/dev/null || warn "Failed to reload systemd daemon after M60"
-            substep "M60: Updated lobstertalk-incoming-handler service to use SSH pre-check wrapper"
+            sudo systemctl daemon-reload 2>/dev/null || warn "Failed to reload systemd daemon after M62"
+            substep "M62: Updated lobstertalk-incoming-handler service to use SSH pre-check wrapper"
             migrated=$((migrated + 1))
         fi
     fi

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2264,6 +2264,27 @@ PYEOF
         migrated=$((migrated + 1))
     fi
 
+    # Migration 60: Wire lobstertalk-incoming-handler service to use the SSH pre-check wrapper.
+    # The service was created calling dispatch-job.sh directly, which means it spawns
+    # a Claude subagent even when the bot-talk host (46.224.41.108) is unreachable and
+    # fails noisily. The pre-check wrapper (lobstertalk-incoming-check-dispatch.sh) tests
+    # SSH connectivity first and exits cleanly if the host is down.
+    local LOBSTERTALK_SERVICE="/etc/systemd/system/lobster-lobstertalk-incoming-handler.service"
+    local LOBSTERTALK_PRECHECK_SCRIPT="$LOBSTER_DIR/scheduled-tasks/lobstertalk-incoming-check-dispatch.sh"
+    local LOBSTERTALK_RUN_SCRIPT="$LOBSTER_DIR/scheduled-tasks/run-lobstertalk-incoming-handler.sh"
+    if [ -f "$LOBSTERTALK_SERVICE" ] && [ -f "$LOBSTERTALK_PRECHECK_SCRIPT" ]; then
+        if grep -q "dispatch-job.sh lobstertalk-incoming-handler" "$LOBSTERTALK_SERVICE"; then
+            chmod +x "$LOBSTERTALK_PRECHECK_SCRIPT" 2>/dev/null || true
+            chmod +x "$LOBSTERTALK_RUN_SCRIPT" 2>/dev/null || true
+            sudo sed -i \
+                "s|ExecStart=.*/dispatch-job.sh lobstertalk-incoming-handler|ExecStart=$LOBSTER_DIR/scheduled-tasks/run-lobstertalk-incoming-handler.sh|" \
+                "$LOBSTERTALK_SERVICE"
+            sudo systemctl daemon-reload 2>/dev/null || warn "Failed to reload systemd daemon after M60"
+            substep "M60: Updated lobstertalk-incoming-handler service to use SSH pre-check wrapper"
+            migrated=$((migrated + 1))
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

Every 5 minutes, the `lobstertalk-incoming-handler` timer fires and unconditionally dispatches a message to the inbox — spawning a Claude subagent regardless of whether the bot-talk host (`46.224.41.108`) is reachable. When the host is down, the subagent spins up, tries to connect, fails, and surfaces a noisy error. There is no guard: the system never checks whether SSH is even possible before invoking Claude.

This PR adds a shell-level SSH pre-check that runs before any LLM work. If the host is unreachable, the job exits cleanly with a one-line log entry and no subagent is spawned. If reachable, the flow continues unchanged.

## What changed

**New file: `scheduled-tasks/lobstertalk-incoming-check-dispatch.sh`**

Mirrors the existing `bot-talk-check-dispatch.sh` pre-check pattern (already used for the bot-talk-poller). Runs `ssh -o ConnectTimeout=5 -o BatchMode=yes shared@46.224.41.108 exit` before calling `dispatch-job.sh`. On SSH failure: logs "host unreachable, skipping", exits 0. On success: delegates to `dispatch-job.sh` as normal.

The host and user are read from `BOT_TALK_HOST` / `BOT_TALK_USER` env vars (set in config.env), falling back to the hardcoded defaults if unset.

**Updated: `scheduled-tasks/run-lobstertalk-incoming-handler.sh`**

This wrapper existed on disk but was not committed to the repo. Now committed; it delegates to `lobstertalk-incoming-check-dispatch.sh` rather than `dispatch-job.sh` directly.

**Migration M60 in `scripts/upgrade.sh`**

The live systemd service (`lobster-lobstertalk-incoming-handler.service`) calls `dispatch-job.sh` directly — bypassing the run wrapper. Migration M60 idempotently rewires the service's `ExecStart` to use `run-lobstertalk-incoming-handler.sh` and runs `systemctl daemon-reload`.

**No changes to the task file or LLM behavior.** The pre-check is entirely at the shell layer; when the host is reachable, the subagent receives the same task file it always has.

## Flow (before → after)

```
Before:
  timer fires → dispatch-job.sh → inbox write → Claude subagent → SSH connect fails → error

After:
  timer fires → run-lobstertalk-incoming-handler.sh
                  └─ lobstertalk-incoming-check-dispatch.sh
                       ├─ host unreachable → log "skipping" → exit 0 (no subagent)
                       └─ host reachable   → dispatch-job.sh → inbox write → Claude subagent
```

## Tests run

- [x] `bash -n scheduled-tasks/lobstertalk-incoming-check-dispatch.sh` — syntax clean
- [x] `bash -n scheduled-tasks/run-lobstertalk-incoming-handler.sh` — syntax clean
- [ ] Live SSH test against 46.224.41.108 — skipped: not run from this environment; behavior mirrors the tested `bot-talk-check-dispatch.sh` pre-check which uses the same SSH pattern
- [ ] Migration M60 — not applied: requires `sudo systemctl` on target host; will run on next `upgrade.sh` execution

Closes #1099