### PR TITLE
feat: two-tier group message gating in handle_message

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -38,6 +38,26 @@ try:
 except ImportError:
     pass  # channels package not yet installed; type hint only
 
+# multiplayer-telegram-bot skill — group gating library.
+# Adds the skill's src/ directory to sys.path so we can import the pure
+# gating/whitelist/router modules without a full package install.
+_SKILL_DIR = str(Path(__file__).resolve().parent.parent.parent
+                 / "lobster-shop" / "multiplayer-telegram-bot" / "src")
+if _SKILL_DIR not in _sys.path:
+    _sys.path.insert(0, _SKILL_DIR)
+
+try:
+    from multiplayer_telegram_bot.whitelist import load_whitelist
+    from multiplayer_telegram_bot.gating import gate_message, GatingAction
+    from multiplayer_telegram_bot.router import get_source_for_chat
+    _GROUP_GATING_ENABLED = True
+except ImportError:
+    _GROUP_GATING_ENABLED = False
+    import logging as _logging
+    _logging.getLogger(__name__).warning(
+        "multiplayer-telegram-bot skill not available — group gating disabled"
+    )
+
 import re
 from dataclasses import dataclass, field
 from typing import Optional
@@ -902,8 +922,41 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return
 
     user = update.effective_user
-    if not user or user.id not in ALLOWED_USERS:
+    if not user:
         return
+
+    chat = message.chat
+    if chat.type in ("group", "supergroup"):
+        # Tier 1 + Tier 2 — group gating
+        if _GROUP_GATING_ENABLED:
+            store = load_whitelist()
+            result = gate_message(chat.id, user.id, store)
+            if result.action == GatingAction.DROP_SILENT:
+                log.debug(f"Group message silently dropped: {result.reason}")
+                return
+            elif result.action == GatingAction.SEND_REGISTRATION_DM:
+                log.info(
+                    f"Sending registration DM to user {user.id} for group {chat.id}"
+                )
+                try:
+                    await bot_app.bot.send_message(
+                        chat_id=user.id,
+                        text=(
+                            "Hi! To use Lobster in this group, please ask the "
+                            "group admin to whitelist you."
+                        ),
+                    )
+                except Exception as e:
+                    log.warning(f"Failed to send registration DM to {user.id}: {e}")
+                return
+            # GatingAction.ALLOW — fall through to message handling
+        else:
+            # Skill not available; drop all group messages silently
+            return
+    else:
+        # DM path — unchanged behaviour
+        if user.id not in ALLOWED_USERS:
+            return
 
     # Wake Claude if hibernating (non-blocking — spawns subprocess if needed)
     wake_claude_if_hibernating()
@@ -938,9 +991,12 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return
 
     # Create message file in inbox
+    _is_group = chat.type in ("group", "supergroup")
     msg_data = {
         "id": msg_id,
-        "source": "telegram",
+        "source": (
+            get_source_for_chat(chat.type) if _GROUP_GATING_ENABLED else "telegram"
+        ),
         "type": "text",
         "chat_id": message.chat_id,
         "telegram_message_id": message.message_id,
@@ -950,6 +1006,9 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "text": text,
         "timestamp": datetime.utcnow().isoformat(),
     }
+    if _is_group:
+        msg_data["group_chat_id"] = chat.id
+        msg_data["group_title"] = chat.title
 
     # Capture full reply-to context if this message is a reply
     reply_ctx = extract_reply_to_context(message)


### PR DESCRIPTION
## What this fixes

Before this change, `handle_message` applied a single `ALLOWED_USERS` check to every message. Group messages always failed that check and were silently dropped — groups were completely unsupported regardless of whether they appeared in the whitelist.

## What changes

`handle_message` now routes group and DM messages through separate paths:

```
Incoming message
├── chat.type == group/supergroup
│   ├── _GROUP_GATING_ENABLED = False  → silent drop (skill missing)
│   └── _GROUP_GATING_ENABLED = True
│       ├── gate_message → DROP_SILENT         → silent drop (group not whitelisted)
│       ├── gate_message → SEND_REGISTRATION_DM → send DM to user, drop message
│       └── gate_message → ALLOW              → write to inbox with source="lobster-group"
└── chat.type == private/other
    ├── user.id not in ALLOWED_USERS → drop (unchanged)
    └── user.id in ALLOWED_USERS     → write to inbox with source="telegram" (unchanged)
```

Group messages that reach the inbox also carry `group_chat_id` and `group_title` in `msg_data`, so replies are directed to the group chat rather than a user DM.

## Phase 1 prerequisite included

Phase 1 (sys.path injection + soft-imports of `load_whitelist`, `gate_message`, `GatingAction`, `get_source_for_chat`) is included here because Phase 1 PR is not yet merged. The soft-import pattern means the bot starts cleanly even if the skill directory is missing — `_GROUP_GATING_ENABLED = False` and all group messages are silently dropped, preserving the pre-change behaviour.

## Functional patterns used

The gating logic is entirely delegated to the pure functions in `multiplayer_telegram_bot.gating` and `multiplayer_telegram_bot.whitelist` — no mutable state, no side effects inside the decision path. `handle_message` itself only performs I/O (sending DMs, writing inbox files) after the pure gate decision is made.

## What is NOT in scope

- Edited/audio/photo/document handlers still use the old single-guard (Phase 4)
- Command handlers `/enable_group_bot`, `/whitelist`, `/unwhitelist` (Phase 3)
- `my_chat_member` auto-whitelist handler (Phase 1 proper)
- upgrade.sh migration (Phase 5)

## Tests run

- [x] `uv run pytest tests/unit/test_bot/ -v` — 129 passed, 0 failed
- [x] `uv run pytest tests/ -v` (multiplayer-telegram-bot skill) — 155 passed, 0 failed
- [ ] Live Telegram group test — blocked: requires BotFather privacy mode change (manual prerequisite from #1288) and running bot instance

**Blocked items needing attention before merge:** Live group test requires BotFather privacy mode disabled on @Awp_Sebastian_bot — safe to merge, this is a manual pre-deployment step noted in the epic.

Closes #1292
Relates to #1288