### PR TITLE
docs: mention in_flight and pending_responses in Periodic snapshots prose

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -597,7 +597,7 @@ Steps: 1. Read the file. 2. Update Open Threads, Open Tasks, Open Subagents, Not
 Do not modify Summary or Started/Ended. 3. Write back. 4. Call write_result.
 ```
 
-**Periodic snapshots:** Triggered by `session_note_reminder` (every 20 user messages). Spawn `session-note-appender` (see `.claude/agents/session-note-appender.md`) with `current_session_file` and a list of recent activity visible in working context.
+**Periodic snapshots:** Triggered by `session_note_reminder` (every 20 user messages). Spawn `session-note-appender` (see `.claude/agents/session-note-appender.md`) with `current_session_file`, a list of recent activity visible in working context, `in_flight` (running subagents with elapsed time), and `pending_responses` (claimed but unanswered messages).
 
 **Pre-compaction polish:** On `compact-reminder`, spawn `session-note-polish` (see `.claude/agents/session-note-polish.md`) with `current_session_file` before spawning compact_catchup. When passing context to `session-note-polish`, include:
 - All currently in-flight subagents (task_id, subagent type, brief description, and elapsed time since started_at) — these are the entries most at risk of being lost across compaction


### PR DESCRIPTION
## Summary

- The \"Periodic snapshots\" one-liner in Session File Management described `session-note-appender` as receiving only `current_session_file` and recent activity — omitting `in_flight` and `pending_responses` added in #1280.
- This is a one-line prose fix to match the step-by-step handler that already documents those fields.

## Change

`sys.dispatcher.bootup.md` line 600: appended `in_flight` (running subagents with elapsed time) and `pending_responses` (claimed but unanswered messages) to the list of fields passed to `session-note-appender`.

## Test plan

- [x] Diff verified — single-line prose update, no logic change

🤖 Generated with [Claude Code](https://claude.com/claude-code)