### PR TITLE
fix: rename data/events.jsonl -> memory-events.jsonl + add 1GB rotation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ Never use cron for user-space jobs. Never use systemd tools for system-level inf
   - `CLAUDE.md` → symlink to `~/lobster/CLAUDE.md` — same, live immediately
   - `projects/` - All Lobster-managed projects (`$LOBSTER_PROJECTS`)
   - `data/memory.db` - Vector memory SQLite DB
-  - `data/events.jsonl` - Event log
+  - `data/memory-events.jsonl` - StaticMemory event log (JSONL fallback backend)
   - `scheduled-jobs/jobs.json` - Job registry state
   - `scheduled-jobs/tasks/` - Task definition markdown files
   - `scheduled-jobs/logs/` - Execution logs

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2280,6 +2280,16 @@ PYEOF
         migrated=$((migrated + 1))
     fi
 
+    # Migration 63: Rename data/events.jsonl -> data/memory-events.jsonl.
+    # StaticMemory now writes to memory-events.jsonl to distinguish it from the
+    # EventBus operational log at logs/events.jsonl. Rename any existing file
+    # so history is preserved without manual intervention.
+    if [ -f "$WORKSPACE_DIR/data/events.jsonl" ] && [ ! -f "$WORKSPACE_DIR/data/memory-events.jsonl" ]; then
+        mv "$WORKSPACE_DIR/data/events.jsonl" "$WORKSPACE_DIR/data/memory-events.jsonl"
+        substep "Renamed data/events.jsonl -> data/memory-events.jsonl"
+        migrated=$((migrated + 1))
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/src/mcp/memory/static_memory.py
+++ b/src/mcp/memory/static_memory.py
@@ -25,7 +25,9 @@ log = logging.getLogger("lobster-memory")
 _WORKSPACE = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
 _USER_CONFIG = Path(os.environ.get("LOBSTER_USER_CONFIG", Path.home() / "lobster-user-config"))
 DEFAULT_CANONICAL_DIR = _USER_CONFIG / "memory" / "canonical"
-DEFAULT_EVENT_LOG = _WORKSPACE / "data" / "events.jsonl"
+DEFAULT_EVENT_LOG = _WORKSPACE / "data" / "memory-events.jsonl"
+
+_ROTATION_THRESHOLD = 1_073_741_824  # 1 GB in bytes
 
 
 class StaticMemory:
@@ -67,8 +69,25 @@ class StaticMemory:
                     continue
         return max_id + 1
 
+    def _rotate_if_needed(self) -> None:
+        """Rotate the event log if it exceeds the 1 GB threshold.
+
+        Renames the current file to <name>.1 (overwriting any previous rotation)
+        and starts a fresh log. Does not compress or delete — the rotated file
+        is kept intact for manual inspection or archival.
+        """
+        if not self._event_log.exists():
+            return
+        if self._event_log.stat().st_size < _ROTATION_THRESHOLD:
+            return
+        rotated = self._event_log.with_suffix(self._event_log.suffix + ".1")
+        self._event_log.rename(rotated)
+        log.info("Rotated %s -> %s (exceeded 1 GB)", self._event_log, rotated)
+
     def store(self, event: MemoryEvent) -> int:
-        """Append event to JSONL log file."""
+        """Append event to JSONL log file, rotating if the file exceeds 1 GB."""
+        self._rotate_if_needed()
+
         event.id = self._next_id
         self._next_id += 1
 

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -280,6 +280,57 @@ class TestStaticMemory:
     def test_close_is_noop(self, static_mem):
         static_mem.close()  # Should not raise
 
+    def test_rotate_if_needed_fires_at_threshold(self, temp_dir):
+        """File at or above 1 GB triggers rename to <name>.1."""
+        from src.mcp.memory.static_memory import StaticMemory, _ROTATION_THRESHOLD
+        event_log = temp_dir / "memory-events.jsonl"
+        canonical_dir = temp_dir / "canonical"
+        mem = StaticMemory(canonical_dir=canonical_dir, event_log=event_log)
+
+        # Write a file that is exactly at the threshold
+        event_log.write_bytes(b"x" * _ROTATION_THRESHOLD)
+        mem._rotate_if_needed()
+
+        rotated = event_log.with_suffix(event_log.suffix + ".1")
+        assert rotated.exists(), "Rotated file .1 should exist after rotation"
+        assert not event_log.exists(), "Original file should be gone after rotation"
+
+    def test_rotate_if_needed_skips_below_threshold(self, temp_dir):
+        """File below 1 GB leaves the log file untouched."""
+        from src.mcp.memory.static_memory import StaticMemory, _ROTATION_THRESHOLD
+        event_log = temp_dir / "memory-events.jsonl"
+        canonical_dir = temp_dir / "canonical"
+        mem = StaticMemory(canonical_dir=canonical_dir, event_log=event_log)
+
+        event_log.write_bytes(b"x" * (_ROTATION_THRESHOLD - 1))
+        mem._rotate_if_needed()
+
+        assert event_log.exists(), "Original file should still exist below threshold"
+        rotated = event_log.with_suffix(event_log.suffix + ".1")
+        assert not rotated.exists(), "No .1 file should be created below threshold"
+
+    def test_rotate_if_needed_clobbers_existing_rotation(self, temp_dir):
+        """A second rotation overwrites any existing .1 file."""
+        from src.mcp.memory.static_memory import StaticMemory, _ROTATION_THRESHOLD
+        event_log = temp_dir / "memory-events.jsonl"
+        canonical_dir = temp_dir / "canonical"
+        rotated = event_log.with_suffix(event_log.suffix + ".1")
+
+        mem = StaticMemory(canonical_dir=canonical_dir, event_log=event_log)
+
+        # Simulate a stale .1 file from a previous rotation
+        rotated.write_text("old rotation content")
+
+        # Write a new log that exceeds the threshold
+        event_log.write_bytes(b"y" * _ROTATION_THRESHOLD)
+        mem._rotate_if_needed()
+
+        assert rotated.exists(), "Rotated .1 file should exist"
+        # The stale content should have been overwritten
+        assert rotated.read_bytes() == b"y" * _ROTATION_THRESHOLD, (
+            "Existing .1 file should be clobbered by the new rotation"
+        )
+
 
 # ============================================================================
 # VectorMemory Tests

--- a/tests/unit/test_path_guard.py
+++ b/tests/unit/test_path_guard.py
@@ -52,7 +52,7 @@ class TestAssertNotInGitRepo:
             assert_not_in_git_repo(fake_repo)
 
     def test_allows_path_outside_git_repo(self, non_repo):
-        target = non_repo / "data" / "events.jsonl"
+        target = non_repo / "data" / "memory-events.jsonl"
         target.parent.mkdir(parents=True)
         target.touch()
         assert_not_in_git_repo(target)  # should not raise


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

Two related files shared the name `events.jsonl` in different directories, making it easy to confuse the StaticMemory fallback log (`data/events.jsonl`) with the EventBus operational log (`logs/events.jsonl`). This PR renames the former and adds a size cap to prevent unbounded growth.

## What changed

**Rename:** `StaticMemory` now writes to `data/memory-events.jsonl` instead of `data/events.jsonl`. The new name makes clear this is the StaticMemory JSONL backend — the Layer 3 fallback used when sqlite-vec is unavailable — not the structured EventBus log.

**1 GB rotation:** `StaticMemory.store()` now calls `_rotate_if_needed()` before each append. When the file exceeds 1,073,741,824 bytes, the current file is renamed to `memory-events.jsonl.1` and a fresh file is started. The rotated file is preserved intact — no compression, no deletion. On long-running installs where sqlite-vec was never available, this file could otherwise grow without bound.

**Migration 63** in `upgrade.sh` handles existing installs: if `data/events.jsonl` exists and `data/memory-events.jsonl` does not, it renames the file. History is preserved.

**`CLAUDE.md`** updated to reflect the new path.

## What is not changed

- The EventBus `JsonlFileListener` at `logs/events.jsonl` is untouched — different file, different system.
- VectorMemory behavior is unchanged; StaticMemory is only the fallback path.
- Rotation keeps exactly one backup (`.1`). No multi-generation rotation.

## Functional patterns used

Pure function for the rotation predicate (`_rotate_if_needed` has no observable side effect beyond the filesystem rename, and is idempotent if called multiple times below threshold). Side effect (rename) is isolated at the boundary of `store()`.

## Tests run

- [x] `uv run pytest tests/unit/test_memory.py -k "not test_falls_back_to_static and not test_force_static"` — 35 passed, 0 failed. The two excluded tests fail due to a pre-existing environment issue (lobster-user-config is a git repo in this environment), not related to this change.
- [x] `uv run pytest tests/unit/test_event_bus.py` — 25 passed, 0 failed
- [x] `uv run python -c "import py_compile; py_compile.compile('src/mcp/memory/static_memory.py')"` — syntax OK

**Blocked items needing attention before merge:** none