### PR TITLE
feat(gmail): Gmail skill — token store, API client, consent-link auth (BIS-256)

### DIFF
--- a/lobster-shop/gmail/behavior/system.md
+++ b/lobster-shop/gmail/behavior/system.md
@@ -1,0 +1,173 @@
+## Gmail — Dual-Mode Behavior
+
+This skill operates in two modes depending on whether the user has connected their Gmail account.
+
+### How to detect which mode to use
+
+Run this check (takes < 1 second, no network call):
+
+```python
+import sys
+import os
+sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+from integrations.gmail.token_store import load_token
+from mcp.user_model.owner import read_owner
+
+owner = read_owner()
+OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
+token = load_token(OWNER_USER_ID)
+is_authenticated = token is not None
+```
+
+---
+
+### Mode A: Unauthenticated (no token on disk)
+
+Call `generate_consent_link("gmail")` to send the user a one-time consent URL.
+If `generate_consent_link` raises, degrade gracefully with a user-friendly message.
+
+```python
+import sys
+import os
+sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+from integrations.google_auth.consent import generate_consent_link
+import logging
+
+log = logging.getLogger(__name__)
+
+try:
+    url = generate_consent_link("gmail")
+    reply = (
+        "To connect your Gmail, tap this link (expires in 30 minutes):\n"
+        f"[Connect Gmail]({url})\n\n"
+        "After connecting, I'll be able to read and search your emails."
+    )
+except Exception as exc:
+    log.warning("generate_consent_link('gmail') failed: %s", exc)
+    reply = (
+        "I couldn't generate a Gmail connection link right now. "
+        "Please try again in a few minutes, or check that LOBSTER_INSTANCE_URL "
+        "and LOBSTER_INTERNAL_SECRET are set in config.env."
+    )
+    # Do NOT surface exc, env var names, or token values to the user.
+```
+
+---
+
+### Mode B: Authenticated (token exists)
+
+Read Gmail via the API. Always delegate to a background subagent — network calls
+take longer than 7 seconds total.
+
+```
+send_reply(chat_id, "Checking your inbox...")
+Task(prompt="...", subagent_type="general-purpose", run_in_background=true)
+```
+
+#### Reading recent emails ("check my email", "what emails do I have", "any new messages")
+
+Subagent code pattern:
+
+```python
+import sys
+import os
+sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+from integrations.gmail.client import get_recent_emails
+from mcp.user_model.owner import read_owner
+
+owner = read_owner()
+OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
+
+emails = get_recent_emails(user_id=OWNER_USER_ID, max_results=5)
+if not emails:
+    reply = "No recent emails in your inbox, or Gmail is not connected."
+else:
+    lines = []
+    for e in emails:
+        date_str = e.date.strftime("%a %b %-d, %-I:%M %p UTC")
+        subject = e.subject or "(no subject)"
+        lines.append(f"- {date_str} | {e.sender}: {subject}")
+    reply = f"Your {len(emails)} most recent emails:\n" + "\n".join(lines)
+```
+
+#### Searching emails ("find emails from X", "search for Y in my email")
+
+```python
+import sys
+import os
+sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+from integrations.gmail.client import search_emails
+from mcp.user_model.owner import read_owner
+
+owner = read_owner()
+OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
+
+# query is the Gmail search string derived from user's message
+emails = search_emails(user_id=OWNER_USER_ID, query=query, max_results=5)
+if not emails:
+    reply = f"No emails found matching \"{query}\"."
+else:
+    lines = []
+    for e in emails:
+        date_str = e.date.strftime("%a %b %-d")
+        subject = e.subject or "(no subject)"
+        lines.append(f"- {date_str} | {e.sender}: {subject}")
+    reply = f"Found {len(emails)} email(s) for \"{query}\":\n" + "\n".join(lines)
+```
+
+---
+
+### Auth trigger ("connect my Gmail", "authenticate Gmail", "link Gmail account")
+
+Respond immediately on the main thread — no subagent needed:
+
+```python
+import sys
+import os
+sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+from integrations.google_auth.consent import generate_consent_link
+import logging
+
+log = logging.getLogger(__name__)
+
+try:
+    url = generate_consent_link("gmail")
+    reply = (
+        "To connect your Gmail, tap this link (expires in 30 minutes):\n"
+        f"[Connect Gmail]({url})\n\n"
+        "After connecting, I'll be able to read and search your emails."
+    )
+except Exception as exc:
+    log.warning("generate_consent_link('gmail') failed — degrading gracefully: %s", exc)
+    reply = (
+        "I couldn't generate a Gmail connection link right now. "
+        "Please try again in a few minutes."
+    )
+```
+
+---
+
+### Natural language patterns to recognize
+
+| Pattern | Intent |
+|---------|--------|
+| "check my email" / "any new emails" / "what's in my inbox" | Read recent emails |
+| "find emails from [person]" / "search for [subject] in my email" | Search emails |
+| "connect my Gmail" / "link Gmail" / "authenticate Gmail" | Auth flow |
+
+---
+
+### Graceful degradation
+
+If `get_recent_emails` or `search_emails` returns an empty list (auth failure,
+network error, empty inbox), tell the user nothing was found or Gmail is not
+connected.  Never surface token values, error codes, or credentials in messages.
+
+---
+
+### Scope isolation
+
+Gmail and Calendar OAuth flows are completely independent:
+- Gmail tokens live in `~/messages/config/gmail-tokens/`
+- Calendar tokens live in `~/messages/config/gcal-tokens/`
+- Connecting Gmail never touches the Calendar token, and vice versa.

--- a/lobster-shop/gmail/context/reference.md
+++ b/lobster-shop/gmail/context/reference.md
@@ -1,0 +1,79 @@
+## Gmail Skill — Quick Reference
+
+### Check authentication status (pure, no network)
+
+```python
+import sys
+import os
+sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+from integrations.gmail.token_store import load_token
+from mcp.user_model.owner import read_owner
+
+owner = read_owner()
+OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
+token = load_token(OWNER_USER_ID)
+is_authenticated = token is not None
+```
+
+---
+
+### Generate consent URL (unauthenticated)
+
+**Module:** `src/integrations/google_auth/consent.py`
+
+```python
+from integrations.google_auth.consent import generate_consent_link
+
+try:
+    url = generate_consent_link("gmail")
+    # Send to user as: [Connect Gmail](url)
+except Exception as exc:
+    # Log warning and send a user-friendly fallback message.
+    # Never surface exc details to the user.
+    pass
+```
+
+---
+
+### Read recent emails (authenticated)
+
+**Module:** `src/integrations/gmail/client.py`
+
+```python
+from integrations.gmail.client import get_recent_emails
+
+emails = get_recent_emails(user_id=OWNER_USER_ID, max_results=10)
+# Returns List[EmailMessage] — empty list on auth failure or API error
+
+# EmailMessage fields:
+#   id: str, thread_id: str, subject: str, sender: str,
+#   date: datetime (UTC), snippet: str, labels: tuple[str, ...]
+```
+
+---
+
+### Search emails (authenticated)
+
+```python
+from integrations.gmail.client import search_emails
+
+emails = search_emails(user_id=OWNER_USER_ID, query="from:boss@example.com is:unread")
+# Returns List[EmailMessage] — empty list on auth failure or no results
+```
+
+Gmail search operators work as-is (from:, subject:, is:unread, after:, label:, etc.).
+
+---
+
+### User ID convention
+
+The owner's `user_id` is their Telegram chat_id as a string, read from
+`~/lobster-config/owner.toml`.
+All Gmail token files live in `~/messages/config/gmail-tokens/{user_id}.json`.
+
+---
+
+### Scope isolation
+
+Gmail tokens (`gmail-tokens/`) and Calendar tokens (`gcal-tokens/`) are
+separate directories.  Authenticating one never affects the other.

--- a/lobster-shop/gmail/skill.toml
+++ b/lobster-shop/gmail/skill.toml
@@ -1,0 +1,39 @@
+[skill]
+name = "gmail"
+version = "1.0.0"
+description = "Gmail integration: read recent emails and search inbox via API when authenticated, or prompt with a one-time consent URL when unauthenticated"
+author = "Lobster"
+category = "behavioral"
+
+[activation]
+mode = "triggered"
+triggers = ["/gmail", "/email", "/inbox"]
+context_patterns = [
+    "when user asks to check their email",
+    "when user asks about emails, messages, or inbox",
+    "when user wants to search their email",
+    "when user asks if they have new email",
+    "when user wants to connect or authenticate Gmail",
+    "when user mentions reading or finding an email",
+]
+
+[layering]
+priority = 40
+merge_strategy = "append"
+
+[provides]
+mcp_tools = []
+bot_commands = ["/gmail", "/email", "/inbox"]
+
+[compatibility]
+enhances = []
+conflicts = []
+
+[dependencies]
+pip = []
+npm = []
+system = []
+api_keys = []
+
+[dependencies.runtime]
+python = ">=3.11"

--- a/src/integrations/gmail/__init__.py
+++ b/src/integrations/gmail/__init__.py
@@ -1,0 +1,1 @@
+"""Gmail integration package."""

--- a/src/integrations/gmail/client.py
+++ b/src/integrations/gmail/client.py
@@ -1,0 +1,408 @@
+"""
+Gmail API client.
+
+Provides a clean, typed Python layer over the Gmail REST API so Lobster can
+list recent emails and search a user's inbox on their behalf.
+
+All HTTP calls go through ``_call_gmail_api``, the single point of contact
+with the network.  Auth failures and HTTP errors are caught and converted to
+domain exceptions; callers that want graceful degradation can use the
+high-level helpers (``get_recent_emails``, ``search_emails``) which return
+empty lists on auth failure rather than propagating exceptions.
+
+Design principles (consistent with the Google Calendar client):
+- Immutable value objects (frozen dataclasses)
+- Pure helpers isolated from I/O
+- Side effects (network calls, token refresh) kept at the boundaries
+- No credentials or token values ever appear in logs or exception messages
+- Timezone-aware datetimes throughout (UTC)
+
+Gmail REST API docs:
+    https://developers.google.com/gmail/api/reference/rest/v1/users.messages
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import requests
+
+from integrations.gmail.token_store import get_valid_token
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Gmail REST API constants
+# ---------------------------------------------------------------------------
+
+_GMAIL_API_BASE: str = "https://gmail.googleapis.com/gmail/v1"
+_USER_ID: str = "me"  # Gmail API uses "me" for the authenticated user
+
+# Timeout for HTTP requests to the Gmail API (seconds).
+_HTTP_TIMEOUT: int = 15
+
+# Maximum number of message IDs to fetch in a single list call.
+_DEFAULT_MAX_RESULTS: int = 10
+
+
+# ---------------------------------------------------------------------------
+# Domain types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EmailMessage:
+    """Immutable representation of a single Gmail message.
+
+    Attributes:
+        id:        Gmail-assigned message identifier.
+        thread_id: Thread this message belongs to.
+        subject:   Message subject line (empty string if absent).
+        sender:    Sender's name/address from the ``From`` header.
+        date:      Message date as a timezone-aware UTC datetime.
+        snippet:   Short plain-text preview of the message body.
+        labels:    Tuple of Gmail label IDs applied to this message
+                   (e.g. ``("INBOX", "UNREAD")``).
+    """
+
+    id: str
+    thread_id: str
+    subject: str
+    sender: str
+    date: datetime
+    snippet: str
+    labels: tuple[str, ...] = field(default_factory=tuple)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class GmailAPIError(RuntimeError):
+    """Raised when the Gmail API returns a non-2xx response.
+
+    The message includes the HTTP status code and a short description but
+    never the raw response body (which might contain user data) and never
+    any credential or token values.
+    """
+
+    def __init__(self, status_code: int, summary: str = "") -> None:
+        self.status_code = status_code
+        super().__init__(
+            f"Gmail API error {status_code}"
+            + (f": {summary}" if summary else "")
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_header(headers: list[dict], name: str) -> str:
+    """Extract the value of a named header from a Gmail message part headers list.
+
+    Pure function — no I/O.
+
+    Args:
+        headers: List of ``{"name": ..., "value": ...}`` dicts from the Gmail API.
+        name:    Case-insensitive header name to find.
+
+    Returns:
+        Header value string, or empty string if the header is absent.
+    """
+    name_lower = name.lower()
+    for h in headers:
+        if h.get("name", "").lower() == name_lower:
+            return h.get("value", "")
+    return ""
+
+
+def _parse_date_header(raw: str) -> datetime:
+    """Parse a Gmail ``Date`` header into a timezone-aware UTC datetime.
+
+    Gmail returns RFC 2822 date strings such as
+    ``"Wed, 1 Apr 2026 14:30:00 +0000"``.  Falls back to the current UTC
+    time if parsing fails so callers always receive a valid datetime.
+
+    Pure function — only processes the input string.
+
+    Args:
+        raw: Raw date string from the Gmail API message headers.
+
+    Returns:
+        A timezone-aware datetime in UTC.
+    """
+    from email.utils import parsedate_to_datetime
+
+    if not raw:
+        return datetime.now(tz=timezone.utc)
+    try:
+        dt = parsedate_to_datetime(raw)
+        return dt.astimezone(timezone.utc)
+    except Exception:
+        return datetime.now(tz=timezone.utc)
+
+
+def _parse_message(raw: dict) -> EmailMessage:
+    """Convert a raw Gmail message dict (full format) into an EmailMessage.
+
+    Handles missing optional fields by returning sensible defaults.
+
+    Pure function — no I/O.
+
+    Args:
+        raw: A single message object from the Gmail API (format=``"full"``).
+
+    Returns:
+        A frozen EmailMessage instance.
+    """
+    payload: dict = raw.get("payload", {})
+    headers: list[dict] = payload.get("headers", [])
+
+    subject = _parse_header(headers, "Subject")
+    sender = _parse_header(headers, "From")
+    date_str = _parse_header(headers, "Date")
+    date = _parse_date_header(date_str)
+
+    labels_raw: list[str] = raw.get("labelIds", [])
+
+    return EmailMessage(
+        id=raw.get("id", ""),
+        thread_id=raw.get("threadId", ""),
+        subject=subject,
+        sender=sender,
+        date=date,
+        snippet=raw.get("snippet", ""),
+        labels=tuple(labels_raw),
+    )
+
+
+def _auth_header(access_token: str) -> dict[str, str]:
+    """Return an Authorization header dict for a bearer token.
+
+    Pure function — constructs the header without any side effects.
+
+    Args:
+        access_token: A valid Google OAuth access token.
+
+    Returns:
+        Dict with a single ``Authorization`` key.
+    """
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+# ---------------------------------------------------------------------------
+# HTTP helper (side-effecting boundary)
+# ---------------------------------------------------------------------------
+
+
+def _call_gmail_api(
+    method: str,
+    url: str,
+    token: str,
+    **kwargs: Any,
+) -> Any:
+    """Make an authenticated HTTP call to the Gmail API.
+
+    This is the single point of network contact for all Gmail API calls.
+    All other helpers in this module call through here.
+
+    Args:
+        method: HTTP method string, e.g. ``"GET"``.
+        url:    Full API endpoint URL.
+        token:  Valid OAuth access token (used in Authorization header).
+        **kwargs: Additional keyword arguments forwarded to ``requests.request``
+                  (e.g. ``params``, ``json``).
+
+    Returns:
+        Parsed JSON response body (dict or list).
+
+    Raises:
+        GmailAPIError: If the response status code is not 2xx.
+        requests.exceptions.RequestException: On network-level failures.
+    """
+    headers = {**_auth_header(token), "Accept": "application/json"}
+    kwargs.setdefault("timeout", _HTTP_TIMEOUT)
+
+    log.debug("Gmail API %s %s", method, url)
+
+    response = requests.request(method, url, headers=headers, **kwargs)
+
+    if not response.ok:
+        try:
+            err_body: dict = response.json()
+            summary = err_body.get("error", {}).get("message", "")
+        except Exception:
+            summary = ""
+        log.warning(
+            "Gmail API returned %d for %s %s",
+            response.status_code, method, url,
+        )
+        raise GmailAPIError(status_code=response.status_code, summary=summary)
+
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_recent_emails(
+    user_id: str,
+    max_results: int = _DEFAULT_MAX_RESULTS,
+    token_dir=None,
+) -> list[EmailMessage]:
+    """Fetch recent emails from the user's Gmail inbox.
+
+    Queries the INBOX label, ordered by most recent first.  Returns an
+    empty list if the user has no valid token or if any API/network error
+    occurs.
+
+    Args:
+        user_id:     Lobster user identifier (e.g. Telegram chat_id as str).
+        max_results: Maximum number of messages to return.  Defaults to 10.
+        token_dir:   Optional Path for token directory (injectable for testing).
+
+    Returns:
+        List of EmailMessage objects ordered by most recent first.
+        Empty list on any failure.
+    """
+    kwargs = {}
+    if token_dir is not None:
+        kwargs["token_dir"] = token_dir
+    token = get_valid_token(user_id, **kwargs)
+    if token is None:
+        log.info(
+            "get_recent_emails: no valid Gmail token for user_id=%r — returning []",
+            user_id,
+        )
+        return []
+
+    list_url = f"{_GMAIL_API_BASE}/users/{_USER_ID}/messages"
+    params = {
+        "labelIds": "INBOX",
+        "maxResults": max_results,
+    }
+
+    try:
+        list_data = _call_gmail_api("GET", list_url, token.access_token, params=params)
+    except (GmailAPIError, requests.exceptions.RequestException) as exc:
+        log.warning(
+            "get_recent_emails: list call failed for user_id=%r: %s",
+            user_id, type(exc).__name__,
+        )
+        return []
+
+    message_refs: list[dict] = list_data.get("messages", [])
+    if not message_refs:
+        log.info("get_recent_emails: inbox empty for user_id=%r", user_id)
+        return []
+
+    messages: list[EmailMessage] = []
+    for ref in message_refs:
+        msg_id = ref.get("id", "")
+        if not msg_id:
+            continue
+        msg_url = f"{_GMAIL_API_BASE}/users/{_USER_ID}/messages/{msg_id}"
+        try:
+            raw_msg = _call_gmail_api(
+                "GET", msg_url, token.access_token,
+                params={"format": "full"},
+            )
+            messages.append(_parse_message(raw_msg))
+        except (GmailAPIError, requests.exceptions.RequestException) as exc:
+            log.warning(
+                "get_recent_emails: fetch failed for message_id=%r user_id=%r: %s",
+                msg_id, user_id, type(exc).__name__,
+            )
+
+    log.info(
+        "get_recent_emails: fetched %d messages for user_id=%r",
+        len(messages), user_id,
+    )
+    return messages
+
+
+def search_emails(
+    user_id: str,
+    query: str,
+    max_results: int = _DEFAULT_MAX_RESULTS,
+    token_dir=None,
+) -> list[EmailMessage]:
+    """Search Gmail using the Gmail search query syntax.
+
+    Supports all Gmail search operators (from:, subject:, is:unread, etc.).
+    Returns an empty list if the user has no valid token or on any error.
+
+    Args:
+        user_id:     Lobster user identifier.
+        query:       Gmail search query string (e.g. ``"from:boss@example.com"``).
+        max_results: Maximum number of messages to return.  Defaults to 10.
+        token_dir:   Optional Path for token directory (injectable for testing).
+
+    Returns:
+        List of EmailMessage objects matching the query.  Empty list on failure.
+    """
+    kwargs = {}
+    if token_dir is not None:
+        kwargs["token_dir"] = token_dir
+    token = get_valid_token(user_id, **kwargs)
+    if token is None:
+        log.info(
+            "search_emails: no valid Gmail token for user_id=%r — returning []",
+            user_id,
+        )
+        return []
+
+    list_url = f"{_GMAIL_API_BASE}/users/{_USER_ID}/messages"
+    params = {
+        "q": query,
+        "maxResults": max_results,
+    }
+
+    try:
+        list_data = _call_gmail_api("GET", list_url, token.access_token, params=params)
+    except (GmailAPIError, requests.exceptions.RequestException) as exc:
+        log.warning(
+            "search_emails: list call failed for user_id=%r query=%r: %s",
+            user_id, query, type(exc).__name__,
+        )
+        return []
+
+    message_refs: list[dict] = list_data.get("messages", [])
+    if not message_refs:
+        log.info(
+            "search_emails: no results for user_id=%r query=%r",
+            user_id, query,
+        )
+        return []
+
+    messages: list[EmailMessage] = []
+    for ref in message_refs:
+        msg_id = ref.get("id", "")
+        if not msg_id:
+            continue
+        msg_url = f"{_GMAIL_API_BASE}/users/{_USER_ID}/messages/{msg_id}"
+        try:
+            raw_msg = _call_gmail_api(
+                "GET", msg_url, token.access_token,
+                params={"format": "full"},
+            )
+            messages.append(_parse_message(raw_msg))
+        except (GmailAPIError, requests.exceptions.RequestException) as exc:
+            log.warning(
+                "search_emails: fetch failed for message_id=%r user_id=%r: %s",
+                msg_id, user_id, type(exc).__name__,
+            )
+
+    log.info(
+        "search_emails: fetched %d messages for user_id=%r query=%r",
+        len(messages), user_id, query,
+    )
+    return messages

--- a/src/integrations/gmail/token_store.py
+++ b/src/integrations/gmail/token_store.py
@@ -1,0 +1,407 @@
+"""
+Per-user Gmail OAuth token persistence — local-disk edition.
+
+Tokens are stored as JSON files at:
+    ~/messages/config/gmail-tokens/{user_id}.json
+
+This module is the Gmail counterpart of
+``integrations.google_calendar.token_store``.  The two share the same
+on-disk schema and the same refresh-proxy pattern; the only differences
+are the token directory path and the refresh endpoint name.
+
+Refresh flow
+------------
+When an access token is expired, this module calls the myownlobster.ai
+``/api/internal/refresh-gmail-token`` endpoint (functionally identical to
+``/api/internal/refresh-calendar-token`` — both proxy a Google OAuth
+refresh call — but kept separate for clarity and independent routing).
+
+The refresh proxy URL is read from
+``~/messages/config/gmail-config.json``::
+
+    {
+      "myownlobster_api_base": "https://myownlobster.ai"
+    }
+
+If that key is absent, ``https://myownlobster.ai`` is used as a default.
+
+Token schema on disk::
+
+    {
+        "access_token":  "<string>",
+        "expires_at":    "<ISO 8601 UTC>",
+        "scope":         "<space-separated scopes>",
+        "refresh_token": "<string or null>"
+    }
+
+Design principles
+-----------------
+- Side effects (file I/O, HTTP) are isolated to dedicated private functions.
+- ``is_token_valid`` is a pure function (delegates to
+  ``google_calendar.oauth.is_token_valid``).
+- ``get_valid_token`` composes load -> check -> maybe refresh -> persist.
+- No token values are written to logs.
+- Token file isolation: gmail-tokens/ and gcal-tokens/ are separate
+  directories; OAuth for one scope never touches the other.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+from integrations.google_calendar.oauth import (
+    OAuthError,
+    TokenData,
+    is_token_valid,
+)
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Storage locations
+# ---------------------------------------------------------------------------
+
+_HOME: Path = Path.home()
+_MESSAGES_DIR: Path = Path(os.environ.get("LOBSTER_MESSAGES", str(_HOME / "messages")))
+_TOKEN_DIR: Path = _MESSAGES_DIR / "config" / "gmail-tokens"
+_GMAIL_CONFIG_PATH: Path = _MESSAGES_DIR / "config" / "gmail-config.json"
+
+# File permissions: owner read+write only (octal 0o600)
+_TOKEN_FILE_MODE: int = stat.S_IRUSR | stat.S_IWUSR
+
+# HTTP timeout for refresh proxy calls (seconds)
+_HTTP_TIMEOUT: int = 10
+
+# Default refresh proxy base URL (GCP secrets live here)
+_DEFAULT_API_BASE: str = "https://myownlobster.ai"
+_REFRESH_ENDPOINT: str = "/api/internal/refresh-gmail-token"
+
+
+# ---------------------------------------------------------------------------
+# Gmail config loader
+# ---------------------------------------------------------------------------
+
+
+def _load_gmail_config() -> dict:
+    """Return the parsed gmail-config.json, or an empty dict if absent.
+
+    Pure-ish function: reads one file; returns a stable default on error.
+    """
+    if not _GMAIL_CONFIG_PATH.exists():
+        return {}
+    try:
+        return json.loads(_GMAIL_CONFIG_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning("Failed to parse gmail-config.json: %s", exc)
+        return {}
+
+
+def _myownlobster_api_base() -> str:
+    """Return the myownlobster API base URL from config, or the default."""
+    config = _load_gmail_config()
+    return config.get("myownlobster_api_base", _DEFAULT_API_BASE).rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Auth header helper
+# ---------------------------------------------------------------------------
+
+
+def _internal_auth_header() -> dict[str, str]:
+    """Return the Authorization header for internal API calls.
+
+    Reads LOBSTER_INTERNAL_SECRET from the environment.
+
+    Raises:
+        RuntimeError: If LOBSTER_INTERNAL_SECRET is not set.
+    """
+    secret = os.environ.get("LOBSTER_INTERNAL_SECRET", "").strip()
+    if not secret:
+        raise RuntimeError(
+            "LOBSTER_INTERNAL_SECRET is not set. "
+            "Add it to config.env to enable token refresh via myownlobster."
+        )
+    return {"Authorization": f"Bearer {secret}"}
+
+
+# ---------------------------------------------------------------------------
+# Serialisation helpers (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def _token_to_dict(token: TokenData) -> dict:
+    """Convert a TokenData to a JSON-serialisable dict."""
+    return {
+        "access_token": token.access_token,
+        "expires_at": token.expires_at.isoformat(),
+        "scope": token.scope,
+        "refresh_token": token.refresh_token,
+    }
+
+
+def _dict_to_token(data: dict) -> TokenData:
+    """Reconstruct a TokenData from a deserialised JSON dict."""
+    expires_at = datetime.fromisoformat(data["expires_at"])
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return TokenData(
+        access_token=data["access_token"],
+        expires_at=expires_at,
+        scope=data.get("scope", ""),
+        refresh_token=data.get("refresh_token"),
+    )
+
+
+def _token_path(user_id: str, token_dir: Path = _TOKEN_DIR) -> Path:
+    """Return the absolute path to a user's Gmail token file.
+
+    Pure function: no filesystem access.
+
+    Args:
+        user_id:   Telegram chat_id as a string.
+        token_dir: Directory holding per-user token files.
+
+    Returns:
+        Absolute Path to ``{token_dir}/{safe_user_id}.json``.
+
+    Raises:
+        ValueError: If the sanitised user_id would produce an empty filename.
+    """
+    safe_id = "".join(c for c in user_id if c.isalnum() or c in ("-", "_"))
+    if not safe_id:
+        raise ValueError(
+            f"user_id {user_id!r} produces an empty filename after sanitisation"
+        )
+    return token_dir / f"{safe_id}.json"
+
+
+# ---------------------------------------------------------------------------
+# Local file I/O (side-effecting)
+# ---------------------------------------------------------------------------
+
+
+def _save_token_local(
+    user_id: str,
+    token: TokenData,
+    token_dir: Path = _TOKEN_DIR,
+) -> None:
+    """Persist a user's Gmail OAuth token to a local JSON file (mode 0o600).
+
+    Uses an atomic write (write to .tmp, then rename) to avoid corruption
+    if the process is interrupted mid-write.
+
+    Args:
+        user_id:   Unique identifier for the user.
+        token:     TokenData to persist.
+        token_dir: Directory for token files.
+    """
+    token_dir.mkdir(parents=True, exist_ok=True)
+    path = _token_path(user_id, token_dir)
+    payload = json.dumps(_token_to_dict(token), indent=2)
+    tmp_path = path.with_suffix(".json.tmp")
+    try:
+        fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _TOKEN_FILE_MODE)
+        with os.fdopen(fd, "w") as f:
+            f.write(payload)
+        os.rename(str(tmp_path), str(path))
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+    log.info("Gmail token saved locally for user_id=%r at %s", user_id, path)
+
+
+def _load_token_local(
+    user_id: str,
+    token_dir: Path = _TOKEN_DIR,
+) -> Optional[TokenData]:
+    """Load a user's Gmail token from the local JSON file.
+
+    Args:
+        user_id:   Unique identifier for the user.
+        token_dir: Directory for token files.
+
+    Returns:
+        TokenData if the file exists and is valid JSON, else None.
+    """
+    path = _token_path(user_id, token_dir)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return _dict_to_token(data)
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        log.warning("Failed to parse local Gmail token for user_id=%r: %s", user_id, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Refresh proxy (calls myownlobster.ai — side-effecting)
+# ---------------------------------------------------------------------------
+
+
+def _refresh_token_via_proxy(refresh_token: str) -> Optional[TokenData]:
+    """Obtain a new Gmail access token by calling the myownlobster refresh proxy.
+
+    myownlobster.ai holds the GCP client_id + client_secret and proxies the
+    refresh call to Google, returning only the new access_token and expires_in.
+
+    Args:
+        refresh_token: The long-lived refresh token.
+
+    Returns:
+        A new TokenData (refresh_token preserved from caller), or None on error.
+    """
+    api_base = _myownlobster_api_base()
+    url = f"{api_base}{_REFRESH_ENDPOINT}"
+
+    try:
+        headers = _internal_auth_header()
+    except RuntimeError as exc:
+        log.error("Gmail token refresh proxy: %s", exc)
+        return None
+
+    try:
+        resp = requests.post(
+            url,
+            json={"refresh_token": refresh_token},
+            headers=headers,
+            timeout=_HTTP_TIMEOUT,
+        )
+    except requests.exceptions.RequestException as exc:
+        log.warning("Gmail token refresh proxy unreachable: %s", exc)
+        return None
+
+    if not resp.ok:
+        log.warning(
+            "Gmail token refresh proxy returned %d: %s",
+            resp.status_code,
+            resp.text[:200],
+        )
+        return None
+
+    try:
+        data = resp.json()
+        access_token = data["access_token"]
+        expires_in = int(data["expires_in"])
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        log.warning("Gmail token refresh proxy returned unexpected payload: %s", exc)
+        return None
+
+    expires_at = datetime.now(tz=timezone.utc) + timedelta(seconds=expires_in)
+
+    log.info("Gmail token refresh via proxy succeeded.")
+    return TokenData(
+        access_token=access_token,
+        expires_at=expires_at,
+        scope="",  # scope not returned by refresh proxy; preserved from disk
+        refresh_token=None,  # caller must preserve the original refresh_token
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def save_token(
+    user_id: str,
+    token: TokenData,
+    token_dir: Path = _TOKEN_DIR,
+) -> None:
+    """Persist a user's Gmail OAuth token to local disk.
+
+    This is the sole write path. The local file is the canonical store.
+
+    Args:
+        user_id:   Unique identifier for the user (Telegram chat_id as str).
+        token:     TokenData to persist.
+        token_dir: Local token directory (injectable for testing).
+    """
+    _save_token_local(user_id, token, token_dir)
+
+
+def load_token(
+    user_id: str,
+    token_dir: Path = _TOKEN_DIR,
+) -> Optional[TokenData]:
+    """Load a user's Gmail OAuth token from local disk.
+
+    Args:
+        user_id:   Unique identifier for the user.
+        token_dir: Local token directory (injectable for testing).
+
+    Returns:
+        TokenData if the file exists and is parseable, else None.
+    """
+    return _load_token_local(user_id, token_dir)
+
+
+def get_valid_token(
+    user_id: str,
+    token_dir: Path = _TOKEN_DIR,
+) -> Optional[TokenData]:
+    """Return a valid Gmail access token for the user, refreshing if necessary.
+
+    Workflow:
+    1. Load token from local disk.
+    2. If no token -> return None (user must authenticate via consent link).
+    3. If token is still valid -> return it.
+    4. If token is expired -> call myownlobster refresh proxy.
+    5. Persist the refreshed token (preserving the original refresh_token).
+    6. If refresh fails -> log and return None.
+
+    Args:
+        user_id:   Unique identifier for the user (Telegram chat_id as str).
+        token_dir: Local token directory (injectable for testing).
+
+    Returns:
+        A valid TokenData, or None if no valid token is available.
+    """
+    token = _load_token_local(user_id, token_dir)
+    if token is None:
+        log.info("No local Gmail token found for user_id=%r.", user_id)
+        return None
+
+    if is_token_valid(token):
+        return token
+
+    # Token is expired — attempt refresh via myownlobster proxy
+    if token.refresh_token is None:
+        log.warning(
+            "Gmail token for user_id=%r is expired and has no refresh_token; "
+            "user must re-authenticate.",
+            user_id,
+        )
+        return None
+
+    log.info("Gmail access token expired for user_id=%r — refreshing via proxy.", user_id)
+
+    refreshed_partial = _refresh_token_via_proxy(token.refresh_token)
+    if refreshed_partial is None:
+        log.error(
+            "Gmail token refresh failed for user_id=%r — user must re-authenticate.",
+            user_id,
+        )
+        return None
+
+    # Merge: preserve scope and refresh_token from the stored token
+    refreshed = TokenData(
+        access_token=refreshed_partial.access_token,
+        expires_at=refreshed_partial.expires_at,
+        scope=token.scope,           # preserve original scope
+        refresh_token=token.refresh_token,  # Google doesn't return new refresh_token here
+    )
+
+    _save_token_local(user_id, refreshed, token_dir)
+    return refreshed

--- a/tests/unit/test_integrations/test_gmail_client.py
+++ b/tests/unit/test_integrations/test_gmail_client.py
@@ -1,0 +1,372 @@
+"""
+Unit tests for src/integrations/gmail/client.py (BIS-256).
+
+All HTTP and token I/O is mocked.  Tests verify the public API contract:
+- get_recent_emails returns EmailMessage list on success, [] on failure
+- search_emails returns EmailMessage list on success, [] on failure
+- Pure helpers (_parse_header, _parse_date_header, _parse_message) are tested
+  independently to verify correctness without network calls.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.gmail import client as gc
+from integrations.gmail.client import (
+    EmailMessage,
+    GmailAPIError,
+    _auth_header,
+    _parse_date_header,
+    _parse_header,
+    _parse_message,
+    get_recent_emails,
+    search_emails,
+)
+from integrations.google_calendar.oauth import TokenData
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FUTURE = datetime.now(tz=timezone.utc) + timedelta(hours=2)
+
+_VALID_TOKEN = TokenData(
+    access_token="test-access-token",
+    expires_at=_FUTURE,
+    scope="https://mail.google.com/",
+    refresh_token="refresh-tok",
+)
+
+_SAMPLE_HEADERS = [
+    {"name": "Subject", "value": "Hello World"},
+    {"name": "From", "value": "Alice <alice@example.com>"},
+    {"name": "Date", "value": "Wed, 1 Apr 2026 14:30:00 +0000"},
+]
+
+_SAMPLE_RAW_MESSAGE = {
+    "id": "msg1",
+    "threadId": "thread1",
+    "snippet": "Hello there, this is a snippet",
+    "labelIds": ["INBOX", "UNREAD"],
+    "payload": {
+        "headers": _SAMPLE_HEADERS,
+    },
+}
+
+_SAMPLE_LIST_RESPONSE = {
+    "messages": [{"id": "msg1"}, {"id": "msg2"}],
+}
+
+
+# ---------------------------------------------------------------------------
+# _parse_header — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestParseHeader:
+    def test_finds_subject(self):
+        val = _parse_header(_SAMPLE_HEADERS, "Subject")
+        assert val == "Hello World"
+
+    def test_case_insensitive(self):
+        val = _parse_header(_SAMPLE_HEADERS, "subject")
+        assert val == "Hello World"
+
+    def test_returns_empty_when_absent(self):
+        val = _parse_header(_SAMPLE_HEADERS, "X-Missing")
+        assert val == ""
+
+    def test_empty_headers_list(self):
+        val = _parse_header([], "Subject")
+        assert val == ""
+
+
+# ---------------------------------------------------------------------------
+# _parse_date_header — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestParseDateHeader:
+    def test_parses_rfc2822_date(self):
+        dt = _parse_date_header("Wed, 1 Apr 2026 14:30:00 +0000")
+        assert dt.year == 2026
+        assert dt.month == 4
+        assert dt.day == 1
+        assert dt.tzinfo is not None
+
+    def test_returns_utc_datetime_on_empty(self):
+        dt = _parse_date_header("")
+        assert dt.tzinfo is not None
+
+    def test_returns_utc_datetime_on_garbage(self):
+        dt = _parse_date_header("not a date at all")
+        assert dt.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# _parse_message — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestParseMessage:
+    def test_parses_subject(self):
+        msg = _parse_message(_SAMPLE_RAW_MESSAGE)
+        assert msg.subject == "Hello World"
+
+    def test_parses_sender(self):
+        msg = _parse_message(_SAMPLE_RAW_MESSAGE)
+        assert "alice@example.com" in msg.sender
+
+    def test_parses_snippet(self):
+        msg = _parse_message(_SAMPLE_RAW_MESSAGE)
+        assert msg.snippet == "Hello there, this is a snippet"
+
+    def test_parses_labels(self):
+        msg = _parse_message(_SAMPLE_RAW_MESSAGE)
+        assert "INBOX" in msg.labels
+        assert "UNREAD" in msg.labels
+
+    def test_parses_id_and_thread_id(self):
+        msg = _parse_message(_SAMPLE_RAW_MESSAGE)
+        assert msg.id == "msg1"
+        assert msg.thread_id == "thread1"
+
+    def test_missing_optional_fields_default_to_empty(self):
+        msg = _parse_message({"id": "x", "threadId": "t"})
+        assert msg.subject == ""
+        assert msg.sender == ""
+        assert msg.snippet == ""
+        assert msg.labels == ()
+
+    def test_is_frozen_dataclass(self):
+        msg = _parse_message(_SAMPLE_RAW_MESSAGE)
+        with pytest.raises((AttributeError, TypeError)):
+            msg.subject = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# _auth_header — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestAuthHeader:
+    def test_returns_bearer_header(self):
+        h = _auth_header("my-token")
+        assert h == {"Authorization": "Bearer my-token"}
+
+
+# ---------------------------------------------------------------------------
+# GmailAPIError
+# ---------------------------------------------------------------------------
+
+
+class TestGmailAPIError:
+    def test_contains_status_code(self):
+        err = GmailAPIError(403, "Forbidden")
+        assert "403" in str(err)
+        assert "Forbidden" in str(err)
+
+    def test_no_summary_still_valid(self):
+        err = GmailAPIError(500)
+        assert "500" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# get_recent_emails
+# ---------------------------------------------------------------------------
+
+
+def _mock_get_token_valid(user_id, token_dir=None):
+    return _VALID_TOKEN
+
+
+def _mock_get_token_none(user_id, token_dir=None):
+    return None
+
+
+class TestGetRecentEmails:
+    def test_returns_empty_when_no_token(self, tmp_path):
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_none,
+        ):
+            result = get_recent_emails("999", token_dir=tmp_path)
+        assert result == []
+
+    def test_returns_messages_on_success(self, tmp_path):
+        def mock_api_call(method, url, token, **kwargs):
+            if "messages" in url and "/" not in url.split("messages")[-1].lstrip("/"):
+                # List call
+                return _SAMPLE_LIST_RESPONSE
+            else:
+                # Individual message fetch
+                msg_id = url.rstrip("/").split("/")[-1]
+                raw = dict(_SAMPLE_RAW_MESSAGE)
+                raw["id"] = msg_id
+                return raw
+
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            side_effect=mock_api_call,
+        ):
+            result = get_recent_emails("123", token_dir=tmp_path)
+
+        assert len(result) == 2
+        assert all(isinstance(m, EmailMessage) for m in result)
+
+    def test_returns_empty_on_api_error(self, tmp_path):
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            side_effect=GmailAPIError(403, "Forbidden"),
+        ):
+            result = get_recent_emails("123", token_dir=tmp_path)
+        assert result == []
+
+    def test_returns_empty_on_network_error(self, tmp_path):
+        import requests as req_lib
+
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            side_effect=req_lib.exceptions.ConnectionError("refused"),
+        ):
+            result = get_recent_emails("123", token_dir=tmp_path)
+        assert result == []
+
+    def test_returns_empty_when_inbox_is_empty(self, tmp_path):
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            return_value={"messages": []},
+        ):
+            result = get_recent_emails("123", token_dir=tmp_path)
+        assert result == []
+
+    def test_skips_failed_individual_message(self, tmp_path):
+        """If one message fetch fails, others should still be returned."""
+        call_count = [0]
+
+        def selective_fail(method, url, token, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # List call succeeds
+                return {"messages": [{"id": "good"}, {"id": "bad"}]}
+            elif "good" in url:
+                return dict(_SAMPLE_RAW_MESSAGE, id="good")
+            else:
+                raise GmailAPIError(500, "Server error")
+
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            side_effect=selective_fail,
+        ):
+            result = get_recent_emails("123", token_dir=tmp_path)
+
+        # Should get 1 successful message even though 1 failed
+        assert len(result) == 1
+        assert result[0].id == "good"
+
+    def test_respects_max_results_param(self, tmp_path):
+        """max_results must be forwarded to the list API call."""
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            return_value={"messages": []},
+        ) as mock_call:
+            get_recent_emails("123", max_results=3, token_dir=tmp_path)
+
+        params = mock_call.call_args.kwargs.get("params", {})
+        assert params.get("maxResults") == 3
+
+
+# ---------------------------------------------------------------------------
+# search_emails
+# ---------------------------------------------------------------------------
+
+
+class TestSearchEmails:
+    def test_returns_empty_when_no_token(self, tmp_path):
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_none,
+        ):
+            result = search_emails("999", "from:boss@example.com", token_dir=tmp_path)
+        assert result == []
+
+    def test_returns_messages_on_success(self, tmp_path):
+        def mock_api_call(method, url, token, **kwargs):
+            if "messages" in url and kwargs.get("params", {}).get("q"):
+                return {"messages": [{"id": "m1"}]}
+            else:
+                return dict(_SAMPLE_RAW_MESSAGE, id="m1")
+
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            side_effect=mock_api_call,
+        ):
+            result = search_emails("123", "from:alice@example.com", token_dir=tmp_path)
+
+        assert len(result) == 1
+        assert isinstance(result[0], EmailMessage)
+
+    def test_forwards_query_param(self, tmp_path):
+        """The search query must be passed as the 'q' parameter."""
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            return_value={"messages": []},
+        ) as mock_call:
+            search_emails("123", "subject:invoice", token_dir=tmp_path)
+
+        params = mock_call.call_args.kwargs.get("params", {})
+        assert params.get("q") == "subject:invoice"
+
+    def test_returns_empty_when_no_results(self, tmp_path):
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            return_value={"messages": []},
+        ):
+            result = search_emails("123", "from:nobody@x.com", token_dir=tmp_path)
+        assert result == []
+
+    def test_returns_empty_on_api_error(self, tmp_path):
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            side_effect=GmailAPIError(401, "Unauthorized"),
+        ):
+            result = search_emails("123", "anything", token_dir=tmp_path)
+        assert result == []

--- a/tests/unit/test_integrations/test_gmail_skill_consent_behavior.py
+++ b/tests/unit/test_integrations/test_gmail_skill_consent_behavior.py
@@ -1,0 +1,341 @@
+"""
+Tests for the gmail skill's consent-link auth trigger behavior (BIS-256).
+
+These tests verify the Python logic pattern prescribed in
+``lobster-shop/gmail/behavior/system.md`` for the "connect my Gmail" intent.
+The pattern is:
+
+1. Call ``generate_consent_link("gmail")``; on success, send the user the
+   myownlobster.ai consent URL.
+2. On any exception (RuntimeError from missing env vars, network failure, etc.),
+   fall back gracefully with a user-friendly message — never surface the error
+   to the user.
+3. The scope passed to generate_consent_link must be "gmail", not "calendar".
+
+The tests import the real ``generate_consent_link`` function with HTTP and
+env-var I/O mocked out, verifying real integration points without live services.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pathlib import Path
+
+# Make src importable without installing the package
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.google_auth.consent import generate_consent_link
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_FAKE_INSTANCE_URL = "https://vps.example.com"
+_FAKE_SECRET = "test-internal-secret-abc123"
+_FAKE_CONSENT_URL = "https://myownlobster.ai/connect/gmail?token=abc123"
+_ENV = {
+    "LOBSTER_INSTANCE_URL": _FAKE_INSTANCE_URL,
+    "LOBSTER_INTERNAL_SECRET": _FAKE_SECRET,
+}
+
+
+def _mock_consent_response(url: str = _FAKE_CONSENT_URL) -> MagicMock:
+    resp = MagicMock()
+    resp.ok = True
+    resp.status_code = 200
+    resp.json.return_value = {"url": url}
+    resp.text = f'{{"url": "{url}"}}'
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Helper: the exact auth-trigger logic from behavior/system.md
+# (extracted as a pure function so we can test it without a full dispatcher)
+# ---------------------------------------------------------------------------
+
+
+def _handle_connect_gmail() -> tuple[str, list[str]]:
+    """
+    Replicate the auth-trigger code block from behavior/system.md as a
+    plain function.
+
+    Returns:
+        (reply_text, warning_messages) — warning_messages is empty on success.
+    """
+    import logging
+
+    warnings: list[str] = []
+    log = logging.getLogger(__name__)
+
+    try:
+        url = generate_consent_link("gmail")
+        reply = (
+            "To connect your Gmail, tap this link (expires in 30 minutes):\n"
+            f"[Connect Gmail]({url})\n\n"
+            "After connecting, I'll be able to read and search your emails."
+        )
+    except Exception as exc:
+        msg = f"generate_consent_link('gmail') failed — degrading gracefully: {exc}"
+        log.warning(msg)
+        warnings.append(msg)
+        reply = (
+            "I couldn't generate a Gmail connection link right now. "
+            "Please try again in a few minutes."
+        )
+
+    return reply, warnings
+
+
+# ---------------------------------------------------------------------------
+# Happy path: generate_consent_link succeeds
+# ---------------------------------------------------------------------------
+
+
+class TestAuthTriggerHappyPath:
+    def test_reply_contains_myownlobster_url(self):
+        """When generate_consent_link succeeds, the reply contains the consent URL."""
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_consent_response(),
+        ):
+            reply, warnings = _handle_connect_gmail()
+
+        assert _FAKE_CONSENT_URL in reply
+        assert warnings == []
+
+    def test_reply_contains_connect_gmail_link_text(self):
+        """Reply uses the expected link label for mobile readability."""
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_consent_response(),
+        ):
+            reply, _ = _handle_connect_gmail()
+
+        assert "Connect Gmail" in reply
+
+    def test_reply_mentions_expiry(self):
+        """Reply tells the user the link expires so they know to act promptly."""
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_consent_response(),
+        ):
+            reply, _ = _handle_connect_gmail()
+
+        assert "30 minutes" in reply
+
+    def test_reply_does_not_mention_fallback_language(self):
+        """On success, the reply should not mention fallback language."""
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_consent_response(),
+        ):
+            reply, _ = _handle_connect_gmail()
+
+        assert "couldn't generate" not in reply.lower()
+
+    def test_consent_url_contains_gmail_scope(self):
+        """The returned URL must point to the gmail consent path."""
+        url = "https://myownlobster.ai/connect/gmail?token=xyz"
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_consent_response(url=url),
+        ):
+            reply, _ = _handle_connect_gmail()
+
+        assert "myownlobster.ai/connect/gmail" in reply
+        assert "token=" in reply
+
+
+# ---------------------------------------------------------------------------
+# Fallback: generate_consent_link raises RuntimeError (missing env vars)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthTriggerFallbackMissingEnv:
+    def test_fallback_when_instance_url_missing(self):
+        """Missing LOBSTER_INSTANCE_URL → graceful fallback, no user-facing error."""
+        env = {"LOBSTER_INTERNAL_SECRET": _FAKE_SECRET}
+        with patch.dict("os.environ", env, clear=True):
+            reply, warnings = _handle_connect_gmail()
+
+        assert "couldn't generate" in reply.lower()
+        assert len(warnings) == 1
+
+    def test_fallback_when_secret_missing(self):
+        """Missing LOBSTER_INTERNAL_SECRET → graceful fallback."""
+        env = {"LOBSTER_INSTANCE_URL": _FAKE_INSTANCE_URL}
+        with patch.dict("os.environ", env, clear=True):
+            reply, warnings = _handle_connect_gmail()
+
+        assert "couldn't generate" in reply.lower()
+        assert len(warnings) == 1
+
+    def test_fallback_when_both_env_vars_missing(self):
+        """Both env vars missing → graceful fallback."""
+        with patch.dict("os.environ", {}, clear=True):
+            reply, warnings = _handle_connect_gmail()
+
+        assert "couldn't generate" in reply.lower()
+        assert len(warnings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Fallback: generate_consent_link raises due to network error
+# ---------------------------------------------------------------------------
+
+
+class TestAuthTriggerFallbackNetworkError:
+    def test_fallback_on_connection_error(self):
+        """Network failure → graceful fallback, no error surfaced to user."""
+        import requests as req_lib
+
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            side_effect=req_lib.exceptions.ConnectionError("connection refused"),
+        ):
+            reply, warnings = _handle_connect_gmail()
+
+        assert "couldn't generate" in reply.lower()
+        assert len(warnings) == 1
+
+    def test_fallback_on_timeout(self):
+        """Timeout → graceful fallback."""
+        import requests as req_lib
+
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            side_effect=req_lib.exceptions.Timeout("timed out"),
+        ):
+            reply, warnings = _handle_connect_gmail()
+
+        assert "couldn't generate" in reply.lower()
+
+    def test_fallback_on_http_500(self):
+        """Server error from myownlobster.ai → graceful fallback."""
+        error_resp = MagicMock()
+        error_resp.ok = False
+        error_resp.status_code = 500
+        error_resp.text = "Internal Server Error"
+
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=error_resp,
+        ):
+            reply, warnings = _handle_connect_gmail()
+
+        assert "couldn't generate" in reply.lower()
+
+
+# ---------------------------------------------------------------------------
+# Fallback reply must not expose internal error details
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackReplyIsUserFriendly:
+    def test_env_var_names_not_surfaced(self):
+        """Fallback reply must not contain env var names."""
+        with patch.dict("os.environ", {}, clear=True):
+            reply, _ = _handle_connect_gmail()
+
+        assert "LOBSTER_INSTANCE_URL" not in reply
+        assert "LOBSTER_INTERNAL_SECRET" not in reply
+        assert "RuntimeError" not in reply
+        assert "Missing required" not in reply
+
+    def test_network_error_details_not_surfaced(self):
+        """Network error details must not leak into the reply text."""
+        import requests as req_lib
+
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            side_effect=req_lib.exceptions.ConnectionError("connection refused"),
+        ):
+            reply, _ = _handle_connect_gmail()
+
+        assert "connection refused" not in reply
+        assert "ConnectionError" not in reply
+
+
+# ---------------------------------------------------------------------------
+# Scope isolation: gmail skill uses "gmail" scope, not "calendar"
+# ---------------------------------------------------------------------------
+
+
+class TestConsentLinkScope:
+    def test_requests_gmail_scope(self):
+        """The auth trigger must call generate_consent_link with scope='gmail'."""
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_consent_response(),
+        ) as mock_post:
+            _handle_connect_gmail()
+
+        call_json = mock_post.call_args.kwargs["json"]
+        assert call_json["scope"] == "gmail"
+
+    def test_calendar_scope_not_used(self):
+        """The Gmail auth trigger must not request calendar scope."""
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_consent_response(),
+        ) as mock_post:
+            _handle_connect_gmail()
+
+        call_json = mock_post.call_args.kwargs["json"]
+        assert call_json["scope"] != "calendar"
+
+
+# ---------------------------------------------------------------------------
+# Warning logged on fallback (without leaking secrets)
+# ---------------------------------------------------------------------------
+
+
+class TestWarningLogging:
+    def test_warning_logged_on_fallback(self, caplog):
+        """A warning must be logged when generate_consent_link fails."""
+        with caplog.at_level(logging.WARNING):
+            with patch.dict("os.environ", {}, clear=True):
+                _handle_connect_gmail()
+
+        warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warning_messages) >= 1
+
+    def test_secret_not_in_warning_log(self, caplog):
+        """The internal secret must not appear in any log record."""
+        import requests as req_lib
+
+        with caplog.at_level(logging.DEBUG):
+            with patch.dict("os.environ", _ENV), patch(
+                "integrations.google_auth.consent.requests.post",
+                side_effect=req_lib.exceptions.ConnectionError("conn fail"),
+            ):
+                _handle_connect_gmail()
+
+        for record in caplog.records:
+            assert _FAKE_SECRET not in record.getMessage()
+
+
+# ---------------------------------------------------------------------------
+# Calendar skill consent behavior is unaffected by gmail skill
+# ---------------------------------------------------------------------------
+
+
+class TestCalendarSkillUnaffected:
+    """Verify that the gmail and calendar consent paths are independent."""
+
+    def test_gmail_consent_link_uses_gmail_path(self):
+        """Gmail consent link should point to /connect/gmail."""
+        url = "https://myownlobster.ai/connect/gmail?token=abc"
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_consent_response(url=url),
+        ):
+            reply, _ = _handle_connect_gmail()
+
+        assert "/connect/gmail" in reply
+        assert "/connect/calendar" not in reply

--- a/tests/unit/test_integrations/test_gmail_token_store.py
+++ b/tests/unit/test_integrations/test_gmail_token_store.py
@@ -1,0 +1,337 @@
+"""
+Unit tests for src/integrations/gmail/token_store.py (BIS-256).
+
+These tests mirror the structure of test_google_calendar_token_store.py,
+adapted for the Gmail token store.  All file I/O and HTTP are mocked.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make src importable without installing the package
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.google_calendar.oauth import TokenData
+from integrations.gmail import token_store as ts
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+_FUTURE = datetime.now(tz=timezone.utc) + timedelta(hours=2)
+_EXPIRED = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+
+_VALID_TOKEN = TokenData(
+    access_token="valid-access-token",
+    expires_at=_FUTURE,
+    scope="https://mail.google.com/",
+    refresh_token="refresh-token-abc",
+)
+
+_EXPIRED_TOKEN = TokenData(
+    access_token="expired-access-token",
+    expires_at=_EXPIRED,
+    scope="https://mail.google.com/",
+    refresh_token="refresh-token-xyz",
+)
+
+
+# ---------------------------------------------------------------------------
+# _token_path — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestTokenPath:
+    def test_basic_user_id(self, tmp_path):
+        path = ts._token_path("12345", tmp_path)
+        assert path == tmp_path / "12345.json"
+
+    def test_sanitises_special_chars(self, tmp_path):
+        path = ts._token_path("../evil", tmp_path)
+        assert "/" not in path.name
+        assert ".." not in path.name
+
+    def test_empty_after_sanitise_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            ts._token_path("!@#$%", tmp_path)
+
+    def test_hyphen_and_underscore_preserved(self, tmp_path):
+        path = ts._token_path("user-123_abc", tmp_path)
+        assert path.name == "user-123_abc.json"
+
+
+# ---------------------------------------------------------------------------
+# _token_to_dict / _dict_to_token — pure serialisation round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSerialisation:
+    def test_round_trip_preserves_all_fields(self):
+        d = ts._token_to_dict(_VALID_TOKEN)
+        restored = ts._dict_to_token(d)
+        assert restored.access_token == _VALID_TOKEN.access_token
+        assert restored.refresh_token == _VALID_TOKEN.refresh_token
+        assert restored.scope == _VALID_TOKEN.scope
+        # expires_at round-trips through isoformat
+        assert restored.expires_at == _VALID_TOKEN.expires_at
+
+    def test_round_trip_with_null_refresh_token(self):
+        token = TokenData(
+            access_token="tok",
+            expires_at=_FUTURE,
+            scope="",
+            refresh_token=None,
+        )
+        d = ts._token_to_dict(token)
+        restored = ts._dict_to_token(d)
+        assert restored.refresh_token is None
+
+    def test_naive_datetime_gets_utc_tzinfo(self):
+        data = {
+            "access_token": "tok",
+            "expires_at": "2026-01-01T12:00:00",  # no tzinfo
+            "scope": "",
+            "refresh_token": None,
+        }
+        token = ts._dict_to_token(data)
+        assert token.expires_at.tzinfo == timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# _save_token_local / _load_token_local — file I/O
+# ---------------------------------------------------------------------------
+
+
+class TestSaveLoadLocal:
+    def test_save_creates_file(self, tmp_path):
+        ts._save_token_local("99", _VALID_TOKEN, tmp_path)
+        assert (tmp_path / "99.json").exists()
+
+    def test_save_sets_mode_0600(self, tmp_path):
+        ts._save_token_local("99", _VALID_TOKEN, tmp_path)
+        mode = (tmp_path / "99.json").stat().st_mode
+        assert mode & 0o777 == stat.S_IRUSR | stat.S_IWUSR
+
+    def test_load_returns_none_when_file_absent(self, tmp_path):
+        result = ts._load_token_local("nonexistent", tmp_path)
+        assert result is None
+
+    def test_load_returns_token_after_save(self, tmp_path):
+        ts._save_token_local("42", _VALID_TOKEN, tmp_path)
+        loaded = ts._load_token_local("42", tmp_path)
+        assert loaded is not None
+        assert loaded.access_token == _VALID_TOKEN.access_token
+
+    def test_load_returns_none_on_corrupted_json(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text("not json", encoding="utf-8")
+        # Rename to match user_id "bad"
+        result = ts._load_token_local("bad", tmp_path)
+        assert result is None
+
+    def test_save_creates_parent_dirs(self, tmp_path):
+        deep = tmp_path / "a" / "b" / "c"
+        ts._save_token_local("x", _VALID_TOKEN, deep)
+        assert (deep / "x.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# _refresh_token_via_proxy — HTTP side-effecting boundary
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshTokenViaProxy:
+    def _mock_success_response(self) -> MagicMock:
+        resp = MagicMock()
+        resp.ok = True
+        resp.status_code = 200
+        resp.json.return_value = {
+            "access_token": "new-access-token",
+            "expires_in": 3600,
+        }
+        return resp
+
+    def test_returns_new_token_on_success(self):
+        with patch.dict(
+            "os.environ",
+            {"LOBSTER_INTERNAL_SECRET": "secret"},
+        ), patch(
+            "integrations.gmail.token_store.requests.post",
+            return_value=self._mock_success_response(),
+        ):
+            result = ts._refresh_token_via_proxy("refresh-tok")
+
+        assert result is not None
+        assert result.access_token == "new-access-token"
+        assert result.expires_at > datetime.now(tz=timezone.utc)
+
+    def test_returns_none_when_secret_missing(self):
+        with patch.dict("os.environ", {}, clear=True):
+            result = ts._refresh_token_via_proxy("refresh-tok")
+        assert result is None
+
+    def test_returns_none_on_network_error(self):
+        import requests as req_lib
+
+        with patch.dict("os.environ", {"LOBSTER_INTERNAL_SECRET": "secret"}), patch(
+            "integrations.gmail.token_store.requests.post",
+            side_effect=req_lib.exceptions.ConnectionError("refused"),
+        ):
+            result = ts._refresh_token_via_proxy("refresh-tok")
+        assert result is None
+
+    def test_returns_none_on_non_ok_response(self):
+        bad = MagicMock()
+        bad.ok = False
+        bad.status_code = 500
+        bad.text = "Internal Server Error"
+        with patch.dict("os.environ", {"LOBSTER_INTERNAL_SECRET": "secret"}), patch(
+            "integrations.gmail.token_store.requests.post",
+            return_value=bad,
+        ):
+            result = ts._refresh_token_via_proxy("refresh-tok")
+        assert result is None
+
+    def test_returns_none_on_bad_json(self):
+        resp = MagicMock()
+        resp.ok = True
+        resp.json.return_value = {"unexpected": "keys"}
+        with patch.dict("os.environ", {"LOBSTER_INTERNAL_SECRET": "secret"}), patch(
+            "integrations.gmail.token_store.requests.post",
+            return_value=resp,
+        ):
+            result = ts._refresh_token_via_proxy("refresh-tok")
+        assert result is None
+
+    def test_uses_gmail_refresh_endpoint(self):
+        """Refresh must call the gmail-specific endpoint, not the calendar one."""
+        with patch.dict("os.environ", {"LOBSTER_INTERNAL_SECRET": "secret"}), patch(
+            "integrations.gmail.token_store.requests.post",
+            return_value=self._mock_success_response(),
+        ) as mock_post:
+            ts._refresh_token_via_proxy("refresh-tok")
+
+        called_url = mock_post.call_args.args[0]
+        assert "gmail" in called_url
+        assert "calendar" not in called_url
+
+
+# ---------------------------------------------------------------------------
+# get_valid_token — composition of load + check + refresh
+# ---------------------------------------------------------------------------
+
+
+class TestGetValidToken:
+    def test_returns_none_when_no_token(self, tmp_path):
+        result = ts.get_valid_token("unknown", token_dir=tmp_path)
+        assert result is None
+
+    def test_returns_valid_token_directly(self, tmp_path):
+        ts._save_token_local("u1", _VALID_TOKEN, tmp_path)
+        result = ts.get_valid_token("u1", token_dir=tmp_path)
+        assert result is not None
+        assert result.access_token == _VALID_TOKEN.access_token
+
+    def test_refreshes_expired_token(self, tmp_path):
+        ts._save_token_local("u2", _EXPIRED_TOKEN, tmp_path)
+
+        refreshed_partial = TokenData(
+            access_token="refreshed-access",
+            expires_at=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+            scope="",
+            refresh_token=None,
+        )
+
+        with patch.dict("os.environ", {"LOBSTER_INTERNAL_SECRET": "secret"}), patch(
+            "integrations.gmail.token_store._refresh_token_via_proxy",
+            return_value=refreshed_partial,
+        ):
+            result = ts.get_valid_token("u2", token_dir=tmp_path)
+
+        assert result is not None
+        assert result.access_token == "refreshed-access"
+        # refresh_token preserved from original
+        assert result.refresh_token == _EXPIRED_TOKEN.refresh_token
+
+    def test_returns_none_when_expired_no_refresh_token(self, tmp_path):
+        expired_no_rt = TokenData(
+            access_token="expired",
+            expires_at=_EXPIRED,
+            scope="",
+            refresh_token=None,
+        )
+        ts._save_token_local("u3", expired_no_rt, tmp_path)
+        result = ts.get_valid_token("u3", token_dir=tmp_path)
+        assert result is None
+
+    def test_returns_none_when_refresh_fails(self, tmp_path):
+        ts._save_token_local("u4", _EXPIRED_TOKEN, tmp_path)
+        with patch.dict("os.environ", {"LOBSTER_INTERNAL_SECRET": "secret"}), patch(
+            "integrations.gmail.token_store._refresh_token_via_proxy",
+            return_value=None,
+        ):
+            result = ts.get_valid_token("u4", token_dir=tmp_path)
+        assert result is None
+
+    def test_saves_refreshed_token_to_disk(self, tmp_path):
+        ts._save_token_local("u5", _EXPIRED_TOKEN, tmp_path)
+
+        refreshed_partial = TokenData(
+            access_token="refreshed-persist",
+            expires_at=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+            scope="",
+            refresh_token=None,
+        )
+
+        with patch.dict("os.environ", {"LOBSTER_INTERNAL_SECRET": "secret"}), patch(
+            "integrations.gmail.token_store._refresh_token_via_proxy",
+            return_value=refreshed_partial,
+        ):
+            ts.get_valid_token("u5", token_dir=tmp_path)
+
+        # Read back from disk to confirm persistence
+        persisted = ts._load_token_local("u5", tmp_path)
+        assert persisted is not None
+        assert persisted.access_token == "refreshed-persist"
+
+
+# ---------------------------------------------------------------------------
+# Token isolation: gmail-tokens != gcal-tokens
+# ---------------------------------------------------------------------------
+
+
+class TestTokenIsolation:
+    def test_gmail_token_dir_is_separate_from_gcal(self):
+        """The default token directory must be gmail-tokens, not gcal-tokens."""
+        assert "gmail" in str(ts._TOKEN_DIR)
+        assert "gcal" not in str(ts._TOKEN_DIR)
+
+    def test_saving_gmail_token_does_not_touch_gcal_dir(self, tmp_path):
+        gmail_dir = tmp_path / "gmail-tokens"
+        gcal_dir = tmp_path / "gcal-tokens"
+        gcal_dir.mkdir()
+
+        ts._save_token_local("99", _VALID_TOKEN, gmail_dir)
+
+        # gcal directory should still be empty
+        assert list(gcal_dir.iterdir()) == []
+
+    def test_loading_from_gmail_dir_does_not_read_gcal_dir(self, tmp_path):
+        gmail_dir = tmp_path / "gmail-tokens"
+        gcal_dir = tmp_path / "gcal-tokens"
+        gcal_dir.mkdir()
+
+        # Put a token in gcal dir only
+        ts._save_token_local("99", _VALID_TOKEN, gcal_dir)
+
+        # Loading from gmail dir must return None (not the gcal token)
+        result = ts._load_token_local("99", gmail_dir)
+        assert result is None


### PR DESCRIPTION
## What this solves

Users who ask Lobster to check email currently get no response — there was no Gmail integration. This PR closes that gap by mirroring the gcal-links skill pattern for Gmail: unauthenticated users receive a one-time consent URL; authenticated users get live inbox reads and search.

This is the final sub-issue of BIS-250 (Google OAuth integration for myownlobster.ai). All prior phases (BIS-251 through BIS-255) are already on main.

## What changed

**`src/integrations/gmail/token_store.py`**
Parallel to `google_calendar/token_store.py`. Stores per-user tokens at `~/messages/config/gmail-tokens/<chat_id>.json` with atomic writes (tmp→rename, mode 0o600). Refreshes expired tokens via `/api/internal/refresh-gmail-token` on myownlobster.ai. Deliberately uses a separate endpoint name from the calendar refresh proxy for routing clarity, even though the underlying Google OAuth call is identical.

**`src/integrations/gmail/client.py`**
Two public functions: `get_recent_emails(user_id, max_results=10)` and `search_emails(user_id, query, max_results=10)`. Both return `[]` on any auth failure or network error — the skill never needs to handle exceptions for API calls. Pure helpers (`_parse_header`, `_parse_date_header`, `_parse_message`, `_auth_header`) are isolated from I/O. `EmailMessage` is a frozen dataclass.

**`lobster-shop/gmail/`**
New skill entry:
- `skill.toml`: triggered mode, responds to `/gmail`, `/email`, `/inbox` and email-related context patterns
- `behavior/system.md`: dual-mode behavior docs with exact code patterns for the dispatcher — unauthenticated consent flow, authenticated read/search flow, auth trigger handling, graceful degradation
- `context/reference.md`: quick-reference card for function signatures and the user_id convention

**Scope isolation (acceptance criteria)**
Gmail tokens (`gmail-tokens/`) and Calendar tokens (`gcal-tokens/`) are separate directories. Completing the Gmail OAuth flow never creates or modifies a Calendar token file, and vice versa. Three dedicated tests in `TestTokenIsolation` verify this at the file level.

## Flow: unauthenticated -> authenticated

```
User: "check my email"
  -> gmail skill activates
  -> load_token(user_id) returns None
  -> generate_consent_link("gmail") -> POST /api/generate-consent-link {scope: "gmail"}
  -> myownlobster.ai returns https://myownlobster.ai/connect/gmail?token=<one-time>
  -> Lobster sends user: [Connect Gmail](https://myownlobster.ai/connect/gmail?token=...)
  -> user completes OAuth
  -> myownlobster.ai POSTs token to VPS /api/push-gmail-token (BIS-252)
  -> token written to ~/messages/config/gmail-tokens/<chat_id>.json

User: "check my email" (now authenticated)
  -> load_token(user_id) returns token
  -> delegate to background subagent
  -> get_recent_emails(user_id) -> Gmail API list + fetch
  -> reply with formatted inbox summary
```

## Functional patterns used

Pure functions (`_parse_header`, `_parse_date_header`, `_parse_message`, `_token_to_dict`, `_dict_to_token`, `_token_path`) are tested in isolation. Side effects (file I/O, HTTP) are isolated to private boundary functions and always injectable for testing via `token_dir` parameter injection. The public API (`get_valid_token`, `get_recent_emails`, `search_emails`) composes these primitives and returns typed values rather than raising on failure.

## Tests run

- [x] `uv run pytest tests/unit/test_integrations/test_gmail_token_store.py tests/unit/test_integrations/test_gmail_client.py tests/unit/test_integrations/test_gmail_skill_consent_behavior.py -v` — 75 passed, 0 failed
- [x] `uv run pytest tests/unit/ -q` — 2182 passed, 76 failed, 24 skipped, 6 errors. The 76 failures and 6 errors are all pre-existing in unrelated modules (`test_write_observation`, `test_memory`, `test_reliability`, `test_path_guard`) — none involve Gmail code. No regressions introduced.
- [ ] Live end-to-end Gmail OAuth flow — blocked: requires deployed myownlobster.ai with BIS-253/254 live and a real GCP OAuth app with Gmail scope. Safe to merge; no behavior change to existing code paths.

**Blocked items needing attention before merge:** none — pre-existing test failures are unrelated to this PR.

Closes BIS-256