### PR TITLE
feat: Slack Connector Phase 4 — Trigger Engine

### DIFF
--- a/lobster-shop/slack-connector/src/rules/README.md
+++ b/lobster-shop/slack-connector/src/rules/README.md
@@ -1,0 +1,56 @@
+# Trigger Engine Rules
+
+Drop TOML rule files in this directory to configure automated triggers.
+The trigger engine hot-reloads rules on any file change — no restart required.
+
+## Rule format
+
+Each rule file contains three sections: `[rule]`, `[trigger]`, and `[action]`.
+
+```toml
+[rule]
+name = "unique-rule-name"          # Required, must be unique across all files
+description = "What this rule does" # Optional
+enabled = true                      # Set to false to disable without deleting
+
+[trigger]
+event = "message"                   # message | reaction_added | app_mention | file_shared | slash_command
+channels = ["C03GHI789"]           # Empty list matches ALL channels
+users = []                          # Empty list matches ALL users
+keywords = ["deploy", "outage"]     # Matched case-insensitively against message text
+keyword_mode = "any"                # "any" = at least one keyword | "all" = every keyword
+# Optional trigger fields:
+# emoji = "thumbsup"               # For reaction_added events
+# command = "/deploy"               # For slash_command events
+# file_type = "pdf"                 # For file_shared events
+# regex = "JIRA-\\d+"              # Regex pattern matched against message text
+
+[action]
+type = "lobster_task"               # lobster_task | send_reply | telegram_notify | webhook | shell
+# Action-specific fields vary by type (see examples/)
+```
+
+## Template variables
+
+Use `{variable_name}` in action fields. Available variables:
+
+| Variable | Description |
+|----------|-------------|
+| `{message_text}` | The message text |
+| `{channel_id}` | Slack channel ID |
+| `{channel_name}` | Channel name |
+| `{user_id}` | Slack user ID |
+| `{username}` | Username |
+| `{ts}` | Message timestamp |
+| `{thread_ts}` | Thread timestamp |
+| `{emoji}` | Reaction emoji name |
+| `{original_message_text}` | Original message (for reactions) |
+| `{command_text}` | Slash command text |
+| `{file_name}` | Shared file name |
+| `{date}` | Current date (YYYY-MM-DD) |
+
+## File placement
+
+- Place active rules directly in this directory (e.g., `my-rule.toml`)
+- Files in `examples/` are not auto-loaded
+- Subdirectories (except `examples/`) are scanned recursively

--- a/lobster-shop/slack-connector/src/rules/examples/keyword-alert.toml
+++ b/lobster-shop/slack-connector/src/rules/examples/keyword-alert.toml
@@ -1,0 +1,21 @@
+# Example: Alert when deployment or incident keywords appear in #engineering
+#
+# Copy this file to the parent rules/ directory and edit to activate.
+# The trigger engine will hot-reload it automatically.
+
+[rule]
+name = "keyword-deploy-alert"
+description = "Alert when 'deploy', 'outage', or 'incident' mentioned in #engineering"
+enabled = true
+
+[trigger]
+event = "message"
+channels = ["C03GHI789"]           # Replace with your #engineering channel ID
+users = []                          # Match all users
+keywords = ["deploy", "outage", "incident"]
+keyword_mode = "any"                # Fire when ANY keyword is present
+
+[action]
+type = "telegram_notify"
+message = """Slack alert from #{channel_name}:
+@{username} said: {message_text}"""

--- a/lobster-shop/slack-connector/src/rules/examples/mention-handler.toml
+++ b/lobster-shop/slack-connector/src/rules/examples/mention-handler.toml
@@ -1,0 +1,28 @@
+# Example: Handle @lobster mentions with a custom Lobster task
+#
+# Copy this file to the parent rules/ directory and edit to activate.
+
+[rule]
+name = "lobster-mention-handler"
+description = "When Lobster is mentioned, analyze the request and respond"
+enabled = true
+
+[trigger]
+event = "app_mention"
+channels = []                       # Match all channels
+users = []                          # Match all users
+
+[action]
+type = "lobster_task"
+task_prompt = """User {username} mentioned Lobster in #{channel_name} (channel {channel_id}).
+
+Their message: {message_text}
+
+Analyze the request and prepare a helpful response. Consider:
+1. Is this a question? Answer it directly.
+2. Is this a task request? Plan and execute it.
+3. Is this feedback? Acknowledge and note it.
+
+Reply concisely — the user is likely on mobile."""
+subagent_type = "general-purpose"
+run_in_background = true

--- a/lobster-shop/slack-connector/src/rules/examples/reaction-trigger.toml
+++ b/lobster-shop/slack-connector/src/rules/examples/reaction-trigger.toml
@@ -1,0 +1,25 @@
+# Example: Trigger a Lobster task when someone reacts with :eyes: emoji
+#
+# Copy this file to the parent rules/ directory and edit to activate.
+
+[rule]
+name = "eyes-reaction-review"
+description = "When someone reacts with :eyes:, ask Lobster to review the message"
+enabled = true
+
+[trigger]
+event = "reaction_added"
+channels = []                       # Match all channels
+users = []                          # Match all users
+emoji = "eyes"                      # Only trigger on :eyes: reaction
+
+[action]
+type = "lobster_task"
+task_prompt = """A message in Slack channel {channel_id} received an :eyes: reaction from user {user_id}.
+
+Original message: {original_message_text}
+
+Please review this message and determine if any action is needed. If it's a question
+that Lobster can help with, draft a response. If it's an FYI, acknowledge it."""
+subagent_type = "general-purpose"
+run_in_background = true

--- a/lobster-shop/slack-connector/src/trigger_engine.py
+++ b/lobster-shop/slack-connector/src/trigger_engine.py
@@ -1,0 +1,707 @@
+"""
+Slack Connector — Rule-Based Trigger Engine.
+
+Matches Slack events against TOML rule files and fires actions.
+Hot-reloads rules from a watched directory without restart.
+
+Design principles:
+- Pure functions for all matching logic (event matching, keyword checks, template interpolation)
+- Side effects isolated to fire_action() boundary and file-watching
+- Immutable rule snapshots: reload() atomically swaps the entire rule set
+- Rules are data (TOML files), not code — editable without restarting
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+log = logging.getLogger("slack-trigger-engine")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_DEFAULT_RULES_DIR = Path(
+    os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace")
+) / "slack-connector" / "rules"
+
+_SHELL_TIMEOUT_SECONDS = 30
+
+VALID_ACTION_TYPES = frozenset({
+    "lobster_task",
+    "send_reply",
+    "telegram_notify",
+    "webhook",
+    "shell",
+})
+
+VALID_EVENT_TYPES = frozenset({
+    "message",
+    "reaction_added",
+    "app_mention",
+    "file_shared",
+    "slash_command",
+})
+
+VALID_KEYWORD_MODES = frozenset({"any", "all"})
+
+
+# ---------------------------------------------------------------------------
+# Pure functions — TOML parsing and validation
+# ---------------------------------------------------------------------------
+
+
+def parse_rule(raw: dict[str, Any], source_path: str = "") -> Optional[dict[str, Any]]:
+    """Parse and validate a raw TOML dict into a normalized rule.
+
+    Pure function: takes parsed TOML, returns structured rule or None on error.
+    The source_path is stored for debugging but does not affect logic.
+    """
+    rule_section = raw.get("rule", {})
+    trigger_section = raw.get("trigger", {})
+    action_section = raw.get("action", {})
+
+    name = rule_section.get("name", "")
+    if not name:
+        log.warning("Rule at %s has no name, skipping", source_path)
+        return None
+
+    enabled = rule_section.get("enabled", True)
+    event = trigger_section.get("event", "message")
+
+    if event not in VALID_EVENT_TYPES:
+        log.warning(
+            "Rule %r has invalid event type %r, skipping",
+            name, event,
+        )
+        return None
+
+    action_type = action_section.get("type", "")
+    if action_type not in VALID_ACTION_TYPES:
+        log.warning(
+            "Rule %r has invalid action type %r, skipping",
+            name, action_type,
+        )
+        return None
+
+    keyword_mode = trigger_section.get("keyword_mode", "any")
+    if keyword_mode not in VALID_KEYWORD_MODES:
+        log.warning(
+            "Rule %r has invalid keyword_mode %r, defaulting to 'any'",
+            name, keyword_mode,
+        )
+        keyword_mode = "any"
+
+    # Compile regex if provided
+    regex_pattern = trigger_section.get("regex")
+    compiled_regex = None
+    if regex_pattern:
+        try:
+            compiled_regex = re.compile(regex_pattern, re.IGNORECASE)
+        except re.error as e:
+            log.warning("Rule %r has invalid regex %r: %s", name, regex_pattern, e)
+            return None
+
+    return {
+        "name": name,
+        "description": rule_section.get("description", ""),
+        "enabled": bool(enabled),
+        "source_path": source_path,
+        # Trigger
+        "event": event,
+        "channels": list(trigger_section.get("channels", []) or []),
+        "users": list(trigger_section.get("users", []) or []),
+        "keywords": list(trigger_section.get("keywords", []) or []),
+        "keyword_mode": keyword_mode,
+        "emoji": trigger_section.get("emoji"),
+        "command": trigger_section.get("command"),
+        "file_type": trigger_section.get("file_type"),
+        "regex": regex_pattern,
+        "compiled_regex": compiled_regex,
+        # Action
+        "action_type": action_type,
+        "action": dict(action_section),
+    }
+
+
+def load_rules_from_dir(rules_dir: Path) -> dict[str, dict[str, Any]]:
+    """Load all TOML rule files from a directory into a {name: rule} dict.
+
+    Pure-ish: performs file I/O reads but produces an immutable snapshot.
+    Skips invalid files gracefully.
+    """
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    rules: dict[str, dict[str, Any]] = {}
+
+    if not rules_dir.exists():
+        log.info("Rules directory %s does not exist, no rules loaded", rules_dir)
+        return rules
+
+    toml_files = sorted(rules_dir.glob("**/*.toml"))
+    # Exclude files in examples/ subdirectory from auto-loading
+    toml_files = [
+        f for f in toml_files
+        if "examples" not in f.relative_to(rules_dir).parts
+    ]
+
+    for path in toml_files:
+        try:
+            raw = tomllib.loads(path.read_text())
+            rule = parse_rule(raw, source_path=str(path))
+            if rule is not None:
+                if rule["name"] in rules:
+                    log.warning(
+                        "Duplicate rule name %r (in %s), overwriting",
+                        rule["name"], path,
+                    )
+                rules[rule["name"]] = rule
+        except Exception:
+            log.exception("Failed to parse rule file %s, skipping", path)
+
+    log.info("Loaded %d rules from %s", len(rules), rules_dir)
+    return rules
+
+
+# ---------------------------------------------------------------------------
+# Pure functions — event matching
+# ---------------------------------------------------------------------------
+
+
+def matches_event_type(rule: dict[str, Any], event: dict[str, Any]) -> bool:
+    """Check if the event type matches the rule's trigger event.
+
+    Pure function.
+    """
+    event_type = event.get("type", event.get("event_type", "message"))
+    return rule["event"] == event_type
+
+
+def matches_channel(rule: dict[str, Any], event: dict[str, Any]) -> bool:
+    """Check if the event's channel matches the rule's channel filter.
+
+    Pure function. Empty channels list matches all channels.
+    """
+    rule_channels = rule.get("channels", [])
+    if not rule_channels:
+        return True
+    channel_id = event.get("channel", event.get("channel_id", ""))
+    return channel_id in rule_channels
+
+
+def matches_user(rule: dict[str, Any], event: dict[str, Any]) -> bool:
+    """Check if the event's user matches the rule's user filter.
+
+    Pure function. Empty users list matches all users.
+    """
+    rule_users = rule.get("users", [])
+    if not rule_users:
+        return True
+    user_id = event.get("user", event.get("user_id", ""))
+    return user_id in rule_users
+
+
+def matches_keywords(rule: dict[str, Any], event: dict[str, Any]) -> bool:
+    """Check if the event text matches the rule's keyword filter.
+
+    Pure function.
+    - No keywords configured: always matches
+    - keyword_mode "any": at least one keyword present
+    - keyword_mode "all": all keywords must be present
+    Keywords are matched case-insensitively against the message text.
+    """
+    keywords = rule.get("keywords", [])
+    if not keywords:
+        return True
+
+    text = event.get("text", "").lower()
+    keyword_mode = rule.get("keyword_mode", "any")
+
+    keyword_checks = (kw.lower() in text for kw in keywords)
+
+    if keyword_mode == "all":
+        return all(kw.lower() in text for kw in keywords)
+    else:  # "any"
+        return any(kw.lower() in text for kw in keywords)
+
+
+def matches_emoji(rule: dict[str, Any], event: dict[str, Any]) -> bool:
+    """Check if the event's reaction emoji matches the rule's emoji filter.
+
+    Pure function. None emoji filter matches all.
+    """
+    rule_emoji = rule.get("emoji")
+    if rule_emoji is None:
+        return True
+    event_emoji = event.get("reaction", event.get("emoji", ""))
+    return event_emoji == rule_emoji
+
+
+def matches_command(rule: dict[str, Any], event: dict[str, Any]) -> bool:
+    """Check if the event's slash command matches the rule's command filter.
+
+    Pure function. None command filter matches all.
+    """
+    rule_command = rule.get("command")
+    if rule_command is None:
+        return True
+    event_command = event.get("command", "")
+    return event_command == rule_command
+
+
+def matches_file_type(rule: dict[str, Any], event: dict[str, Any]) -> bool:
+    """Check if the event's file type matches the rule's file_type filter.
+
+    Pure function. None file_type filter matches all.
+    """
+    rule_file_type = rule.get("file_type")
+    if rule_file_type is None:
+        return True
+    # Check files array or top-level file_type
+    files = event.get("files", [])
+    if files:
+        return any(f.get("filetype", f.get("mimetype", "")) == rule_file_type for f in files)
+    return event.get("filetype", "") == rule_file_type
+
+
+def matches_regex(rule: dict[str, Any], event: dict[str, Any]) -> bool:
+    """Check if the event text matches the rule's regex pattern.
+
+    Pure function. None regex matches all.
+    """
+    compiled = rule.get("compiled_regex")
+    if compiled is None:
+        return True
+    text = event.get("text", "")
+    return compiled.search(text) is not None
+
+
+def evaluate_rule(rule: dict[str, Any], event: dict[str, Any]) -> bool:
+    """Evaluate whether a single rule matches an event.
+
+    Pure function. Composes all individual matchers via conjunction (AND).
+    A rule matches only when ALL of its configured predicates pass.
+    """
+    if not rule.get("enabled", True):
+        return False
+
+    matchers = (
+        matches_event_type,
+        matches_channel,
+        matches_user,
+        matches_keywords,
+        matches_emoji,
+        matches_command,
+        matches_file_type,
+        matches_regex,
+    )
+
+    return all(matcher(rule, event) for matcher in matchers)
+
+
+def evaluate_all(
+    rules: dict[str, dict[str, Any]], event: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Evaluate all rules against an event. Returns matched rules.
+
+    Pure function.
+    """
+    return [rule for rule in rules.values() if evaluate_rule(rule, event)]
+
+
+# ---------------------------------------------------------------------------
+# Pure functions — template variable interpolation
+# ---------------------------------------------------------------------------
+
+
+def build_template_vars(event: dict[str, Any]) -> dict[str, str]:
+    """Build a template variable dict from an event.
+
+    Pure function. Returns {var_name: value} for all known template variables.
+    """
+    now = datetime.now(timezone.utc)
+
+    return {
+        "message_text": event.get("text", ""),
+        "channel_id": event.get("channel", event.get("channel_id", "")),
+        "channel_name": event.get("channel_name", ""),
+        "user_id": event.get("user", event.get("user_id", "")),
+        "username": event.get("username", ""),
+        "ts": event.get("ts", ""),
+        "thread_ts": event.get("thread_ts", ""),
+        "emoji": event.get("reaction", event.get("emoji", "")),
+        "original_message_text": _extract_original_message_text(event),
+        "command_text": event.get("text", event.get("command_text", "")),
+        "file_name": _extract_file_name(event),
+        "date": now.strftime("%Y-%m-%d"),
+    }
+
+
+def _extract_original_message_text(event: dict[str, Any]) -> str:
+    """Extract original message text from reaction or thread events.
+
+    Pure function.
+    """
+    item = event.get("item", {})
+    if isinstance(item, dict):
+        return item.get("text", "")
+    return ""
+
+
+def _extract_file_name(event: dict[str, Any]) -> str:
+    """Extract the first file name from an event.
+
+    Pure function.
+    """
+    files = event.get("files", [])
+    if files and isinstance(files[0], dict):
+        return files[0].get("name", "")
+    return event.get("file_name", "")
+
+
+def interpolate_template(template: str, variables: dict[str, str]) -> str:
+    """Replace {var_name} placeholders in a template string.
+
+    Pure function. Unknown variables are left as-is.
+    Uses a safe approach that only replaces known variable patterns.
+    """
+    result = template
+    for key, value in variables.items():
+        result = result.replace(f"{{{key}}}", str(value))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# TriggerEngine — stateful orchestrator with hot-reload
+# ---------------------------------------------------------------------------
+
+
+class TriggerEngine:
+    """Rule-based trigger engine for Slack events.
+
+    State is limited to the loaded rules snapshot and the optional
+    file watcher. All matching and interpolation logic delegates
+    to pure functions above.
+    """
+
+    def __init__(self, rules_dir: Optional[str] = None) -> None:
+        self._rules_dir = Path(rules_dir) if rules_dir else _DEFAULT_RULES_DIR
+        self._rules: dict[str, dict[str, Any]] = {}
+        self._lock = threading.Lock()
+        self._watcher_thread: Optional[threading.Thread] = None
+        self._watcher_stop = threading.Event()
+        self.reload_rules()
+
+    @property
+    def rules(self) -> dict[str, dict[str, Any]]:
+        """Return a snapshot of the current rules. Thread-safe read."""
+        with self._lock:
+            return dict(self._rules)
+
+    @property
+    def rule_count(self) -> int:
+        """Number of currently loaded rules."""
+        with self._lock:
+            return len(self._rules)
+
+    def evaluate(self, event: dict[str, Any]) -> list[dict[str, Any]]:
+        """Match event against all loaded rules. Returns list of matched rules.
+
+        Thread-safe: reads a snapshot of rules under lock.
+        """
+        with self._lock:
+            rules_snapshot = dict(self._rules)
+        return evaluate_all(rules_snapshot, event)
+
+    def fire_action(self, rule: dict[str, Any], event: dict[str, Any]) -> dict[str, Any]:
+        """Execute the action defined in a matched rule.
+
+        Side-effect boundary: this is where I/O happens (subprocess, HTTP, etc.).
+        Returns a result dict with status and any output/error.
+        """
+        action_type = rule.get("action_type", "")
+        action = rule.get("action", {})
+        template_vars = build_template_vars(event)
+
+        handler = _ACTION_HANDLERS.get(action_type)
+        if handler is None:
+            return {"status": "error", "error": f"Unknown action type: {action_type}"}
+
+        try:
+            return handler(action, template_vars)
+        except Exception as e:
+            log.exception("Error firing action for rule %r", rule.get("name", "?"))
+            return {"status": "error", "error": str(e)}
+
+    def reload_rules(self) -> None:
+        """Re-read all TOML files from rules_dir. Atomic swap under lock."""
+        new_rules = load_rules_from_dir(self._rules_dir)
+        with self._lock:
+            self._rules = new_rules
+
+    def watch_rules_dir(self) -> None:
+        """Start a background thread that watches rules_dir for changes.
+
+        Uses watchdog for inotify-based file watching. On any TOML file
+        change (create, modify, delete), triggers reload_rules().
+        """
+        if self._watcher_thread is not None and self._watcher_thread.is_alive():
+            log.warning("Watcher already running")
+            return
+
+        self._watcher_stop.clear()
+        self._watcher_thread = threading.Thread(
+            target=self._run_watcher,
+            daemon=True,
+            name="trigger-engine-watcher",
+        )
+        self._watcher_thread.start()
+        log.info("Started rules directory watcher for %s", self._rules_dir)
+
+    def stop_watcher(self) -> None:
+        """Stop the background file watcher."""
+        self._watcher_stop.set()
+        if self._watcher_thread is not None:
+            self._watcher_thread.join(timeout=5)
+            self._watcher_thread = None
+            log.info("Stopped rules directory watcher")
+
+    def _run_watcher(self) -> None:
+        """Background watcher loop using watchdog."""
+        try:
+            from watchdog.observers import Observer
+            from watchdog.events import FileSystemEventHandler, FileSystemEvent
+
+            engine = self
+
+            class _RuleFileHandler(FileSystemEventHandler):
+                """Handles file system events for TOML rule files."""
+
+                def on_any_event(self, event: FileSystemEvent) -> None:
+                    if event.is_directory:
+                        return
+                    src_path = str(event.src_path)
+                    if not src_path.endswith(".toml"):
+                        return
+                    # Skip example files
+                    if "/examples/" in src_path:
+                        return
+                    log.info(
+                        "Rule file change detected (%s): %s",
+                        event.event_type,
+                        src_path,
+                    )
+                    engine.reload_rules()
+
+            self._rules_dir.mkdir(parents=True, exist_ok=True)
+            observer = Observer()
+            observer.schedule(_RuleFileHandler(), str(self._rules_dir), recursive=True)
+            observer.start()
+
+            try:
+                while not self._watcher_stop.wait(timeout=1.0):
+                    pass
+            finally:
+                observer.stop()
+                observer.join(timeout=5)
+
+        except ImportError:
+            log.error(
+                "watchdog library not available — hot-reload disabled. "
+                "Install with: uv add watchdog"
+            )
+        except Exception:
+            log.exception("Rules directory watcher crashed")
+
+
+# ---------------------------------------------------------------------------
+# Action handlers — each performs one type of side effect
+# ---------------------------------------------------------------------------
+
+
+def _handle_lobster_task(
+    action: dict[str, Any], template_vars: dict[str, str]
+) -> dict[str, Any]:
+    """Spawn a Claude subprocess with an interpolated task prompt.
+
+    Side effect: spawns a subprocess.
+    """
+    task_prompt = action.get("task_prompt", "")
+    if not task_prompt:
+        return {"status": "error", "error": "lobster_task action missing task_prompt"}
+
+    prompt = interpolate_template(task_prompt, template_vars)
+    subagent_type = action.get("subagent_type", "general-purpose")
+    run_in_background = action.get("run_in_background", True)
+
+    log.info(
+        "Firing lobster_task: subagent_type=%s, background=%s, prompt_length=%d",
+        subagent_type, run_in_background, len(prompt),
+    )
+
+    return {
+        "status": "pending",
+        "action_type": "lobster_task",
+        "task_prompt": prompt,
+        "subagent_type": subagent_type,
+        "run_in_background": run_in_background,
+    }
+
+
+def _handle_send_reply(
+    action: dict[str, Any], template_vars: dict[str, str]
+) -> dict[str, Any]:
+    """Post a static message to a Slack channel.
+
+    Returns the interpolated message for the caller to dispatch.
+    """
+    message = action.get("message", action.get("text", ""))
+    if not message:
+        return {"status": "error", "error": "send_reply action missing message"}
+
+    channel = action.get("channel", template_vars.get("channel_id", ""))
+    interpolated = interpolate_template(message, template_vars)
+
+    return {
+        "status": "ready",
+        "action_type": "send_reply",
+        "channel": channel,
+        "message": interpolated,
+    }
+
+
+def _handle_telegram_notify(
+    action: dict[str, Any], template_vars: dict[str, str]
+) -> dict[str, Any]:
+    """Send a notification to the admin via Telegram.
+
+    Returns the interpolated message for the caller to dispatch.
+    """
+    message = action.get("message", action.get("text", ""))
+    if not message:
+        return {"status": "error", "error": "telegram_notify action missing message"}
+
+    chat_id = action.get("chat_id", os.environ.get("LOBSTER_ADMIN_CHAT_ID", ""))
+    interpolated = interpolate_template(message, template_vars)
+
+    return {
+        "status": "ready",
+        "action_type": "telegram_notify",
+        "chat_id": chat_id,
+        "message": interpolated,
+    }
+
+
+def _handle_webhook(
+    action: dict[str, Any], template_vars: dict[str, str]
+) -> dict[str, Any]:
+    """HTTP POST to a URL with JSON event payload.
+
+    Side effect: makes HTTP request.
+    """
+    url = action.get("url", "")
+    if not url:
+        return {"status": "error", "error": "webhook action missing url"}
+
+    import json
+    import urllib.request
+    import urllib.error
+
+    payload = {
+        "rule_triggered": True,
+        "variables": template_vars,
+    }
+
+    # Allow custom body template
+    body_template = action.get("body")
+    if body_template:
+        interpolated_body = interpolate_template(body_template, template_vars)
+        try:
+            payload = json.loads(interpolated_body)
+        except json.JSONDecodeError:
+            payload = {"text": interpolated_body, "variables": template_vars}
+
+    data = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+
+    # Merge custom headers
+    custom_headers = action.get("headers", {})
+    if isinstance(custom_headers, dict):
+        headers.update(custom_headers)
+
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return {
+                "status": "success",
+                "action_type": "webhook",
+                "url": url,
+                "response_code": resp.status,
+            }
+    except urllib.error.URLError as e:
+        return {
+            "status": "error",
+            "action_type": "webhook",
+            "url": url,
+            "error": str(e),
+        }
+
+
+def _handle_shell(
+    action: dict[str, Any], template_vars: dict[str, str]
+) -> dict[str, Any]:
+    """Run a shell command with timeout.
+
+    Side effect: spawns subprocess.
+    """
+    command = action.get("command", "")
+    if not command:
+        return {"status": "error", "error": "shell action missing command"}
+
+    interpolated = interpolate_template(command, template_vars)
+    timeout = min(action.get("timeout", _SHELL_TIMEOUT_SECONDS), _SHELL_TIMEOUT_SECONDS)
+
+    try:
+        result = subprocess.run(
+            interpolated,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return {
+            "status": "success" if result.returncode == 0 else "error",
+            "action_type": "shell",
+            "command": interpolated,
+            "returncode": result.returncode,
+            "stdout": result.stdout[:1000],  # Truncate for safety
+            "stderr": result.stderr[:1000],
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "status": "error",
+            "action_type": "shell",
+            "command": interpolated,
+            "error": f"Command timed out after {timeout}s",
+        }
+
+
+# Handler dispatch table — maps action type string to handler function
+_ACTION_HANDLERS: dict[str, Any] = {
+    "lobster_task": _handle_lobster_task,
+    "send_reply": _handle_send_reply,
+    "telegram_notify": _handle_telegram_notify,
+    "webhook": _handle_webhook,
+    "shell": _handle_shell,
+}

--- a/lobster-shop/slack-connector/tests/test_trigger_engine.py
+++ b/lobster-shop/slack-connector/tests/test_trigger_engine.py
@@ -1,0 +1,836 @@
+"""Tests for trigger_engine module — pure functions and TriggerEngine class."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.trigger_engine import (
+    TriggerEngine,
+    build_template_vars,
+    evaluate_all,
+    evaluate_rule,
+    interpolate_template,
+    load_rules_from_dir,
+    matches_channel,
+    matches_command,
+    matches_emoji,
+    matches_event_type,
+    matches_file_type,
+    matches_keywords,
+    matches_regex,
+    matches_user,
+    parse_rule,
+    VALID_ACTION_TYPES,
+    VALID_EVENT_TYPES,
+    VALID_KEYWORD_MODES,
+    _handle_lobster_task,
+    _handle_send_reply,
+    _handle_shell,
+    _handle_telegram_notify,
+    _handle_webhook,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_rule(**overrides) -> dict:
+    """Build a valid rule dict with sensible defaults, applying overrides."""
+    base = {
+        "name": "test-rule",
+        "description": "A test rule",
+        "enabled": True,
+        "source_path": "/tmp/test.toml",
+        "event": "message",
+        "channels": [],
+        "users": [],
+        "keywords": [],
+        "keyword_mode": "any",
+        "emoji": None,
+        "command": None,
+        "file_type": None,
+        "regex": None,
+        "compiled_regex": None,
+        "action_type": "send_reply",
+        "action": {"type": "send_reply", "message": "Hello"},
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_event(**overrides) -> dict:
+    """Build a minimal Slack message event with overrides."""
+    base = {
+        "type": "message",
+        "channel": "C001",
+        "user": "U001",
+        "text": "hello world",
+        "ts": "1234567890.123456",
+        "thread_ts": "",
+        "username": "alice",
+        "channel_name": "general",
+    }
+    base.update(overrides)
+    return base
+
+
+SAMPLE_TOML = """\
+[rule]
+name = "test-keyword"
+description = "Test keyword rule"
+enabled = true
+
+[trigger]
+event = "message"
+channels = ["C001", "C002"]
+keywords = ["deploy", "outage"]
+keyword_mode = "any"
+
+[action]
+type = "send_reply"
+message = "Alert: {message_text} in #{channel_name}"
+"""
+
+DISABLED_TOML = """\
+[rule]
+name = "disabled-rule"
+enabled = false
+
+[trigger]
+event = "message"
+
+[action]
+type = "send_reply"
+message = "Should not fire"
+"""
+
+REGEX_TOML = """\
+[rule]
+name = "jira-tracker"
+description = "Track JIRA ticket mentions"
+enabled = true
+
+[trigger]
+event = "message"
+regex = "JIRA-\\\\d+"
+
+[action]
+type = "telegram_notify"
+message = "JIRA ticket mentioned: {message_text}"
+"""
+
+
+@pytest.fixture
+def rules_dir(tmp_path: Path) -> Path:
+    """Create a temp rules directory with sample TOML files."""
+    d = tmp_path / "rules"
+    d.mkdir()
+    (d / "keyword.toml").write_text(SAMPLE_TOML)
+    (d / "disabled.toml").write_text(DISABLED_TOML)
+    return d
+
+
+@pytest.fixture
+def rules_dir_with_examples(rules_dir: Path) -> Path:
+    """Rules dir with an examples/ subdirectory that should be excluded."""
+    examples = rules_dir / "examples"
+    examples.mkdir()
+    (examples / "sample.toml").write_text(SAMPLE_TOML.replace("test-keyword", "example-rule"))
+    return rules_dir
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests: parse_rule
+# ---------------------------------------------------------------------------
+
+
+class TestParseRule:
+    def test_valid_rule(self):
+        try:
+            import tomllib
+        except ImportError:
+            import tomli as tomllib
+
+        raw = tomllib.loads(SAMPLE_TOML)
+        rule = parse_rule(raw, source_path="/tmp/test.toml")
+        assert rule is not None
+        assert rule["name"] == "test-keyword"
+        assert rule["event"] == "message"
+        assert rule["channels"] == ["C001", "C002"]
+        assert rule["keywords"] == ["deploy", "outage"]
+        assert rule["keyword_mode"] == "any"
+        assert rule["action_type"] == "send_reply"
+        assert rule["enabled"] is True
+
+    def test_missing_name_returns_none(self):
+        raw = {"rule": {}, "trigger": {"event": "message"}, "action": {"type": "send_reply"}}
+        assert parse_rule(raw) is None
+
+    def test_invalid_event_returns_none(self):
+        raw = {
+            "rule": {"name": "bad"},
+            "trigger": {"event": "invalid_event"},
+            "action": {"type": "send_reply"},
+        }
+        assert parse_rule(raw) is None
+
+    def test_invalid_action_type_returns_none(self):
+        raw = {
+            "rule": {"name": "bad"},
+            "trigger": {"event": "message"},
+            "action": {"type": "invalid_action"},
+        }
+        assert parse_rule(raw) is None
+
+    def test_invalid_keyword_mode_defaults_to_any(self):
+        raw = {
+            "rule": {"name": "test"},
+            "trigger": {"event": "message", "keyword_mode": "banana"},
+            "action": {"type": "send_reply"},
+        }
+        rule = parse_rule(raw)
+        assert rule is not None
+        assert rule["keyword_mode"] == "any"
+
+    def test_invalid_regex_returns_none(self):
+        raw = {
+            "rule": {"name": "test"},
+            "trigger": {"event": "message", "regex": "[invalid("},
+            "action": {"type": "send_reply"},
+        }
+        assert parse_rule(raw) is None
+
+    def test_defaults_applied(self):
+        raw = {
+            "rule": {"name": "minimal"},
+            "trigger": {},
+            "action": {"type": "send_reply"},
+        }
+        rule = parse_rule(raw)
+        assert rule is not None
+        assert rule["event"] == "message"
+        assert rule["channels"] == []
+        assert rule["users"] == []
+        assert rule["keywords"] == []
+        assert rule["keyword_mode"] == "any"
+        assert rule["enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests: load_rules_from_dir
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRulesFromDir:
+    def test_loads_rules(self, rules_dir):
+        rules = load_rules_from_dir(rules_dir)
+        assert "test-keyword" in rules
+        assert "disabled-rule" in rules
+        assert len(rules) == 2
+
+    def test_nonexistent_dir(self, tmp_path):
+        rules = load_rules_from_dir(tmp_path / "nonexistent")
+        assert rules == {}
+
+    def test_skips_invalid_files(self, rules_dir):
+        (rules_dir / "bad.toml").write_text("this is not valid toml {{{}}")
+        rules = load_rules_from_dir(rules_dir)
+        # Should still load the valid rules
+        assert "test-keyword" in rules
+
+    def test_excludes_examples_dir(self, rules_dir_with_examples):
+        rules = load_rules_from_dir(rules_dir_with_examples)
+        assert "example-rule" not in rules
+        assert "test-keyword" in rules
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests: event matching
+# ---------------------------------------------------------------------------
+
+
+class TestMatchesEventType:
+    def test_matching_type(self):
+        rule = _make_rule(event="message")
+        event = _make_event(type="message")
+        assert matches_event_type(rule, event) is True
+
+    def test_non_matching_type(self):
+        rule = _make_rule(event="reaction_added")
+        event = _make_event(type="message")
+        assert matches_event_type(rule, event) is False
+
+    def test_event_type_fallback_key(self):
+        rule = _make_rule(event="message")
+        event = {"event_type": "message"}
+        assert matches_event_type(rule, event) is True
+
+
+class TestMatchesChannel:
+    def test_empty_channels_matches_all(self):
+        rule = _make_rule(channels=[])
+        event = _make_event(channel="C999")
+        assert matches_channel(rule, event) is True
+
+    def test_matching_channel(self):
+        rule = _make_rule(channels=["C001", "C002"])
+        assert matches_channel(rule, _make_event(channel="C001")) is True
+        assert matches_channel(rule, _make_event(channel="C002")) is True
+
+    def test_non_matching_channel(self):
+        rule = _make_rule(channels=["C001"])
+        assert matches_channel(rule, _make_event(channel="C999")) is False
+
+    def test_channel_id_fallback_key(self):
+        rule = _make_rule(channels=["C001"])
+        event = {"channel_id": "C001"}
+        assert matches_channel(rule, event) is True
+
+
+class TestMatchesUser:
+    def test_empty_users_matches_all(self):
+        rule = _make_rule(users=[])
+        assert matches_user(rule, _make_event(user="U999")) is True
+
+    def test_matching_user(self):
+        rule = _make_rule(users=["U001"])
+        assert matches_user(rule, _make_event(user="U001")) is True
+
+    def test_non_matching_user(self):
+        rule = _make_rule(users=["U001"])
+        assert matches_user(rule, _make_event(user="U999")) is False
+
+
+class TestMatchesKeywords:
+    def test_no_keywords_matches_all(self):
+        rule = _make_rule(keywords=[])
+        assert matches_keywords(rule, _make_event(text="anything")) is True
+
+    def test_any_mode_single_match(self):
+        rule = _make_rule(keywords=["deploy", "outage"], keyword_mode="any")
+        assert matches_keywords(rule, _make_event(text="starting deploy now")) is True
+
+    def test_any_mode_no_match(self):
+        rule = _make_rule(keywords=["deploy", "outage"], keyword_mode="any")
+        assert matches_keywords(rule, _make_event(text="hello world")) is False
+
+    def test_all_mode_all_present(self):
+        rule = _make_rule(keywords=["deploy", "staging"], keyword_mode="all")
+        assert matches_keywords(rule, _make_event(text="deploy to staging now")) is True
+
+    def test_all_mode_partial_match(self):
+        rule = _make_rule(keywords=["deploy", "staging"], keyword_mode="all")
+        assert matches_keywords(rule, _make_event(text="deploy to production")) is False
+
+    def test_case_insensitive(self):
+        rule = _make_rule(keywords=["Deploy"], keyword_mode="any")
+        assert matches_keywords(rule, _make_event(text="DEPLOY NOW")) is True
+        assert matches_keywords(rule, _make_event(text="deploy now")) is True
+
+    def test_empty_text(self):
+        rule = _make_rule(keywords=["deploy"], keyword_mode="any")
+        assert matches_keywords(rule, _make_event(text="")) is False
+
+
+class TestMatchesEmoji:
+    def test_no_emoji_filter_matches_all(self):
+        rule = _make_rule(emoji=None)
+        assert matches_emoji(rule, _make_event()) is True
+
+    def test_matching_emoji(self):
+        rule = _make_rule(emoji="eyes")
+        event = _make_event(reaction="eyes")
+        assert matches_emoji(rule, event) is True
+
+    def test_non_matching_emoji(self):
+        rule = _make_rule(emoji="eyes")
+        event = _make_event(reaction="thumbsup")
+        assert matches_emoji(rule, event) is False
+
+
+class TestMatchesCommand:
+    def test_no_command_filter_matches_all(self):
+        rule = _make_rule(command=None)
+        assert matches_command(rule, _make_event()) is True
+
+    def test_matching_command(self):
+        rule = _make_rule(command="/deploy")
+        event = _make_event(command="/deploy")
+        assert matches_command(rule, event) is True
+
+    def test_non_matching_command(self):
+        rule = _make_rule(command="/deploy")
+        event = _make_event(command="/status")
+        assert matches_command(rule, event) is False
+
+
+class TestMatchesFileType:
+    def test_no_file_type_matches_all(self):
+        rule = _make_rule(file_type=None)
+        assert matches_file_type(rule, _make_event()) is True
+
+    def test_matching_file_type_in_files_array(self):
+        rule = _make_rule(file_type="pdf")
+        event = _make_event(files=[{"filetype": "pdf", "name": "doc.pdf"}])
+        assert matches_file_type(rule, event) is True
+
+    def test_non_matching_file_type(self):
+        rule = _make_rule(file_type="pdf")
+        event = _make_event(files=[{"filetype": "png", "name": "image.png"}])
+        assert matches_file_type(rule, event) is False
+
+
+class TestMatchesRegex:
+    def test_no_regex_matches_all(self):
+        rule = _make_rule(compiled_regex=None)
+        assert matches_regex(rule, _make_event()) is True
+
+    def test_matching_regex(self):
+        import re
+        rule = _make_rule(compiled_regex=re.compile(r"JIRA-\d+", re.IGNORECASE))
+        assert matches_regex(rule, _make_event(text="Fix for JIRA-123")) is True
+
+    def test_non_matching_regex(self):
+        import re
+        rule = _make_rule(compiled_regex=re.compile(r"JIRA-\d+", re.IGNORECASE))
+        assert matches_regex(rule, _make_event(text="No ticket here")) is False
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests: evaluate_rule (composition)
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateRule:
+    def test_enabled_rule_matches(self):
+        rule = _make_rule(event="message", channels=["C001"], keywords=["hello"])
+        event = _make_event(type="message", channel="C001", text="hello world")
+        assert evaluate_rule(rule, event) is True
+
+    def test_disabled_rule_never_matches(self):
+        rule = _make_rule(enabled=False, event="message")
+        event = _make_event(type="message")
+        assert evaluate_rule(rule, event) is False
+
+    def test_channel_mismatch_fails(self):
+        rule = _make_rule(channels=["C999"])
+        event = _make_event(channel="C001")
+        assert evaluate_rule(rule, event) is False
+
+    def test_keyword_mismatch_fails(self):
+        rule = _make_rule(keywords=["deploy"])
+        event = _make_event(text="hello world")
+        assert evaluate_rule(rule, event) is False
+
+    def test_all_filters_must_pass(self):
+        """Rule with multiple filters requires ALL to match (conjunction)."""
+        rule = _make_rule(
+            channels=["C001"],
+            users=["U001"],
+            keywords=["deploy"],
+        )
+        # Matches all
+        event = _make_event(channel="C001", user="U001", text="deploy now")
+        assert evaluate_rule(rule, event) is True
+
+        # Wrong user
+        event = _make_event(channel="C001", user="U999", text="deploy now")
+        assert evaluate_rule(rule, event) is False
+
+
+class TestEvaluateAll:
+    def test_returns_matching_rules(self):
+        rules = {
+            "r1": _make_rule(name="r1", keywords=["deploy"]),
+            "r2": _make_rule(name="r2", keywords=["outage"]),
+            "r3": _make_rule(name="r3", keywords=["hello"]),
+        }
+        event = _make_event(text="deploy is happening")
+        matched = evaluate_all(rules, event)
+        assert len(matched) == 1
+        assert matched[0]["name"] == "r1"
+
+    def test_multiple_matches(self):
+        rules = {
+            "r1": _make_rule(name="r1", keywords=[]),  # matches everything
+            "r2": _make_rule(name="r2", keywords=[]),  # matches everything
+        }
+        event = _make_event(text="hello")
+        matched = evaluate_all(rules, event)
+        assert len(matched) == 2
+
+    def test_disabled_rules_excluded(self):
+        rules = {
+            "r1": _make_rule(name="r1", enabled=False),
+        }
+        event = _make_event()
+        assert evaluate_all(rules, event) == []
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests: template interpolation
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTemplateVars:
+    def test_extracts_vars(self):
+        event = _make_event(
+            text="deploy now",
+            channel="C001",
+            user="U001",
+            username="alice",
+            channel_name="eng",
+            ts="1234.5678",
+            thread_ts="1234.0000",
+        )
+        v = build_template_vars(event)
+        assert v["message_text"] == "deploy now"
+        assert v["channel_id"] == "C001"
+        assert v["channel_name"] == "eng"
+        assert v["user_id"] == "U001"
+        assert v["username"] == "alice"
+        assert v["ts"] == "1234.5678"
+        assert v["thread_ts"] == "1234.0000"
+
+    def test_file_name_from_files(self):
+        event = _make_event(files=[{"name": "report.pdf"}])
+        v = build_template_vars(event)
+        assert v["file_name"] == "report.pdf"
+
+    def test_emoji_from_reaction(self):
+        event = _make_event(reaction="thumbsup")
+        v = build_template_vars(event)
+        assert v["emoji"] == "thumbsup"
+
+    def test_date_is_populated(self):
+        event = _make_event()
+        v = build_template_vars(event)
+        assert len(v["date"]) == 10  # YYYY-MM-DD
+
+
+class TestInterpolateTemplate:
+    def test_basic_interpolation(self):
+        result = interpolate_template(
+            "Hello {username} in #{channel_name}",
+            {"username": "alice", "channel_name": "general"},
+        )
+        assert result == "Hello alice in #general"
+
+    def test_unknown_vars_left_intact(self):
+        result = interpolate_template(
+            "Hello {unknown_var}",
+            {"username": "alice"},
+        )
+        assert result == "Hello {unknown_var}"
+
+    def test_multiple_occurrences(self):
+        result = interpolate_template(
+            "{user} said {user}",
+            {"user": "bob"},
+        )
+        assert result == "bob said bob"
+
+    def test_empty_template(self):
+        assert interpolate_template("", {"x": "y"}) == ""
+
+
+# ---------------------------------------------------------------------------
+# Action handler tests (with mocked side effects)
+# ---------------------------------------------------------------------------
+
+
+class TestHandleLobsterTask:
+    def test_returns_interpolated_prompt(self):
+        action = {
+            "type": "lobster_task",
+            "task_prompt": "Analyze message from {username}: {message_text}",
+            "subagent_type": "general-purpose",
+            "run_in_background": True,
+        }
+        template_vars = {"username": "alice", "message_text": "deploy now"}
+        result = _handle_lobster_task(action, template_vars)
+        assert result["status"] == "pending"
+        assert "alice" in result["task_prompt"]
+        assert "deploy now" in result["task_prompt"]
+        assert result["subagent_type"] == "general-purpose"
+
+    def test_missing_prompt_errors(self):
+        result = _handle_lobster_task({"type": "lobster_task"}, {})
+        assert result["status"] == "error"
+
+
+class TestHandleSendReply:
+    def test_returns_interpolated_message(self):
+        action = {"type": "send_reply", "message": "Alert: {message_text}"}
+        result = _handle_send_reply(action, {"message_text": "deploy", "channel_id": "C001"})
+        assert result["status"] == "ready"
+        assert result["message"] == "Alert: deploy"
+        assert result["channel"] == "C001"
+
+    def test_missing_message_errors(self):
+        result = _handle_send_reply({"type": "send_reply"}, {})
+        assert result["status"] == "error"
+
+    def test_custom_channel(self):
+        action = {"type": "send_reply", "message": "hi", "channel": "C999"}
+        result = _handle_send_reply(action, {"channel_id": "C001"})
+        assert result["channel"] == "C999"
+
+
+class TestHandleTelegramNotify:
+    def test_returns_interpolated_message(self):
+        action = {"type": "telegram_notify", "message": "Alert: {message_text}"}
+        with patch.dict(os.environ, {"LOBSTER_ADMIN_CHAT_ID": "12345"}):
+            result = _handle_telegram_notify(action, {"message_text": "outage"})
+        assert result["status"] == "ready"
+        assert result["message"] == "Alert: outage"
+        assert result["chat_id"] == "12345"
+
+    def test_custom_chat_id(self):
+        action = {"type": "telegram_notify", "message": "hi", "chat_id": "99999"}
+        result = _handle_telegram_notify(action, {})
+        assert result["chat_id"] == "99999"
+
+    def test_missing_message_errors(self):
+        result = _handle_telegram_notify({"type": "telegram_notify"}, {})
+        assert result["status"] == "error"
+
+
+class TestHandleShell:
+    def test_successful_command(self):
+        action = {"type": "shell", "command": "echo hello"}
+        result = _handle_shell(action, {})
+        assert result["status"] == "success"
+        assert "hello" in result["stdout"]
+        assert result["returncode"] == 0
+
+    def test_failed_command(self):
+        action = {"type": "shell", "command": "false"}
+        result = _handle_shell(action, {})
+        assert result["status"] == "error"
+        assert result["returncode"] != 0
+
+    def test_template_interpolation(self):
+        action = {"type": "shell", "command": "echo {username}"}
+        result = _handle_shell(action, {"username": "alice"})
+        assert "alice" in result["stdout"]
+
+    def test_missing_command_errors(self):
+        result = _handle_shell({"type": "shell"}, {})
+        assert result["status"] == "error"
+
+    def test_timeout(self):
+        action = {"type": "shell", "command": "sleep 60", "timeout": 1}
+        result = _handle_shell(action, {})
+        assert result["status"] == "error"
+        assert "timed out" in result["error"].lower()
+
+
+class TestHandleWebhook:
+    def test_missing_url_errors(self):
+        result = _handle_webhook({"type": "webhook"}, {})
+        assert result["status"] == "error"
+
+    def test_successful_post(self):
+        """Test webhook with a mocked urlopen."""
+        from unittest.mock import MagicMock
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        action = {"type": "webhook", "url": "https://example.com/hook"}
+        with patch("urllib.request.urlopen", return_value=mock_response):
+            result = _handle_webhook(action, {"message_text": "hello"})
+        assert result["status"] == "success"
+        assert result["response_code"] == 200
+
+
+# ---------------------------------------------------------------------------
+# TriggerEngine class tests (stateful wrapper)
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerEngine:
+    def test_loads_rules_on_init(self, rules_dir):
+        engine = TriggerEngine(rules_dir=str(rules_dir))
+        assert engine.rule_count == 2
+
+    def test_evaluate_returns_matches(self, rules_dir):
+        engine = TriggerEngine(rules_dir=str(rules_dir))
+        event = _make_event(channel="C001", text="deploy is starting")
+        matched = engine.evaluate(event)
+        assert len(matched) == 1
+        assert matched[0]["name"] == "test-keyword"
+
+    def test_evaluate_excludes_disabled(self, rules_dir):
+        engine = TriggerEngine(rules_dir=str(rules_dir))
+        event = _make_event(text="anything")
+        matched = engine.evaluate(event)
+        # disabled-rule should not match even though it has no keyword filter
+        names = [r["name"] for r in matched]
+        assert "disabled-rule" not in names
+
+    def test_evaluate_no_match(self, rules_dir):
+        engine = TriggerEngine(rules_dir=str(rules_dir))
+        event = _make_event(channel="C999", text="no keywords here")
+        matched = engine.evaluate(event)
+        assert matched == []
+
+    def test_fire_action_send_reply(self, rules_dir):
+        engine = TriggerEngine(rules_dir=str(rules_dir))
+        rule = engine.rules["test-keyword"]
+        event = _make_event(text="deploy", username="alice", channel_name="eng")
+        result = engine.fire_action(rule, event)
+        assert result["status"] == "ready"
+        assert "deploy" in result["message"]
+        assert "eng" in result["message"]
+
+    def test_fire_action_unknown_type(self, rules_dir):
+        engine = TriggerEngine(rules_dir=str(rules_dir))
+        rule = _make_rule(action_type="nonexistent")
+        result = engine.fire_action(rule, _make_event())
+        assert result["status"] == "error"
+
+    def test_reload_picks_up_new_rules(self, rules_dir):
+        engine = TriggerEngine(rules_dir=str(rules_dir))
+        assert engine.rule_count == 2
+
+        # Add a new rule
+        new_toml = """\
+[rule]
+name = "new-rule"
+enabled = true
+
+[trigger]
+event = "message"
+
+[action]
+type = "send_reply"
+message = "new!"
+"""
+        (rules_dir / "new.toml").write_text(new_toml)
+        engine.reload_rules()
+        assert engine.rule_count == 3
+        assert "new-rule" in engine.rules
+
+    def test_reload_removes_deleted_rules(self, rules_dir):
+        engine = TriggerEngine(rules_dir=str(rules_dir))
+        assert "test-keyword" in engine.rules
+
+        (rules_dir / "keyword.toml").unlink()
+        engine.reload_rules()
+        assert "test-keyword" not in engine.rules
+
+    def test_reload_updates_modified_rules(self, rules_dir):
+        engine = TriggerEngine(rules_dir=str(rules_dir))
+        rule = engine.rules["test-keyword"]
+        assert rule["channels"] == ["C001", "C002"]
+
+        # Modify the rule
+        modified = SAMPLE_TOML.replace('channels = ["C001", "C002"]', 'channels = ["C999"]')
+        (rules_dir / "keyword.toml").write_text(modified)
+        engine.reload_rules()
+        assert engine.rules["test-keyword"]["channels"] == ["C999"]
+
+    def test_nonexistent_dir_loads_empty(self, tmp_path):
+        engine = TriggerEngine(rules_dir=str(tmp_path / "nonexistent"))
+        assert engine.rule_count == 0
+        assert engine.evaluate(_make_event()) == []
+
+    def test_enabled_false_disables_immediately(self, rules_dir):
+        """Setting enabled=false in TOML prevents rule from firing."""
+        engine = TriggerEngine(rules_dir=str(rules_dir))
+        # Modify keyword rule to be disabled
+        disabled = SAMPLE_TOML.replace("enabled = true", "enabled = false")
+        (rules_dir / "keyword.toml").write_text(disabled)
+        engine.reload_rules()
+
+        event = _make_event(channel="C001", text="deploy now")
+        assert engine.evaluate(event) == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: end-to-end evaluate + fire
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    def test_keyword_alert_fires(self, rules_dir):
+        """Posting text with a keyword fires the matching rule."""
+        engine = TriggerEngine(rules_dir=str(rules_dir))
+        event = _make_event(
+            channel="C001",
+            text="deploy to production please",
+            username="bob",
+            channel_name="engineering",
+        )
+        matched = engine.evaluate(event)
+        assert len(matched) == 1
+
+        result = engine.fire_action(matched[0], event)
+        assert result["status"] == "ready"
+        assert "deploy to production please" in result["message"]
+        assert "engineering" in result["message"]
+
+    def test_all_keyword_mode(self, rules_dir):
+        """keyword_mode='all' requires every keyword present."""
+        all_toml = """\
+[rule]
+name = "all-keywords"
+enabled = true
+
+[trigger]
+event = "message"
+keywords = ["deploy", "staging"]
+keyword_mode = "all"
+
+[action]
+type = "send_reply"
+message = "Both keywords found"
+"""
+        (rules_dir / "all.toml").write_text(all_toml)
+        engine = TriggerEngine(rules_dir=str(rules_dir))
+
+        # Only one keyword — should not match
+        event1 = _make_event(text="deploy to production")
+        matched1 = [r for r in engine.evaluate(event1) if r["name"] == "all-keywords"]
+        assert matched1 == []
+
+        # Both keywords — should match
+        event2 = _make_event(text="deploy to staging now")
+        matched2 = [r for r in engine.evaluate(event2) if r["name"] == "all-keywords"]
+        assert len(matched2) == 1
+
+    def test_empty_channels_matches_all(self, tmp_path):
+        """channels=[] should match messages from any channel."""
+        d = tmp_path / "rules2"
+        d.mkdir()
+        toml = """\
+[rule]
+name = "global"
+enabled = true
+
+[trigger]
+event = "message"
+channels = []
+keywords = ["lobster-test"]
+
+[action]
+type = "send_reply"
+message = "Triggered!"
+"""
+        (d / "global.toml").write_text(toml)
+        engine = TriggerEngine(rules_dir=str(d))
+
+        for ch in ["C001", "C002", "C999"]:
+            event = _make_event(channel=ch, text="lobster-test in channel")
+            assert len(engine.evaluate(event)) == 1


### PR DESCRIPTION
## Summary

Operators need rule-based automation for Slack events — "when keyword X appears in channel Y, do Z" — without writing Python or restarting services. This PR adds a trigger engine that reads TOML rule files from a watched directory, matches incoming Slack events against configured predicates, and fires one of five action types.

**Problem:** The Slack Connector can log and route events (Phases 1–3), but has no automation layer. Every reaction to a Slack event requires either manual intervention or custom code.

**Solution:** A declarative trigger engine where rules are TOML data files. Drop a file → engine picks it up. Edit it → next event uses the new version. Delete it → rule gone immediately. No restart, no deploy.

## What this enables

- **Keyword alerts:** "Deploy" or "outage" in #engineering → notify admin via Telegram
- **Reaction triggers:** :eyes: reaction → spawn a Lobster task to review the message
- **Mention handlers:** @lobster in any channel → analyze and respond
- **Webhooks:** POST event payload to external services
- **Shell commands:** Run scripts with interpolated event data (30s timeout)

## Design

All matching logic is implemented as **pure functions** composed via conjunction — each rule has 8 independent predicate functions (event type, channel, user, keywords, emoji, command, file type, regex), all of which must pass for a match. This makes the engine highly testable: 85 unit tests cover every predicate in isolation and in composition.

**Architecture:**
```
Slack Event
    │
    ▼
TriggerEngine.evaluate(event)
    │ Pure: matches event against all loaded rules
    │ Returns: list of matched rule dicts
    ▼
TriggerEngine.fire_action(rule, event)
    │ Side-effect boundary: interpolates templates, dispatches action
    │ Returns: result dict with status
    ▼
Action Handler (one of 5 types)
    lobster_task │ send_reply │ telegram_notify │ webhook │ shell
```

**Hot-reload:** Uses watchdog inotify watcher on the rules directory. On any TOML file create/modify/delete, atomically reloads all rules (load into temp dict, then swap reference under lock).

**Functional patterns used:**
- Pure predicate functions composed via `all()` (conjunction)
- Immutable rule snapshots with atomic swap on reload
- Side effects isolated to `fire_action()` boundary
- Higher-order function dispatch table for action handlers
- Template interpolation as a pure string transformation

## What is NOT changed

- Existing ingress logger, log store, channel config, and user permissions are untouched
- No changes to the Slack router or dispatcher integration (that's Phase 5)
- Example rules in `examples/` are not auto-loaded — they're reference templates

## Files added

| File | Purpose |
|------|---------|
| `src/trigger_engine.py` | Core engine: rule parsing, event matching, action dispatch, hot-reload |
| `src/rules/README.md` | Operator docs for the TOML rule format and template variables |
| `src/rules/examples/*.toml` | Three example rules (keyword alert, reaction trigger, mention handler) |
| `tests/test_trigger_engine.py` | 85 tests covering all pure functions, action handlers, and engine integration |

## Tests run

- [x] `uv run pytest tests/test_trigger_engine.py -v` — 85 passed, 0 failed
- [x] `uv run pytest tests/ -v` — 182 passed, 0 failed (full suite including Phases 1–3)

## Manual test

N/A — this phase adds a library module with no systemd, cron, or external service dependencies. The engine is exercised entirely through unit tests with mocked I/O. Integration with the live Slack router happens in Phase 5.

Relates to BIS-270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)