### PR TITLE
feat(bot): apply two-tier group gating to handle_edited_message and handle_reaction

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -1111,6 +1111,49 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await message.reply_text("📨 Message received. Processing...")
 
 
+async def _check_message_access(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> bool:
+    """Return True if this message should be processed, False if it should be dropped.
+
+    Applies two-tier gating:
+    - Group messages: require group whitelist via gate_message() (Tier 1 + Tier 2).
+    - DM messages: require user.id in ALLOWED_USERS (existing behaviour).
+
+    This helper centralises the gating logic so all handlers apply it identically.
+    It operates on update.effective_message and update.effective_user, both of which
+    are populated for every update type that has an associated chat and user.
+    """
+    user = update.effective_user
+    message = update.effective_message
+    if not user or not message:
+        return False
+
+    chat = message.chat
+    if chat.type in ("group", "supergroup"):
+        if _GROUP_GATING_ENABLED:
+            store = load_whitelist()
+            result = gate_message(chat.id, user.id, store)
+            if result.action == GatingAction.DROP_SILENT:
+                log.debug(f"Group message silently dropped: {result.reason}")
+                return False
+            elif result.action == GatingAction.SEND_REGISTRATION_DM:
+                log.debug(
+                    f"Non-whitelisted user {user.id} in whitelisted group {chat.id}: "
+                    "silently dropped"
+                )
+                return False
+            # GatingAction.ALLOW — fall through
+            return True
+        else:
+            # Skill not available; drop all group messages silently
+            return False
+    else:
+        # DM path — unchanged behaviour
+        return user.id in ALLOWED_USERS
+
+
 def _find_message_by_telegram_id(tg_message_id: int) -> Path | None:
     """Scan inbox/ and processing/ for a message file with a matching telegram_message_id.
 
@@ -1150,14 +1193,16 @@ async def handle_edited_message(update: Update, context: ContextTypes.DEFAULT_TY
     if not message:
         return
 
-    user = update.effective_user
-    if not user or user.id not in ALLOWED_USERS:
+    if not await _check_message_access(update, context):
         return
 
+    user = update.effective_user
     text = message.text
     if not text:
         return  # Ignore non-text edits (media caption edits are not yet handled)
 
+    chat = message.chat
+    _is_group = chat.type in ("group", "supergroup")
     original_tg_id = message.message_id
     original_file = _find_message_by_telegram_id(original_tg_id)
 
@@ -1165,7 +1210,9 @@ async def handle_edited_message(update: Update, context: ContextTypes.DEFAULT_TY
 
     msg_data = {
         "id": msg_id,
-        "source": "telegram",
+        "source": (
+            get_source_for_chat(chat.type) if _GROUP_GATING_ENABLED else "telegram"
+        ),
         "type": "text",
         "chat_id": message.chat_id,
         "telegram_message_id": message.message_id,
@@ -1176,6 +1223,9 @@ async def handle_edited_message(update: Update, context: ContextTypes.DEFAULT_TY
         "timestamp": datetime.utcnow().isoformat(),
         "_edit_of_telegram_id": original_tg_id,
     }
+    if _is_group:
+        msg_data["group_chat_id"] = chat.id
+        msg_data["group_title"] = chat.title
 
     if original_file is not None:
         msg_data["_replaces_inbox_id"] = original_file.stem
@@ -1209,11 +1259,16 @@ async def _emit_reaction_signal(
     chat_id: int,
     tg_msg_id: int,
     emoji: str,
+    chat_type: str = "private",
+    chat_title: str | None = None,
 ) -> None:
     """Write a reaction inbox entry after the undo window has elapsed.
 
     This coroutine is scheduled as an asyncio.Task and cancelled if the user
     removes the reaction within REACTION_UNDO_WINDOW_SECS.
+
+    chat_type and chat_title are forwarded from handle_reaction so that group
+    reactions carry the correct source and group context fields.
     """
     # Note: pending reactions are dropped on bot restart — acceptable given the 5s window
     await asyncio.sleep(REACTION_UNDO_WINDOW_SECS)
@@ -1221,9 +1276,12 @@ async def _emit_reaction_signal(
     reacted_to_text = _lookup_reacted_to_text(tg_msg_id)
     msg_id = f"{int(time.time() * 1000)}_reaction_{tg_msg_id}"
 
+    _is_group = chat_type in ("group", "supergroup")
     msg_data = {
         "id": msg_id,
-        "source": "telegram",
+        "source": (
+            get_source_for_chat(chat_type) if _GROUP_GATING_ENABLED else "telegram"
+        ),
         "type": "reaction",
         "chat_id": chat_id,
         "telegram_message_id": tg_msg_id,
@@ -1232,6 +1290,9 @@ async def _emit_reaction_signal(
         "text": f"[Reaction: {emoji} on message {tg_msg_id}]",
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
+    if _is_group:
+        msg_data["group_chat_id"] = chat_id
+        msg_data["group_title"] = chat_title or ""
 
     inbox_file = INBOX_DIR / f"{msg_id}.json"
     atomic_write_json(inbox_file, msg_data)
@@ -1267,8 +1328,28 @@ async def handle_reaction(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         return
 
     user = update.effective_user
-    if not user or user.id not in ALLOWED_USERS:
+    if not user:
         return
+
+    # Apply two-tier gating for group reactions; fall back to ALLOWED_USERS for DMs.
+    # MessageReactionUpdated has its own .chat attribute (not update.effective_message).
+    reaction_chat = reaction_update.chat
+    if reaction_chat.type in ("group", "supergroup"):
+        if _GROUP_GATING_ENABLED:
+            store = load_whitelist()
+            result = gate_message(reaction_chat.id, user.id, store)
+            if result.action in (GatingAction.DROP_SILENT, GatingAction.SEND_REGISTRATION_DM):
+                log.debug(
+                    f"Group reaction silently dropped for user={user.id} "
+                    f"chat={reaction_chat.id}: {result.action}"
+                )
+                return
+            # GatingAction.ALLOW — fall through
+        else:
+            return  # Skill not available; drop all group reactions silently
+    else:
+        if user.id not in ALLOWED_USERS:
+            return
 
     chat_id: int = reaction_update.chat.id
     tg_msg_id: int = reaction_update.message_id
@@ -1296,7 +1377,13 @@ async def handle_reaction(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
         # Schedule delivery after the undo window
         task = asyncio.create_task(
-            _emit_reaction_signal(chat_id, tg_msg_id, emoji)
+            _emit_reaction_signal(
+                chat_id,
+                tg_msg_id,
+                emoji,
+                chat_type=reaction_chat.type,
+                chat_title=getattr(reaction_chat, "title", None),
+            )
         )
         _pending_reactions[pending_key] = task
         log.info(

--- a/tests/unit/test_bot/test_phase4_group_gating.py
+++ b/tests/unit/test_bot/test_phase4_group_gating.py
@@ -1,0 +1,547 @@
+"""
+Unit tests for Phase 4: two-tier group gating in handle_edited_message and handle_reaction.
+
+Verifies that:
+- _check_message_access returns True for allowed DM users
+- _check_message_access returns False for non-allowed DM users
+- _check_message_access allows group users when gate_message returns ALLOW
+- _check_message_access drops group users when gate_message returns DROP_SILENT
+- _check_message_access drops group users when gate_message returns SEND_REGISTRATION_DM
+- _check_message_access drops all group messages when gating is unavailable
+- handle_edited_message applies two-tier gating (group + DM)
+- handle_edited_message sets source="lobster-group" and group context fields for group edits
+- handle_reaction applies two-tier gating (group + DM)
+- _emit_reaction_signal includes group_chat_id and group_title for group reactions
+"""
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_dm_update(user_id: int, text: str = "hello") -> MagicMock:
+    """Build a mock Update for a private DM edited_message or text message."""
+    update = MagicMock()
+    update.effective_user = MagicMock()
+    update.effective_user.id = user_id
+    update.effective_user.username = "testuser"
+    update.effective_user.first_name = "Test"
+
+    msg = MagicMock()
+    msg.text = text
+    msg.message_id = 1
+    msg.chat_id = user_id
+    msg.chat.type = "private"
+    msg.chat.id = user_id
+    msg.chat.title = None
+    msg.reply_to_message = None
+
+    update.effective_message = msg
+    update.edited_message = msg
+    update.message_reaction = None
+    return update
+
+
+def _make_group_update(
+    user_id: int,
+    chat_id: int = -100123,
+    chat_title: str = "Test Group",
+    text: str = "hello from group",
+) -> MagicMock:
+    """Build a mock Update for a group edited_message or text message."""
+    update = MagicMock()
+    update.effective_user = MagicMock()
+    update.effective_user.id = user_id
+    update.effective_user.username = "groupuser"
+    update.effective_user.first_name = "Group"
+
+    msg = MagicMock()
+    msg.text = text
+    msg.message_id = 42
+    msg.chat_id = chat_id
+    msg.chat.type = "supergroup"
+    msg.chat.id = chat_id
+    msg.chat.title = chat_title
+    msg.reply_to_message = None
+
+    update.effective_message = msg
+    update.edited_message = msg
+    update.message_reaction = None
+    return update
+
+
+def _make_reaction_update(
+    user_id: int,
+    chat_id: int,
+    chat_type: str = "private",
+    chat_title: str | None = None,
+    msg_id: int = 10,
+    new_emojis: list[str] | None = None,
+    old_emojis: list[str] | None = None,
+) -> MagicMock:
+    """Build a mock Update for a MessageReactionUpdated event."""
+    update = MagicMock()
+    update.effective_user = MagicMock()
+    update.effective_user.id = user_id
+
+    def _make_reaction(emoji: str) -> MagicMock:
+        r = MagicMock()
+        r.emoji = emoji
+        return r
+
+    reaction_update = MagicMock()
+    reaction_update.chat.id = chat_id
+    reaction_update.chat.type = chat_type
+    reaction_update.chat.title = chat_title
+    reaction_update.message_id = msg_id
+    reaction_update.new_reaction = [_make_reaction(e) for e in (new_emojis or [])]
+    reaction_update.old_reaction = [_make_reaction(e) for e in (old_emojis or [])]
+
+    update.message_reaction = reaction_update
+    update.effective_message = None  # reactions have no effective_message
+    return update
+
+
+def _gate_result(action_name: str) -> MagicMock:
+    """Build a mock gate_message result with the given action."""
+    result = MagicMock()
+
+    class _Action:
+        pass
+
+    result.action = action_name
+    result.reason = action_name
+    return result
+
+
+# ---------------------------------------------------------------------------
+# _check_message_access
+# ---------------------------------------------------------------------------
+
+
+class TestCheckMessageAccess:
+    """Pure unit tests for the _check_message_access helper."""
+
+    @pytest.mark.asyncio
+    async def test_allowed_dm_user_is_accepted(self, bot_module):
+        update = _make_dm_update(user_id=123456)
+        result = await bot_module._check_message_access(update, MagicMock())
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_non_allowed_dm_user_is_rejected(self, bot_module):
+        update = _make_dm_update(user_id=999999)
+        result = await bot_module._check_message_access(update, MagicMock())
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_group_user_allowed_when_gate_returns_allow(self, bot_module):
+        update = _make_group_update(user_id=999999)
+        allow_result = MagicMock()
+        allow_result.action = bot_module.GatingAction.ALLOW
+
+        with (
+            patch.object(bot_module, "_GROUP_GATING_ENABLED", True),
+            patch.object(bot_module, "gate_message", return_value=allow_result),
+            patch.object(bot_module, "load_whitelist", return_value={}),
+        ):
+            result = await bot_module._check_message_access(update, MagicMock())
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_group_user_dropped_when_gate_returns_drop_silent(self, bot_module):
+        update = _make_group_update(user_id=999999)
+        drop_result = MagicMock()
+        drop_result.action = bot_module.GatingAction.DROP_SILENT
+        drop_result.reason = "group not whitelisted"
+
+        with (
+            patch.object(bot_module, "_GROUP_GATING_ENABLED", True),
+            patch.object(bot_module, "gate_message", return_value=drop_result),
+            patch.object(bot_module, "load_whitelist", return_value={}),
+        ):
+            result = await bot_module._check_message_access(update, MagicMock())
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_group_user_dropped_when_gate_returns_registration_dm(self, bot_module):
+        update = _make_group_update(user_id=999999)
+        reg_result = MagicMock()
+        reg_result.action = bot_module.GatingAction.SEND_REGISTRATION_DM
+        reg_result.reason = "user not whitelisted"
+
+        with (
+            patch.object(bot_module, "_GROUP_GATING_ENABLED", True),
+            patch.object(bot_module, "gate_message", return_value=reg_result),
+            patch.object(bot_module, "load_whitelist", return_value={}),
+        ):
+            result = await bot_module._check_message_access(update, MagicMock())
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_group_message_dropped_when_gating_unavailable(self, bot_module):
+        update = _make_group_update(user_id=123456)
+
+        with patch.object(bot_module, "_GROUP_GATING_ENABLED", False):
+            result = await bot_module._check_message_access(update, MagicMock())
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_user_missing(self, bot_module):
+        update = MagicMock()
+        update.effective_user = None
+        update.effective_message = MagicMock()
+        result = await bot_module._check_message_access(update, MagicMock())
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_message_missing(self, bot_module):
+        update = MagicMock()
+        update.effective_user = MagicMock()
+        update.effective_message = None
+        result = await bot_module._check_message_access(update, MagicMock())
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# handle_edited_message — group gating
+# ---------------------------------------------------------------------------
+
+
+class TestHandleEditedMessageGroupGating:
+    """Verify that handle_edited_message applies two-tier gating."""
+
+    @pytest.mark.asyncio
+    async def test_non_allowed_dm_user_edit_is_dropped(
+        self, bot_module, temp_messages_dir
+    ):
+        """Edited messages from non-allowed DM users must be dropped."""
+        inbox = temp_messages_dir / "inbox"
+        update = _make_dm_update(user_id=999999, text="edited text")
+
+        with patch.object(bot_module, "INBOX_DIR", inbox):
+            await bot_module.handle_edited_message(update, MagicMock())
+
+        assert list(inbox.glob("*.json")) == []
+
+    @pytest.mark.asyncio
+    async def test_allowed_dm_user_edit_is_accepted(
+        self, bot_module, temp_messages_dir
+    ):
+        """Edited messages from allowed DM users must be written to inbox."""
+        inbox = temp_messages_dir / "inbox"
+        processing = temp_messages_dir / "processing"
+        processing.mkdir(parents=True, exist_ok=True)
+        update = _make_dm_update(user_id=123456, text="edited text")
+
+        with (
+            patch.object(bot_module, "INBOX_DIR", inbox),
+            patch.object(bot_module, "_MESSAGES", temp_messages_dir),
+        ):
+            await bot_module.handle_edited_message(update, MagicMock())
+
+        files = list(inbox.glob("*.json"))
+        assert len(files) == 1
+        data = json.loads(files[0].read_text())
+        assert data["text"] == "edited text"
+        assert data["source"] == "telegram"
+
+    @pytest.mark.asyncio
+    async def test_non_whitelisted_group_edit_is_dropped(
+        self, bot_module, temp_messages_dir
+    ):
+        """Edited messages from non-whitelisted group users must be dropped."""
+        inbox = temp_messages_dir / "inbox"
+        update = _make_group_update(user_id=999999, text="edited group text")
+
+        drop_result = MagicMock()
+        drop_result.action = bot_module.GatingAction.DROP_SILENT
+        drop_result.reason = "group not whitelisted"
+
+        with (
+            patch.object(bot_module, "_GROUP_GATING_ENABLED", True),
+            patch.object(bot_module, "gate_message", return_value=drop_result),
+            patch.object(bot_module, "load_whitelist", return_value={}),
+            patch.object(bot_module, "INBOX_DIR", inbox),
+        ):
+            await bot_module.handle_edited_message(update, MagicMock())
+
+        assert list(inbox.glob("*.json")) == []
+
+    @pytest.mark.asyncio
+    async def test_whitelisted_group_edit_sets_correct_source_and_context(
+        self, bot_module, temp_messages_dir
+    ):
+        """Edited messages from whitelisted group users must use lobster-group source
+        and include group_chat_id and group_title fields."""
+        inbox = temp_messages_dir / "inbox"
+        processing = temp_messages_dir / "processing"
+        processing.mkdir(parents=True, exist_ok=True)
+
+        update = _make_group_update(
+            user_id=999999,
+            chat_id=-100999,
+            chat_title="My Group",
+            text="edited group text",
+        )
+
+        allow_result = MagicMock()
+        allow_result.action = bot_module.GatingAction.ALLOW
+
+        with (
+            patch.object(bot_module, "_GROUP_GATING_ENABLED", True),
+            patch.object(bot_module, "gate_message", return_value=allow_result),
+            patch.object(bot_module, "load_whitelist", return_value={}),
+            patch.object(bot_module, "get_source_for_chat", return_value="lobster-group"),
+            patch.object(bot_module, "INBOX_DIR", inbox),
+            patch.object(bot_module, "_MESSAGES", temp_messages_dir),
+        ):
+            await bot_module.handle_edited_message(update, MagicMock())
+
+        files = list(inbox.glob("*.json"))
+        assert len(files) == 1
+        data = json.loads(files[0].read_text())
+        assert data["source"] == "lobster-group"
+        assert data["group_chat_id"] == -100999
+        assert data["group_title"] == "My Group"
+        assert data["text"] == "edited group text"
+
+    @pytest.mark.asyncio
+    async def test_group_edit_dropped_when_gating_unavailable(
+        self, bot_module, temp_messages_dir
+    ):
+        """When gating skill is unavailable, all group edits must be dropped."""
+        inbox = temp_messages_dir / "inbox"
+        update = _make_group_update(user_id=123456, text="edited group text")
+
+        with (
+            patch.object(bot_module, "_GROUP_GATING_ENABLED", False),
+            patch.object(bot_module, "INBOX_DIR", inbox),
+        ):
+            await bot_module.handle_edited_message(update, MagicMock())
+
+        assert list(inbox.glob("*.json")) == []
+
+
+# ---------------------------------------------------------------------------
+# handle_reaction — group gating
+# ---------------------------------------------------------------------------
+
+
+class TestHandleReactionGroupGating:
+    """Verify that handle_reaction applies two-tier gating for group reactions."""
+
+    @pytest.mark.asyncio
+    async def test_dm_non_allowed_user_reaction_dropped(self, bot_module):
+        """DM reactions from non-allowed users must be dropped."""
+        bot_module._pending_reactions.clear()
+        update = _make_reaction_update(
+            user_id=999999,
+            chat_id=999999,
+            chat_type="private",
+            new_emojis=["\U0001f44d"],
+        )
+
+        with patch.object(bot_module, "REACTION_UNDO_WINDOW_SECS", 60):
+            await bot_module.handle_reaction(update, MagicMock())
+
+        assert (999999, 10) not in bot_module._pending_reactions
+
+    @pytest.mark.asyncio
+    async def test_dm_allowed_user_reaction_buffered(self, bot_module):
+        """DM reactions from allowed users must be buffered."""
+        bot_module._pending_reactions.clear()
+        update = _make_reaction_update(
+            user_id=123456,
+            chat_id=123456,
+            chat_type="private",
+            new_emojis=["\U0001f44d"],
+        )
+
+        with patch.object(bot_module, "REACTION_UNDO_WINDOW_SECS", 60):
+            await bot_module.handle_reaction(update, MagicMock())
+
+        key = (123456, 10)
+        assert key in bot_module._pending_reactions
+        bot_module._pending_reactions.pop(key).cancel()
+
+    @pytest.mark.asyncio
+    async def test_group_non_whitelisted_reaction_dropped(self, bot_module):
+        """Group reactions from non-whitelisted users must be silently dropped."""
+        bot_module._pending_reactions.clear()
+        update = _make_reaction_update(
+            user_id=999999,
+            chat_id=-100888,
+            chat_type="supergroup",
+            chat_title="Test Group",
+            new_emojis=["\U0001f44d"],
+        )
+
+        drop_result = MagicMock()
+        drop_result.action = bot_module.GatingAction.DROP_SILENT
+        drop_result.reason = "group not whitelisted"
+
+        with (
+            patch.object(bot_module, "_GROUP_GATING_ENABLED", True),
+            patch.object(bot_module, "gate_message", return_value=drop_result),
+            patch.object(bot_module, "load_whitelist", return_value={}),
+            patch.object(bot_module, "REACTION_UNDO_WINDOW_SECS", 60),
+        ):
+            await bot_module.handle_reaction(update, MagicMock())
+
+        assert (-100888, 10) not in bot_module._pending_reactions
+
+    @pytest.mark.asyncio
+    async def test_group_whitelisted_reaction_buffered(self, bot_module):
+        """Group reactions from whitelisted users must be buffered."""
+        bot_module._pending_reactions.clear()
+        update = _make_reaction_update(
+            user_id=999999,
+            chat_id=-100888,
+            chat_type="supergroup",
+            chat_title="Test Group",
+            new_emojis=["\U0001f44d"],
+        )
+
+        allow_result = MagicMock()
+        allow_result.action = bot_module.GatingAction.ALLOW
+
+        with (
+            patch.object(bot_module, "_GROUP_GATING_ENABLED", True),
+            patch.object(bot_module, "gate_message", return_value=allow_result),
+            patch.object(bot_module, "load_whitelist", return_value={}),
+            patch.object(bot_module, "REACTION_UNDO_WINDOW_SECS", 60),
+        ):
+            await bot_module.handle_reaction(update, MagicMock())
+
+        key = (-100888, 10)
+        assert key in bot_module._pending_reactions
+        bot_module._pending_reactions.pop(key).cancel()
+
+    @pytest.mark.asyncio
+    async def test_group_reaction_dropped_when_gating_unavailable(self, bot_module):
+        """When gating skill is unavailable, all group reactions must be dropped."""
+        bot_module._pending_reactions.clear()
+        update = _make_reaction_update(
+            user_id=123456,
+            chat_id=-100888,
+            chat_type="supergroup",
+            new_emojis=["\U0001f44d"],
+        )
+
+        with (
+            patch.object(bot_module, "_GROUP_GATING_ENABLED", False),
+            patch.object(bot_module, "REACTION_UNDO_WINDOW_SECS", 60),
+        ):
+            await bot_module.handle_reaction(update, MagicMock())
+
+        assert (-100888, 10) not in bot_module._pending_reactions
+
+
+# ---------------------------------------------------------------------------
+# _emit_reaction_signal — group context fields
+# ---------------------------------------------------------------------------
+
+
+class TestEmitReactionSignalGroupContext:
+    """Verify that _emit_reaction_signal includes group fields for group reactions."""
+
+    @pytest.mark.asyncio
+    async def test_group_reaction_includes_group_context_fields(
+        self, bot_module, temp_messages_dir
+    ):
+        inbox = temp_messages_dir / "inbox"
+        bot_module._sent_message_buffer.clear()
+
+        with (
+            patch.object(bot_module, "REACTION_UNDO_WINDOW_SECS", 0),
+            patch.object(bot_module, "INBOX_DIR", inbox),
+            patch.object(bot_module, "_GROUP_GATING_ENABLED", True),
+            patch.object(bot_module, "get_source_for_chat", return_value="lobster-group"),
+        ):
+            await bot_module._emit_reaction_signal(
+                -100888,
+                99,
+                "\U0001f44d",
+                chat_type="supergroup",
+                chat_title="My Group",
+            )
+
+        files = list(inbox.glob("*.json"))
+        assert len(files) == 1
+        data = json.loads(files[0].read_text())
+        assert data["source"] == "lobster-group"
+        assert data["group_chat_id"] == -100888
+        assert data["group_title"] == "My Group"
+
+    @pytest.mark.asyncio
+    async def test_dm_reaction_excludes_group_context_fields(
+        self, bot_module, temp_messages_dir
+    ):
+        inbox = temp_messages_dir / "inbox"
+        bot_module._sent_message_buffer.clear()
+
+        with (
+            patch.object(bot_module, "REACTION_UNDO_WINDOW_SECS", 0),
+            patch.object(bot_module, "INBOX_DIR", inbox),
+        ):
+            await bot_module._emit_reaction_signal(
+                123456,
+                99,
+                "\U0001f44d",
+                chat_type="private",
+                chat_title=None,
+            )
+
+        files = list(inbox.glob("*.json"))
+        assert len(files) == 1
+        data = json.loads(files[0].read_text())
+        assert "group_chat_id" not in data
+        assert "group_title" not in data
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bot_module(tmp_path, monkeypatch):
+    """Load lobster_bot with a patched environment and fresh module state."""
+    import importlib
+
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test_token")
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "123456")
+    monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path / "messages"))
+
+    (tmp_path / "messages" / "inbox").mkdir(parents=True, exist_ok=True)
+
+    import src.bot.lobster_bot as module
+
+    importlib.reload(module)
+
+    module._pending_reactions.clear()
+    module._sent_message_buffer.clear()
+
+    yield module
+
+    for task in list(module._pending_reactions.values()):
+        task.cancel()
+    module._pending_reactions.clear()
+
+
+@pytest.fixture
+def temp_messages_dir(tmp_path):
+    """Create a temporary messages directory structure."""
+    inbox = tmp_path / "inbox"
+    inbox.mkdir(parents=True, exist_ok=True)
+    return tmp_path


### PR DESCRIPTION
## What problem this solves

Before this PR, edited messages and emoji reactions from group users bypassed the group whitelist gate. A user blocked at the group level (non-whitelisted, or in a non-whitelisted group) could still interact with the bot by editing a message or reacting with an emoji. The audio, photo, and document handlers were already protected because they are only reachable through `handle_message`, which already applies the full two-tier gate.

## What changed

**New helper: `_check_message_access`**

A pure boolean function that encapsulates the two-tier access logic:
- Group chats: calls `gate_message()` from the whitelist skill; returns `False` on `DROP_SILENT` or `SEND_REGISTRATION_DM`, `True` on `ALLOW`. When the skill is unavailable, drops all group messages.
- DMs: checks `user.id in ALLOWED_USERS` (unchanged behaviour).

This helper is reusable across any handler that operates on `update.effective_message` + `update.effective_user`.

**`handle_edited_message`**

Replaced the inline `user.id not in ALLOWED_USERS` guard with `_check_message_access`. Also updated the `msg_data` dict to:
- Set `source` via `get_source_for_chat(chat.type)` (same pattern as `handle_message`)
- Include `group_chat_id` and `group_title` for group edits

**`handle_reaction`**

`MessageReactionUpdated` has no `update.effective_message`, so `_check_message_access` cannot be used here (it needs a message to get the chat). The gating logic is applied inline using `reaction_update.chat` directly, which is the canonical chat object for reaction events.

**`_emit_reaction_signal`**

Extended with `chat_type` and `chat_title` parameters so group reactions carry the correct `source="lobster-group"`, `group_chat_id`, and `group_title` fields in the inbox JSON — consistent with how `handle_message` enriches group messages.

## What is NOT changed

- The DM gating path in all handlers is identical to before.
- `handle_audio_message`, `handle_photo_message`, `handle_document_message` are not touched — they are called only from within `handle_message`, which already gates.
- No dispatcher changes.

## Before / after: access gate coverage

```
Handler                    Before          After
──────────────────────────────────────────────────────
handle_message             two-tier gate   two-tier gate  (no change)
handle_edited_message      ALLOWED_USERS   two-tier gate  fixed
handle_reaction            ALLOWED_USERS   two-tier gate  fixed
handle_audio_message       n/a (via hm)    n/a (via hm)   (no change)
handle_photo_message       n/a (via hm)    n/a (via hm)   (no change)
handle_document_message    n/a (via hm)    n/a (via hm)   (no change)
```
(hm = handle_message, all media types are dispatched from handle_message after it gates)

## Functional patterns

Pure boolean helper (`_check_message_access`), guard-at-entry pattern, composition (helper shared across handlers), immutable message dict construction.

## Tests run

- [x] `uv run pytest tests/unit/test_bot/test_phase4_group_gating.py -v` — 20 passed, 0 failed (new tests covering `_check_message_access`, edited message gating, reaction gating, and group context fields in `_emit_reaction_signal`)
- [x] `uv run pytest tests/unit/test_bot/ -v` — 168 passed, 0 failed (no regressions in existing bot tests)

Closes #1295
Relates to #1288