### PR TITLE
feat: Slack Connector Phase 5 — Haiku Indexer

### DIFF
--- a/lobster-shop/slack-connector/src/indexer.py
+++ b/lobster-shop/slack-connector/src/indexer.py
@@ -1,0 +1,607 @@
+"""
+Slack Indexer — async enrichment pipeline for JSONL message logs.
+
+Three indexing layers, each at different cadences:
+1. Keyword index (FTS5) — every 5 minutes, cursor-based incremental
+2. Thread summaries (Haiku) — every 15 minutes, threads idle >2h
+3. Topic clusters + action items (Haiku) — nightly at 2am UTC
+
+Design principles:
+- Pure data transformations separated from I/O boundaries
+- Cost guardrails: env flag, batch limits, channel filtering
+- Composable pipeline stages (read → filter → transform → write)
+- Haiku calls isolated behind an invocation abstraction for testability
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import textwrap
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from src.keyword_index import KeywordIndex, _filter_after_cursor, _max_ts
+from src.log_store import SlackLogStore
+
+log = logging.getLogger("slack-indexer")
+
+# ---------------------------------------------------------------------------
+# Constants & defaults
+# ---------------------------------------------------------------------------
+
+_DEFAULT_WORKSPACE = Path(
+    os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace")
+)
+_DEFAULT_CONNECTOR_ROOT = _DEFAULT_WORKSPACE / "slack-connector"
+
+_MAX_MESSAGES_PER_HAIKU_BATCH = 50
+_THREAD_IDLE_SECONDS = 2 * 60 * 60  # 2 hours
+
+_INDEX_ENABLED_ENV = "LOBSTER_SLACK_INDEX_ENABLED"
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_index_enabled() -> bool:
+    """Check whether Haiku indexing is enabled via environment variable.
+
+    Defaults to True if the env var is not set.
+    """
+    val = os.environ.get(_INDEX_ENABLED_ENV, "true").lower()
+    return val in ("true", "1", "yes")
+
+
+def _load_channel_config(config_path: Path) -> dict[str, dict[str, Any]]:
+    """Load channels.yaml and return a mapping of channel_id -> config.
+
+    Returns empty dict if file doesn't exist. Pure-ish (reads one file).
+    """
+    if not config_path.exists():
+        return {}
+
+    try:
+        import yaml
+    except ImportError:
+        # If PyYAML not available, skip channel config filtering
+        log.warning("PyYAML not installed; channel config filtering disabled")
+        return {}
+
+    with open(config_path) as f:
+        data = yaml.safe_load(f) or {}
+
+    channels = data.get("channels", [])
+    return {ch["id"]: ch for ch in channels if "id" in ch}
+
+
+def _is_channel_ignored(
+    channel_id: str, channel_config: dict[str, dict[str, Any]]
+) -> bool:
+    """Check if a channel is configured as mode: ignore.
+
+    Pure function. Returns False if channel not in config (default: not ignored).
+    """
+    ch = channel_config.get(channel_id, {})
+    return ch.get("mode", "monitor") == "ignore"
+
+
+def _group_by_thread(
+    messages: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Group messages by thread_ts. Non-threaded messages are excluded.
+
+    Pure function. Returns mapping of thread_ts -> list of messages.
+    """
+    threads: dict[str, list[dict[str, Any]]] = {}
+    for msg in messages:
+        thread_ts = msg.get("thread_ts")
+        if thread_ts:
+            threads.setdefault(thread_ts, []).append(msg)
+    return threads
+
+
+def _is_thread_idle(
+    thread_messages: list[dict[str, Any]],
+    now: datetime,
+    idle_seconds: int = _THREAD_IDLE_SECONDS,
+) -> bool:
+    """Check if a thread has been idle for longer than the threshold.
+
+    Pure function. Compares latest message ts to current time.
+    """
+    if not thread_messages:
+        return False
+
+    latest_ts = max(
+        float(m.get("ts", "0")) for m in thread_messages
+    )
+    last_activity = datetime.fromtimestamp(latest_ts, tz=timezone.utc)
+    return (now - last_activity).total_seconds() > idle_seconds
+
+
+def _extract_participants(messages: list[dict[str, Any]]) -> list[str]:
+    """Extract unique participant usernames/user_ids from thread messages.
+
+    Pure function. Preserves insertion order, deduplicates.
+    """
+    seen: set[str] = set()
+    participants: list[str] = []
+    for msg in messages:
+        name = msg.get("username") or msg.get("display_name") or msg.get("user_id", "")
+        if name and name not in seen:
+            seen.add(name)
+            participants.append(name)
+    return participants
+
+
+def _build_thread_context(
+    messages: list[dict[str, Any]], max_messages: int = _MAX_MESSAGES_PER_HAIKU_BATCH
+) -> str:
+    """Build a text block of thread messages for Haiku summarization.
+
+    Pure function. Truncates to max_messages most recent.
+    """
+    sorted_msgs = sorted(messages, key=lambda m: m.get("ts", "0"))
+    truncated = sorted_msgs[-max_messages:]
+    lines = []
+    for msg in truncated:
+        name = msg.get("username") or msg.get("user_id", "unknown")
+        text = msg.get("text", "")
+        lines.append(f"{name}: {text}")
+    return "\n".join(lines)
+
+
+def _build_nightly_context(
+    messages: list[dict[str, Any]], max_messages: int = _MAX_MESSAGES_PER_HAIKU_BATCH
+) -> str:
+    """Build a text block of day's messages for nightly Haiku analysis.
+
+    Pure function. Truncates to max_messages.
+    """
+    truncated = messages[:max_messages]
+    lines = []
+    for msg in truncated:
+        name = msg.get("username") or msg.get("user_id", "unknown")
+        text = msg.get("text", "")
+        ts = msg.get("ts", "")
+        lines.append(f"[{ts}] {name}: {text}")
+    return "\n".join(lines)
+
+
+def _build_thread_summary_record(
+    channel_id: str,
+    thread_ts: str,
+    messages: list[dict[str, Any]],
+    haiku_result: dict[str, Any],
+) -> dict[str, Any]:
+    """Build a thread summary JSONL record from Haiku output.
+
+    Pure function.
+    """
+    return {
+        "channel_id": channel_id,
+        "thread_ts": thread_ts,
+        "message_count": len(messages),
+        "participants": _extract_participants(messages),
+        "summary": haiku_result.get("summary", ""),
+        "action_items": haiku_result.get("action_items", []),
+        "sentiment": haiku_result.get("sentiment", "neutral"),
+        "indexed_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Haiku invocation (side-effect boundary)
+# ---------------------------------------------------------------------------
+
+
+def _default_haiku_invoke(prompt: str) -> str:
+    """Invoke Haiku via claude CLI subprocess.
+
+    This is the production Haiku invocation boundary. In tests,
+    this function is replaced with a mock.
+
+    Returns raw text output from Haiku.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "claude",
+                "--model", "haiku",
+                "--print",
+                "--max-turns", "1",
+                prompt,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            log.error("Haiku invocation failed: %s", result.stderr)
+            return ""
+        return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        log.error("Haiku invocation error: %s", e)
+        return ""
+
+
+def _parse_haiku_json(raw: str) -> dict[str, Any]:
+    """Parse JSON from Haiku output, handling markdown fences.
+
+    Attempts to extract JSON from the response, tolerating
+    common LLM output artifacts like ```json fences.
+    """
+    text = raw.strip()
+
+    # Strip markdown JSON fences
+    if text.startswith("```"):
+        lines = text.split("\n")
+        # Remove first and last lines (fences)
+        lines = [l for l in lines[1:] if not l.strip().startswith("```")]
+        text = "\n".join(lines)
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        log.warning("Failed to parse Haiku output as JSON: %.100s...", text)
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# SlackIndexer
+# ---------------------------------------------------------------------------
+
+
+class SlackIndexer:
+    """Async indexing pipeline for Slack message logs.
+
+    Orchestrates three indexing layers:
+    1. FTS5 keyword index (no LLM)
+    2. Thread summaries (Haiku)
+    3. Nightly topic clusters + action items (Haiku)
+
+    Haiku invocation is injectable for testability.
+    """
+
+    def __init__(
+        self,
+        connector_root: Path | None = None,
+        log_store: SlackLogStore | None = None,
+        keyword_index: KeywordIndex | None = None,
+        haiku_invoke: Callable[[str], str] | None = None,
+    ) -> None:
+        self._root = connector_root or _DEFAULT_CONNECTOR_ROOT
+        self._log_store = log_store or SlackLogStore()
+        self._keyword_index = keyword_index or KeywordIndex(
+            state_dir=self._root / "state"
+        )
+        self._haiku_invoke = haiku_invoke or _default_haiku_invoke
+
+        # Derived paths
+        self._config_path = self._root / "config" / "channels.yaml"
+        self._index_dir = self._root / "index"
+        self._thread_summaries_dir = self._index_dir / "thread-summaries"
+        self._topic_clusters_dir = self._index_dir / "topic-clusters"
+        self._action_items_dir = self._index_dir / "action-items"
+
+    def _channel_config(self) -> dict[str, dict[str, Any]]:
+        """Load channel config. Cached per invocation only."""
+        return _load_channel_config(self._config_path)
+
+    # -------------------------------------------------------------------
+    # Layer 1: Keyword index (no LLM)
+    # -------------------------------------------------------------------
+
+    def build_keyword_index(self, channel_id: str, date: str) -> int:
+        """Populate FTS5 from JSONL logs. Incremental via cursor.
+
+        Reads messages from the log store for the given channel/date,
+        filters to only new messages (after the cursor), and indexes them.
+        Updates the cursor on success.
+
+        Returns count of messages indexed.
+        """
+        config = self._channel_config()
+        if _is_channel_ignored(channel_id, config):
+            log.debug("Skipping ignored channel %s", channel_id)
+            return 0
+
+        messages = self._log_store.query(channel_id, date)
+        if not messages:
+            return 0
+
+        cursor_ts = self._keyword_index.get_cursor(channel_id)
+        new_messages = _filter_after_cursor(messages, cursor_ts)
+
+        if not new_messages:
+            return 0
+
+        count = self._keyword_index.index_messages(new_messages)
+
+        new_cursor = _max_ts(new_messages)
+        if new_cursor:
+            self._keyword_index.set_cursor(channel_id, new_cursor)
+
+        log.info(
+            "Keyword-indexed %d messages for %s on %s", count, channel_id, date
+        )
+        return count
+
+    def build_keyword_index_all(self, date: str) -> int:
+        """Build keyword index for all known channels on a date.
+
+        Convenience method that iterates over all channels in the log store.
+        Returns total count indexed.
+        """
+        total = 0
+        for channel_id in self._log_store.list_channels():
+            total += self.build_keyword_index(channel_id, date)
+        return total
+
+    # -------------------------------------------------------------------
+    # Layer 2: Thread summaries (Haiku)
+    # -------------------------------------------------------------------
+
+    def summarize_idle_threads(self, date: str | None = None) -> int:
+        """Find threads idle >2h, summarize with Haiku, write JSONL.
+
+        Scans all channels for threads where the last reply was >2h ago.
+        Calls Haiku to produce a summary for each idle thread.
+        Writes results to index/thread-summaries/{channel_id}/{date}.jsonl.
+
+        Returns count of threads summarized.
+        """
+        if not _is_index_enabled():
+            log.info("Slack indexing disabled; skipping thread summaries")
+            return 0
+
+        config = self._channel_config()
+        now = datetime.now(timezone.utc)
+        target_date = date or now.strftime("%Y-%m-%d")
+        count = 0
+
+        for channel_id in self._log_store.list_channels():
+            if _is_channel_ignored(channel_id, config):
+                continue
+
+            messages = self._log_store.query(channel_id, target_date)
+            threads = _group_by_thread(messages)
+
+            for thread_ts, thread_msgs in threads.items():
+                if not _is_thread_idle(thread_msgs, now):
+                    continue
+
+                # Skip if already summarized
+                if self._thread_summary_exists(channel_id, thread_ts, target_date):
+                    continue
+
+                # Enforce batch limit
+                if len(thread_msgs) > _MAX_MESSAGES_PER_HAIKU_BATCH:
+                    thread_msgs = sorted(
+                        thread_msgs, key=lambda m: m.get("ts", "0")
+                    )[-_MAX_MESSAGES_PER_HAIKU_BATCH:]
+
+                summary = self._summarize_thread(channel_id, thread_ts, thread_msgs)
+                if summary:
+                    self._write_thread_summary(channel_id, target_date, summary)
+                    count += 1
+
+        log.info("Summarized %d idle threads", count)
+        return count
+
+    def _summarize_thread(
+        self,
+        channel_id: str,
+        thread_ts: str,
+        messages: list[dict[str, Any]],
+    ) -> dict[str, Any] | None:
+        """Invoke Haiku to summarize a single thread."""
+        context = _build_thread_context(messages)
+        prompt = textwrap.dedent(f"""\
+            Summarize this Slack thread conversation. Return valid JSON with these fields:
+            - "summary": A 1-3 sentence summary of what was discussed and decided.
+            - "action_items": A list of strings, each describing a committed action (format: "person: action").
+            - "sentiment": One of "positive", "negative", "neutral", "mixed".
+
+            Thread messages:
+            {context}
+
+            Return ONLY valid JSON, no other text.
+        """)
+
+        raw = self._haiku_invoke(prompt)
+        if not raw:
+            return None
+
+        result = _parse_haiku_json(raw)
+        if not result:
+            return None
+
+        return _build_thread_summary_record(channel_id, thread_ts, messages, result)
+
+    def _thread_summary_exists(
+        self, channel_id: str, thread_ts: str, date: str
+    ) -> bool:
+        """Check if a thread summary already exists for deduplication."""
+        summary_file = self._thread_summaries_dir / channel_id / f"{date}.jsonl"
+        if not summary_file.exists():
+            return False
+
+        with open(summary_file) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                    if record.get("thread_ts") == thread_ts:
+                        return True
+                except json.JSONDecodeError:
+                    continue
+        return False
+
+    def _write_thread_summary(
+        self, channel_id: str, date: str, summary: dict[str, Any]
+    ) -> None:
+        """Append a thread summary record to the JSONL output file."""
+        out_dir = self._thread_summaries_dir / channel_id
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_file = out_dir / f"{date}.jsonl"
+
+        with open(out_file, "a") as f:
+            f.write(json.dumps(summary, ensure_ascii=False) + "\n")
+
+        log.debug(
+            "Wrote thread summary for %s/%s to %s",
+            channel_id,
+            summary.get("thread_ts"),
+            out_file,
+        )
+
+    # -------------------------------------------------------------------
+    # Layer 3: Nightly topic clusters + action items (Haiku)
+    # -------------------------------------------------------------------
+
+    def run_nightly_index(self, channel_id: str, date: str) -> None:
+        """Nightly analysis: topic clusters + action items for a channel/date.
+
+        Uses Haiku to analyze the day's messages and produce:
+        - topic-clusters/{channel_id}/{date}.json
+        - action-items/{channel_id}/{date}.json
+
+        Skipped if indexing is disabled or channel is ignored.
+        """
+        if not _is_index_enabled():
+            log.info("Slack indexing disabled; skipping nightly index")
+            return
+
+        config = self._channel_config()
+        if _is_channel_ignored(channel_id, config):
+            log.debug("Skipping ignored channel %s", channel_id)
+            return
+
+        messages = self._log_store.query(channel_id, date)
+        if not messages:
+            log.debug("No messages for %s on %s", channel_id, date)
+            return
+
+        # Process in batches if needed
+        batch = messages[:_MAX_MESSAGES_PER_HAIKU_BATCH]
+        has_more = len(messages) > _MAX_MESSAGES_PER_HAIKU_BATCH
+
+        context = _build_nightly_context(batch)
+
+        # Topic clusters
+        topic_result = self._analyze_topics(context)
+        if topic_result:
+            self._write_json_index(
+                self._topic_clusters_dir, channel_id, date, topic_result
+            )
+
+        # Action items
+        action_result = self._analyze_actions(context)
+        if action_result:
+            self._write_json_index(
+                self._action_items_dir, channel_id, date, action_result
+            )
+
+        if has_more:
+            remaining = len(messages) - _MAX_MESSAGES_PER_HAIKU_BATCH
+            log.info(
+                "Nightly index for %s/%s processed %d of %d messages; "
+                "%d remaining for continuation",
+                channel_id,
+                date,
+                len(batch),
+                len(messages),
+                remaining,
+            )
+
+    def run_nightly_index_all(self, date: str) -> None:
+        """Run nightly index for all known channels."""
+        if not _is_index_enabled():
+            log.info("Slack indexing disabled; skipping nightly index")
+            return
+
+        for channel_id in self._log_store.list_channels():
+            self.run_nightly_index(channel_id, date)
+
+    def _analyze_topics(self, context: str) -> dict[str, Any] | None:
+        """Invoke Haiku to extract topic clusters from day's messages."""
+        prompt = textwrap.dedent(f"""\
+            Analyze these Slack messages and identify topic clusters.
+            Return valid JSON with:
+            - "topics": A list of objects, each with:
+              - "topic": Short topic label (2-5 words)
+              - "message_count": How many messages relate to this topic
+              - "key_points": List of 1-3 key points discussed
+              - "participants": List of usernames involved
+
+            Messages:
+            {context}
+
+            Return ONLY valid JSON, no other text.
+        """)
+
+        raw = self._haiku_invoke(prompt)
+        if not raw:
+            return None
+
+        result = _parse_haiku_json(raw)
+        if not result or "topics" not in result:
+            return None
+
+        result["analyzed_at"] = datetime.now(timezone.utc).isoformat()
+        return result
+
+    def _analyze_actions(self, context: str) -> dict[str, Any] | None:
+        """Invoke Haiku to extract action items from day's messages."""
+        prompt = textwrap.dedent(f"""\
+            Extract action items from these Slack messages.
+            An action item is something someone committed to doing or was asked to do.
+            Return valid JSON with:
+            - "action_items": A list of objects, each with:
+              - "assignee": Username of the person responsible
+              - "action": What they committed to or were asked to do
+              - "context": Brief context (which conversation, thread)
+              - "urgency": "high", "medium", or "low"
+
+            Messages:
+            {context}
+
+            Return ONLY valid JSON, no other text.
+        """)
+
+        raw = self._haiku_invoke(prompt)
+        if not raw:
+            return None
+
+        result = _parse_haiku_json(raw)
+        if not result or "action_items" not in result:
+            return None
+
+        result["analyzed_at"] = datetime.now(timezone.utc).isoformat()
+        return result
+
+    def _write_json_index(
+        self,
+        base_dir: Path,
+        channel_id: str,
+        date: str,
+        data: dict[str, Any],
+    ) -> None:
+        """Write a JSON index file to the appropriate directory."""
+        out_dir = base_dir / channel_id
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_file = out_dir / f"{date}.json"
+
+        with open(out_file, "w") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+
+        log.debug("Wrote index to %s", out_file)

--- a/lobster-shop/slack-connector/src/keyword_index.py
+++ b/lobster-shop/slack-connector/src/keyword_index.py
@@ -1,0 +1,220 @@
+"""
+Keyword Index — SQLite FTS5 full-text search over Slack message logs.
+
+Provides near-real-time keyword search across all logged Slack messages.
+Uses SQLite FTS5 with porter stemming for English-language queries.
+Cursor-based incremental indexing prevents reprocessing.
+
+Design principles:
+- Pure query functions where possible
+- Side effects (DB writes) isolated to index_messages / set_cursor
+- Composable search with optional channel filtering
+- Idempotent schema creation (safe to call repeatedly)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("slack-keyword-index")
+
+_DEFAULT_STATE_DIR = Path(
+    os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace")
+) / "slack-connector" / "state"
+
+_DB_FILENAME = "keyword_index.db"
+
+# ---------------------------------------------------------------------------
+# Schema SQL (pure constants)
+# ---------------------------------------------------------------------------
+
+_CREATE_FTS_TABLE = """
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+    ts, channel_id, user_id, text,
+    tokenize='porter ascii'
+);
+"""
+
+_CREATE_CURSOR_TABLE = """
+CREATE TABLE IF NOT EXISTS index_cursors (
+    channel_id TEXT PRIMARY KEY,
+    last_ts TEXT NOT NULL
+);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_fts_row(msg: dict[str, Any]) -> tuple[str, str, str, str] | None:
+    """Extract FTS-indexable fields from a message record.
+
+    Pure function. Returns None if the message lacks required fields.
+    """
+    ts = msg.get("ts", "")
+    channel_id = msg.get("channel_id", "")
+    text = msg.get("text", "")
+
+    if not ts or not channel_id or not text:
+        return None
+
+    user_id = msg.get("user_id", "")
+    return (ts, channel_id, user_id, text)
+
+
+def _filter_after_cursor(
+    messages: list[dict[str, Any]], cursor_ts: str | None
+) -> list[dict[str, Any]]:
+    """Filter messages to only those with ts > cursor_ts.
+
+    Pure function. Returns all messages if cursor_ts is None.
+    """
+    if cursor_ts is None:
+        return messages
+    return [m for m in messages if m.get("ts", "") > cursor_ts]
+
+
+def _max_ts(messages: list[dict[str, Any]]) -> str | None:
+    """Find the maximum timestamp from a list of messages.
+
+    Pure function. Returns None for empty lists.
+    """
+    timestamps = [m.get("ts", "") for m in messages if m.get("ts")]
+    return max(timestamps) if timestamps else None
+
+
+# ---------------------------------------------------------------------------
+# KeywordIndex
+# ---------------------------------------------------------------------------
+
+
+class KeywordIndex:
+    """SQLite FTS5 keyword index for Slack messages.
+
+    Manages a full-text search index backed by SQLite. Supports
+    incremental indexing via cursor tracking per channel.
+    """
+
+    def __init__(self, state_dir: Path | None = None) -> None:
+        self._state_dir = state_dir or _DEFAULT_STATE_DIR
+        self._db_path = self._state_dir / _DB_FILENAME
+        self._conn: sqlite3.Connection | None = None
+
+    def _ensure_db(self) -> sqlite3.Connection:
+        """Lazily create DB connection and ensure schema exists."""
+        if self._conn is not None:
+            return self._conn
+
+        self._state_dir.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._db_path))
+        self._conn.execute("PRAGMA journal_mode=WAL;")
+        self._conn.execute(_CREATE_FTS_TABLE)
+        self._conn.execute(_CREATE_CURSOR_TABLE)
+        self._conn.commit()
+        return self._conn
+
+    def close(self) -> None:
+        """Close the database connection."""
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    def index_messages(self, messages: list[dict[str, Any]]) -> int:
+        """Index a batch of messages into FTS5.
+
+        Skips messages missing required fields (ts, channel_id, text).
+        Returns count of messages successfully indexed.
+        """
+        conn = self._ensure_db()
+        rows = [
+            row
+            for msg in messages
+            if (row := _build_fts_row(msg)) is not None
+        ]
+
+        if not rows:
+            return 0
+
+        conn.executemany(
+            "INSERT INTO messages_fts(ts, channel_id, user_id, text) VALUES (?, ?, ?, ?);",
+            rows,
+        )
+        conn.commit()
+        log.info("Indexed %d messages into FTS5", len(rows))
+        return len(rows)
+
+    def search(
+        self,
+        query: str,
+        channel_id: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Full-text search over indexed messages.
+
+        Uses FTS5 MATCH syntax (supports AND, OR, NOT, phrase queries).
+        Optionally filters by channel_id.
+
+        Returns list of matching records as dicts with keys:
+        ts, channel_id, user_id, text, rank.
+        """
+        conn = self._ensure_db()
+
+        if channel_id:
+            sql = (
+                "SELECT ts, channel_id, user_id, text, rank "
+                "FROM messages_fts "
+                "WHERE messages_fts MATCH ? AND channel_id = ? "
+                "ORDER BY rank "
+                "LIMIT ?;"
+            )
+            cursor = conn.execute(sql, (query, channel_id, limit))
+        else:
+            sql = (
+                "SELECT ts, channel_id, user_id, text, rank "
+                "FROM messages_fts "
+                "WHERE messages_fts MATCH ? "
+                "ORDER BY rank "
+                "LIMIT ?;"
+            )
+            cursor = conn.execute(sql, (query, limit))
+
+        return [
+            {
+                "ts": row[0],
+                "channel_id": row[1],
+                "user_id": row[2],
+                "text": row[3],
+                "rank": row[4],
+            }
+            for row in cursor.fetchall()
+        ]
+
+    def get_cursor(self, channel_id: str) -> str | None:
+        """Get the last-indexed timestamp for a channel.
+
+        Returns None if no messages have been indexed for this channel.
+        """
+        conn = self._ensure_db()
+        row = conn.execute(
+            "SELECT last_ts FROM index_cursors WHERE channel_id = ?;",
+            (channel_id,),
+        ).fetchone()
+        return row[0] if row else None
+
+    def set_cursor(self, channel_id: str, ts: str) -> None:
+        """Update the last-indexed timestamp for a channel.
+
+        Uses INSERT OR REPLACE for idempotent upsert.
+        """
+        conn = self._ensure_db()
+        conn.execute(
+            "INSERT OR REPLACE INTO index_cursors(channel_id, last_ts) VALUES (?, ?);",
+            (channel_id, ts),
+        )
+        conn.commit()

--- a/lobster-shop/slack-connector/tests/test_indexer.py
+++ b/lobster-shop/slack-connector/tests/test_indexer.py
@@ -1,0 +1,502 @@
+"""Tests for indexer.py — Slack indexing pipeline.
+
+All Haiku calls are mocked. Tests verify:
+- Pure helper functions (no mocking needed)
+- Keyword indexing integration (cursor-based incremental)
+- Thread summary pipeline (with mock Haiku)
+- Nightly index pipeline (with mock Haiku)
+- Cost guardrails (env flag, batch limits, channel filtering)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.indexer import (
+    SlackIndexer,
+    _build_nightly_context,
+    _build_thread_context,
+    _build_thread_summary_record,
+    _extract_participants,
+    _group_by_thread,
+    _is_channel_ignored,
+    _is_index_enabled,
+    _is_thread_idle,
+    _parse_haiku_json,
+)
+from src.keyword_index import KeywordIndex
+from src.log_store import SlackLogStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_msg(
+    ts: str = "1743724800.000000",
+    channel_id: str = "C01ABC123",
+    user_id: str = "U01",
+    username: str = "alice",
+    text: str = "test message",
+    thread_ts: str | None = None,
+) -> dict[str, Any]:
+    """Build a minimal test message record."""
+    msg: dict[str, Any] = {
+        "ts": ts,
+        "channel_id": channel_id,
+        "user_id": user_id,
+        "username": username,
+        "text": text,
+    }
+    if thread_ts:
+        msg["thread_ts"] = thread_ts
+    return msg
+
+
+def _setup_log_store(tmp_path: Path, messages: list[dict], channel_id: str = "C01ABC123", date: str = "2026-04-03") -> SlackLogStore:
+    """Create a log store with test data written to JSONL files."""
+    log_dir = tmp_path / "logs" / "channels" / channel_id
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    jsonl_file = log_dir / f"{date}.jsonl"
+    with open(jsonl_file, "w") as f:
+        for msg in messages:
+            f.write(json.dumps(msg) + "\n")
+
+    return SlackLogStore(log_root=tmp_path / "logs")
+
+
+def _mock_haiku_thread_summary(prompt: str) -> str:
+    """Mock Haiku response for thread summarization."""
+    return json.dumps({
+        "summary": "Team discussed the deploy outage. Root cause identified.",
+        "action_items": ["alice: fix migration by EOD"],
+        "sentiment": "neutral",
+    })
+
+
+def _mock_haiku_topics(prompt: str) -> str:
+    """Mock Haiku response for topic clustering."""
+    if "topic" in prompt.lower():
+        return json.dumps({
+            "topics": [
+                {
+                    "topic": "Deploy outage",
+                    "message_count": 3,
+                    "key_points": ["Root cause: stale migration"],
+                    "participants": ["alice", "bob"],
+                }
+            ],
+        })
+    elif "action" in prompt.lower():
+        return json.dumps({
+            "action_items": [
+                {
+                    "assignee": "alice",
+                    "action": "Fix stale migration",
+                    "context": "deploy thread",
+                    "urgency": "high",
+                }
+            ],
+        })
+    return "{}"
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsIndexEnabled:
+    def test_default_true(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("LOBSTER_SLACK_INDEX_ENABLED", None)
+            assert _is_index_enabled() is True
+
+    def test_false(self) -> None:
+        with patch.dict(os.environ, {"LOBSTER_SLACK_INDEX_ENABLED": "false"}):
+            assert _is_index_enabled() is False
+
+    def test_true_explicit(self) -> None:
+        with patch.dict(os.environ, {"LOBSTER_SLACK_INDEX_ENABLED": "true"}):
+            assert _is_index_enabled() is True
+
+
+class TestIsChannelIgnored:
+    def test_not_in_config_is_not_ignored(self) -> None:
+        assert _is_channel_ignored("C01", {}) is False
+
+    def test_mode_ignore(self) -> None:
+        config = {"C01": {"id": "C01", "mode": "ignore"}}
+        assert _is_channel_ignored("C01", config) is True
+
+    def test_mode_monitor(self) -> None:
+        config = {"C01": {"id": "C01", "mode": "monitor"}}
+        assert _is_channel_ignored("C01", config) is False
+
+
+class TestGroupByThread:
+    def test_groups_by_thread_ts(self) -> None:
+        msgs = [
+            _make_msg(ts="1", thread_ts="T1"),
+            _make_msg(ts="2", thread_ts="T1"),
+            _make_msg(ts="3", thread_ts="T2"),
+        ]
+        groups = _group_by_thread(msgs)
+        assert len(groups) == 2
+        assert len(groups["T1"]) == 2
+        assert len(groups["T2"]) == 1
+
+    def test_non_threaded_messages_excluded(self) -> None:
+        msgs = [_make_msg(ts="1"), _make_msg(ts="2")]
+        groups = _group_by_thread(msgs)
+        assert groups == {}
+
+
+class TestIsThreadIdle:
+    def test_idle_thread(self) -> None:
+        old_ts = str(time.time() - 3 * 3600)  # 3 hours ago
+        msgs = [_make_msg(ts=old_ts)]
+        now = datetime.now(timezone.utc)
+        assert _is_thread_idle(msgs, now) is True
+
+    def test_active_thread(self) -> None:
+        recent_ts = str(time.time() - 60)  # 1 minute ago
+        msgs = [_make_msg(ts=recent_ts)]
+        now = datetime.now(timezone.utc)
+        assert _is_thread_idle(msgs, now) is False
+
+    def test_empty_messages(self) -> None:
+        now = datetime.now(timezone.utc)
+        assert _is_thread_idle([], now) is False
+
+
+class TestExtractParticipants:
+    def test_unique_participants(self) -> None:
+        msgs = [
+            _make_msg(username="alice"),
+            _make_msg(username="bob"),
+            _make_msg(username="alice"),
+        ]
+        result = _extract_participants(msgs)
+        assert result == ["alice", "bob"]
+
+    def test_falls_back_to_user_id(self) -> None:
+        msgs = [{"user_id": "U01"}, {"user_id": "U02"}]
+        result = _extract_participants(msgs)
+        assert result == ["U01", "U02"]
+
+
+class TestBuildThreadContext:
+    def test_builds_context_string(self) -> None:
+        msgs = [
+            _make_msg(ts="1", username="alice", text="hello"),
+            _make_msg(ts="2", username="bob", text="world"),
+        ]
+        ctx = _build_thread_context(msgs)
+        assert "alice: hello" in ctx
+        assert "bob: world" in ctx
+
+    def test_truncates_to_max(self) -> None:
+        msgs = [_make_msg(ts=str(i), text=f"msg {i}") for i in range(100)]
+        ctx = _build_thread_context(msgs, max_messages=5)
+        lines = [l for l in ctx.strip().split("\n") if l]
+        assert len(lines) == 5
+
+
+class TestBuildNightlyContext:
+    def test_includes_timestamps(self) -> None:
+        msgs = [_make_msg(ts="12345", username="alice", text="hello")]
+        ctx = _build_nightly_context(msgs)
+        assert "[12345]" in ctx
+        assert "alice: hello" in ctx
+
+
+class TestBuildThreadSummaryRecord:
+    def test_builds_record(self) -> None:
+        msgs = [_make_msg(username="alice"), _make_msg(username="bob")]
+        haiku_result = {
+            "summary": "Team discussed X",
+            "action_items": ["alice: do Y"],
+            "sentiment": "neutral",
+        }
+        record = _build_thread_summary_record("C01", "T1", msgs, haiku_result)
+        assert record["channel_id"] == "C01"
+        assert record["thread_ts"] == "T1"
+        assert record["message_count"] == 2
+        assert record["participants"] == ["alice", "bob"]
+        assert record["summary"] == "Team discussed X"
+        assert "indexed_at" in record
+
+
+class TestParseHaikuJson:
+    def test_plain_json(self) -> None:
+        raw = '{"summary": "test"}'
+        assert _parse_haiku_json(raw) == {"summary": "test"}
+
+    def test_json_in_fences(self) -> None:
+        raw = '```json\n{"summary": "test"}\n```'
+        assert _parse_haiku_json(raw) == {"summary": "test"}
+
+    def test_invalid_json_returns_empty(self) -> None:
+        assert _parse_haiku_json("not json at all") == {}
+
+    def test_empty_string(self) -> None:
+        assert _parse_haiku_json("") == {}
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — keyword indexing
+# ---------------------------------------------------------------------------
+
+
+class TestBuildKeywordIndex:
+    def test_indexes_messages_from_log_store(self, tmp_path: Path) -> None:
+        messages = [
+            _make_msg(ts=f"174372480{i}.000000", text=f"message about deploy {i}")
+            for i in range(5)
+        ]
+        log_store = _setup_log_store(tmp_path, messages)
+        keyword_index = KeywordIndex(state_dir=tmp_path / "state")
+
+        indexer = SlackIndexer(
+            connector_root=tmp_path,
+            log_store=log_store,
+            keyword_index=keyword_index,
+        )
+        count = indexer.build_keyword_index("C01ABC123", "2026-04-03")
+        assert count == 5
+
+        results = keyword_index.search("deploy")
+        assert len(results) == 5
+        keyword_index.close()
+
+    def test_incremental_indexing_via_cursor(self, tmp_path: Path) -> None:
+        """Re-running should not re-index already-processed messages."""
+        messages = [
+            _make_msg(ts="1743724800.000000", text="first deploy"),
+            _make_msg(ts="1743724801.000000", text="second deploy"),
+        ]
+        log_store = _setup_log_store(tmp_path, messages)
+        keyword_index = KeywordIndex(state_dir=tmp_path / "state")
+
+        indexer = SlackIndexer(
+            connector_root=tmp_path,
+            log_store=log_store,
+            keyword_index=keyword_index,
+        )
+
+        # First run indexes all
+        count1 = indexer.build_keyword_index("C01ABC123", "2026-04-03")
+        assert count1 == 2
+
+        # Second run finds nothing new
+        count2 = indexer.build_keyword_index("C01ABC123", "2026-04-03")
+        assert count2 == 0
+
+        keyword_index.close()
+
+    def test_skips_ignored_channels(self, tmp_path: Path) -> None:
+        messages = [_make_msg(text="should not index")]
+        log_store = _setup_log_store(tmp_path, messages)
+        keyword_index = KeywordIndex(state_dir=tmp_path / "state")
+
+        # Write channels.yaml with mode: ignore
+        config_dir = tmp_path / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "channels.yaml").write_text(
+            "channels:\n  - id: C01ABC123\n    mode: ignore\n"
+        )
+
+        indexer = SlackIndexer(
+            connector_root=tmp_path,
+            log_store=log_store,
+            keyword_index=keyword_index,
+        )
+        count = indexer.build_keyword_index("C01ABC123", "2026-04-03")
+        assert count == 0
+        keyword_index.close()
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — thread summaries
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizeIdleThreads:
+    def test_summarizes_idle_thread(self, tmp_path: Path) -> None:
+        # Thread with messages from 3 hours ago
+        old_ts = str(time.time() - 3 * 3600)
+        messages = [
+            _make_msg(ts=old_ts, text="thread start", thread_ts=old_ts, username="alice"),
+            _make_msg(ts=str(float(old_ts) + 60), text="reply", thread_ts=old_ts, username="bob"),
+        ]
+        date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        log_store = _setup_log_store(tmp_path, messages, date=date)
+
+        indexer = SlackIndexer(
+            connector_root=tmp_path,
+            log_store=log_store,
+            haiku_invoke=_mock_haiku_thread_summary,
+        )
+        count = indexer.summarize_idle_threads(date=date)
+        assert count == 1
+
+        # Verify output file
+        summary_file = tmp_path / "index" / "thread-summaries" / "C01ABC123" / f"{date}.jsonl"
+        assert summary_file.exists()
+        with open(summary_file) as f:
+            record = json.loads(f.readline())
+        assert record["thread_ts"] == old_ts
+        assert record["message_count"] == 2
+        assert "deploy outage" in record["summary"]
+
+    def test_skips_active_threads(self, tmp_path: Path) -> None:
+        recent_ts = str(time.time() - 60)  # 1 minute ago
+        messages = [
+            _make_msg(ts=recent_ts, text="active thread", thread_ts=recent_ts),
+        ]
+        date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        log_store = _setup_log_store(tmp_path, messages, date=date)
+
+        indexer = SlackIndexer(
+            connector_root=tmp_path,
+            log_store=log_store,
+            haiku_invoke=_mock_haiku_thread_summary,
+        )
+        count = indexer.summarize_idle_threads(date=date)
+        assert count == 0
+
+    def test_disabled_via_env(self, tmp_path: Path) -> None:
+        old_ts = str(time.time() - 3 * 3600)
+        messages = [_make_msg(ts=old_ts, thread_ts=old_ts)]
+        date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        log_store = _setup_log_store(tmp_path, messages, date=date)
+
+        with patch.dict(os.environ, {"LOBSTER_SLACK_INDEX_ENABLED": "false"}):
+            indexer = SlackIndexer(
+                connector_root=tmp_path,
+                log_store=log_store,
+                haiku_invoke=_mock_haiku_thread_summary,
+            )
+            count = indexer.summarize_idle_threads(date=date)
+            assert count == 0
+
+    def test_deduplicates_already_summarized(self, tmp_path: Path) -> None:
+        old_ts = str(time.time() - 3 * 3600)
+        messages = [_make_msg(ts=old_ts, text="thread", thread_ts=old_ts)]
+        date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        log_store = _setup_log_store(tmp_path, messages, date=date)
+
+        indexer = SlackIndexer(
+            connector_root=tmp_path,
+            log_store=log_store,
+            haiku_invoke=_mock_haiku_thread_summary,
+        )
+
+        # First run
+        count1 = indexer.summarize_idle_threads(date=date)
+        assert count1 == 1
+
+        # Second run — should skip already-summarized thread
+        count2 = indexer.summarize_idle_threads(date=date)
+        assert count2 == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — nightly index
+# ---------------------------------------------------------------------------
+
+
+class TestRunNightlyIndex:
+    def test_produces_topic_and_action_files(self, tmp_path: Path) -> None:
+        messages = [
+            _make_msg(ts=f"174372480{i}.000000", text=f"discussing deploy issue {i}")
+            for i in range(5)
+        ]
+        log_store = _setup_log_store(tmp_path, messages)
+
+        indexer = SlackIndexer(
+            connector_root=tmp_path,
+            log_store=log_store,
+            haiku_invoke=_mock_haiku_topics,
+        )
+        indexer.run_nightly_index("C01ABC123", "2026-04-03")
+
+        # Verify topic clusters file
+        topic_file = tmp_path / "index" / "topic-clusters" / "C01ABC123" / "2026-04-03.json"
+        assert topic_file.exists()
+        data = json.loads(topic_file.read_text())
+        assert "topics" in data
+        assert data["topics"][0]["topic"] == "Deploy outage"
+
+        # Verify action items file
+        action_file = tmp_path / "index" / "action-items" / "C01ABC123" / "2026-04-03.json"
+        assert action_file.exists()
+        data = json.loads(action_file.read_text())
+        assert "action_items" in data
+
+    def test_disabled_via_env(self, tmp_path: Path) -> None:
+        messages = [_make_msg(text="should not process")]
+        log_store = _setup_log_store(tmp_path, messages)
+
+        with patch.dict(os.environ, {"LOBSTER_SLACK_INDEX_ENABLED": "false"}):
+            indexer = SlackIndexer(
+                connector_root=tmp_path,
+                log_store=log_store,
+                haiku_invoke=_mock_haiku_topics,
+            )
+            indexer.run_nightly_index("C01ABC123", "2026-04-03")
+
+        # No files should be created
+        topic_file = tmp_path / "index" / "topic-clusters" / "C01ABC123" / "2026-04-03.json"
+        assert not topic_file.exists()
+
+    def test_skips_ignored_channel(self, tmp_path: Path) -> None:
+        messages = [_make_msg(text="ignored channel")]
+        log_store = _setup_log_store(tmp_path, messages)
+
+        config_dir = tmp_path / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "channels.yaml").write_text(
+            "channels:\n  - id: C01ABC123\n    mode: ignore\n"
+        )
+
+        indexer = SlackIndexer(
+            connector_root=tmp_path,
+            log_store=log_store,
+            haiku_invoke=_mock_haiku_topics,
+        )
+        indexer.run_nightly_index("C01ABC123", "2026-04-03")
+
+        topic_file = tmp_path / "index" / "topic-clusters" / "C01ABC123" / "2026-04-03.json"
+        assert not topic_file.exists()
+
+    def test_logs_continuation_for_large_batches(self, tmp_path: Path, caplog) -> None:
+        """More than 50 messages should log a continuation notice."""
+        messages = [
+            _make_msg(ts=f"17437248{i:04d}.000000", text=f"msg {i}")
+            for i in range(60)
+        ]
+        log_store = _setup_log_store(tmp_path, messages)
+
+        indexer = SlackIndexer(
+            connector_root=tmp_path,
+            log_store=log_store,
+            haiku_invoke=_mock_haiku_topics,
+        )
+
+        import logging
+        with caplog.at_level(logging.INFO, logger="slack-indexer"):
+            indexer.run_nightly_index("C01ABC123", "2026-04-03")
+
+        assert any("continuation" in r.message for r in caplog.records)

--- a/lobster-shop/slack-connector/tests/test_keyword_index.py
+++ b/lobster-shop/slack-connector/tests/test_keyword_index.py
@@ -1,0 +1,209 @@
+"""Tests for keyword_index.py — SQLite FTS5 keyword search."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.keyword_index import (
+    KeywordIndex,
+    _build_fts_row,
+    _filter_after_cursor,
+    _max_ts,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFtsRow:
+    """Tests for _build_fts_row — pure extraction of FTS-indexable fields."""
+
+    def test_valid_message(self) -> None:
+        msg = {
+            "ts": "1743724800.123456",
+            "channel_id": "C01ABC123",
+            "user_id": "U01DEF456",
+            "text": "deploy outage in production",
+        }
+        result = _build_fts_row(msg)
+        assert result == ("1743724800.123456", "C01ABC123", "U01DEF456", "deploy outage in production")
+
+    def test_missing_ts_returns_none(self) -> None:
+        msg = {"channel_id": "C01", "text": "hello", "user_id": "U01"}
+        assert _build_fts_row(msg) is None
+
+    def test_missing_channel_id_returns_none(self) -> None:
+        msg = {"ts": "123", "text": "hello", "user_id": "U01"}
+        assert _build_fts_row(msg) is None
+
+    def test_missing_text_returns_none(self) -> None:
+        msg = {"ts": "123", "channel_id": "C01", "user_id": "U01"}
+        assert _build_fts_row(msg) is None
+
+    def test_empty_text_returns_none(self) -> None:
+        msg = {"ts": "123", "channel_id": "C01", "user_id": "U01", "text": ""}
+        assert _build_fts_row(msg) is None
+
+    def test_missing_user_id_defaults_empty(self) -> None:
+        msg = {"ts": "123", "channel_id": "C01", "text": "hello"}
+        result = _build_fts_row(msg)
+        assert result is not None
+        assert result[2] == ""  # user_id defaults to ""
+
+
+class TestFilterAfterCursor:
+    """Tests for _filter_after_cursor — pure cursor-based filtering."""
+
+    def test_none_cursor_returns_all(self) -> None:
+        msgs = [{"ts": "1"}, {"ts": "2"}, {"ts": "3"}]
+        assert _filter_after_cursor(msgs, None) == msgs
+
+    def test_filters_messages_before_cursor(self) -> None:
+        msgs = [{"ts": "1"}, {"ts": "2"}, {"ts": "3"}]
+        result = _filter_after_cursor(msgs, "2")
+        assert len(result) == 1
+        assert result[0]["ts"] == "3"
+
+    def test_cursor_at_max_returns_empty(self) -> None:
+        msgs = [{"ts": "1"}, {"ts": "2"}]
+        assert _filter_after_cursor(msgs, "2") == []
+
+    def test_empty_messages_returns_empty(self) -> None:
+        assert _filter_after_cursor([], "1") == []
+
+
+class TestMaxTs:
+    """Tests for _max_ts — pure max timestamp extraction."""
+
+    def test_returns_max(self) -> None:
+        msgs = [{"ts": "1"}, {"ts": "3"}, {"ts": "2"}]
+        assert _max_ts(msgs) == "3"
+
+    def test_empty_returns_none(self) -> None:
+        assert _max_ts([]) is None
+
+    def test_missing_ts_fields_skipped(self) -> None:
+        msgs = [{"ts": "1"}, {}, {"ts": "2"}]
+        assert _max_ts(msgs) == "2"
+
+
+# ---------------------------------------------------------------------------
+# KeywordIndex integration tests (uses temp SQLite DB)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def keyword_index(tmp_path: Path) -> KeywordIndex:
+    """Create a KeywordIndex backed by a temp directory."""
+    idx = KeywordIndex(state_dir=tmp_path)
+    yield idx
+    idx.close()
+
+
+def _make_messages(count: int, channel_id: str = "C01") -> list[dict]:
+    """Generate a batch of test messages."""
+    return [
+        {
+            "ts": f"174372480{i}.000000",
+            "channel_id": channel_id,
+            "user_id": f"U0{i}",
+            "text": f"test message number {i} about deploy",
+        }
+        for i in range(count)
+    ]
+
+
+class TestKeywordIndexBasic:
+    """Tests for KeywordIndex core operations."""
+
+    def test_index_and_search(self, keyword_index: KeywordIndex) -> None:
+        messages = _make_messages(5)
+        count = keyword_index.index_messages(messages)
+        assert count == 5
+
+        results = keyword_index.search("deploy")
+        assert len(results) == 5
+        assert all("deploy" in r["text"] for r in results)
+
+    def test_search_with_channel_filter(self, keyword_index: KeywordIndex) -> None:
+        msgs_a = _make_messages(3, channel_id="CA")
+        msgs_b = _make_messages(2, channel_id="CB")
+        keyword_index.index_messages(msgs_a + msgs_b)
+
+        results_a = keyword_index.search("deploy", channel_id="CA")
+        results_b = keyword_index.search("deploy", channel_id="CB")
+        assert len(results_a) == 3
+        assert len(results_b) == 2
+
+    def test_search_no_results(self, keyword_index: KeywordIndex) -> None:
+        keyword_index.index_messages(_make_messages(3))
+        results = keyword_index.search("nonexistent_xyz")
+        assert results == []
+
+    def test_search_limit(self, keyword_index: KeywordIndex) -> None:
+        keyword_index.index_messages(_make_messages(10))
+        results = keyword_index.search("deploy", limit=3)
+        assert len(results) == 3
+
+    def test_index_skips_invalid_messages(self, keyword_index: KeywordIndex) -> None:
+        messages = [
+            {"ts": "1", "channel_id": "C01", "user_id": "U01", "text": "valid"},
+            {"channel_id": "C01", "text": "missing ts"},
+            {"ts": "2", "text": "missing channel"},
+            {},
+        ]
+        count = keyword_index.index_messages(messages)
+        assert count == 1
+
+    def test_index_empty_list(self, keyword_index: KeywordIndex) -> None:
+        count = keyword_index.index_messages([])
+        assert count == 0
+
+
+class TestKeywordIndexCursors:
+    """Tests for cursor tracking — incremental indexing support."""
+
+    def test_cursor_initially_none(self, keyword_index: KeywordIndex) -> None:
+        assert keyword_index.get_cursor("C01") is None
+
+    def test_set_and_get_cursor(self, keyword_index: KeywordIndex) -> None:
+        keyword_index.set_cursor("C01", "1743724800.000000")
+        assert keyword_index.get_cursor("C01") == "1743724800.000000"
+
+    def test_cursor_per_channel(self, keyword_index: KeywordIndex) -> None:
+        keyword_index.set_cursor("CA", "100")
+        keyword_index.set_cursor("CB", "200")
+        assert keyword_index.get_cursor("CA") == "100"
+        assert keyword_index.get_cursor("CB") == "200"
+
+    def test_cursor_upsert(self, keyword_index: KeywordIndex) -> None:
+        keyword_index.set_cursor("C01", "100")
+        keyword_index.set_cursor("C01", "200")
+        assert keyword_index.get_cursor("C01") == "200"
+
+
+class TestKeywordIndexSchema:
+    """Tests for schema creation — idempotent and correct."""
+
+    def test_db_created_on_first_access(self, tmp_path: Path) -> None:
+        idx = KeywordIndex(state_dir=tmp_path)
+        idx.index_messages([])  # triggers lazy init
+        assert (tmp_path / "keyword_index.db").exists()
+        idx.close()
+
+    def test_reopening_preserves_data(self, tmp_path: Path) -> None:
+        idx1 = KeywordIndex(state_dir=tmp_path)
+        idx1.index_messages(_make_messages(3))
+        idx1.set_cursor("C01", "999")
+        idx1.close()
+
+        idx2 = KeywordIndex(state_dir=tmp_path)
+        results = idx2.search("deploy")
+        assert len(results) == 3
+        assert idx2.get_cursor("C01") == "999"
+        idx2.close()


### PR DESCRIPTION
## Summary

Slack logs accumulate in JSONL files (Phase 1) but are unsearchable. This phase adds an async enrichment pipeline that makes them queryable and produces LLM-generated intelligence without requiring real-time processing at ingestion.

**Three indexing layers, each at different cadences:**

1. **SQLite FTS5 keyword index** — cursor-based incremental indexing from JSONL logs, no LLM calls. Supports porter-stemmed full-text search with optional channel filtering. Re-running is safe (cursor tracking prevents reprocessing).

2. **Thread summaries** (Haiku) — scans for threads with no activity in >2h, invokes Haiku to generate a structured summary (participants, action items, sentiment). Deduplicates against existing summaries to avoid reprocessing.

3. **Nightly topic clusters + action items** (Haiku) — batch analysis of each day's messages, producing JSON indexes under \`index/topic-clusters/\` and \`index/action-items/\`.

**Cost guardrails enforced at every Haiku call boundary:**
- \`LOBSTER_SLACK_INDEX_ENABLED=false\` disables all LLM indexing without crashing keyword search
- Max 50 messages per Haiku invocation; logs continuation when more remain
- Channels configured as \`mode: ignore\` are excluded from all indexing

**Functional patterns used:**
- Pure data transformations (grouping, filtering, record building) separated from I/O boundaries
- Injectable Haiku invocation function — tests use mocks, production uses subprocess
- Composable pipeline: read JSONL → filter → transform → write index
- Immutable record construction via \`_build_*\` pure functions

**Out of scope:** Scheduled job registration via MCP (left for integration phase), user activity index (deferred to later phase).

## Not changed

- Phase 1 files (\`ingress_logger.py\`, \`log_store.py\`) are unmodified
- No changes to \`slack_router.py\` or the Slack ingress path
- No changes to the dispatcher or MCP server

## Tests run

- [x] \`cd lobster-shop/slack-connector && uv run pytest tests/ -v\` — 105 passed (57 new + 48 existing Phase 1), 0 failed, 0.66s
- [ ] Scheduled job registration — deferred: requires MCP \`create_scheduled_job\`, will register during integration phase
- [ ] Live Haiku invocation — not tested: mock-only (production uses \`claude --model haiku\` subprocess)

## Manual test

N/A — no systemd units, cron entries, external service calls, or DB schema changes in this PR. All I/O is to local filesystem and in-process SQLite. Haiku calls are behind an injectable boundary and mocked in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)