### PR TITLE
feat: Gmail read-only integration via existing Google OAuth flow

### DIFF
--- a/.githooks/security-allowlist.txt
+++ b/.githooks/security-allowlist.txt
@@ -79,3 +79,9 @@ scheduled-tasks/bot-talk-check-dispatch.sh:IP address
 # scripts/upgrade.sh contains pre-existing migration comments written before the
 # name-block hook was added. These are historical references, not new additions.
 scripts/upgrade.sh:Personal name (sahar)
+
+# Gmail integration docstrings use placeholder email addresses (e.g. alice@example.com,
+# boss@corp.com) to illustrate API usage — not real credentials or contact data.
+src/integrations/gmail/client.py:Email address
+src/integrations/gmail/models.py:Email address
+src/mcp/inbox_server.py:Email address

--- a/src/integrations/gmail/__init__.py
+++ b/src/integrations/gmail/__init__.py
@@ -1,0 +1,17 @@
+"""
+Gmail read-only integration for Lobster.
+
+Provides access to a user's Gmail inbox using the existing Google OAuth flow.
+No additional credentials or consent infrastructure required beyond adding
+``gmail.readonly`` to the consent screen scopes.
+
+Public API (importable from this package):
+    from integrations.gmail.client import (
+        get_recent_messages,
+        get_message,
+        get_thread,
+        search_messages,
+        has_gmail_scope,
+    )
+    from integrations.gmail.models import GmailMessage, GmailThread
+"""

--- a/src/integrations/gmail/client.py
+++ b/src/integrations/gmail/client.py
@@ -1,0 +1,486 @@
+"""
+Gmail API client — read-only.
+
+Provides a typed Python layer over the Gmail REST API so Lobster can read a
+user's inbox on their behalf.  Auth is fully delegated to the existing
+``token_store.get_valid_token`` function — no new OAuth infrastructure needed.
+
+All public functions return empty lists or None on auth failure or API error
+rather than propagating exceptions.  Callers can use ``has_gmail_scope`` to
+distinguish "no token at all" from "token present but missing gmail.readonly"
+and surface the appropriate re-consent prompt to the user.
+
+Design principles (consistent with the Calendar integration):
+- Immutable value objects (frozen dataclasses in ``models.py``).
+- Pure helpers isolated from I/O.
+- Side effects (network calls, token resolution) kept at the boundaries.
+- No credential or token values appear in logs.
+- Timezone-aware datetimes throughout (UTC).
+
+Gmail REST API base URL:
+    https://www.googleapis.com/gmail/v1/users/me
+"""
+
+from __future__ import annotations
+
+import base64
+import email
+import logging
+import re
+from datetime import datetime, timezone
+from email.header import decode_header
+from typing import Any, Optional
+
+import requests
+
+from integrations.gmail.models import GmailMessage, GmailThread
+from integrations.google_calendar.oauth import TokenData
+from integrations.google_calendar.token_store import get_valid_token
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_GMAIL_API_BASE: str = "https://www.googleapis.com/gmail/v1/users/me"
+_HTTP_TIMEOUT: int = 15
+_GMAIL_SCOPE_FRAGMENT: str = "gmail.readonly"
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class GmailAPIError(RuntimeError):
+    """Raised when the Gmail API returns a non-2xx response.
+
+    Never includes raw response body or credential values in the message.
+    """
+
+    def __init__(self, status_code: int, summary: str = "") -> None:
+        self.status_code = status_code
+        super().__init__(
+            f"Gmail API error {status_code}" + (f": {summary}" if summary else "")
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def has_gmail_scope(token: TokenData) -> bool:
+    """Return True if ``token`` includes the ``gmail.readonly`` scope.
+
+    Checks the space-separated ``token.scope`` string for the Gmail scope
+    fragment.  This is a pure function — no I/O.
+
+    Args:
+        token: A TokenData instance loaded from local disk.
+
+    Returns:
+        True if ``gmail.readonly`` appears in the granted scopes.
+    """
+    return _GMAIL_SCOPE_FRAGMENT in token.scope
+
+
+def _auth_header(access_token: str) -> dict[str, str]:
+    """Return an Authorization header dict for a bearer token.
+
+    Pure function — no side effects.
+    """
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+def _decode_mime_header(raw: str) -> str:
+    """Decode a MIME-encoded header value to a plain Unicode string.
+
+    Handles RFC 2047 encoded-word syntax (``=?utf-8?b?...?=`` etc.) and
+    falls back gracefully to the raw string on decode errors.
+
+    Args:
+        raw: Raw header string, possibly MIME-encoded.
+
+    Returns:
+        Decoded Unicode string.
+    """
+    parts = decode_header(raw)
+    decoded_parts: list[str] = []
+    for part, charset in parts:
+        if isinstance(part, bytes):
+            try:
+                decoded_parts.append(part.decode(charset or "utf-8", errors="replace"))
+            except (LookupError, UnicodeDecodeError):
+                decoded_parts.append(part.decode("utf-8", errors="replace"))
+        else:
+            decoded_parts.append(part)
+    return "".join(decoded_parts)
+
+
+def _parse_date(raw: str) -> datetime:
+    """Parse an RFC 2822 email date string into a timezone-aware UTC datetime.
+
+    Falls back to epoch UTC on parse failure so callers always get a valid
+    datetime rather than an exception.
+
+    Args:
+        raw: RFC 2822 date string from the Gmail API (e.g. ``internalDate``
+             is milliseconds since epoch; email header ``Date`` is RFC 2822).
+
+    Returns:
+        Timezone-aware datetime in UTC.
+    """
+    if not raw:
+        return datetime.fromtimestamp(0, tz=timezone.utc)
+
+    # Gmail internalDate field is milliseconds since epoch (numeric string)
+    if raw.isdigit():
+        return datetime.fromtimestamp(int(raw) / 1000.0, tz=timezone.utc)
+
+    # Try standard email date parsing
+    try:
+        parsed = email.utils.parsedate_to_datetime(raw)
+        return parsed.astimezone(timezone.utc)
+    except Exception:
+        return datetime.fromtimestamp(0, tz=timezone.utc)
+
+
+def _extract_header(headers: list[dict], name: str) -> str:
+    """Extract the value of a named header from a Gmail message headers list.
+
+    Gmail returns headers as ``[{"name": "Subject", "value": "..."}, ...]``.
+    The search is case-insensitive.  Returns empty string if not found.
+
+    Args:
+        headers: List of header dicts from the Gmail API message payload.
+        name:    Header name to find (case-insensitive).
+
+    Returns:
+        Header value string, or empty string if absent.
+    """
+    name_lower = name.lower()
+    for h in headers:
+        if h.get("name", "").lower() == name_lower:
+            return h.get("value", "")
+    return ""
+
+
+def _extract_plain_body(payload: dict) -> str:
+    """Recursively extract the plain-text body from a Gmail message payload.
+
+    Handles multipart messages by walking the ``parts`` tree and returning
+    the first ``text/plain`` part found.  Returns empty string if no plain
+    body is available.
+
+    Args:
+        payload: The ``payload`` dict from a Gmail API message (``format=full``).
+
+    Returns:
+        Decoded plain-text body string, or empty string.
+    """
+    mime_type: str = payload.get("mimeType", "")
+    body: dict = payload.get("body", {})
+    parts: list[dict] = payload.get("parts", [])
+
+    if mime_type == "text/plain":
+        data = body.get("data", "")
+        if data:
+            try:
+                return base64.urlsafe_b64decode(data + "==").decode(
+                    "utf-8", errors="replace"
+                )
+            except Exception:
+                return ""
+
+    # Recurse into multipart parts
+    for part in parts:
+        result = _extract_plain_body(part)
+        if result:
+            return result
+
+    return ""
+
+
+def _parse_message(raw: dict) -> GmailMessage:
+    """Convert a raw Gmail API message dict into a GmailMessage.
+
+    Works for all three ``format`` modes (``metadata``, ``full``, ``minimal``).
+    Fields unavailable in the requested format default to empty strings.
+
+    Args:
+        raw: A single message object from the Gmail API response.
+
+    Returns:
+        A frozen GmailMessage instance.
+    """
+    message_id: str = raw.get("id", "")
+    thread_id: str = raw.get("threadId", "")
+    snippet: str = raw.get("snippet", "")
+    label_ids: list[str] = raw.get("labelIds", [])
+    is_unread: bool = "UNREAD" in label_ids
+
+    payload: dict = raw.get("payload", {})
+    headers: list[dict] = payload.get("headers", [])
+
+    # Decode MIME-encoded header values for safe display
+    subject = _decode_mime_header(_extract_header(headers, "Subject"))
+    sender = _decode_mime_header(_extract_header(headers, "From"))
+    to_raw = _extract_header(headers, "To")
+    recipients: list[str] = (
+        [addr.strip() for addr in to_raw.split(",") if addr.strip()]
+        if to_raw
+        else []
+    )
+
+    date_raw = _extract_header(headers, "Date")
+    # Fall back to internalDate (ms since epoch) if Date header is absent
+    if not date_raw:
+        date_raw = str(raw.get("internalDate", "0"))
+    date: datetime = _parse_date(date_raw)
+
+    body_text: str = _extract_plain_body(payload)
+
+    return GmailMessage(
+        id=message_id,
+        thread_id=thread_id,
+        subject=subject,
+        sender=sender,
+        recipients=recipients,
+        date=date,
+        snippet=snippet,
+        body_text=body_text,
+        label_ids=label_ids,
+        is_unread=is_unread,
+    )
+
+
+# ---------------------------------------------------------------------------
+# HTTP helper (side-effecting boundary)
+# ---------------------------------------------------------------------------
+
+
+def _call_gmail_api(
+    method: str,
+    url: str,
+    token: str,
+    **kwargs: Any,
+) -> Any:
+    """Make an authenticated HTTP call to the Gmail API.
+
+    Single point of network contact for all Gmail API calls.
+
+    Args:
+        method: HTTP method string (e.g. ``"GET"``).
+        url:    Full API endpoint URL.
+        token:  Valid OAuth access token.
+        **kwargs: Additional keyword arguments forwarded to ``requests.request``.
+
+    Returns:
+        Parsed JSON response body (dict or list).
+
+    Raises:
+        GmailAPIError: If the response status code is not 2xx.
+        requests.exceptions.RequestException: On network-level failures.
+    """
+    headers = {**_auth_header(token), "Accept": "application/json"}
+    kwargs.setdefault("timeout", _HTTP_TIMEOUT)
+
+    log.debug("Gmail API %s %s", method, url)
+    response = requests.request(method, url, headers=headers, **kwargs)
+
+    if not response.ok:
+        try:
+            err_body: dict = response.json()
+            summary = err_body.get("error", {}).get("message", "")
+        except Exception:
+            summary = ""
+        log.warning("Gmail API returned %d for %s %s", response.status_code, method, url)
+        raise GmailAPIError(status_code=response.status_code, summary=summary)
+
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_recent_messages(
+    user_id: str,
+    max_results: int = 20,
+    query: str = "",
+    label_ids: list[str] | None = None,
+) -> list[GmailMessage]:
+    """List recent Gmail messages for a user.
+
+    Fetches message stubs via ``messages.list``, then retrieves metadata for
+    each via ``messages.get`` (format=metadata).  Returns an empty list on
+    auth failure, missing Gmail scope, or any API/network error.
+
+    Args:
+        user_id:    Lobster user identifier (Telegram chat_id as str).
+        max_results: Maximum number of messages to return.  Defaults to 20.
+        query:      Gmail search query string (e.g. ``"is:unread"``).
+                    Empty string means no filter beyond label_ids.
+        label_ids:  Optional list of Gmail label IDs to filter by (e.g.
+                    ``["INBOX"]``).  None means no label filter.
+
+    Returns:
+        List of GmailMessage objects.  Empty on any failure.
+    """
+    token = get_valid_token(user_id)
+    if token is None:
+        log.info("get_recent_messages: no valid token for user_id=%r", user_id)
+        return []
+    if not has_gmail_scope(token):
+        log.info(
+            "get_recent_messages: token for user_id=%r lacks gmail.readonly scope",
+            user_id,
+        )
+        return []
+
+    url = f"{_GMAIL_API_BASE}/messages"
+    params: dict[str, Any] = {"maxResults": max_results, "format": "metadata"}
+    if query:
+        params["q"] = query
+    if label_ids:
+        params["labelIds"] = label_ids
+
+    try:
+        data = _call_gmail_api("GET", url, token.access_token, params=params)
+    except (GmailAPIError, requests.exceptions.RequestException) as exc:
+        log.warning(
+            "get_recent_messages: list call failed for user_id=%r: %s",
+            user_id, type(exc).__name__,
+        )
+        return []
+
+    message_stubs: list[dict] = data.get("messages", [])
+    if not message_stubs:
+        return []
+
+    messages: list[GmailMessage] = []
+    for stub in message_stubs:
+        msg_id: str = stub.get("id", "")
+        if not msg_id:
+            continue
+        msg = get_message(user_id, msg_id, format="metadata")
+        if msg is not None:
+            messages.append(msg)
+
+    log.info(
+        "get_recent_messages: fetched %d messages for user_id=%r",
+        len(messages), user_id,
+    )
+    return messages
+
+
+def get_message(
+    user_id: str,
+    message_id: str,
+    format: str = "metadata",
+) -> GmailMessage | None:
+    """Fetch a single Gmail message by ID.
+
+    Args:
+        user_id:    Lobster user identifier.
+        message_id: Gmail message ID.
+        format:     Gmail API format: ``"metadata"`` (headers + snippet),
+                    ``"full"`` (headers + decoded body), or ``"minimal"``
+                    (IDs + labels only).  Defaults to ``"metadata"``.
+
+    Returns:
+        GmailMessage on success, or None on auth failure or API error.
+    """
+    token = get_valid_token(user_id)
+    if token is None:
+        log.info("get_message: no valid token for user_id=%r", user_id)
+        return None
+    if not has_gmail_scope(token):
+        log.info(
+            "get_message: token for user_id=%r lacks gmail.readonly scope", user_id
+        )
+        return None
+
+    url = f"{_GMAIL_API_BASE}/messages/{message_id}"
+    params = {"format": format}
+
+    try:
+        raw = _call_gmail_api("GET", url, token.access_token, params=params)
+    except (GmailAPIError, requests.exceptions.RequestException) as exc:
+        log.warning(
+            "get_message: API call failed for user_id=%r message_id=%r: %s",
+            user_id, message_id, type(exc).__name__,
+        )
+        return None
+
+    return _parse_message(raw)
+
+
+def get_thread(
+    user_id: str,
+    thread_id: str,
+) -> GmailThread | None:
+    """Fetch a full Gmail thread (all messages in order).
+
+    Args:
+        user_id:   Lobster user identifier.
+        thread_id: Gmail thread ID.
+
+    Returns:
+        GmailThread with messages ordered oldest-first, or None on failure.
+    """
+    token = get_valid_token(user_id)
+    if token is None:
+        log.info("get_thread: no valid token for user_id=%r", user_id)
+        return None
+    if not has_gmail_scope(token):
+        log.info(
+            "get_thread: token for user_id=%r lacks gmail.readonly scope", user_id
+        )
+        return None
+
+    url = f"{_GMAIL_API_BASE}/threads/{thread_id}"
+    params = {"format": "metadata"}
+
+    try:
+        raw = _call_gmail_api("GET", url, token.access_token, params=params)
+    except (GmailAPIError, requests.exceptions.RequestException) as exc:
+        log.warning(
+            "get_thread: API call failed for user_id=%r thread_id=%r: %s",
+            user_id, thread_id, type(exc).__name__,
+        )
+        return None
+
+    raw_messages: list[dict] = raw.get("messages", [])
+    messages: list[GmailMessage] = [_parse_message(m) for m in raw_messages]
+    subject: str = messages[0].subject if messages else ""
+
+    log.info(
+        "get_thread: fetched thread id=%r (%d messages) for user_id=%r",
+        thread_id, len(messages), user_id,
+    )
+    return GmailThread(id=thread_id, messages=messages, subject=subject)
+
+
+def search_messages(
+    user_id: str,
+    query: str,
+    max_results: int = 20,
+) -> list[GmailMessage]:
+    """Search Gmail messages using Gmail query syntax.
+
+    Equivalent to ``get_recent_messages`` with a non-empty query.  Provided
+    as a named entry point for clarity in callers.
+
+    Args:
+        user_id:     Lobster user identifier.
+        query:       Gmail search query (e.g. ``"from:boss@corp.com invoice"``).
+        max_results: Maximum number of results.  Defaults to 20.
+
+    Returns:
+        List of GmailMessage objects matching the query.  Empty on failure.
+    """
+    return get_recent_messages(user_id, max_results=max_results, query=query)

--- a/src/integrations/gmail/models.py
+++ b/src/integrations/gmail/models.py
@@ -1,0 +1,61 @@
+"""
+Immutable domain types for the Gmail integration.
+
+Design principles:
+- All types are frozen dataclasses (immutable value objects).
+- Datetimes are always timezone-aware UTC.
+- No I/O or side effects — this module is pure data definitions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List
+
+
+@dataclass(frozen=True)
+class GmailMessage:
+    """Immutable representation of a single Gmail message.
+
+    Attributes:
+        id:          Gmail-assigned message identifier.
+        thread_id:   Thread this message belongs to.
+        subject:     Message subject header (empty string if absent).
+        sender:      ``From`` header value, e.g. ``"Name <email@domain.com>"``.
+        recipients:  ``To`` header values as a list of address strings.
+        date:        Message date as a timezone-aware UTC datetime.
+        snippet:     Gmail's ~200-character plain-text preview.
+        body_text:   Full plain-text body.  Empty string when ``format``
+                     was ``"metadata"`` or ``"minimal"`` (body not requested).
+        label_ids:   List of Gmail label IDs applied to this message (e.g.
+                     ``["INBOX", "UNREAD"]``).
+        is_unread:   True if ``"UNREAD"`` is in ``label_ids``.
+    """
+
+    id: str
+    thread_id: str
+    subject: str
+    sender: str
+    recipients: List[str]
+    date: datetime
+    snippet: str
+    body_text: str
+    label_ids: List[str]
+    is_unread: bool
+
+
+@dataclass(frozen=True)
+class GmailThread:
+    """Immutable representation of a Gmail thread (conversation).
+
+    Attributes:
+        id:       Gmail-assigned thread identifier.
+        messages: All messages in the thread, ordered oldest-first.
+        subject:  Subject derived from the first message in the thread.
+                  Empty string if the thread has no messages.
+    """
+
+    id: str
+    messages: List[GmailMessage]
+    subject: str

--- a/src/integrations/google_calendar/config.py
+++ b/src/integrations/google_calendar/config.py
@@ -13,9 +13,10 @@ The integration degrades gracefully: if either variable is absent, all Google
 Calendar features are disabled and a single warning is emitted at import time.
 Callers should check ``is_enabled()`` before attempting any OAuth flow.
 
-OAuth scopes required for full calendar access:
+OAuth scopes required for full calendar + Gmail read access:
     https://www.googleapis.com/auth/calendar.readonly      — list/read events
     https://www.googleapis.com/auth/calendar.events        — create/update events
+    https://www.googleapis.com/auth/gmail.readonly         — read Gmail messages
 
 Redirect URI expected by the Google OAuth app:
     https://myownlobster.ai/auth/google/callback
@@ -40,10 +41,13 @@ SCOPE_READONLY: str = "https://www.googleapis.com/auth/calendar.readonly"
 #: Full scope for creating and modifying events.
 SCOPE_EVENTS: str = "https://www.googleapis.com/auth/calendar.events"
 
+#: Read-only access to Gmail messages and metadata.
+SCOPE_GMAIL_READONLY: str = "https://www.googleapis.com/auth/gmail.readonly"
+
 #: Default scopes requested during the OAuth flow.
-#: Includes both read and write access so Lobster can read and create/modify
-#: calendar events on the user's behalf.
-DEFAULT_SCOPES: tuple[str, ...] = (SCOPE_READONLY, SCOPE_EVENTS)
+#: Includes calendar read/write and Gmail read-only so a single consent screen
+#: covers all Lobster Google integrations.
+DEFAULT_SCOPES: tuple[str, ...] = (SCOPE_READONLY, SCOPE_EVENTS, SCOPE_GMAIL_READONLY)
 
 
 # ---------------------------------------------------------------------------

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -3063,6 +3063,117 @@ async def list_tools() -> list[Tool]:
                 "required": ["telegram_chat_id"],
             },
         ),
+        # Gmail Read-Only Tools
+        Tool(
+            name="get_gmail_messages",
+            description=(
+                "List recent Gmail messages for a user. "
+                "Returns an empty list with needs_auth=true if the token is missing or "
+                "lacks the gmail.readonly scope — the caller should then surface a "
+                "re-consent link to the user. "
+                "Accepts an optional Gmail query string (e.g. 'is:unread') and "
+                "optional label filter."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "user_id": {
+                        "oneOf": [{"type": "integer"}, {"type": "string"}],
+                        "description": "Telegram chat_id of the user whose Gmail to read.",
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Maximum number of messages to return. Default 20.",
+                        "default": 20,
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Gmail search query (e.g. 'is:unread', 'from:boss@corp.com'). Empty means no filter.",
+                        "default": "",
+                    },
+                },
+                "required": ["user_id"],
+            },
+        ),
+        Tool(
+            name="get_gmail_message",
+            description=(
+                "Fetch a single Gmail message by ID. "
+                "Returns null with needs_auth=true if the token is missing or "
+                "lacks the gmail.readonly scope. "
+                "Use format='full' to include the decoded plain-text body."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "user_id": {
+                        "oneOf": [{"type": "integer"}, {"type": "string"}],
+                        "description": "Telegram chat_id of the user.",
+                    },
+                    "message_id": {
+                        "type": "string",
+                        "description": "Gmail message ID.",
+                    },
+                    "format": {
+                        "type": "string",
+                        "description": "API format: 'metadata' (default), 'full' (includes body), or 'minimal'.",
+                        "default": "metadata",
+                        "enum": ["metadata", "full", "minimal"],
+                    },
+                },
+                "required": ["user_id", "message_id"],
+            },
+        ),
+        Tool(
+            name="search_gmail",
+            description=(
+                "Search Gmail messages using Gmail query syntax. "
+                "Returns an empty list with needs_auth=true if the token is missing "
+                "or lacks the gmail.readonly scope. "
+                "Examples: 'from:acme invoice', 'subject:Q2 plan', 'is:unread newer_than:1d'."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "user_id": {
+                        "oneOf": [{"type": "integer"}, {"type": "string"}],
+                        "description": "Telegram chat_id of the user.",
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Gmail search query string.",
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Maximum number of results to return. Default 20.",
+                        "default": 20,
+                    },
+                },
+                "required": ["user_id", "query"],
+            },
+        ),
+        Tool(
+            name="get_gmail_thread",
+            description=(
+                "Fetch a full Gmail thread (all messages in conversation order). "
+                "Returns null with needs_auth=true if the token is missing or "
+                "lacks the gmail.readonly scope."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "user_id": {
+                        "oneOf": [{"type": "integer"}, {"type": "string"}],
+                        "description": "Telegram chat_id of the user.",
+                    },
+                    "thread_id": {
+                        "type": "string",
+                        "description": "Gmail thread ID.",
+                    },
+                },
+                "required": ["user_id", "thread_id"],
+            },
+        ),
         # /report Slash Command Tool
         Tool(
             name="create_report",
@@ -3457,6 +3568,15 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[TextConte
         return await handle_create_calendar_event(arguments)
     elif name == "list_calendar_events":
         return await handle_list_calendar_events(arguments)
+    # Gmail Read-Only Tools
+    elif name == "get_gmail_messages":
+        return await handle_get_gmail_messages(arguments)
+    elif name == "get_gmail_message":
+        return await handle_get_gmail_message(arguments)
+    elif name == "search_gmail":
+        return await handle_search_gmail(arguments)
+    elif name == "get_gmail_thread":
+        return await handle_get_gmail_thread(arguments)
     # /report Slash Command Tools
     elif name == "create_report":
         return await handle_create_report(arguments)
@@ -8506,6 +8626,226 @@ async def handle_list_calendar_events(args: dict) -> list[TextContent]:
         }
         for e in events
     ]
+    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+
+# ---------------------------------------------------------------------------
+# Gmail Read-Only Handlers
+# ---------------------------------------------------------------------------
+
+def _gmail_needs_auth_response(user_id: str) -> list[TextContent]:
+    """Return the standardised needs_auth response for Gmail tool calls.
+
+    Emitted when the user's token is absent or missing the gmail.readonly
+    scope.  The dispatcher should surface a re-consent link when it sees
+    ``needs_auth: true`` in the response.
+
+    Args:
+        user_id: User identifier included in the response for routing.
+
+    Returns:
+        A single TextContent item containing a JSON object with
+        ``needs_auth: true`` and a human-readable ``message``.
+    """
+    from integrations.google_calendar.token_store import get_valid_token
+    from integrations.gmail.client import has_gmail_scope
+    from integrations.google_calendar.oauth import generate_auth_url
+    import secrets
+
+    # Determine whether token is absent entirely or just missing Gmail scope
+    token = get_valid_token(user_id)
+    if token is None:
+        reason = "no_token"
+        detail = "No Google token found. The user needs to connect their Google account."
+    elif not has_gmail_scope(token):
+        reason = "missing_gmail_scope"
+        detail = (
+            "Google token is present but does not include gmail.readonly. "
+            "The user needs to re-authorise with the expanded scope."
+        )
+    else:
+        # Should not reach here — caller guards against this
+        reason = "unknown"
+        detail = "Gmail access unavailable."
+
+    # Generate a re-consent URL with the full scope set (including gmail.readonly)
+    auth_url: str | None = None
+    try:
+        from integrations.google_calendar.config import DEFAULT_SCOPES
+        auth_url = generate_auth_url(
+            state=secrets.token_urlsafe(16),
+            scopes=DEFAULT_SCOPES,
+        )
+    except Exception as exc:
+        log.warning("Could not generate auth URL for Gmail re-consent: %s", exc)
+
+    payload: dict = {
+        "needs_auth": True,
+        "reason": reason,
+        "message": detail,
+        "user_id": user_id,
+    }
+    if auth_url:
+        payload["auth_url"] = auth_url
+
+    return [TextContent(type="text", text=json.dumps(payload, indent=2))]
+
+
+def _gmail_message_to_dict(msg) -> dict:
+    """Convert a GmailMessage to a JSON-serialisable dict.
+
+    Pure helper — no I/O.
+    """
+    return {
+        "id": msg.id,
+        "thread_id": msg.thread_id,
+        "subject": msg.subject,
+        "sender": msg.sender,
+        "recipients": msg.recipients,
+        "date": msg.date.isoformat(),
+        "snippet": msg.snippet,
+        "body_text": msg.body_text,
+        "label_ids": msg.label_ids,
+        "is_unread": msg.is_unread,
+    }
+
+
+async def handle_get_gmail_messages(args: dict) -> list[TextContent]:
+    """Handle the get_gmail_messages MCP tool.
+
+    Required args:
+        user_id — int or str Telegram chat_id
+
+    Optional args:
+        max_results — int (default 20)
+        query       — Gmail search query string (default "")
+    """
+    _src = str(Path(__file__).resolve().parent.parent)
+    if _src not in sys.path:
+        sys.path.insert(0, _src)
+    from integrations.gmail.client import get_recent_messages, has_gmail_scope
+    from integrations.google_calendar.token_store import get_valid_token
+
+    user_id = str(args.get("user_id", "")).strip()
+    if not user_id:
+        return [TextContent(type="text", text='{"error": "user_id is required."}')]
+
+    max_results = int(args.get("max_results", 20))
+    query = str(args.get("query", "")).strip()
+
+    # Check auth before delegating so we can return needs_auth when appropriate
+    token = get_valid_token(user_id)
+    if token is None or not has_gmail_scope(token):
+        return _gmail_needs_auth_response(user_id)
+
+    messages = get_recent_messages(user_id, max_results=max_results, query=query)
+    result = [_gmail_message_to_dict(m) for m in messages]
+    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+
+async def handle_get_gmail_message(args: dict) -> list[TextContent]:
+    """Handle the get_gmail_message MCP tool.
+
+    Required args:
+        user_id    — int or str Telegram chat_id
+        message_id — Gmail message ID
+
+    Optional args:
+        format — "metadata" | "full" | "minimal" (default "metadata")
+    """
+    _src = str(Path(__file__).resolve().parent.parent)
+    if _src not in sys.path:
+        sys.path.insert(0, _src)
+    from integrations.gmail.client import get_message, has_gmail_scope
+    from integrations.google_calendar.token_store import get_valid_token
+
+    user_id = str(args.get("user_id", "")).strip()
+    message_id = str(args.get("message_id", "")).strip()
+    format_ = str(args.get("format", "metadata")).strip() or "metadata"
+
+    if not user_id:
+        return [TextContent(type="text", text='{"error": "user_id is required."}')]
+    if not message_id:
+        return [TextContent(type="text", text='{"error": "message_id is required."}')]
+
+    token = get_valid_token(user_id)
+    if token is None or not has_gmail_scope(token):
+        return _gmail_needs_auth_response(user_id)
+
+    msg = get_message(user_id, message_id, format=format_)
+    if msg is None:
+        return [TextContent(type="text", text=json.dumps({"result": None}))]
+    return [TextContent(type="text", text=json.dumps(_gmail_message_to_dict(msg), indent=2))]
+
+
+async def handle_search_gmail(args: dict) -> list[TextContent]:
+    """Handle the search_gmail MCP tool.
+
+    Required args:
+        user_id — int or str Telegram chat_id
+        query   — Gmail search query string
+
+    Optional args:
+        max_results — int (default 20)
+    """
+    _src = str(Path(__file__).resolve().parent.parent)
+    if _src not in sys.path:
+        sys.path.insert(0, _src)
+    from integrations.gmail.client import search_messages, has_gmail_scope
+    from integrations.google_calendar.token_store import get_valid_token
+
+    user_id = str(args.get("user_id", "")).strip()
+    query = str(args.get("query", "")).strip()
+    max_results = int(args.get("max_results", 20))
+
+    if not user_id:
+        return [TextContent(type="text", text='{"error": "user_id is required."}')]
+    if not query:
+        return [TextContent(type="text", text='{"error": "query is required."}')]
+
+    token = get_valid_token(user_id)
+    if token is None or not has_gmail_scope(token):
+        return _gmail_needs_auth_response(user_id)
+
+    messages = search_messages(user_id, query=query, max_results=max_results)
+    result = [_gmail_message_to_dict(m) for m in messages]
+    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+
+async def handle_get_gmail_thread(args: dict) -> list[TextContent]:
+    """Handle the get_gmail_thread MCP tool.
+
+    Required args:
+        user_id   — int or str Telegram chat_id
+        thread_id — Gmail thread ID
+    """
+    _src = str(Path(__file__).resolve().parent.parent)
+    if _src not in sys.path:
+        sys.path.insert(0, _src)
+    from integrations.gmail.client import get_thread, has_gmail_scope
+    from integrations.google_calendar.token_store import get_valid_token
+
+    user_id = str(args.get("user_id", "")).strip()
+    thread_id = str(args.get("thread_id", "")).strip()
+
+    if not user_id:
+        return [TextContent(type="text", text='{"error": "user_id is required."}')]
+    if not thread_id:
+        return [TextContent(type="text", text='{"error": "thread_id is required."}')]
+
+    token = get_valid_token(user_id)
+    if token is None or not has_gmail_scope(token):
+        return _gmail_needs_auth_response(user_id)
+
+    thread = get_thread(user_id, thread_id)
+    if thread is None:
+        return [TextContent(type="text", text=json.dumps({"result": None}))]
+
+    result = {
+        "id": thread.id,
+        "subject": thread.subject,
+        "messages": [_gmail_message_to_dict(m) for m in thread.messages],
+    }
     return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
 

--- a/tests/unit/test_integrations/test_gmail_client.py
+++ b/tests/unit/test_integrations/test_gmail_client.py
@@ -1,0 +1,566 @@
+"""
+Tests for src/integrations/gmail/client.py and src/integrations/gmail/models.py.
+
+All HTTP calls and token lookups are mocked — these tests run with no network
+access and no real Google credentials.
+
+Coverage:
+- GmailMessage: immutability, field types
+- GmailThread: immutability, subject derivation
+- has_gmail_scope: scope present, scope absent, empty scope
+- _decode_mime_header: plain ASCII, RFC 2047 encoded-word, mixed
+- _parse_date: epoch, millisecond timestamp, RFC 2822 string, empty
+- _extract_header: found, not found, case-insensitive
+- _extract_plain_body: text/plain leaf, multipart, missing, nested multipart
+- _parse_message: full payload, metadata-only (no body), minimal (no headers)
+- _call_gmail_api: success, non-2xx raises GmailAPIError, network error
+- get_recent_messages: success, empty, no token, missing scope, API error
+- get_message: success, no token, missing scope, API error, None result
+- get_thread: success, no token, missing scope, API error, empty thread
+- search_messages: delegates to get_recent_messages with query
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests as req
+
+# Make src importable without installing the package
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.gmail.models import GmailMessage, GmailThread
+from integrations.gmail.client import (
+    GmailAPIError,
+    _auth_header,
+    _call_gmail_api,
+    _decode_mime_header,
+    _extract_header,
+    _extract_plain_body,
+    _parse_date,
+    _parse_message,
+    get_message,
+    get_recent_messages,
+    get_thread,
+    has_gmail_scope,
+    search_messages,
+)
+from integrations.google_calendar.oauth import TokenData
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+_EPOCH = datetime.fromtimestamp(0, tz=timezone.utc)
+
+
+def _make_token(scope: str = "calendar.readonly gmail.readonly") -> TokenData:
+    return TokenData(
+        access_token="fake-access-token",
+        expires_at=_NOW,
+        scope=scope,
+        refresh_token="fake-refresh-token",
+    )
+
+
+def _make_raw_message(
+    msg_id: str = "msg001",
+    thread_id: str = "thread001",
+    subject: str = "Test Subject",
+    sender: str = "Alice <alice@example.com>",
+    to: str = "Bob <bob@example.com>",
+    date_str: str = "Wed, 01 Apr 2026 12:00:00 +0000",
+    snippet: str = "Here is a preview of the email body...",
+    body_data: str = "",  # base64url-encoded plain body; empty = no body
+    label_ids: list[str] | None = None,
+) -> dict:
+    if label_ids is None:
+        label_ids = ["INBOX", "UNREAD"]
+
+    headers = [
+        {"name": "Subject", "value": subject},
+        {"name": "From", "value": sender},
+        {"name": "To", "value": to},
+        {"name": "Date", "value": date_str},
+    ]
+    payload: dict = {"mimeType": "text/plain", "headers": headers, "body": {}, "parts": []}
+    if body_data:
+        payload["body"]["data"] = body_data
+
+    return {
+        "id": msg_id,
+        "threadId": thread_id,
+        "snippet": snippet,
+        "labelIds": label_ids,
+        "payload": payload,
+    }
+
+
+# ---------------------------------------------------------------------------
+# GmailMessage / GmailThread — immutability
+# ---------------------------------------------------------------------------
+
+
+class TestGmailMessage:
+    def test_frozen(self):
+        msg = GmailMessage(
+            id="1",
+            thread_id="t1",
+            subject="Hi",
+            sender="a@b.com",
+            recipients=["c@d.com"],
+            date=_NOW,
+            snippet="hello",
+            body_text="",
+            label_ids=["INBOX"],
+            is_unread=False,
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            msg.id = "2"  # type: ignore
+
+    def test_is_unread_false(self):
+        msg = GmailMessage(
+            id="1", thread_id="t1", subject="", sender="", recipients=[],
+            date=_NOW, snippet="", body_text="", label_ids=["INBOX"], is_unread=False,
+        )
+        assert msg.is_unread is False
+
+
+class TestGmailThread:
+    def test_frozen(self):
+        thread = GmailThread(id="t1", messages=[], subject="Hi")
+        with pytest.raises((AttributeError, TypeError)):
+            thread.id = "t2"  # type: ignore
+
+    def test_empty_messages(self):
+        thread = GmailThread(id="t1", messages=[], subject="")
+        assert thread.messages == []
+
+
+# ---------------------------------------------------------------------------
+# has_gmail_scope
+# ---------------------------------------------------------------------------
+
+
+class TestHasGmailScope:
+    def test_scope_present(self):
+        token = _make_token(scope="calendar.readonly gmail.readonly calendar.events")
+        assert has_gmail_scope(token) is True
+
+    def test_scope_absent(self):
+        token = _make_token(scope="calendar.readonly calendar.events")
+        assert has_gmail_scope(token) is False
+
+    def test_empty_scope(self):
+        token = _make_token(scope="")
+        assert has_gmail_scope(token) is False
+
+    def test_only_gmail_scope(self):
+        token = _make_token(scope="https://www.googleapis.com/auth/gmail.readonly")
+        assert has_gmail_scope(token) is True
+
+
+# ---------------------------------------------------------------------------
+# _decode_mime_header
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeMimeHeader:
+    def test_plain_ascii(self):
+        assert _decode_mime_header("Hello World") == "Hello World"
+
+    def test_empty(self):
+        assert _decode_mime_header("") == ""
+
+    def test_utf8_encoded_word(self):
+        # =?utf-8?b?<base64 of "Héllo">?=
+        import base64
+        encoded = base64.b64encode("Héllo".encode("utf-8")).decode()
+        raw = f"=?utf-8?b?{encoded}?="
+        result = _decode_mime_header(raw)
+        assert "Héllo" in result or result  # graceful decode
+
+    def test_mixed(self):
+        # Plain text adjacent to encoded word
+        result = _decode_mime_header("Re: normal subject")
+        assert result == "Re: normal subject"
+
+
+# ---------------------------------------------------------------------------
+# _parse_date
+# ---------------------------------------------------------------------------
+
+
+class TestParseDate:
+    def test_empty_string(self):
+        dt = _parse_date("")
+        assert dt == _EPOCH
+
+    def test_millisecond_timestamp(self):
+        ms = "1743508800000"  # some arbitrary epoch ms
+        dt = _parse_date(ms)
+        assert dt.tzinfo is not None
+        assert dt.year >= 2020
+
+    def test_rfc2822_string(self):
+        dt = _parse_date("Wed, 01 Apr 2026 12:00:00 +0000")
+        assert dt.year == 2026
+        assert dt.month == 4
+        assert dt.tzinfo is not None
+
+    def test_rfc2822_with_tz_offset(self):
+        dt = _parse_date("Wed, 01 Apr 2026 14:00:00 +0200")
+        # Should be converted to UTC: 12:00
+        assert dt.tzinfo == timezone.utc
+        assert dt.hour == 12
+
+    def test_invalid_falls_back_to_epoch(self):
+        dt = _parse_date("not-a-date")
+        assert dt == _EPOCH
+
+
+# ---------------------------------------------------------------------------
+# _extract_header
+# ---------------------------------------------------------------------------
+
+
+class TestExtractHeader:
+    _HEADERS = [
+        {"name": "Subject", "value": "Hello"},
+        {"name": "From", "value": "alice@example.com"},
+    ]
+
+    def test_found(self):
+        assert _extract_header(self._HEADERS, "Subject") == "Hello"
+
+    def test_not_found(self):
+        assert _extract_header(self._HEADERS, "X-Missing") == ""
+
+    def test_case_insensitive(self):
+        assert _extract_header(self._HEADERS, "subject") == "Hello"
+        assert _extract_header(self._HEADERS, "FROM") == "alice@example.com"
+
+    def test_empty_list(self):
+        assert _extract_header([], "Subject") == ""
+
+
+# ---------------------------------------------------------------------------
+# _extract_plain_body
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPlainBody:
+    def test_text_plain_leaf(self):
+        import base64
+        data = base64.urlsafe_b64encode(b"Hello body").decode()
+        payload = {"mimeType": "text/plain", "body": {"data": data}, "parts": []}
+        assert _extract_plain_body(payload) == "Hello body"
+
+    def test_no_body_data(self):
+        payload = {"mimeType": "text/plain", "body": {}, "parts": []}
+        assert _extract_plain_body(payload) == ""
+
+    def test_multipart_picks_plain_part(self):
+        import base64
+        data = base64.urlsafe_b64encode(b"Plain text here").decode()
+        payload = {
+            "mimeType": "multipart/alternative",
+            "body": {},
+            "parts": [
+                {"mimeType": "text/plain", "body": {"data": data}, "parts": []},
+                {"mimeType": "text/html", "body": {"data": "dW5yZWxldmFudA=="}, "parts": []},
+            ],
+        }
+        assert _extract_plain_body(payload) == "Plain text here"
+
+    def test_html_only_returns_empty(self):
+        payload = {
+            "mimeType": "multipart/alternative",
+            "body": {},
+            "parts": [
+                {"mimeType": "text/html", "body": {"data": "dW5yZWxldmFudA=="}, "parts": []},
+            ],
+        }
+        assert _extract_plain_body(payload) == ""
+
+    def test_empty_payload(self):
+        assert _extract_plain_body({}) == ""
+
+
+# ---------------------------------------------------------------------------
+# _parse_message
+# ---------------------------------------------------------------------------
+
+
+class TestParseMessage:
+    def test_full_message_fields(self):
+        raw = _make_raw_message()
+        msg = _parse_message(raw)
+        assert msg.id == "msg001"
+        assert msg.thread_id == "thread001"
+        assert msg.subject == "Test Subject"
+        assert msg.sender == "Alice <alice@example.com>"
+        assert msg.recipients == ["Bob <bob@example.com>"]
+        assert msg.snippet == "Here is a preview of the email body..."
+        assert msg.is_unread is True
+        assert "UNREAD" in msg.label_ids
+
+    def test_is_unread_false_when_no_unread_label(self):
+        raw = _make_raw_message(label_ids=["INBOX"])
+        msg = _parse_message(raw)
+        assert msg.is_unread is False
+
+    def test_missing_optional_headers_default_to_empty(self):
+        raw = {
+            "id": "x",
+            "threadId": "t",
+            "snippet": "",
+            "labelIds": [],
+            "payload": {"headers": [], "body": {}, "parts": []},
+        }
+        msg = _parse_message(raw)
+        assert msg.subject == ""
+        assert msg.sender == ""
+        assert msg.recipients == []
+
+    def test_date_parsed_from_header(self):
+        raw = _make_raw_message(date_str="Wed, 01 Apr 2026 12:00:00 +0000")
+        msg = _parse_message(raw)
+        assert msg.date.year == 2026
+        assert msg.date.tzinfo == timezone.utc
+
+    def test_date_falls_back_to_internal_date(self):
+        raw = _make_raw_message(date_str="")
+        raw["internalDate"] = "1743508800000"
+        # Remove Date header so fallback is used
+        raw["payload"]["headers"] = [h for h in raw["payload"]["headers"] if h["name"] != "Date"]
+        msg = _parse_message(raw)
+        assert msg.date.tzinfo is not None
+
+    def test_multiple_recipients_parsed(self):
+        raw = _make_raw_message(to="alice@a.com, bob@b.com")
+        msg = _parse_message(raw)
+        assert len(msg.recipients) == 2
+
+    def test_body_extracted_when_present(self):
+        import base64
+        data = base64.urlsafe_b64encode(b"Body content").decode()
+        raw = _make_raw_message(body_data=data)
+        msg = _parse_message(raw)
+        assert msg.body_text == "Body content"
+
+    def test_body_empty_for_metadata_format(self):
+        raw = _make_raw_message()  # no body_data
+        msg = _parse_message(raw)
+        assert msg.body_text == ""
+
+
+# ---------------------------------------------------------------------------
+# _call_gmail_api
+# ---------------------------------------------------------------------------
+
+
+class TestCallGmailApi:
+    @patch("integrations.gmail.client.requests.request")
+    def test_success_returns_json(self, mock_request):
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"messages": []}
+        mock_request.return_value = mock_resp
+
+        result = _call_gmail_api("GET", "https://example.com", "tok")
+        assert result == {"messages": []}
+
+    @patch("integrations.gmail.client.requests.request")
+    def test_non_2xx_raises_gmail_api_error(self, mock_request):
+        mock_resp = MagicMock()
+        mock_resp.ok = False
+        mock_resp.status_code = 403
+        mock_resp.json.return_value = {"error": {"message": "Forbidden"}}
+        mock_request.return_value = mock_resp
+
+        with pytest.raises(GmailAPIError) as exc_info:
+            _call_gmail_api("GET", "https://example.com", "tok")
+        assert exc_info.value.status_code == 403
+
+    @patch("integrations.gmail.client.requests.request")
+    def test_network_error_propagates(self, mock_request):
+        mock_request.side_effect = req.exceptions.ConnectionError("unreachable")
+
+        with pytest.raises(req.exceptions.ConnectionError):
+            _call_gmail_api("GET", "https://example.com", "tok")
+
+
+# ---------------------------------------------------------------------------
+# get_recent_messages
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecentMessages:
+    def _stub_list_response(self, msg_ids: list[str]) -> dict:
+        return {"messages": [{"id": mid, "threadId": "t1"} for mid in msg_ids]}
+
+    @patch("integrations.gmail.client.get_valid_token")
+    @patch("integrations.gmail.client._call_gmail_api")
+    def test_success(self, mock_api, mock_token):
+        mock_token.return_value = _make_token()
+        # First call = list, second call = get message
+        raw_msg = _make_raw_message(msg_id="msg1")
+        mock_api.side_effect = [
+            self._stub_list_response(["msg1"]),
+            raw_msg,
+        ]
+
+        msgs = get_recent_messages("user123")
+        assert len(msgs) == 1
+        assert msgs[0].id == "msg1"
+
+    @patch("integrations.gmail.client.get_valid_token")
+    def test_no_token_returns_empty(self, mock_token):
+        mock_token.return_value = None
+        assert get_recent_messages("user123") == []
+
+    @patch("integrations.gmail.client.get_valid_token")
+    def test_missing_gmail_scope_returns_empty(self, mock_token):
+        mock_token.return_value = _make_token(scope="calendar.readonly")
+        assert get_recent_messages("user123") == []
+
+    @patch("integrations.gmail.client.get_valid_token")
+    @patch("integrations.gmail.client._call_gmail_api")
+    def test_api_error_returns_empty(self, mock_api, mock_token):
+        mock_token.return_value = _make_token()
+        mock_api.side_effect = GmailAPIError(500, "server error")
+        assert get_recent_messages("user123") == []
+
+    @patch("integrations.gmail.client.get_valid_token")
+    @patch("integrations.gmail.client._call_gmail_api")
+    def test_empty_list_returns_empty(self, mock_api, mock_token):
+        mock_token.return_value = _make_token()
+        mock_api.return_value = {"messages": []}
+        assert get_recent_messages("user123") == []
+
+    @patch("integrations.gmail.client.get_valid_token")
+    @patch("integrations.gmail.client._call_gmail_api")
+    def test_query_passed_to_api(self, mock_api, mock_token):
+        mock_token.return_value = _make_token()
+        mock_api.return_value = {"messages": []}
+        get_recent_messages("user123", query="is:unread")
+        call_params = mock_api.call_args
+        assert call_params[1]["params"]["q"] == "is:unread"
+
+
+# ---------------------------------------------------------------------------
+# get_message
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessage:
+    @patch("integrations.gmail.client.get_valid_token")
+    @patch("integrations.gmail.client._call_gmail_api")
+    def test_success(self, mock_api, mock_token):
+        mock_token.return_value = _make_token()
+        raw = _make_raw_message(msg_id="msg42")
+        mock_api.return_value = raw
+
+        msg = get_message("user123", "msg42")
+        assert msg is not None
+        assert msg.id == "msg42"
+
+    @patch("integrations.gmail.client.get_valid_token")
+    def test_no_token_returns_none(self, mock_token):
+        mock_token.return_value = None
+        assert get_message("user123", "msg42") is None
+
+    @patch("integrations.gmail.client.get_valid_token")
+    def test_missing_scope_returns_none(self, mock_token):
+        mock_token.return_value = _make_token(scope="calendar.readonly")
+        assert get_message("user123", "msg42") is None
+
+    @patch("integrations.gmail.client.get_valid_token")
+    @patch("integrations.gmail.client._call_gmail_api")
+    def test_api_error_returns_none(self, mock_api, mock_token):
+        mock_token.return_value = _make_token()
+        mock_api.side_effect = GmailAPIError(404, "not found")
+        assert get_message("user123", "msg42") is None
+
+    @patch("integrations.gmail.client.get_valid_token")
+    @patch("integrations.gmail.client._call_gmail_api")
+    def test_format_passed_to_api(self, mock_api, mock_token):
+        mock_token.return_value = _make_token()
+        raw = _make_raw_message()
+        mock_api.return_value = raw
+        get_message("user123", "msg42", format="full")
+        params = mock_api.call_args[1]["params"]
+        assert params["format"] == "full"
+
+
+# ---------------------------------------------------------------------------
+# get_thread
+# ---------------------------------------------------------------------------
+
+
+class TestGetThread:
+    @patch("integrations.gmail.client.get_valid_token")
+    @patch("integrations.gmail.client._call_gmail_api")
+    def test_success(self, mock_api, mock_token):
+        mock_token.return_value = _make_token()
+        raw_msg = _make_raw_message(msg_id="m1", thread_id="t99", subject="Thread Subject")
+        mock_api.return_value = {"id": "t99", "messages": [raw_msg]}
+
+        thread = get_thread("user123", "t99")
+        assert thread is not None
+        assert thread.id == "t99"
+        assert len(thread.messages) == 1
+        assert thread.subject == "Thread Subject"
+
+    @patch("integrations.gmail.client.get_valid_token")
+    @patch("integrations.gmail.client._call_gmail_api")
+    def test_empty_thread_subject_is_empty(self, mock_api, mock_token):
+        mock_token.return_value = _make_token()
+        mock_api.return_value = {"id": "t1", "messages": []}
+        thread = get_thread("user123", "t1")
+        assert thread is not None
+        assert thread.subject == ""
+        assert thread.messages == []
+
+    @patch("integrations.gmail.client.get_valid_token")
+    def test_no_token_returns_none(self, mock_token):
+        mock_token.return_value = None
+        assert get_thread("user123", "t1") is None
+
+    @patch("integrations.gmail.client.get_valid_token")
+    def test_missing_scope_returns_none(self, mock_token):
+        mock_token.return_value = _make_token(scope="calendar.readonly")
+        assert get_thread("user123", "t1") is None
+
+    @patch("integrations.gmail.client.get_valid_token")
+    @patch("integrations.gmail.client._call_gmail_api")
+    def test_api_error_returns_none(self, mock_api, mock_token):
+        mock_token.return_value = _make_token()
+        mock_api.side_effect = GmailAPIError(500)
+        assert get_thread("user123", "t1") is None
+
+
+# ---------------------------------------------------------------------------
+# search_messages
+# ---------------------------------------------------------------------------
+
+
+class TestSearchMessages:
+    @patch("integrations.gmail.client.get_recent_messages")
+    def test_delegates_to_get_recent_messages(self, mock_get):
+        mock_get.return_value = []
+        search_messages("user123", "from:boss@corp.com", max_results=5)
+        mock_get.assert_called_once_with("user123", max_results=5, query="from:boss@corp.com")
+
+    @patch("integrations.gmail.client.get_recent_messages")
+    def test_returns_results(self, mock_get):
+        fake_msg = MagicMock(spec=GmailMessage)
+        mock_get.return_value = [fake_msg]
+        result = search_messages("user123", "is:unread")
+        assert result == [fake_msg]


### PR DESCRIPTION
## What problem this solves

Users can ask Lobster about their email ("what's in my inbox?", "find the invoice from Acme") but Lobster had no way to read Gmail. This PR adds Gmail read access by extending the OAuth flow that already handles Google Calendar — no new credentials, no new GCP Console work, no schema changes.

## What changed

The existing Calendar OAuth infrastructure already handles token storage, refresh, and scope tracking. Gmail access requires one additional consent scope. The token file format (`scope` stored as a space-separated string) already supports multiple scopes, so no storage migration is needed.

### Scope change (`config.py`)

`SCOPE_GMAIL_READONLY` is added as a constant and included in `DEFAULT_SCOPES`. New users get Calendar + Gmail on a single consent screen. Existing users with a Calendar token but no Gmail scope see a `needs_auth: true` response with a re-consent link — they tap once and the updated token is pushed by the existing `push-calendar-token` endpoint.

### New package: `src/integrations/gmail/`

Mirrors the structure of `src/integrations/google_calendar/`:

- `models.py` — frozen `GmailMessage` and `GmailThread` dataclasses (immutable value objects, timezone-aware UTC datetimes throughout)
- `client.py` — four public functions (`get_recent_messages`, `get_message`, `get_thread`, `search_messages`) plus `has_gmail_scope`. All functions return empty/None rather than raising on auth failure or API error. Side effects (HTTP, token resolution) are isolated at the boundaries; all parsing helpers are pure functions.

### Four new MCP tools (`inbox_server.py`)

`get_gmail_messages`, `get_gmail_message`, `search_gmail`, `get_gmail_thread` — all return a structured `{"needs_auth": true, "auth_url": "..."}` response when the token is absent or missing the Gmail scope, so the dispatcher can surface the re-consent link inline without a separate check.

### Security scanner allowlist

Three new entries for docstring placeholder emails (`alice@example.com`, `boss@corp.com`) that are false positives from the pre-push scanner.

## What is not changed

- Token storage schema — unchanged; `scope` field already stores space-separated scopes
- `push-calendar-token` endpoint — unchanged; it is scope-agnostic
- Calendar tools — unchanged; the `DEFAULT_SCOPES` expansion only affects new consent flows
- No write scopes, no label management, no Drive integration (those are separate issues)
- No proactive Gmail poller (listed as out-of-scope in the issue; can be a follow-on scheduled job)

## Functional patterns used

Pure functions for all parsing (MIME header decoding, body extraction, date parsing, message parsing). Immutable value objects (`GmailMessage`, `GmailThread` frozen dataclasses). Side effects isolated to `_call_gmail_api`, `get_valid_token` calls, and the MCP handler layer. Composition: `search_messages` delegates to `get_recent_messages` with a query argument.

## Tests run

- [x] `uv run pytest tests/unit/test_integrations/test_gmail_client.py -v` — 55 passed, 0 failed
- [x] `uv run pytest tests/unit/test_integrations/ -v` — 387 passed, 0 failed (all existing Calendar tests still pass after `DEFAULT_SCOPES` expansion)
- [x] `uv run pytest tests/unit/ -q` — 2099 passed, 78 failed (pre-existing failures unrelated to this PR), 24 skipped — no new failures introduced
- [ ] Live Gmail API round-trip — blocked: requires a real Google token with `gmail.readonly` scope; needs production re-consent flow to test end-to-end. Safe to merge — auth failure path is well-tested and returns a structured error rather than crashing.

**Blocked items needing attention before merge:** Live API test requires production re-consent. The `needs_auth` path is exercised by unit tests; actual Gmail API call correctness requires a token with the new scope.

Closes #1364