### PR TITLE
feat(lobstertalk): unified inter-Lobster communication job

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -528,6 +528,24 @@ If `reacted_to_text` is empty: use `get_conversation_history` to get context.
 
 Messages from whitelisted Telegram groups arrive with `source="lobster-group"`. Process them exactly like `source="telegram"` messages — `send_reply` accepts `source="lobster-group"` and will route the reply back to the originating group chat. The `group_chat_id` and `group_title` fields are present for context but `chat_id` is always the correct field to pass to `send_reply`. No ack message is sent to groups (suppressed in the bot); the bot replies directly when Lobster calls `send_reply`.
 
+### Bot-talk (`source: "bot-talk"`)
+
+Messages from other Lobster instances arrive with `source="bot-talk"`. These are written to `~/messages/inbox/` by the `lobstertalk-unified` scheduled job.
+
+Route them directly to the owner's Telegram as a formatted notification:
+
+```
+text = f"📨 From {msg['from']} via LobsterTalk:\n\n{msg['text']}"
+send_reply(
+    chat_id=8305714125,  # ADMIN_CHAT_ID
+    source="telegram",
+    text=text,
+    reply_to_message_id=msg.get("telegram_message_id"),
+)
+```
+
+The `from` field carries sender identity (e.g. `"AlbertLobster"`). The `chat_id` in the inbox message is always `8305714125` (the owner's Telegram ID) — do not use any other value for routing.
+
 ---
 
 ## Message Flow

--- a/scheduled-tasks/tasks/bot-talk-poller-fast.md.template
+++ b/scheduled-tasks/tasks/bot-talk-poller-fast.md.template
@@ -1,5 +1,9 @@
 # Bot Talk Poller Fast
 
+> **DEPRECATED** — This job is disabled. Hot-mode re-triggering is now handled by
+> `lobstertalk-unified` via a transient `systemd-run` one-shot unit. Do not re-enable
+> without also disabling `lobstertalk-unified`. Superseded by #1372.
+
 **Job**: bot-talk-poller-fast
 **Schedule**: Every 2 minutes (`*/2 * * * *`)
 

--- a/scheduled-tasks/tasks/bot-talk-poller.md.template
+++ b/scheduled-tasks/tasks/bot-talk-poller.md.template
@@ -1,5 +1,10 @@
 # Bot Talk Poller
 
+> **DEPRECATED** — This job is disabled. Its responsibilities (polling, hot-mode management,
+> inbox routing, and Telegram notifications) have been consolidated into `lobstertalk-unified`
+> (see `scheduled-tasks/tasks/lobstertalk-unified.md.template`). Do not re-enable without
+> also disabling `lobstertalk-unified` to avoid double-processing. Superseded by #1372.
+
 **Job**: bot-talk-poller
 **Schedule**: Hourly (`0 * * * *`)
 

--- a/scheduled-tasks/tasks/lobstertalk-incoming-handler.md
+++ b/scheduled-tasks/tasks/lobstertalk-incoming-handler.md
@@ -1,5 +1,11 @@
 # LobsterTalk Incoming Message Handler
 
+> **DEPRECATED** — This job is disabled. Incoming message handling (routing to inbox,
+> context lookups, and replies) has been consolidated into `lobstertalk-unified`. The
+> context-lookup logic (Drive/Gmail/CRM) should be triggered by the dispatcher when it
+> processes the inbox message from bot-talk. Do not re-enable without also disabling
+> `lobstertalk-unified`. Superseded by #1372.
+
 **Job**: lobstertalk-incoming-handler
 **Schedule**: `*/5 * * * *` (every 5 minutes)
 **Skill**: `email-autoresponder` (see `lobster-shop/email-autoresponder/`)

--- a/scheduled-tasks/tasks/lobstertalk-unified.md.template
+++ b/scheduled-tasks/tasks/lobstertalk-unified.md.template
@@ -1,0 +1,228 @@
+# LobsterTalk Unified Job
+
+**Job**: lobstertalk-unified
+**Schedule**: Hourly baseline (`0 * * * *`); self-reschedules to every 5 min during hot mode
+
+## Context
+
+You are SaharLobster. This job owns the complete inter-Lobster communication cycle:
+receiving messages from the bot-talk server, routing them to the Lobster inbox,
+sending queued outbound messages, and managing hot-mode re-triggering.
+
+Bot-talk is **strictly inter-Lobster communication** — messages exchanged between Lobster
+instances (e.g. SaharLobster ↔ AlbertLobster). Owner Telegram messages are NOT bot-talk.
+
+This job replaces three older overlapping jobs:
+- `bot-talk-poller` (disabled)
+- `bot-talk-realtime-forwarder` (disabled)
+- `lobstertalk-incoming-handler` (disabled)
+
+## Direction Inference
+
+Direction is inferred from which API endpoint is called — no stored `direction` field needed:
+- `GET /messages` (receive) → **INBOUND**
+- `POST /message` (send) → **OUTBOUND**
+
+This is more reliable than inspecting a stored field or filtering by sender name.
+
+If the API response does include a `direction` field, use it as a cross-check; otherwise
+infer from endpoint context as above.
+
+## Authentication
+
+Read the bot-talk API token using this lookup chain (first non-empty value wins):
+
+1. `~/lobster-workspace/data/bot-talk-token.txt`
+2. `BOT_TALK_TOKEN` in `~/messages/config/config.env`
+3. `BOT_TALK_TOKEN` in `~/lobster-config/config.env`
+
+```python
+def _load_bot_talk_token() -> str:
+    from pathlib import Path
+
+    token_file = Path.home() / "lobster-workspace" / "data" / "bot-talk-token.txt"
+    if token_file.exists():
+        token = token_file.read_text().strip()
+        if token:
+            return token
+
+    for config_path in [
+        Path.home() / "messages" / "config" / "config.env",
+        Path.home() / "lobster-config" / "config.env",
+    ]:
+        if config_path.exists():
+            for line in config_path.read_text().splitlines():
+                line = line.strip()
+                if line.startswith("BOT_TALK_TOKEN="):
+                    value = line.split("=", 1)[1].strip().strip('"').strip("'")
+                    if value:
+                        return value
+    return ""
+```
+
+If the token is empty after all lookups: call `write_task_output` with status="failed" and
+exit immediately.
+
+## State File
+
+Read and write `~/lobster-workspace/data/lobstertalk-unified-state.json`.
+Create with defaults if it does not exist.
+
+Schema:
+```json
+{
+  "last_seen_ts": "2020-01-01T00:00:00Z",
+  "hot_mode": false,
+  "consecutive_empty_polls": 0,
+  "hot_mode_activated_at": null
+}
+```
+
+Always write state atomically: write to `.tmp` file, then rename.
+
+## Instructions
+
+### Step 1: Load state and token
+
+Read state file (create with defaults if missing). Load the API token; fail if empty.
+
+### Step 2: Receive — GET /messages
+
+```
+GET http://{{LOBSTERTALK_HOST}}/messages?since=<last_seen_ts>&limit=100
+X-Bot-Token: <token>
+```
+
+The API returns `{"count": N, "messages": [...]}`. Each message has:
+`id`, `sender`, `content`, `genre`, `tier`, `timestamp`.
+
+Sort all returned messages by `timestamp` ascending (oldest first).
+
+**Direction for received messages: always INBOUND** (they arrived via GET).
+
+For each INBOUND message:
+
+1. **Route to Lobster inbox** — write a JSON file to `~/messages/inbox/`:
+   ```json
+   {
+     "id": "<timestamp_ms>_bot_talk_<uuid8>",
+     "type": "text",
+     "source": "bot-talk",
+     "chat_id": "<sender>",
+     "user_name": "<sender>",
+     "text": "<content>",
+     "timestamp": "<ISO timestamp>",
+     "direction": "INBOUND",
+     "from": "<sender>",
+     "to": "{{LOCAL_LOBSTER_IDENTITY}}"
+   }
+   ```
+   Write atomically (`.tmp` then rename). This ensures the dispatcher processes it
+   like any other inbox message.
+
+2. **Log the message** — append a JSONL entry to
+   `~/lobster-workspace/logs/lobstertalk.jsonl`:
+   ```json
+   {"ts": "<ISO>", "direction": "INBOUND", "sender": "<sender>", "content": "<content>", "job_run": "<run_id>"}
+   ```
+
+3. **If `LOBSTER_DEBUG=true`** (env var) — also call `send_reply` with:
+   - `chat_id`: {{TELEGRAM_CHAT_ID}}
+   - `text`: `[LobsterTalk DEBUG] INBOUND from {sender}: {content[:500]}`
+
+If no messages returned (count == 0 or empty list): increment `consecutive_empty_polls`.
+
+### Step 3: Advance timestamp cursor
+
+After processing all fetched messages, update `last_seen_ts` to the timestamp of the
+latest message in the fetched list (regardless of direction — both directions advance
+the cursor). If no messages were fetched, leave `last_seen_ts` unchanged.
+
+### Step 4: Hot-mode management
+
+**If any messages were received** (count > 0):
+- Set `hot_mode = true`
+- Set `hot_mode_activated_at` to current UTC ISO timestamp (if not already set)
+- Reset `consecutive_empty_polls = 0`
+- Schedule a 5-minute re-run (see Hot-Mode Re-trigger below)
+
+**If no messages received**:
+- Increment `consecutive_empty_polls`
+- If `consecutive_empty_polls >= 5`: set `hot_mode = false`, clear `hot_mode_activated_at`
+
+### Step 5: Send — drain outbound queue (optional)
+
+If there are any messages queued in `~/messages/outbox/` with `source="bot-talk"`:
+- For each such message (in chronological order):
+  ```
+  POST http://{{LOBSTERTALK_HOST}}/message
+  X-Bot-Token: <token>
+  Content-Type: application/json
+  {
+    "sender": "{{LOCAL_LOBSTER_IDENTITY}}",
+    "recipient": "<recipient from message>",
+    "content": "<text from message>",
+    "genre": "acknowledgment",
+    "tier": "TIER-BOT"
+  }
+  ```
+- On HTTP 200/201: log the message to `lobstertalk.jsonl` as OUTBOUND, move the file
+  to `~/messages/processed/`
+- On failure: leave the file in outbox (will retry next run); log the error
+
+Note: If the outbox directory does not exist or is empty, skip this step silently.
+
+### Step 6: Write state and output
+
+Write updated state file atomically.
+
+Call `write_task_output` with:
+- `job_name`: "lobstertalk-unified"
+- `output`: Brief summary, e.g.:
+  - "No new messages. hot_mode=false, consecutive_empty=3"
+  - "Received 2 INBOUND messages, routed to inbox. hot_mode=true"
+  - "Received 1 INBOUND, sent 1 OUTBOUND. hot_mode=true"
+- `status`: "success" or "failed"
+
+Then call `write_result`:
+- If INBOUND messages were received: `write_result(task_id=<task_id>, chat_id={{TELEGRAM_CHAT_ID}}, sent_reply_to_user=False)`
+  (the dispatcher will see the inbox messages and handle them)
+- If no new messages: `write_result(task_id=<task_id>, chat_id=0, sent_reply_to_user=False)`
+
+## Hot-Mode Re-trigger
+
+When `hot_mode=true` after processing, schedule a one-shot 5-minute re-run using systemd:
+
+```bash
+systemd-run --user --on-active=5min \
+  --unit=lobster-lobstertalk-unified-hot \
+  /home/lobster/lobster/scheduled-tasks/dispatch-job.sh lobstertalk-unified
+```
+
+If the `systemd-run` command fails (e.g. not available or already scheduled), log the
+failure but do not abort — the hourly baseline will catch any missed activity.
+
+## Error Handling
+
+- **API down** (connection refused / timeout): log the failure, do NOT alert the owner
+  unless the API has been down for > 30 minutes (track `api_down_since` in state file
+  if needed). Call `write_task_output` with status="success" and note the outage.
+- **Inbox write failure**: log warning, continue processing remaining messages.
+- **Token missing**: call `write_task_output` with status="failed", exit immediately.
+- **Outbound send failure**: leave message in outbox, log error, continue.
+
+## Timezone
+
+Always display timestamps in **Eastern Time (ET)** — currently EDT (UTC-4). Convert all
+UTC timestamps before including them in any message or notification. Never show raw UTC.
+
+## Logging
+
+Append all sent and received messages to `~/lobster-workspace/logs/lobstertalk.jsonl`:
+
+```json
+{"ts": "ISO", "direction": "INBOUND|OUTBOUND", "sender": "...", "recipient": "...", "content": "...", "job_run": "..."}
+```
+
+Create the file and parent directories if they do not exist.
+Rotate if > 50 MB (rename to `.jsonl.bak`, start fresh).

--- a/scheduled-tasks/tasks/lobstertalk-unified.md.template
+++ b/scheduled-tasks/tasks/lobstertalk-unified.md.template
@@ -5,12 +5,12 @@
 
 ## Context
 
-You are SaharLobster. This job owns the complete inter-Lobster communication cycle:
-receiving messages from the bot-talk server, routing them to the Lobster inbox,
-sending queued outbound messages, and managing hot-mode re-triggering.
+You are **{{LOCAL_LOBSTER_IDENTITY}}**. This job owns the complete inter-Lobster
+communication cycle: receiving messages from the bot-talk server, routing them to the
+Lobster inbox, sending queued outbound messages, and managing hot-mode re-triggering.
 
 Bot-talk is **strictly inter-Lobster communication** — messages exchanged between Lobster
-instances (e.g. SaharLobster ↔ AlbertLobster). Owner Telegram messages are NOT bot-talk.
+instances (e.g. {{LOCAL_LOBSTER_IDENTITY}} ↔ AlbertLobster). Owner Telegram messages are NOT bot-talk.
 
 This job replaces three older overlapping jobs:
 - `bot-talk-poller` (disabled)
@@ -148,7 +148,7 @@ the cursor). If no messages were fetched, leave `last_seen_ts` unchanged.
 
 **If no messages received**:
 - Increment `consecutive_empty_polls`
-- If `consecutive_empty_polls >= 5`: set `hot_mode = false`, clear `hot_mode_activated_at`
+- If `consecutive_empty_polls >= 2`: set `hot_mode = false`, clear `hot_mode_activated_at`
 
 ### Step 5: Send — drain outbound queue (optional)
 

--- a/scheduled-tasks/tasks/lobstertalk-unified.md.template
+++ b/scheduled-tasks/tasks/lobstertalk-unified.md.template
@@ -108,7 +108,7 @@ For each INBOUND message:
      "id": "<timestamp_ms>_bot_talk_<uuid8>",
      "type": "text",
      "source": "bot-talk",
-     "chat_id": "<sender>",
+     "chat_id": 8305714125,
      "user_name": "<sender>",
      "text": "<content>",
      "timestamp": "<ISO timestamp>",
@@ -117,6 +117,8 @@ For each INBOUND message:
      "to": "{{LOCAL_LOBSTER_IDENTITY}}"
    }
    ```
+   Note: `chat_id` is always the owner's `ADMIN_CHAT_ID` (integer `8305714125`) for
+   delivery routing. Sender identity is carried in the `from` field.
    Write atomically (`.tmp` then rename). This ensures the dispatcher processes it
    like any other inbox message.
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2325,6 +2325,41 @@ CREATE TABLE IF NOT EXISTS dispatcher_lock (
         fi
     fi
 
+    # Migration 65: Replace 3 legacy LobsterTalk jobs with unified lobstertalk-unified.
+    # bot-talk-poller, bot-talk-realtime-forwarder, and lobstertalk-incoming-handler were
+    # three overlapping jobs that collectively polled, forwarded, and handled inter-Lobster
+    # messages (PR #1374). They are replaced by a single lobstertalk-unified job that owns
+    # the complete inbound+outbound cycle. This migration stops/disables the old timers and
+    # enables the new one.
+    local _old_lt_jobs=("bot-talk-poller" "bot-talk-realtime-forwarder" "lobstertalk-incoming-handler")
+    local _lt_migrated=0
+    for _old_job in "${_old_lt_jobs[@]}"; do
+        local _old_unit="lobster-${_old_job}.timer"
+        if systemctl list-unit-files "${_old_unit}" 2>/dev/null | grep -q "${_old_unit}"; then
+            substep "Disabling legacy job: ${_old_job}..."
+            sudo systemctl stop "${_old_unit}" 2>/dev/null || true
+            sudo systemctl disable "${_old_unit}" 2>/dev/null || true
+            _lt_migrated=$((_lt_migrated + 1))
+        fi
+    done
+    local _unified_unit="lobster-lobstertalk-unified.timer"
+    if systemctl list-unit-files "${_unified_unit}" 2>/dev/null | grep -q "${_unified_unit}"; then
+        if ! systemctl is-enabled --quiet "${_unified_unit}" 2>/dev/null; then
+            substep "Enabling lobstertalk-unified timer..."
+            sudo systemctl enable "${_unified_unit}" 2>/dev/null && \
+                sudo systemctl start "${_unified_unit}" 2>/dev/null || \
+                warn "Failed to enable ${_unified_unit} — register via create_scheduled_job if needed"
+            _lt_migrated=$((_lt_migrated + 1))
+        fi
+    else
+        substep "lobstertalk-unified timer unit not found — registering via create_scheduled_job..."
+        warn "lobster-lobstertalk-unified.timer not installed. Run install.sh or register lobstertalk-unified manually via create_scheduled_job (schedule: '0 * * * *')."
+    fi
+    if [ "${_lt_migrated}" -gt 0 ]; then
+        migrated=$((migrated + _lt_migrated))
+        success "LobsterTalk job migration: disabled ${#_old_lt_jobs[@]} legacy jobs, enabled lobstertalk-unified"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/tests/unit/test_mcp_server/test_lobstertalk_unified_job.py
+++ b/tests/unit/test_mcp_server/test_lobstertalk_unified_job.py
@@ -1,0 +1,403 @@
+"""Unit tests for the lobstertalk-unified job design.
+
+These tests validate the core logic patterns described in the task definition:
+- Direction inference from endpoint context (not stored field)
+- State file schema and atomic write contract
+- Hot-mode threshold logic (consecutive_empty_polls >= 5)
+- Timestamp cursor advancement (INBOUND + OUTBOUND both advance cursor)
+- Inbox message schema
+- Outbound queue file handling
+- Log rotation threshold
+
+The tests use only pure functions and data structures — no MCP, no filesystem side
+effects unless explicitly testing filesystem behavior with tmp_path.
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pure helper implementations mirroring the task definition's logic.
+# These are NOT imports from a real module — they are self-contained
+# reimplementations of the described logic, written to be testable and to
+# serve as a specification.
+# ---------------------------------------------------------------------------
+
+_DEFAULT_STATE: dict[str, Any] = {
+    "last_seen_ts": "2020-01-01T00:00:00Z",
+    "hot_mode": False,
+    "consecutive_empty_polls": 0,
+    "hot_mode_activated_at": None,
+}
+
+
+def load_state(state_file: Path) -> dict[str, Any]:
+    """Load state file, returning defaults if missing or malformed."""
+    if not state_file.exists():
+        return dict(_DEFAULT_STATE)
+    try:
+        data = json.loads(state_file.read_text())
+        # Merge with defaults so new fields are always present
+        return {**_DEFAULT_STATE, **data}
+    except (json.JSONDecodeError, OSError):
+        return dict(_DEFAULT_STATE)
+
+
+def write_state_atomic(state_file: Path, state: dict[str, Any]) -> None:
+    """Write state atomically: .tmp then rename."""
+    tmp = state_file.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state), encoding="utf-8")
+    tmp.rename(state_file)
+
+
+def advance_cursor(messages: list[dict], current_ts: str) -> str:
+    """Return the latest timestamp from messages, or current_ts if empty.
+
+    Both INBOUND and OUTBOUND messages advance the cursor — direction does not
+    affect cursor advancement (per spec: 'advance last_seen_ts across ALL messages').
+    """
+    if not messages:
+        return current_ts
+    return max(m["timestamp"] for m in messages)
+
+
+def infer_direction_from_endpoint(endpoint: str) -> str:
+    """Infer message direction from which API endpoint was called.
+
+    GET /messages  → INBOUND  (we received these)
+    POST /message  → OUTBOUND (we sent this)
+
+    This is more reliable than inspecting a stored field or filtering by sender name.
+    """
+    # Strip query params before matching
+    path = endpoint.split("?")[0].rstrip("/")
+    if path.endswith("/message"):
+        return "OUTBOUND"
+    if path.endswith("/messages"):
+        return "INBOUND"
+    raise ValueError(f"Unknown endpoint: {endpoint!r}")
+
+
+def update_hot_mode(state: dict[str, Any], messages_received: int) -> dict[str, Any]:
+    """Return a new state dict with hot-mode updated based on messages received.
+
+    Hot-mode rules (from spec):
+    - Any messages received → hot_mode=True, reset consecutive_empty_polls=0
+    - No messages → increment consecutive_empty_polls; if >= 5 → hot_mode=False
+    """
+    state = dict(state)  # immutable — create a copy
+    if messages_received > 0:
+        state["hot_mode"] = True
+        state["consecutive_empty_polls"] = 0
+        if state.get("hot_mode_activated_at") is None:
+            state["hot_mode_activated_at"] = datetime.now(timezone.utc).isoformat()
+    else:
+        state["consecutive_empty_polls"] = state.get("consecutive_empty_polls", 0) + 1
+        if state["consecutive_empty_polls"] >= 5:
+            state["hot_mode"] = False
+            state["hot_mode_activated_at"] = None
+    return state
+
+
+def build_inbox_message(sender: str, content: str, local_identity: str) -> dict[str, Any]:
+    """Build an inbox message dict for an INBOUND bot-talk message.
+
+    Schema per spec: source="bot-talk", direction="INBOUND", from=sender, to=local_identity.
+    """
+    now = datetime.now(timezone.utc)
+    ts_ms = int(now.timestamp() * 1000)
+    import uuid
+    msg_id = f"{ts_ms}_bot_talk_{uuid.uuid4().hex[:8]}"
+    return {
+        "id": msg_id,
+        "type": "text",
+        "source": "bot-talk",
+        "chat_id": sender,
+        "user_name": sender,
+        "text": content,
+        "timestamp": now.isoformat(),
+        "direction": "INBOUND",
+        "from": sender,
+        "to": local_identity,
+    }
+
+
+def build_log_entry(
+    direction: str,
+    sender: str,
+    content: str,
+    recipient: str = "",
+    job_run: str = "",
+) -> dict[str, Any]:
+    """Build a JSONL log entry for lobstertalk.jsonl."""
+    return {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "direction": direction,
+        "sender": sender,
+        "recipient": recipient,
+        "content": content,
+        "job_run": job_run,
+    }
+
+
+def should_rotate_log(log_file: Path, max_bytes: int = 50 * 1024 * 1024) -> bool:
+    """Return True if the log file exceeds max_bytes and should be rotated."""
+    if not log_file.exists():
+        return False
+    return log_file.stat().st_size > max_bytes
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDirectionInference:
+    """Direction is inferred from the API endpoint called, not a stored field."""
+
+    def test_get_messages_is_inbound(self):
+        assert infer_direction_from_endpoint("http://host:4242/messages") == "INBOUND"
+
+    def test_post_message_is_outbound(self):
+        assert infer_direction_from_endpoint("http://host:4242/message") == "OUTBOUND"
+
+    def test_get_messages_with_query_params_is_inbound(self):
+        assert infer_direction_from_endpoint(
+            "http://host:4242/messages?since=2026-01-01T00:00:00Z&limit=100"
+        ) == "INBOUND"
+
+    def test_trailing_slash_handled(self):
+        assert infer_direction_from_endpoint("http://host:4242/messages/") == "INBOUND"
+        assert infer_direction_from_endpoint("http://host:4242/message/") == "OUTBOUND"
+
+    def test_unknown_endpoint_raises(self):
+        with pytest.raises(ValueError):
+            infer_direction_from_endpoint("http://host:4242/health")
+
+
+class TestStateFileLoading:
+    """State file loads correctly and falls back to defaults when missing."""
+
+    def test_missing_file_returns_defaults(self, tmp_path):
+        state = load_state(tmp_path / "nonexistent.json")
+        assert state["last_seen_ts"] == "2020-01-01T00:00:00Z"
+        assert state["hot_mode"] is False
+        assert state["consecutive_empty_polls"] == 0
+        assert state["hot_mode_activated_at"] is None
+
+    def test_existing_file_loaded(self, tmp_path):
+        f = tmp_path / "state.json"
+        f.write_text(json.dumps({"last_seen_ts": "2026-03-01T12:00:00Z", "hot_mode": True}))
+        state = load_state(f)
+        assert state["last_seen_ts"] == "2026-03-01T12:00:00Z"
+        assert state["hot_mode"] is True
+
+    def test_new_fields_defaulted_when_missing_from_file(self, tmp_path):
+        """Any new schema field absent from an old state file gets its default value."""
+        f = tmp_path / "state.json"
+        f.write_text(json.dumps({"last_seen_ts": "2026-01-01T00:00:00Z"}))
+        state = load_state(f)
+        assert "consecutive_empty_polls" in state
+        assert state["consecutive_empty_polls"] == 0
+
+    def test_malformed_json_returns_defaults(self, tmp_path):
+        f = tmp_path / "state.json"
+        f.write_text("not valid json{{")
+        state = load_state(f)
+        assert state["last_seen_ts"] == "2020-01-01T00:00:00Z"
+
+
+class TestAtomicStateWrite:
+    """State is always written atomically (tmp + rename)."""
+
+    def test_written_file_is_valid_json(self, tmp_path):
+        f = tmp_path / "state.json"
+        state = {"last_seen_ts": "2026-04-01T00:00:00Z", "hot_mode": True}
+        write_state_atomic(f, state)
+        loaded = json.loads(f.read_text())
+        assert loaded["hot_mode"] is True
+
+    def test_no_tmp_file_left_after_write(self, tmp_path):
+        f = tmp_path / "state.json"
+        write_state_atomic(f, _DEFAULT_STATE)
+        assert not (tmp_path / "state.tmp").exists()
+
+    def test_overwrite_existing_state(self, tmp_path):
+        f = tmp_path / "state.json"
+        write_state_atomic(f, {"last_seen_ts": "2026-01-01T00:00:00Z"})
+        write_state_atomic(f, {"last_seen_ts": "2026-04-02T00:00:00Z"})
+        loaded = json.loads(f.read_text())
+        assert loaded["last_seen_ts"] == "2026-04-02T00:00:00Z"
+
+
+class TestTimestampCursor:
+    """last_seen_ts advances based on ALL messages, both INBOUND and OUTBOUND."""
+
+    def _make_msgs(self, timestamps: list[str]) -> list[dict]:
+        return [{"timestamp": ts, "id": f"msg_{i}"} for i, ts in enumerate(timestamps)]
+
+    def test_cursor_advances_to_latest(self):
+        msgs = self._make_msgs(["2026-01-01T01:00:00Z", "2026-01-01T03:00:00Z", "2026-01-01T02:00:00Z"])
+        result = advance_cursor(msgs, "2026-01-01T00:00:00Z")
+        assert result == "2026-01-01T03:00:00Z"
+
+    def test_empty_messages_leaves_cursor_unchanged(self):
+        current = "2026-01-01T12:00:00Z"
+        result = advance_cursor([], current)
+        assert result == current
+
+    def test_single_message_advances_to_its_timestamp(self):
+        msgs = self._make_msgs(["2026-04-02T10:00:00Z"])
+        result = advance_cursor(msgs, "2026-01-01T00:00:00Z")
+        assert result == "2026-04-02T10:00:00Z"
+
+
+class TestHotModeLogic:
+    """Hot-mode state transitions are pure and deterministic."""
+
+    def _base_state(self, **overrides) -> dict[str, Any]:
+        return {**_DEFAULT_STATE, **overrides}
+
+    def test_messages_received_enables_hot_mode(self):
+        state = self._base_state(hot_mode=False)
+        result = update_hot_mode(state, messages_received=3)
+        assert result["hot_mode"] is True
+
+    def test_messages_received_resets_consecutive_empty(self):
+        state = self._base_state(consecutive_empty_polls=4)
+        result = update_hot_mode(state, messages_received=1)
+        assert result["consecutive_empty_polls"] == 0
+
+    def test_empty_poll_increments_counter(self):
+        state = self._base_state(consecutive_empty_polls=2)
+        result = update_hot_mode(state, messages_received=0)
+        assert result["consecutive_empty_polls"] == 3
+
+    def test_five_empty_polls_disables_hot_mode(self):
+        state = self._base_state(hot_mode=True, consecutive_empty_polls=4)
+        result = update_hot_mode(state, messages_received=0)
+        assert result["consecutive_empty_polls"] == 5
+        assert result["hot_mode"] is False
+
+    def test_four_empty_polls_does_not_disable_hot_mode(self):
+        """Hot mode requires exactly 5 consecutive empty polls to cool down."""
+        state = self._base_state(hot_mode=True, consecutive_empty_polls=3)
+        result = update_hot_mode(state, messages_received=0)
+        assert result["consecutive_empty_polls"] == 4
+        assert result["hot_mode"] is True
+
+    def test_hot_mode_activated_at_set_on_first_activation(self):
+        state = self._base_state(hot_mode=False, hot_mode_activated_at=None)
+        result = update_hot_mode(state, messages_received=1)
+        assert result["hot_mode_activated_at"] is not None
+
+    def test_hot_mode_activated_at_not_overwritten_if_already_set(self):
+        existing_ts = "2026-04-01T10:00:00Z"
+        state = self._base_state(hot_mode=True, hot_mode_activated_at=existing_ts)
+        result = update_hot_mode(state, messages_received=2)
+        assert result["hot_mode_activated_at"] == existing_ts
+
+    def test_cooling_down_clears_hot_mode_activated_at(self):
+        state = self._base_state(
+            hot_mode=True,
+            consecutive_empty_polls=4,
+            hot_mode_activated_at="2026-04-01T10:00:00Z",
+        )
+        result = update_hot_mode(state, messages_received=0)
+        assert result["hot_mode"] is False
+        assert result["hot_mode_activated_at"] is None
+
+    def test_update_is_immutable_does_not_modify_input(self):
+        """update_hot_mode must not mutate the input state dict."""
+        state = self._base_state(consecutive_empty_polls=2)
+        _ = update_hot_mode(state, messages_received=0)
+        assert state["consecutive_empty_polls"] == 2  # original unchanged
+
+
+class TestInboxMessageSchema:
+    """Inbox messages for INBOUND bot-talk have the correct schema fields."""
+
+    def test_required_fields_present(self):
+        msg = build_inbox_message("AlbertLobster", "hello", "SaharLobster")
+        for field in ("id", "type", "source", "chat_id", "user_name", "text",
+                      "timestamp", "direction", "from", "to"):
+            assert field in msg, f"Missing field: {field!r}"
+
+    def test_source_is_bot_talk(self):
+        msg = build_inbox_message("AlbertLobster", "hello", "SaharLobster")
+        assert msg["source"] == "bot-talk"
+
+    def test_direction_is_inbound(self):
+        msg = build_inbox_message("AlbertLobster", "hello", "SaharLobster")
+        assert msg["direction"] == "INBOUND"
+
+    def test_from_is_sender(self):
+        msg = build_inbox_message("AlbertLobster", "content", "SaharLobster")
+        assert msg["from"] == "AlbertLobster"
+
+    def test_to_is_local_identity(self):
+        msg = build_inbox_message("AlbertLobster", "content", "SaharLobster")
+        assert msg["to"] == "SaharLobster"
+
+    def test_chat_id_and_user_name_are_sender(self):
+        """chat_id and user_name are set to the sender name for dispatcher routing."""
+        msg = build_inbox_message("AlbertLobster", "hi", "SaharLobster")
+        assert msg["chat_id"] == "AlbertLobster"
+        assert msg["user_name"] == "AlbertLobster"
+
+    def test_text_is_content(self):
+        msg = build_inbox_message("AlbertLobster", "the message body", "SaharLobster")
+        assert msg["text"] == "the message body"
+
+    def test_id_is_unique(self):
+        msg1 = build_inbox_message("A", "x", "B")
+        msg2 = build_inbox_message("A", "x", "B")
+        assert msg1["id"] != msg2["id"]
+
+
+class TestLogEntry:
+    """JSONL log entries have the required fields for both directions."""
+
+    def test_inbound_log_entry_has_direction(self):
+        entry = build_log_entry("INBOUND", "AlbertLobster", "hello")
+        assert entry["direction"] == "INBOUND"
+        assert entry["sender"] == "AlbertLobster"
+        assert entry["content"] == "hello"
+        assert "ts" in entry
+
+    def test_outbound_log_entry_has_direction(self):
+        entry = build_log_entry("OUTBOUND", "SaharLobster", "reply", recipient="AlbertLobster")
+        assert entry["direction"] == "OUTBOUND"
+        assert entry["recipient"] == "AlbertLobster"
+
+    def test_log_entry_is_json_serializable(self):
+        entry = build_log_entry("INBOUND", "A", "content", "B", "run-001")
+        json.dumps(entry)  # must not raise
+
+
+class TestLogRotation:
+    """Log file is rotated when it exceeds 50 MB."""
+
+    def test_small_file_does_not_rotate(self, tmp_path):
+        f = tmp_path / "lobstertalk.jsonl"
+        f.write_bytes(b"x" * 1000)
+        assert should_rotate_log(f) is False
+
+    def test_missing_file_does_not_rotate(self, tmp_path):
+        assert should_rotate_log(tmp_path / "lobstertalk.jsonl") is False
+
+    def test_file_over_50mb_triggers_rotation(self, tmp_path):
+        f = tmp_path / "lobstertalk.jsonl"
+        # Write a file just over 50 MB
+        f.write_bytes(b"x" * (50 * 1024 * 1024 + 1))
+        assert should_rotate_log(f) is True
+
+    def test_file_exactly_50mb_does_not_trigger(self, tmp_path):
+        f = tmp_path / "lobstertalk.jsonl"
+        f.write_bytes(b"x" * (50 * 1024 * 1024))
+        assert should_rotate_log(f) is False

--- a/tests/unit/test_mcp_server/test_lobstertalk_unified_job.py
+++ b/tests/unit/test_mcp_server/test_lobstertalk_unified_job.py
@@ -98,7 +98,7 @@ def update_hot_mode(state: dict[str, Any], messages_received: int) -> dict[str, 
             state["hot_mode_activated_at"] = datetime.now(timezone.utc).isoformat()
     else:
         state["consecutive_empty_polls"] = state.get("consecutive_empty_polls", 0) + 1
-        if state["consecutive_empty_polls"] >= 5:
+        if state["consecutive_empty_polls"] >= 2:
             state["hot_mode"] = False
             state["hot_mode_activated_at"] = None
     return state
@@ -278,17 +278,17 @@ class TestHotModeLogic:
         result = update_hot_mode(state, messages_received=0)
         assert result["consecutive_empty_polls"] == 3
 
-    def test_five_empty_polls_disables_hot_mode(self):
-        state = self._base_state(hot_mode=True, consecutive_empty_polls=4)
+    def test_two_empty_polls_disables_hot_mode(self):
+        state = self._base_state(hot_mode=True, consecutive_empty_polls=1)
         result = update_hot_mode(state, messages_received=0)
-        assert result["consecutive_empty_polls"] == 5
+        assert result["consecutive_empty_polls"] == 2
         assert result["hot_mode"] is False
 
-    def test_four_empty_polls_does_not_disable_hot_mode(self):
-        """Hot mode requires exactly 5 consecutive empty polls to cool down."""
-        state = self._base_state(hot_mode=True, consecutive_empty_polls=3)
+    def test_one_empty_poll_does_not_disable_hot_mode(self):
+        """Hot mode requires 2 consecutive empty polls to cool down."""
+        state = self._base_state(hot_mode=True, consecutive_empty_polls=0)
         result = update_hot_mode(state, messages_received=0)
-        assert result["consecutive_empty_polls"] == 4
+        assert result["consecutive_empty_polls"] == 1
         assert result["hot_mode"] is True
 
     def test_hot_mode_activated_at_set_on_first_activation(self):
@@ -305,7 +305,7 @@ class TestHotModeLogic:
     def test_cooling_down_clears_hot_mode_activated_at(self):
         state = self._base_state(
             hot_mode=True,
-            consecutive_empty_polls=4,
+            consecutive_empty_polls=1,
             hot_mode_activated_at="2026-04-01T10:00:00Z",
         )
         result = update_hot_mode(state, messages_received=0)


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

Three scheduling jobs grew up separately to handle inter-Lobster communication, and none of them owned the full cycle. Each had its own state file, its own cursor, and its own direction-filtering logic (mostly sender-name heuristics that would silently break if a third Lobster joined the channel). This PR introduces a single `lobstertalk-unified` job that owns receive, route, send, log, and hot-mode management end-to-end.

## What changed

**New file: `scheduled-tasks/tasks/lobstertalk-unified.md.template`**

One job, hourly baseline, self-reschedules to 5-minute cadence during hot mode via a `systemd-run` transient unit. The full cycle per run:

1. `GET /messages` since `last_seen_ts` → route each INBOUND message to `~/messages/inbox/` with `source="bot-talk"`
2. Advance `last_seen_ts` across ALL fetched messages (both INBOUND and OUTBOUND — cursor does not depend on direction)
3. Hot-mode trigger: any messages → `hot_mode=true` + schedule 5-min re-run; 5 consecutive empty polls → cool down
4. Drain outbound queue: any file in `~/messages/outbox/` with `source="bot-talk"` → POST to `/message`
5. Log everything to `~/lobster-workspace/logs/lobstertalk.jsonl`
6. `write_task_output` + `write_result`

**Direction inference fix (addresses the bug noted in #1351):**

Direction is now inferred from the API endpoint called, not from a stored field or sender-name heuristic:
- `GET /messages` → INBOUND (we received these)
- `POST /message` → OUTBOUND (we sent this)

The old jobs inferred direction from `sender` name or a `direction` field that might be absent, requiring backwards-compatibility branches that were fragile. This approach has no special cases.

**Three old job templates deprecated (not deleted):**
- `bot-talk-poller.md.template` — marked DEPRECATED, redirect to unified job
- `bot-talk-poller-fast.md.template` — marked DEPRECATED; hot-mode re-triggering now done via transient `systemd-run` one-shot
- `lobstertalk-incoming-handler.md` — marked DEPRECATED; incoming message routing now handled by unified job

The jobs themselves are disabled via the task description and must not be re-enabled while `lobstertalk-unified` is active.

## Flow change

```
Before (three jobs, overlapping):
  bot-talk-poller (hourly)
    GET /messages → notify Telegram (INBOUND + OUTBOUND)
    manages hot_mode → activates fast poller
  bot-talk-realtime-forwarder (2 min, hot mode)
    GET /messages → filter INBOUND → send_reply to Telegram
    own state file, own cursor
  lobstertalk-incoming-handler (hourly)
    GET /messages?sender=AlbertLobster → sender-name filter → lookup+reply
    own state file, own cursor

After (one job):
  lobstertalk-unified (hourly, 5-min in hot mode)
    GET /messages → route ALL INBOUND to ~/messages/inbox/ (dispatcher handles)
    advance cursor across ALL messages
    hot_mode → systemd-run transient 5-min re-run
    drain ~/messages/outbox/ source=bot-talk → POST /message
    log to lobstertalk.jsonl
```

## Areas to review closely

- The outbound queue drain (Step 5) assumes outbox files have `source="bot-talk"` and a `recipient` field. The dispatcher would need to write them in that format. This is marked as a future integration point — the task definition describes the contract, but the dispatcher's outbox writer is out of scope for this PR.
- Hot-mode re-triggering via `systemd-run` replaces the old `bot-talk-poller-fast` job. The old fast poller is disabled but not deleted — confirm it is not still enabled in `~/lobster-workspace/scheduled-jobs/jobs.json` before merging to production.
- The three old MCP jobs (`bot-talk-poller`, `bot-talk-realtime-forwarder`, `lobstertalk-incoming-handler`) must be disabled via `update_scheduled_job(name=..., enabled=False)` before activating this new job. That runtime step is not automated in this PR.

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_lobstertalk_unified_job.py -v` — 39 passed, 0 failed. Covers: direction inference, state load/defaults, atomic state write, timestamp cursor, hot-mode transitions (including immutability), inbox message schema, JSONL log entry, and log rotation threshold.
- [x] `uv run pytest tests/unit/ --tb=no -q` — 2217 passed, 80 failed, 24 skipped. The 80 failures are all pre-existing (baseline verified: identical count on `origin/main` before any changes). Zero new failures introduced.

## Manual test

N/A for this PR — the change is a new task definition template and unit tests only. No systemd units, cron entries, external service calls, or schema changes are made in this PR. The task definition is activated only when an operator creates the `lobstertalk-unified` MCP scheduled job (out of scope here).

Closes #1372
Supersedes #1081, #1082
Relates to #1351 (direction inference approach adopted here; the sender-name heuristic fallback removed)