### PR TITLE
fix(phase1): bot leaves non-whitelisted groups; unit tests for handle_my_chat_member

### DIFF
--- a/lobster-shop/multiplayer-telegram-bot/src/multiplayer_telegram_bot/whitelist.py
+++ b/lobster-shop/multiplayer-telegram-bot/src/multiplayer_telegram_bot/whitelist.py
@@ -172,3 +172,13 @@ def remove_allowed_user(
     group["allowed_user_ids"] = allowed
     groups[key] = group  # type: ignore[assignment]
     return {"groups": groups}
+
+
+def remove_group(
+    chat_id: str | int,
+    store: WhitelistStore,
+) -> WhitelistStore:
+    """Return a new store with the group entry removed entirely."""
+    key = str(chat_id)
+    groups = {k: v for k, v in store["groups"].items() if k != key}
+    return {"groups": groups}

--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -35,7 +35,7 @@ _SKILL_DIR = str(Path(__file__).resolve().parent.parent.parent /
 if _SKILL_DIR not in _sys.path:
     _sys.path.insert(0, _SKILL_DIR)
 try:
-    from multiplayer_telegram_bot.whitelist import load_whitelist, enable_group, add_allowed_user, save_whitelist  # noqa: E402
+    from multiplayer_telegram_bot.whitelist import load_whitelist, enable_group, add_allowed_user, remove_group, save_whitelist  # noqa: E402
     _GROUP_GATING_ENABLED = True
 except ImportError:
     _GROUP_GATING_ENABLED = False
@@ -1654,8 +1654,9 @@ async def handle_my_chat_member(update: Update, context: ContextTypes.DEFAULT_TY
 
     When added by a whitelisted user: auto-enables the group in group-whitelist.json
     and seeds all ALLOWED_USERS as allowed members.
-    When added by a non-whitelisted user: silently ignores (no whitelist entry written).
-    When removed from a group: logs the removal only.
+    When added by a non-whitelisted user: immediately leaves the group so the bot
+    cannot be used in unauthorized contexts.
+    When removed from a group: removes the group from the whitelist.
     """
     if not update.my_chat_member:
         return
@@ -1685,10 +1686,23 @@ async def handle_my_chat_member(update: Update, context: ContextTypes.DEFAULT_TY
         else:
             adder_id = adder.id if adder else "unknown"
             log.info(
-                f"Bot added to group {chat.id} by non-whitelisted user {adder_id} — ignoring"
+                f"Bot added to group {chat.id} by non-whitelisted user {adder_id} — leaving"
             )
+            try:
+                await context.bot.leave_chat(chat.id)
+                log.info(f"Left group {chat.id} (added by non-whitelisted user {adder_id})")
+            except Exception as e:
+                log.error(f"Failed to leave group {chat.id}: {e}")
     elif new_status in ("left", "kicked"):
-        log.info(f"Bot removed from group {chat.id} ({chat.title})")
+        log.info(f"Bot removed from group {chat.id} ({chat.title or str(chat.id)})")
+        if _GROUP_GATING_ENABLED:
+            try:
+                store = load_whitelist()
+                store = remove_group(chat.id, store)
+                save_whitelist(store)
+                log.info(f"Group {chat.id} removed from whitelist")
+            except Exception as e:
+                log.error(f"Failed to remove group {chat.id} from whitelist: {e}")
 
 
 async def error_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/tests/unit/test_bot/test_my_chat_member.py
+++ b/tests/unit/test_bot/test_my_chat_member.py
@@ -1,0 +1,192 @@
+"""
+Tests for handle_my_chat_member
+
+Covers:
+- Whitelisted user adds bot: group whitelisted, no leave
+- Non-whitelisted user adds bot: bot leaves, group NOT whitelisted
+- Bot removed from group: group removed from whitelist
+- Idempotent: adding same group twice is safe (enable_group is idempotent)
+"""
+
+import importlib
+import os
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+
+def _make_member_update(chat_id, chat_type, adder_id, new_status):
+    """Build a minimal mock Update for a my_chat_member event."""
+    update = MagicMock()
+    event = MagicMock()
+    event.new_chat_member.status = new_status
+    event.chat.id = chat_id
+    event.chat.type = chat_type
+    event.chat.title = f"Group {chat_id}"
+    event.from_user.id = adder_id
+    update.my_chat_member = event
+    return update
+
+
+def _make_context(bot=None):
+    ctx = MagicMock()
+    ctx.bot = bot or MagicMock()
+    ctx.bot.leave_chat = AsyncMock()
+    return ctx
+
+
+class TestHandleMyChatMember:
+    """Tests for handle_my_chat_member."""
+
+    @pytest.mark.asyncio
+    async def test_whitelisted_user_adds_bot_group_is_whitelisted(self, tmp_path):
+        """Whitelisted adder triggers whitelist write; bot does not leave."""
+        whitelist_file = tmp_path / "group-whitelist.json"
+
+        with patch.dict(
+            os.environ,
+            {
+                "TELEGRAM_BOT_TOKEN": "test_token",
+                "TELEGRAM_ALLOWED_USERS": "111,222",
+            },
+        ):
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_member_update(
+                chat_id=-100123,
+                chat_type="supergroup",
+                adder_id=111,
+                new_status="member",
+            )
+            ctx = _make_context()
+
+            with patch.object(bot_module, "_GROUP_GATING_ENABLED", True), \
+                 patch("multiplayer_telegram_bot.whitelist._default_whitelist_path", return_value=whitelist_file):
+                await bot_module.handle_my_chat_member(update, ctx)
+
+            # Bot must NOT leave
+            ctx.bot.leave_chat.assert_not_called()
+
+            # Group must be in whitelist
+            import json
+            store = json.loads(whitelist_file.read_text())
+            key = str(-100123)
+            assert key in store["groups"]
+            assert store["groups"][key]["enabled"] is True
+            # Both allowed users seeded
+            assert 111 in store["groups"][key]["allowed_user_ids"]
+            assert 222 in store["groups"][key]["allowed_user_ids"]
+
+    @pytest.mark.asyncio
+    async def test_non_whitelisted_user_adds_bot_leaves_and_not_whitelisted(self, tmp_path):
+        """Non-whitelisted adder: bot leaves immediately and group is NOT written to whitelist."""
+        whitelist_file = tmp_path / "group-whitelist.json"
+
+        with patch.dict(
+            os.environ,
+            {
+                "TELEGRAM_BOT_TOKEN": "test_token",
+                "TELEGRAM_ALLOWED_USERS": "111",
+            },
+        ):
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_member_update(
+                chat_id=-100456,
+                chat_type="group",
+                adder_id=999,  # not in ALLOWED_USERS
+                new_status="member",
+            )
+            ctx = _make_context()
+
+            with patch.object(bot_module, "_GROUP_GATING_ENABLED", True), \
+                 patch("multiplayer_telegram_bot.whitelist._default_whitelist_path", return_value=whitelist_file):
+                await bot_module.handle_my_chat_member(update, ctx)
+
+            # Bot must leave
+            ctx.bot.leave_chat.assert_awaited_once_with(-100456)
+
+            # Group must NOT be in whitelist
+            assert not whitelist_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_bot_removed_from_group_removes_from_whitelist(self, tmp_path):
+        """Bot removed (status=left) removes the group entry from the whitelist."""
+        import json
+        from multiplayer_telegram_bot.whitelist import enable_group, save_whitelist
+
+        whitelist_file = tmp_path / "group-whitelist.json"
+        # Seed whitelist with the group already present
+        store = enable_group(-100789, "My Group", {"groups": {}})
+        with patch("multiplayer_telegram_bot.whitelist._default_whitelist_path", return_value=whitelist_file):
+            save_whitelist(store)
+
+        with patch.dict(
+            os.environ,
+            {
+                "TELEGRAM_BOT_TOKEN": "test_token",
+                "TELEGRAM_ALLOWED_USERS": "111",
+            },
+        ):
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_member_update(
+                chat_id=-100789,
+                chat_type="supergroup",
+                adder_id=111,
+                new_status="left",
+            )
+            ctx = _make_context()
+
+            with patch.object(bot_module, "_GROUP_GATING_ENABLED", True), \
+                 patch("multiplayer_telegram_bot.whitelist._default_whitelist_path", return_value=whitelist_file):
+                await bot_module.handle_my_chat_member(update, ctx)
+
+        # Group must be gone from whitelist
+        result = json.loads(whitelist_file.read_text())
+        assert str(-100789) not in result["groups"]
+
+    @pytest.mark.asyncio
+    async def test_adding_same_group_twice_is_idempotent(self, tmp_path):
+        """Adding bot to the same group twice produces the same whitelist state."""
+        import json
+        whitelist_file = tmp_path / "group-whitelist.json"
+
+        with patch.dict(
+            os.environ,
+            {
+                "TELEGRAM_BOT_TOKEN": "test_token",
+                "TELEGRAM_ALLOWED_USERS": "111,222",
+            },
+        ):
+            import src.bot.lobster_bot as bot_module
+            importlib.reload(bot_module)
+
+            update = _make_member_update(
+                chat_id=-100321,
+                chat_type="supergroup",
+                adder_id=111,
+                new_status="member",
+            )
+            ctx = _make_context()
+
+            with patch.object(bot_module, "_GROUP_GATING_ENABLED", True), \
+                 patch("multiplayer_telegram_bot.whitelist._default_whitelist_path", return_value=whitelist_file):
+                # First add
+                await bot_module.handle_my_chat_member(update, ctx)
+                store_after_first = json.loads(whitelist_file.read_text())
+
+                # Second add (re-add same group)
+                await bot_module.handle_my_chat_member(update, ctx)
+                store_after_second = json.loads(whitelist_file.read_text())
+
+        # Both stores must be identical
+        assert store_after_first == store_after_second
+
+        key = str(-100321)
+        assert store_after_second["groups"][key]["enabled"] is True
+        # No duplicate user IDs
+        user_ids = store_after_second["groups"][key]["allowed_user_ids"]
+        assert len(user_ids) == len(set(user_ids))


### PR DESCRIPTION
## Problem

Two gaps from the NEEDS-WORK review on PR #1301:

**1. Bot stayed in groups added by non-whitelisted users.** The handler logged and returned without leaving, meaning the bot would silently receive and process messages in any group an unauthorized user could add it to. Unless Phase 2 gating catches everything, this is a policy gap.

**2. No unit tests for `handle_my_chat_member` itself.** The 155 existing tests cover the skill library's pure functions, not the handler's branching logic (ALLOWED_USERS, _GROUP_GATING_ENABLED, new_status, chat.type). The handler had zero coverage.

## What this changes

**Bot now leaves immediately when added by a non-whitelisted user.** The non-whitelisted branch now calls `await context.bot.leave_chat(chat.id)` instead of logging and returning. A failed leave is logged and does not raise.

**Bot removal now cleans up the whitelist.** The left/kicked branch previously only logged. It now calls `load_whitelist → remove_group → save_whitelist` — the same pure-function composition pattern as the enable path. `remove_group` is added to `whitelist.py` as a simple dict projection (immutable, returns new store).

**4 unit tests added** in `tests/unit/test_bot/test_my_chat_member.py`:
- Whitelisted adder: group written to whitelist, `leave_chat` not called
- Non-whitelisted adder: `leave_chat` called, whitelist not written
- Bot removed: group removed from whitelist
- Idempotent re-add: second call produces identical store, no duplicate user IDs

## Flow after this change

```
my_chat_member update
        |
        +-- status=member/administrator, chat=group/supergroup
        |       |
        |       +-- adder.id in ALLOWED_USERS?
        |               +-- YES: enable_group -> add_allowed_user(xN) -> save_whitelist
        |               +-- NO:  leave_chat(chat.id)   [NEW]
        |       
        +-- status=left/kicked
                +-- remove_group -> save_whitelist      [NEW; was: log only]
```

## Functional patterns

`remove_group` follows the same immutable dict projection pattern as `enable_group` and `add_allowed_user` — takes a store, returns a new store, no mutation. The handler composes pure functions and hands the result to a single `save_whitelist` call at the boundary.

## Tests run

- [x] `uv run pytest tests/unit/test_bot/test_my_chat_member.py -v` -- 4 passed, 0 failed
- [x] `uv run pytest tests/unit/test_bot/ -v` -- 133 passed, 0 failed
- [x] `uv run pytest lobster-shop/multiplayer-telegram-bot/tests/ -v` -- 155 passed, 0 failed
- [ ] Live Telegram group add/remove -- blocked: requires running bot with valid BOT_TOKEN in production

Relates to #1290