### PR TITLE
security: fix shell injection in trigger engine shell action handler

### DIFF
--- a/lobster-shop/slack-connector/src/trigger_engine.py
+++ b/lobster-shop/slack-connector/src/trigger_engine.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import shlex
 import subprocess
 import threading
 from datetime import datetime, timezone
@@ -226,8 +227,6 @@ def matches_keywords(rule: dict[str, Any], event: dict[str, Any]) -> bool:
 
     text = event.get("text", "").lower()
     keyword_mode = rule.get("keyword_mode", "any")
-
-    keyword_checks = (kw.lower() in text for kw in keywords)
 
     if keyword_mode == "all":
         return all(kw.lower() in text for kw in keywords)
@@ -669,7 +668,8 @@ def _handle_shell(
     if not command:
         return {"status": "error", "error": "shell action missing command"}
 
-    interpolated = interpolate_template(command, template_vars)
+    quoted_vars = {k: shlex.quote(str(v)) for k, v in template_vars.items()}
+    interpolated = interpolate_template(command, quoted_vars)
     timeout = min(action.get("timeout", _SHELL_TIMEOUT_SECONDS), _SHELL_TIMEOUT_SECONDS)
 
     try:


### PR DESCRIPTION
## Summary

- **Vulnerability**: `_handle_shell` in `trigger_engine.py` interpolated Slack-user-controlled data (e.g. `message_text`, `username`) directly into a shell command string passed to `subprocess.run(..., shell=True)` — classic shell injection.
- **Fix**: All template variables are now passed through `shlex.quote()` before interpolation, ensuring user-controlled values cannot break out of their intended argument positions.
- **Bonus cleanup**: Removed the dead `keyword_checks` generator variable in `matches_keywords` (noted in PR #1413 review).

## Changes

- Added `import shlex` to imports
- In `_handle_shell`: introduced `quoted_vars = {k: shlex.quote(str(v)) for k, v in template_vars.items()}` and use `quoted_vars` for interpolation instead of raw `template_vars`
- In `matches_keywords`: removed unused `keyword_checks` generator

## Test plan

- [x] All 285 existing tests pass (`uv run -m pytest lobster-shop/slack-connector/ -q`)
- [x] Injection payloads like `message_text = "; rm -rf /"` are now safely quoted

Fixes shell injection introduced in PR #1413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)