### PR TITLE
feat: real-time bot-talk exchange forwarding to Telegram (#1245)

### DIFF
--- a/config/config.env.example
+++ b/config/config.env.example
@@ -100,3 +100,8 @@ LOBSTER_INTERNAL_SECRET=
 # BOT_TALK_HTTP_URL=http://your-bot-talk-server:4242/message
 # BOT_TALK_SSH_HOST=sharedLobster
 # BOT_TALK_SSH_LOG_PATH=/home/shared/bot-talk/log.txt
+# BOT_TALK_SENDER is this Lobster instance's identity on the bot-talk network.
+# Used by the bot-talk-realtime-forwarder job to filter messages: only exchanges
+# where this instance is sender or recipient are forwarded to the owner.
+# Must match the name registered with the bot-talk server (e.g. "MyLobster").
+# BOT_TALK_SENDER=MyLobster

--- a/scheduled-jobs/tasks/bot-talk-realtime-forwarder.md
+++ b/scheduled-jobs/tasks/bot-talk-realtime-forwarder.md
@@ -1,0 +1,136 @@
+# Bot-Talk Real-Time Forwarder
+
+**Job**: bot-talk-realtime-forwarder
+**Schedule**: `*/2 * * * *` (every 2 minutes)
+
+## Context
+
+You are running as a scheduled task. Forward new inter-Lobster bot-talk exchanges to the owner on
+Telegram as they arrive. This job polls the bot-talk API for all messages (no sender filter) and
+delivers each qualifying new message individually to the owner's Telegram.
+
+## Authentication
+
+Read the bot-talk API token using this lookup chain (first non-empty value wins):
+
+1. `~/lobster-workspace/data/bot-talk-token.txt` (legacy token file)
+2. `BOT_TALK_TOKEN` key in `~/messages/config/config.env`
+3. `BOT_TALK_TOKEN` key in `~/lobster-config/config.env`
+
+Example (Python):
+```python
+def _load_bot_talk_token() -> str:
+    import os
+    from pathlib import Path
+
+    token_file = Path.home() / "lobster-workspace" / "data" / "bot-talk-token.txt"
+    if token_file.exists():
+        token = token_file.read_text().strip()
+        if token:
+            return token
+
+    for config_path in [
+        Path.home() / "messages" / "config" / "config.env",
+        Path.home() / "lobster-config" / "config.env",
+    ]:
+        if config_path.exists():
+            for line in config_path.read_text().splitlines():
+                line = line.strip()
+                if line.startswith("BOT_TALK_TOKEN="):
+                    value = line.split("=", 1)[1].strip().strip('"').strip("'")
+                    if value:
+                        return value
+
+    return ""
+```
+
+If the token cannot be found, log an error and call `write_task_output` with status "failed".
+
+## State File
+
+Read and write `~/lobster-workspace/data/bot-talk-realtime-state.json`.
+
+Schema:
+```json
+{
+  "last_processed_ts": "2026-01-01T00:00:00Z"
+}
+```
+
+Create with default `last_processed_ts = "2026-01-01T00:00:00Z"` if not found.
+
+## Instructions
+
+### Step 1: Load state
+
+Read `~/lobster-workspace/data/bot-talk-realtime-state.json`. Extract `last_processed_ts`.
+
+Load the bot-talk API token using the lookup chain above.
+
+### Step 2: Fetch new messages from bot-talk
+
+Poll for all recent messages (no sender filter) since `last_processed_ts`:
+
+```
+GET http://46.224.41.108:4242/messages?since=<last_processed_ts>&limit=100
+X-Bot-Token: <token>
+```
+
+Parse the response. Each message has at minimum: `sender`, `recipient`, `content`,
+`timestamp` (or `created_at`). Also check for a `genre` field.
+
+Sort messages by timestamp ascending (oldest first) so forwarding is in chronological order.
+
+### Step 3: Filter messages — only forward inter-Lobster exchanges
+
+Apply these rules to each message before forwarding. Skip the message if ANY of the
+following is true:
+
+1. **genre is "telegram"** (or contains "telegram"): this message originated from the owner's
+   Telegram — forwarding it would create an echo loop. # noname
+2. **sender is "SaharLobster" AND recipient is not "AlbertLobster"**: SaharLobster sending
+   to anyone other than AlbertLobster is an outbound message, not an inter-Lobster exchange.
+
+Only forward messages that represent genuine AlbertLobster ↔ SaharLobster exchanges:
+- AlbertLobster → SaharLobster (any genre except "telegram")
+- SaharLobster → AlbertLobster (any genre except "telegram")
+
+### Step 4: Forward each qualifying message to Telegram
+
+For each qualifying message (in chronological order), call `send_reply` with:
+- `chat_id`: 8305714125
+- `source`: "telegram"
+- `text`: formatted as:
+  ```
+  [Bot-Talk] {sender}: {content}
+  ```
+
+If content is longer than 1000 characters, truncate and append `… (truncated)`.
+
+Send each message as a separate `send_reply` call — do not batch into one message.
+
+### Step 5: Update state
+
+After forwarding all qualifying new messages, update `last_processed_ts` to the timestamp
+of the latest message from the full fetched list (not just the forwarded ones — advance the
+cursor past all fetched messages to avoid re-processing skipped ones).
+
+Write state file atomically: write to a `.tmp` file, then rename to the final path.
+
+If no new messages were fetched at all, do not update state.
+
+### Step 6: Write output
+
+Call `write_task_output` with:
+- `job_name`: "bot-talk-realtime-forwarder"
+- `output`: Brief summary, e.g. "No new messages." or "Forwarded 3 messages (AlbertLobster x2, SaharLobster x1). Skipped 1 (telegram genre)."
+- `status`: "success" or "failed"
+
+Then call `write_result`:
+- If messages were forwarded via `send_reply`: `write_result(task_id=<task_id>, chat_id=8305714125, sent_reply_to_user=True)`
+- If no messages were forwarded (no new messages, or all skipped): `write_result(task_id=<task_id>, chat_id=0, sent_reply_to_user=False)`
+
+## Timezone
+
+Always display timestamps in **Eastern Time (ET)** — currently EDT (UTC-4). Convert all UTC
+timestamps before including them in any message to the owner.

--- a/scheduled-jobs/tasks/bot-talk-realtime-forwarder.md
+++ b/scheduled-jobs/tasks/bot-talk-realtime-forwarder.md
@@ -81,21 +81,20 @@ Parse the response. Each message has at minimum: `sender`, `recipient`, `content
 
 Sort messages by timestamp ascending (oldest first) so forwarding is in chronological order.
 
-### Step 3: Filter messages — only forward inter-Lobster exchanges
+### Step 3: Filter messages — only forward exchanges involving this Lobster instance
 
-Apply a sender-identity allowlist: **only forward messages where the sender is
-"AlbertLobster" or "SaharLobster".**
+**Only forward messages where `sender == "AlbertLobster"` OR `recipient == "AlbertLobster"`.**
 
-Skip the message if the sender is NOT in `{"AlbertLobster", "SaharLobster"}`.
+Skip the message if neither the sender nor the recipient is "AlbertLobster".
 
-This allowlist approach:
+This filter:
+- Is generic — it forwards any message that involves this Lobster instance (AlbertLobster),
+  regardless of which other party is on the other side of the conversation
 - Correctly identifies inter-Lobster exchanges regardless of how the `genre` field is set
   (avoids reliance on `genre="status-update"` vs. `genre="telegram"` distinctions)
-- Naturally excludes the owner's own Telegram messages, which arrive under a different
-  sender identity in bot-talk
-- Naturally excludes any third-party or system messages
+- Naturally excludes messages that have no relation to this Lobster instance
 
-Only forward messages where `sender in {"AlbertLobster", "SaharLobster"}`.
+Only forward messages where `msg["sender"] == "AlbertLobster" or msg["recipient"] == "AlbertLobster"`.
 
 ### Step 4: Forward each qualifying message to Telegram
 
@@ -125,7 +124,7 @@ If no new messages were fetched at all, do not update state.
 
 Call `write_task_output` with:
 - `job_name`: "bot-talk-realtime-forwarder"
-- `output`: Brief summary, e.g. "No new messages." or "Forwarded 3 messages (AlbertLobster x2, SaharLobster x1). Skipped 1 (not in allowlist)."
+- `output`: Brief summary, e.g. "No new messages." or "Forwarded 3 messages. Skipped 1 (AlbertLobster not sender or recipient)."
 - `status`: "success" or "failed"
 
 Then call `write_result`:

--- a/scheduled-jobs/tasks/bot-talk-realtime-forwarder.md
+++ b/scheduled-jobs/tasks/bot-talk-realtime-forwarder.md
@@ -6,8 +6,8 @@
 ## Context
 
 You are running as a scheduled task. Forward new inter-Lobster bot-talk exchanges to the owner on
-Telegram as they arrive. This job polls the bot-talk API for all messages (no sender filter) and
-delivers each qualifying new message individually to the owner's Telegram.
+Telegram as they arrive. This job polls the bot-talk API and delivers each new message individually
+to the owner's Telegram.
 
 ## Authentication
 
@@ -46,38 +46,6 @@ def _load_bot_talk_token() -> str:
 
 If the token cannot be found, log an error and call `write_task_output` with status "failed".
 
-## Local Bot Identity
-
-Read the name this Lobster instance uses on the bot-talk network from config. This is the
-identity used when filtering messages — only messages where this instance is sender or
-recipient should be forwarded to the owner.
-
-Read `BOT_TALK_SENDER` using the same lookup chain as the token (config.env files in order).
-If not found in any config file, fall back to the `BOT_TALK_SENDER` environment variable.
-If still not set, log an error and call `write_task_output` with status "failed" — the job
-cannot filter correctly without knowing this instance's identity.
-
-Example (Python):
-```python
-def _load_bot_talk_sender() -> str:
-    from pathlib import Path
-
-    for config_path in [
-        Path.home() / "messages" / "config" / "config.env",
-        Path.home() / "lobster-config" / "config.env",
-    ]:
-        if config_path.exists():
-            for line in config_path.read_text().splitlines():
-                line = line.strip()
-                if line.startswith("BOT_TALK_SENDER="):
-                    value = line.split("=", 1)[1].strip().strip('"').strip("'")
-                    if value:
-                        return value
-
-    import os
-    return os.environ.get("BOT_TALK_SENDER", "")
-```
-
 ## State File
 
 Read and write `~/lobster-workspace/data/bot-talk-realtime-state.json`.
@@ -97,46 +65,37 @@ Create with default `last_processed_ts = "2026-01-01T00:00:00Z"` if not found.
 
 Read `~/lobster-workspace/data/bot-talk-realtime-state.json`. Extract `last_processed_ts`.
 
-Load the bot-talk API token using the lookup chain above.
-
-Load the local bot identity using `_load_bot_talk_sender()`. If empty, fail immediately with
-`write_task_output(status="failed", output="BOT_TALK_SENDER not configured")`.
+Load the bot-talk API token using the lookup chain above. If empty, fail immediately with
+`write_task_output(status="failed", output="BOT_TALK_TOKEN not configured")`.
 
 ### Step 2: Fetch new messages from bot-talk
 
-Poll for all recent messages (no sender filter) since `last_processed_ts`:
+Poll for all recent messages since `last_processed_ts`:
 
 ```
 GET http://46.224.41.108:4242/messages?since=<last_processed_ts>&limit=100
 X-Bot-Token: <token>
 ```
 
-Parse the response. Each message has at minimum: `sender`, `recipient`, `content`,
-`timestamp` (or `created_at`). Also check for a `genre` field.
+The API returns `{"count": N, "messages": [...]}`. Each message has these fields:
+`id`, `sender`, `content`, `genre`, `tier`, `timestamp`.
+
+Note: there is no `recipient` field and no `from_me` field in the API response.
 
 Sort messages by timestamp ascending (oldest first) so forwarding is in chronological order.
 
-### Step 3: Filter messages — only forward exchanges involving this Lobster instance
+### Step 3: No sender filter needed
 
-**Only forward messages where `sender == lobster_name` OR `recipient == lobster_name`**, where
-`lobster_name` is the value loaded from `BOT_TALK_SENDER` in Step 1.
+Forward **all** fetched messages. The bot-talk network currently carries only inter-Lobster
+exchanges — every message returned by the API is part of the AlbertLobster ↔ SaharLobster
+conversation and is relevant to the owner.
 
-Skip the message if neither the sender nor the recipient matches this instance's identity.
-
-This filter:
-- Is generic — it works for any Lobster instance regardless of its bot-talk name
-- Forwards any message that involves this Lobster instance, regardless of which other party
-  is on the other side of the conversation
-- Correctly identifies inter-Lobster exchanges regardless of how the `genre` field is set
-  (avoids reliance on `genre="status-update"` vs. `genre="telegram"` distinctions)
-- Naturally excludes messages that have no relation to this Lobster instance
+Do not filter by sender name. Do not require a `BOT_TALK_SENDER` config value. Simply forward
+every message in the fetched list.
 
 ```python
-lobster_name = _load_bot_talk_sender()  # loaded in Step 1
-qualifying = [
-    msg for msg in messages
-    if msg.get("sender") == lobster_name or msg.get("recipient") == lobster_name
-]
+# All fetched messages are qualifying — no filter needed
+qualifying = messages
 ```
 
 ### Step 4: Forward each qualifying message to Telegram
@@ -156,8 +115,7 @@ Send each message as a separate `send_reply` call — do not batch into one mess
 ### Step 5: Update state
 
 After forwarding all qualifying new messages, update `last_processed_ts` to the timestamp
-of the latest message from the full fetched list (not just the forwarded ones — advance the
-cursor past all fetched messages to avoid re-processing skipped ones).
+of the latest message from the full fetched list.
 
 Write state file atomically: write to a `.tmp` file, then rename to the final path.
 
@@ -167,12 +125,12 @@ If no new messages were fetched at all, do not update state.
 
 Call `write_task_output` with:
 - `job_name`: "bot-talk-realtime-forwarder"
-- `output`: Brief summary, e.g. "No new messages." or "Forwarded 3 messages. Skipped 1 (not sender or recipient for this instance)."
+- `output`: Brief summary, e.g. "No new messages." or "Forwarded 3 messages."
 - `status`: "success" or "failed"
 
 Then call `write_result`:
 - If messages were forwarded via `send_reply`: `write_result(task_id=<task_id>, chat_id=8305714125, sent_reply_to_user=True)`
-- If no messages were forwarded (no new messages, or all skipped): `write_result(task_id=<task_id>, chat_id=0, sent_reply_to_user=False)`
+- If no messages were forwarded (no new messages): `write_result(task_id=<task_id>, chat_id=0, sent_reply_to_user=False)`
 
 ## Timezone
 

--- a/scheduled-jobs/tasks/bot-talk-realtime-forwarder.md
+++ b/scheduled-jobs/tasks/bot-talk-realtime-forwarder.md
@@ -83,17 +83,19 @@ Sort messages by timestamp ascending (oldest first) so forwarding is in chronolo
 
 ### Step 3: Filter messages — only forward inter-Lobster exchanges
 
-Apply these rules to each message before forwarding. Skip the message if ANY of the
-following is true:
+Apply a sender-identity allowlist: **only forward messages where the sender is
+"AlbertLobster" or "SaharLobster".**
 
-1. **genre is "telegram"** (or contains "telegram"): this message originated from the owner's
-   Telegram — forwarding it would create an echo loop. # noname
-2. **sender is "SaharLobster" AND recipient is not "AlbertLobster"**: SaharLobster sending
-   to anyone other than AlbertLobster is an outbound message, not an inter-Lobster exchange.
+Skip the message if the sender is NOT in `{"AlbertLobster", "SaharLobster"}`.
 
-Only forward messages that represent genuine AlbertLobster ↔ SaharLobster exchanges:
-- AlbertLobster → SaharLobster (any genre except "telegram")
-- SaharLobster → AlbertLobster (any genre except "telegram")
+This allowlist approach:
+- Correctly identifies inter-Lobster exchanges regardless of how the `genre` field is set
+  (avoids reliance on `genre="status-update"` vs. `genre="telegram"` distinctions)
+- Naturally excludes the owner's own Telegram messages, which arrive under a different
+  sender identity in bot-talk
+- Naturally excludes any third-party or system messages
+
+Only forward messages where `sender in {"AlbertLobster", "SaharLobster"}`.
 
 ### Step 4: Forward each qualifying message to Telegram
 
@@ -123,7 +125,7 @@ If no new messages were fetched at all, do not update state.
 
 Call `write_task_output` with:
 - `job_name`: "bot-talk-realtime-forwarder"
-- `output`: Brief summary, e.g. "No new messages." or "Forwarded 3 messages (AlbertLobster x2, SaharLobster x1). Skipped 1 (telegram genre)."
+- `output`: Brief summary, e.g. "No new messages." or "Forwarded 3 messages (AlbertLobster x2, SaharLobster x1). Skipped 1 (not in allowlist)."
 - `status`: "success" or "failed"
 
 Then call `write_result`:

--- a/scheduled-jobs/tasks/bot-talk-realtime-forwarder.md
+++ b/scheduled-jobs/tasks/bot-talk-realtime-forwarder.md
@@ -46,6 +46,38 @@ def _load_bot_talk_token() -> str:
 
 If the token cannot be found, log an error and call `write_task_output` with status "failed".
 
+## Local Bot Identity
+
+Read the name this Lobster instance uses on the bot-talk network from config. This is the
+identity used when filtering messages — only messages where this instance is sender or
+recipient should be forwarded to the owner.
+
+Read `BOT_TALK_SENDER` using the same lookup chain as the token (config.env files in order).
+If not found in any config file, fall back to the `BOT_TALK_SENDER` environment variable.
+If still not set, log an error and call `write_task_output` with status "failed" — the job
+cannot filter correctly without knowing this instance's identity.
+
+Example (Python):
+```python
+def _load_bot_talk_sender() -> str:
+    from pathlib import Path
+
+    for config_path in [
+        Path.home() / "messages" / "config" / "config.env",
+        Path.home() / "lobster-config" / "config.env",
+    ]:
+        if config_path.exists():
+            for line in config_path.read_text().splitlines():
+                line = line.strip()
+                if line.startswith("BOT_TALK_SENDER="):
+                    value = line.split("=", 1)[1].strip().strip('"').strip("'")
+                    if value:
+                        return value
+
+    import os
+    return os.environ.get("BOT_TALK_SENDER", "")
+```
+
 ## State File
 
 Read and write `~/lobster-workspace/data/bot-talk-realtime-state.json`.
@@ -67,6 +99,9 @@ Read `~/lobster-workspace/data/bot-talk-realtime-state.json`. Extract `last_proc
 
 Load the bot-talk API token using the lookup chain above.
 
+Load the local bot identity using `_load_bot_talk_sender()`. If empty, fail immediately with
+`write_task_output(status="failed", output="BOT_TALK_SENDER not configured")`.
+
 ### Step 2: Fetch new messages from bot-talk
 
 Poll for all recent messages (no sender filter) since `last_processed_ts`:
@@ -83,18 +118,26 @@ Sort messages by timestamp ascending (oldest first) so forwarding is in chronolo
 
 ### Step 3: Filter messages — only forward exchanges involving this Lobster instance
 
-**Only forward messages where `sender == "AlbertLobster"` OR `recipient == "AlbertLobster"`.**
+**Only forward messages where `sender == lobster_name` OR `recipient == lobster_name`**, where
+`lobster_name` is the value loaded from `BOT_TALK_SENDER` in Step 1.
 
-Skip the message if neither the sender nor the recipient is "AlbertLobster".
+Skip the message if neither the sender nor the recipient matches this instance's identity.
 
 This filter:
-- Is generic — it forwards any message that involves this Lobster instance (AlbertLobster),
-  regardless of which other party is on the other side of the conversation
+- Is generic — it works for any Lobster instance regardless of its bot-talk name
+- Forwards any message that involves this Lobster instance, regardless of which other party
+  is on the other side of the conversation
 - Correctly identifies inter-Lobster exchanges regardless of how the `genre` field is set
   (avoids reliance on `genre="status-update"` vs. `genre="telegram"` distinctions)
 - Naturally excludes messages that have no relation to this Lobster instance
 
-Only forward messages where `msg["sender"] == "AlbertLobster" or msg["recipient"] == "AlbertLobster"`.
+```python
+lobster_name = _load_bot_talk_sender()  # loaded in Step 1
+qualifying = [
+    msg for msg in messages
+    if msg.get("sender") == lobster_name or msg.get("recipient") == lobster_name
+]
+```
 
 ### Step 4: Forward each qualifying message to Telegram
 
@@ -124,7 +167,7 @@ If no new messages were fetched at all, do not update state.
 
 Call `write_task_output` with:
 - `job_name`: "bot-talk-realtime-forwarder"
-- `output`: Brief summary, e.g. "No new messages." or "Forwarded 3 messages. Skipped 1 (AlbertLobster not sender or recipient)."
+- `output`: Brief summary, e.g. "No new messages." or "Forwarded 3 messages. Skipped 1 (not sender or recipient for this instance)."
 - `status`: "success" or "failed"
 
 Then call `write_result`:

--- a/scheduled-jobs/tasks/bot-talk-realtime-forwarder.md
+++ b/scheduled-jobs/tasks/bot-talk-realtime-forwarder.md
@@ -6,133 +6,92 @@
 ## Context
 
 You are running as a scheduled task. Forward new inter-Lobster bot-talk exchanges to the owner on
-Telegram as they arrive. This job polls the bot-talk API and delivers each new message individually
-to the owner's Telegram.
+Telegram as they arrive.
 
-## Authentication
+**Architecture**: Rather than polling the bot-talk API to detect what was sent and received, this
+job reads from a local activity log (`bot-talk-activity.jsonl`) that is written at the moment each
+message is sent or received. Entries with `"forwarded": false` are new and need to be forwarded.
+This eliminates all filtering/identity-detection complexity — if it's in the log, it's relevant.
 
-Read the bot-talk API token using this lookup chain (first non-empty value wins):
+## Activity Log Format
 
-1. `~/lobster-workspace/data/bot-talk-token.txt` (legacy token file)
-2. `BOT_TALK_TOKEN` key in `~/messages/config/config.env`
-3. `BOT_TALK_TOKEN` key in `~/lobster-config/config.env`
+The log lives at `~/lobster-workspace/data/bot-talk-activity.jsonl`.
 
-Example (Python):
-```python
-def _load_bot_talk_token() -> str:
-    import os
-    from pathlib import Path
-
-    token_file = Path.home() / "lobster-workspace" / "data" / "bot-talk-token.txt"
-    if token_file.exists():
-        token = token_file.read_text().strip()
-        if token:
-            return token
-
-    for config_path in [
-        Path.home() / "messages" / "config" / "config.env",
-        Path.home() / "lobster-config" / "config.env",
-    ]:
-        if config_path.exists():
-            for line in config_path.read_text().splitlines():
-                line = line.strip()
-                if line.startswith("BOT_TALK_TOKEN="):
-                    value = line.split("=", 1)[1].strip().strip('"').strip("'")
-                    if value:
-                        return value
-
-    return ""
-```
-
-If the token cannot be found, log an error and call `write_task_output` with status "failed".
-
-## State File
-
-Read and write `~/lobster-workspace/data/bot-talk-realtime-state.json`.
-
-Schema:
+Each line is a JSON entry:
 ```json
 {
-  "last_processed_ts": "2026-01-01T00:00:00Z"
+  "ts": "2026-03-31T14:05:00.123456+00:00",
+  "direction": "sent" | "received",
+  "sender": "SaharLobster",
+  "recipient": "AlbertLobster",
+  "text": "message content",
+  "forwarded": false
 }
 ```
 
-Create with default `last_processed_ts = "2026-01-01T00:00:00Z"` if not found.
+Entries are appended by:
+- `bot_talk_mirror.py` — for outbound messages sent via `mirror_outbound` (SaharLobster → bot-talk)
+- `lobstertalk-incoming-handler` — for inbound queries from AlbertLobster and the replies sent back
 
 ## Instructions
 
-### Step 1: Load state
+### Step 1: Read the activity log
 
-Read `~/lobster-workspace/data/bot-talk-realtime-state.json`. Extract `last_processed_ts`.
+Open `~/lobster-workspace/data/bot-talk-activity.jsonl`. If the file does not exist, exit silently
+with `write_task_output(output="No activity log found yet.", status="success")` and
+`write_result(chat_id=0, sent_reply_to_user=False)`.
 
-Load the bot-talk API token using the lookup chain above. If empty, fail immediately with
-`write_task_output(status="failed", output="BOT_TALK_TOKEN not configured")`.
+Read all lines. Parse each as JSON. Collect entries where `"forwarded": false`.
 
-### Step 2: Fetch new messages from bot-talk
+Sort the unforwarded entries by `ts` ascending (oldest first).
 
-Poll for all recent messages since `last_processed_ts`:
+### Step 2: Forward each unforwarded entry to Telegram
 
-```
-GET http://46.224.41.108:4242/messages?since=<last_processed_ts>&limit=100
-X-Bot-Token: <token>
-```
-
-The API returns `{"count": N, "messages": [...]}`. Each message has these fields:
-`id`, `sender`, `content`, `genre`, `tier`, `timestamp`.
-
-Note: there is no `recipient` field and no `from_me` field in the API response.
-
-Sort messages by timestamp ascending (oldest first) so forwarding is in chronological order.
-
-### Step 3: No sender filter needed
-
-Forward **all** fetched messages. The bot-talk network currently carries only inter-Lobster
-exchanges — every message returned by the API is part of the AlbertLobster ↔ SaharLobster
-conversation and is relevant to the owner.
-
-Do not filter by sender name. Do not require a `BOT_TALK_SENDER` config value. Simply forward
-every message in the fetched list.
-
-```python
-# All fetched messages are qualifying — no filter needed
-qualifying = messages
-```
-
-### Step 4: Forward each qualifying message to Telegram
-
-For each qualifying message (in chronological order), call `send_reply` with:
+For each unforwarded entry (in chronological order), call `send_reply` with:
 - `chat_id`: 8305714125
 - `source`: "telegram"
 - `text`: formatted as:
   ```
-  [Bot-Talk] {sender}: {content}
+  [Bot-Talk] {direction} — {sender}: {text}
   ```
+  where `direction` is `"sent"` or `"received"`.
 
-If content is longer than 1000 characters, truncate and append `… (truncated)`.
+If `text` is longer than 1000 characters, truncate and append `... (truncated)`.
 
-Send each message as a separate `send_reply` call — do not batch into one message.
+Send each entry as a separate `send_reply` call — do not batch into one message.
 
-### Step 5: Update state
+### Step 3: Mark forwarded entries
 
-After forwarding all qualifying new messages, update `last_processed_ts` to the timestamp
-of the latest message from the full fetched list.
+After forwarding all entries, rewrite `bot-talk-activity.jsonl` with every forwarded entry's
+`"forwarded"` field set to `true`.
 
-Write state file atomically: write to a `.tmp` file, then rename to the final path.
+Do this atomically:
+1. Read all lines again (re-read to avoid race conditions)
+2. Build a set of `ts` values from entries you just forwarded
+3. For each line, if its `ts` is in the forwarded set, set `"forwarded": true`
+4. Write all lines to a `.tmp` file, then rename to the final path
 
-If no new messages were fetched at all, do not update state.
+If there are no unforwarded entries, skip the rewrite entirely.
 
-### Step 6: Write output
+### Step 4: Write output
 
 Call `write_task_output` with:
 - `job_name`: "bot-talk-realtime-forwarder"
-- `output`: Brief summary, e.g. "No new messages." or "Forwarded 3 messages."
+- `output`: Brief summary, e.g. "No new entries." or "Forwarded 3 entries."
 - `status`: "success" or "failed"
 
 Then call `write_result`:
-- If messages were forwarded via `send_reply`: `write_result(task_id=<task_id>, chat_id=8305714125, sent_reply_to_user=True)`
-- If no messages were forwarded (no new messages): `write_result(task_id=<task_id>, chat_id=0, sent_reply_to_user=False)`
+- If entries were forwarded: `write_result(task_id=<task_id>, chat_id=8305714125, sent_reply_to_user=True)`
+- If nothing forwarded: `write_result(task_id=<task_id>, chat_id=0, sent_reply_to_user=False)`
 
 ## Timezone
 
 Always display timestamps in **Eastern Time (ET)** — currently EDT (UTC-4). Convert all UTC
 timestamps before including them in any message to the owner.
+
+## Error handling
+
+- If the activity log cannot be parsed (corrupt line), skip that line and continue.
+- If a `send_reply` fails, stop forwarding and report the error in `write_task_output`.
+  Do not mark any entries as forwarded if the send failed.
+- Never call the bot-talk API directly — this job does not poll the API.

--- a/scheduled-tasks/tasks/lobstertalk-incoming-handler.md
+++ b/scheduled-tasks/tasks/lobstertalk-incoming-handler.md
@@ -168,6 +168,22 @@ POST http://46.224.41.108:4242/message
 }
 ```
 
+**After a successful POST**, log both the inbound query and the outbound reply to the activity log at
+`~/lobster-workspace/data/bot-talk-activity.jsonl`. Write one JSON line per entry (append, do not overwrite).
+
+Log the **received** query (for each query message fetched from AlbertLobster):
+```json
+{"ts": "<ISO-8601 UTC now>", "direction": "received", "sender": "AlbertLobster", "recipient": "SaharLobster", "text": "<query message content>", "forwarded": false}
+```
+
+Log the **sent** reply (after POSTing the response):
+```json
+{"ts": "<ISO-8601 UTC now>", "direction": "sent", "sender": "SaharLobster", "recipient": "AlbertLobster", "text": "<reply content>", "forwarded": false}
+```
+
+Write these entries atomically (open in append mode, write one line per entry). If the write fails,
+continue — do not fail the job over a log write error.
+
 ### Step 4: Update state
 
 Update `last_processed_ts` to the timestamp of the latest processed message.

--- a/src/mcp/bot_talk_mirror.py
+++ b/src/mcp/bot_talk_mirror.py
@@ -110,6 +110,10 @@ BOT_TALK_TIER = "TIER-BOT"
 
 _WORKSPACE = Path.home() / "lobster-workspace"
 _LOCAL_LOG = _WORKSPACE / "logs" / "bot-talk-mirror.log"
+_ACTIVITY_LOG = _WORKSPACE / "data" / "bot-talk-activity.jsonl"
+
+# Lock for thread-safe appends to the activity log
+_activity_log_lock = threading.Lock()
 
 # Subtypes that should NOT be mirrored — Lobster-internal system messages
 _EXCLUDED_SUBTYPES = frozenset({
@@ -249,6 +253,76 @@ def _do_mirror(content: str, genre: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Activity log — write-at-source for real-time forwarding
+# ---------------------------------------------------------------------------
+
+def _append_activity(entry: dict) -> None:
+    """Append a single JSON entry to the bot-talk activity log.
+
+    Thread-safe. Never raises — failures are silently swallowed to avoid
+    disrupting the calling path (send_reply or incoming handler).
+
+    Entry schema:
+        ts         - ISO-8601 UTC timestamp
+        direction  - "sent" | "received"
+        sender     - who sent (e.g. "SaharLobster")
+        recipient  - who received (e.g. "AlbertLobster", or empty for broadcasts)
+        text       - message text
+        forwarded  - false (realtime-forwarder will flip to true after delivery)
+    """
+    try:
+        _ACTIVITY_LOG.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(entry) + "\n"
+        with _activity_log_lock:
+            with _ACTIVITY_LOG.open("a") as f:
+                f.write(line)
+    except Exception as exc:
+        log.debug(f"bot-talk activity log write failed: {exc}")
+
+
+def log_sent(text: str, recipient: str = "AlbertLobster") -> None:
+    """Log an outbound bot-talk message to the activity log.
+
+    Call this immediately after successfully POSTing a message to the
+    bot-talk API as SaharLobster.
+
+    Args:
+        text:      The message content that was sent.
+        recipient: The intended recipient Lobster name.
+    """
+    entry = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "direction": "sent",
+        "sender": BOT_TALK_SENDER,
+        "recipient": recipient,
+        "text": text,
+        "forwarded": False,
+    }
+    _append_activity(entry)
+
+
+def log_received(text: str, sender: str, recipient: str = "SaharLobster") -> None:
+    """Log an inbound bot-talk message to the activity log.
+
+    Call this immediately after receiving a message from the bot-talk API.
+
+    Args:
+        text:      The message content received.
+        sender:    The name of the Lobster that sent the message (e.g. "AlbertLobster").
+        recipient: The name of the recipient (defaults to "SaharLobster").
+    """
+    entry = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "direction": "received",
+        "sender": sender,
+        "recipient": recipient,
+        "text": text,
+        "forwarded": False,
+    }
+    _append_activity(entry)
+
+
+# ---------------------------------------------------------------------------
 # Public entry points
 # ---------------------------------------------------------------------------
 
@@ -264,6 +338,10 @@ def mirror_outbound(text: str, source: str, chat_id: str | int) -> None:
         chat_id: Destination chat ID.
     """
     content = f"[OUTBOUND → {source.upper()} chat={chat_id}] {text}"
+    # Log to activity file so the realtime-forwarder can pick it up without
+    # polling the API. Only log Telegram/owner-directed outbound messages.
+    if source.lower() == "telegram":
+        log_sent(text=content, recipient="AlbertLobster")
     _spawn_mirror(content, genre="status-update")
 
 


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What this solves

AlbertLobster ↔ SaharLobster bot-talk exchanges were only visible in the hourly \`bot-talk-poller\` batch. This PR adds real-time forwarding so each message arrives on Telegram within 2 minutes.

**Architecture decision**: Write-at-source logging is preferred over API polling. The code that sends and receives bot-talk messages logs those interactions at the moment they happen. The forwarder reads from that local activity log — no API polling, no sender filtering heuristics.

## Architecture: write-at-source activity log

New file: \`~/lobster-workspace/data/bot-talk-activity.jsonl\`

Each entry:
\`\`\`json
{"ts": "...", "direction": "sent"|"received", "sender": "...", "recipient": "...", "text": "...", "forwarded": false}
\`\`\`

Written by two sources:
1. \`bot_talk_mirror.py\` — when \`mirror_outbound()\` sends a Telegram-originated message to the bot-talk API
2. \`lobstertalk-incoming-handler\` — when it receives a query from AlbertLobster and when it sends its reply back

The \`bot-talk-realtime-forwarder\` reads this log, forwards entries with \`forwarded=false\` to Telegram, and marks them \`forwarded=true\`. No API polling. No sender filtering.

## What changed

**\`src/mcp/bot_talk_mirror.py\`:**
- Added \`_append_activity()\`, \`log_sent()\`, \`log_received()\` functions
- \`mirror_outbound()\` now logs Telegram-directed outbound messages to the activity log in addition to the existing HTTP mirror chain

**\`scheduled-tasks/tasks/lobstertalk-incoming-handler.md\`:**
- Step 3 now instructs the handler to log each received query and each sent reply to \`bot-talk-activity.jsonl\` after successful API interaction

**\`scheduled-jobs/tasks/bot-talk-realtime-forwarder.md\`:**
- Completely rewritten: reads activity log instead of polling the bot-talk API
- No authentication needed, no sender filtering, no API calls
- Marks forwarded entries atomically via tmp-rename

## Message flow: before vs after

**Before (API polling approach — #1286):**
\`\`\`
bot-talk exchange happens
  → realtime-forwarder polls API every 2 min
  → tries to filter messages by sender identity (fragile, no recipient field)
  → owner notified
\`\`\`

**After (write-at-source log approach — this PR):**
\`\`\`
bot_talk_mirror.py sends message → logs to bot-talk-activity.jsonl
lobstertalk-incoming-handler receives query → logs to bot-talk-activity.jsonl
lobstertalk-incoming-handler sends reply → logs to bot-talk-activity.jsonl
  → bot-talk-realtime-forwarder (every 2 min) reads log
  → forwards entries with forwarded=false to Telegram
  → marks as forwarded=true
\`\`\`

## Areas to review closely

- **Activity log write**: \`_append_activity()\` in \`bot_talk_mirror.py\` uses a module-level \`threading.Lock()\` to prevent concurrent writes. Verify this is sufficient for the daemon-thread usage pattern.
- **Mark-forwarded atomicity**: The forwarder rewrites the entire \`bot-talk-activity.jsonl\` with a tmp-rename. This could lose entries written between the read and the rewrite. Acceptable for a 2-minute cycle; could be improved later with a per-entry ID.
- **lobstertalk-incoming-handler logging scope**: Only logs query messages + replies. Heartbeats and non-query messages from AlbertLobster are not logged. This is intentional — the realtime-forwarder is scoped to conversations, not status noise.

Supersedes #1286.