### PR TITLE
process: add commitment durability — deferred questions survive session boundaries

### DIFF
--- a/.claude/agents/compact-catchup.md
+++ b/.claude/agents/compact-catchup.md
@@ -135,7 +135,7 @@ Rolling summary: write failed (<reason>)
 
 ### Phase 4: Commitment carry-forward
 
-After Phase 3, verify that open commitments in the session notes are also captured in handoff.md. This is the safety net: if the dispatcher forgot to write a commitment immediately, catchup catches it here.
+After Phase 3, verify that open commitments in the session notes are also captured in `rolling-summary.md`. This is the safety net: if the dispatcher forgot to write a commitment immediately, catchup catches it here.
 
 17. Scan the tier-1 session files (the 2 most recent, already read in Phase 1) for lines matching any of these patterns:
     - `ANSWER the user:` (case-insensitive)
@@ -145,22 +145,22 @@ After Phase 3, verify that open commitments in the session notes are also captur
 
     Collect each such line as a **candidate commitment**.
 
-18. Read `~/lobster-user-config/memory/canonical/handoff.md`.
+18. Read `~/lobster-user-config/memory/canonical/rolling-summary.md`.
 
-19. For each candidate commitment, check whether handoff.md already contains it (substring match, case-insensitive). If the commitment is **not** present in handoff.md:
-    - Locate the `**Active urgent items:**` bullet list under `## CURRENT STATE`. If the section is absent, add it directly under the `---` separator after the CURRENT STATE header.
+19. For each candidate commitment, check whether `rolling-summary.md` already contains it (substring match, case-insensitive). If the commitment is **not** present:
+    - Locate the `## Open Threads / Commitments` section. If the section is absent, add it after `## Active PRs & Decisions`.
     - Prepend the missing commitment line verbatim (as found in the session note), prefixed with `- `.
     - Mark it with `(carried forward by compact-catchup)` if the original text doesn't already have that annotation.
 
-20. If any commitments were added: write handoff.md back. Include in the `write_result` footer:
+20. If any commitments were added: write `rolling-summary.md` back. Include in the `write_result` footer:
     ```
-    Commitment carry-forward: <N> item(s) added to handoff.md CRITICAL
+    Commitment carry-forward: <N> item(s) added to rolling-summary.md
     ```
     If none were missing: include:
     ```
     Commitment carry-forward: none needed
     ```
-    If handoff.md could not be read or written, note the failure but do not abort catchup.
+    If `rolling-summary.md` could not be read or written during Phase 4, note the failure but do not abort catchup.
 
 ## Session notes reading
 
@@ -211,7 +211,7 @@ Active agents: <N> (<comma-separated task_ids or "none">)
 ### Rolling summary
 Updated: <path> (<line_count> lines)
 ### Commitment carry-forward
-<N> item(s) added to handoff.md CRITICAL (or "none needed")
+<N> item(s) added to rolling-summary.md (or "none needed")
 ```
 
 Omit the "Session context" section entirely if no session files were found.
@@ -230,7 +230,7 @@ Keep each line to one sentence. The dispatcher is on mobile -- brevity matters.
 - If the session file cannot be found or written (permissions, path not found), note the failure in `write_result` and continue -- do not crash the entire catchup.
 - If `rolling-summary.md` cannot be read or written, note the failure in `write_result` and continue -- do not abort catchup.
 - Never remove content from rolling-summary.md unless there is clear evidence in the inbox scan that the item is resolved. When in doubt, carry it forward.
-- If handoff.md cannot be read or written during Phase 4, note the failure in `write_result` and continue -- do not abort catchup.
+- If `rolling-summary.md` cannot be read or written during Phase 4, note the failure in `write_result` and continue -- do not abort catchup (this is separate from the Phase 3 rolling summary update).
 
 ## Delivering results
 

--- a/.claude/agents/compact-catchup.md
+++ b/.claude/agents/compact-catchup.md
@@ -133,6 +133,35 @@ Or, on failure:
 Rolling summary: write failed (<reason>)
 ```
 
+### Phase 4: Commitment carry-forward
+
+After Phase 3, verify that open commitments in the session notes are also captured in handoff.md. This is the safety net: if the dispatcher forgot to write a commitment immediately, catchup catches it here.
+
+17. Scan the tier-1 session files (the 2 most recent, already read in Phase 1) for lines matching any of these patterns:
+    - `ANSWER the user:` (case-insensitive)
+    - `CRITICAL open commitment`
+    - `still pending` / `never answered` / `needs answer`
+    - `deferred — needs answer`
+
+    Collect each such line as a **candidate commitment**.
+
+18. Read `~/lobster-user-config/memory/canonical/handoff.md`.
+
+19. For each candidate commitment, check whether handoff.md already contains it (substring match, case-insensitive). If the commitment is **not** present in handoff.md:
+    - Locate the `**Active urgent items:**` bullet list under `## CURRENT STATE`. If the section is absent, add it directly under the `---` separator after the CURRENT STATE header.
+    - Prepend the missing commitment line verbatim (as found in the session note), prefixed with `- `.
+    - Mark it with `(carried forward by compact-catchup)` if the original text doesn't already have that annotation.
+
+20. If any commitments were added: write handoff.md back. Include in the `write_result` footer:
+    ```
+    Commitment carry-forward: <N> item(s) added to handoff.md CRITICAL
+    ```
+    If none were missing: include:
+    ```
+    Commitment carry-forward: none needed
+    ```
+    If handoff.md could not be read or written, note the failure but do not abort catchup.
+
 ## Session notes reading
 
 Read session notes from `~/lobster-user-config/memory/canonical/sessions/` in tiers:
@@ -181,6 +210,8 @@ Updated: <path>
 Active agents: <N> (<comma-separated task_ids or "none">)
 ### Rolling summary
 Updated: <path> (<line_count> lines)
+### Commitment carry-forward
+<N> item(s) added to handoff.md CRITICAL (or "none needed")
 ```
 
 Omit the "Session context" section entirely if no session files were found.
@@ -199,6 +230,7 @@ Keep each line to one sentence. The dispatcher is on mobile -- brevity matters.
 - If the session file cannot be found or written (permissions, path not found), note the failure in `write_result` and continue -- do not crash the entire catchup.
 - If `rolling-summary.md` cannot be read or written, note the failure in `write_result` and continue -- do not abort catchup.
 - Never remove content from rolling-summary.md unless there is clear evidence in the inbox scan that the item is resolved. When in doubt, carry it forward.
+- If handoff.md cannot be read or written during Phase 4, note the failure in `write_result` and continue -- do not abort catchup.
 
 ## Delivering results
 

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -853,3 +853,40 @@ If fewer than 2 trackable questions are present, apply no special handling — r
 - **One note maximum per turn.** If multiple questions are unaddressed, list them all in a single "Note:" line.
 - **No loop behavior.** Never ask "did I answer all your questions?" Do not re-surface unanswered questions on the next turn unless the user brings them up.
 - **Rhetorical questions are not tracked.** Do not append notes for questions that are clearly rhetorical (see detection rules above).
+
+---
+
+## Commitment Durability
+
+A **commitment** is created when you tell the user you will answer something or do something later — not just note it. Commitments must survive session boundaries. Session notes do not survive compaction reliably; handoff.md CRITICAL does.
+
+**Trigger:** You defer a response with language like:
+- "I'll check on that"
+- "I need to look into this"
+- "I'll get back to you on X"
+- "Checking now" (when spawning a subagent that may not complete before compaction)
+- Any explicit question from the user that you cannot answer inline AND you do not answer within the same session turn
+
+**Required action:** Immediately after sending the deferral reply, spawn a background subagent to write the deferred commitment to `handoff.md`:
+
+```
+Task(
+    subagent_type="lobster-generalist",
+    run_in_background=True,
+    prompt=(
+        "---\ntask_id: commitment-capture-<slug>\nchat_id: 0\nsource: system\n---\n\n"
+        "Capture an open commitment in handoff.md.\n\n"
+        "1. Read ~/lobster-user-config/memory/canonical/handoff.md\n"
+        "2. Find the '**Active urgent items:**' bullet list under ## CURRENT STATE. "
+           "If the section does not exist, add it.\n"
+        "3. Add this line if it is not already present (check for substring match to avoid duplicates):\n"
+        "   - ANSWER the user: <exact question text> (asked <HH:MM ET>, deferred — needs answer)\n"
+        "4. Write the file back.\n"
+        "5. Call write_result with task_id='commitment-capture-<slug>', chat_id=0, source='system'."
+    ),
+)
+```
+
+**Idempotency:** Before adding the line, check that no existing line in the file already captures the same question (substring match is sufficient). Do not add duplicates.
+
+**Scope:** Only direct questions or explicit commitments from the user. Do not apply to internal system events, subagent status queries, or rhetorical questions.

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -858,7 +858,7 @@ If fewer than 2 trackable questions are present, apply no special handling — r
 
 ## Commitment Durability
 
-A **commitment** is created when you tell the user you will answer something or do something later — not just note it. Commitments must survive session boundaries. Session notes do not survive compaction reliably; handoff.md CRITICAL does.
+A **commitment** is created when you tell the user you will answer something or do something later — not just note it. Commitments must survive session boundaries. Session notes do not survive compaction reliably; `rolling-summary.md` is the designated cross-session truth and is read at every session start.
 
 **Trigger:** You defer a response with language like:
 - "I'll check on that"
@@ -867,7 +867,7 @@ A **commitment** is created when you tell the user you will answer something or 
 - "Checking now" (when spawning a subagent that may not complete before compaction)
 - Any explicit question from the user that you cannot answer inline AND you do not answer within the same session turn
 
-**Required action:** Immediately after sending the deferral reply, spawn a background subagent to write the deferred commitment to `handoff.md`:
+**Required action:** Immediately after sending the deferral reply, spawn a background subagent to write the deferred commitment to `rolling-summary.md`:
 
 ```
 Task(
@@ -875,12 +875,12 @@ Task(
     run_in_background=True,
     prompt=(
         "---\ntask_id: commitment-capture-<slug>\nchat_id: 0\nsource: system\n---\n\n"
-        "Capture an open commitment in handoff.md.\n\n"
-        "1. Read ~/lobster-user-config/memory/canonical/handoff.md\n"
-        "2. Find the '**Active urgent items:**' bullet list under ## CURRENT STATE. "
-           "If the section does not exist, add it.\n"
+        "Capture an open commitment in rolling-summary.md.\n\n"
+        "1. Read ~/lobster-user-config/memory/canonical/rolling-summary.md\n"
+        "2. Find the '## Open Threads / Commitments' section. "
+           "If the section does not exist, add it after '## Active PRs & Decisions'.\n"
         "3. Add this line if it is not already present (check for substring match to avoid duplicates):\n"
-        "   - ANSWER the user: <exact question text> (asked <HH:MM ET>, deferred — needs answer)\n"
+        "   - **ANSWER the user**: <exact question text> (asked <HH:MM ET>, deferred — needs answer)\n"
         "4. Write the file back.\n"
         "5. Call write_result with task_id='commitment-capture-<slug>', chat_id=0, source='system'."
     ),


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

Commitments made to the user (questions deferred, tasks promised) were only recorded in session notes. Session notes don't survive compaction reliably — they exist in long-term storage but are not re-loaded at session start unless catchup explicitly surfaces them. The result: a question asked at 9:32 AM was noted as pending across 5 consecutive sessions (005–009) without ever being answered.

## What this changes

**Two independent fixes that compose:**

**1. Dispatcher: immediate commitment capture (proactive)**

A new `## Commitment Durability` section in `sys.dispatcher.bootup.md` establishes: when the dispatcher defers a response to the user (with language like "I'll check on this", "checking now", or any question that cannot be answered inline), it must immediately spawn a background subagent to write that commitment to `rolling-summary.md` under `## Open Threads / Commitments`. `rolling-summary.md` is the designated cross-session truth file and is read at every session start; session notes are not.

The subagent uses an idempotency check (substring match) before writing, so re-spawning is safe.

This is distinct from the "no automated follow-up spawning" constraint in Multi-Question Handling, which governs question-tracking. This is commitment capture: the dispatcher already decided to defer — it just needs to record that deferral durably.

**2. compact-catchup: commitment carry-forward (safety net)**

A new Phase 4 in `compact-catchup.md` runs after the rolling summary update. It scans the two most recent session files (already read during Phase 1) for commitment patterns (`ANSWER the user:`, `needs answer`, `never answered`, `deferred — needs answer`) and verifies each one is present in `rolling-summary.md`. Any missing items are prepended to the `## Open Threads / Commitments` section.

This catches the failure mode where the dispatcher forgot to write the commitment immediately (the bug that existed before fix 1) and also handles any edge cases where fix 1 fires but the write fails.

**Why `rolling-summary.md`, not `handoff.md`:**

`rolling-summary.md` is the designated cross-session truth file — it already has an `## Open Threads / Commitments` section purpose-built for this, and it is explicitly read at session start. `handoff.md` exists but is being superseded; using `rolling-summary.md` is architecturally correct and consistent with where current session-bridge context lives.

**Flow before/after:**

```
BEFORE:
  User asks question → dispatcher notes it in session file → session ends
  → compaction fires → session note is archived, not re-surfaced
  → new session reads rolling-summary.md (no mention) → question dropped

AFTER (fix 1):
  User asks question → dispatcher defers → IMMEDIATELY spawns subagent
  → subagent writes to rolling-summary.md ## Open Threads / Commitments
  → session ends → new session reads rolling-summary.md → question is visible → gets answered

AFTER (fix 2, safety net):
  compact-catchup runs → scans recent session notes for commitment patterns
  → finds items not in rolling-summary.md → prepends them to ## Open Threads / Commitments
  → dispatcher reads rolling-summary.md at next startup → question is visible
```

## What is NOT changed

- The "No automated follow-up spawning" constraint in Multi-Question Handling is unchanged. That rule governs question-tracking behavior (don't spawn subagents just to note questions). Commitment capture is a different action triggered after the dispatcher has already decided to defer.
- Session note format and session-note-polish/session-note-appender agents are unchanged.
- No changes to `rolling-summary.md` format — the existing `## Open Threads / Commitments` and `## Active PRs & Decisions` sections are used as-is.
- `handoff.md` is not touched by either fix.

## Functional patterns used

Pure functions and declarative patterns: Phase 4 in compact-catchup is a pure scan-and-compare — read session notes, read `rolling-summary.md`, compute the diff, write the result. No side effects until the diff is confirmed non-empty. The idempotency check in the dispatcher commitment-capture subagent follows the same pattern.

## Tests run

- [ ] No automated tests exist for these behavioral instruction files — changes are verified by inspection
- [x] Reviewed that Phase 4 step numbers (17–20) don't conflict with existing steps 1–16
- [x] Verified "Sahar" name substituted with "the user" per pre-commit hook requirement
- [x] Pre-push PII scanner: clean

**Blocked items needing attention before merge:** none

*(Updated: redesigned per Sahar's direction — storage moved from handoff.md to rolling-summary.md)*