### PR TITLE
feat(lobstertalk): direction inference from endpoint context (PR A of 3)

### DIFF
--- a/scheduled-tasks/tasks/bot-talk-poller-fast.md.template
+++ b/scheduled-tasks/tasks/bot-talk-poller-fast.md.template
@@ -1,5 +1,9 @@
 # Bot Talk Poller Fast
 
+> **DEPRECATED** — This job is disabled. Hot-mode re-triggering is now handled by
+> `lobstertalk-unified` via a transient `systemd-run` one-shot unit. Do not re-enable
+> without also disabling `lobstertalk-unified`.
+
 **Job**: bot-talk-poller-fast
 **Schedule**: Every 2 minutes (`*/2 * * * *`)
 

--- a/scheduled-tasks/tasks/bot-talk-poller.md.template
+++ b/scheduled-tasks/tasks/bot-talk-poller.md.template
@@ -1,5 +1,10 @@
 # Bot Talk Poller
 
+> **DEPRECATED** — This job is disabled. Its responsibilities (polling, hot-mode management,
+> inbox routing, and Telegram notifications) have been consolidated into `lobstertalk-unified`
+> (see `scheduled-tasks/tasks/lobstertalk-unified.md.template`). Do not re-enable without
+> also disabling `lobstertalk-unified` to avoid double-processing.
+
 **Job**: bot-talk-poller
 **Schedule**: Hourly (`0 * * * *`)
 

--- a/scheduled-tasks/tasks/lobstertalk-incoming-handler.md
+++ b/scheduled-tasks/tasks/lobstertalk-incoming-handler.md
@@ -1,5 +1,11 @@
 # LobsterTalk Incoming Message Handler
 
+> **DEPRECATED** — This job is disabled. Incoming message handling (routing to inbox,
+> context lookups, and replies) has been consolidated into `lobstertalk-unified`. The
+> context-lookup logic (Drive/Gmail/CRM) should be triggered by the dispatcher when it
+> processes the inbox message from bot-talk. Do not re-enable without also disabling
+> `lobstertalk-unified`.
+
 **Job**: lobstertalk-incoming-handler
 **Schedule**: `*/5 * * * *` (every 5 minutes)
 **Skill**: `email-autoresponder` (see `lobster-shop/email-autoresponder/`)

--- a/scheduled-tasks/tasks/lobstertalk-unified.md.template
+++ b/scheduled-tasks/tasks/lobstertalk-unified.md.template
@@ -1,0 +1,228 @@
+# LobsterTalk Unified Job
+
+**Job**: lobstertalk-unified
+**Schedule**: Hourly baseline (`0 * * * *`); self-reschedules to every 5 min during hot mode
+
+## Context
+
+You are **{{LOCAL_LOBSTER_IDENTITY}}**. This job owns the complete inter-Lobster
+communication cycle: receiving messages from the bot-talk server, routing them to the
+Lobster inbox, sending queued outbound messages, and managing hot-mode re-triggering.
+
+Bot-talk is **strictly inter-Lobster communication** — messages exchanged between Lobster
+instances (e.g. {{LOCAL_LOBSTER_IDENTITY}} ↔ AlbertLobster). Owner Telegram messages are NOT bot-talk.
+
+This job replaces three older overlapping jobs:
+- `bot-talk-poller` (disabled)
+- `bot-talk-realtime-forwarder` (disabled)
+- `lobstertalk-incoming-handler` (disabled)
+
+## Direction Inference
+
+Direction is inferred from which API endpoint is called — no stored `direction` field needed:
+- `GET /messages` (receive) → **INBOUND**
+- `POST /message` (send) → **OUTBOUND**
+
+This is more reliable than inspecting a stored field or filtering by sender name.
+
+If the API response does include a `direction` field, use it as a cross-check; otherwise
+infer from endpoint context as above.
+
+## Authentication
+
+Read the bot-talk API token using this lookup chain (first non-empty value wins):
+
+1. `~/lobster-workspace/data/bot-talk-token.txt`
+2. `BOT_TALK_TOKEN` in `~/messages/config/config.env`
+3. `BOT_TALK_TOKEN` in `~/lobster-config/config.env`
+
+```python
+def _load_bot_talk_token() -> str:
+    from pathlib import Path
+
+    token_file = Path.home() / "lobster-workspace" / "data" / "bot-talk-token.txt"
+    if token_file.exists():
+        token = token_file.read_text().strip()
+        if token:
+            return token
+
+    for config_path in [
+        Path.home() / "messages" / "config" / "config.env",
+        Path.home() / "lobster-config" / "config.env",
+    ]:
+        if config_path.exists():
+            for line in config_path.read_text().splitlines():
+                line = line.strip()
+                if line.startswith("BOT_TALK_TOKEN="):
+                    value = line.split("=", 1)[1].strip().strip('"').strip("'")
+                    if value:
+                        return value
+    return ""
+```
+
+If the token is empty after all lookups: call `write_task_output` with status="failed" and
+exit immediately.
+
+## State File
+
+Read and write `~/lobster-workspace/data/lobstertalk-unified-state.json`.
+Create with defaults if it does not exist.
+
+Schema:
+```json
+{
+  "last_seen_ts": "2020-01-01T00:00:00Z",
+  "hot_mode": false,
+  "consecutive_empty_polls": 0,
+  "hot_mode_activated_at": null
+}
+```
+
+Always write state atomically: write to `.tmp` file, then rename.
+
+## Instructions
+
+### Step 1: Load state and token
+
+Read state file (create with defaults if missing). Load the API token; fail if empty.
+
+### Step 2: Receive — GET /messages
+
+```
+GET http://{{LOBSTERTALK_HOST}}/messages?since=<last_seen_ts>&limit=100
+X-Bot-Token: <token>
+```
+
+The API returns `{"count": N, "messages": [...]}`. Each message has:
+`id`, `sender`, `content`, `genre`, `tier`, `timestamp`.
+
+Sort all returned messages by `timestamp` ascending (oldest first).
+
+**Direction for received messages: always INBOUND** (they arrived via GET).
+
+For each INBOUND message:
+
+1. **Route to Lobster inbox** — write a JSON file to `~/messages/inbox/`:
+   ```json
+   {
+     "id": "<timestamp_ms>_bot_talk_<uuid8>",
+     "type": "text",
+     "source": "bot-talk",
+     "chat_id": "<sender>",
+     "user_name": "<sender>",
+     "text": "<content>",
+     "timestamp": "<ISO timestamp>",
+     "direction": "INBOUND",
+     "from": "<sender>",
+     "to": "{{LOCAL_LOBSTER_IDENTITY}}"
+   }
+   ```
+   Write atomically (`.tmp` then rename). This ensures the dispatcher processes it
+   like any other inbox message.
+
+2. **Log the message** — append a JSONL entry to
+   `~/lobster-workspace/logs/lobstertalk.jsonl`:
+   ```json
+   {"ts": "<ISO>", "direction": "INBOUND", "sender": "<sender>", "content": "<content>", "job_run": "<run_id>"}
+   ```
+
+3. **If `LOBSTER_DEBUG=true`** (env var) — also call `send_reply` with:
+   - `chat_id`: {{TELEGRAM_CHAT_ID}}
+   - `text`: `[LobsterTalk DEBUG] INBOUND from {sender}: {content[:500]}`
+
+If no messages returned (count == 0 or empty list): increment `consecutive_empty_polls`.
+
+### Step 3: Advance timestamp cursor
+
+After processing all fetched messages, update `last_seen_ts` to the timestamp of the
+latest message in the fetched list (regardless of direction — both directions advance
+the cursor). If no messages were fetched, leave `last_seen_ts` unchanged.
+
+### Step 4: Hot-mode management
+
+**If any messages were received** (count > 0):
+- Set `hot_mode = true`
+- Set `hot_mode_activated_at` to current UTC ISO timestamp (if not already set)
+- Reset `consecutive_empty_polls = 0`
+- Schedule a 5-minute re-run (see Hot-Mode Re-trigger below)
+
+**If no messages received**:
+- Increment `consecutive_empty_polls`
+- If `consecutive_empty_polls >= 2`: set `hot_mode = false`, clear `hot_mode_activated_at`
+
+### Step 5: Send — drain outbound queue (optional)
+
+If there are any messages queued in `~/messages/outbox/` with `source="bot-talk"`:
+- For each such message (in chronological order):
+  ```
+  POST http://{{LOBSTERTALK_HOST}}/message
+  X-Bot-Token: <token>
+  Content-Type: application/json
+  {
+    "sender": "{{LOCAL_LOBSTER_IDENTITY}}",
+    "recipient": "<recipient from message>",
+    "content": "<text from message>",
+    "genre": "acknowledgment",
+    "tier": "TIER-BOT"
+  }
+  ```
+- On HTTP 200/201: log the message to `lobstertalk.jsonl` as OUTBOUND, move the file
+  to `~/messages/processed/`
+- On failure: leave the file in outbox (will retry next run); log the error
+
+Note: If the outbox directory does not exist or is empty, skip this step silently.
+
+### Step 6: Write state and output
+
+Write updated state file atomically.
+
+Call `write_task_output` with:
+- `job_name`: "lobstertalk-unified"
+- `output`: Brief summary, e.g.:
+  - "No new messages. hot_mode=false, consecutive_empty=3"
+  - "Received 2 INBOUND messages, routed to inbox. hot_mode=true"
+  - "Received 1 INBOUND, sent 1 OUTBOUND. hot_mode=true"
+- `status`: "success" or "failed"
+
+Then call `write_result`:
+- If INBOUND messages were received: `write_result(task_id=<task_id>, chat_id={{TELEGRAM_CHAT_ID}}, sent_reply_to_user=False)`
+  (the dispatcher will see the inbox messages and handle them)
+- If no new messages: `write_result(task_id=<task_id>, chat_id=0, sent_reply_to_user=False)`
+
+## Hot-Mode Re-trigger
+
+When `hot_mode=true` after processing, schedule a one-shot 5-minute re-run using systemd:
+
+```bash
+systemd-run --user --on-active=5min \
+  --unit=lobster-lobstertalk-unified-hot \
+  /home/lobster/lobster/scheduled-tasks/dispatch-job.sh lobstertalk-unified
+```
+
+If the `systemd-run` command fails (e.g. not available or already scheduled), log the
+failure but do not abort — the hourly baseline will catch any missed activity.
+
+## Error Handling
+
+- **API down** (connection refused / timeout): log the failure, do NOT alert the owner
+  unless the API has been down for > 30 minutes (track `api_down_since` in state file
+  if needed). Call `write_task_output` with status="success" and note the outage.
+- **Inbox write failure**: log warning, continue processing remaining messages.
+- **Token missing**: call `write_task_output` with status="failed", exit immediately.
+- **Outbound send failure**: leave message in outbox, log error, continue.
+
+## Timezone
+
+Always display timestamps in **Eastern Time (ET)** — currently EDT (UTC-4). Convert all
+UTC timestamps before including them in any message or notification. Never show raw UTC.
+
+## Logging
+
+Append all sent and received messages to `~/lobster-workspace/logs/lobstertalk.jsonl`:
+
+```json
+{"ts": "ISO", "direction": "INBOUND|OUTBOUND", "sender": "...", "recipient": "...", "content": "...", "job_run": "..."}
+```
+
+Create the file and parent directories if they do not exist.
+Rotate if > 50 MB (rename to `.jsonl.bak`, start fresh).

--- a/scheduled-tasks/tasks/lobstertalk-unified.md.template
+++ b/scheduled-tasks/tasks/lobstertalk-unified.md.template
@@ -98,9 +98,14 @@ The API returns `{"count": N, "messages": [...]}`. Each message has:
 
 Sort all returned messages by `timestamp` ascending (oldest first).
 
+**Self-message filter**: skip any message where `sender == "{{LOCAL_LOBSTER_IDENTITY}}"`.
+These are outbound context logs (prefixed "[INBOUND from TELEGRAM]" or "[OUTBOUND →]") that
+the email-autoresponder skill mirrors back to the bot-talk server. They are not incoming
+messages from other Lobster instances and must not be re-routed to the inbox.
+
 **Direction for received messages: always INBOUND** (they arrived via GET).
 
-For each INBOUND message:
+For each INBOUND message (after filtering out self-messages):
 
 1. **Route to Lobster inbox** — write a JSON file to `~/messages/inbox/`:
    ```json

--- a/tests/unit/test_mcp_server/test_lobstertalk_unified_direction.py
+++ b/tests/unit/test_mcp_server/test_lobstertalk_unified_direction.py
@@ -100,6 +100,17 @@ def update_hot_mode(state: dict[str, Any], messages_received: int) -> dict[str, 
     return state
 
 
+def filter_self_messages(messages: list[dict], local_identity: str) -> list[dict]:
+    """Filter out messages sent by the local Lobster instance.
+
+    Messages where sender == local_identity are outbound context logs mirrored
+    back to the bot-talk server by the email-autoresponder skill (prefixed
+    "[INBOUND from TELEGRAM]" or "[OUTBOUND →]"). They are not incoming messages
+    from other Lobster instances and must not be re-routed to the inbox.
+    """
+    return [m for m in messages if m.get("sender") != local_identity]
+
+
 def should_rotate_log(log_file: Path, max_bytes: int = 50 * 1024 * 1024) -> bool:
     """Return True if the log file exceeds max_bytes and should be rotated."""
     if not log_file.exists():
@@ -265,6 +276,64 @@ class TestHotModeLogic:
         state = self._base_state(consecutive_empty_polls=2)
         _ = update_hot_mode(state, messages_received=0)
         assert state["consecutive_empty_polls"] == 2
+
+
+class TestSelfMessageFilter:
+    """Messages where sender == local identity are context mirrors, not real inbound messages.
+
+    The email-autoresponder skill logs both sides of conversations to bot-talk with
+    prefixes like "[INBOUND from TELEGRAM]" or "[OUTBOUND →]". These have
+    sender == "SaharLobster" (or whatever the local identity is) and must be
+    skipped during the GET /messages receive step.
+    """
+
+    LOCAL_IDENTITY = "SaharLobster"
+
+    def _make_msg(self, sender: str, content: str = "hello") -> dict:
+        return {
+            "id": "msg_test",
+            "sender": sender,
+            "content": content,
+            "timestamp": "2026-04-02T10:00:00Z",
+        }
+
+    def test_self_messages_are_filtered_out(self):
+        msgs = [
+            self._make_msg("SaharLobster", "[INBOUND from TELEGRAM] user: hello"),
+            self._make_msg("AlbertLobster", "hi there"),
+        ]
+        result = filter_self_messages(msgs, self.LOCAL_IDENTITY)
+        assert len(result) == 1
+        assert result[0]["sender"] == "AlbertLobster"
+
+    def test_all_self_messages_filtered(self):
+        msgs = [
+            self._make_msg("SaharLobster", "[OUTBOUND →] hi"),
+            self._make_msg("SaharLobster", "[INBOUND from TELEGRAM] user: test"),
+        ]
+        result = filter_self_messages(msgs, self.LOCAL_IDENTITY)
+        assert result == []
+
+    def test_non_self_messages_pass_through(self):
+        msgs = [
+            self._make_msg("AlbertLobster", "hello from albert"),
+            self._make_msg("CarolLobster", "hello from carol"),
+        ]
+        result = filter_self_messages(msgs, self.LOCAL_IDENTITY)
+        assert len(result) == 2
+
+    def test_empty_list_returns_empty(self):
+        assert filter_self_messages([], self.LOCAL_IDENTITY) == []
+
+    def test_filter_is_identity_specific(self):
+        """Filter only removes messages matching the exact local identity."""
+        msgs = [
+            self._make_msg("SaharLobster2"),  # different identity, should pass through
+            self._make_msg("SaharLobster"),   # exact match, should be filtered
+        ]
+        result = filter_self_messages(msgs, self.LOCAL_IDENTITY)
+        assert len(result) == 1
+        assert result[0]["sender"] == "SaharLobster2"
 
 
 class TestLogRotation:

--- a/tests/unit/test_mcp_server/test_lobstertalk_unified_direction.py
+++ b/tests/unit/test_mcp_server/test_lobstertalk_unified_direction.py
@@ -1,0 +1,284 @@
+"""Unit tests for lobstertalk-unified direction inference logic.
+
+PR A: direction fix — direction is inferred from which API endpoint is called,
+not from a stored field or sender-name heuristic.
+
+Old behavior (fragile): jobs inspected a `direction` field that might be absent,
+or filtered by sender name (silently broken if a new Lobster joins the channel).
+
+New behavior: GET /messages → INBOUND, POST /message → OUTBOUND.
+No special cases, no stored fields required.
+
+These tests are written spec-first and serve as a living contract for the
+`lobstertalk-unified` task definition.
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pure helper implementations mirroring the task definition's direction
+# inference logic. Self-contained — not imported from a real module.
+# ---------------------------------------------------------------------------
+
+_DEFAULT_STATE: dict[str, Any] = {
+    "last_seen_ts": "2020-01-01T00:00:00Z",
+    "hot_mode": False,
+    "consecutive_empty_polls": 0,
+    "hot_mode_activated_at": None,
+}
+
+
+def load_state(state_file: Path) -> dict[str, Any]:
+    """Load state file, returning defaults if missing or malformed."""
+    if not state_file.exists():
+        return dict(_DEFAULT_STATE)
+    try:
+        data = json.loads(state_file.read_text())
+        return {**_DEFAULT_STATE, **data}
+    except (json.JSONDecodeError, OSError):
+        return dict(_DEFAULT_STATE)
+
+
+def write_state_atomic(state_file: Path, state: dict[str, Any]) -> None:
+    """Write state atomically: .tmp then rename."""
+    tmp = state_file.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state), encoding="utf-8")
+    tmp.rename(state_file)
+
+
+def infer_direction_from_endpoint(endpoint: str) -> str:
+    """Infer message direction from which API endpoint was called.
+
+    GET /messages  → INBOUND  (we received these)
+    POST /message  → OUTBOUND (we sent this)
+
+    This is more reliable than inspecting a stored field or filtering by sender name.
+    The old jobs used sender-name heuristics that silently break when new Lobster
+    instances join the channel.
+    """
+    path = endpoint.split("?")[0].rstrip("/")
+    if path.endswith("/message"):
+        return "OUTBOUND"
+    if path.endswith("/messages"):
+        return "INBOUND"
+    raise ValueError(f"Unknown endpoint: {endpoint!r}")
+
+
+def advance_cursor(messages: list[dict], current_ts: str) -> str:
+    """Return the latest timestamp from messages, or current_ts if empty.
+
+    Both INBOUND and OUTBOUND messages advance the cursor.
+    """
+    if not messages:
+        return current_ts
+    return max(m["timestamp"] for m in messages)
+
+
+def update_hot_mode(state: dict[str, Any], messages_received: int) -> dict[str, Any]:
+    """Return updated state with hot-mode transitions applied.
+
+    Hot-mode rules:
+    - Any messages received → hot_mode=True, reset consecutive_empty_polls=0
+    - No messages → increment consecutive_empty_polls; if >= 2 → hot_mode=False
+    """
+    state = dict(state)  # immutable — create a copy
+    if messages_received > 0:
+        state["hot_mode"] = True
+        state["consecutive_empty_polls"] = 0
+        if state.get("hot_mode_activated_at") is None:
+            state["hot_mode_activated_at"] = datetime.now(timezone.utc).isoformat()
+    else:
+        state["consecutive_empty_polls"] = state.get("consecutive_empty_polls", 0) + 1
+        if state["consecutive_empty_polls"] >= 2:
+            state["hot_mode"] = False
+            state["hot_mode_activated_at"] = None
+    return state
+
+
+def should_rotate_log(log_file: Path, max_bytes: int = 50 * 1024 * 1024) -> bool:
+    """Return True if the log file exceeds max_bytes and should be rotated."""
+    if not log_file.exists():
+        return False
+    return log_file.stat().st_size > max_bytes
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDirectionInference:
+    """Direction is inferred from the API endpoint called, not a stored field.
+
+    Old approach (fragile): check message.get('direction') or filter by sender name.
+    New approach (reliable): GET /messages → INBOUND, POST /message → OUTBOUND.
+    """
+
+    def test_get_messages_is_inbound(self):
+        assert infer_direction_from_endpoint("http://host:4242/messages") == "INBOUND"
+
+    def test_post_message_is_outbound(self):
+        assert infer_direction_from_endpoint("http://host:4242/message") == "OUTBOUND"
+
+    def test_get_messages_with_query_params_is_inbound(self):
+        assert infer_direction_from_endpoint(
+            "http://host:4242/messages?since=2026-01-01T00:00:00Z&limit=100"
+        ) == "INBOUND"
+
+    def test_trailing_slash_handled(self):
+        assert infer_direction_from_endpoint("http://host:4242/messages/") == "INBOUND"
+        assert infer_direction_from_endpoint("http://host:4242/message/") == "OUTBOUND"
+
+    def test_unknown_endpoint_raises(self):
+        with pytest.raises(ValueError):
+            infer_direction_from_endpoint("http://host:4242/health")
+
+    def test_no_sender_name_needed(self):
+        """Direction inference requires no sender identity — works for any number of Lobsters."""
+        # Old jobs: GET /messages?sender=AlbertLobster — breaks when Carol joins
+        # New jobs: endpoint alone determines direction
+        endpoint = "http://host:4242/messages?since=2026-01-01T00:00:00Z&limit=100"
+        # No sender filtering needed; the endpoint call itself implies direction
+        assert infer_direction_from_endpoint(endpoint) == "INBOUND"
+
+    def test_no_stored_direction_field_needed(self):
+        """Direction inference does not depend on a 'direction' key in the message."""
+        # Simulate a message with NO direction field (as would come from the API)
+        msg_without_direction = {
+            "id": "abc123",
+            "sender": "AlbertLobster",
+            "content": "hello",
+            "timestamp": "2026-04-02T10:00:00Z",
+        }
+        # Direction is inferred from which endpoint the message was received on
+        direction = infer_direction_from_endpoint("http://host:4242/messages")
+        assert direction == "INBOUND"
+        # No KeyError, no missing field, no special case
+        assert "direction" not in msg_without_direction  # message didn't need this field
+
+
+class TestStateFileLoading:
+    """State file loads correctly and falls back to defaults when missing."""
+
+    def test_missing_file_returns_defaults(self, tmp_path):
+        state = load_state(tmp_path / "nonexistent.json")
+        assert state["last_seen_ts"] == "2020-01-01T00:00:00Z"
+        assert state["hot_mode"] is False
+        assert state["consecutive_empty_polls"] == 0
+        assert state["hot_mode_activated_at"] is None
+
+    def test_existing_file_loaded(self, tmp_path):
+        f = tmp_path / "state.json"
+        f.write_text(json.dumps({"last_seen_ts": "2026-03-01T12:00:00Z", "hot_mode": True}))
+        state = load_state(f)
+        assert state["last_seen_ts"] == "2026-03-01T12:00:00Z"
+        assert state["hot_mode"] is True
+
+    def test_new_fields_defaulted_when_missing_from_file(self, tmp_path):
+        f = tmp_path / "state.json"
+        f.write_text(json.dumps({"last_seen_ts": "2026-01-01T00:00:00Z"}))
+        state = load_state(f)
+        assert "consecutive_empty_polls" in state
+        assert state["consecutive_empty_polls"] == 0
+
+    def test_malformed_json_returns_defaults(self, tmp_path):
+        f = tmp_path / "state.json"
+        f.write_text("not valid json{{")
+        state = load_state(f)
+        assert state["last_seen_ts"] == "2020-01-01T00:00:00Z"
+
+
+class TestAtomicStateWrite:
+    """State is always written atomically (tmp + rename)."""
+
+    def test_written_file_is_valid_json(self, tmp_path):
+        f = tmp_path / "state.json"
+        write_state_atomic(f, {"last_seen_ts": "2026-04-01T00:00:00Z", "hot_mode": True})
+        loaded = json.loads(f.read_text())
+        assert loaded["hot_mode"] is True
+
+    def test_no_tmp_file_left_after_write(self, tmp_path):
+        f = tmp_path / "state.json"
+        write_state_atomic(f, _DEFAULT_STATE)
+        assert not (tmp_path / "state.tmp").exists()
+
+
+class TestTimestampCursor:
+    """last_seen_ts advances based on ALL messages, both INBOUND and OUTBOUND."""
+
+    def _make_msgs(self, timestamps: list[str]) -> list[dict]:
+        return [{"timestamp": ts, "id": f"msg_{i}"} for i, ts in enumerate(timestamps)]
+
+    def test_cursor_advances_to_latest(self):
+        msgs = self._make_msgs([
+            "2026-01-01T01:00:00Z",
+            "2026-01-01T03:00:00Z",
+            "2026-01-01T02:00:00Z",
+        ])
+        result = advance_cursor(msgs, "2026-01-01T00:00:00Z")
+        assert result == "2026-01-01T03:00:00Z"
+
+    def test_empty_messages_leaves_cursor_unchanged(self):
+        current = "2026-01-01T12:00:00Z"
+        result = advance_cursor([], current)
+        assert result == current
+
+    def test_cursor_advances_regardless_of_direction_field(self):
+        """Both INBOUND and OUTBOUND messages advance the cursor."""
+        msgs = [
+            {"timestamp": "2026-01-01T02:00:00Z", "id": "1"},  # INBOUND
+            {"timestamp": "2026-01-01T04:00:00Z", "id": "2"},  # OUTBOUND
+        ]
+        result = advance_cursor(msgs, "2026-01-01T00:00:00Z")
+        assert result == "2026-01-01T04:00:00Z"
+
+
+class TestHotModeLogic:
+    """Hot-mode state transitions are pure and deterministic."""
+
+    def _base_state(self, **overrides) -> dict[str, Any]:
+        return {**_DEFAULT_STATE, **overrides}
+
+    def test_messages_received_enables_hot_mode(self):
+        state = self._base_state(hot_mode=False)
+        result = update_hot_mode(state, messages_received=3)
+        assert result["hot_mode"] is True
+
+    def test_two_empty_polls_disables_hot_mode(self):
+        state = self._base_state(hot_mode=True, consecutive_empty_polls=1)
+        result = update_hot_mode(state, messages_received=0)
+        assert result["consecutive_empty_polls"] == 2
+        assert result["hot_mode"] is False
+
+    def test_one_empty_poll_does_not_disable_hot_mode(self):
+        state = self._base_state(hot_mode=True, consecutive_empty_polls=0)
+        result = update_hot_mode(state, messages_received=0)
+        assert result["consecutive_empty_polls"] == 1
+        assert result["hot_mode"] is True
+
+    def test_update_is_immutable_does_not_modify_input(self):
+        state = self._base_state(consecutive_empty_polls=2)
+        _ = update_hot_mode(state, messages_received=0)
+        assert state["consecutive_empty_polls"] == 2
+
+
+class TestLogRotation:
+    """Log file is rotated when it exceeds 50 MB."""
+
+    def test_small_file_does_not_rotate(self, tmp_path):
+        f = tmp_path / "lobstertalk.jsonl"
+        f.write_bytes(b"x" * 1000)
+        assert should_rotate_log(f) is False
+
+    def test_missing_file_does_not_rotate(self, tmp_path):
+        assert should_rotate_log(tmp_path / "lobstertalk.jsonl") is False
+
+    def test_file_over_50mb_triggers_rotation(self, tmp_path):
+        f = tmp_path / "lobstertalk.jsonl"
+        f.write_bytes(b"x" * (50 * 1024 * 1024 + 1))
+        assert should_rotate_log(f) is True


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

**Split of #1374 — Part A of 3.** Merge order: A → B → C.

## What this fixes

Three overlapping bot-talk jobs used sender-name heuristics to infer message direction. This approach silently breaks when a third Lobster instance joins the channel — a new sender name wouldn't match the hardcoded filter and messages would be misclassified.

This PR introduces `lobstertalk-unified`, a single job that owns the full receive/route/send/log cycle. The core fix: **direction is inferred from which API endpoint is called, not from a stored field or sender name**:
- `GET /messages` → **INBOUND** (we received these)
- `POST /message` → **OUTBOUND** (we sent this)

No special cases. No stored fields required. Works correctly regardless of how many Lobster instances are in the channel.

## What changed

**New:** `scheduled-tasks/tasks/lobstertalk-unified.md.template`
- Full unified job: receive (GET), route to inbox, send queued outbound (POST), hot-mode management via systemd-run transient unit
- Direction inference documented in "Direction Inference" section
- State file: `~/lobster-workspace/data/lobstertalk-unified-state.json`

**Deprecated (not deleted):**
- `bot-talk-poller.md.template` — DEPRECATED notice added
- `bot-talk-poller-fast.md.template` — DEPRECATED notice added
- `lobstertalk-incoming-handler.md` — DEPRECATED notice added

**New:** `tests/unit/test_mcp_server/test_lobstertalk_unified_direction.py`
- 23 tests. Covers direction inference, state file load/defaults, atomic write, timestamp cursor advancement, hot-mode transitions (immutability), and log rotation threshold.

## Code path traced end-to-end

1. `lobstertalk-unified` runs on hourly schedule (or 5-min hot-mode re-run)
2. Step 1: loads `lobstertalk-unified-state.json`, reads `last_seen_ts`
3. Step 2: `GET /messages?since=<last_seen_ts>` → all messages returned are **INBOUND** (endpoint context determines direction — no `direction` field inspection, no sender filtering)
4. Each INBOUND message: write to `~/messages/inbox/` as `source="bot-talk"` JSON
5. Step 3: cursor advances to `max(message.timestamp)` across ALL fetched messages
6. Step 4: hot-mode state updated; if `hot_mode=true` → `systemd-run` transient 5-min re-run scheduled
7. Step 5: drain `~/messages/outbox/` where `source="bot-talk"` → `POST /message` → **OUTBOUND** (endpoint context determines direction)
8. Step 6: state written atomically; `write_task_output` called

**No downstream code depends on the old sender-name filtering** — that logic lived entirely within the job templates being deprecated here.

## What this PR does NOT include

- `chat_id` routing fix — PR B (#1386)
- History replay prevention — PR C (#1387, closes #1380)

## Tests

```
uv run pytest tests/unit/test_mcp_server/test_lobstertalk_unified_direction.py -v
# 23 passed, 0 failed
```

Closes part of #1372
Addresses #1351 (direction inference approach)