### PR TITLE
feat: enrich nightly consolidation with session files + GitHub daily activity

### DIFF
--- a/.claude/agents/nightly-consolidation.md
+++ b/.claude/agents/nightly-consolidation.md
@@ -19,7 +19,7 @@ You will receive a prompt containing the consolidation trigger timestamp.
    If the result is empty, note that in your write_result and exit — nothing to consolidate.
 
 **1b. Read today's session files.**
-List `~/lobster-user-config/memory/canonical/sessions/` for files matching today's date pattern (`YYYYMMDD-*.md` where `YYYYMMDD` = today's date).
+Run `date +%Y%m%d` to get today's date string (e.g. `20260331`). Then list `~/lobster-user-config/memory/canonical/sessions/` for files matching `<date>-*.md`.
 Read each file. Extract:
 - Snapshot blocks (`## Snapshot [timestamp]`) — these contain the running activity log
 - Open Threads and Open Tasks sections (from session header)
@@ -34,13 +34,15 @@ Merge this context with the memory_recent results from step 1. Session files oft
 Run these commands to get today's GitHub work (use --limit flags to keep output manageable):
 
 ```bash
+today=$(date +%Y-%m-%d)
+
 # PRs merged today
 gh pr list --repo SiderealPress/lobster --state merged --limit 20 --json number,title,mergedAt,author | \
-  python3 -c "import json,sys; prs=json.load(sys.stdin); today='$(date +%Y-%m-%d)'; [print(f'Merged PR #{p[\"number\"]}: {p[\"title\"]}') for p in prs if p.get('mergedAt','').startswith(today)]"
+  python3 -c "import json,sys; today='$today'; prs=json.load(sys.stdin); [print(f'Merged PR #{p[\"number\"]}: {p[\"title\"]}') for p in prs if p.get('mergedAt','').startswith(today)]"
 
 # Issues opened/closed today
 gh issue list --repo SiderealPress/lobster --state all --limit 30 --json number,title,state,createdAt,closedAt | \
-  python3 -c "import json,sys; issues=json.load(sys.stdin); today='$(date +%Y-%m-%d)'; [print(f'Issue #{i[\"number\"]} ({i[\"state\"]}): {i[\"title\"]}') for i in issues if (i.get('createdAt','') or i.get('closedAt','')).startswith(today)]"
+  python3 -c "import json,sys; today='$today'; issues=json.load(sys.stdin); [print(f'Issue #{i[\"number\"]} ({i[\"state\"]}): {i[\"title\"]}') for i in issues if (i.get('createdAt','') or i.get('closedAt','')).startswith(today)]"
 ```
 
 Include the GitHub activity summary in the synthesis for rolling-summary.md and daily-digest.md. List merged PRs under a "Code shipped" bullet. List new/closed issues under an "Issues" bullet. If no GitHub activity, omit this section.
@@ -52,6 +54,8 @@ Include the GitHub activity summary in the synthesis for rolling-summary.md and 
    - Active work streams that progressed
    - Unresolved threads or blockers
    - Any notable mood or energy signals
+   - **Code shipped** bullet: merged PRs from step 2b (if any)
+   - **Issues** bullet: opened/closed issues from step 2b (if any)
    Keep each entry concise — 5-10 bullet points max. Do NOT rewrite past entries.
 
 4. **Update `daily-digest.md`.**

--- a/.claude/agents/nightly-consolidation.md
+++ b/.claude/agents/nightly-consolidation.md
@@ -18,8 +18,32 @@ You will receive a prompt containing the consolidation trigger timestamp.
    Call `memory_recent(hours=24)` to retrieve all observations and events from the past 24 hours.
    If the result is empty, note that in your write_result and exit — nothing to consolidate.
 
+**1b. Read today's session files.**
+List `~/lobster-user-config/memory/canonical/sessions/` for files matching today's date pattern (`YYYYMMDD-*.md` where `YYYYMMDD` = today's date).
+Read each file. Extract:
+- Snapshot blocks (`## Snapshot [timestamp]`) — these contain the running activity log
+- Open Threads and Open Tasks sections (from session header)
+- Notable Events sections
+
+Merge this context with the memory_recent results from step 1. Session files often contain richer conversational context than memory events — prefer session file content for narrative synthesis (steps 3-6) when available.
+
 2. **Search for key mentions.**
    Call `memory_search()` for any prominent project names, person names, or topics that appeared in step 1. This surfaces related older context that might be relevant to the synthesis.
+
+**2b. Pull today's GitHub activity.**
+Run these commands to get today's GitHub work (use --limit flags to keep output manageable):
+
+```bash
+# PRs merged today
+gh pr list --repo SiderealPress/lobster --state merged --limit 20 --json number,title,mergedAt,author | \
+  python3 -c "import json,sys; prs=json.load(sys.stdin); today='$(date +%Y-%m-%d)'; [print(f'Merged PR #{p[\"number\"]}: {p[\"title\"]}') for p in prs if p.get('mergedAt','').startswith(today)]"
+
+# Issues opened/closed today
+gh issue list --repo SiderealPress/lobster --state all --limit 30 --json number,title,state,createdAt,closedAt | \
+  python3 -c "import json,sys; issues=json.load(sys.stdin); today='$(date +%Y-%m-%d)'; [print(f'Issue #{i[\"number\"]} ({i[\"state\"]}): {i[\"title\"]}') for i in issues if (i.get('createdAt','') or i.get('closedAt','')).startswith(today)]"
+```
+
+Include the GitHub activity summary in the synthesis for rolling-summary.md and daily-digest.md. List merged PRs under a "Code shipped" bullet. List new/closed issues under an "Issues" bullet. If no GitHub activity, omit this section.
 
 3. **Update `rolling-summary.md`.**
    Read `~/lobster-user-config/memory/canonical/rolling-summary.md`.
@@ -158,7 +182,7 @@ You will receive a prompt containing the consolidation trigger timestamp.
 mcp__lobster-inbox__write_result(
     task_id=task_id,   # from your prompt header
     chat_id=0,
-    text="Nightly consolidation complete. Updated: rolling-summary.md, daily-digest.md, handoff.md, _context.md. Projects updated: <list or 'none'>. People updated: <list or 'none'>. Events consolidated: <count>.",
+    text="Nightly consolidation complete. Updated: rolling-summary.md, daily-digest.md, handoff.md, _context.md. Projects updated: <list or 'none'>. People updated: <list or 'none'>. Events consolidated: <count>. Session files read: <count>. GitHub PRs merged: <count>. GitHub issues opened/closed: <count>.",
     source="system",
     status="success",
     sent_reply_to_user=False,


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

Part of the nightly consolidation integration work (Sahar's 'connected to all systems' goal).

Before this change, nightly consolidation only saw raw memory events from `memory_recent`. Two rich data sources were completely invisible to it: the session files that capture live conversational context throughout the day, and the GitHub activity log showing what code actually shipped.

This PR adds two new data-gathering steps that run before synthesis begins:

**Step 1b — Session files:** Reads `~/lobster-user-config/memory/canonical/sessions/YYYYMMDD-*.md` for today. Extracts snapshot blocks, open threads/tasks, and notable events. Session files carry richer narrative context than memory events and are explicitly preferred as the synthesis source when both are available.

**Step 2b — GitHub activity:** Runs `gh pr list` and `gh issue list` filtered to today's date, then folds merged PRs and opened/closed issues into rolling-summary.md and daily-digest.md under "Code shipped" and "Issues" bullets. Omits the section entirely if there's no activity.

**write_result template updated** to report session file count, PR count, and issue count in the completion line — making consolidation runs auditable at a glance.

## What is not changed

- No cron entries, systemd units, or install.sh changes. Runs via the existing 3AM trigger.
- All existing steps (1–10) are unchanged in behavior and ordering.
- The "What NOT to do" guardrails are untouched.

## Functional patterns

Pure data gathering followed by declarative synthesis: steps 1b and 2b are read-only collectors; the synthesis steps (3-6) consume the merged context. No shared mutable state between steps.

## Tests run

- [x] Verified diff is structurally correct — new steps inserted at the right positions, write_result template updated
- [ ] Live 3AM run — not applicable in this environment; behavior verified by reading the prompt instructions directly

**Blocked items needing attention before merge:** none