### PR TITLE
fix(sessions): ensure short-lived sessions always produce recoverable records

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -27,7 +27,7 @@ When you first start (or after reading this file), follow these steps:
 1. Call `session_start(agent_type='dispatcher', claude_session_id=hook_input["session_id"])` — pass the Claude session UUID injected by the SessionStart hook. This writes the UUID to `$LOBSTER_WORKSPACE/data/dispatcher-claude-session-id`, enabling `inject-bootup-context.py` to identify your session as the dispatcher and inject this file on future restarts. Without this call, the primary detection path is never populated and you will receive the subagent bootup file instead of this one.
 1a. Read `~/lobster-user-config/memory/canonical/handoff.md` — user context, active projects, key people, git rules, available integrations.
 2. Read `~/lobster-workspace/user-model/_context.md` if it exists — pre-computed summary of user values, preferences, and active projects. Skip if absent.
-2a. Create a new session file inline (see Session File Management). Store its path as `current_session_file`.
+2a. Create a new session file inline (see Session File Management). Store its path as `current_session_file`. Immediately after copying the template, write the session's start timestamp and set `Messages processed: 0` and `End reason: active` — this makes the file recoverable even if the session ends before any subagent writes to it.
 2b. Call `list_rules(enabled_only=true)` to load IFTTT behavioral rules into working context.
 2c. Check `~/lobster-workspace/data/context-handoff.json`:
     - If **recent** (< 10 min, based on `triggered_at`): read `context_pct`, `pending_tasks`, `last_user_message`. Notify user: "Restarted — context was at {context_pct}%. Resuming from where we left off." Re-queue any stuck messages from `~/messages/processing/`. Delete the file.
@@ -539,16 +539,22 @@ Written by `hooks/context-monitor.py` when context window >= 70%.
 
 ```
 1. mark_processing(message_id)
-2. Enter wind-down mode:
+2. Write a tombstone to the current session file (inline, no subagent needed — this is fast):
+   - Set Ended to current UTC ISO timestamp
+   - Set Messages processed to the count of messages handled this session (tracked in working context as MESSAGE_COUNT)
+   - Set End reason to "context_warning"
+   - Set Summary to "Graceful wind-down triggered at {context_pct}% context. [Brief list of what was in progress, if anything.]"
+   This ensures the session file is recoverable even if nothing else was written during this session.
+3. Enter wind-down mode:
    - Set WIND_DOWN_MODE = True
    - Do NOT spawn new non-trivial subagents
    - For new user messages: ack, create_task to record, tell user "Compacting context shortly — will pick this up after."
-3. Drain in-flight agents: poll get_active_sessions() every 10s. Process arriving subagent results normally.
-4. Write ~/lobster-workspace/data/context-handoff.json:
+4. Drain in-flight agents: poll get_active_sessions() every 10s. Process arriving subagent results normally.
+5. Write ~/lobster-workspace/data/context-handoff.json:
    {"triggered_at": "<iso8601>", "context_pct": <pct>, "pending_tasks": <list>, "last_user_message": "<text>", "note": "Graceful wind-down"}
-5. Send user (use admin chat_id from config): "Context at {pct}% — entering wind-down mode. Handing off cleanly."
-6. Stop the main loop — do NOT call wait_for_messages() again. Claude Code will compact naturally.
-7. mark_processed(message_id)
+6. Send user (use admin chat_id from config): "Context at {pct}% — entering wind-down mode. Handing off cleanly."
+7. Stop the main loop — do NOT call wait_for_messages() again. Claude Code will compact naturally.
+8. mark_processed(message_id)
 ```
 
 Rules: `chat_id` is 0 — use admin chat_id for step 5. Never re-enter wind-down for a second warning. Do NOT call `lobster restart` — compaction is the recovery mechanism.
@@ -707,7 +713,11 @@ One session note file per session. Lives in `~/lobster-user-config/memory/canoni
 1. List the directory, find highest sequence number for today. If none, start at 001.
 2. Copy `session.template.md` to the new path.
 3. Replace `Started` placeholder with current UTC ISO timestamp.
-4. Store full path as `current_session_file`.
+4. Replace `Messages processed` placeholder with `0`.
+5. Replace `End reason` placeholder with `active`.
+6. Store full path as `current_session_file`.
+
+> **Why this matters:** The session file is created at startup but subagent writes only happen when real work occurs. If the session ends before any subagent writes (crash, rapid restart, short session), the file stays as a template stub — useless for recovery. Writing minimal tombstone metadata at creation time (start time, messages=0, reason=active) means even a 30-second session leaves a partially recoverable record. Subsequent updates fill in the rest.
 
 **When to update** (via background `lobster-generalist` subagent — never inline):
 - A subagent result arrives with non-trivial content (PR opened, task completed, error)
@@ -730,6 +740,16 @@ Steps: 1. Read the file. 2. Update Open Threads, Open Tasks, Open Subagents, Not
 Do not modify Summary or Started/Ended. 3. Write back. 4. Call write_result.
 ```
 
+**Tombstone on session end (unconditional):** Whenever the session ends for any reason, write a tombstone update to the session file before stopping. This is done inline (not via subagent) and takes <1 second. Minimum content:
+- `Ended`: current UTC ISO timestamp
+- `Messages processed`: MESSAGE_COUNT (tracked in working context; increment on each `mark_processed` call)
+- `End reason`: one of `graceful wind-down`, `context_warning`, `short session`, `crash` (use `short session` if session ran < 5 minutes and no reason is known)
+- `Summary`: at minimum, "Session ended [reason]. [N] messages processed." — fill in more if context permits.
+
+This rule is unconditional — even if the session processed zero messages, the tombstone must be written. A stub file with only a start timestamp is nearly as bad as no file at all.
+
+**MESSAGE_COUNT tracking:** On startup, initialize `MESSAGE_COUNT = 0` in working context. Increment it each time you call `mark_processed(message_id)` for a real user message (not system messages like `session_note_reminder`).
+
 **Periodic snapshots:** Triggered by `session_note_reminder` (every 20 user messages). Spawn `session-note-appender` (see `.claude/agents/session-note-appender.md`) with `current_session_file`, a list of recent activity visible in working context, `in_flight` (running subagents with elapsed time), and `pending_responses` (claimed but unanswered messages).
 
 **Pre-compaction polish:** On `compact-reminder`, spawn `session-note-polish` (see `.claude/agents/session-note-polish.md`) with `current_session_file` before spawning compact_catchup. When passing context to `session-note-polish`, include:
@@ -737,7 +757,7 @@ Do not modify Summary or Started/Ended. 3. Write back. 4. Call write_result.
 - Any pending user responses (messages that were mark_processing-d but not yet replied to)
 - The current MESSAGE_COUNT at time of compaction
 
-**On context_warning:** Spawn a session note update subagent as the very first step — captures current state before graceful restart erases working context.
+**On context_warning:** Write a tombstone inline as step 2 (see context_warning handler above) — this is faster and more reliable than spawning a subagent, and ensures the record survives even if wind-down is interrupted.
 
 ---
 

--- a/memory/canonical-templates/sessions/session.template.md
+++ b/memory/canonical-templates/sessions/session.template.md
@@ -11,6 +11,8 @@
 
 **Started:** <ISO timestamp, e.g. 2026-03-25T14:32:00Z>
 **Ended:** <ISO timestamp or "active">
+**Messages processed:** <count or "unknown">
+**End reason:** <"active" | "graceful wind-down" | "context_warning" | "short session" | "crash">
 
 ## Summary
 <1-3 sentence summary of what happened this session: main topics, decisions made, work completed.>


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

Sessions 003, 006, and 007 on 2026-03-31 were template stubs — the session file was created at startup but the note-polish subagent only fires above a message/time threshold. A 30-second session that ends in a crash or rapid restart leaves exactly the template placeholders that compact-catchup cannot read.

The root cause is that the session file creation and the session content writes are fully decoupled: the file is born empty and stays empty unless work happens. This PR breaks that coupling by making minimal tombstone metadata part of file creation itself.

## What changed

**session.template.md** gains two new fields: `Messages processed` and `End reason`. These give tombstone writes named slots to fill in rather than appending free-form text.

**Startup step 2a** now specifies that immediately after copying the template, the dispatcher writes `Messages processed: 0` and `End reason: active`. From the moment the file is created it is partially recoverable — compact-catchup can see "this session started at T, processed 0 messages, reason: active (crashed before update)" rather than a wall of template placeholders.

**context_warning handler** gains a new step 2 that writes the tombstone inline before entering wind-down mode. Inline (not via subagent) because it is fast, takes no I/O beyond a single file write, and must survive even if wind-down is interrupted. The previous "On context_warning: spawn a session note update subagent as the very first step" in the Session File Management section was correct in intent but the context_warning numbered steps didn't include it — so it was easy to skip.

**Session File Management** gains two new subsections:
- *Tombstone on session end (unconditional)*: specifies minimum content (Ended, Messages processed, End reason, Summary) and makes the write unconditional — even a zero-message session must write a tombstone.
- *MESSAGE_COUNT tracking*: specifies that the dispatcher initializes `MESSAGE_COUNT = 0` at startup and increments it on each real user `mark_processed` call, so tombstones have an accurate count.

## Flow change

Before:
```
startup → create file (template stubs) → [maybe] note-polish runs if session long enough → [otherwise] stub survives
```

After:
```
startup → create file → immediately write start time + messages=0 + reason=active
                                    |
         context_warning → write tombstone inline (step 2) before wind-down
                                    |
         any session end → write tombstone (unconditional rule)
```

A session that crashes before doing anything now leaves: start time, messages=0, reason=active. A session that ends via context_warning leaves: start time, end time, message count, reason=context_warning, brief summary. Both are usable by compact-catchup.

## Areas to review closely

- The inline tombstone write in context_warning (step 2) is a file write on the main thread, which normally violates the 7-second rule. It is intentionally an exception — tombstone writes are tiny (< 50ms), must happen before wind-down begins, and cannot be delegated to a subagent that may not complete before the session exits. The comment "inline, no subagent needed — this is fast" captures this intent.
- The "unconditional tombstone" rule in Session File Management does not specify a mechanism for crash terminations — it cannot, because a crash does not give the dispatcher a chance to write anything. The value here is covering graceful exits and context_warning. Crash tombstones get the partial record from step 2a (start time, messages=0, reason=active) rather than nothing.
- The session note update subagent prompt template says "Do not modify Summary or Started/Ended" — that constraint is now in tension with the tombstone rule which does update Ended and End reason. The tombstone write is inline (not via that subagent), so the constraint is not violated — but a reviewer might notice the apparent conflict.

## Tests run
- [x] Python edit script with 6 assertion checks — all passed; verified each changed section appears correctly in the output file.
- [ ] Live dispatcher session — not run; this change is documentation/prompt only (no executable code changed). Behavior change takes effect on next dispatcher restart.

Closes #1258