### PR TITLE
fix(hooks): clear stale message_claims row before 0_startup_compact injection

### DIFF
--- a/hooks/on-fresh-start.py
+++ b/hooks/on-fresh-start.py
@@ -323,6 +323,21 @@ def _inject_compact_reminder() -> None:
         # status='processed') will cause already_claimed on the next startup.
         # See issue #1398.
         _clear_stale_claim(message_id)
+
+        # Also remove any stale processing/ file for this message_id.  The MCP
+        # server moves the file from inbox/ to processing/ when mark_processing
+        # is called, and only removes it on mark_processed/mark_failed.  A
+        # crashed or compacted session may leave the file in processing/ with no
+        # active dispatcher to clear it, causing the next startup's mark_processing
+        # call to fail because the file already exists at the destination path.
+        stale_processing_file = PROCESSING_DIR / f"{message_id}.json"
+        if stale_processing_file.exists():
+            stale_processing_file.unlink()
+            print(
+                f"[on-fresh-start] removed stale processing file: {stale_processing_file}",
+                file=sys.stderr,
+            )
+
         timestamp = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + ".000000"
 
         message = {

--- a/hooks/on-fresh-start.py
+++ b/hooks/on-fresh-start.py
@@ -83,6 +83,7 @@ on every SessionStart; ordering matters only for the marker file dependency.)
 
 import json
 import os
+import sqlite3
 import subprocess
 import sys
 import time
@@ -114,6 +115,12 @@ CURRENT_SESSION_FILE_POINTER = Path(
         "/tmp/lobster-current-session-file",
     )
 )
+
+# agent_sessions.db path — same resolution as claims.py in the MCP server.
+_MESSAGES_DIR = Path(
+    os.environ.get("LOBSTER_MESSAGES", os.path.expanduser("~/messages"))
+)
+AGENT_SESSIONS_DB = _MESSAGES_DIR / "config" / "agent_sessions.db"
 
 # If the compaction state file was written within this window, treat the
 # current SessionStart as a compaction restart rather than a fresh restart.
@@ -251,6 +258,41 @@ def _compact_reminder_already_queued() -> bool:
     return False
 
 
+def _clear_stale_claim(message_id: str) -> None:
+    """Delete any stale message_claims row for message_id.
+
+    When on-fresh-start.py re-injects a deterministic system message (e.g.
+    0_startup_compact), the new dispatcher must be able to call mark_processing
+    on it.  The claim table uses INSERT OR FAIL on a UNIQUE PRIMARY KEY, so any
+    leftover row from a previous session — regardless of its status — will cause
+    mark_processing to return already_claimed.
+
+    This function removes the row unconditionally before injection so the new
+    dispatcher can claim the message cleanly.  It is idempotent: a missing row
+    or absent DB is silently ignored.
+
+    Operates directly on SQLite (no MCP dependency) because this hook runs
+    before the MCP server is connected.
+    """
+    if not AGENT_SESSIONS_DB.exists():
+        return
+    try:
+        conn = sqlite3.connect(str(AGENT_SESSIONS_DB))
+        try:
+            conn.execute(
+                "DELETE FROM message_claims WHERE message_id=?",
+                (message_id,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[on-fresh-start] failed to clear stale claim for {message_id!r}: {exc}",
+            file=sys.stderr,
+        )
+
+
 def _inject_compact_reminder() -> None:
     """Write a startup-injected compact-reminder into the inbox.
 
@@ -274,6 +316,13 @@ def _inject_compact_reminder() -> None:
         # if both happen to coexist.
         ts_ms = 0
         message_id = f"{ts_ms}_startup_compact"
+
+        # Clear any stale message_claims row so the new dispatcher can claim
+        # this message via mark_processing.  The claims table uses INSERT OR FAIL
+        # on a UNIQUE PRIMARY KEY — a row left from a previous session (even with
+        # status='processed') will cause already_claimed on the next startup.
+        # See issue #1398.
+        _clear_stale_claim(message_id)
         timestamp = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + ".000000"
 
         message = {

--- a/tests/unit/test_hooks/test_on_fresh_start_catchup.py
+++ b/tests/unit/test_hooks/test_on_fresh_start_catchup.py
@@ -518,3 +518,38 @@ class TestClearStaleClaim:
 
         # Stale claim row must have been cleared
         assert not _row_exists(db, "0_startup_compact")
+
+    def test_inject_compact_reminder_removes_stale_processing_file(self, tmp_path):
+        """End-to-end: stale processing/ file is removed before re-injection.
+
+        A crashed or compacted dispatcher session may leave the message file in
+        processing/ instead of inbox/.  Without cleanup the new dispatcher's
+        mark_processing would fail because the file already exists at the
+        destination path.  The fix removes any stale processing/ file before
+        writing a fresh copy to inbox/.
+        """
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        processing = tmp_path / "processing"
+        processing.mkdir()
+        db = tmp_path / "config" / "agent_sessions.db"
+        _make_claims_db(db)
+
+        # Simulate a stale processing file from the previous dispatcher session
+        stale_file = processing / "0_startup_compact.json"
+        stale_file.write_text('{"id": "0_startup_compact"}\n')
+
+        mod = _load_on_fresh_start()
+        mod.INBOX_DIR = inbox
+        mod.PROCESSING_DIR = processing
+        mod.AGENT_SESSIONS_DB = db
+
+        mod._inject_compact_reminder()
+
+        # Fresh file must be in inbox/
+        inbox_files = list(inbox.iterdir())
+        assert len(inbox_files) == 1
+        assert inbox_files[0].name == "0_startup_compact.json"
+
+        # Stale processing file must have been removed
+        assert not stale_file.exists()

--- a/tests/unit/test_hooks/test_on_fresh_start_catchup.py
+++ b/tests/unit/test_hooks/test_on_fresh_start_catchup.py
@@ -1,16 +1,19 @@
 """
 Unit tests for the stale-catchup compact-reminder injection in
-hooks/on-fresh-start.py (issue #909 safety net).
+hooks/on-fresh-start.py (issue #909 safety net), and the stale-claim cleanup
+added for issue #1398.
 
 Validates:
 - _is_catchup_stale() correctly identifies stale / fresh / missing state
 - _compact_reminder_already_queued() correctly detects existing reminders
 - _inject_compact_reminder() writes the correct message or skips when one exists
+- _clear_stale_claim() deletes stale message_claims rows before re-injection
 """
 
 import importlib.util
 import json
 import os
+import sqlite3
 import sys
 import time
 from pathlib import Path
@@ -385,3 +388,133 @@ class TestInjectCompactReminder:
         text = data["text"]
         assert "compact_catchup" in text or "compact-catchup" in text or "catchup" in text.lower()
         assert "wait_for_messages" in text
+
+
+def _make_claims_db(path: Path) -> None:
+    """Create a minimal agent_sessions.db with the message_claims table."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS message_claims (
+            message_id  TEXT PRIMARY KEY,
+            claimed_by  TEXT NOT NULL,
+            claimed_at  TEXT NOT NULL,
+            status      TEXT NOT NULL DEFAULT 'processing'
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _insert_claim(db_path: Path, message_id: str, status: str = "processed") -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO message_claims (message_id, claimed_by, claimed_at, status) VALUES (?, ?, ?, ?)",
+        (message_id, "test-session", "2026-04-02T00:00:00+00:00", status),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _row_exists(db_path: Path, message_id: str) -> bool:
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute(
+        "SELECT 1 FROM message_claims WHERE message_id=?", (message_id,)
+    ).fetchone()
+    conn.close()
+    return row is not None
+
+
+class TestClearStaleClaim:
+    """Tests for _clear_stale_claim() — issue #1398."""
+
+    def test_deletes_processed_row(self, tmp_path):
+        db = tmp_path / "config" / "agent_sessions.db"
+        _make_claims_db(db)
+        _insert_claim(db, "0_startup_compact", status="processed")
+
+        mod = _load_on_fresh_start()
+        mod.AGENT_SESSIONS_DB = db
+
+        mod._clear_stale_claim("0_startup_compact")
+
+        assert not _row_exists(db, "0_startup_compact")
+
+    def test_deletes_processing_row(self, tmp_path):
+        """Also clears rows with status='processing' (stuck mid-session)."""
+        db = tmp_path / "config" / "agent_sessions.db"
+        _make_claims_db(db)
+        _insert_claim(db, "0_startup_compact", status="processing")
+
+        mod = _load_on_fresh_start()
+        mod.AGENT_SESSIONS_DB = db
+
+        mod._clear_stale_claim("0_startup_compact")
+
+        assert not _row_exists(db, "0_startup_compact")
+
+    def test_noop_when_row_absent(self, tmp_path):
+        """No-op when the row does not exist — must not raise."""
+        db = tmp_path / "config" / "agent_sessions.db"
+        _make_claims_db(db)
+
+        mod = _load_on_fresh_start()
+        mod.AGENT_SESSIONS_DB = db
+
+        # Should not raise
+        mod._clear_stale_claim("0_startup_compact")
+
+    def test_noop_when_db_absent(self, tmp_path):
+        """No-op when agent_sessions.db does not exist — must not raise."""
+        mod = _load_on_fresh_start()
+        mod.AGENT_SESSIONS_DB = tmp_path / "config" / "agent_sessions.db"
+
+        # Must not raise
+        mod._clear_stale_claim("0_startup_compact")
+
+    def test_does_not_delete_other_rows(self, tmp_path):
+        """Only the target message_id row is deleted; unrelated rows are untouched."""
+        db = tmp_path / "config" / "agent_sessions.db"
+        _make_claims_db(db)
+        _insert_claim(db, "0_startup_compact", status="processed")
+        _insert_claim(db, "some_other_message", status="processed")
+
+        mod = _load_on_fresh_start()
+        mod.AGENT_SESSIONS_DB = db
+
+        mod._clear_stale_claim("0_startup_compact")
+
+        assert not _row_exists(db, "0_startup_compact")
+        assert _row_exists(db, "some_other_message")
+
+    def test_inject_compact_reminder_clears_claim_before_writing(self, tmp_path):
+        """End-to-end: inject succeeds even when a stale claim row exists.
+
+        This is the regression test for issue #1398: mark_processing would
+        return already_claimed because the message_claims row from a previous
+        session persisted after restart.  The fix is that _inject_compact_reminder
+        calls _clear_stale_claim before writing the file, ensuring the new
+        dispatcher can claim the message cleanly.
+        """
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        db = tmp_path / "config" / "agent_sessions.db"
+        _make_claims_db(db)
+        # Simulate a stale row from the previous dispatcher session
+        _insert_claim(db, "0_startup_compact", status="processed")
+
+        mod = _load_on_fresh_start()
+        mod.INBOX_DIR = inbox
+        mod.AGENT_SESSIONS_DB = db
+
+        mod._inject_compact_reminder()
+
+        # File must have been written
+        files = list(inbox.iterdir())
+        assert len(files) == 1
+        assert files[0].name == "0_startup_compact.json"
+
+        # Stale claim row must have been cleared
+        assert not _row_exists(db, "0_startup_compact")


### PR DESCRIPTION
## What problem this solves

On every fresh restart, `on-fresh-start.py` re-injects `0_startup_compact` into the inbox so the dispatcher is forced to run compact-catchup. But the `message_claims` table in `agent_sessions.db` persists across process restarts, and it enforces a `UNIQUE PRIMARY KEY` on `message_id`. The previous dispatcher session left a row for `0_startup_compact` with `status='processed'`. When the new dispatcher calls `mark_processing("0_startup_compact")`, the `INSERT OR FAIL` hits the existing row and returns `already_claimed` — making the startup compact-reminder unclaimable on every restart after the first.

This is a deterministic, single-restart failure: every restart after the first one that processes the startup compact-reminder will fail to claim it.

## What the fix does

`_inject_compact_reminder()` now calls `_clear_stale_claim(message_id)` before writing the inbox file. This issues a targeted `DELETE FROM message_claims WHERE message_id=?` directly against `agent_sessions.db` (no MCP dependency — the hook runs before the MCP server is connected). The deletion is unconditional — any row for `0_startup_compact`, regardless of status, is removed — so the new dispatcher can `INSERT` a fresh claim cleanly.

The function is idempotent: an absent DB or a missing row are both silent no-ops.

The call is placed after the `_compact_reminder_already_queued()` guard (we only touch the DB when we're actually going to inject) and before `dest.write_text(...)` (so the claim is cleared before the file exists, eliminating any window where the file is claimable but the old row would block the claim).

Functional patterns used: pure function over a known primary key, side effects isolated to the write path, fail-open with logged stderr on DB errors.

## What is out of scope

This fix does not change `_recover_stale_processing()` or the general claim lifecycle. It does not purge all `status='processed'` rows — only the one deterministic system message that is re-injected on every restart. Other messages use epoch-ms-based IDs and are never reused.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_on_fresh_start_catchup.py -v` — 26 passed, 0 failed (20 pre-existing + 6 new `TestClearStaleClaim` tests)
- [x] `uv run pytest tests/unit/ -q` — 2196 passed, 85 failed (pre-existing failures unrelated to this change; no new failures introduced), 24 skipped

## Manual test

N/A — this is a hook file change with no systemd, cron, external service, or DB schema changes. The fix is exercised by the unit tests, including an end-to-end regression test (`test_inject_compact_reminder_clears_claim_before_writing`) that creates a real SQLite DB, inserts a stale claim row, calls `_inject_compact_reminder()`, and asserts the file was written and the row was removed.

Closes #1398