### PR TITLE
feat: add generate_consent_link() + LOBSTER_INSTANCE_URL (BIS-251)

### DIFF
--- a/config/config.env.example
+++ b/config/config.env.example
@@ -85,6 +85,15 @@ OPENAI_API_KEY=your_openai_api_key_here
 # The installer generates this automatically. If you need to regenerate,
 # update BOTH this file AND the myownlobster.ai Vercel env var.
 LOBSTER_INTERNAL_SECRET=
+
+# Public base URL of this Lobster VPS instance (myownlobster.ai hosted installs)
+# Used by generate_consent_link() to tell myownlobster.ai where to push the
+# OAuth tokens after the user completes the Google consent flow.
+# Must be the externally-reachable HTTPS URL of this server, e.g.:
+#   LOBSTER_INSTANCE_URL=https://vps.example.com
+# The installer prompts for this value or derives it from the server's public IP.
+# If unset, generate_consent_link() raises RuntimeError and consent flows are disabled.
+LOBSTER_INSTANCE_URL=
 # See ~/messages/config/calendar-config.json for oauth_backend configuration
 
 # Google Workspace CLI (gws) — optional, for Gmail/Workspace integration

--- a/install.sh
+++ b/install.sh
@@ -2157,6 +2157,35 @@ if [ -f "$CONFIG_FILE" ]; then
 fi
 
 #===============================================================================
+# Set LOBSTER_INSTANCE_URL (required for Google OAuth consent-link flow)
+#===============================================================================
+
+if [ -f "$CONFIG_FILE" ]; then
+    source "$CONFIG_FILE"
+    if [ -z "${LOBSTER_INSTANCE_URL:-}" ]; then
+        step "Setting LOBSTER_INSTANCE_URL..."
+        # Attempt to auto-detect the public IP and build an https URL.
+        # The user can update this later if the auto-detected value is wrong.
+        DETECTED_IP=$(curl -s --max-time 5 https://api.ipify.org 2>/dev/null || true)
+        if [ -n "$DETECTED_IP" ]; then
+            INSTANCE_URL="https://${DETECTED_IP}"
+            warn "Auto-detected LOBSTER_INSTANCE_URL=${INSTANCE_URL}"
+            warn "Update this in config.env if your domain name differs from the IP."
+        else
+            INSTANCE_URL=""
+            warn "Could not auto-detect public IP. Set LOBSTER_INSTANCE_URL in config.env manually."
+        fi
+        echo "" >> "$CONFIG_FILE"
+        echo "# Public base URL of this Lobster VPS (used by generate_consent_link for Google OAuth)" >> "$CONFIG_FILE"
+        echo "# Update to your actual domain, e.g. https://vps.example.com" >> "$CONFIG_FILE"
+        echo "LOBSTER_INSTANCE_URL=${INSTANCE_URL}" >> "$CONFIG_FILE"
+        success "LOBSTER_INSTANCE_URL written to config.env"
+    else
+        success "LOBSTER_INSTANCE_URL already set"
+    fi
+fi
+
+#===============================================================================
 # Developer Mode: Enable LOBSTER_DEBUG
 #===============================================================================
 

--- a/src/integrations/google_auth/__init__.py
+++ b/src/integrations/google_auth/__init__.py
@@ -1,0 +1,11 @@
+"""Google OAuth helpers shared across Calendar and Gmail integrations.
+
+This module provides the `generate_consent_link` function, which asks
+myownlobster.ai to mint a one-time consent URL for a given OAuth scope.
+The VPS never holds GCP credentials; it delegates that responsibility to
+the myownlobster.ai web app.
+"""
+
+from integrations.google_auth.consent import generate_consent_link
+
+__all__ = ["generate_consent_link"]

--- a/src/integrations/google_auth/consent.py
+++ b/src/integrations/google_auth/consent.py
@@ -1,0 +1,207 @@
+"""generate_consent_link — VPS side of the OAuth consent-link flow.
+
+The VPS never holds GCP client credentials.  Instead it calls
+``POST https://myownlobster.ai/api/generate-consent-link``, which:
+
+1. Validates the shared secret (LOBSTER_INTERNAL_SECRET).
+2. Creates a short-lived (30-min) one-time token keyed by scope +
+   instance_url.
+3. Returns the full consent URL for the user to visit.
+
+The caller (skill handler, MCP tool, etc.) sends that URL to the user;
+the user clicks it, grants consent in their browser, and myownlobster.ai
+pushes the resulting tokens back to the VPS via
+``/api/push-calendar-token`` or ``/api/push-gmail-token``.
+
+Design principles
+-----------------
+- ``generate_consent_link`` is a pure function of its inputs + env;
+  the only side effect is the outbound HTTP POST.
+- Secrets never appear in log output (we log scope and instance_url
+  but not the secret itself).
+- Configuration is read from environment variables at call time so that
+  the function is trivially testable by patching ``os.environ``.
+
+Environment variables required
+-------------------------------
+LOBSTER_INSTANCE_URL
+    The public base URL of this Lobster VPS instance
+    (e.g. ``https://vps.example.com``).  myownlobster.ai uses this to
+    route the token-push callback back to the correct instance.
+
+LOBSTER_INTERNAL_SECRET
+    The shared secret that authenticates VPS→myownlobster requests.
+    Must match the ``LOBSTER_INTERNAL_SECRET`` Vercel env var on the
+    myownlobster.ai deployment.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import requests
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CONSENT_ENDPOINT: str = "https://myownlobster.ai/api/generate-consent-link"
+_HTTP_TIMEOUT: int = 10
+
+_VALID_SCOPES: frozenset[str] = frozenset({"calendar", "gmail"})
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def generate_consent_link(scope: str) -> str:
+    """Call myownlobster.ai to generate a one-time consent URL.
+
+    Args:
+        scope: ``"calendar"`` or ``"gmail"``.  The myownlobster.ai endpoint
+               uses this to select the correct Google OAuth scopes and to
+               build the per-scope redirect path
+               (``/connect/calendar?token=…`` or ``/connect/gmail?token=…``).
+
+    Returns:
+        The full one-time consent URL to send to the user.
+
+    Raises:
+        ValueError: If ``scope`` is not ``"calendar"`` or ``"gmail"``.
+        RuntimeError: If ``LOBSTER_INSTANCE_URL`` or
+            ``LOBSTER_INTERNAL_SECRET`` are not set in the environment.
+        RuntimeError: If the myownlobster.ai endpoint returns a non-2xx
+            response or an unexpected payload.
+    """
+    if scope not in _VALID_SCOPES:
+        raise ValueError(
+            f"Invalid scope {scope!r}. Must be one of: {sorted(_VALID_SCOPES)}"
+        )
+
+    instance_url, instance_secret = _read_env()
+
+    log.info(
+        "Requesting consent link from myownlobster.ai: scope=%r instance_url=%r",
+        scope,
+        instance_url,
+    )
+
+    url = _post_generate_consent_link(
+        scope=scope,
+        instance_url=instance_url,
+        instance_secret=instance_secret,
+    )
+
+    log.info(
+        "Consent link obtained from myownlobster.ai: scope=%r url_prefix=%r",
+        scope,
+        url[:60] if url else "",
+    )
+    return url
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_env() -> tuple[str, str]:
+    """Read and validate required environment variables.
+
+    Returns:
+        ``(instance_url, instance_secret)`` — both stripped of whitespace.
+
+    Raises:
+        RuntimeError: If either variable is absent or empty.
+    """
+    instance_url = os.environ.get("LOBSTER_INSTANCE_URL", "").strip()
+    instance_secret = os.environ.get("LOBSTER_INTERNAL_SECRET", "").strip()
+
+    missing = [
+        name
+        for name, value in (
+            ("LOBSTER_INSTANCE_URL", instance_url),
+            ("LOBSTER_INTERNAL_SECRET", instance_secret),
+        )
+        if not value
+    ]
+    if missing:
+        raise RuntimeError(
+            f"Missing required environment variables: {', '.join(missing)}. "
+            "Both LOBSTER_INSTANCE_URL and LOBSTER_INTERNAL_SECRET must be set "
+            "to generate a consent link."
+        )
+
+    return instance_url, instance_secret
+
+
+def _post_generate_consent_link(
+    scope: str,
+    instance_url: str,
+    instance_secret: str,
+    endpoint: str = _CONSENT_ENDPOINT,
+    timeout: int = _HTTP_TIMEOUT,
+) -> str:
+    """POST to myownlobster.ai and extract the consent URL.
+
+    Separated from ``generate_consent_link`` so the HTTP call is injectable
+    in tests without patching the entire function.
+
+    Args:
+        scope:           ``"calendar"`` or ``"gmail"``.
+        instance_url:    Public base URL of this Lobster instance.
+        instance_secret: Shared secret (sent in the JSON body, not a header,
+                         so that the myownlobster.ai route handler can validate
+                         it before issuing the token).
+        endpoint:        Full URL of the myownlobster.ai endpoint
+                         (injectable for testing).
+        timeout:         HTTP request timeout in seconds.
+
+    Returns:
+        The consent URL string from the ``"url"`` key of the JSON response.
+
+    Raises:
+        RuntimeError: On HTTP error or unexpected response schema.
+    """
+    try:
+        resp = requests.post(
+            endpoint,
+            json={
+                "scope": scope,
+                "instance_url": instance_url,
+                "instance_secret": instance_secret,
+            },
+            timeout=timeout,
+        )
+    except requests.exceptions.RequestException as exc:
+        raise RuntimeError(
+            f"Failed to reach myownlobster.ai consent-link endpoint: {exc}"
+        ) from exc
+
+    if not resp.ok:
+        raise RuntimeError(
+            f"myownlobster.ai returned HTTP {resp.status_code} "
+            f"for generate-consent-link (scope={scope!r}): {resp.text[:200]}"
+        )
+
+    try:
+        data = resp.json()
+        url: str = data["url"]
+    except (ValueError, KeyError) as exc:
+        raise RuntimeError(
+            f"Unexpected response from myownlobster.ai consent-link endpoint: {exc}. "
+            f"Body: {resp.text[:200]}"
+        ) from exc
+
+    if not url:
+        raise RuntimeError(
+            "myownlobster.ai returned an empty consent URL "
+            f"for scope={scope!r}."
+        )
+
+    return url

--- a/tests/unit/test_integrations/test_google_auth_consent.py
+++ b/tests/unit/test_integrations/test_google_auth_consent.py
@@ -1,0 +1,358 @@
+"""
+Tests for src/integrations/google_auth/consent.py.
+
+Covers:
+- generate_consent_link: returns URL for "calendar" and "gmail" scopes
+- generate_consent_link: raises ValueError for unknown scope
+- generate_consent_link: raises RuntimeError when LOBSTER_INSTANCE_URL missing
+- generate_consent_link: raises RuntimeError when LOBSTER_INTERNAL_SECRET missing
+- generate_consent_link: raises RuntimeError when both env vars are missing
+- generate_consent_link: raises RuntimeError on HTTP error response
+- generate_consent_link: raises RuntimeError on network error
+- generate_consent_link: raises RuntimeError when response JSON missing "url" key
+- generate_consent_link: raises RuntimeError when response "url" is empty string
+- _read_env: returns stripped values from environment
+- _post_generate_consent_link: posts correct JSON payload
+- Secrets do not appear in log output
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+# Make src importable without installing the package
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.google_auth.consent import (
+    _post_generate_consent_link,
+    _read_env,
+    generate_consent_link,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / constants
+# ---------------------------------------------------------------------------
+
+_FAKE_INSTANCE_URL = "https://vps.example.com"
+_FAKE_SECRET = "test-internal-secret-abc123"
+_FAKE_CALENDAR_URL = "https://myownlobster.ai/connect/calendar?token=test-uuid"
+_FAKE_GMAIL_URL = "https://myownlobster.ai/connect/gmail?token=test-uuid"
+
+
+def _mock_response(url: str, status_code: int = 200) -> MagicMock:
+    """Build a requests.Response mock that returns the given URL."""
+    resp = MagicMock()
+    resp.ok = status_code < 400
+    resp.status_code = status_code
+    resp.json.return_value = {"url": url}
+    resp.text = f'{{"url": "{url}"}}'
+    return resp
+
+
+def _env(instance_url: str = _FAKE_INSTANCE_URL, secret: str = _FAKE_SECRET) -> dict:
+    return {
+        "LOBSTER_INSTANCE_URL": instance_url,
+        "LOBSTER_INTERNAL_SECRET": secret,
+    }
+
+
+# ---------------------------------------------------------------------------
+# generate_consent_link — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateConsentLinkHappyPath:
+    def test_calendar_scope_returns_url(self):
+        with patch.dict("os.environ", _env()), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_response(_FAKE_CALENDAR_URL),
+        ) as mock_post:
+            result = generate_consent_link("calendar")
+
+        assert result == _FAKE_CALENDAR_URL
+        mock_post.assert_called_once()
+
+    def test_gmail_scope_returns_url(self):
+        with patch.dict("os.environ", _env()), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_response(_FAKE_GMAIL_URL),
+        ) as mock_post:
+            result = generate_consent_link("gmail")
+
+        assert result == _FAKE_GMAIL_URL
+        mock_post.assert_called_once()
+
+    def test_posts_correct_json_payload(self):
+        with patch.dict("os.environ", _env()), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_response(_FAKE_CALENDAR_URL),
+        ) as mock_post:
+            generate_consent_link("calendar")
+
+        call_kwargs = mock_post.call_args
+        # Payload is passed as keyword argument "json"
+        payload = call_kwargs.kwargs.get("json") or call_kwargs.args[1] if len(call_kwargs.args) > 1 else call_kwargs.kwargs["json"]
+        assert payload["scope"] == "calendar"
+        assert payload["instance_url"] == _FAKE_INSTANCE_URL
+        assert payload["instance_secret"] == _FAKE_SECRET
+
+    def test_uses_myownlobster_endpoint_by_default(self):
+        with patch.dict("os.environ", _env()), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_response(_FAKE_CALENDAR_URL),
+        ) as mock_post:
+            generate_consent_link("calendar")
+
+        called_url = mock_post.call_args.args[0] if mock_post.call_args.args else mock_post.call_args.kwargs["url"]
+        # Use the positional arg (first arg to requests.post)
+        positional_url = mock_post.call_args[0][0] if mock_post.call_args[0] else mock_post.call_args.kwargs.get("url", "")
+        assert "myownlobster.ai" in positional_url
+        assert "generate-consent-link" in positional_url
+
+
+# ---------------------------------------------------------------------------
+# generate_consent_link — scope validation
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateConsentLinkScopeValidation:
+    def test_invalid_scope_raises_value_error(self):
+        with patch.dict("os.environ", _env()):
+            with pytest.raises(ValueError, match="Invalid scope"):
+                generate_consent_link("drive")
+
+    def test_empty_scope_raises_value_error(self):
+        with patch.dict("os.environ", _env()):
+            with pytest.raises(ValueError, match="Invalid scope"):
+                generate_consent_link("")
+
+    def test_scope_case_sensitive(self):
+        """Scope must be lowercase exactly; 'Calendar' is rejected."""
+        with patch.dict("os.environ", _env()):
+            with pytest.raises(ValueError, match="Invalid scope"):
+                generate_consent_link("Calendar")
+
+
+# ---------------------------------------------------------------------------
+# generate_consent_link — missing env vars
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateConsentLinkMissingEnv:
+    def test_missing_instance_url_raises(self):
+        env = {"LOBSTER_INTERNAL_SECRET": _FAKE_SECRET}
+        with patch.dict("os.environ", env, clear=True):
+            with pytest.raises(RuntimeError, match="LOBSTER_INSTANCE_URL"):
+                generate_consent_link("calendar")
+
+    def test_missing_secret_raises(self):
+        env = {"LOBSTER_INSTANCE_URL": _FAKE_INSTANCE_URL}
+        with patch.dict("os.environ", env, clear=True):
+            with pytest.raises(RuntimeError, match="LOBSTER_INTERNAL_SECRET"):
+                generate_consent_link("calendar")
+
+    def test_both_missing_raises(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(RuntimeError, match="Missing required environment variables"):
+                generate_consent_link("calendar")
+
+    def test_empty_string_instance_url_raises(self):
+        env = {"LOBSTER_INSTANCE_URL": "   ", "LOBSTER_INTERNAL_SECRET": _FAKE_SECRET}
+        with patch.dict("os.environ", env, clear=True):
+            with pytest.raises(RuntimeError, match="LOBSTER_INSTANCE_URL"):
+                generate_consent_link("calendar")
+
+    def test_empty_string_secret_raises(self):
+        env = {"LOBSTER_INSTANCE_URL": _FAKE_INSTANCE_URL, "LOBSTER_INTERNAL_SECRET": ""}
+        with patch.dict("os.environ", env, clear=True):
+            with pytest.raises(RuntimeError, match="LOBSTER_INTERNAL_SECRET"):
+                generate_consent_link("calendar")
+
+
+# ---------------------------------------------------------------------------
+# generate_consent_link — HTTP failure cases
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateConsentLinkHTTPErrors:
+    def test_http_4xx_raises_runtime_error(self):
+        error_resp = MagicMock()
+        error_resp.ok = False
+        error_resp.status_code = 403
+        error_resp.text = "Forbidden"
+
+        with patch.dict("os.environ", _env()), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=error_resp,
+        ):
+            with pytest.raises(RuntimeError, match="HTTP 403"):
+                generate_consent_link("calendar")
+
+    def test_http_5xx_raises_runtime_error(self):
+        error_resp = MagicMock()
+        error_resp.ok = False
+        error_resp.status_code = 503
+        error_resp.text = "Service Unavailable"
+
+        with patch.dict("os.environ", _env()), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=error_resp,
+        ):
+            with pytest.raises(RuntimeError, match="HTTP 503"):
+                generate_consent_link("gmail")
+
+    def test_network_error_raises_runtime_error(self):
+        with patch.dict("os.environ", _env()), patch(
+            "integrations.google_auth.consent.requests.post",
+            side_effect=requests.exceptions.ConnectionError("connection refused"),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to reach"):
+                generate_consent_link("calendar")
+
+    def test_timeout_raises_runtime_error(self):
+        with patch.dict("os.environ", _env()), patch(
+            "integrations.google_auth.consent.requests.post",
+            side_effect=requests.exceptions.Timeout("timed out"),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to reach"):
+                generate_consent_link("calendar")
+
+    def test_missing_url_key_in_response_raises(self):
+        resp = MagicMock()
+        resp.ok = True
+        resp.status_code = 200
+        resp.json.return_value = {"token": "some-uuid"}  # "url" key absent
+        resp.text = '{"token": "some-uuid"}'
+
+        with patch.dict("os.environ", _env()), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=resp,
+        ):
+            with pytest.raises(RuntimeError, match="Unexpected response"):
+                generate_consent_link("calendar")
+
+    def test_empty_url_in_response_raises(self):
+        resp = MagicMock()
+        resp.ok = True
+        resp.status_code = 200
+        resp.json.return_value = {"url": ""}
+        resp.text = '{"url": ""}'
+
+        with patch.dict("os.environ", _env()), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=resp,
+        ):
+            with pytest.raises(RuntimeError, match="empty consent URL"):
+                generate_consent_link("calendar")
+
+    def test_invalid_json_response_raises(self):
+        resp = MagicMock()
+        resp.ok = True
+        resp.status_code = 200
+        resp.json.side_effect = ValueError("not JSON")
+        resp.text = "not json"
+
+        with patch.dict("os.environ", _env()), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=resp,
+        ):
+            with pytest.raises(RuntimeError, match="Unexpected response"):
+                generate_consent_link("calendar")
+
+
+# ---------------------------------------------------------------------------
+# _read_env: unit tests for the env-reading helper
+# ---------------------------------------------------------------------------
+
+
+class TestReadEnv:
+    def test_returns_stripped_values(self):
+        env = {
+            "LOBSTER_INSTANCE_URL": "  https://vps.example.com  ",
+            "LOBSTER_INTERNAL_SECRET": "  mysecret  ",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            url, secret = _read_env()
+        assert url == "https://vps.example.com"
+        assert secret == "mysecret"
+
+    def test_raises_listing_all_missing(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(RuntimeError) as exc_info:
+                _read_env()
+        msg = str(exc_info.value)
+        assert "LOBSTER_INSTANCE_URL" in msg
+        assert "LOBSTER_INTERNAL_SECRET" in msg
+
+
+# ---------------------------------------------------------------------------
+# Secrets must not appear in log output
+# ---------------------------------------------------------------------------
+
+
+class TestNoSecretsInLogs:
+    def test_secret_not_logged(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="integrations.google_auth.consent"):
+            with patch.dict("os.environ", _env(secret="super-secret-value")), patch(
+                "integrations.google_auth.consent.requests.post",
+                return_value=_mock_response(_FAKE_CALENDAR_URL),
+            ):
+                generate_consent_link("calendar")
+
+        for record in caplog.records:
+            assert "super-secret-value" not in record.getMessage()
+
+    def test_instance_url_logged_but_not_secret(self, caplog):
+        """instance_url appears in logs (it's not sensitive); secret does not."""
+        with caplog.at_level(logging.INFO, logger="integrations.google_auth.consent"):
+            with patch.dict("os.environ", _env(secret="do-not-log-me")), patch(
+                "integrations.google_auth.consent.requests.post",
+                return_value=_mock_response(_FAKE_CALENDAR_URL),
+            ):
+                generate_consent_link("calendar")
+
+        all_log_text = " ".join(r.getMessage() for r in caplog.records)
+        assert "do-not-log-me" not in all_log_text
+
+
+# ---------------------------------------------------------------------------
+# _post_generate_consent_link: injectable endpoint for testing
+# ---------------------------------------------------------------------------
+
+
+class TestPostGenerateConsentLink:
+    def test_uses_custom_endpoint(self):
+        with patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_response("https://test.example.com/connect/calendar?token=abc"),
+        ) as mock_post:
+            result = _post_generate_consent_link(
+                scope="calendar",
+                instance_url=_FAKE_INSTANCE_URL,
+                instance_secret=_FAKE_SECRET,
+                endpoint="https://staging.myownlobster.ai/api/generate-consent-link",
+            )
+
+        assert result == "https://test.example.com/connect/calendar?token=abc"
+        called_url = mock_post.call_args[0][0]
+        assert called_url == "https://staging.myownlobster.ai/api/generate-consent-link"
+
+    def test_passes_timeout(self):
+        with patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_response(_FAKE_CALENDAR_URL),
+        ) as mock_post:
+            _post_generate_consent_link(
+                scope="calendar",
+                instance_url=_FAKE_INSTANCE_URL,
+                instance_secret=_FAKE_SECRET,
+                timeout=42,
+            )
+
+        assert mock_post.call_args.kwargs["timeout"] == 42


### PR DESCRIPTION
## What problem this solves

Skills that want to connect a user's Google account (Calendar, Gmail) need to send
the user a one-time consent URL. Before this PR, there was no VPS-side mechanism
to request that URL from myownlobster.ai — the function simply didn't exist.

This PR adds `generate_consent_link(scope)` to the VPS, completing the VPS half
of the short-lived consent-link flow described in BIS-250. The web-app half
(the `POST /api/generate-consent-link` endpoint on myownlobster.ai) is implemented
in a separate sub-issue. Unit tests mock the HTTP call so this PR can be merged
independently.

## What changed

**New module: `src/integrations/google_auth/`**

`consent.py` exposes one public function:

```
generate_consent_link(scope: str) -> str
```

It reads `LOBSTER_INSTANCE_URL` and `LOBSTER_INTERNAL_SECRET` from the environment,
POSTs both to `https://myownlobster.ai/api/generate-consent-link`, and returns the
`"url"` field from the JSON response. The secret is never logged. Scope is validated
against the allowlist `{"calendar", "gmail"}` before any I/O.

**Functional patterns used:** pure `_read_env` + `_post_generate_consent_link`
helpers compose into `generate_consent_link`; HTTP side-effect is isolated to
`_post_generate_consent_link` which is injectable in tests via an `endpoint`
parameter; no global mutable state.

**Config / install changes**

- `config/config.env.example`: adds `LOBSTER_INSTANCE_URL` with an explanatory
  comment immediately below the existing `LOBSTER_INTERNAL_SECRET` block.
- `install.sh`: on fresh installs, auto-detects the server's public IP via
  `api.ipify.org` and writes `LOBSTER_INSTANCE_URL=https://<IP>` to `config.env`,
  with a warning to update it if the domain name differs. Idempotent: skipped when
  the var is already set.

**What is NOT changed:** no existing modules, no token-store logic, no existing
`google_calendar` integration code.

## Flow (no change to existing flows — this is purely additive)

```
Skill handler
     |
     v
generate_consent_link("calendar")
     |
     v
POST https://myownlobster.ai/api/generate-consent-link
     { scope, instance_url, instance_secret }
     |
     v
returns { url: "https://myownlobster.ai/connect/calendar?token=<uuid>" }
     |
     v
Skill handler sends URL to user
```

The token-push leg (`/api/push-calendar-token` → VPS) is implemented by BIS-250
sub-issue 4 and is out of scope here.

## Tests run

- [x] `uv run pytest tests/unit/test_integrations/test_google_auth_consent.py -v` — 25 passed, 0 failed
- [x] `uv run pytest tests/unit/ -q` — 173 passed, 1 failed (pre-existing failure on `main`: `test_group_passive_message_no_ack` in `test_group_ack_policy.py` — unrelated to this PR, confirmed failing on `main` before this branch was cut)

**Blocked items needing attention before merge:** none