### PR TITLE
fix(bot): Phase 3 review — conftest path and silent-drop consistency

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -752,7 +752,6 @@ async def enable_group_bot_command(update: Update, context: ContextTypes.DEFAULT
     if not user or user.id not in ALLOWED_USERS:
         return
     if update.effective_chat.type != "private":
-        await update.message.reply_text("This command only works in a private DM with me.")
         return
     if not _GROUP_COMMANDS_ENABLED:
         await update.message.reply_text("Group management commands are not available (skill not installed).")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,11 +46,9 @@ sys.path.insert(0, str(TESTS_DIR.parent))
 
 # Add multiplayer-telegram-bot skill to path so group command handler tests
 # can import it directly and so lobster_bot.py finds it when reloaded.
-# The worktree lives at  ~/lobster-workspace/projects/<branch>/
-# so three levels up lands at ~/lobster-workspace/, then we navigate to the
-# canonical repo location.
-_WORKTREE_ROOT = Path(__file__).parent.parent
-_SKILL_SRC = _WORKTREE_ROOT.parent.parent.parent / "lobster" / "lobster-shop" / "multiplayer-telegram-bot" / "src"
+# Use an absolute path anchored to $HOME so this works regardless of which
+# worktree or directory the tests are run from.
+_SKILL_SRC = Path.home() / "lobster" / "lobster-shop" / "multiplayer-telegram-bot" / "src"
 if _SKILL_SRC.exists() and str(_SKILL_SRC) not in sys.path:
     sys.path.insert(0, str(_SKILL_SRC))
 

--- a/tests/unit/test_bot/test_group_commands.py
+++ b/tests/unit/test_bot/test_group_commands.py
@@ -6,8 +6,7 @@ Tests the four command handlers added in Phase 3:
 
 Each handler must:
   - Silently drop commands from non-ALLOWED_USERS (no reply)
-  - Reply with an error for commands sent from non-DM chats (group chats)
-    (only /enable_group_bot sends an error; the rest silently drop)
+  - Silently drop commands sent from non-DM chats (group chats) — no reply
   - Delegate to the multiplayer_telegram_bot skill's command functions
   - Reply to the user with the result
 """
@@ -83,8 +82,8 @@ class TestEnableGroupBotCommand:
             update.message.reply_text.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_group_chat_gets_error_reply(self):
-        """Command sent from a group chat returns a DM-only error message."""
+    async def test_group_chat_silently_drops(self):
+        """Command sent from a group chat is silently dropped (no reply)."""
         with patch.dict(os.environ, _make_env()):
             import importlib
             import src.bot.lobster_bot as bot_module
@@ -93,9 +92,7 @@ class TestEnableGroupBotCommand:
             update = _make_update(chat_type="group")
             await bot_module.enable_group_bot_command(update, _make_context())
 
-            update.message.reply_text.assert_called_once()
-            reply = update.message.reply_text.call_args[0][0]
-            assert "private" in reply.lower() or "DM" in reply
+            update.message.reply_text.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_valid_command_enables_group(self):


### PR DESCRIPTION
## Problem

PR #1303 (Phase 3 group command handlers) was merged while carrying two issues flagged in review:

1. **conftest.py worktree path** resolves incorrectly: the path to the multiplayer-telegram-bot skill src was built by traversing five parent directories from `__file__`, which lands in the wrong place in a worktree. The skill src was silently missing from `sys.path`, causing import errors in CI worktree environments.

2. **`/enable_group_bot` inconsistently replies in group chats**: when called from a group, it sent an explicit `"This command only works in a private DM with me."` reply, while `/whitelist`, `/unwhitelist`, and `/list_groups` all silently drop. The explicit reply creates noise in groups and exposes bot internals.

## What this changes

**conftest.py** — replaces the relative five-parent traversal with `Path.home() / "lobster" / "lobster-shop" / "multiplayer-telegram-bot" / "src"`. Absolute path, correct from any worktree or invocation directory.

**lobster_bot.py** — removes the `reply_text` call from `enable_group_bot_command`'s group-chat guard. The handler now returns silently when `chat.type != "private"`, matching the behavior of the other three handlers.

**test_group_commands.py** — `test_group_chat_gets_error_reply` renamed to `test_group_chat_silently_drops` and assertion changed from `assert_called_once()` to `assert_not_called()`.

## Out of scope

No behavior change to `/whitelist`, `/unwhitelist`, `/list_groups`, or any other handler. The sys.path deduplication (Phase 1 vs Phase 2 `_SKILL_DIR` blocks) was already resolved cleanly when #1303 merged.

## Functional patterns used

No new patterns introduced. This is a pure behavior correction and path fix — the handlers remain thin pure-delegation wrappers.

## Tests run

- [x] `uv run pytest tests/unit/test_bot/test_group_commands.py -v` — 16 passed, 0 failed
- [x] `uv run pytest tests/unit/test_bot/ -v` — 148 passed, 0 failed (no regressions)

Relates to #1303