### PR TITLE
fix(bot-talk): replace hardcoded AlbertLobster filter with config-driven BOT_TALK_SELF_USER

### DIFF
--- a/scheduled-tasks/tasks/README.md
+++ b/scheduled-tasks/tasks/README.md
@@ -45,6 +45,7 @@ time. Common placeholders:
 |---|---|---|
 | `bot-talk-poller.md.template` | `bot-talk-poller` | Hourly baseline poller for bot-talk messages |
 | `bot-talk-poller-fast.md.template` | `bot-talk-poller-fast` | 2-minute fast poller (hot-mode only) |
+| `bot-talk-realtime-forwarder.md.template` | `bot-talk-realtime-forwarder` | 2-minute real-time forwarder; config-driven sender filtering via BOT_TALK_SELF_USER/BOT_TALK_SENDER |
 | `gmail-email-pipeline.md.template` | `gmail-email-pipeline` | Gmail polling with CRM enrichment |
 
 ## How to instantiate a template

--- a/scheduled-tasks/tasks/bot-talk-poller-fast.md.template
+++ b/scheduled-tasks/tasks/bot-talk-poller-fast.md.template
@@ -44,6 +44,41 @@ Schema:
 Always write updated state atomically: write to a `.tmp` file, then rename to the
 final path.
 
+## Identity and Filtering
+
+Read the self-identity from config at runtime (same pattern as the hourly poller):
+
+```python
+def _load_self_user() -> str:
+    from pathlib import Path
+    import os
+
+    for key in ("BOT_TALK_SELF_USER", "BOT_TALK_SENDER"):
+        val = os.environ.get(key, "").strip()
+        if val:
+            return val
+
+    for config_path in [
+        Path.home() / "messages" / "config" / "config.env",
+        Path.home() / "lobster-config" / "config.env",
+    ]:
+        if config_path.exists():
+            for line in config_path.read_text().splitlines():
+                line = line.strip()
+                for key in ("BOT_TALK_SELF_USER", "BOT_TALK_SENDER"):
+                    if line.startswith(f"{key}="):
+                        value = line.split("=", 1)[1].strip().strip('"').strip("'")
+                        if value:
+                            return value
+
+    return "{{LOCAL_LOBSTER_IDENTITY}}"
+
+SELF_USER = _load_self_user()
+```
+
+**Filter rule**: Only notify for messages where `sender != SELF_USER` (received from the
+remote side). Messages from `SELF_USER` are outbound — suppress them silently.
+
 ## Instructions
 
 1. **Fast-exit if not in hot mode:**
@@ -55,24 +90,25 @@ final path.
 2. **Poll for new messages from both senders:**
    - Fetch all messages from `{{LOBSTERTALK_HOST}}/messages` with
      timestamp > `last_message_ts`.
-   - Collect messages from **both** `sender={{LOCAL_LOBSTER_IDENTITY}}` AND `sender={{REMOTE_LOBSTER_IDENTITY}}`.
+   - Collect messages from **both** senders.
    - Sort by timestamp ascending (oldest first).
+   - Filter to find remote messages only (sender != SELF_USER) for notification purposes.
 
 3. **If new messages found:**
-   - Format each message with a directional prefix:
-     - {{LOCAL_LOBSTER_IDENTITY}} messages: `📤 {{LOCAL_LOBSTER_IDENTITY}} → remote: <content>`
-     - {{REMOTE_LOBSTER_IDENTITY}} messages: `📥 {{REMOTE_LOBSTER_IDENTITY}} → the owner: <content>`
-   - Send a single Telegram notification to the owner (chat_id={{TELEGRAM_CHAT_ID}}) with the full
-     conversation block, e.g.:
+   - **Only if there are new remote messages** (sender != SELF_USER):
+     - Format each remote message: `📥 {{REMOTE_LOBSTER_IDENTITY}} → the owner: <content>`
+     - Send a single Telegram notification to the owner (chat_id={{TELEGRAM_CHAT_ID}}), e.g.:
 
-     ```
-     New bot-talk activity:
+       ```
+       New message from {{REMOTE_LOBSTER_IDENTITY}}:
 
-     📤 {{LOCAL_LOBSTER_IDENTITY}} → remote: Hello!
-     📥 {{REMOTE_LOBSTER_IDENTITY}} → the owner: Hi back!
-     ```
+       📥 {{REMOTE_LOBSTER_IDENTITY}} → the owner: Hi back!
+       ```
 
-   - Update `last_message_ts` to the latest timestamp across both senders.
+   - **If only SELF_USER messages (no remote messages)**:
+     - Do NOT send a Telegram notification. Complete silently.
+   - Update `last_message_ts` to the latest timestamp across both senders
+     (SELF_USER messages still advance the cursor even if not notified).
    - Reset `consecutive_empty_polls` to 0.
 
 4. **If no new messages:**

--- a/scheduled-tasks/tasks/bot-talk-poller.md.template
+++ b/scheduled-tasks/tasks/bot-talk-poller.md.template
@@ -8,8 +8,8 @@
 You are running as a scheduled task. The main Lobster instance created this job.
 
 This is the **hourly baseline poller**. It also manages the hot-mode state that drives
-`bot-talk-poller-fast` (the 2-minute fast poller). When {{REMOTE_LOBSTER_IDENTITY}} is
-active, set `hot_mode=true` so the fast poller takes over. When activity stops, the fast
+`bot-talk-poller-fast` (the 2-minute fast poller). When the remote Lobster ({{REMOTE_LOBSTER_IDENTITY}})
+is active, set `hot_mode=true` so the fast poller takes over. When activity stops, the fast
 poller self-cools and this job confirms the quiet state each hour.
 
 ## Authentication
@@ -80,6 +80,46 @@ Schema:
 Always write the updated state back atomically: write to a `.tmp` file, then rename to
 the final path.
 
+## Identity and Filtering
+
+This instance's configured identity in bot-talk is `{{LOCAL_LOBSTER_IDENTITY}}` (set via
+`BOT_TALK_SENDER` in config.env). At runtime, read the self-identity from config so the
+filter is always based on current config, not baked-in names:
+
+```python
+def _load_self_user() -> str:
+    """Load BOT_TALK_SELF_USER (or BOT_TALK_SENDER) from config — determines which
+    messages are 'ours' (sent by us) vs 'theirs' (received from the remote side)."""
+    from pathlib import Path
+    import os
+
+    for key in ("BOT_TALK_SELF_USER", "BOT_TALK_SENDER"):
+        val = os.environ.get(key, "").strip()
+        if val:
+            return val
+
+    for config_path in [
+        Path.home() / "messages" / "config" / "config.env",
+        Path.home() / "lobster-config" / "config.env",
+    ]:
+        if config_path.exists():
+            for line in config_path.read_text().splitlines():
+                line = line.strip()
+                for key in ("BOT_TALK_SELF_USER", "BOT_TALK_SENDER"):
+                    if line.startswith(f"{key}="):
+                        value = line.split("=", 1)[1].strip().strip('"').strip("'")
+                        if value:
+                            return value
+
+    return "{{LOCAL_LOBSTER_IDENTITY}}"  # fallback to instantiation-time value
+
+SELF_USER = _load_self_user()
+```
+
+**Filter rule**: Messages where `sender == SELF_USER` are outbound (sent by us); the owner
+already knows about those. Only notify for messages where `sender != SELF_USER` (received
+from the remote side).
+
 ## Instructions
 
 1. Poll `{{LOBSTERTALK_HOST}}/messages` for new messages from **both** {{LOCAL_LOBSTER_IDENTITY}}
@@ -92,13 +132,17 @@ the final path.
      with timestamp > last_message_ts.
    - Sort them by timestamp (ascending — oldest first, so the conversation reads
      chronologically).
+   - **Only notify for messages where `sender != SELF_USER`** (messages received from the remote side).
+     Messages from `SELF_USER` are outbound — the owner sent those and doesn't need to see them again.
    - Format each message with a directional prefix:
-     - {{LOCAL_LOBSTER_IDENTITY}} messages: `📤 {{LOCAL_LOBSTER_IDENTITY}} → remote: <content>`
-     - {{REMOTE_LOBSTER_IDENTITY}} messages: `📥 {{REMOTE_LOBSTER_IDENTITY}} → the owner: <content>`
-   - For each {{REMOTE_LOBSTER_IDENTITY}} message, also post a comment on the relevant GitHub issue
+     - `SELF_USER` messages: `📤 {{LOCAL_LOBSTER_IDENTITY}} → remote: <content>`
+     - remote messages: `📥 {{REMOTE_LOBSTER_IDENTITY}} → the owner: <content>`
+   - For each remote message, also post a comment on the relevant GitHub issue
      if actionable (configure repo in `BOT_TALK_GITHUB_REPO` env var if used).
-   - Notify the owner via Telegram (chat_id={{TELEGRAM_CHAT_ID}}) with the full conversation block
-     showing both sides.
+   - **Only if there are new remote messages** (sender != SELF_USER): notify the owner via
+     Telegram (chat_id={{TELEGRAM_CHAT_ID}}).
+   - **If only SELF_USER messages (no remote messages)**: do NOT send a Telegram notification.
+     Complete silently.
    - Update `last_message_ts` in state file to the latest seen message timestamp
      (across both senders).
    - Set `hot_mode=true` in state file.
@@ -119,28 +163,32 @@ the final path.
 
 ## Telegram Notification Format
 
-When there are new messages, send a single notification to the owner showing the full
-conversation block. Example:
+When there are new messages from the remote side, send a single notification to the owner
+showing only the remote messages (sender != SELF_USER). Example:
 
 ```
-New bot-talk activity:
+New message from {{REMOTE_LOBSTER_IDENTITY}}:
 
-📤 {{LOCAL_LOBSTER_IDENTITY}} → remote: What do you think about the new plan?
 📥 {{REMOTE_LOBSTER_IDENTITY}} → the owner: I reviewed it. Looks reasonable, a few questions though.
 📥 {{REMOTE_LOBSTER_IDENTITY}} → the owner: Can you clarify item 3?
-📤 {{LOCAL_LOBSTER_IDENTITY}} → remote: Sure, item 3 means we delay the deployment.
 ```
 
-Messages are sorted chronologically so the conversation is readable top-to-bottom.
+Messages are sorted chronologically. Do NOT include SELF_USER outbound messages in the
+notification — the owner sent those and doesn't need to see them again.
 
 ## Telegram Notification Rules
 
-Only send a Telegram message to the owner (chat_id={{TELEGRAM_CHAT_ID}}) when there is genuinely new content:
-- One or more new messages (from either sender) since last run
+Only send a Telegram message to the owner (chat_id={{TELEGRAM_CHAT_ID}}) when:
+- One or more new messages from the **remote side** (sender != SELF_USER) since last run
 - A new actionable GitHub comment requiring attention
 - The HTTP API has been continuously down for more than 30 minutes
 
-For routine no-op cycles (no new messages, API healthy, nothing actionable): do NOT call send_reply. Instead, call write_task_output with status "success" and a brief internal note like "no new activity". The dispatcher will handle it silently.
+Do NOT notify for messages from SELF_USER — the owner sent those herself and does not need to hear about them.
+
+For routine no-op cycles (no new messages, API healthy, nothing actionable) OR cycles where
+only SELF_USER outbound messages are seen: do NOT call send_reply. Instead, call
+write_task_output with status "success" and a brief internal note like "no new activity" or
+"only outbound messages, no notification sent". The dispatcher will handle it silently.
 
 ## Output
 

--- a/scheduled-tasks/tasks/bot-talk-realtime-forwarder.md.template
+++ b/scheduled-tasks/tasks/bot-talk-realtime-forwarder.md.template
@@ -1,0 +1,200 @@
+# Bot-Talk Real-Time Forwarder
+
+**Job**: bot-talk-realtime-forwarder
+**Schedule**: `*/2 * * * *` (every 2 minutes)
+
+## Context
+
+You are running as a scheduled task. Forward new inter-Lobster bot-talk exchanges to the owner on
+Telegram as they arrive. This job polls the bot-talk API and delivers each new message individually
+to the owner's Telegram.
+
+## Identity
+
+This instance's bot-talk identity is `{{LOCAL_LOBSTER_IDENTITY}}` (value from `BOT_TALK_SENDER`
+in config.env). The remote Lobster's identity is `{{REMOTE_LOBSTER_IDENTITY}}`.
+
+**Filter logic**: Only forward messages where `sender != {{LOCAL_LOBSTER_IDENTITY}}` — these are
+messages received by this instance, sent by the remote side. Suppress messages where
+`sender == {{LOCAL_LOBSTER_IDENTITY}}` — those are outbound messages this instance sent, and
+the owner doesn't need to see them again.
+
+At runtime, read the self-identity from config using this fallback chain:
+
+```python
+def _load_self_user() -> str:
+    """Load BOT_TALK_SELF_USER (or fall back to BOT_TALK_SENDER) from config."""
+    from pathlib import Path
+    import os
+
+    # 1. BOT_TALK_SELF_USER env var (explicit override)
+    val = os.environ.get("BOT_TALK_SELF_USER", "").strip()
+    if val:
+        return val
+
+    # 2. BOT_TALK_SENDER env var (same value used by the mirror module)
+    val = os.environ.get("BOT_TALK_SENDER", "").strip()
+    if val:
+        return val
+
+    # 3. config.env files
+    for config_path in [
+        Path.home() / "messages" / "config" / "config.env",
+        Path.home() / "lobster-config" / "config.env",
+    ]:
+        if config_path.exists():
+            for line in config_path.read_text().splitlines():
+                line = line.strip()
+                for key in ("BOT_TALK_SELF_USER", "BOT_TALK_SENDER"):
+                    if line.startswith(f"{key}="):
+                        value = line.split("=", 1)[1].strip().strip('"').strip("'")
+                        if value:
+                            return value
+
+    # 4. Hardcoded fallback (legacy)
+    return "{{LOCAL_LOBSTER_IDENTITY}}"
+
+SELF_USER = _load_self_user()
+```
+
+## Authentication
+
+Read the bot-talk API token using this lookup chain (first non-empty value wins):
+
+1. `~/lobster-workspace/data/bot-talk-token.txt` (legacy token file)
+2. `BOT_TALK_TOKEN` key in `~/messages/config/config.env`
+3. `BOT_TALK_TOKEN` key in `~/lobster-config/config.env`
+
+Example (Python):
+```python
+def _load_bot_talk_token() -> str:
+    import os
+    from pathlib import Path
+
+    token_file = Path.home() / "lobster-workspace" / "data" / "bot-talk-token.txt"
+    if token_file.exists():
+        token = token_file.read_text().strip()
+        if token:
+            return token
+
+    for config_path in [
+        Path.home() / "messages" / "config" / "config.env",
+        Path.home() / "lobster-config" / "config.env",
+    ]:
+        if config_path.exists():
+            for line in config_path.read_text().splitlines():
+                line = line.strip()
+                if line.startswith("BOT_TALK_TOKEN="):
+                    value = line.split("=", 1)[1].strip().strip('"').strip("'")
+                    if value:
+                        return value
+
+    return ""
+```
+
+If the token cannot be found, log an error and call `write_task_output` with status "failed".
+
+## State File
+
+Read and write `~/lobster-workspace/data/bot-talk-realtime-state.json`.
+
+Schema:
+```json
+{
+  "last_processed_ts": "2026-01-01T00:00:00Z"
+}
+```
+
+Create with default `last_processed_ts = "2026-01-01T00:00:00Z"` if not found.
+
+## Instructions
+
+### Step 1: Load state and identity
+
+Read `~/lobster-workspace/data/bot-talk-realtime-state.json`. Extract `last_processed_ts`.
+
+Load `SELF_USER` using the fallback chain above. Load the API token using the lookup chain.
+If token is empty, fail immediately with `write_task_output(status="failed", output="BOT_TALK_TOKEN not configured")`.
+
+### Step 2: Fetch new messages from bot-talk
+
+Poll for all recent messages since `last_processed_ts`:
+
+```
+GET {{LOBSTERTALK_HOST}}/messages?since=<last_processed_ts>&limit=100
+X-Bot-Token: <token>
+```
+
+The API returns `{"count": N, "messages": [...]}`. Each message has these fields:
+`id`, `sender`, `content`, `genre`, `tier`, `timestamp`.
+
+Note: there is no `recipient` field and no `from_me` field in the API response.
+Endpoints `/me`, `/whoami`, and `/identity` do not exist on this API.
+
+Sort messages by timestamp ascending (oldest first) so forwarding is in chronological order.
+
+### Step 3: Filter messages
+
+Apply two filters:
+
+1. **Filter out own outbound status messages** — messages with content starting with `[OUTBOUND →`
+   represent this Lobster logging its own Telegram/Slack deliveries. Forwarding these creates a
+   feedback loop.
+
+2. **Filter out own sent messages** — messages where `sender == SELF_USER` are messages this
+   instance sent. The owner sent those (via this Lobster) and does not need to see them again.
+
+Only forward messages where:
+- `sender != SELF_USER` (i.e. received from the remote side), AND
+- content does NOT start with `[OUTBOUND →`
+
+```python
+qualifying = [
+    m for m in messages
+    if m["sender"] != SELF_USER
+    and not m["content"].startswith("[OUTBOUND →")
+]
+```
+
+Note: The state timestamp (`last_processed_ts`) must still advance based on the full fetched
+list (including filtered-out messages) — see Step 5. This prevents re-processing old messages
+on subsequent runs.
+
+### Step 4: Forward each qualifying message to Telegram
+
+For each qualifying message (in chronological order), call `send_reply` with:
+- `chat_id`: {{TELEGRAM_CHAT_ID}}
+- `source`: "telegram"
+- `text`: formatted as:
+  ```
+  [Bot-Talk] {sender}: {content}
+  ```
+
+If content is longer than 1000 characters, truncate and append `… (truncated)`.
+
+Send each message as a separate `send_reply` call — do not batch into one message.
+
+### Step 5: Update state
+
+After forwarding all qualifying new messages, update `last_processed_ts` to the timestamp
+of the latest message from the full fetched list.
+
+Write state file atomically: write to a `.tmp` file, then rename to the final path.
+
+If no new messages were fetched at all, do not update state.
+
+### Step 6: Write output
+
+Call `write_task_output` with:
+- `job_name`: "bot-talk-realtime-forwarder"
+- `output`: Brief summary, e.g. "No new messages." or "Forwarded 3 messages."
+- `status`: "success" or "failed"
+
+Then call `write_result`:
+- If messages were forwarded via `send_reply`: `write_result(task_id=<task_id>, chat_id={{TELEGRAM_CHAT_ID}}, sent_reply_to_user=True)`
+- If no messages were forwarded (no new messages): `write_result(task_id=<task_id>, chat_id=0, sent_reply_to_user=False)`
+
+## Timezone
+
+Always display timestamps in **Eastern Time (ET)** — currently EDT (UTC-4). Convert all UTC
+timestamps before including them in any message to the owner.

--- a/src/mcp/bot_talk_mirror.py
+++ b/src/mcp/bot_talk_mirror.py
@@ -25,8 +25,9 @@ Configuration (all overridable via environment variables):
 
 Anti-duplication
 ----------------
-The bot-talk poller reads only messages with sender="AlbertLobster".
-This module writes sender="SaharLobster", so there is no echo loop.
+The bot-talk poller reads only messages where sender != BOT_TALK_SELF_USER (i.e. the
+remote side's messages). This module writes with BOT_TALK_SENDER configured via the
+BOT_TALK_SENDER env variable or config.env, so there is no echo loop.
 
 Filtering
 ---------
@@ -105,7 +106,11 @@ BOT_TALK_TOKEN: str = (
 )
 BOT_TALK_HTTP_TIMEOUT = 3.0   # seconds
 BOT_TALK_HTTP_RETRIES = 2
-BOT_TALK_SENDER = "SaharLobster"
+BOT_TALK_SENDER: str = (
+    os.environ.get("BOT_TALK_SENDER")
+    or _read_config_env("BOT_TALK_SENDER")
+    or "SaharLobster"  # fallback for legacy installs without BOT_TALK_SENDER in config
+)
 BOT_TALK_TIER = "TIER-BOT"
 
 _WORKSPACE = Path.home() / "lobster-workspace"

--- a/tests/unit/test_mcp_server/test_bot_talk_mirror.py
+++ b/tests/unit/test_mcp_server/test_bot_talk_mirror.py
@@ -43,15 +43,15 @@ class TestBuildHttpPayload:
         payload = btm._build_http_payload("some content here", "query")
         assert payload["content"] == "some content here"
 
-    def test_sender_is_saharlобster(self):
+    def test_sender_matches_configured_bot_talk_sender(self):
         payload = btm._build_http_payload("x", "status-update")
-        assert payload["sender"] == "SaharLobster"
+        assert payload["sender"] == btm.BOT_TALK_SENDER
 
 
 class TestBuildSshLogLine:
     def test_log_line_contains_sender_tier_genre(self):
         line = btm._build_ssh_log_line("msg content", "status-update")
-        assert "[SaharLobster]" in line
+        assert f"[{btm.BOT_TALK_SENDER}]" in line
         assert "[TIER-BOT]" in line
         assert "[status-update]" in line
 
@@ -267,7 +267,7 @@ class TestWriteLocalLog:
         lines = log_file.read_text().strip().splitlines()
         assert len(lines) == 1
         entry = json.loads(lines[0])
-        assert entry["sender"] == "SaharLobster"
+        assert entry["sender"] == btm.BOT_TALK_SENDER
         assert entry["genre"] == "status-update"
         assert "test content" in entry["content"]
         assert entry["mirror_failed_reason"] == "http_and_ssh_both_failed"


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Summary

The bot-talk poller and realtime-forwarder hardcoded `AlbertLobster` as the sender to notify about, and silently suppressed messages from `SaharLobster` as "outbound". This means Albert's side of the shared bot-talk channel would incorrectly see messages from himself (or miss Sahar's messages) — the logic was written assuming a single, fixed deployment topology. The fix makes the "who am I" determination config-driven so both sides of a shared deployment work correctly without code changes.

## What changed

**`bot_talk_mirror.py`**: `BOT_TALK_SENDER` was a hardcoded string constant (`"SaharLobster"`). It now reads from `BOT_TALK_SENDER` env var or `config.env` at module load time, with `"SaharLobster"` as a fallback for legacy installs that don't have the config key. No behavior change for existing deployments that don't set the key.

**Task templates** (`bot-talk-poller.md.template`, `bot-talk-poller-fast.md.template`): Added a `_load_self_user()` snippet that reads `BOT_TALK_SELF_USER` → `BOT_TALK_SENDER` → `config.env` at runtime. The filter predicate changes from `sender == "AlbertLobster"` (hardcoded) to `sender != SELF_USER` (config-driven). A deployment with `BOT_TALK_SENDER=AlbertLobster` will now correctly notify for `SaharLobster` messages and suppress `AlbertLobster` messages.

**New template**: `bot-talk-realtime-forwarder.md.template` — this task had no committed template in the repo. Added one with the config-driven filter as the canonical pattern.

**Tests**: Two assertions comparing against the literal `"SaharLobster"` string updated to compare against `btm.BOT_TALK_SENDER`.

## What is not changed

The live task files in `~/lobster-workspace/scheduled-jobs/tasks/` (not committed) are updated separately as a runtime-only fix. The shell-level pre-check in `bot-talk-check-dispatch.sh` doesn't filter by sender — it only checks whether there are any new messages at all — so it needs no change.

## Filter logic before/after

```
Before:
  notify if sender == "AlbertLobster"   (hardcoded — wrong on Albert's side)
  suppress if sender == "SaharLobster"  (hardcoded — wrong on Albert's side)

After:
  SELF_USER = _load_self_user()  # reads BOT_TALK_SELF_USER or BOT_TALK_SENDER from config
  notify if sender != SELF_USER   (config-driven — correct on both sides)
  suppress if sender == SELF_USER (config-driven — correct on both sides)
```

## Functional patterns used

Pure `_load_self_user()` function (no side effects, composable), config read at call-site rather than baked into a constant, fallback chain expressed as ordered short-circuit evaluation.

## Tests run
- [x] `uv run pytest tests/unit/test_mcp_server/test_bot_talk_mirror.py -v` — 38 passed, 0 failed
- [ ] Integration test against live bot-talk API — skipped: requires live token and running server

Closes #1345