### PR TITLE
feat: Slack Connector Phase 2 — Skill Scaffold

### DIFF
--- a/lobster-shop/slack-connector/README.md
+++ b/lobster-shop/slack-connector/README.md
@@ -1,0 +1,50 @@
+# Slack Connector
+
+Full Slack integration for Lobster: dumb ingress logging, per-channel configuration, trigger automations, and log analysis.
+
+## What it does
+
+- **Dumb ingress logging** — Every Slack message is written to disk at wire speed before any LLM processing
+- **Per-channel config** — Fine-grained control over which channels Lobster monitors and what it does in each
+- **Trigger automations** — Rule-based automations fired by Slack events (keyword matches, reactions, file uploads)
+- **Log analysis** — Search, summarize, and analyze Slack history on demand
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/slack` | Slack connector status and quick actions |
+| `/slack-status` | Show connection health, channel list, log stats |
+| `/analyze-logs` | Search and analyze Slack message logs |
+
+## Setup
+
+```bash
+bash ~/lobster/lobster-shop/slack-connector/install.sh
+```
+
+The installer will:
+1. Install Python dependencies (slack-bolt, slack-sdk, watchdog)
+2. Create runtime directories under `~/lobster-workspace/slack-connector/`
+3. Copy example configs
+4. Check for required API tokens in `~/lobster-config/config.env`
+
+## Required tokens
+
+| Variable | Type | Purpose |
+|----------|------|---------|
+| `LOBSTER_SLACK_BOT_TOKEN` | `xoxb-*` | Bot user OAuth token for API calls |
+| `LOBSTER_SLACK_APP_TOKEN` | `xapp-*` | App-level token for Socket Mode |
+
+## Configuration
+
+Channel-level configuration lives in `~/lobster-workspace/slack-connector/config/channels.yaml`. See `config/channels.yaml.example` for the format.
+
+## Phases
+
+- **Phase 1:** Research & design (complete)
+- **Phase 2:** Skill scaffold (this phase)
+- **Phase 3:** Dumb ingress logging worker
+- **Phase 4:** Log indexing and search
+- **Phase 5:** Trigger automation framework
+- **Phase 6:** Morning briefing integration

--- a/lobster-shop/slack-connector/behavior/onboarding.md
+++ b/lobster-shop/slack-connector/behavior/onboarding.md
@@ -1,0 +1,13 @@
+## Slack Connector — Onboarding
+
+When the user first activates the slack-connector skill, guide them through setup:
+
+1. **Token check** — Verify `LOBSTER_SLACK_BOT_TOKEN` and `LOBSTER_SLACK_APP_TOKEN` are set in `~/lobster-config/config.env`. If missing, explain how to create a Slack App with Socket Mode enabled and obtain both tokens.
+
+2. **Channel selection** — Ask which channels to monitor. Create the initial `channels.yaml` from their response. Default to logging all public channels the bot is invited to.
+
+3. **Ingress preferences** — Confirm default logging settings: messages, reactions, files, and edits are logged; deletes are not. Explain they can change these later via skill preferences.
+
+4. **First run** — Run `install.sh` to install dependencies and start the ingress worker. Confirm the Socket Mode connection is established and messages are being logged.
+
+5. **Verification** — After a few minutes, run `/slack-status` to show the user that messages are flowing and logs are accumulating.

--- a/lobster-shop/slack-connector/behavior/system.md
+++ b/lobster-shop/slack-connector/behavior/system.md
@@ -1,0 +1,13 @@
+## Slack Connector Skill
+
+When the slack-connector skill is active, Lobster has access to Slack workspace logging, search, and analysis capabilities. A background ingress worker continuously logs all messages from configured channels to disk. The dispatcher can query these logs, generate channel summaries, and search message history without making live Slack API calls — all reads hit the local log store.
+
+### Command handling
+
+- **`/slack-status`** — Report the connection health of the Slack Socket Mode session, list monitored channels with message counts, and show log storage stats (disk usage, oldest/newest entry, total messages). Spawn a subagent to gather this data.
+- **`/analyze-logs`** — Accept a natural-language query (e.g., "/analyze-logs what did #engineering discuss about deployments this week") and search the local log index. Return a concise summary of matching messages with timestamps, authors, and thread context. For broad queries, limit results to the 20 most relevant messages and offer to narrow the search.
+- **`/slack`** — General entry point. Show a brief status line and offer quick actions: "search logs", "channel summary", "check triggers". Route to the appropriate handler based on the user's follow-up.
+
+### Privacy constraint
+
+DM content logged by the ingress worker must never be surfaced to public channels or included in summaries shared outside of the DM participants. When generating channel summaries or search results, always filter out DM-sourced messages unless the requesting user is a participant in that DM. This applies to morning briefing integrations as well — DM content stays private.

--- a/lobster-shop/slack-connector/behavior/with-morning-briefing.md
+++ b/lobster-shop/slack-connector/behavior/with-morning-briefing.md
@@ -1,0 +1,21 @@
+## Slack Connector × Morning Briefing
+
+When both slack-connector and morning-briefing skills are active, the morning briefing includes a Slack activity section.
+
+### Additional briefing section: Slack highlights
+
+Insert after "Yesterday's activity" and before "Background agents":
+
+**Slack highlights**
+- Summarize notable threads from monitored channels in the last 24 hours
+- Highlight any unresolved @mentions of the owner
+- Note channels with unusually high activity (>2× their 7-day average message count)
+- Include any trigger rule matches that fired overnight
+
+### Data source
+
+Pull from the local log index — do not make live Slack API calls during briefing generation. Use `slack_channel_summary` for each monitored channel, filtered to the last 24 hours.
+
+### Privacy
+
+Never include DM content in the briefing unless the briefing recipient is a DM participant. Channel messages from public channels are fine to summarize.

--- a/lobster-shop/slack-connector/config/channels.yaml.example
+++ b/lobster-shop/slack-connector/config/channels.yaml.example
@@ -1,0 +1,32 @@
+# Slack Connector — Channel Configuration
+#
+# Copy this file to channels.yaml and customize.
+# Each channel entry controls what Lobster does in that channel.
+#
+# To apply changes: the ingress worker hot-reloads this file automatically.
+
+# Default settings applied to all channels unless overridden
+defaults:
+  log: true            # Log messages to disk
+  index: true          # Include in search index
+  llm_route: false     # Don't send to LLM dispatcher by default
+  triggers: true       # Evaluate trigger rules
+
+channels:
+  # Example: monitor #general, log everything, don't route to LLM
+  # general:
+  #   log: true
+  #   index: true
+  #   llm_route: false
+
+  # Example: monitor #alerts, route all messages to LLM for processing
+  # alerts:
+  #   log: true
+  #   index: true
+  #   llm_route: true
+  #   triggers: true
+
+  # Example: ignore #random entirely
+  # random:
+  #   log: false
+  #   index: false

--- a/lobster-shop/slack-connector/context/domain.md
+++ b/lobster-shop/slack-connector/context/domain.md
@@ -1,0 +1,61 @@
+## Slack Connector — Domain Reference
+
+### Socket Mode vs Events API
+
+Slack offers two primary mechanisms for receiving events:
+
+**Socket Mode** (used by this skill): The app opens a WebSocket connection to Slack's servers. Events are pushed over the socket in real time. No public URL or webhook endpoint is required — ideal for self-hosted setups behind NAT/firewalls. Requires an app-level token (`xapp-`). Tradeoff: the connection must be maintained continuously; if it drops, events are buffered by Slack for up to ~30 seconds before being lost. The `slack-bolt` library handles reconnection automatically.
+
+**Events API**: Slack sends HTTP POST requests to a public endpoint you configure. More resilient to brief outages (Slack retries for up to 3 hours with exponential backoff). Requires a publicly reachable HTTPS URL. More complex to set up for self-hosted environments.
+
+For Lobster's use case (single-server, self-hosted, no public URL), Socket Mode is the clear choice.
+
+### Channel types
+
+| Type | API prefix | Description |
+|------|-----------|-------------|
+| Public channel | `C` | Open to all workspace members |
+| Private channel | `G` | Invite-only, not visible to non-members |
+| DM (im) | `D` | Direct message between two users |
+| Group DM (mpim) | `G` | Multi-party direct message |
+
+Bot tokens can only access channels the bot has been invited to. User tokens can access any channel the user is a member of.
+
+### Timestamp format (`ts`)
+
+Slack uses a unique timestamp format: `"1234567890.123456"` — Unix epoch seconds with a microsecond suffix. This serves as both a timestamp and a unique message ID within a channel. Thread replies reference the parent message's `ts` as `thread_ts`.
+
+### Thread model
+
+- A message becomes a thread parent when it receives its first reply
+- Replies carry both their own `ts` and the parent's `thread_ts`
+- `reply_count` and `latest_reply` are available on the parent message
+- Thread replies do not appear in the channel timeline unless explicitly broadcast (`subtype: "thread_broadcast"`)
+
+### Rate limits
+
+Slack API methods are grouped into tiers with different rate limits:
+
+| Tier | Rate limit | Examples |
+|------|-----------|----------|
+| Tier 1 | 1 req/min | `admin.*`, `migration.*` |
+| Tier 2 | 20 req/min | `conversations.list`, `users.list` |
+| Tier 3 | 50 req/min | `conversations.history`, `conversations.replies` |
+| Tier 4 | 100 req/min | `chat.postMessage`, `reactions.add` |
+
+Rate limit responses return HTTP 429 with a `Retry-After` header (seconds). The `slack-sdk` handles retry automatically when configured with `retry_handlers`.
+
+### Bot vs user token capabilities
+
+| Capability | Bot token (`xoxb-`) | User token (`xoxp-`) |
+|-----------|---------------------|---------------------|
+| Read public channels (joined) | ✓ | ✓ |
+| Read private channels (joined) | ✓ | ✓ |
+| Read all public channels | ✗ | ✓ |
+| Post messages | ✓ | ✓ |
+| Read DMs | Only bot DMs | All user DMs |
+| Access user profile | ✓ (basic) | ✓ (full) |
+| Admin actions | ✗ | ✓ (if admin) |
+| Socket Mode | ✓ (via app token) | ✗ |
+
+The `account_type` preference controls which token mode is used. Bot mode is the default and recommended approach. Person mode (user token) is available for use cases requiring broader access but carries higher risk — the token has the full permissions of the user account.

--- a/lobster-shop/slack-connector/install.sh
+++ b/lobster-shop/slack-connector/install.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+#===============================================================================
+# Slack Connector Skill Installer
+#
+# Idempotent installer for the slack-connector Lobster skill.
+# Sets up:
+#   1. Python dependencies (slack-bolt, slack-sdk, watchdog) in the Lobster venv
+#   2. Runtime directories under ~/lobster-workspace/slack-connector/
+#   3. Example configs (no-clobber copy)
+#   4. Token validation
+#   5. Service restart (if running)
+#
+# Usage: bash ~/lobster/lobster-shop/slack-connector/install.sh
+#===============================================================================
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
+success() { echo -e "${GREEN}[OK]${NC} $1"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error()   { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+step()    { echo -e "\n${CYAN}${BOLD}--- $1${NC}"; }
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+LOBSTER_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
+LOBSTER_WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+SKILL_DIR="$LOBSTER_DIR/lobster-shop/slack-connector"
+RUNTIME_DIR="$LOBSTER_WORKSPACE/slack-connector"
+CONFIG_ENV="$HOME/lobster-config/config.env"
+PIP_BIN="$LOBSTER_DIR/.venv/bin/pip"
+
+echo ""
+echo -e "${BOLD}Slack Connector Skill Installer${NC}"
+echo "================================="
+echo ""
+
+#===============================================================================
+# Step 1: Check prerequisites
+#===============================================================================
+step "Checking prerequisites"
+
+# Lobster venv pip
+if [ ! -f "$PIP_BIN" ]; then
+    error "Lobster venv not found at $LOBSTER_DIR/.venv/bin/pip — run Lobster install first"
+fi
+success "Lobster venv pip found"
+
+# Skill directory
+if [ ! -f "$SKILL_DIR/skill.toml" ]; then
+    error "Skill directory not found at $SKILL_DIR — is the repo up to date?"
+fi
+success "Skill directory found"
+
+#===============================================================================
+# Step 2: Install Python dependencies
+#===============================================================================
+step "Installing Python dependencies"
+
+$PIP_BIN install --quiet "slack-bolt>=1.18" "slack-sdk>=3.26" "watchdog>=3.0" 2>&1 | tail -5
+success "slack-bolt, slack-sdk, watchdog installed"
+
+#===============================================================================
+# Step 3: Create runtime directories
+#===============================================================================
+step "Creating runtime directories"
+
+readonly DIRS=(
+    "$RUNTIME_DIR"
+    "$RUNTIME_DIR/logs"
+    "$RUNTIME_DIR/config"
+    "$RUNTIME_DIR/config/rules"
+    "$RUNTIME_DIR/index"
+    "$RUNTIME_DIR/data"
+)
+
+for dir in "${DIRS[@]}"; do
+    mkdir -p "$dir"
+done
+success "Runtime directories created at $RUNTIME_DIR/"
+
+#===============================================================================
+# Step 4: Copy example configs (no-clobber)
+#===============================================================================
+step "Copying example configs"
+
+copy_no_clobber() {
+    local src="$1"
+    local dest="$2"
+    if [ -f "$dest" ]; then
+        info "$(basename "$dest") already exists — skipping"
+    else
+        cp "$src" "$dest"
+        success "Copied $(basename "$dest")"
+    fi
+}
+
+copy_no_clobber "$SKILL_DIR/config/channels.yaml.example" "$RUNTIME_DIR/config/channels.yaml"
+
+#===============================================================================
+# Step 5: Check for required tokens
+#===============================================================================
+step "Checking API tokens"
+
+check_token() {
+    local token_name="$1"
+    if [ -f "$CONFIG_ENV" ] && grep -q "^${token_name}=" "$CONFIG_ENV"; then
+        local token_value
+        token_value=$(grep "^${token_name}=" "$CONFIG_ENV" | head -1 | cut -d'=' -f2-)
+        if [ -n "$token_value" ] && [ "$token_value" != '""' ] && [ "$token_value" != "''" ]; then
+            success "$token_name is set"
+            return 0
+        fi
+    fi
+    warn "$token_name is not set in $CONFIG_ENV"
+    echo "  To set it, add this line to $CONFIG_ENV:"
+    echo "    ${token_name}=xoxb-your-token-here"
+    return 1
+}
+
+TOKENS_OK=true
+check_token "LOBSTER_SLACK_BOT_TOKEN" || TOKENS_OK=false
+check_token "LOBSTER_SLACK_APP_TOKEN" || TOKENS_OK=false
+
+if [ "$TOKENS_OK" = false ]; then
+    warn "Some tokens are missing — the skill will install but won't connect until tokens are configured"
+fi
+
+#===============================================================================
+# Step 6: Restart lobster-slack-router if running
+#===============================================================================
+step "Checking lobster-slack-router service"
+
+if systemctl is-active --quiet lobster-slack-router 2>/dev/null; then
+    info "Restarting lobster-slack-router to pick up changes..."
+    sudo systemctl restart lobster-slack-router
+    success "lobster-slack-router restarted"
+elif systemctl is-enabled --quiet lobster-slack-router 2>/dev/null; then
+    info "lobster-slack-router is enabled but not running — starting..."
+    sudo systemctl start lobster-slack-router
+    success "lobster-slack-router started"
+else
+    info "lobster-slack-router service not found — skipping (will be configured in a later phase)"
+fi
+
+#===============================================================================
+# Done
+#===============================================================================
+echo ""
+echo -e "${GREEN}${BOLD}Slack Connector skill installed!${NC}"
+echo ""
+echo "  Runtime dir:  $RUNTIME_DIR/"
+echo "  Config:       $RUNTIME_DIR/config/channels.yaml"
+echo "  Logs:         $RUNTIME_DIR/logs/"
+echo "  Trigger rules: $RUNTIME_DIR/config/rules/"
+echo ""
+if [ "$TOKENS_OK" = false ]; then
+    echo -e "  ${YELLOW}⚠ Set missing tokens in $CONFIG_ENV and re-run this script${NC}"
+    echo ""
+fi
+echo "  To activate:  /skill activate slack-connector"
+echo ""

--- a/lobster-shop/slack-connector/preferences/defaults.toml
+++ b/lobster-shop/slack-connector/preferences/defaults.toml
@@ -1,0 +1,35 @@
+[account]
+account_type = "bot"
+
+[logging]
+enabled = true
+log_dir = "~/lobster-workspace/slack-connector/logs"
+rotate_daily = true
+max_age_days = 90
+
+[ingress]
+log_messages = true
+log_reactions = true
+log_files = true
+log_edits = true
+log_deletes = false
+
+[llm_routing]
+route_mentions = true
+route_dms = true
+route_all = false
+
+[indexing]
+enabled = true
+thread_summary_idle_hours = 2
+nightly_index_hour = 2
+keyword_index_enabled = true
+keyword_index_lag_minutes = 5
+
+[triggers]
+enabled = true
+rules_dir = "~/lobster-workspace/slack-connector/config/rules"
+hot_reload = true
+
+[permissions]
+use_allowlist = true

--- a/lobster-shop/slack-connector/preferences/schema.toml
+++ b/lobster-shop/slack-connector/preferences/schema.toml
@@ -1,0 +1,16 @@
+[account.account_type]
+type = "string"
+enum = ["bot", "person"]
+description = "Slack account type: bot (App token) or person (user token)"
+
+[logging.max_age_days]
+type = "integer"
+min = 1
+max = 3650
+description = "Days to retain raw logs before deletion"
+
+[indexing.thread_summary_idle_hours]
+type = "integer"
+min = 1
+max = 48
+description = "Hours of thread inactivity before summary is generated"

--- a/lobster-shop/slack-connector/skill.toml
+++ b/lobster-shop/slack-connector/skill.toml
@@ -1,0 +1,36 @@
+[skill]
+name = "slack-connector"
+version = "1.0.0"
+description = "Full Slack integration: dumb ingress logging, per-channel config, trigger automations, and log analysis"
+author = "Lobster"
+category = "integration"
+
+[activation]
+mode = "triggered"
+triggers = ["/slack", "/analyze-logs", "/slack-status"]
+context_patterns = [
+    "when user asks about Slack messages or channels",
+    "when user wants to search Slack logs",
+    "when user asks what happened in a Slack channel",
+    "when user wants to set up a Slack automation",
+    "when user asks about their Slack workspace",
+]
+
+[layering]
+priority = 55
+merge_strategy = "append"
+
+[provides]
+mcp_tools = ["slack_log_search", "slack_channel_summary", "slack_thread_summary"]
+bot_commands = ["/slack", "/analyze-logs", "/slack-status"]
+
+[compatibility]
+enhances = ["morning-briefing", "lobster-status"]
+conflicts = []
+
+[dependencies]
+pip = ["slack-bolt>=1.18", "slack-sdk>=3.26", "watchdog>=3.0"]
+api_keys = ["LOBSTER_SLACK_BOT_TOKEN", "LOBSTER_SLACK_APP_TOKEN"]
+
+[dependencies.runtime]
+python = ">=3.11"

--- a/lobster-shop/slack-connector/src/__init__.py
+++ b/lobster-shop/slack-connector/src/__init__.py
@@ -1,1 +1,6 @@
-# Slack Connector — Phase 1: Dumb Ingress Logger
+# slack-connector skill — src package
+#
+# Functional code will be added in later phases:
+#   Phase 3: ingress worker (dumb logging)
+#   Phase 4: log indexer and search
+#   Phase 5: trigger automation framework


### PR DESCRIPTION
## Summary

Slack-connector needs to exist as a skill before any functional code can land. This PR creates the complete directory structure and metadata so `list_skills` discovers it and `/skill activate slack-connector` succeeds — without shipping any runtime behavior yet.

**What this enables:**
- `list_skills` shows slack-connector with its triggers, context patterns, and dependency list
- Activation injects the behavior and context docs into the dispatcher
- `install.sh` provisions the venv deps and runtime directories on a clean workspace
- The morning-briefing composition file (`with-morning-briefing.md`) is ready for Phase 6 integration

**What this does NOT include:** No ingress worker, no log indexer, no trigger framework, no MCP tool implementations. Those are Phases 3–5.

### Functional patterns

Pure data files (TOML manifests, markdown behavior docs, YAML config) with a single side-effectful boundary (`install.sh`). The installer is idempotent — all directory creation uses `mkdir -p`, config copies use no-clobber semantics, and token checks are advisory (warn, don't fail).

### File inventory

| Path | Purpose |
|------|---------|
| `skill.toml` | Skill manifest: identity, activation triggers, dependencies |
| `behavior/system.md` | Dispatcher instructions: command handling, privacy constraints |
| `behavior/onboarding.md` | First-activation guided setup flow |
| `behavior/with-morning-briefing.md` | Composition layer for morning-briefing integration |
| `context/domain.md` | Slack API reference: Socket Mode, channel types, rate limits, token capabilities |
| `preferences/defaults.toml` | Default config: logging, ingress, indexing, triggers, permissions |
| `preferences/schema.toml` | Preference validation schema (types, ranges, enums) |
| `config/channels.yaml.example` | Example per-channel configuration |
| `install.sh` | Idempotent installer: deps, dirs, config copy, token check, service restart |
| `src/__init__.py` | Empty package marker for future phases |
| `README.md` | Skill overview, setup instructions, phase roadmap |

### Out of scope

- Runtime Python code (Phases 3–5)
- MCP tool implementations (`slack_log_search`, etc.)
- systemd service files for the ingress worker
- Actual Slack API integration

## Tests run

- [x] `uv run python -c "import tomllib; ..."` — all 3 TOML files (skill.toml, defaults.toml, schema.toml) parse without error
- [x] `bash -n install.sh` — shell syntax check passes
- [x] File inventory verified: all 11 required files present
- [ ] `list_skills` MCP call — not available in this environment; skill discovery depends on `skill.toml` existing at the expected path, which it does
- [ ] `install.sh` end-to-end run — skipped: would install packages into the live venv; safe to test post-merge

**Blocked items needing attention before merge:** none

## Manual test

N/A — this PR contains only static files (TOML, markdown, YAML, shell script). No systemd, cron, external services, or runtime state changes. The `install.sh` script should be tested after merge on the live system.

Relates to BIS-266