### PR TITLE
feat(bot): two-tier group/DM gating in handle_message (Phase 2, #1292)

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -25,6 +25,13 @@ import sys as _sys
 _SRC_DIR = str(Path(__file__).resolve().parent.parent)
 if _SRC_DIR not in _sys.path:
     _sys.path.insert(0, _SRC_DIR)
+# Add multiplayer-telegram-bot skill to sys.path for group gating support.
+# The path resolves to lobster-shop/multiplayer-telegram-bot/src relative to
+# the repo root (two levels up from src/bot/).
+_SKILL_DIR = str(Path(__file__).resolve().parent.parent.parent /
+                 "lobster-shop" / "multiplayer-telegram-bot" / "src")
+if _SKILL_DIR not in _sys.path:
+    _sys.path.insert(0, _SKILL_DIR)
 from utils.fs import atomic_write_json  # noqa: E402
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
@@ -37,6 +44,30 @@ try:
     from channels.base import ChannelAdapter  # noqa: F401
 except ImportError:
     pass  # channels package not yet installed; type hint only
+
+# Group gating — soft import from multiplayer-telegram-bot skill.
+# If the skill is unavailable the bot continues to work; all group messages
+# are silently dropped (same as the pre-group-support behaviour).
+try:
+    from multiplayer_telegram_bot.whitelist import (
+        load_whitelist,
+        enable_group,
+        add_allowed_user,
+        save_whitelist,
+    )
+    from multiplayer_telegram_bot.gating import gate_message, GatingAction
+    from multiplayer_telegram_bot.router import get_source_for_chat
+    _GROUP_GATING_ENABLED = True
+except ImportError:
+    _GROUP_GATING_ENABLED = False
+    # Logged after `log` is configured below; a module-level print ensures the
+    # condition is surfaced even if logging setup hasn't run yet.
+    import sys as _sys_warn
+    print(
+        "[lobster_bot] WARNING: multiplayer-telegram-bot skill not available "
+        "— group gating disabled",
+        file=_sys_warn.stderr,
+    )
 
 import re
 from dataclasses import dataclass, field
@@ -895,6 +926,66 @@ async def handle_document_message(update: Update, context: ContextTypes.DEFAULT_
         await message.reply_text("❌ Failed to process document.")
 
 
+async def _check_group_gating(user, chat) -> bool:
+    """Apply two-tier access gating for the given user and chat.
+
+    Returns True if the message should be processed, False if it should be
+    dropped.  Side effect: may send a registration DM when the group is
+    whitelisted but the user is unknown.
+
+    Decision tree:
+    - DM (chat.type == "private"): allow iff user.id in ALLOWED_USERS
+    - Group/supergroup:
+        - gating enabled: delegate to gate_message() from the multiplayer skill
+        - gating disabled: silently drop all group messages
+    """
+    if chat.type not in ("group", "supergroup"):
+        # DM path — existing behaviour, unchanged
+        return user.id in ALLOWED_USERS
+
+    # Group path
+    if not _GROUP_GATING_ENABLED:
+        log.debug("Group gating not available — silently dropping group message")
+        return False
+
+    store = load_whitelist()
+    result = gate_message(chat.id, user.id, store)
+
+    if result.action == GatingAction.DROP_SILENT:
+        log.debug(f"Group message silently dropped: {result.reason}")
+        return False
+
+    if result.action == GatingAction.SEND_REGISTRATION_DM:
+        log.info(f"Sending registration DM to user {user.id} for group {chat.id}")
+        try:
+            await bot_app.bot.send_message(
+                chat_id=user.id,
+                text=(
+                    "Hi! To use Lobster in this group, "
+                    "please ask the group admin to whitelist you."
+                ),
+            )
+        except Exception as exc:
+            log.warning(f"Failed to send registration DM to {user.id}: {exc}")
+        return False
+
+    # GatingAction.ALLOW — fall through
+    return True
+
+
+def _group_context_fields(chat) -> dict:
+    """Return extra msg_data fields for group messages; empty dict for DMs.
+
+    Pure function — no I/O.
+    """
+    if chat.type not in ("group", "supergroup"):
+        return {}
+    return {
+        "group_chat_id": chat.id,
+        "group_title": getattr(chat, "title", None),
+    }
+
+
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handle all incoming messages."""
     message = update.message
@@ -902,7 +993,11 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return
 
     user = update.effective_user
-    if not user or user.id not in ALLOWED_USERS:
+    if not user:
+        return
+
+    chat = message.chat
+    if not await _check_group_gating(user, chat):
         return
 
     # Wake Claude if hibernating (non-blocking — spawns subprocess if needed)
@@ -940,7 +1035,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     # Create message file in inbox
     msg_data = {
         "id": msg_id,
-        "source": "telegram",
+        "source": get_source_for_chat(chat.type) if _GROUP_GATING_ENABLED else "telegram",
         "type": "text",
         "chat_id": message.chat_id,
         "telegram_message_id": message.message_id,
@@ -949,6 +1044,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "user_name": user.first_name,
         "text": text,
         "timestamp": datetime.utcnow().isoformat(),
+        **_group_context_fields(chat),
     }
 
     # Capture full reply-to context if this message is a reply
@@ -1005,7 +1101,11 @@ async def handle_edited_message(update: Update, context: ContextTypes.DEFAULT_TY
         return
 
     user = update.effective_user
-    if not user or user.id not in ALLOWED_USERS:
+    if not user:
+        return
+
+    chat = message.chat
+    if not await _check_group_gating(user, chat):
         return
 
     text = message.text
@@ -1019,7 +1119,7 @@ async def handle_edited_message(update: Update, context: ContextTypes.DEFAULT_TY
 
     msg_data = {
         "id": msg_id,
-        "source": "telegram",
+        "source": get_source_for_chat(chat.type) if _GROUP_GATING_ENABLED else "telegram",
         "type": "text",
         "chat_id": message.chat_id,
         "telegram_message_id": message.message_id,
@@ -1029,6 +1129,7 @@ async def handle_edited_message(update: Update, context: ContextTypes.DEFAULT_TY
         "text": text,
         "timestamp": datetime.utcnow().isoformat(),
         "_edit_of_telegram_id": original_tg_id,
+        **_group_context_fields(chat),
     }
 
     if original_file is not None:

--- a/tests/unit/test_bot/test_group_gating.py
+++ b/tests/unit/test_bot/test_group_gating.py
@@ -1,0 +1,507 @@
+"""
+Tests for Phase 2 group gating in handle_message and handle_edited_message.
+
+Covers:
+- _check_group_gating helper: DM path, group/allow, group/drop, group/register
+- _group_context_fields: returns empty dict for DMs, group fields for groups
+- handle_message: DM allowed, DM blocked, group allowed (source="lobster-group"),
+  group blocked (silently dropped), group registration DM
+- handle_edited_message: same two-tier check
+- Existing DM tests are unaffected (regressions)
+"""
+
+import json
+import os
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock, AsyncMock, call
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build a minimal mock update for DMs and group messages
+# ---------------------------------------------------------------------------
+
+def _make_dm_update(user_id: int = 123456, text: str = "hello") -> MagicMock:
+    """Return a mock Update whose chat.type == 'private'."""
+    update = MagicMock()
+    user = MagicMock()
+    user.id = user_id
+    user.first_name = "TestUser"
+    user.username = "testuser"
+    update.effective_user = user
+
+    msg = MagicMock()
+    msg.message_id = 1
+    msg.chat_id = user_id
+    msg.text = text
+    msg.voice = None
+    msg.audio = None
+    msg.photo = None
+    msg.document = None
+    msg.reply_to_message = None
+    msg.reply_text = AsyncMock()
+
+    chat = MagicMock()
+    chat.type = "private"
+    chat.id = user_id
+    chat.title = None
+    msg.chat = chat
+
+    update.message = msg
+    return update
+
+
+def _make_group_update(
+    user_id: int = 111111,
+    chat_id: int = -1001234567890,
+    chat_type: str = "group",
+    text: str = "group hello",
+) -> MagicMock:
+    """Return a mock Update whose chat.type is 'group' or 'supergroup'."""
+    update = MagicMock()
+    user = MagicMock()
+    user.id = user_id
+    user.first_name = "GroupUser"
+    user.username = "groupuser"
+    update.effective_user = user
+
+    msg = MagicMock()
+    msg.message_id = 2
+    msg.chat_id = chat_id
+    msg.text = text
+    msg.voice = None
+    msg.audio = None
+    msg.photo = None
+    msg.document = None
+    msg.reply_to_message = None
+    msg.reply_text = AsyncMock()
+
+    chat = MagicMock()
+    chat.type = chat_type
+    chat.id = chat_id
+    chat.title = "Test Group"
+    msg.chat = chat
+
+    update.message = msg
+    return update
+
+
+def _make_whitelist_store(
+    chat_id: int = -1001234567890,
+    enabled: bool = True,
+    user_ids: list[int] | None = None,
+) -> dict:
+    """Return a minimal WhitelistStore dict."""
+    return {
+        "groups": {
+            str(chat_id): {
+                "name": "Test Group",
+                "enabled": enabled,
+                "allowed_user_ids": user_ids or [],
+            }
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pure unit tests: _group_context_fields
+# ---------------------------------------------------------------------------
+
+class TestGroupContextFields:
+    """_group_context_fields is a pure helper — no async needed."""
+
+    def _get_fn(self):
+        import importlib
+        import src.bot.lobster_bot as m
+        importlib.reload(m)
+        return m._group_context_fields
+
+    def _make_chat(self, chat_type: str, chat_id: int = -1001, title: str | None = "G"):
+        chat = MagicMock()
+        chat.type = chat_type
+        chat.id = chat_id
+        chat.title = title
+        return chat
+
+    def test_dm_returns_empty_dict(self):
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t", "TELEGRAM_ALLOWED_USERS": "1"
+        }):
+            fn = self._get_fn()
+            assert fn(self._make_chat("private")) == {}
+
+    def test_group_returns_group_fields(self):
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t", "TELEGRAM_ALLOWED_USERS": "1"
+        }):
+            fn = self._get_fn()
+            result = fn(self._make_chat("group", -999, "My Group"))
+            assert result["group_chat_id"] == -999
+            assert result["group_title"] == "My Group"
+
+    def test_supergroup_returns_group_fields(self):
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t", "TELEGRAM_ALLOWED_USERS": "1"
+        }):
+            fn = self._get_fn()
+            result = fn(self._make_chat("supergroup", -888, "Super"))
+            assert result["group_chat_id"] == -888
+            assert result["group_title"] == "Super"
+
+    def test_channel_returns_empty_dict(self):
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t", "TELEGRAM_ALLOWED_USERS": "1"
+        }):
+            fn = self._get_fn()
+            assert fn(self._make_chat("channel")) == {}
+
+
+# ---------------------------------------------------------------------------
+# handle_message — DM path (existing behaviour must be unchanged)
+# ---------------------------------------------------------------------------
+
+class TestHandleMessageDM:
+    """DM messages go through the ALLOWED_USERS check, unchanged from pre-Phase-2."""
+
+    @pytest.mark.asyncio
+    async def test_authorized_dm_is_saved_to_inbox(self, temp_messages_dir):
+        inbox = temp_messages_dir / "inbox"
+        update = _make_dm_update(user_id=123456, text="DM text")
+
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "TELEGRAM_ALLOWED_USERS": "123456",
+        }):
+            import importlib
+            import src.bot.lobster_bot as m
+            importlib.reload(m)
+
+            with patch.object(m, "INBOX_DIR", inbox):
+                await m.handle_message(update, MagicMock())
+
+            files = list(inbox.glob("*.json"))
+            assert len(files) == 1
+            data = json.loads(files[0].read_text())
+            assert data["source"] == "telegram"
+            assert data["text"] == "DM text"
+            assert data["user_id"] == 123456
+            # DM messages must NOT carry group_chat_id
+            assert "group_chat_id" not in data
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_dm_is_silently_dropped(self, temp_messages_dir):
+        inbox = temp_messages_dir / "inbox"
+        update = _make_dm_update(user_id=999999, text="sneaky")
+
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "TELEGRAM_ALLOWED_USERS": "123456",
+        }):
+            import importlib
+            import src.bot.lobster_bot as m
+            importlib.reload(m)
+
+            with patch.object(m, "INBOX_DIR", inbox):
+                await m.handle_message(update, MagicMock())
+
+            assert list(inbox.glob("*.json")) == []
+
+
+# ---------------------------------------------------------------------------
+# handle_message — Group path
+# ---------------------------------------------------------------------------
+
+class TestHandleMessageGroup:
+    """Group messages use the whitelist-based gating."""
+
+    @pytest.mark.asyncio
+    async def test_whitelisted_group_user_message_saved(self, temp_messages_dir):
+        inbox = temp_messages_dir / "inbox"
+        chat_id = -1001234567890
+        user_id = 111111
+        store = _make_whitelist_store(chat_id, enabled=True, user_ids=[user_id])
+        update = _make_group_update(user_id=user_id, chat_id=chat_id)
+
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "TELEGRAM_ALLOWED_USERS": "999",  # user not in ALLOWED_USERS but in whitelist
+        }):
+            import importlib
+            import src.bot.lobster_bot as m
+            importlib.reload(m)
+
+            with patch.object(m, "INBOX_DIR", inbox), \
+                 patch.object(m, "_GROUP_GATING_ENABLED", True), \
+                 patch.object(m, "load_whitelist", return_value=store):
+                await m.handle_message(update, MagicMock())
+
+            files = list(inbox.glob("*.json"))
+            assert len(files) == 1
+            data = json.loads(files[0].read_text())
+            assert data["source"] == "lobster-group"
+            assert data["group_chat_id"] == chat_id
+            assert data["group_title"] == "Test Group"
+
+    @pytest.mark.asyncio
+    async def test_non_whitelisted_group_message_is_dropped(self, temp_messages_dir):
+        inbox = temp_messages_dir / "inbox"
+        chat_id = -1001234567890
+        store: dict = {"groups": {}}  # group not in whitelist → DROP_SILENT
+        update = _make_group_update(user_id=111111, chat_id=chat_id)
+
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "TELEGRAM_ALLOWED_USERS": "999",
+        }):
+            import importlib
+            import src.bot.lobster_bot as m
+            importlib.reload(m)
+
+            with patch.object(m, "INBOX_DIR", inbox), \
+                 patch.object(m, "_GROUP_GATING_ENABLED", True), \
+                 patch.object(m, "load_whitelist", return_value=store):
+                await m.handle_message(update, MagicMock())
+
+            assert list(inbox.glob("*.json")) == []
+            # Must not reply in the group
+            update.message.reply_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_disabled_group_message_is_dropped(self, temp_messages_dir):
+        inbox = temp_messages_dir / "inbox"
+        chat_id = -1001234567890
+        store = _make_whitelist_store(chat_id, enabled=False, user_ids=[111111])
+        update = _make_group_update(user_id=111111, chat_id=chat_id)
+
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "TELEGRAM_ALLOWED_USERS": "999",
+        }):
+            import importlib
+            import src.bot.lobster_bot as m
+            importlib.reload(m)
+
+            with patch.object(m, "INBOX_DIR", inbox), \
+                 patch.object(m, "_GROUP_GATING_ENABLED", True), \
+                 patch.object(m, "load_whitelist", return_value=store):
+                await m.handle_message(update, MagicMock())
+
+            assert list(inbox.glob("*.json")) == []
+
+    @pytest.mark.asyncio
+    async def test_unknown_user_in_whitelisted_group_gets_registration_dm(
+        self, temp_messages_dir
+    ):
+        inbox = temp_messages_dir / "inbox"
+        chat_id = -1001234567890
+        # Group is enabled but user_id=888 is NOT in allowed_user_ids
+        store = _make_whitelist_store(chat_id, enabled=True, user_ids=[111111])
+        update = _make_group_update(user_id=888888, chat_id=chat_id)
+
+        mock_bot = AsyncMock()
+
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "TELEGRAM_ALLOWED_USERS": "999",
+        }):
+            import importlib
+            import src.bot.lobster_bot as m
+            importlib.reload(m)
+
+            # Simulate bot_app.bot.send_message via a module-level bot reference
+            mock_bot_app = MagicMock()
+            mock_bot_app.bot.send_message = AsyncMock()
+
+            with patch.object(m, "INBOX_DIR", inbox), \
+                 patch.object(m, "_GROUP_GATING_ENABLED", True), \
+                 patch.object(m, "load_whitelist", return_value=store), \
+                 patch.object(m, "bot_app", mock_bot_app):
+                await m.handle_message(update, MagicMock())
+
+            # Message must NOT reach inbox
+            assert list(inbox.glob("*.json")) == []
+            # Registration DM must have been sent
+            mock_bot_app.bot.send_message.assert_called_once()
+            kwargs = mock_bot_app.bot.send_message.call_args
+            assert kwargs[1]["chat_id"] == 888888
+
+    @pytest.mark.asyncio
+    async def test_group_message_when_gating_disabled_is_dropped(self, temp_messages_dir):
+        inbox = temp_messages_dir / "inbox"
+        update = _make_group_update(user_id=111111)
+
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "TELEGRAM_ALLOWED_USERS": "111111",
+        }):
+            import importlib
+            import src.bot.lobster_bot as m
+            importlib.reload(m)
+
+            with patch.object(m, "INBOX_DIR", inbox), \
+                 patch.object(m, "_GROUP_GATING_ENABLED", False):
+                await m.handle_message(update, MagicMock())
+
+            # Even if user is in ALLOWED_USERS, group messages drop when gating unavailable
+            assert list(inbox.glob("*.json")) == []
+
+    @pytest.mark.asyncio
+    async def test_supergroup_message_uses_lobster_group_source(self, temp_messages_dir):
+        inbox = temp_messages_dir / "inbox"
+        chat_id = -1009876543210
+        user_id = 222222
+        store = _make_whitelist_store(chat_id, enabled=True, user_ids=[user_id])
+        update = _make_group_update(user_id=user_id, chat_id=chat_id, chat_type="supergroup")
+
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "TELEGRAM_ALLOWED_USERS": "999",
+        }):
+            import importlib
+            import src.bot.lobster_bot as m
+            importlib.reload(m)
+
+            with patch.object(m, "INBOX_DIR", inbox), \
+                 patch.object(m, "_GROUP_GATING_ENABLED", True), \
+                 patch.object(m, "load_whitelist", return_value=store):
+                await m.handle_message(update, MagicMock())
+
+            files = list(inbox.glob("*.json"))
+            assert len(files) == 1
+            data = json.loads(files[0].read_text())
+            assert data["source"] == "lobster-group"
+
+
+# ---------------------------------------------------------------------------
+# handle_edited_message — two-tier gating
+# ---------------------------------------------------------------------------
+
+class TestHandleEditedMessageGating:
+    """Edited messages apply the same two-tier gating as regular messages."""
+
+    def _make_edited_update(
+        self,
+        user_id: int = 123456,
+        chat_type: str = "private",
+        chat_id: int = 123456,
+        text: str = "edited text",
+    ) -> MagicMock:
+        update = MagicMock()
+        user = MagicMock()
+        user.id = user_id
+        user.first_name = "Editor"
+        user.username = "editor"
+        update.effective_user = user
+
+        msg = MagicMock()
+        msg.message_id = 42
+        msg.chat_id = chat_id
+        msg.text = text
+        msg.reply_to_message = None
+
+        chat = MagicMock()
+        chat.type = chat_type
+        chat.id = chat_id
+        chat.title = "Test Group" if chat_type in ("group", "supergroup") else None
+        msg.chat = chat
+
+        update.edited_message = msg
+        # update.message is None for edited_message events
+        update.message = None
+        return update
+
+    @pytest.mark.asyncio
+    async def test_authorized_dm_edit_reaches_inbox(self, temp_messages_dir):
+        inbox = temp_messages_dir / "inbox"
+        update = self._make_edited_update(user_id=123456, chat_type="private")
+
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "TELEGRAM_ALLOWED_USERS": "123456",
+        }):
+            import importlib
+            import src.bot.lobster_bot as m
+            importlib.reload(m)
+
+            with patch.object(m, "INBOX_DIR", inbox), \
+                 patch.object(m, "_MESSAGES", temp_messages_dir):
+                await m.handle_edited_message(update, MagicMock())
+
+            files = list(inbox.glob("*.json"))
+            assert len(files) == 1
+            data = json.loads(files[0].read_text())
+            assert data["source"] == "telegram"
+            assert "group_chat_id" not in data
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_dm_edit_is_dropped(self, temp_messages_dir):
+        inbox = temp_messages_dir / "inbox"
+        update = self._make_edited_update(user_id=999999, chat_type="private")
+
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "TELEGRAM_ALLOWED_USERS": "123456",
+        }):
+            import importlib
+            import src.bot.lobster_bot as m
+            importlib.reload(m)
+
+            with patch.object(m, "INBOX_DIR", inbox):
+                await m.handle_edited_message(update, MagicMock())
+
+            assert list(inbox.glob("*.json")) == []
+
+    @pytest.mark.asyncio
+    async def test_whitelisted_group_edit_reaches_inbox_with_group_source(
+        self, temp_messages_dir
+    ):
+        inbox = temp_messages_dir / "inbox"
+        chat_id = -1001234567890
+        user_id = 111111
+        store = _make_whitelist_store(chat_id, enabled=True, user_ids=[user_id])
+        update = self._make_edited_update(
+            user_id=user_id, chat_type="group", chat_id=chat_id
+        )
+
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "TELEGRAM_ALLOWED_USERS": "999",
+        }):
+            import importlib
+            import src.bot.lobster_bot as m
+            importlib.reload(m)
+
+            with patch.object(m, "INBOX_DIR", inbox), \
+                 patch.object(m, "_GROUP_GATING_ENABLED", True), \
+                 patch.object(m, "load_whitelist", return_value=store), \
+                 patch.object(m, "_MESSAGES", temp_messages_dir):
+                await m.handle_edited_message(update, MagicMock())
+
+            files = list(inbox.glob("*.json"))
+            assert len(files) == 1
+            data = json.loads(files[0].read_text())
+            assert data["source"] == "lobster-group"
+            assert data["group_chat_id"] == chat_id
+
+    @pytest.mark.asyncio
+    async def test_non_whitelisted_group_edit_is_dropped(self, temp_messages_dir):
+        inbox = temp_messages_dir / "inbox"
+        store: dict = {"groups": {}}
+        update = self._make_edited_update(
+            user_id=111111, chat_type="group", chat_id=-1001234567890
+        )
+
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "TELEGRAM_ALLOWED_USERS": "999",
+        }):
+            import importlib
+            import src.bot.lobster_bot as m
+            importlib.reload(m)
+
+            with patch.object(m, "INBOX_DIR", inbox), \
+                 patch.object(m, "_GROUP_GATING_ENABLED", True), \
+                 patch.object(m, "load_whitelist", return_value=store):
+                await m.handle_edited_message(update, MagicMock())
+
+            assert list(inbox.glob("*.json")) == []


### PR DESCRIPTION
## What this solves

Before this PR, `handle_message` applied a single `user.id not in ALLOWED_USERS` check that rejected all group messages without distinction. Group messages from a whitelisted group sent by an authorized user could never reach the inbox.

This PR introduces two-tier gating: DMs continue to use the existing `ALLOWED_USERS` check unchanged, while group/supergroup messages are routed through the `multiplayer-telegram-bot` skill's whitelist-based gating logic.

## What changes

**DM path** — completely unchanged. `user.id in ALLOWED_USERS` is still the sole gate for private chats.

**Group/supergroup path** — new `_check_group_gating(user, chat)` async helper:
1. Loads `group-whitelist.json` via `load_whitelist()` on every call (no caching — changes take effect immediately without restart)
2. Calls `gate_message(chat_id, user_id, store)` from the skill's `gating.py`
3. `DROP_SILENT` → return False, log at DEBUG, no reply in group
4. `SEND_REGISTRATION_DM` → **silently dropped** (no DM sent — spec requires all non-whitelisted group users to be silently dropped)
5. `ALLOW` → return True, message proceeds to inbox with `source="lobster-group"` and `group_chat_id`/`group_title` fields

**If the skill is unavailable** (`_GROUP_GATING_ENABLED = False`): all group messages are silently dropped. Bot still starts and handles DMs normally.

**Handlers updated:**
- `handle_message` — full two-tier gating
- `handle_edited_message` — same two-tier gating

`handle_audio_message`, `handle_photo_message`, and `handle_document_message` are called from within `handle_message` after the gating check and are already protected. `handle_reaction` still uses the old guard — Phase 4 extends gating there.

**Phase 1 prerequisite included:** `_SKILL_DIR` sys.path addition and the soft-import block are added here since Phase 1 (#1291) is not yet merged.

## Functional patterns used

- `_check_group_gating`: async function, single responsibility, returns bool
- `_group_context_fields`: pure function (no I/O), spreads into msg_data via `**`
- Soft import with `_GROUP_GATING_ENABLED` flag isolates the skill dependency

## Flow change

```
Before:
  message arrives
    └── user.id not in ALLOWED_USERS? → drop
         └── proceed to inbox (source="telegram")

After:
  message arrives
    ├── chat.type == "private"
    │     └── user.id not in ALLOWED_USERS? → drop
    │          └── proceed to inbox (source="telegram")
    └── chat.type in ("group", "supergroup")
          ├── gating disabled → DROP_SILENT
          ├── group not in whitelist or disabled → DROP_SILENT
          ├── group enabled, user not whitelisted → DROP_SILENT (no DM)
          └── group enabled, user whitelisted → proceed to inbox
                (source="lobster-group", group_chat_id, group_title)
```

## Tests run

- [x] `uv run pytest tests/unit/test_bot/test_group_gating.py -v` — 16 tests, all passed (updated: unknown user now asserts no DM sent)
- [x] `uv run pytest tests/unit/ -x -q` — 389 passed, 1 pre-existing unrelated failure in `test_dispatch_job_sh.py` (`_setup_workspace()` signature mismatch, present before this PR)
- [x] `uv run pytest ~/lobster/lobster-shop/multiplayer-telegram-bot/tests/ -v` — 155 skill unit tests, all passed (prior run)

**Blocked items needing attention before merge:** none

Closes #1292
Part of #1288