### PR TITLE
Remove automatic 👀 reaction acknowledgment from Slack router

### DIFF
--- a/src/bot/slack_router.py
+++ b/src/bot/slack_router.py
@@ -285,18 +285,6 @@ def handle_message_events(body, say, logger):
 
     write_message_to_inbox(msg_data)
 
-    # Send acknowledgment reaction
-    try:
-        client.reactions_add(
-            channel=channel_id,
-            timestamp=ts,
-            name="eyes"  # eyes emoji to show message was received
-        )
-    except SlackApiError as e:
-        # Ignore if reaction already exists
-        if e.response.get("error") != "already_reacted":
-            log.warning(f"Could not add reaction: {e}")
-
 
 @app.event("app_mention")
 def handle_app_mention(body, say, logger):


### PR DESCRIPTION
## Summary

- Removes the `reactions_add` block that added a 👀 eyes reaction to every incoming Slack message
- The bot will now process messages silently and reply with text only
- No functional change to message routing or reply behavior

## Change

Deleted the ~11-line acknowledgment reaction block from `src/bot/slack_router.py` (lines 288–298). After this change, the Slack router writes the message to inbox as before, but skips adding the eyes emoji reaction.

## Test plan

- [ ] Restart the Slack router after merging
- [ ] Send a message to the bot in Slack
- [ ] Confirm no 👀 reaction appears
- [ ] Confirm the bot still replies normally via text