### PR TITLE
fix(hooks): skip secondary check in is_dispatcher — format mismatch blocked tertiary fallback

### DIFF
--- a/hooks/session_role.py
+++ b/hooks/session_role.py
@@ -17,14 +17,16 @@ dispatcher or a background subagent.
    server restarts.
    Match → dispatcher.  Mismatch → subagent.  File absent → try next fallback.
 
-2. **MCP HTTP session state file (secondary)**: The MCP server also writes the
-   HTTP transport session ID (32-char hex) to
+2. **MCP HTTP session state file (secondary — currently skipped)**: The MCP
+   server writes the HTTP transport session ID (32-char hex) to
    `$LOBSTER_WORKSPACE/data/dispatcher-session-id` whenever
-   `_tag_dispatcher_session()` is called (Options A, B, or C).  This ID is a
-   different format from the Claude UUID and does NOT match
-   `hook_input["session_id"]`.  Kept as a fallback: when absent it falls through;
-   when present it conclusively identifies subagents (mismatch).
-   Match → dispatcher.  Mismatch → subagent.  File absent → try next fallback.
+   `_tag_dispatcher_session()` is called.  This ID is a DIFFERENT format from
+   the Claude UUID in `hook_input["session_id"]` — they never match.  When the
+   secondary file is present, `_check_state_file()` always returns False
+   (mismatch) for both dispatcher and subagents, making it useless as a
+   discriminator.  Worse, the False short-circuits execution before the
+   tertiary check, which uses the correct UUID format.  The secondary check is
+   intentionally skipped; the file is left on disk for diagnostic purposes only.
 
 3. **Hook marker file (tertiary)**: At dispatcher startup the SessionStart hook
    (`write-dispatcher-session-id.py`) writes the Claude session ID to
@@ -117,14 +119,17 @@ def is_dispatcher(hook_input: dict) -> bool:
     error, returns True (same conservative fail-open as before) so the
     dispatcher is never incorrectly blocked by a transient I/O error.
 
-    ## Why three checks?
+    ## Why two active checks (primary + tertiary)?
 
     The Claude UUID (hook_input["session_id"]) and the MCP HTTP session ID are
     different formats — they never match directly.  The primary check uses the
-    Claude UUID file, which IS the correct comparison for SessionStart hooks.
-    The secondary and tertiary checks are retained as fallbacks for the race
-    window before session_start is called (e.g. on MCP server restart before
-    the dispatcher has had a chance to call session_start).
+    Claude UUID file (dispatcher-claude-session-id), which IS the correct
+    comparison for SessionStart hooks.  The secondary check (dispatcher-session-id)
+    stores the HTTP transport session ID and is intentionally skipped because it
+    always mismatches both dispatcher and subagents, causing false-negative
+    short-circuits before the tertiary check.  The tertiary check (hook marker
+    file ~/messages/config/dispatcher-session-id) stores the Claude UUID and
+    serves as the fallback for the race window before session_start is called.
     """
     session_id = get_session_id(hook_input)
 
@@ -135,14 +140,18 @@ def is_dispatcher(hook_input: dict) -> bool:
     if primary_result is not None:
         return primary_result
 
-    # --- Secondary: MCP HTTP session state file ---
-    # Written by _tag_dispatcher_session() with the HTTP transport session ID.
-    # Different format from session_id, so this will always be a mismatch for
-    # the dispatcher — but it conclusively identifies subagents when the file
-    # exists and the IDs differ.  When absent, falls through to the next check.
-    secondary_result = _check_state_file(_get_mcp_session_state_file(), session_id)
-    if secondary_result is not None:
-        return secondary_result
+    # --- Secondary: MCP HTTP session state file (SKIPPED intentionally) ---
+    # _get_mcp_session_state_file() stores the MCP HTTP transport session ID
+    # (32-char hex, e.g. '43e178fa975741eb9f6c1cb9f328d52b'), but
+    # hook_input["session_id"] is a Claude UUID (36-char UUID4, e.g.
+    # '756633a5-4802-4327-ab98-684243d5fc2a').  These formats never match, so
+    # _check_state_file() always returns False when the secondary file is
+    # present — for BOTH the dispatcher and subagents.  Treating that False as
+    # a conclusive "subagent" result blocks the tertiary check, which uses
+    # ~/messages/config/dispatcher-session-id (a file that DOES store the
+    # correct Claude UUID and WOULD return True for the dispatcher).
+    # The secondary check is not a reliable discriminator; skip it entirely and
+    # fall through to the tertiary check.
 
     # --- Tertiary: hook marker file ---
     tertiary_result = _check_state_file(DISPATCHER_SESSION_FILE, session_id)

--- a/tests/unit/test_hooks/test_session_role_state_file.py
+++ b/tests/unit/test_hooks/test_session_role_state_file.py
@@ -216,24 +216,24 @@ class TestIsDispatcherClaudeUUIDFile:
         # With the fix: primary Claude UUID file matches → dispatcher correctly identified.
         assert sr.is_dispatcher(_hook_input(claude_uuid)) is True
 
-    def test_claude_uuid_file_absent_falls_through_to_http_file(
+    def test_claude_uuid_file_absent_with_only_http_file_returns_false(
         self, monkeypatch, tmp_path
     ):
-        """When the Claude UUID file is absent, fall through to the HTTP session file."""
+        """Primary absent, only HTTP session file present → False (secondary skipped, tertiary absent)."""
         sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(sr)
         data_dir = tmp_path / "data"
         data_dir.mkdir()
 
         # Only the HTTP session file is present (older MCP version or race window).
-        # Since it contains an HTTP session ID, it will mismatch the Claude UUID
-        # and return False (subagent).  This is expected — the fix is to also write
-        # the Claude UUID file.
+        # The secondary check is intentionally skipped (format mismatch — see
+        # session_role.py), and the tertiary hook marker file is also absent,
+        # so is_dispatcher() falls through to the default → False.
         http_session_id = "43e178fa975741eb9f6c1cb9f328d52b"
         claude_uuid = "756633a5-4802-4327-ab98-684243d5fc2a"
         (data_dir / "dispatcher-session-id").write_text(http_session_id)
 
-        # HTTP session ID does not match Claude UUID → secondary check returns False.
-        # This confirms the pre-fix behavior: even the secondary check fails.
         assert sr.is_dispatcher(_hook_input(claude_uuid)) is False
 
     def test_claude_uuid_file_absent_falls_through_to_hook_marker(
@@ -254,30 +254,53 @@ class TestIsDispatcherClaudeUUIDFile:
 
 
 # ---------------------------------------------------------------------------
-# is_dispatcher — MCP HTTP session state file (secondary)
+# is_dispatcher — MCP HTTP session state file (secondary, skipped)
+#
+# The secondary file (dispatcher-session-id) stores the HTTP transport session
+# ID (32-char hex), NOT the Claude UUID. The secondary check is intentionally
+# skipped in is_dispatcher() because it would always return False for both
+# dispatcher and subagents (format mismatch), blocking the tertiary check.
+# These tests verify that the secondary file alone never causes a True return,
+# and that the function falls through correctly to the tertiary check.
 # ---------------------------------------------------------------------------
 
 
 class TestIsDispatcherMCPStateFile:
-    def test_mcp_file_match_returns_true(self, monkeypatch, tmp_path):
-        """Secondary MCP state file matches → dispatcher."""
+    def test_mcp_file_alone_never_returns_true(self, monkeypatch, tmp_path):
+        """Secondary-only: MCP HTTP session file is skipped; returns False (no tertiary)."""
         sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(sr)
         mcp_dir = tmp_path / "data"
         mcp_dir.mkdir()
+        # Write the secondary file with a value that matches the hook input.
+        # Under the old code this would return True; under the fix it is skipped
+        # and the tertiary (hook marker) file is absent → False.
         (mcp_dir / "dispatcher-session-id").write_text("sess-mcp-001")
 
-        assert sr.is_dispatcher(_hook_input("sess-mcp-001")) is True
+        assert sr.is_dispatcher(_hook_input("sess-mcp-001")) is False
 
-    def test_mcp_file_mismatch_returns_false(self, monkeypatch, tmp_path):
-        """Secondary MCP state file contains a different session → subagent."""
+    def test_mcp_file_present_falls_through_to_tertiary(self, monkeypatch, tmp_path):
+        """Secondary file present but skipped → tertiary hook marker file decides."""
         sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(sr)
         mcp_dir = tmp_path / "data"
         mcp_dir.mkdir()
-        (mcp_dir / "dispatcher-session-id").write_text("dispatcher-session")
+        # Write secondary with a hex value (typical real-world content).
+        http_session_id = "43e178fa975741eb9f6c1cb9f328d52b"
+        (mcp_dir / "dispatcher-session-id").write_text(http_session_id)
 
-        assert sr.is_dispatcher(_hook_input("subagent-session")) is False
+        # Write tertiary with the matching Claude UUID.
+        claude_uuid = "756633a5-4802-4327-ab98-684243d5fc2a"
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "dispatcher-session-id").write_text(claude_uuid)
 
-    def test_mcp_file_absent_falls_through_to_secondary(self, monkeypatch, tmp_path):
+        # Secondary is skipped; tertiary matches → dispatcher.
+        assert sr.is_dispatcher(_hook_input(claude_uuid)) is True
+
+    def test_mcp_file_absent_falls_through_to_tertiary(self, monkeypatch, tmp_path):
         """Both MCP files absent → falls through to hook marker file."""
         sr = _reload_session_role(monkeypatch, tmp_path)
         # Set HOME so tertiary hook marker file resolves under tmp_path.
@@ -358,6 +381,84 @@ class TestIsDispatcherDefault:
         (mcp_dir / "dispatcher-claude-session-id").write_text("some-dispatcher-uuid")
 
         assert sr.is_dispatcher({}) is False  # no session_id key
+
+
+# ---------------------------------------------------------------------------
+# Regression: secondary check format mismatch blocked tertiary fallback
+#
+# Bug: when the secondary file (dispatcher-session-id) existed with a 32-char
+# hex HTTP session ID, _check_state_file() returned False (mismatch).  The
+# early-exit `if secondary_result is not None: return secondary_result` then
+# returned False immediately, preventing the tertiary check from running.
+# The tertiary file (~/messages/config/dispatcher-session-id) stores a Claude
+# UUID and WOULD have returned True — but was never reached.
+#
+# Fix: remove the secondary early-exit entirely.  The secondary file stores an
+# incompatible format and is not a reliable discriminator for either session
+# type.  The function falls through to the tertiary check in all cases.
+# ---------------------------------------------------------------------------
+
+
+class TestIsDispatcherSecondaryCheckSkipped:
+    def test_secondary_hex_does_not_block_tertiary_uuid_match(
+        self, monkeypatch, tmp_path
+    ):
+        """Core regression: primary absent, secondary has hex, tertiary has UUID → True.
+
+        This is the exact failure mode that triggered the bug report.  After
+        compaction, the Claude UUID state file (primary) may be absent.  The
+        secondary file exists with a 32-char hex HTTP session ID.  The tertiary
+        hook marker file has the correct Claude UUID.
+
+        Before the fix: secondary returned False (mismatch) → early exit →
+        is_dispatcher() returned False for the dispatcher.
+
+        After the fix: secondary is skipped → tertiary check runs → True.
+        """
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(sr)
+
+        # Primary file absent (simulates post-compaction state).
+
+        # Secondary: MCP HTTP session ID (32-char hex) — real content in production.
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        http_session_id = "43e178fa975741eb9f6c1cb9f328d52b"
+        (data_dir / "dispatcher-session-id").write_text(http_session_id)
+
+        # Tertiary: hook marker file with the correct Claude UUID.
+        claude_uuid = "756633a5-4802-4327-ab98-684243d5fc2a"
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "dispatcher-session-id").write_text(claude_uuid)
+
+        # Must return True — the dispatcher is correctly identified via the
+        # tertiary check, which is now reached because the secondary is skipped.
+        assert sr.is_dispatcher(_hook_input(claude_uuid)) is True
+
+    def test_secondary_hex_does_not_block_tertiary_uuid_mismatch(
+        self, monkeypatch, tmp_path
+    ):
+        """Secondary skipped, tertiary has a different UUID → False (subagent)."""
+        sr = _reload_session_role(monkeypatch, tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(sr)
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        http_session_id = "43e178fa975741eb9f6c1cb9f328d52b"
+        (data_dir / "dispatcher-session-id").write_text(http_session_id)
+
+        # Tertiary has the dispatcher UUID.
+        dispatcher_uuid = "756633a5-4802-4327-ab98-684243d5fc2a"
+        subagent_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "dispatcher-session-id").write_text(dispatcher_uuid)
+
+        # Subagent session ID does not match tertiary → False.
+        assert sr.is_dispatcher(_hook_input(subagent_uuid)) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Summary

After compaction, `is_dispatcher()` silently returned False for the dispatcher because the secondary check short-circuited execution before the tertiary check (which had the correct answer) could run.

The secondary file (`dispatcher-session-id`) stores the MCP HTTP transport session ID — a 32-char hex string (e.g. `43e178fa975741eb9f6c1cb9f328d52b`). The hook receives a Claude UUID (e.g. `756633a5-4802-4327-ab98-684243d5fc2a`). These formats never match. `_check_state_file()` returned `False` (not `None`), and the `if secondary_result is not None: return secondary_result` guard treated that `False` as a conclusive "subagent" result — blocking the tertiary check entirely.

The tertiary file (`~/messages/config/dispatcher-session-id`) stores the Claude UUID and is written by `write-dispatcher-session-id.py` at SessionStart. It would have returned `True` for the dispatcher, but was never reached when the secondary file existed.

## What changed

`hooks/session_role.py`: the secondary check block (two lines + guard) is replaced with a comment explaining why it is skipped. The function now falls through to the tertiary check whenever the primary (`dispatcher-claude-session-id`) is absent.

`tests/unit/test_hooks/test_session_role_state_file.py`: `TestIsDispatcherMCPStateFile` is rewritten — the one test that assumed the secondary file could produce a True result (`test_mcp_file_match_returns_true`) is replaced with a test that asserts the opposite. A new class `TestIsDispatcherSecondaryCheckSkipped` adds two regression tests covering the exact failure mode: primary absent + secondary has hex + tertiary has UUID → True.

## What is not changed

- `_check_state_file()` and `_read_session_id_from_file()` are untouched.
- The secondary file (`dispatcher-session-id`) is still written by the MCP server and retained on disk; only the read path is skipped.
- The primary and tertiary checks are unchanged.

## Functional pattern

Pure predicate function with layered fallbacks. The fix removes a branch that produced a misleading False rather than deferring to the next fallback — the correct pattern for a "None means try next" chain.

## Before / after detection flow

```
Before (broken when secondary file exists):
  hook_input["session_id"] = UUID
  primary (dispatcher-claude-session-id): absent → None → continue
  secondary (dispatcher-session-id):     present, hex != UUID → False → RETURN False  <- blocks tertiary
  tertiary: never reached

After (fixed):
  hook_input["session_id"] = UUID
  primary (dispatcher-claude-session-id): absent → None → continue
  secondary:                              SKIPPED
  tertiary (~/messages/config/...):       present, UUID == UUID → True → RETURN True
```

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_session_role_state_file.py -v` — 33 passed, 0 failed
- [x] `uv run pytest tests/unit/ -q` — 1985 passed, 83 failed (all 83 pre-exist on main — verified against main branch)

Relates to #1255 (the previous session ID mismatch fix that introduced the Claude UUID primary file, but did not remove the blocking secondary early-exit)