### PR TITLE
feat(bot): add my_chat_member handler for group auto-whitelist (Phase 1)

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -29,6 +29,25 @@ from utils.fs import atomic_write_json  # noqa: E402
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 
+# multiplayer-telegram-bot skill — provides group whitelist and gating
+# Path: <repo-root>/lobster-shop/multiplayer-telegram-bot/src
+# lobster_bot.py lives at <repo-root>/src/bot/, so parent.parent.parent = repo root.
+_SKILL_DIR = str(Path(__file__).resolve().parent.parent.parent /
+                 "lobster-shop" / "multiplayer-telegram-bot" / "src")
+if _SKILL_DIR not in _sys.path:
+    _sys.path.insert(0, _SKILL_DIR)
+
+try:
+    from multiplayer_telegram_bot.whitelist import (  # noqa: E402
+        load_whitelist,
+        enable_group,
+        add_allowed_user,
+        save_whitelist,
+    )
+    _GROUP_GATING_ENABLED = True
+except ImportError:
+    _GROUP_GATING_ENABLED = False
+
 # ChannelAdapter Protocol — soft import; lobster_bot satisfies it structurally
 # but keeps its own async OutboxHandler rather than using OutboxFileHandler.
 try:
@@ -43,7 +62,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, ReplyParameters
-from telegram.ext import Application, CommandHandler, MessageHandler, CallbackQueryHandler, MessageReactionHandler, filters, ContextTypes
+from telegram.ext import Application, ChatMemberHandler, CommandHandler, MessageHandler, CallbackQueryHandler, MessageReactionHandler, filters, ContextTypes
 from collections import deque
 
 
@@ -1048,6 +1067,53 @@ async def handle_edited_message(update: Update, context: ContextTypes.DEFAULT_TY
     atomic_write_json(inbox_file, msg_data)
 
 
+async def handle_my_chat_member(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle bot being added to or removed from a group.
+
+    On bot-added: if the inviter is in ALLOWED_USERS, auto-whitelist the group
+    with all ALLOWED_USERS seeded as permitted members. Otherwise log and ignore
+    (silent drop — never add an unrecognised group to the whitelist).
+
+    On bot-removed: log only.
+    """
+    if not update.my_chat_member:
+        return
+    event = update.my_chat_member
+    new_status = event.new_chat_member.status
+    chat = event.chat
+    adder = event.from_user
+
+    if new_status in ("member", "administrator") and chat.type in ("group", "supergroup"):
+        if adder and adder.id in ALLOWED_USERS:
+            log.info(
+                f"Bot added to group {chat.id} ({chat.title!r}) "
+                f"by whitelisted user {adder.id} — auto-enabling"
+            )
+            if _GROUP_GATING_ENABLED:
+                try:
+                    store = load_whitelist()
+                    store = enable_group(chat.id, chat.title or str(chat.id), store)
+                    for uid in ALLOWED_USERS:
+                        store = add_allowed_user(uid, chat.id, store)
+                    save_whitelist(store)
+                    log.info(f"Group {chat.id} auto-whitelisted with users {ALLOWED_USERS}")
+                except Exception as e:
+                    log.error(f"Failed to auto-whitelist group {chat.id}: {e}", exc_info=True)
+            else:
+                log.warning(
+                    "multiplayer-telegram-bot skill not available — "
+                    f"group {chat.id} not written to whitelist"
+                )
+        else:
+            adder_id = adder.id if adder else "unknown"
+            log.info(
+                f"Bot added to group {chat.id} ({chat.title!r}) "
+                f"by non-whitelisted user {adder_id} — ignoring"
+            )
+    elif new_status in ("left", "kicked"):
+        log.info(f"Bot removed from group {chat.id} ({chat.title!r})")
+
+
 def _lookup_reacted_to_text(tg_msg_id: int) -> str:
     """Return the buffered text for a sent message, or empty string if not found.
 
@@ -1621,6 +1687,8 @@ async def run_bot():
     bot_app.add_handler(MessageHandler(filters.UpdateType.EDITED_MESSAGE & filters.TEXT, handle_edited_message))
     # Requires python-telegram-bot >= v20.6 for Update.ALL_TYPES to include message_reaction
     bot_app.add_handler(MessageReactionHandler(handle_reaction))
+    # my_chat_member: fires when the bot is added to or removed from a group
+    bot_app.add_handler(ChatMemberHandler(handle_my_chat_member, ChatMemberHandler.MY_CHAT_MEMBER))
     bot_app.add_error_handler(error_handler)
 
     # Initialize and start

--- a/tests/unit/test_bot/test_my_chat_member.py
+++ b/tests/unit/test_bot/test_my_chat_member.py
@@ -1,0 +1,411 @@
+"""
+Tests for handle_my_chat_member — Phase 1 group chat support.
+
+Covers:
+- Bot added by a whitelisted user → whitelist write attempted
+- Bot added by a non-whitelisted user → whitelist unchanged
+- Bot removed from a group → log only, no writes
+- No my_chat_member event → early return (no-op)
+- Whitelist write failure → exception logged, no crash
+- _GROUP_GATING_ENABLED=False → log warning, no whitelist write
+
+Design note: all whitelist functions are patched at the bot module level because
+they are imported there via a soft-import block. Tests control _GROUP_GATING_ENABLED
+via patch.object, bypassing the ImportError path.
+"""
+
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Ensure multiplayer-telegram-bot skill is importable in tests.
+# Test file lives at tests/unit/test_bot/test_my_chat_member.py, so
+# parents[3] = repo root, then descend into lobster-shop.
+# ---------------------------------------------------------------------------
+_SKILL_SRC = str(
+    Path(__file__).resolve().parents[3]  # repo root
+    / "lobster-shop" / "multiplayer-telegram-bot" / "src"
+)
+if _SKILL_SRC not in sys.path:
+    sys.path.insert(0, _SKILL_SRC)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_chat(chat_id: int = -100123456, title: str = "Test Group", chat_type: str = "supergroup"):
+    chat = MagicMock()
+    chat.id = chat_id
+    chat.title = title
+    chat.type = chat_type
+    return chat
+
+
+def _make_user(user_id: int = 6645894734):
+    user = MagicMock()
+    user.id = user_id
+    return user
+
+
+def _make_chat_member_status(status: str):
+    member = MagicMock()
+    member.status = status
+    return member
+
+
+def _make_update(
+    *,
+    has_event: bool = True,
+    new_status: str = "member",
+    chat_id: int = -100123456,
+    chat_type: str = "supergroup",
+    adder_id: int = 6645894734,
+    adder_none: bool = False,
+):
+    """Build a minimal fake Update object for my_chat_member."""
+    update = MagicMock()
+    if not has_event:
+        update.my_chat_member = None
+        return update
+
+    event = MagicMock()
+    event.new_chat_member = _make_chat_member_status(new_status)
+    event.chat = _make_chat(chat_id=chat_id, chat_type=chat_type)
+    event.from_user = None if adder_none else _make_user(adder_id)
+    update.my_chat_member = event
+    return update
+
+
+# ---------------------------------------------------------------------------
+# Module reload helper — keeps tests independent of each other
+# ---------------------------------------------------------------------------
+
+def _load_bot_module(allowed_users: str = "6645894734,5717728951"):
+    """Reload lobster_bot with the given TELEGRAM_ALLOWED_USERS env var."""
+    env = {
+        "TELEGRAM_BOT_TOKEN": "fake_token_for_tests",
+        "TELEGRAM_ALLOWED_USERS": allowed_users,
+    }
+    with patch.dict(os.environ, env):
+        import src.bot.lobster_bot as bot_module
+        importlib.reload(bot_module)
+        return bot_module
+
+
+# ---------------------------------------------------------------------------
+# Shared mock factory for whitelist functions
+# ---------------------------------------------------------------------------
+
+def _whitelist_mocks(load_return=None, enable_return=None, add_return=None):
+    """Return (load_mock, enable_mock, add_mock, save_mock) as MagicMocks."""
+    empty = {"groups": {}}
+    load_mock = MagicMock(return_value=load_return or empty)
+    enable_mock = MagicMock(return_value=enable_return or empty)
+    add_mock = MagicMock(return_value=add_return or empty)
+    save_mock = MagicMock()
+    return load_mock, enable_mock, add_mock, save_mock
+
+
+def _patch_whitelist(bot_module, load_mock, enable_mock, add_mock, save_mock):
+    """Context manager stack that patches whitelist functions on the bot module."""
+    return (
+        patch.object(bot_module, "load_whitelist", load_mock),
+        patch.object(bot_module, "enable_group", enable_mock),
+        patch.object(bot_module, "add_allowed_user", add_mock),
+        patch.object(bot_module, "save_whitelist", save_mock),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: no event present
+# ---------------------------------------------------------------------------
+
+class TestNoChatMemberEvent:
+    @pytest.mark.asyncio
+    async def test_no_event_returns_early(self):
+        """When update.my_chat_member is None, handler returns immediately."""
+        bot_module = _load_bot_module()
+        update = _make_update(has_event=False)
+        context = MagicMock()
+        load_mock, enable_mock, add_mock, save_mock = _whitelist_mocks()
+
+        with patch.object(bot_module, "_GROUP_GATING_ENABLED", True):
+            with patch.object(bot_module, "load_whitelist", load_mock), \
+                 patch.object(bot_module, "save_whitelist", save_mock):
+                await bot_module.handle_my_chat_member(update, context)
+
+        load_mock.assert_not_called()
+        save_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: bot added by whitelisted user
+# ---------------------------------------------------------------------------
+
+class TestBotAddedByWhitelistedUser:
+    @pytest.mark.asyncio
+    async def test_save_called_for_whitelisted_adder(self):
+        """Whitelisted adder → save_whitelist called once."""
+        bot_module = _load_bot_module("6645894734,5717728951")
+        update = _make_update(new_status="member", adder_id=6645894734)
+        context = MagicMock()
+        load_mock, enable_mock, add_mock, save_mock = _whitelist_mocks()
+
+        with patch.object(bot_module, "_GROUP_GATING_ENABLED", True):
+            with patch.object(bot_module, "load_whitelist", load_mock), \
+                 patch.object(bot_module, "enable_group", enable_mock), \
+                 patch.object(bot_module, "add_allowed_user", add_mock), \
+                 patch.object(bot_module, "save_whitelist", save_mock):
+                await bot_module.handle_my_chat_member(update, context)
+
+        save_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_enable_group_called_with_correct_chat_id(self):
+        """enable_group is called with the incoming chat's ID."""
+        bot_module = _load_bot_module("6645894734,5717728951")
+        chat_id = -100999888
+        update = _make_update(new_status="member", adder_id=6645894734, chat_id=chat_id)
+        context = MagicMock()
+        load_mock, enable_mock, add_mock, save_mock = _whitelist_mocks()
+
+        with patch.object(bot_module, "_GROUP_GATING_ENABLED", True):
+            with patch.object(bot_module, "load_whitelist", load_mock), \
+                 patch.object(bot_module, "enable_group", enable_mock), \
+                 patch.object(bot_module, "add_allowed_user", add_mock), \
+                 patch.object(bot_module, "save_whitelist", save_mock):
+                await bot_module.handle_my_chat_member(update, context)
+
+        first_call_args = enable_mock.call_args[0]
+        assert first_call_args[0] == chat_id
+
+    @pytest.mark.asyncio
+    async def test_all_allowed_users_seeded(self):
+        """add_allowed_user is called once for each user in ALLOWED_USERS."""
+        bot_module = _load_bot_module("6645894734,5717728951")
+        update = _make_update(new_status="member", adder_id=6645894734)
+        context = MagicMock()
+        load_mock, enable_mock, add_mock, save_mock = _whitelist_mocks()
+
+        with patch.object(bot_module, "_GROUP_GATING_ENABLED", True):
+            with patch.object(bot_module, "load_whitelist", load_mock), \
+                 patch.object(bot_module, "enable_group", enable_mock), \
+                 patch.object(bot_module, "add_allowed_user", add_mock), \
+                 patch.object(bot_module, "save_whitelist", save_mock):
+                await bot_module.handle_my_chat_member(update, context)
+
+        assert add_mock.call_count == 2
+        added_user_ids = {c[0][0] for c in add_mock.call_args_list}
+        assert 6645894734 in added_user_ids
+        assert 5717728951 in added_user_ids
+
+    @pytest.mark.asyncio
+    async def test_administrator_status_also_triggers_whitelist(self):
+        """status=administrator (bot promoted) also counts as bot-added."""
+        bot_module = _load_bot_module("6645894734,5717728951")
+        update = _make_update(new_status="administrator", adder_id=6645894734)
+        context = MagicMock()
+        load_mock, enable_mock, add_mock, save_mock = _whitelist_mocks()
+
+        with patch.object(bot_module, "_GROUP_GATING_ENABLED", True):
+            with patch.object(bot_module, "load_whitelist", load_mock), \
+                 patch.object(bot_module, "enable_group", enable_mock), \
+                 patch.object(bot_module, "add_allowed_user", add_mock), \
+                 patch.object(bot_module, "save_whitelist", save_mock):
+                await bot_module.handle_my_chat_member(update, context)
+
+        save_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_group_type_also_auto_whitelisted(self):
+        """chat.type=group (not only supergroup) triggers the whitelist write."""
+        bot_module = _load_bot_module("6645894734,5717728951")
+        update = _make_update(new_status="member", adder_id=6645894734, chat_type="group")
+        context = MagicMock()
+        load_mock, enable_mock, add_mock, save_mock = _whitelist_mocks()
+
+        with patch.object(bot_module, "_GROUP_GATING_ENABLED", True):
+            with patch.object(bot_module, "load_whitelist", load_mock), \
+                 patch.object(bot_module, "enable_group", enable_mock), \
+                 patch.object(bot_module, "add_allowed_user", add_mock), \
+                 patch.object(bot_module, "save_whitelist", save_mock):
+                await bot_module.handle_my_chat_member(update, context)
+
+        save_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_whitelist_written_to_disk_end_to_end(self, tmp_path):
+        """Full I/O round-trip: whitelisted adder → group appears in the JSON file."""
+        from multiplayer_telegram_bot.whitelist import (
+            load_whitelist, save_whitelist, enable_group, add_allowed_user
+        )
+
+        bot_module = _load_bot_module("6645894734,5717728951")
+        update = _make_update(new_status="member", adder_id=6645894734, chat_id=-100123456)
+        context = MagicMock()
+
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        wl_path = config_dir / "group-whitelist.json"
+
+        # Wrap the real functions so they use tmp_path
+        def _load():
+            return load_whitelist(wl_path)
+        def _save(store):
+            return save_whitelist(store, wl_path)
+        def _enable(chat_id, name, store):
+            return enable_group(chat_id, name, store)
+        def _add(uid, chat_id, store):
+            return add_allowed_user(uid, chat_id, store)
+
+        with patch.object(bot_module, "_GROUP_GATING_ENABLED", True):
+            with patch.object(bot_module, "load_whitelist", _load), \
+                 patch.object(bot_module, "enable_group", _enable), \
+                 patch.object(bot_module, "add_allowed_user", _add), \
+                 patch.object(bot_module, "save_whitelist", _save):
+                await bot_module.handle_my_chat_member(update, context)
+
+        data = json.loads(wl_path.read_text())
+        group = data["groups"][str(-100123456)]
+        assert group["enabled"] is True
+        assert 6645894734 in group["allowed_user_ids"]
+        assert 5717728951 in group["allowed_user_ids"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: bot added by non-whitelisted user
+# ---------------------------------------------------------------------------
+
+class TestBotAddedByNonWhitelistedUser:
+    @pytest.mark.asyncio
+    async def test_whitelist_not_written(self):
+        """Non-whitelisted adder → save_whitelist never called."""
+        bot_module = _load_bot_module("6645894734,5717728951")
+        update = _make_update(new_status="member", adder_id=9999999)
+        context = MagicMock()
+        _, _, _, save_mock = _whitelist_mocks()
+
+        with patch.object(bot_module, "_GROUP_GATING_ENABLED", True), \
+             patch.object(bot_module, "save_whitelist", save_mock):
+            await bot_module.handle_my_chat_member(update, context)
+
+        save_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_adder_is_none_does_not_whitelist(self):
+        """from_user=None (anonymous admin) → whitelist not written."""
+        bot_module = _load_bot_module("6645894734,5717728951")
+        update = _make_update(new_status="member", adder_none=True)
+        context = MagicMock()
+        _, _, _, save_mock = _whitelist_mocks()
+
+        with patch.object(bot_module, "_GROUP_GATING_ENABLED", True), \
+             patch.object(bot_module, "save_whitelist", save_mock):
+            await bot_module.handle_my_chat_member(update, context)
+
+        save_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_private_chat_ignored(self):
+        """chat.type=private is not a group — handler takes no action."""
+        bot_module = _load_bot_module("6645894734,5717728951")
+        update = _make_update(new_status="member", adder_id=6645894734, chat_type="private")
+        context = MagicMock()
+        _, _, _, save_mock = _whitelist_mocks()
+
+        with patch.object(bot_module, "_GROUP_GATING_ENABLED", True), \
+             patch.object(bot_module, "save_whitelist", save_mock):
+            await bot_module.handle_my_chat_member(update, context)
+
+        save_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: bot removed from group
+# ---------------------------------------------------------------------------
+
+class TestBotRemovedFromGroup:
+    @pytest.mark.asyncio
+    async def test_left_status_does_not_write_whitelist(self):
+        """status=left → only log, no whitelist write."""
+        bot_module = _load_bot_module("6645894734,5717728951")
+        update = _make_update(new_status="left")
+        context = MagicMock()
+        _, _, _, save_mock = _whitelist_mocks()
+
+        with patch.object(bot_module, "_GROUP_GATING_ENABLED", True), \
+             patch.object(bot_module, "save_whitelist", save_mock):
+            await bot_module.handle_my_chat_member(update, context)
+
+        save_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_kicked_status_does_not_write_whitelist(self):
+        """status=kicked → only log, no whitelist write."""
+        bot_module = _load_bot_module("6645894734,5717728951")
+        update = _make_update(new_status="kicked")
+        context = MagicMock()
+        _, _, _, save_mock = _whitelist_mocks()
+
+        with patch.object(bot_module, "_GROUP_GATING_ENABLED", True), \
+             patch.object(bot_module, "save_whitelist", save_mock):
+            await bot_module.handle_my_chat_member(update, context)
+
+        save_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: _GROUP_GATING_ENABLED = False
+# ---------------------------------------------------------------------------
+
+class TestGatingDisabled:
+    @pytest.mark.asyncio
+    async def test_no_whitelist_write_when_gating_disabled(self):
+        """When _GROUP_GATING_ENABLED=False, no whitelist write even for whitelisted adder."""
+        bot_module = _load_bot_module("6645894734,5717728951")
+        update = _make_update(new_status="member", adder_id=6645894734)
+        context = MagicMock()
+        # save_whitelist may not exist on the module when _GROUP_GATING_ENABLED=False
+        # (soft-import failed); use create=True to inject a sentinel mock
+        save_mock = MagicMock()
+
+        with patch.object(bot_module, "_GROUP_GATING_ENABLED", False):
+            with patch.object(bot_module, "save_whitelist", save_mock, create=True):
+                await bot_module.handle_my_chat_member(update, context)
+
+        save_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: whitelist write failure
+# ---------------------------------------------------------------------------
+
+class TestWhitelistWriteFailure:
+    @pytest.mark.asyncio
+    async def test_exception_logged_not_raised(self):
+        """If save_whitelist raises, exception is caught and logged — handler does not crash."""
+        bot_module = _load_bot_module("6645894734,5717728951")
+        update = _make_update(new_status="member", adder_id=6645894734)
+        context = MagicMock()
+
+        empty_store = {"groups": {}}
+        load_mock = MagicMock(return_value=empty_store)
+        enable_mock = MagicMock(return_value=empty_store)
+        add_mock = MagicMock(return_value=empty_store)
+        save_mock = MagicMock(side_effect=OSError("disk full"))
+
+        with patch.object(bot_module, "_GROUP_GATING_ENABLED", True):
+            with patch.object(bot_module, "load_whitelist", load_mock), \
+                 patch.object(bot_module, "enable_group", enable_mock), \
+                 patch.object(bot_module, "add_allowed_user", add_mock), \
+                 patch.object(bot_module, "save_whitelist", save_mock):
+                # Must not raise — exception is swallowed and logged
+                await bot_module.handle_my_chat_member(update, context)


### PR DESCRIPTION
## What this solves

Before this PR, adding the bot to a Telegram group had no effect. There was no `my_chat_member` handler, so groups were never auto-registered. Every group message would silently fall through to the `user.id not in ALLOWED_USERS` check and get dropped.

This PR is Phase 1 of group chat support (epic #1288). It wires in the group join/leave event lifecycle — specifically the auto-whitelist path on bot-add — without touching `handle_message`. Phases 1 and 2 are independent; this can merge standalone.

## What changed

**`src/bot/lobster_bot.py`**

1. `_SKILL_DIR` sys.path insertion — adds `<repo-root>/lobster-shop/multiplayer-telegram-bot/src` so the whitelist functions are importable. The path calculation uses `parent.parent.parent` (3 levels up from `src/bot/`), which resolves correctly to the repo root. (The issue plan had `parent.parent.parent.parent`, which would have missed.)

2. Soft import block — imports `load_whitelist`, `enable_group`, `add_allowed_user`, `save_whitelist` from `multiplayer_telegram_bot.whitelist` inside a `try/except ImportError`. Sets `_GROUP_GATING_ENABLED = True/False`. The bot starts cleanly if the skill is absent.

3. `ChatMemberHandler` added to the `telegram.ext` import line.

4. `handle_my_chat_member` — new async handler. Decision table:
   - `new_status in ("member", "administrator")` and `chat.type in ("group", "supergroup")` and `adder.id in ALLOWED_USERS` → enable group + seed all `ALLOWED_USERS` + save. Exception caught and logged; bot does not crash.
   - adder not whitelisted (or `from_user` is None) → log only, no write.
   - `new_status in ("left", "kicked")` → log only.
   - `_GROUP_GATING_ENABLED = False` → log warning, no write.

5. Handler registered in `run_bot()` with `ChatMemberHandler.MY_CHAT_MEMBER` (bot-only updates).

**`tests/unit/test_bot/test_my_chat_member.py`** — 14 new unit tests covering all decision branches via mocks. Includes one full I/O round-trip test that writes to `tmp_path` and asserts JSON output directly.

## Functional patterns used

Pure functions from the skill (`enable_group`, `add_allowed_user`) return new stores without mutation. The handler chains them via local rebinding. The soft-import pattern isolates the side-effect boundary cleanly.

## What is NOT changed

- `handle_message` — two-tier gating for group messages is Phase 2
- `handle_edited_message`, audio/photo/document handlers — also Phase 2
- The dispatcher and MCP inbox server
- `group-whitelist.json` — already populated; this handler only appends new entries

## Tests run

- [x] `uv run pytest tests/unit/test_bot/test_my_chat_member.py -v` — 14 passed, 0 failed
- [x] `uv run pytest tests/unit/test_bot/ -v` — 143 passed, 0 failed (all pre-existing bot tests still pass)
- [x] `uv run pytest ~/lobster/lobster-shop/multiplayer-telegram-bot/tests/ -v` — 155 passed, 0 failed (skill tests unaffected)
- [ ] Live Telegram test — blocked: requires bot restart and a live group. Safe to merge; no behavior change to existing DM flows.

Closes #1290