### PR TITLE
fix(agents): add spec-first TDD requirement to functional-engineer

### DIFF
--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -70,6 +70,9 @@ git branch -d feature/issue-42-my-feature
 - Make atomic, well-documented commits with clear messages
 - As you complete items in your plan, use `gh issue edit` or `gh issue comment` to check them off in the issue
 - If you need to deviate from or update your plan, add a comment to the issue explaining the change
+- **Write tests BEFORE writing implementation code.** Tests must be derived from the spec/issue description, not from the code you are about to write. A test written after the code it covers is a transcript — it tells you what the code does, not whether it is correct.
+- **Use named constants for values mentioned in the spec.** If the issue says "after 2 empty polls," write `COOLDOWN_THRESHOLD = 2` and reference that constant in both the test and the implementation. Never use magic literals that a reader must reverse-engineer back to the requirement.
+- **Name tests after the behavior, not the mechanism.** `test_cooldown_after_N_empty_polls` is a test. `test_update_hot_mode_returns_false` is a transcript of implementation detail.
 - Write tests that verify behavior without relying on implementation details
 - **Run tests before opening the PR** — not after. The PR body records what was actually executed, not what you intend to run.
 


### PR DESCRIPTION
## What gap this closes

The `functional-engineer` agent definition required engineers to write tests and run them before opening a PR — but never said *when* tests must be written relative to implementation. The only guidance was:

> Write tests that verify behavior without relying on implementation details

That sentence is silent on ordering. An engineer can satisfy it by writing tests after the code is done. That is what happened: a PR recently shipped with tests written to match already-written code. Those tests pass, but they verify what the code does — not whether the code is correct per the spec. A test that was written after the code it covers is a transcript, not a specification.

## What this adds

Three explicit rules in the Implementation section of `/.claude/agents/functional-engineer.md`:

1. **Write tests BEFORE writing implementation code.** Tests must be derived from the spec/issue description, not from the code you are about to write.
2. **Use named constants for values from the spec.** `COOLDOWN_THRESHOLD = 2`, not a bare `2` whose meaning a reader must infer.
3. **Name tests after the behavior, not the mechanism.** `test_cooldown_after_N_empty_polls` is a test. `test_update_hot_mode_returns_false` is a transcript.

The existing "Write tests that verify behavior without relying on implementation details" line is kept — the new rules precede it and provide the ordering constraint and naming discipline that were missing.

## What this does not change

- No behavior change to any running code
- No change to the PR description format or test-recording requirements
- No change to any other agent definition

## Tests run
- [x] Manual diff review — 3 lines inserted in the correct location within the Implementation section, existing text preserved
- [x] File renders correctly (markdown structure intact)

## Manual test
N/A — documentation-only change, no systemd, cron, external services, file I/O, or DB touched.

Closes #1378