### PR TITLE
fix: call session_start at startup to clear stale dispatcher session ID (#1244)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -21,6 +21,9 @@ When you first start (or after reading this file), follow these steps:
 
 > **Note on stale agent sessions:** The `on-fresh-start.py` SessionStart hook runs automatically before your first turn and calls `agent-monitor.py --mark-failed` to clear any sessions left in "running" state. You do not need to do this manually.
 
+0. Call `session_start(agent_type="dispatcher", agent_id="lobster-dispatcher", description="Lobster dispatcher main loop", chat_id=<ADMIN_CHAT_ID>)` to register this session as the dispatcher. This clears any stale `_dispatcher_session_id` from a previous dispatcher instance and ensures all guarded MCP tools (`send_reply`, `check_inbox`, etc.) work immediately. Without this, a new dispatcher session may be blocked by a stale session ID from the previous instance.
+   - Get ADMIN_CHAT_ID from `lobster.conf` (`grep ADMIN_CHAT_ID ~/lobster-config/lobster.conf` or equivalent), or use the `chat_id` from `context-handoff.json` if available.
+   - This is the FIRST action before any guarded tools — must fire before the warmup `send_reply` at step 2d.
 1. Call `session_start(agent_type='dispatcher', claude_session_id=hook_input["session_id"])` — pass the Claude session UUID injected by the SessionStart hook. This writes the UUID to `$LOBSTER_WORKSPACE/data/dispatcher-claude-session-id`, enabling `inject-bootup-context.py` to identify your session as the dispatcher and inject this file on future restarts. Without this call, the primary detection path is never populated and you will receive the subagent bootup file instead of this one.
 1a. Read `~/lobster-user-config/memory/canonical/handoff.md` — user context, active projects, key people, git rules, available integrations.
 2. Read `~/lobster-workspace/user-model/_context.md` if it exists — pre-computed summary of user values, preferences, and active projects. Skip if absent.


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What this fixes

When the MCP server stays up across dispatcher restarts, the old session's HTTP session ID remains cached in `_dispatcher_session_id`. The next dispatcher instance gets a different session ID and is immediately blocked by the SESSION GUARD on every guarded tool (`send_reply`, `check_inbox`, etc.) — unable to send even its warmup message until `wait_for_messages` eventually fires and re-tags the session.

This is the prompt-layer fix: the startup sequence now calls `session_start(agent_type="dispatcher", ...)` as step 0, before any guarded tools. This triggers the Option B tagging path already present in `inbox_server.py` (`_tag_dispatcher_session`), which overwrites the stale session ID with the current one.

## What changed

`sys.dispatcher.bootup.md` — one new step inserted at the top of the Startup Behavior sequence:

```
0. Call session_start(agent_type="dispatcher", agent_id="lobster-dispatcher",
   description="Lobster dispatcher main loop", chat_id=<ADMIN_CHAT_ID>)
```

The existing steps 1–7 are unchanged. No Python changes, no new hooks, no cron entries, no install.sh changes.

## Startup sequence: before vs. after

**Before:**
```
(stale _dispatcher_session_id may block all guarded tools)
1. session_start(claude_session_id=...) — writes session UUID file
1a. read handoff.md
2d. send_reply warmup  ← blocked if stale session ID present
5. wait_for_messages   ← Option A: tags session only here
```

**After:**
```
0. session_start(agent_type="dispatcher", agent_id="lobster-dispatcher", ...)
   → Option B fires: _tag_dispatcher_session() overwrites stale ID immediately
1. session_start(claude_session_id=...) — writes session UUID file
1a. read handoff.md
2d. send_reply warmup  ← now unblocked
5. wait_for_messages
```

## Scope

This is the prompt-layer fix only. The Python-layer fix (clearing the stale ID in `_is_main_http_session()` when the stored session is no longer present in `_http_session_manager._server_instances`) would be a defense-in-depth companion but is a separate Python PR. This PR covers the prompt-layer half of the two-part fix described in the issue.

## Implementation notes

Uses pure declarative instruction — the behavioral change is entirely in the prompt, relying on the existing Option B code path in `handle_session_start` (line 6861 of `inbox_server.py`). No new Python logic introduced here.

## Tests run

- [x] Verified step 0 appears before step 1 in the startup sequence and references the correct `session_start` parameters.
- [x] Verified existing steps 1–7 and all subsequent sections are unchanged.
- [x] Confirmed `session_start` with `agent_type="dispatcher"` triggers `_tag_dispatcher_session` in `inbox_server.py` (lines 6861–6864) — the code path was already present, this PR activates it at the right moment.
- [ ] Live end-to-end test (restart dispatcher with MCP server running, verify warmup send_reply succeeds without SESSION GUARD error) — requires a production restart, not run here. No behavior risk: the new step 0 is additive and idempotent.

Closes #1244 (prompt-layer fix — Python-layer fix tracked separately)