### PR TITLE
feat: my_chat_member handler — group auto-whitelist on bot join

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -29,6 +29,17 @@ from utils.fs import atomic_write_json  # noqa: E402
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 
+# multiplayer-telegram-bot skill — soft import; enables group whitelist management
+_SKILL_DIR = str(Path(__file__).resolve().parent.parent.parent /
+                 "lobster-shop" / "multiplayer-telegram-bot" / "src")
+if _SKILL_DIR not in _sys.path:
+    _sys.path.insert(0, _SKILL_DIR)
+try:
+    from multiplayer_telegram_bot.whitelist import load_whitelist, enable_group, add_allowed_user, save_whitelist  # noqa: E402
+    _GROUP_GATING_ENABLED = True
+except ImportError:
+    _GROUP_GATING_ENABLED = False
+
 # ChannelAdapter Protocol — soft import; lobster_bot satisfies it structurally
 # but keeps its own async OutboxHandler rather than using OutboxFileHandler.
 try:
@@ -43,7 +54,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, ReplyParameters
-from telegram.ext import Application, CommandHandler, MessageHandler, CallbackQueryHandler, MessageReactionHandler, filters, ContextTypes
+from telegram.ext import Application, CommandHandler, MessageHandler, CallbackQueryHandler, ChatMemberHandler, MessageReactionHandler, filters, ContextTypes
 from collections import deque
 
 
@@ -1579,6 +1590,48 @@ async def sweep_outbox():
             log.error(f"Outbox sweep error: {e}")
 
 
+async def handle_my_chat_member(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle bot being added to or removed from a group.
+
+    When added by a whitelisted user: auto-enables the group in group-whitelist.json
+    and seeds all ALLOWED_USERS as allowed members.
+    When added by a non-whitelisted user: silently ignores (no whitelist entry written).
+    When removed from a group: logs the removal only.
+    """
+    if not update.my_chat_member:
+        return
+    event = update.my_chat_member
+    new_status = event.new_chat_member.status
+    chat = event.chat
+    adder = event.from_user
+
+    if new_status in ("member", "administrator") and chat.type in ("group", "supergroup"):
+        if adder and adder.id in ALLOWED_USERS:
+            log.info(
+                f"Bot added to group {chat.id} ({chat.title}) by whitelisted user "
+                f"{adder.id} — auto-enabling"
+            )
+            if _GROUP_GATING_ENABLED:
+                try:
+                    store = load_whitelist()
+                    store = enable_group(chat.id, chat.title or str(chat.id), store)
+                    for uid in ALLOWED_USERS:
+                        store = add_allowed_user(uid, chat.id, store)
+                    save_whitelist(store)
+                    log.info(f"Group {chat.id} auto-whitelisted with users {ALLOWED_USERS}")
+                except Exception as e:
+                    log.error(f"Failed to auto-whitelist group {chat.id}: {e}")
+            else:
+                log.warning("_GROUP_GATING_ENABLED is False — multiplayer-telegram-bot skill not installed; skipping whitelist update")
+        else:
+            adder_id = adder.id if adder else "unknown"
+            log.info(
+                f"Bot added to group {chat.id} by non-whitelisted user {adder_id} — ignoring"
+            )
+    elif new_status in ("left", "kicked"):
+        log.info(f"Bot removed from group {chat.id} ({chat.title})")
+
+
 async def error_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     from telegram.error import Conflict
     if isinstance(context.error, Conflict):
@@ -1621,6 +1674,7 @@ async def run_bot():
     bot_app.add_handler(MessageHandler(filters.UpdateType.EDITED_MESSAGE & filters.TEXT, handle_edited_message))
     # Requires python-telegram-bot >= v20.6 for Update.ALL_TYPES to include message_reaction
     bot_app.add_handler(MessageReactionHandler(handle_reaction))
+    bot_app.add_handler(ChatMemberHandler(handle_my_chat_member, ChatMemberHandler.MY_CHAT_MEMBER))
     bot_app.add_error_handler(error_handler)
 
     # Initialize and start


### PR DESCRIPTION
## Problem

When a whitelisted user adds the bot to a Telegram group, nothing happened. There was no `my_chat_member` handler in `lobster_bot.py`, so groups could never be auto-enabled via the join event.

## What this does

Adds `handle_my_chat_member` and registers it with `ChatMemberHandler.MY_CHAT_MEMBER`. The logic is:

- **Bot added, adder is whitelisted**: calls `load_whitelist` → `enable_group` → `add_allowed_user` (for each `ALLOWED_USERS` entry) → `save_whitelist`. Group appears in `~/messages/config/group-whitelist.json` with `enabled: true` and all allowed user IDs.
- **Bot added, adder is not whitelisted**: silently ignored — nothing written to the whitelist.
- **Bot removed from a group**: logged only, no whitelist mutation.

The whitelist helpers are imported via a soft-import block guarded by `_GROUP_GATING_ENABLED`. If `multiplayer-telegram-bot` is not installed, the handler still fires and logs the join/leave event; it just skips the whitelist write with a warning. This keeps the bot operational in environments where the skill isn't present.

`ChatMemberHandler` is added to the existing `telegram.ext` import. No changes to `handle_message` or any other handler — DM behavior is untouched.

## Functional patterns

Pure functions from `whitelist.py` (`enable_group`, `add_allowed_user`) return new store values rather than mutating in place. The handler composes them sequentially and hands the final store to `save_whitelist` — a single side-effecting call at the boundary.

## Flow

```
my_chat_member update arrives
        │
        ├─ new_status in (member, administrator) AND chat.type in (group, supergroup)?
        │       │
        │       ├─ adder.id in ALLOWED_USERS?
        │       │       │
        │       │       ├─ YES → load_whitelist → enable_group → add_allowed_user(×N) → save_whitelist
        │       │       │
        │       │       └─ NO  → log "ignoring" (no whitelist write)
        │       
        └─ new_status in (left, kicked)?
                │
                └─ log removal only
```

## Tests run

- [x] `uv run pytest lobster-shop/multiplayer-telegram-bot/ -v` — 155 passed, 0 failed
- [ ] Live Telegram group add/remove — blocked: requires running bot with valid `BOT_TOKEN` and `TELEGRAM_ALLOWED_USERS` in production environment

Closes #1290
Relates to #1288