### PR TITLE
feat(bot): Phase 3 — group management command handlers

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -30,15 +30,30 @@ from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 
 # multiplayer-telegram-bot skill — soft import; enables group whitelist management
+# and group management commands.  Three levels up from src/bot/lobster_bot.py
+# lands at the repo root (~/lobster/), then lobster-shop/ is a subdirectory there.
 _SKILL_DIR = str(Path(__file__).resolve().parent.parent.parent /
                  "lobster-shop" / "multiplayer-telegram-bot" / "src")
 if _SKILL_DIR not in _sys.path:
     _sys.path.insert(0, _SKILL_DIR)
 try:
     from multiplayer_telegram_bot.whitelist import load_whitelist, enable_group, add_allowed_user, save_whitelist  # noqa: E402
+    from multiplayer_telegram_bot.gating import gate_message, GatingAction  # noqa: E402
+    from multiplayer_telegram_bot.router import get_source_for_chat  # noqa: E402
+    from multiplayer_telegram_bot.commands import (  # noqa: E402
+        handle_enable_group_bot,
+        handle_whitelist,
+        handle_unwhitelist,
+    )
     _GROUP_GATING_ENABLED = True
+    _GROUP_COMMANDS_ENABLED = True
 except ImportError:
     _GROUP_GATING_ENABLED = False
+    _GROUP_COMMANDS_ENABLED = False
+    import logging as _logging
+    _logging.getLogger(__name__).warning(
+        "multiplayer-telegram-bot skill not available — group gating and management commands disabled"
+    )
 
 # ChannelAdapter Protocol — soft import; lobster_bot satisfies it structurally
 # but keeps its own async OutboxHandler rather than using OutboxFileHandler.
@@ -48,26 +63,6 @@ try:
     from channels.base import ChannelAdapter  # noqa: F401
 except ImportError:
     pass  # channels package not yet installed; type hint only
-
-# multiplayer-telegram-bot skill — group gating library.
-# Adds the skill's src/ directory to sys.path so we can import the pure
-# gating/whitelist/router modules without a full package install.
-_SKILL_DIR = str(Path(__file__).resolve().parent.parent.parent
-                 / "lobster-shop" / "multiplayer-telegram-bot" / "src")
-if _SKILL_DIR not in _sys.path:
-    _sys.path.insert(0, _SKILL_DIR)
-
-try:
-    from multiplayer_telegram_bot.whitelist import load_whitelist
-    from multiplayer_telegram_bot.gating import gate_message, GatingAction
-    from multiplayer_telegram_bot.router import get_source_for_chat
-    _GROUP_GATING_ENABLED = True
-except ImportError:
-    _GROUP_GATING_ENABLED = False
-    import logging as _logging
-    _logging.getLogger(__name__).warning(
-        "multiplayer-telegram-bot skill not available — group gating disabled"
-    )
 
 import re
 from dataclasses import dataclass, field
@@ -745,6 +740,95 @@ async def onboarding_command(update: Update, context: ContextTypes.DEFAULT_TYPE)
     chunks = split_message(onboarding_msg)
     for chunk in chunks:
         await update.message.reply_text(md_to_html(chunk), parse_mode="HTML")
+
+
+async def enable_group_bot_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /enable_group_bot <chat_id> [name] — enable a group in the whitelist.
+
+    Only works in private DMs from ALLOWED_USERS. Silently drops the command
+    from non-DM chats or non-allowed users.
+    """
+    user = update.effective_user
+    if not user or user.id not in ALLOWED_USERS:
+        return
+    if update.effective_chat.type != "private":
+        await update.message.reply_text("This command only works in a private DM with me.")
+        return
+    if not _GROUP_COMMANDS_ENABLED:
+        await update.message.reply_text("Group management commands are not available (skill not installed).")
+        return
+    result = handle_enable_group_bot(update.message.text)
+    await update.message.reply_text(result.reply)
+
+
+async def whitelist_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /whitelist <user_id> <chat_id> — add a user to a group's whitelist.
+
+    Only works in private DMs from ALLOWED_USERS. Silently drops otherwise.
+    """
+    user = update.effective_user
+    if not user or user.id not in ALLOWED_USERS:
+        return
+    if update.effective_chat.type != "private":
+        return
+    if not _GROUP_COMMANDS_ENABLED:
+        await update.message.reply_text("Group management commands are not available (skill not installed).")
+        return
+    result = handle_whitelist(update.message.text)
+    await update.message.reply_text(result.reply)
+
+
+async def unwhitelist_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /unwhitelist <user_id> <chat_id> — remove a user from a group's whitelist.
+
+    Only works in private DMs from ALLOWED_USERS. Silently drops otherwise.
+    """
+    user = update.effective_user
+    if not user or user.id not in ALLOWED_USERS:
+        return
+    if update.effective_chat.type != "private":
+        return
+    if not _GROUP_COMMANDS_ENABLED:
+        await update.message.reply_text("Group management commands are not available (skill not installed).")
+        return
+    result = handle_unwhitelist(update.message.text)
+    await update.message.reply_text(result.reply)
+
+
+async def list_groups_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /list_groups — show all configured groups and their whitelisted users.
+
+    Only works in private DMs from ALLOWED_USERS. Silently drops otherwise.
+    """
+    user = update.effective_user
+    if not user or user.id not in ALLOWED_USERS:
+        return
+    if update.effective_chat.type != "private":
+        return
+    if not _GROUP_COMMANDS_ENABLED:
+        await update.message.reply_text("Group management commands are not available (skill not installed).")
+        return
+
+    store = load_whitelist()
+    groups = store.get("groups", {})
+
+    if not groups:
+        await update.message.reply_text("No groups configured.")
+        return
+
+    lines = ["Configured groups:\n"]
+    for group_id, config in groups.items():
+        name = config.get("name", group_id)
+        enabled = config.get("enabled", False)
+        allowed_ids = config.get("allowed_user_ids", [])
+        status = "enabled" if enabled else "disabled"
+        lines.append(f"• {name} ({group_id}) — {status}")
+        if allowed_ids:
+            lines.append(f"  Whitelisted users: {', '.join(str(uid) for uid in allowed_ids)}")
+        else:
+            lines.append("  No whitelisted users")
+
+    await update.message.reply_text("\n".join(lines))
 
 
 async def handle_callback_query(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -1725,6 +1809,12 @@ async def run_bot():
     # Add handlers
     bot_app.add_handler(CommandHandler("start", start_command))
     bot_app.add_handler(CommandHandler("onboarding", onboarding_command))
+    # Group management commands — registered before the generic MessageHandler so
+    # they are dispatched as commands rather than falling through to Claude.
+    bot_app.add_handler(CommandHandler("enable_group_bot", enable_group_bot_command))
+    bot_app.add_handler(CommandHandler("whitelist", whitelist_command))
+    bot_app.add_handler(CommandHandler("unwhitelist", unwhitelist_command))
+    bot_app.add_handler(CommandHandler("list_groups", list_groups_command))
     bot_app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
     bot_app.add_handler(MessageHandler(filters.VOICE | filters.AUDIO, handle_message))
     bot_app.add_handler(MessageHandler(filters.PHOTO, handle_message))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,16 @@ TESTS_DIR = Path(__file__).parent
 sys.path.insert(0, str(SRC_DIR))
 sys.path.insert(0, str(TESTS_DIR.parent))
 
+# Add multiplayer-telegram-bot skill to path so group command handler tests
+# can import it directly and so lobster_bot.py finds it when reloaded.
+# The worktree lives at  ~/lobster-workspace/projects/<branch>/
+# so three levels up lands at ~/lobster-workspace/, then we navigate to the
+# canonical repo location.
+_WORKTREE_ROOT = Path(__file__).parent.parent
+_SKILL_SRC = _WORKTREE_ROOT.parent.parent.parent / "lobster" / "lobster-shop" / "multiplayer-telegram-bot" / "src"
+if _SKILL_SRC.exists() and str(_SKILL_SRC) not in sys.path:
+    sys.path.insert(0, str(_SKILL_SRC))
+
 # Import fixtures module
 from tests.fixtures.generators import (
     MessageGenerator,

--- a/tests/unit/test_bot/test_group_commands.py
+++ b/tests/unit/test_bot/test_group_commands.py
@@ -1,0 +1,392 @@
+"""
+Tests for group management command handlers.
+
+Tests the four command handlers added in Phase 3:
+  /enable_group_bot, /whitelist, /unwhitelist, /list_groups
+
+Each handler must:
+  - Silently drop commands from non-ALLOWED_USERS (no reply)
+  - Reply with an error for commands sent from non-DM chats (group chats)
+    (only /enable_group_bot sends an error; the rest silently drop)
+  - Delegate to the multiplayer_telegram_bot skill's command functions
+  - Reply to the user with the result
+"""
+
+import json
+import os
+import pytest
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_env():
+    return {
+        "TELEGRAM_BOT_TOKEN": "test_token",
+        "TELEGRAM_ALLOWED_USERS": "111111,222222",
+    }
+
+
+def _make_update(
+    *,
+    user_id: int = 111111,
+    chat_type: str = "private",
+    message_text: str = "/enable_group_bot -100123456",
+) -> MagicMock:
+    """Build a minimal mock Update object for command handler testing."""
+    update = MagicMock()
+    update.effective_user.id = user_id
+    update.effective_chat.type = chat_type
+    update.message.text = message_text
+    update.message.reply_text = AsyncMock()
+    return update
+
+
+def _make_context() -> MagicMock:
+    return MagicMock()
+
+
+def _minimal_whitelist(group_id: str = "-100123456") -> dict:
+    return {
+        "groups": {
+            group_id: {
+                "name": "Test Group",
+                "enabled": True,
+                "allowed_user_ids": [111111],
+            }
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# enable_group_bot_command
+# ---------------------------------------------------------------------------
+
+class TestEnableGroupBotCommand:
+    """Tests for /enable_group_bot handler."""
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_is_silently_dropped(self):
+        """Non-ALLOWED_USER gets no reply at all."""
+        with patch.dict(os.environ, _make_env()):
+            import importlib
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_update(user_id=999999)
+            await bot_module.enable_group_bot_command(update, _make_context())
+
+            update.message.reply_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_group_chat_gets_error_reply(self):
+        """Command sent from a group chat returns a DM-only error message."""
+        with patch.dict(os.environ, _make_env()):
+            import importlib
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_update(chat_type="group")
+            await bot_module.enable_group_bot_command(update, _make_context())
+
+            update.message.reply_text.assert_called_once()
+            reply = update.message.reply_text.call_args[0][0]
+            assert "private" in reply.lower() or "DM" in reply
+
+    @pytest.mark.asyncio
+    async def test_valid_command_enables_group(self):
+        """Valid command from allowed user in DM enables the group."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump({"groups": {}}, f)
+            wl_path = f.name
+
+        try:
+            with patch.dict(os.environ, _make_env()):
+                import importlib
+                import src.bot.lobster_bot as bot_module
+                importlib.reload(bot_module)
+
+                update = _make_update(
+                    message_text=f"/enable_group_bot -100123456 My Test Group"
+                )
+
+                # Patch handle_enable_group_bot to avoid real file I/O
+                from multiplayer_telegram_bot.commands import CommandResult
+                mock_result = CommandResult(
+                    success=True,
+                    reply="Group My Test Group (-100123456) is now enabled for Lobster bot access.",
+                )
+
+                with patch.object(
+                    bot_module, "handle_enable_group_bot", return_value=mock_result
+                ) as mock_cmd:
+                    await bot_module.enable_group_bot_command(update, _make_context())
+
+                    mock_cmd.assert_called_once_with(update.message.text)
+                    update.message.reply_text.assert_called_once_with(mock_result.reply)
+        finally:
+            os.unlink(wl_path)
+
+    @pytest.mark.asyncio
+    async def test_invalid_group_id_returns_error(self):
+        """Positive group ID produces an error reply (not a crash)."""
+        with patch.dict(os.environ, _make_env()):
+            import importlib
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_update(message_text="/enable_group_bot 12345")
+
+            from multiplayer_telegram_bot.commands import CommandResult
+            error_result = CommandResult(
+                success=False,
+                reply="Group ID must be negative (got 12345). Group IDs start with - or -100.",
+            )
+
+            with patch.object(
+                bot_module, "handle_enable_group_bot", return_value=error_result
+            ):
+                await bot_module.enable_group_bot_command(update, _make_context())
+
+            update.message.reply_text.assert_called_once_with(error_result.reply)
+
+    @pytest.mark.asyncio
+    async def test_skill_not_installed_returns_unavailable(self):
+        """When _GROUP_COMMANDS_ENABLED is False, replies with unavailable message."""
+        with patch.dict(os.environ, _make_env()):
+            import importlib
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_update()
+            original = bot_module._GROUP_COMMANDS_ENABLED
+            bot_module._GROUP_COMMANDS_ENABLED = False
+            try:
+                await bot_module.enable_group_bot_command(update, _make_context())
+            finally:
+                bot_module._GROUP_COMMANDS_ENABLED = original
+
+            update.message.reply_text.assert_called_once()
+            reply = update.message.reply_text.call_args[0][0]
+            assert "not available" in reply.lower()
+
+
+# ---------------------------------------------------------------------------
+# whitelist_command
+# ---------------------------------------------------------------------------
+
+class TestWhitelistCommand:
+    """Tests for /whitelist handler."""
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_is_silently_dropped(self):
+        """Non-ALLOWED_USER gets no reply."""
+        with patch.dict(os.environ, _make_env()):
+            import importlib
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_update(user_id=999999, message_text="/whitelist 555 -100123456")
+            await bot_module.whitelist_command(update, _make_context())
+
+            update.message.reply_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_group_chat_is_silently_dropped(self):
+        """Command from a group chat is silently dropped (no reply)."""
+        with patch.dict(os.environ, _make_env()):
+            import importlib
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_update(
+                chat_type="group", message_text="/whitelist 555 -100123456"
+            )
+            await bot_module.whitelist_command(update, _make_context())
+
+            update.message.reply_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_valid_command_adds_user(self):
+        """Valid /whitelist in DM delegates to handle_whitelist and replies."""
+        with patch.dict(os.environ, _make_env()):
+            import importlib
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_update(message_text="/whitelist 555555 -100123456")
+
+            from multiplayer_telegram_bot.commands import CommandResult
+            mock_result = CommandResult(
+                success=True,
+                reply="User 555555 added to whitelist for group -100123456.",
+            )
+
+            with patch.object(
+                bot_module, "handle_whitelist", return_value=mock_result
+            ) as mock_cmd:
+                await bot_module.whitelist_command(update, _make_context())
+
+                mock_cmd.assert_called_once_with(update.message.text)
+                update.message.reply_text.assert_called_once_with(mock_result.reply)
+
+
+# ---------------------------------------------------------------------------
+# unwhitelist_command
+# ---------------------------------------------------------------------------
+
+class TestUnwhitelistCommand:
+    """Tests for /unwhitelist handler."""
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_is_silently_dropped(self):
+        with patch.dict(os.environ, _make_env()):
+            import importlib
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_update(user_id=999999, message_text="/unwhitelist 555 -100123456")
+            await bot_module.unwhitelist_command(update, _make_context())
+
+            update.message.reply_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_group_chat_is_silently_dropped(self):
+        with patch.dict(os.environ, _make_env()):
+            import importlib
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_update(
+                chat_type="group", message_text="/unwhitelist 555 -100123456"
+            )
+            await bot_module.unwhitelist_command(update, _make_context())
+
+            update.message.reply_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_valid_command_removes_user(self):
+        """Valid /unwhitelist in DM delegates to handle_unwhitelist and replies."""
+        with patch.dict(os.environ, _make_env()):
+            import importlib
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_update(message_text="/unwhitelist 555555 -100123456")
+
+            from multiplayer_telegram_bot.commands import CommandResult
+            mock_result = CommandResult(
+                success=True,
+                reply="User 555555 removed from whitelist for group -100123456.",
+            )
+
+            with patch.object(
+                bot_module, "handle_unwhitelist", return_value=mock_result
+            ) as mock_cmd:
+                await bot_module.unwhitelist_command(update, _make_context())
+
+                mock_cmd.assert_called_once_with(update.message.text)
+                update.message.reply_text.assert_called_once_with(mock_result.reply)
+
+
+# ---------------------------------------------------------------------------
+# list_groups_command
+# ---------------------------------------------------------------------------
+
+class TestListGroupsCommand:
+    """Tests for /list_groups handler."""
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_is_silently_dropped(self):
+        with patch.dict(os.environ, _make_env()):
+            import importlib
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_update(user_id=999999, message_text="/list_groups")
+            await bot_module.list_groups_command(update, _make_context())
+
+            update.message.reply_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_group_chat_is_silently_dropped(self):
+        with patch.dict(os.environ, _make_env()):
+            import importlib
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_update(chat_type="group", message_text="/list_groups")
+            await bot_module.list_groups_command(update, _make_context())
+
+            update.message.reply_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_whitelist_returns_no_groups(self):
+        """When whitelist has no groups, reply says 'No groups configured.'"""
+        with patch.dict(os.environ, _make_env()):
+            import importlib
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_update(message_text="/list_groups")
+
+            with patch.object(
+                bot_module, "load_whitelist", return_value={"groups": {}}
+            ):
+                await bot_module.list_groups_command(update, _make_context())
+
+            update.message.reply_text.assert_called_once_with("No groups configured.")
+
+    @pytest.mark.asyncio
+    async def test_lists_groups_with_whitelisted_users(self):
+        """Reply includes group name, ID, status, and whitelisted user IDs."""
+        with patch.dict(os.environ, _make_env()):
+            import importlib
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_update(message_text="/list_groups")
+            store = _minimal_whitelist()
+
+            with patch.object(bot_module, "load_whitelist", return_value=store):
+                await bot_module.list_groups_command(update, _make_context())
+
+            update.message.reply_text.assert_called_once()
+            reply = update.message.reply_text.call_args[0][0]
+            assert "-100123456" in reply
+            assert "Test Group" in reply
+            assert "enabled" in reply
+            assert "111111" in reply
+
+    @pytest.mark.asyncio
+    async def test_lists_disabled_group(self):
+        """Disabled groups are labeled as disabled."""
+        with patch.dict(os.environ, _make_env()):
+            import importlib
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_update(message_text="/list_groups")
+            store = {
+                "groups": {
+                    "-100999888": {
+                        "name": "Inactive Group",
+                        "enabled": False,
+                        "allowed_user_ids": [],
+                    }
+                }
+            }
+
+            with patch.object(bot_module, "load_whitelist", return_value=store):
+                await bot_module.list_groups_command(update, _make_context())
+
+            reply = update.message.reply_text.call_args[0][0]
+            assert "disabled" in reply
+            assert "Inactive Group" in reply
+            assert "No whitelisted users" in reply


### PR DESCRIPTION
## Problem

Operators had no Telegram interface for managing the group whitelist. The
`multiplayer-telegram-bot` skill ships complete, tested command functions
(`handle_enable_group_bot`, `handle_whitelist`, `handle_unwhitelist`) but
nothing in `lobster_bot.py` called them. There was also no way to inspect
the current whitelist state from Telegram.

## What this changes

Four new command handlers, registered in `lobster_bot.py` before the generic
`MessageHandler` so they are dispatched as bot commands rather than falling
through to Claude:

- `/enable_group_bot <chat_id> [name]` — enable a group in the whitelist
- `/whitelist <user_id> <chat_id>` — add a user to a group's allowed list
- `/unwhitelist <user_id> <chat_id>` — remove a user from a group's allowed list
- `/list_groups` — show all configured groups, their enabled/disabled status, and whitelisted user IDs

Every handler applies two guards before doing anything:
1. `user.id in ALLOWED_USERS` — non-allowed users are silently dropped
2. `chat.type == "private"` — `/enable_group_bot` replies with an error; the
   rest silently drop (whitelist operations have no business in a group context)

The skill is imported via a soft-import try/except block that sets
`_GROUP_COMMANDS_ENABLED`. If the skill package is absent, handlers reply with
a graceful "not available" message rather than crashing.

`list_groups` is pure read: it calls `load_whitelist()` and formats the result
inline — no skill command needed.

## Functional patterns used

- Pure delegation: the handlers are thin wrappers; all parsing and whitelist
  mutation logic lives in the skill's pure functions (`handle_enable_group_bot`,
  `handle_whitelist`, `handle_unwhitelist`, `load_whitelist`)
- Side-effect isolation: file I/O is confined to the skill's command layer; the
  handler wrappers are pure async adapters
- Soft-import guard: `_GROUP_COMMANDS_ENABLED` flag allows the bot to start and
  operate safely even if the skill is not installed

## Out of scope

This PR does not touch `handle_message`, the `my_chat_member` handler, message
gating, or the dispatcher. Those are Phases 1 and 2 (#1291, #1292).

## Tests run

- [x] `uv run pytest tests/unit/test_bot/test_group_commands.py -v` — 16 passed, 0 failed
- [x] `uv run pytest tests/unit/test_bot/ -v` — 145 passed, 0 failed (no regressions in existing bot tests)

Closes #1293