### PR TITLE
fix(bot): silently drop non-whitelisted users in whitelisted groups

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -946,19 +946,11 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 log.debug(f"Group message silently dropped: {result.reason}")
                 return
             elif result.action == GatingAction.SEND_REGISTRATION_DM:
-                log.info(
-                    f"Sending registration DM to user {user.id} for group {chat.id}"
+                # Group is whitelisted but user is not — silently drop, no DM
+                log.debug(
+                    f"Non-whitelisted user {user.id} in whitelisted group {chat.id}: "
+                    "silently dropped"
                 )
-                try:
-                    await bot_app.bot.send_message(
-                        chat_id=user.id,
-                        text=(
-                            "Hi! To use Lobster in this group, please ask the "
-                            "group admin to whitelist you."
-                        ),
-                    )
-                except Exception as e:
-                    log.warning(f"Failed to send registration DM to {user.id}: {e}")
                 return
             # GatingAction.ALLOW — fall through to message handling
         else:


### PR DESCRIPTION
## What this fixes

When a message arrives from a whitelisted group and the sender is not in the group's user whitelist, `gate_message` returns `SEND_REGISTRATION_DM`. The merged Phase 2 code (#1302) handled this by sending a DM to the user. The spec requires a **silent drop** instead — no reply, no DM, just return.

Sending an unsolicited DM leaks bot activity to strangers, creates noise, and violates the intended access model for whitelisted groups where the operator controls who is allowed.

## What changes

`SEND_REGISTRATION_DM` in `handle_message` now logs at DEBUG and returns without any outbound message. The behavior is indistinguishable from `DROP_SILENT` from the user's perspective.

## Flow (corrected)

```
Group message arrives
  ├── group not in whitelist or disabled     → DROP_SILENT (unchanged)
  ├── group whitelisted, user NOT whitelisted → DROP_SILENT  ← was: send DM
  └── group whitelisted, user whitelisted    → inbox (unchanged)
```

## Functional patterns used

Pure delegation to `gate_message` (no I/O in the decision path). The fix removes all I/O from the `SEND_REGISTRATION_DM` branch, making the gating paths symmetric: all non-ALLOW outcomes are silent drops.

## What is NOT in scope

The `GatingAction.SEND_REGISTRATION_DM` variant in `gating.py` is intentionally left as-is — it remains a valid semantic signal from the skill layer. The change is only in how `lobster_bot.py` acts on it.

## Tests run

- [x] `uv run pytest tests/unit/test_bot/ -v` — 129 passed, 0 failed
- [x] `uv run pytest ~/lobster/lobster-shop/multiplayer-telegram-bot/tests/ -v` — 155 passed, 0 failed
- [ ] Live Telegram group test — blocked: requires BotFather privacy mode change and running bot instance (pre-deployment manual step noted in epic #1288)

**Blocked items needing attention before merge:** none

Fixes the bug introduced in #1302. Closes #1292.
Part of #1288