### PR TITLE
fix: raise WFM_STALE_SECONDS to 1200 to prevent spurious restarts during reasoning phase

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -87,7 +87,7 @@ BOOT_GRACE_SECONDS=90                # 90s - skip stale-inbox, WFM, and process 
 
 HIBERNATE_FRESH_SECONDS=30           # Ignore hibernate state younger than this — transient dispatcher hibernation
 
-WFM_STALE_SECONDS=600                # 10 minutes - RED if wait_for_messages not called since this long ago
+WFM_STALE_SECONDS=1200               # 20 minutes - RED if wait_for_messages not called since this long ago (raised from 600 to accommodate long reasoning/subagent-spawning phases)
 HEARTBEAT_FILE="$WORKSPACE_DIR/logs/claude-heartbeat"
 
 OUTBOX_DIR="$MESSAGES_DIR/outbox"


### PR DESCRIPTION
## Summary

The health check was triggering spurious restarts because the dispatcher legitimately goes silent for 10+ minutes while reasoning through complex tasks or spawning subagent batches — without calling `mark_processed` or `wait_for_messages`. With `WFM_STALE_SECONDS=600`, the health check fires RED and restarts the dispatcher unnecessarily.

This is a stop-gap fix: raise the threshold from 600s (10 min) to 1200s (20 min) to give the dispatcher enough headroom for normal heavy-reasoning phases. The proper fix — a PostToolUse heartbeat that updates the WFM timestamp on every tool call — is tracked separately and will make this threshold irrelevant once implemented.

**What the threshold does:** `WFM_STALE_SECONDS` is the window after which the health check considers the dispatcher stale if it has not called `wait_for_messages` or processed a message. Exceeding it triggers a RED alert and automatic restart.

**Why 600 is too low:** A dispatcher handling a scheduled-job batch can spend 10–15 minutes in tool calls and reasoning steps between WFM calls. This is expected behavior, not a hang. The 600s threshold treats normal operation as a failure.

**Why this is a stop-gap:** Doubling the threshold reduces false positives but doesn't eliminate them for very long reasoning chains. The correct fix is a PostToolUse heartbeat (see #1392) so the health check tracks actual activity rather than just WFM calls.

Closes #1392 (stop-gap)

## Tests run
- [x] `grep WFM_STALE_SECONDS scripts/health-check-v3.sh` — confirms value is 1200 and comment updated
- [ ] Live health check cycle — not run; this is a single-line constant change with no logic modification. The health check passes the value directly into an integer comparison — no unit test needed to verify the number changed.

## Manual test
The change is a single integer constant. The health check reads it directly at runtime. No systemd/cron/external-service interaction is altered — only the numeric threshold used in an existing `[[ $age -gt $WFM_STALE_SECONDS ]]` comparison changes.