### PR TITLE
fix: suppress false WFM stale restart when compact-reminder is batched (#1283)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -187,8 +187,10 @@ After a context compaction you lose situational awareness of the last ~30 minute
 
 > **MANDATORY: You MUST spawn compact-catchup before doing any other work after a compaction. Do not skip compact-catchup even if the in-conversation summary appears sufficient. The summary only covers pre-compaction context; compact-catchup also checks for in-flight subagent state and recently-returned results that the summary cannot know about.**
 
+> **CRITICAL — never batch the compact-reminder with other messages.** If `0_compact` arrives alongside other messages in the same WFM batch, handle the compact-reminder first (steps 1–7 below), return to `wait_for_messages()`, and the other messages will be waiting in the next cycle. Batching the compact-reminder with other work causes `record-catchup-state.sh start` to be skipped or forgotten, which disables WFM freshness suppression and causes a spurious health-check restart after ~10 minutes (issue #1283).
+
 ```
-1. mark_processing(message_id)
+1. mark_processing(message_id)  <- compact-reminder ONLY, not other messages
 2. Read the compact-reminder text to re-orient (identity, main loop, key files)
 2.5. Send a random ack message to admin chat (see **Selecting the ack message** in the Startup Behavior section):
    - Pick with `random.choice()` from `~/.claude/compact-ack-messages.json`
@@ -198,7 +200,7 @@ After a context compaction you lose situational awareness of the last ~30 minute
    - See .claude/agents/session-note-polish.md for the agent definition
    - Pass: task_id: "session-note-polish", chat_id: 0, source: "system", current_session_file: <path>, MESSAGE_COUNT: <current message count>
    - Do NOT wait for it — spawn and immediately proceed to step 4
-4. Run: ~/lobster/scripts/record-catchup-state.sh start
+4. Run: ~/lobster/scripts/record-catchup-state.sh start  <- MANDATORY, arms WFM suppression
 5. Spawn compact_catchup subagent (subagent_type: "compact-catchup", run_in_background=True):
    - See .claude/agents/compact-catchup.md for the full prompt
    - Pass task_id: "compact-catchup", chat_id: 0, source: "system"

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -436,60 +436,92 @@ is_compact_grace_period() {
 # Check if a catchup subagent is actively running (or recently started).
 # Returns 0 (true) if the WFM freshness check should be suppressed, 1 otherwise.
 #
-# The dispatcher writes catchup_started_at to lobster-state.json before spawning
-# either the startup-catchup or compact-catchup subagent, and writes
-# catchup_finished_at when the subagent result arrives.  If catchup_finished_at
-# is absent or older than catchup_started_at, the catchup is still in flight.
+# Primary path: the dispatcher writes catchup_started_at to lobster-state.json
+# before spawning either the startup-catchup or compact-catchup subagent, and
+# writes catchup_finished_at when the subagent result arrives.  If
+# catchup_finished_at is absent or older than catchup_started_at, the catchup
+# is still in flight.
 #
-# Suppression window: CATCHUP_SUPPRESS_SECONDS from catchup_started_at.
+# Fallback path (issue #1283): if the dispatcher forgot to call
+# record-catchup-state.sh (e.g. it batched the compact-reminder with other
+# messages), catchup_started_at is never updated.  In that case we fall back
+# to compacted_at: if a compaction is more recent than catchup_finished_at and
+# within CATCHUP_SUPPRESS_SECONDS, we treat catchup as in-flight.
+#
+# Suppression window: CATCHUP_SUPPRESS_SECONDS from the effective start time.
 # This caps suppression even if catchup_finished_at is never written (e.g. the
 # subagent crashed), preventing permanent suppression.
 is_catchup_active() {
     if [[ ! -f "$LOBSTER_STATE_FILE" ]]; then
         return 1
     fi
-    local started_at finished_at
-    started_at=$(python3 -c "
-import json, sys
-try:
-    d = json.load(open('$LOBSTER_STATE_FILE'))
-    print(d.get('catchup_started_at', ''))
-except Exception:
-    print('')
-" 2>/dev/null)
-    if [[ -z "$started_at" ]]; then
-        return 1
-    fi
-    local started_epoch
-    started_epoch=$(date -d "$started_at" +%s 2>/dev/null) || return 1
+
     local now
     now=$(date +%s)
-    local age=$((now - started_epoch))
-    # Hard cap: don't suppress longer than CATCHUP_SUPPRESS_SECONDS even if
-    # catchup_finished_at was never written (subagent crash, etc.)
-    if [[ $age -gt $CATCHUP_SUPPRESS_SECONDS ]]; then
-        log_info "Catchup suppression expired: started ${age}s ago (cap: ${CATCHUP_SUPPRESS_SECONDS}s)"
-        return 1
-    fi
-    # Check if catchup has already finished
-    finished_at=$(python3 -c "
+
+    # Read all relevant timestamps in one python call for efficiency
+    local started_at finished_at compacted_at
+    read -r started_at finished_at compacted_at < <(python3 -c "
 import json, sys
 try:
     d = json.load(open('$LOBSTER_STATE_FILE'))
-    print(d.get('catchup_finished_at', ''))
+    print(d.get('catchup_started_at', ''), d.get('catchup_finished_at', ''), d.get('compacted_at', ''))
 except Exception:
-    print('')
+    print('', '', '')
 " 2>/dev/null)
+
+    local finished_epoch=0
     if [[ -n "$finished_at" ]]; then
-        local finished_epoch
-        finished_epoch=$(date -d "$finished_at" +%s 2>/dev/null) || { log_warn "WARN: failed to parse finished_epoch from finished_at=${finished_at} — treating catchup as still in flight"; true; }
-        if [[ -n "$finished_epoch" && "$finished_epoch" -ge "$started_epoch" ]]; then
-            log_info "Catchup complete: finished_at=$finished_at — WFM suppression lifted"
-            return 1
+        finished_epoch=$(date -d "$finished_at" +%s 2>/dev/null) || finished_epoch=0
+    fi
+
+    # --- Primary path: catchup_started_at is present ---
+    if [[ -n "$started_at" ]]; then
+        local started_epoch
+        started_epoch=$(date -d "$started_at" +%s 2>/dev/null) || started_epoch=0
+        if [[ $started_epoch -gt 0 ]]; then
+            local age=$(( now - started_epoch ))
+            # Hard cap: don't suppress longer than CATCHUP_SUPPRESS_SECONDS even if
+            # catchup_finished_at was never written (subagent crash, etc.)
+            if [[ $age -gt $CATCHUP_SUPPRESS_SECONDS ]]; then
+                log_info "Catchup suppression expired: started ${age}s ago (cap: ${CATCHUP_SUPPRESS_SECONDS}s)"
+                # Fall through to compacted_at fallback — maybe a new compaction
+                # occurred after the cap expired and a new catchup is in flight.
+            else
+                # Check if catchup has already finished
+                if [[ $finished_epoch -gt 0 && $finished_epoch -ge $started_epoch ]]; then
+                    log_info "Catchup complete: finished_at=$finished_at — WFM suppression lifted"
+                    return 1
+                fi
+                log_info "Catchup in flight: started ${age}s ago (cap: ${CATCHUP_SUPPRESS_SECONDS}s) — WFM freshness suppressed"
+                return 0
+            fi
         fi
     fi
-    log_info "Catchup in flight: started ${age}s ago (cap: ${CATCHUP_SUPPRESS_SECONDS}s) — WFM freshness suppressed"
-    return 0
+
+    # --- Fallback path: check compacted_at (issue #1283) ---
+    # If the dispatcher forgot to write catchup_started_at (e.g. it batched
+    # the compact-reminder with other messages), we fall back to compacted_at.
+    # A compaction that is more recent than catchup_finished_at implies that
+    # a new catchup should be in flight but was never registered.
+    if [[ -n "$compacted_at" ]]; then
+        local compacted_epoch
+        compacted_epoch=$(date -d "$compacted_at" +%s 2>/dev/null) || compacted_epoch=0
+        if [[ $compacted_epoch -gt 0 ]]; then
+            local compaction_age=$(( now - compacted_epoch ))
+            if [[ $compaction_age -le $CATCHUP_SUPPRESS_SECONDS ]]; then
+                # Compaction is recent — check if catchup finished AFTER the compaction
+                if [[ $finished_epoch -gt 0 && $finished_epoch -ge $compacted_epoch ]]; then
+                    log_info "Catchup complete (fallback): compacted_at=$compacted_at, finished_at=$finished_at — WFM suppression not needed"
+                    return 1
+                fi
+                log_warn "Catchup fallback active (issue #1283): compacted_at=${compaction_age}s ago, catchup_started_at missing or stale — WFM freshness suppressed"
+                return 0
+            fi
+        fi
+    fi
+
+    return 1
 }
 
 # Check if a boot/restart occurred within the last BOOT_GRACE_SECONDS.


### PR DESCRIPTION
## Summary

Fixes the spurious health-check restart at 2026-03-31 14:52 UTC (issue #1283).

**Root cause:** The dispatcher batched the `compact-reminder` with 3 other messages. As a result, `record-catchup-state.sh start` was never called, so `catchup_started_at` was not updated. The health check saw no suppression in force and fired a RED restart 811s after the last `mark_processed` call — even though a `compact-catchup` subagent was actively running.

## Changes

**`scripts/health-check-v3.sh`** — `is_catchup_active()` fallback path:
- If `catchup_started_at` is absent or expired, check `compacted_at` as a fallback
- If a compaction is more recent than `catchup_finished_at` and within `CATCHUP_SUPPRESS_SECONDS`, suppress the WFM freshness alarm
- Also consolidates three separate `python3` invocations into one for efficiency

**`.claude/sys.dispatcher.bootup.md`** — compact-reminder handler:
- Adds explicit warning: never batch the compact-reminder with other messages
- Marks `record-catchup-state.sh start` (step 4) as MANDATORY with a note explaining what breaks if skipped

## Test plan

- [ ] Verify `is_catchup_active()` returns true when `compacted_at` is recent and `catchup_finished_at` predates it (even with `catchup_started_at` absent)
- [ ] Verify `is_catchup_active()` returns false when `catchup_finished_at` is more recent than `compacted_at`
- [ ] Verify `is_catchup_active()` returns false when `compacted_at` is older than `CATCHUP_SUPPRESS_SECONDS`
- [ ] Normal path (catchup_started_at present) unchanged

Closes #1283

🤖 Generated with [Claude Code](https://claude.com/claude-code)