### PR TITLE
fix(dispatcher): claim pending user messages early in bootup to prevent health-check false positive

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -37,6 +37,12 @@ When you first start (or after reading this file), follow these steps:
     - `gap_seconds <= 15`: stay silent (health-check restart, not a meaningful gap).
     - Skip if step 2c already sent a restart notification.
 3. Run `~/lobster/scripts/record-catchup-state.sh start` (suppresses WFM freshness check for 15 min).
+3b. **Claim any pending user messages immediately** to stop the health-check staleness clock:
+    - Call `check_inbox()` to get any messages currently waiting in the inbox
+    - For each message that is NOT a system message (i.e. `chat_id != 0` and `source != "system"`): call `mark_processing(message_id)`
+    - Do NOT process, reply to, or act on these messages yet — just claim them
+    - They will be returned by `wait_for_messages()` at step 5 and processed normally
+    - Rationale: `mark_processing()` moves messages from `inbox/` to `processing/`, stopping the health check's inbox-age clock. Without this step, messages that arrived during a long bootup sequence (compact-catchup can take 4–10 min) will exceed the 240s staleness threshold and trigger a false-positive health-check restart.
 4. Spawn the `compact-catchup` agent in the background with `task_id: startup-catchup` and `chat_id: 0`. See agent definition at `.claude/agents/compact-catchup.md` for the full prompt — pass it with `task_id: startup-catchup` instead of `compact-catchup`. **Never do catchup inline — it violates the 7-second rule.**
 5. Call `wait_for_messages()` to start listening.
 6. **Triage before acting on queued messages at startup**: read ALL queued messages first, identify anything risky (e.g. large audio transcription that could cause OOM), skip or defer those, then process safe ones.


### PR DESCRIPTION
## Summary

Dispatcher restarts (context compaction, health-check restarts) leave a window where user messages sit unclaimed in `inbox/` while the bootup sequence runs. The health check measures inbox message age from arrival time — not from when the dispatcher started — so a long bootup (compact-catchup alone can take 4–10 min) can cause the 240s staleness threshold to fire even when the dispatcher is working correctly.

This happened on 2026-04-01 at ~03:24 UTC: a message arrived at 03:19, the dispatcher restarted at 03:20, and the health check fired at 03:24 because the message had been sitting unclaimed for 4+ minutes while compact-catchup ran.

The fix is a single early-claim step (3b) in the Startup Behavior sequence: after `record-catchup-state.sh start`, call `check_inbox()` and `mark_processing()` on any pending non-system messages. `mark_processing()` moves files from `inbox/` to `processing/`, which stops the staleness clock. The dispatcher does not process or reply to these messages — they are returned normally by `wait_for_messages()` at step 5.

## Before / After

```
Before:
  3. record-catchup-state.sh start
  4. spawn compact-catchup (background, can take 4–10 min)
  5. wait_for_messages()
       ^^^^ inbox messages sit unclaimed and age during this entire window

After:
  3. record-catchup-state.sh start
 3b. check_inbox() -> mark_processing() on pending non-system messages
       ^^^^ inbox/ cleared to processing/, staleness clock stops here
  4. spawn compact-catchup (background)
  5. wait_for_messages() -- returns the claimed messages for normal processing
```

No code changes -- this is a spec-only fix. `sys.dispatcher.bootup.md` is read by the dispatcher at runtime on every restart; a merge here takes effect on the next restart.

## Functional patterns

The new step is idempotent: `mark_processing()` on an already-claimed message is a no-op at the MCP layer, so repeated calls during bootup cannot cause double-claiming. The step has no dependencies on bootup order beyond requiring `session_start` to have been called (step 0), which is already a prerequisite for all guarded MCP tools.

## What is not changed

- The compact-catchup flow is unchanged
- The compact-reminder handler (mid-session compaction) is NOT changed; it already calls `mark_processing(message_id)` at its step 1
- No code files modified, only the dispatcher runtime spec

## Tests run
- [x] Manual diff review of `.claude/sys.dispatcher.bootup.md` -- new step inserts correctly between steps 3 and 4, surrounding context intact
- [ ] Live runtime test -- would require triggering a real restart with a pending inbox message; spec change only, safe to merge without live test

## Manual test

N/A -- spec-only change, no systemd/cron/external service/file I/O/DB schema changes.

Closes #1370