### PR TITLE
🤖🦞 Lobster (engineer): fix post-compact dispatcher identity gap (Options 1 + 3)

### DIFF
--- a/hooks/inject-bootup-context.py
+++ b/hooks/inject-bootup-context.py
@@ -22,6 +22,15 @@ write-dispatcher-session-id.py ran first. The write is idempotent: if
 write-dispatcher-session-id.py already ran (position 0 in settings.json),
 the file already has the correct ID and this is a no-op; if this hook runs
 first for any reason, the ID is written here and downstream hooks benefit.
+
+Post-compaction sentinel fallback (Option 3, issue #1375):
+After context compaction, CC assigns a NEW session_id to the post-compact
+session.  on-compact.py writes the new UUID to both state files (Option 1),
+but as defense-in-depth this hook also checks for the compact-pending sentinel
+file.  If the sentinel exists AND LOBSTER_MAIN_SESSION=1, the session is
+treated as a post-compact dispatcher session regardless of the ID-match result.
+This bypasses the chicken-and-egg timing problem entirely for the post-compact
+case and ensures dispatcher bootup is always injected when it should be.
 """
 
 import json
@@ -45,6 +54,39 @@ USER_DISPATCHER_BOOTUP = USER_CONFIG_DIR / "user.dispatcher.bootup.md"
 USER_SUBAGENT_BOOTUP = USER_CONFIG_DIR / "user.subagent.bootup.md"
 
 HOOK_NAME = "inject-bootup-context"
+
+# Compact-pending sentinel written by on-compact.py for dispatcher compactions only.
+# Used as the Option 3 fallback: sentinel present + LOBSTER_MAIN_SESSION=1 → dispatcher.
+COMPACT_PENDING_SENTINEL = Path(os.path.expanduser("~/messages/config/compact-pending"))
+
+
+def _is_post_compact_dispatcher() -> bool:
+    """Return True if this looks like a post-compaction dispatcher session.
+
+    This is the Option 3 sentinel-based fallback for issue #1375.  It
+    bypasses the session-ID matching checks entirely for the post-compact case.
+
+    Conditions (both required):
+    - LOBSTER_MAIN_SESSION=1 is set in the environment (marks sessions started
+      by claude-persistent.sh as the dispatcher or its subagents).
+    - The compact-pending sentinel file exists.  on-compact.py writes this
+      file only for dispatcher compactions, so its presence is a reliable
+      dispatcher-scoped signal.
+
+    Why this is safe for subagents:
+    Subagent sessions that compact (rare) also have LOBSTER_MAIN_SESSION=1
+    and the sentinel will be present from the dispatcher's last compaction.
+    However, the sentinel is removed when the dispatcher calls
+    wait_for_messages() via post-compact-gate.py, so by the time a subagent
+    is spawned after a compaction the sentinel is normally gone.  In the
+    narrow window where a subagent starts while the sentinel is still present,
+    injecting dispatcher bootup is low-cost: the subagent will receive extra
+    context that does not conflict with its own bootup.  This is the same
+    acceptable trade-off documented in _is_dispatcher_compact().
+    """
+    if os.environ.get("LOBSTER_MAIN_SESSION", "") != "1":
+        return False
+    return COMPACT_PENDING_SENTINEL.exists()
 
 
 def _read_file_safe(path: Path, label: str) -> str | None:
@@ -89,6 +131,19 @@ def main() -> None:
         hook_input = {}
 
     is_dispatcher = session_role.is_dispatcher(hook_input)
+
+    # Option 3 fallback (issue #1375): if the compact-pending sentinel exists
+    # and LOBSTER_MAIN_SESSION=1, treat this as a post-compact dispatcher session
+    # regardless of what is_dispatcher() returned.  This covers the case where
+    # Option 1 (writing the new UUID in on-compact.py) hasn't propagated yet or
+    # fails silently, and provides defense-in-depth for the post-compact window.
+    if not is_dispatcher and _is_post_compact_dispatcher():
+        print(
+            f"[{HOOK_NAME}] sentinel fallback: compact-pending exists + "
+            "LOBSTER_MAIN_SESSION=1; treating as post-compact dispatcher",
+            file=sys.stderr,
+        )
+        is_dispatcher = True
 
     # If this is the dispatcher session, write the session ID to the marker file.
     # This makes the hook self-sufficient regardless of whether

--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -45,6 +45,7 @@ from session_role import (
     DISPATCHER_SESSION_FILE,
     is_dispatcher,
     write_dispatcher_session_id,
+    write_dispatcher_claude_session_id,
     _read_dispatcher_session_id,
 )
 
@@ -384,13 +385,23 @@ def _is_dispatcher_compact(data: dict) -> bool:
     if not _stored_dispatcher_session_alive():
         return False
 
-    # This looks like a dispatcher compaction.  Update the marker file to the
-    # new session_id so all subsequent hook calls in this session recognise it.
+    # This looks like a dispatcher compaction.  Update both the hook marker
+    # file (tertiary) and the primary MCP Claude UUID state file so all
+    # subsequent hook calls in this session recognise the new session_id.
+    #
+    # Writing the primary file (dispatcher-claude-session-id) is the Option 1
+    # fix for issue #1375: inject-bootup-context.py fires before session_start()
+    # is called, so the MCP server hasn't had a chance to update the primary
+    # file yet.  By writing it here — in on-compact.py, which runs before
+    # inject-bootup-context.py in the SessionStart hook chain — the primary
+    # check in is_dispatcher() passes and dispatcher bootup is injected correctly.
     new_session_id = data.get("session_id", "").strip()
     if new_session_id:
         write_dispatcher_session_id(new_session_id)
+        write_dispatcher_claude_session_id(new_session_id)
         print(
-            f"[on-compact] compaction fallback: updated dispatcher-session-id to {new_session_id}",
+            f"[on-compact] compaction fallback: updated dispatcher-session-id "
+            f"and dispatcher-claude-session-id to {new_session_id}",
             file=sys.stderr,
         )
 

--- a/hooks/session_role.py
+++ b/hooks/session_role.py
@@ -180,6 +180,31 @@ def write_dispatcher_session_id(session_id: str) -> None:
         pass
 
 
+def write_dispatcher_claude_session_id(session_id: str) -> None:
+    """Write session_id to the primary MCP Claude UUID state file.
+
+    This is the primary dispatcher detection file read by is_dispatcher().
+    It stores the Claude session UUID (36-char UUID4) that matches
+    hook_input["session_id"] in SessionStart hooks.
+
+    Called by on-compact.py when a dispatcher compaction is confirmed, so that
+    inject-bootup-context.py can detect the new post-compact session as the
+    dispatcher before session_start() has been called (which would normally
+    write this file via the MCP server).
+
+    Atomic write via a .tmp rename.  Silent on any failure — must never crash
+    the caller.
+    """
+    try:
+        path = _get_mcp_claude_session_file()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_suffix(".tmp")
+        tmp_path.write_text(session_id.strip())
+        tmp_path.replace(path)  # atomic on Linux
+    except Exception:  # noqa: BLE001
+        pass
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_hooks/test_inject_bootup_context_sentinel.py
+++ b/tests/unit/test_hooks/test_inject_bootup_context_sentinel.py
@@ -1,0 +1,347 @@
+"""
+Unit tests for Option 3 of issue #1375: the sentinel-based fallback in
+inject-bootup-context.py.
+
+When the compact-pending sentinel file exists AND LOBSTER_MAIN_SESSION=1,
+inject-bootup-context.py must inject dispatcher bootup context regardless of
+what session_role.is_dispatcher() returns.
+
+This covers the case where Option 1 (writing the UUID in on-compact.py)
+hasn't propagated yet or fails silently, providing defense-in-depth for the
+post-compact window.
+
+Tests focus on the _is_post_compact_dispatcher() helper and the integration
+path in main() that uses it as a fallback.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "inject-bootup-context.py"
+
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _PatchEnv:
+    def __init__(self, env: dict):
+        self._env = env
+        self._saved: dict = {}
+
+    def __enter__(self):
+        for k, v in self._env.items():
+            self._saved[k] = os.environ.get(k)
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        return self
+
+    def __exit__(self, *_):
+        for k, saved_v in self._saved.items():
+            if saved_v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = saved_v
+
+
+def _load_inject_hook(*, home: Path, workspace: Path) -> object:
+    """Load inject-bootup-context.py in a controlled environment."""
+    env = {
+        "HOME": str(home),
+        "LOBSTER_WORKSPACE": str(workspace),
+    }
+    with _PatchEnv(env):
+        spec = importlib.util.spec_from_file_location("inject_bootup", _HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Tests for _is_post_compact_dispatcher()
+# ---------------------------------------------------------------------------
+
+
+class TestIsPostCompactDispatcher:
+    """Unit tests for the _is_post_compact_dispatcher() helper."""
+
+    def test_returns_true_when_sentinel_exists_and_main_session(self, tmp_path):
+        """Sentinel present + LOBSTER_MAIN_SESSION=1 → True."""
+        # Create sentinel.
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        sentinel = config_dir / "compact-pending"
+        sentinel.touch()
+
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1", "HOME": str(tmp_path)}):
+            mod = _load_inject_hook(home=tmp_path, workspace=tmp_path)
+            # Override the sentinel path to point at our tmp sentinel.
+            mod.COMPACT_PENDING_SENTINEL = sentinel
+            result = mod._is_post_compact_dispatcher()
+
+        assert result is True
+
+    def test_returns_false_when_no_sentinel(self, tmp_path):
+        """Sentinel absent → False even if LOBSTER_MAIN_SESSION=1."""
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        sentinel = config_dir / "compact-pending"
+        # sentinel does NOT exist
+
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1", "HOME": str(tmp_path)}):
+            mod = _load_inject_hook(home=tmp_path, workspace=tmp_path)
+            mod.COMPACT_PENDING_SENTINEL = sentinel
+            result = mod._is_post_compact_dispatcher()
+
+        assert result is False
+
+    def test_returns_false_when_lobster_main_session_not_set(self, tmp_path):
+        """LOBSTER_MAIN_SESSION absent → False even if sentinel exists."""
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        sentinel = config_dir / "compact-pending"
+        sentinel.touch()
+
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": None, "HOME": str(tmp_path)}):
+            mod = _load_inject_hook(home=tmp_path, workspace=tmp_path)
+            mod.COMPACT_PENDING_SENTINEL = sentinel
+            result = mod._is_post_compact_dispatcher()
+
+        assert result is False
+
+    def test_returns_false_when_lobster_main_session_is_zero(self, tmp_path):
+        """LOBSTER_MAIN_SESSION=0 → False even if sentinel exists."""
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        sentinel = config_dir / "compact-pending"
+        sentinel.touch()
+
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "0", "HOME": str(tmp_path)}):
+            mod = _load_inject_hook(home=tmp_path, workspace=tmp_path)
+            mod.COMPACT_PENDING_SENTINEL = sentinel
+            result = mod._is_post_compact_dispatcher()
+
+        assert result is False
+
+    def test_returns_false_when_both_absent(self, tmp_path):
+        """Neither sentinel nor LOBSTER_MAIN_SESSION=1 → False."""
+        sentinel = tmp_path / "no-sentinel"
+
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": None, "HOME": str(tmp_path)}):
+            mod = _load_inject_hook(home=tmp_path, workspace=tmp_path)
+            mod.COMPACT_PENDING_SENTINEL = sentinel
+            result = mod._is_post_compact_dispatcher()
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: main() uses sentinel fallback to inject dispatcher bootup
+# ---------------------------------------------------------------------------
+
+
+class TestMainSentinelFallback:
+    """main() in inject-bootup-context.py uses the sentinel as a fallback
+    when is_dispatcher() returns False but the post-compact sentinel is present.
+    """
+
+    def _make_bootup_files(self, claude_dir: Path) -> tuple[Path, Path]:
+        """Write minimal dispatcher and subagent bootup stubs."""
+        dispatcher_bootup = claude_dir / "sys.dispatcher.bootup.md"
+        subagent_bootup = claude_dir / "sys.subagent.bootup.md"
+        dispatcher_bootup.write_text("# DISPATCHER BOOTUP\n")
+        subagent_bootup.write_text("# SUBAGENT BOOTUP\n")
+        return dispatcher_bootup, subagent_bootup
+
+    def test_sentinel_fallback_injects_dispatcher_bootup(self, tmp_path, capsys):
+        """When is_dispatcher()=False but sentinel+LOBSTER_MAIN_SESSION=1,
+        dispatcher bootup must be injected (not subagent bootup).
+        """
+        # Set up file structure.
+        claude_dir = tmp_path / "lobster" / ".claude"
+        claude_dir.mkdir(parents=True)
+        dispatcher_bootup, _ = self._make_bootup_files(claude_dir)
+
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        sentinel = config_dir / "compact-pending"
+        sentinel.touch()
+
+        # No dispatcher session ID files → is_dispatcher() will return False.
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+
+        hook_input = json.dumps({"session_id": "unknown-post-compact-uuid"})
+
+        with _PatchEnv(
+            {
+                "HOME": str(tmp_path),
+                "LOBSTER_WORKSPACE": str(tmp_path),
+                "LOBSTER_MAIN_SESSION": "1",
+            }
+        ):
+            spec = importlib.util.spec_from_file_location("inject_main_test", _HOOK_PATH)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+
+            # Override paths to use our tmp structure.
+            mod.DISPATCHER_BOOTUP = dispatcher_bootup
+            mod.COMPACT_PENDING_SENTINEL = sentinel
+            # Point user config to a non-existent dir so extra files aren't injected.
+            mod.USER_CONFIG_DIR = tmp_path / "no-user-config"
+            mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+            mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+            mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+
+            with patch("sys.stdin", io.StringIO(hook_input)):
+                with pytest.raises(SystemExit):
+                    mod.main()
+
+        captured = capsys.readouterr()
+        assert "DISPATCHER BOOTUP" in captured.out, (
+            "Dispatcher bootup should have been injected via sentinel fallback"
+        )
+        assert "SUBAGENT BOOTUP" not in captured.out
+
+    def test_no_sentinel_normal_subagent_gets_subagent_bootup(self, tmp_path, capsys):
+        """Without sentinel, an unrecognised session gets subagent bootup (normal path)."""
+        claude_dir = tmp_path / "lobster" / ".claude"
+        claude_dir.mkdir(parents=True)
+        _, subagent_bootup = self._make_bootup_files(claude_dir)
+
+        # No sentinel, no dispatcher session files.
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+
+        hook_input = json.dumps({"session_id": "random-subagent-uuid"})
+
+        with _PatchEnv(
+            {
+                "HOME": str(tmp_path),
+                "LOBSTER_WORKSPACE": str(tmp_path),
+                "LOBSTER_MAIN_SESSION": "1",
+            }
+        ):
+            spec = importlib.util.spec_from_file_location("inject_sub_test", _HOOK_PATH)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+
+            # Override paths.
+            mod.SUBAGENT_BOOTUP = subagent_bootup
+            sentinel_path = tmp_path / "messages" / "config" / "compact-pending"
+            mod.COMPACT_PENDING_SENTINEL = sentinel_path  # does not exist
+            mod.USER_CONFIG_DIR = tmp_path / "no-user-config"
+            mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+            mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+            mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+
+            with patch("sys.stdin", io.StringIO(hook_input)):
+                with pytest.raises(SystemExit):
+                    mod.main()
+
+        captured = capsys.readouterr()
+        assert "SUBAGENT BOOTUP" in captured.out, (
+            "Subagent bootup should be injected for unrecognised session without sentinel"
+        )
+        assert "DISPATCHER BOOTUP" not in captured.out
+
+    def test_sentinel_with_lobster_main_session_zero_gets_subagent_bootup(
+        self, tmp_path, capsys
+    ):
+        """Sentinel present but LOBSTER_MAIN_SESSION != '1' → subagent bootup, not dispatcher."""
+        claude_dir = tmp_path / "lobster" / ".claude"
+        claude_dir.mkdir(parents=True)
+        _, subagent_bootup = self._make_bootup_files(claude_dir)
+
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        sentinel = config_dir / "compact-pending"
+        sentinel.touch()
+
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+
+        hook_input = json.dumps({"session_id": "outside-session-uuid"})
+
+        with _PatchEnv(
+            {
+                "HOME": str(tmp_path),
+                "LOBSTER_WORKSPACE": str(tmp_path),
+                "LOBSTER_MAIN_SESSION": "0",  # NOT the main session
+            }
+        ):
+            spec = importlib.util.spec_from_file_location("inject_outside_test", _HOOK_PATH)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+
+            mod.SUBAGENT_BOOTUP = subagent_bootup
+            mod.COMPACT_PENDING_SENTINEL = sentinel
+            mod.USER_CONFIG_DIR = tmp_path / "no-user-config"
+            mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+            mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+            mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+
+            with patch("sys.stdin", io.StringIO(hook_input)):
+                with pytest.raises(SystemExit):
+                    mod.main()
+
+        captured = capsys.readouterr()
+        assert "SUBAGENT BOOTUP" in captured.out
+        assert "DISPATCHER BOOTUP" not in captured.out
+
+    def test_primary_file_match_still_works_without_sentinel(self, tmp_path, capsys):
+        """When is_dispatcher() returns True via primary file, no sentinel needed."""
+        claude_dir = tmp_path / "lobster" / ".claude"
+        claude_dir.mkdir(parents=True)
+        dispatcher_bootup, _ = self._make_bootup_files(claude_dir)
+
+        # Write dispatcher UUID to primary file.
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        dispatcher_uuid = "known-dispatcher-uuid-abc"
+        (data_dir / "dispatcher-claude-session-id").write_text(dispatcher_uuid)
+
+        # No sentinel.
+        (tmp_path / "messages" / "config").mkdir(parents=True, exist_ok=True)
+
+        hook_input = json.dumps({"session_id": dispatcher_uuid})
+
+        with _PatchEnv(
+            {
+                "HOME": str(tmp_path),
+                "LOBSTER_WORKSPACE": str(tmp_path),
+                "LOBSTER_MAIN_SESSION": "1",
+            }
+        ):
+            spec = importlib.util.spec_from_file_location("inject_primary_test", _HOOK_PATH)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+
+            mod.DISPATCHER_BOOTUP = dispatcher_bootup
+            sentinel_path = tmp_path / "messages" / "config" / "compact-pending"
+            mod.COMPACT_PENDING_SENTINEL = sentinel_path  # does not exist
+            mod.USER_CONFIG_DIR = tmp_path / "no-user-config"
+            mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+            mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+            mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+
+            with patch("sys.stdin", io.StringIO(hook_input)):
+                with pytest.raises(SystemExit):
+                    mod.main()
+
+        captured = capsys.readouterr()
+        assert "DISPATCHER BOOTUP" in captured.out
+        assert "SUBAGENT BOOTUP" not in captured.out

--- a/tests/unit/test_hooks/test_on_compact_write_claude_session_id.py
+++ b/tests/unit/test_hooks/test_on_compact_write_claude_session_id.py
@@ -1,0 +1,301 @@
+"""
+Unit tests for Option 1 of issue #1375: on-compact.py writes the new
+post-compact session UUID to the primary MCP Claude UUID state file
+(dispatcher-claude-session-id) when _is_dispatcher_compact() confirms a
+dispatcher compaction.
+
+Previously, on-compact.py only updated the tertiary hook marker file
+(~/messages/config/dispatcher-session-id) when the compaction fallback fired.
+The primary file remained stale, causing inject-bootup-context.py to inject
+subagent bootup context instead of dispatcher bootup after every compaction.
+
+The fix adds a call to write_dispatcher_claude_session_id(new_session_id) so
+the primary file is up-to-date before any subsequent hooks run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "on-compact.py"
+
+# Make session_role importable for assertions.
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _PatchEnv:
+    """Context manager to temporarily set/unset environment variables."""
+
+    def __init__(self, env: dict):
+        self._env = env
+        self._saved: dict = {}
+
+    def __enter__(self):
+        for k, v in self._env.items():
+            self._saved[k] = os.environ.get(k)
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        return self
+
+    def __exit__(self, *_):
+        for k, saved_v in self._saved.items():
+            if saved_v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = saved_v
+
+
+def _load_on_compact(
+    *,
+    workspace: Path,
+    state_file: Path | None = None,
+    compaction_state_file: Path | None = None,
+    last_compact_ts_file: Path | None = None,
+):
+    """Load on-compact.py with test-controlled file paths."""
+    env = {
+        "LOBSTER_WORKSPACE": str(workspace),
+        "LOBSTER_MAIN_SESSION": "1",
+    }
+    if state_file:
+        env["LOBSTER_STATE_FILE_OVERRIDE"] = str(state_file)
+    if compaction_state_file:
+        env["LOBSTER_COMPACTION_STATE_FILE_OVERRIDE"] = str(compaction_state_file)
+    if last_compact_ts_file:
+        env["LOBSTER_LAST_COMPACT_TS_FILE_OVERRIDE"] = str(last_compact_ts_file)
+
+    with _PatchEnv(env):
+        spec = importlib.util.spec_from_file_location("on_compact_test", _HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
+
+def _dispatcher_hook_input(session_id: str) -> dict:
+    return {"session_id": session_id}
+
+
+# ---------------------------------------------------------------------------
+# Tests for write_dispatcher_claude_session_id in session_role
+# ---------------------------------------------------------------------------
+
+
+class TestWriteDispatcherClaudeSessionId:
+    """session_role.write_dispatcher_claude_session_id writes the primary file."""
+
+    def test_writes_primary_file(self, monkeypatch, tmp_path):
+        """write_dispatcher_claude_session_id writes the Claude UUID state file."""
+        import importlib
+        import session_role as _sr
+
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        sr = importlib.reload(_sr)
+
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+
+        sr.write_dispatcher_claude_session_id("new-compact-uuid-001")
+
+        written = (tmp_path / "data" / "dispatcher-claude-session-id").read_text().strip()
+        assert written == "new-compact-uuid-001"
+
+    def test_strips_whitespace(self, monkeypatch, tmp_path):
+        import importlib
+        import session_role as _sr
+
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        sr = importlib.reload(_sr)
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+
+        sr.write_dispatcher_claude_session_id("  padded-uuid  ")
+
+        written = (tmp_path / "data" / "dispatcher-claude-session-id").read_text().strip()
+        assert written == "padded-uuid"
+
+    def test_creates_parent_directory(self, monkeypatch, tmp_path):
+        import importlib
+        import session_role as _sr
+
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        sr = importlib.reload(_sr)
+        # data/ does NOT exist — write_dispatcher_claude_session_id must create it.
+        assert not (tmp_path / "data").exists()
+
+        sr.write_dispatcher_claude_session_id("uuid-creates-dir")
+
+        assert (tmp_path / "data" / "dispatcher-claude-session-id").exists()
+
+    def test_silent_on_failure(self, monkeypatch, tmp_path):
+        """Errors during write are silently swallowed — must not raise."""
+        import importlib
+        import session_role as _sr
+
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        sr = importlib.reload(_sr)
+
+        # Point workspace at an unwritable location.
+        monkeypatch.setenv("LOBSTER_WORKSPACE", "/proc/lobster-no-write-test")
+        sr = importlib.reload(_sr)
+
+        # Must not raise.
+        sr.write_dispatcher_claude_session_id("any-uuid")
+
+    def test_is_dispatcher_passes_after_write(self, monkeypatch, tmp_path):
+        """After write_dispatcher_claude_session_id, is_dispatcher() returns True."""
+        import importlib
+        import session_role as _sr
+
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        # Also redirect HOME so tertiary marker file lives in tmp_path.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(_sr)
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+
+        new_uuid = "post-compact-uuid-1111-2222-3333"
+        sr.write_dispatcher_claude_session_id(new_uuid)
+
+        assert sr.is_dispatcher({"session_id": new_uuid}) is True
+
+    def test_old_uuid_no_longer_matches_after_write(self, monkeypatch, tmp_path):
+        """After updating the primary file, the old UUID is rejected."""
+        import importlib
+        import session_role as _sr
+
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(_sr)
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+
+        old_uuid = "old-dispatcher-uuid-0000"
+        new_uuid = "new-compact-uuid-1111"
+        (tmp_path / "data" / "dispatcher-claude-session-id").write_text(old_uuid)
+
+        sr.write_dispatcher_claude_session_id(new_uuid)
+
+        # Old UUID should now fail the primary check.
+        assert sr.is_dispatcher({"session_id": old_uuid}) is False
+        # New UUID should pass.
+        assert sr.is_dispatcher({"session_id": new_uuid}) is True
+
+
+# ---------------------------------------------------------------------------
+# Tests verifying on-compact.py calls write_dispatcher_claude_session_id
+# ---------------------------------------------------------------------------
+
+
+class TestOnCompactWritesPrimarySessionFile:
+    """on-compact.py must write the new UUID to the primary Claude session file
+    when the compaction fallback fires (_is_dispatcher_compact returns True via
+    LOBSTER_MAIN_SESSION + stored JSONL alive path).
+    """
+
+    def _setup_stored_session_jsonl(self, home_dir: Path, stored_uuid: str) -> None:
+        """Create a fake stored-session JSONL so _stored_dispatcher_session_alive returns True."""
+        projects_dir = home_dir / ".claude" / "projects" / "fake-project"
+        projects_dir.mkdir(parents=True, exist_ok=True)
+        (projects_dir / f"{stored_uuid}.jsonl").write_text('{"type":"text"}\n')
+
+    def test_primary_file_written_on_dispatcher_compaction(self, monkeypatch, tmp_path):
+        """When the dispatcher compact fallback fires, primary Claude session file is updated."""
+        import importlib
+        import session_role as _sr
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+
+        # Write stored (old) session UUID to the tertiary marker file.
+        stored_uuid = "old-session-uuid-stored"
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "dispatcher-session-id").write_text(stored_uuid)
+
+        # Create the JSONL so _stored_dispatcher_session_alive() returns True.
+        self._setup_stored_session_jsonl(tmp_path, stored_uuid)
+
+        # New post-compact session ID.
+        new_uuid = "new-post-compact-uuid-9999"
+
+        # Minimal support files.
+        state_file = tmp_path / "lobster-state.json"
+        state_file.write_text('{"mode":"active"}')
+        compaction_state = tmp_path / "compaction-state.json"
+        last_compact_ts = tmp_path / "last-compact.ts"
+
+        # Reload session_role so path resolution picks up new HOME/WORKSPACE.
+        sr = importlib.reload(_sr)
+
+        env_overrides = {
+            "LOBSTER_WORKSPACE": str(tmp_path),
+            "LOBSTER_MAIN_SESSION": "1",
+            "HOME": str(tmp_path),
+            "LOBSTER_STATE_FILE_OVERRIDE": str(state_file),
+            "LOBSTER_COMPACTION_STATE_FILE_OVERRIDE": str(compaction_state),
+            "LOBSTER_LAST_COMPACT_TS_FILE_OVERRIDE": str(last_compact_ts),
+        }
+
+        hook_input = json.dumps({"session_id": new_uuid, "hook_event_name": "PostCompact"})
+
+        with _PatchEnv(env_overrides):
+            with patch("urllib.request.urlopen"):  # suppress Telegram call
+                spec = importlib.util.spec_from_file_location("on_compact_t", _HOOK_PATH)
+                mod = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(mod)
+                # Call _is_dispatcher_compact + write path directly.
+                mod._is_dispatcher_compact({"session_id": new_uuid})
+
+        # After the call, the primary file should contain the new UUID.
+        primary_file = tmp_path / "data" / "dispatcher-claude-session-id"
+        assert primary_file.exists(), (
+            "Primary Claude session file should have been written by on-compact.py"
+        )
+        assert primary_file.read_text().strip() == new_uuid
+
+    def test_primary_file_not_written_for_subagent_compaction(self, monkeypatch, tmp_path):
+        """Subagent compactions must not write the primary dispatcher session file."""
+        import importlib
+        import session_role as _sr
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+
+        # No stored dispatcher session — _stored_dispatcher_session_alive() returns False.
+        # LOBSTER_MAIN_SESSION is set to something other than '1' to simulate subagent.
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+
+        subagent_uuid = "subagent-uuid-no-write"
+
+        sr = importlib.reload(_sr)
+
+        env_overrides = {
+            "LOBSTER_WORKSPACE": str(tmp_path),
+            "LOBSTER_MAIN_SESSION": "0",  # not the main session
+            "HOME": str(tmp_path),
+        }
+
+        with _PatchEnv(env_overrides):
+            spec = importlib.util.spec_from_file_location("on_compact_sub", _HOOK_PATH)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            result = mod._is_dispatcher_compact({"session_id": subagent_uuid})
+
+        assert result is False
+        primary_file = tmp_path / "data" / "dispatcher-claude-session-id"
+        assert not primary_file.exists(), (
+            "Primary session file should NOT be written for subagent compaction"
+        )


### PR DESCRIPTION
Fixes #1375

## Problem

After context compaction, the new dispatcher session took >600s to start processing messages. The root cause: `inject-bootup-context.py` injected subagent bootup context instead of dispatcher bootup context, so the dispatcher woke up confused about its role.

The failure was a chicken-and-egg timing problem. `inject-bootup-context.py` fires during `SessionStart` — before the dispatcher has called `session_start()` on the MCP server. So:

- **Primary check** (`dispatcher-claude-session-id`): stale — still has the old pre-compact UUID; MCP server hasn't written the new one yet
- **Tertiary check** (`~/messages/config/dispatcher-session-id`): also stale — had the old UUID
- Result: `is_dispatcher()` returns False → subagent bootup injected → dispatcher stalls

`on-compact.py` had the new post-compact UUID in `data["session_id"]` and already confirmed it was a dispatcher compaction via `_is_dispatcher_compact()`, but only updated the tertiary marker file — not the primary one.

## Two-layer fix

### Option 1 — Write primary state file in `on-compact.py`

`session_role` gains a new function `write_dispatcher_claude_session_id(session_id)` that writes to the primary file (`dispatcher-claude-session-id` in `$LOBSTER_WORKSPACE/data/`). `on-compact.py`'s `_is_dispatcher_compact()` now calls it alongside the existing `write_dispatcher_session_id()` call. Since `on-compact.py` runs in the hook chain before `inject-bootup-context.py`, the primary file is correct by the time the identity check runs.

### Option 3 — Sentinel-based fallback in `inject-bootup-context.py`

A new `_is_post_compact_dispatcher()` helper: if `compact-pending` sentinel exists AND `LOBSTER_MAIN_SESSION=1`, treat the session as a post-compact dispatcher regardless of the ID-match result. The sentinel is written by `on-compact.py` exclusively for dispatcher compactions, making it a reliable scoped signal. This provides defense-in-depth if Option 1 ever fails silently (e.g. transient filesystem error).

## Before / after hook flow

```
Before (broken):
SessionStart fires
  on-compact.py: detects dispatcher compact, writes tertiary marker
  inject-bootup-context.py: calls is_dispatcher()
    primary file: stale → mismatch → False
    tertiary file: has old UUID → mismatch → False
    result: False → subagent bootup injected → dispatcher stalls

After (fixed):
SessionStart fires
  on-compact.py: detects dispatcher compact
    → writes tertiary marker (existing behavior)
    → writes primary file with new UUID (Option 1)
  inject-bootup-context.py: calls is_dispatcher()
    primary file: correct new UUID → match → True
    → dispatcher bootup injected immediately
  [If Option 1 write fails silently:]
    _is_post_compact_dispatcher(): sentinel exists + LOBSTER_MAIN_SESSION=1 → True (Option 3)
    → dispatcher bootup injected via sentinel fallback
```

## Functional patterns

`_is_post_compact_dispatcher()` is a pure predicate (no side effects). File writes are isolated to named write functions following the existing `write_dispatcher_session_id()` pattern. Both fixes are idempotent.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_on_compact_write_claude_session_id.py tests/unit/test_hooks/test_inject_bootup_context_sentinel.py -v` — 17 passed, 0 failed
- [x] `uv run pytest tests/unit/ -x --tb=short -q` — 522 passed, 1 pre-existing failure in `test_hibernation.py::test_timeout_without_hibernate_flag_does_not_write_state` (confirmed failing on `main` before this branch)

## Manual test

N/A — this change is limited to Python hook logic and file writes. No systemd, cron, external services, or database schema changes.

## Areas to review closely

- `_is_post_compact_dispatcher()` in `inject-bootup-context.py`: the subagent edge case. A subagent that compacts while the sentinel is still present will get dispatcher bootup injected. This is the same acceptable trade-off documented in `_is_dispatcher_compact()` — subagent compactions are rare and receiving extra dispatcher context is low-cost.
- `write_dispatcher_claude_session_id()` in `session_role.py`: atomic `.tmp` rename, `mkdir(parents=True, exist_ok=True)`, silent on failure — same pattern as `write_dispatcher_session_id()`.

## Concerns / known gaps

None. Both options are in place; either alone would fix the bug.