### PR TITLE
feat: Slack Connector Phase 8 — MCP Server + Skill Commands

### DIFF
--- a/lobster-shop/slack-connector/behavior/system.md
+++ b/lobster-shop/slack-connector/behavior/system.md
@@ -2,12 +2,33 @@
 
 When the slack-connector skill is active, Lobster has access to Slack workspace logging, search, and analysis capabilities. A background ingress worker continuously logs all messages from configured channels to disk. The dispatcher can query these logs, generate channel summaries, and search message history without making live Slack API calls — all reads hit the local log store.
 
-### Command handling
+### MCP tools available
 
-- **`/slack-status`** — Report the connection health of the Slack Socket Mode session, list monitored channels with message counts, and show log storage stats (disk usage, oldest/newest entry, total messages). Spawn a subagent to gather this data.
-- **`/analyze-logs`** — Accept a natural-language query (e.g., "/analyze-logs what did #engineering discuss about deployments this week") and search the local log index. Return a concise summary of matching messages with timestamps, authors, and thread context. For broad queries, limit results to the 20 most relevant messages and offer to narrow the search.
-- **`/slack`** — General entry point. Show a brief status line and offer quick actions: "search logs", "channel summary", "check triggers". Route to the appropriate handler based on the user's follow-up.
+When this skill is active, the `slack-connector` MCP server provides these tools:
+
+- **`slack_log_search`** — Full-text search over logged Slack messages. Uses FTS5 index when available, falls back to JSONL scan. Supports channel filtering and date ranges.
+- **`slack_channel_summary`** — Structured summary of a channel's activity for a given date/time window: message count, participants, thread count, and sample messages.
+- **`slack_thread_summary`** — All messages in a specific thread with participant list.
+- **`slack_status`** — Connection state, account type, channels monitored, events logged today, log size, and trigger rule count.
+
+### Command dispatch
+
+When the user sends these patterns, use the corresponding MCP tool:
+
+| User input | Action |
+|---|---|
+| `/slack-status` or "slack status" or "how is slack logging" | Call `slack_status()`, format the result as a concise status report, reply. |
+| `/analyze-logs <query>` or "search slack logs for `<query>`" | Call `slack_log_search(query=<query>)`, synthesize matching messages into a readable summary, reply. For broad queries, limit results to the 20 most relevant and offer to narrow. |
+| "summarize #`<channel>` today" or "what happened in #`<channel>`" | Call `slack_channel_summary(channel_id=<id>)`, format as a narrative summary, reply. |
+| `/slack channels` or "what channels are you monitoring" | Call `slack_status()`, extract `channel_ids`, list them with any available channel names from the config. |
+| `/slack rules` or "what slack triggers are active" | Read trigger rule files from `~/lobster-workspace/slack-connector/config/rules/`, list rule names and descriptions. |
+| `/slack reload` | Trigger hot-reload: re-read `channels.yaml` and trigger rules. Confirm reload to user. |
+| `/slack` (bare) | Show a brief status line and offer quick actions: "search logs", "channel summary", "check triggers". |
 
 ### Privacy constraint
 
 DM content logged by the ingress worker must never be surfaced to public channels or included in summaries shared outside of the DM participants. When generating channel summaries or search results, always filter out DM-sourced messages unless the requesting user is a participant in that DM. This applies to morning briefing integrations as well — DM content stays private.
+
+### Security
+
+Never expose raw Slack token values in replies. Never route DM content to public channels. All search results and summaries are generated from local log files — no live Slack API calls are made by the MCP tools.

--- a/lobster-shop/slack-connector/install.sh
+++ b/lobster-shop/slack-connector/install.sh
@@ -332,7 +332,90 @@ else
 fi
 
 #===============================================================================
-# Step 8: Done — print success
+# Step 8: Register MCP server in Claude Code config
+#===============================================================================
+step "8: Registering MCP server"
+
+CLAUDE_JSON="$HOME/.claude.json"
+MCP_SERVER_PATH="$SKILL_DIR/src/mcp_server.py"
+
+# Register the slack-connector MCP server in ~/.claude.json
+# Uses Python for safe JSON manipulation (no jq dependency)
+if [ -f "$CLAUDE_JSON" ]; then
+    ALREADY_REGISTERED=$("$PYTHON_BIN" -c "
+import json, sys
+try:
+    with open('$CLAUDE_JSON') as f:
+        data = json.load(f)
+    servers = data.get('mcpServers', {})
+    print('yes' if 'slack-connector' in servers else 'no')
+except Exception:
+    print('no')
+" 2>/dev/null || echo "no")
+
+    if [ "$ALREADY_REGISTERED" = "yes" ]; then
+        info "slack-connector MCP server already registered in $CLAUDE_JSON"
+    else
+        "$PYTHON_BIN" -c "
+import json, os
+
+claude_json_path = '$CLAUDE_JSON'
+mcp_server_path = '$MCP_SERVER_PATH'
+python_bin = '$PYTHON_BIN'
+workspace = '$LOBSTER_WORKSPACE'
+
+with open(claude_json_path) as f:
+    data = json.load(f)
+
+if 'mcpServers' not in data:
+    data['mcpServers'] = {}
+
+data['mcpServers']['slack-connector'] = {
+    'command': python_bin,
+    'args': [mcp_server_path],
+    'env': {
+        'LOBSTER_WORKSPACE': workspace,
+    },
+}
+
+with open(claude_json_path, 'w') as f:
+    json.dump(data, f, indent=2)
+    f.write('\n')
+" 2>/dev/null
+        if [ $? -eq 0 ]; then
+            success "slack-connector MCP server registered in $CLAUDE_JSON"
+        else
+            warn "Could not register MCP server automatically"
+            echo ""
+            echo "  Add this to your ~/.claude.json mcpServers section:"
+            echo ""
+            echo "    \"slack-connector\": {"
+            echo "      \"command\": \"$PYTHON_BIN\","
+            echo "      \"args\": [\"$MCP_SERVER_PATH\"],"
+            echo "      \"env\": {"
+            echo "        \"LOBSTER_WORKSPACE\": \"$LOBSTER_WORKSPACE\""
+            echo "      }"
+            echo "    }"
+            echo ""
+        fi
+    fi
+else
+    warn "$CLAUDE_JSON not found — MCP server not registered"
+    echo ""
+    echo "  When Claude Code is available, add this to ~/.claude.json mcpServers:"
+    echo ""
+    echo "    \"slack-connector\": {"
+    echo "      \"command\": \"$PYTHON_BIN\","
+    echo "      \"args\": [\"$MCP_SERVER_PATH\"],"
+    echo "      \"env\": {"
+    echo "        \"LOBSTER_WORKSPACE\": \"$LOBSTER_WORKSPACE\""
+    echo "      }"
+    echo "    }"
+    echo ""
+fi
+
+#===============================================================================
+# Step 9: Done — print success
 #===============================================================================
 echo ""
 echo -e "${GREEN}${BOLD}Slack Connector skill installed!${NC}"

--- a/lobster-shop/slack-connector/skill.toml
+++ b/lobster-shop/slack-connector/skill.toml
@@ -21,8 +21,8 @@ priority = 55
 merge_strategy = "append"
 
 [provides]
-mcp_tools = ["slack_log_search", "slack_channel_summary", "slack_thread_summary"]
-bot_commands = ["/slack", "/analyze-logs", "/slack-status"]
+mcp_tools = ["slack_log_search", "slack_channel_summary", "slack_thread_summary", "slack_status"]
+bot_commands = ["/slack", "/analyze-logs", "/slack-status", "/slack channels", "/slack rules", "/slack reload"]
 
 [compatibility]
 enhances = ["morning-briefing", "lobster-status"]

--- a/lobster-shop/slack-connector/src/mcp_server.py
+++ b/lobster-shop/slack-connector/src/mcp_server.py
@@ -1,0 +1,650 @@
+#!/usr/bin/env python3
+"""
+Slack Connector MCP Server — exposes Slack log search, channel summaries,
+thread summaries, and status as MCP tools for Claude Code.
+
+Runs as a standalone stdio MCP server. Registered in ~/.claude.json by
+the skill's install.sh.
+
+Design principles:
+- Pure query functions composed with thin MCP wrappers
+- All reads hit local log files and SQLite indexes — no Slack API calls
+- FTS5 keyword search with automatic fallback to JSONL scan
+- Immutable data: query results are snapshots, never mutated
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import Tool, TextContent
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+log = logging.getLogger("slack-connector-mcp")
+log.setLevel(logging.INFO)
+_handler = logging.StreamHandler(sys.stderr)
+_handler.setFormatter(logging.Formatter("[%(levelname)s] %(name)s: %(message)s"))
+log.addHandler(_handler)
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_WORKSPACE = Path(
+    os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace")
+)
+_SLACK_DIR = _WORKSPACE / "slack-connector"
+_LOG_ROOT = _SLACK_DIR / "logs"
+_STATE_DIR = _SLACK_DIR / "state"
+_CONFIG_DIR = _SLACK_DIR / "config"
+
+# Add skill src to path so we can import sibling modules
+_SKILL_SRC = Path(__file__).resolve().parent
+if str(_SKILL_SRC) not in sys.path:
+    sys.path.insert(0, str(_SKILL_SRC))
+
+
+# ---------------------------------------------------------------------------
+# Lazy imports — these modules live in the same src/ directory.
+# Imported at call time to avoid startup failures if log directories
+# don't exist yet.
+# ---------------------------------------------------------------------------
+
+
+def _get_log_store():
+    """Lazy import and instantiate SlackLogStore."""
+    from log_store import SlackLogStore
+    return SlackLogStore(log_root=_LOG_ROOT)
+
+
+def _get_keyword_index():
+    """Lazy import and instantiate KeywordIndex. Returns None if unavailable."""
+    try:
+        from keyword_index import KeywordIndex
+        idx = KeywordIndex(state_dir=_STATE_DIR)
+        # Verify FTS5 is available by touching the DB
+        idx._ensure_db()
+        return idx
+    except Exception as e:
+        log.warning("FTS5 keyword index unavailable: %s", e)
+        return None
+
+
+def _get_channel_config():
+    """Lazy import and instantiate ChannelConfig."""
+    from channel_config import ChannelConfig
+    config_path = _CONFIG_DIR / "channels.yaml"
+    return ChannelConfig(config_path=str(config_path))
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — data transformation with no side effects
+# ---------------------------------------------------------------------------
+
+
+def _today_str() -> str:
+    """Current date as YYYY-MM-DD string."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _date_n_days_ago(n: int) -> str:
+    """Date N days ago as YYYY-MM-DD string."""
+    dt = datetime.now(timezone.utc) - timedelta(days=n)
+    return dt.strftime("%Y-%m-%d")
+
+
+def _parse_date_or_default(date_str: str | None, default: str) -> str:
+    """Validate a YYYY-MM-DD string, returning default if invalid/missing."""
+    if not date_str:
+        return default
+    try:
+        datetime.strptime(date_str, "%Y-%m-%d")
+        return date_str
+    except ValueError:
+        return default
+
+
+def _filter_messages_by_query(
+    messages: list[dict[str, Any]], query: str
+) -> list[dict[str, Any]]:
+    """Filter messages by case-insensitive substring match on text field.
+
+    Pure function — JSONL fallback when FTS5 is unavailable.
+    """
+    query_lower = query.lower()
+    terms = query_lower.split()
+    return [
+        msg for msg in messages
+        if all(term in msg.get("text", "").lower() for term in terms)
+    ]
+
+
+def _format_message_for_display(msg: dict[str, Any]) -> dict[str, Any]:
+    """Extract display-relevant fields from a log record.
+
+    Pure function — strips raw event data, keeps only what's needed
+    for search results and summaries.
+    """
+    return {
+        "ts": msg.get("ts", ""),
+        "channel_id": msg.get("channel_id", ""),
+        "channel_name": msg.get("channel_name", ""),
+        "user_id": msg.get("user_id", ""),
+        "username": msg.get("username", ""),
+        "display_name": msg.get("display_name", ""),
+        "text": msg.get("text", ""),
+        "thread_ts": msg.get("thread_ts"),
+    }
+
+
+def _group_by_thread(
+    messages: list[dict[str, Any]],
+) -> dict[str | None, list[dict[str, Any]]]:
+    """Group messages by thread_ts. Messages without a thread go under None.
+
+    Pure function.
+    """
+    groups: dict[str | None, list[dict[str, Any]]] = {}
+    for msg in messages:
+        key = msg.get("thread_ts")
+        groups.setdefault(key, []).append(msg)
+    return groups
+
+
+def _build_channel_summary(
+    messages: list[dict[str, Any]], channel_id: str, date: str
+) -> dict[str, Any]:
+    """Build a structured channel summary from a day's messages.
+
+    Pure function — no I/O.
+    """
+    if not messages:
+        return {
+            "channel_id": channel_id,
+            "date": date,
+            "message_count": 0,
+            "participants": [],
+            "threads": 0,
+            "summary": "No messages found for this channel on this date.",
+        }
+
+    participants = sorted(set(
+        msg.get("username") or msg.get("user_id", "unknown")
+        for msg in messages
+    ))
+
+    threads = _group_by_thread(messages)
+    # Count threads that have at least 2 messages (actual conversations)
+    thread_count = sum(
+        1 for ts, msgs in threads.items()
+        if ts is not None and len(msgs) >= 2
+    )
+
+    # Build a text digest of the messages for summarization
+    sample_texts = [
+        msg.get("text", "")[:200]
+        for msg in messages[:50]
+        if msg.get("text", "").strip()
+    ]
+
+    return {
+        "channel_id": channel_id,
+        "date": date,
+        "message_count": len(messages),
+        "participants": participants,
+        "participant_count": len(participants),
+        "threads": thread_count,
+        "messages": [_format_message_for_display(m) for m in messages[:100]],
+        "sample_texts": sample_texts[:20],
+    }
+
+
+def _build_thread_summary(
+    messages: list[dict[str, Any]], channel_id: str, thread_ts: str
+) -> dict[str, Any]:
+    """Build a structured thread summary from thread messages.
+
+    Pure function — no I/O.
+    """
+    # Filter to only messages in this thread
+    thread_msgs = [
+        msg for msg in messages
+        if msg.get("thread_ts") == thread_ts or msg.get("ts") == thread_ts
+    ]
+
+    if not thread_msgs:
+        return {
+            "channel_id": channel_id,
+            "thread_ts": thread_ts,
+            "message_count": 0,
+            "participants": [],
+            "messages": [],
+        }
+
+    participants = sorted(set(
+        msg.get("username") or msg.get("user_id", "unknown")
+        for msg in thread_msgs
+    ))
+
+    return {
+        "channel_id": channel_id,
+        "thread_ts": thread_ts,
+        "message_count": len(thread_msgs),
+        "participants": participants,
+        "messages": [_format_message_for_display(m) for m in thread_msgs],
+    }
+
+
+def _count_events_today(log_root: Path) -> int:
+    """Count total log events across all channels for today.
+
+    Read-only file I/O — counts lines in today's JSONL files.
+    """
+    today = _today_str()
+    total = 0
+    for category in ("channels", "dms"):
+        category_dir = log_root / category
+        if not category_dir.exists():
+            continue
+        for channel_dir in category_dir.iterdir():
+            if not channel_dir.is_dir():
+                continue
+            log_file = channel_dir / f"{today}.jsonl"
+            if log_file.exists():
+                with open(log_file) as f:
+                    total += sum(1 for line in f if line.strip())
+    return total
+
+
+def _log_size_mb(log_root: Path) -> float:
+    """Calculate total log directory size in MB.
+
+    Read-only file I/O.
+    """
+    total_bytes = 0
+    if not log_root.exists():
+        return 0.0
+    for path in log_root.rglob("*.jsonl"):
+        total_bytes += path.stat().st_size
+    return round(total_bytes / (1024 * 1024), 2)
+
+
+def _last_event_timestamp(log_root: Path) -> str | None:
+    """Find the timestamp of the most recent logged event.
+
+    Reads the last line of the most recent JSONL file.
+    """
+    latest_file: Path | None = None
+    latest_mtime: float = 0.0
+
+    for category in ("channels", "dms"):
+        category_dir = log_root / category
+        if not category_dir.exists():
+            continue
+        for jsonl_file in category_dir.rglob("*.jsonl"):
+            mtime = jsonl_file.stat().st_mtime
+            if mtime > latest_mtime:
+                latest_mtime = mtime
+                latest_file = jsonl_file
+
+    if latest_file is None:
+        return None
+
+    # Read last non-empty line
+    try:
+        with open(latest_file) as f:
+            last_line = ""
+            for line in f:
+                if line.strip():
+                    last_line = line.strip()
+            if last_line:
+                record = json.loads(last_line)
+                return record.get("logged_at") or record.get("ts")
+    except (json.JSONDecodeError, OSError):
+        pass
+    return None
+
+
+def _count_trigger_rules(config_dir: Path) -> int:
+    """Count loaded trigger rule files (.toml) in the rules directory."""
+    rules_dir = config_dir / "rules"
+    if not rules_dir.exists():
+        return 0
+    return sum(1 for f in rules_dir.iterdir() if f.suffix == ".toml")
+
+
+def _build_status(
+    log_root: Path,
+    config_dir: Path,
+    state_dir: Path,
+    channels: list[str],
+) -> dict[str, Any]:
+    """Build a complete status snapshot.
+
+    Combines pure computations with read-only file I/O.
+    """
+    # Check if slack router service is running
+    connected = False
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["systemctl", "is-active", "lobster-slack-router"],
+            capture_output=True, text=True, timeout=5,
+        )
+        connected = result.stdout.strip() == "active"
+    except Exception:
+        pass
+
+    # Detect account type from preferences
+    account_type = "bot"
+    prefs_file = Path(__file__).resolve().parent.parent / "preferences" / "defaults.toml"
+    if prefs_file.exists():
+        try:
+            content = prefs_file.read_text()
+            if 'account_type = "person"' in content:
+                account_type = "person"
+        except OSError:
+            pass
+
+    return {
+        "connected": connected,
+        "account_type": account_type,
+        "channels_monitored": len(channels),
+        "channel_ids": channels,
+        "events_logged_today": _count_events_today(log_root),
+        "log_size_mb": _log_size_mb(log_root),
+        "last_event_at": _last_event_timestamp(log_root),
+        "trigger_rules_loaded": _count_trigger_rules(config_dir),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers — thin wrappers that compose pure functions with I/O
+# ---------------------------------------------------------------------------
+
+
+def _handle_slack_log_search(arguments: dict[str, Any]) -> str:
+    """Handle slack_log_search tool call.
+
+    Strategy: try FTS5 first, fall back to JSONL scan.
+    """
+    query = arguments.get("query", "").strip()
+    if not query:
+        return json.dumps({"error": "query parameter is required"})
+
+    channel_id = arguments.get("channel_id")
+    start_date = _parse_date_or_default(
+        arguments.get("start_date"), _date_n_days_ago(7)
+    )
+    end_date = _parse_date_or_default(
+        arguments.get("end_date"), _today_str()
+    )
+    limit = min(arguments.get("limit", 50), 200)
+
+    # Strategy 1: FTS5 keyword index
+    idx = _get_keyword_index()
+    if idx is not None:
+        try:
+            results = idx.search(query=query, channel_id=channel_id, limit=limit)
+            if results:
+                return json.dumps({
+                    "source": "fts5",
+                    "query": query,
+                    "result_count": len(results),
+                    "results": results,
+                })
+        except Exception as e:
+            log.warning("FTS5 search failed, falling back to JSONL: %s", e)
+        finally:
+            idx.close()
+
+    # Strategy 2: JSONL scan fallback
+    store = _get_log_store()
+    all_messages: list[dict[str, Any]] = []
+
+    if channel_id:
+        channels_to_scan = [channel_id]
+    else:
+        channels_to_scan = store.list_channels()
+
+    for ch_id in channels_to_scan:
+        messages = store.query_range(ch_id, start_date, end_date)
+        matching = _filter_messages_by_query(messages, query)
+        all_messages.extend(
+            _format_message_for_display(m) for m in matching
+        )
+        if len(all_messages) >= limit:
+            break
+
+    return json.dumps({
+        "source": "jsonl_scan",
+        "query": query,
+        "date_range": {"start": start_date, "end": end_date},
+        "result_count": min(len(all_messages), limit),
+        "results": all_messages[:limit],
+    })
+
+
+def _handle_slack_channel_summary(arguments: dict[str, Any]) -> str:
+    """Handle slack_channel_summary tool call."""
+    channel_id = arguments.get("channel_id", "").strip()
+    if not channel_id:
+        return json.dumps({"error": "channel_id parameter is required"})
+
+    hours = arguments.get("hours", 24)
+    date = _parse_date_or_default(arguments.get("date"), _today_str())
+
+    store = _get_log_store()
+
+    # If hours > 24, span multiple days
+    if hours > 24:
+        days_back = (hours // 24) + 1
+        start_date = _date_n_days_ago(days_back)
+        messages = store.query_range(channel_id, start_date, date)
+    else:
+        messages = store.query(channel_id, date)
+
+    summary = _build_channel_summary(messages, channel_id, date)
+    return json.dumps(summary)
+
+
+def _handle_slack_thread_summary(arguments: dict[str, Any]) -> str:
+    """Handle slack_thread_summary tool call."""
+    channel_id = arguments.get("channel_id", "").strip()
+    thread_ts = arguments.get("thread_ts", "").strip()
+
+    if not channel_id or not thread_ts:
+        return json.dumps(
+            {"error": "channel_id and thread_ts parameters are required"}
+        )
+
+    store = _get_log_store()
+
+    # Determine the date from thread_ts (Slack ts = epoch.sequence)
+    try:
+        epoch = float(thread_ts.split(".")[0])
+        thread_date = datetime.fromtimestamp(epoch, tz=timezone.utc)
+        date_str = thread_date.strftime("%Y-%m-%d")
+    except (ValueError, IndexError):
+        date_str = _today_str()
+
+    # Search across a few days in case thread spans midnight
+    start_date = (
+        datetime.strptime(date_str, "%Y-%m-%d") - timedelta(days=1)
+    ).strftime("%Y-%m-%d")
+    end_date = (
+        datetime.strptime(date_str, "%Y-%m-%d") + timedelta(days=3)
+    ).strftime("%Y-%m-%d")
+
+    messages = store.query_range(channel_id, start_date, end_date)
+    summary = _build_thread_summary(messages, channel_id, thread_ts)
+    return json.dumps(summary)
+
+
+def _handle_slack_status(arguments: dict[str, Any]) -> str:
+    """Handle slack_status tool call."""
+    store = _get_log_store()
+    channels = store.list_channels()
+    status = _build_status(_LOG_ROOT, _CONFIG_DIR, _STATE_DIR, channels)
+    return json.dumps(status)
+
+
+# ---------------------------------------------------------------------------
+# MCP Server definition
+# ---------------------------------------------------------------------------
+
+server = Server("slack-connector")
+
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    """List available Slack Connector tools."""
+    return [
+        Tool(
+            name="slack_log_search",
+            description=(
+                "Search Slack message logs by keyword. Uses FTS5 full-text "
+                "index when available, falls back to JSONL file scan. "
+                "Returns matching messages with timestamps, authors, and text."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Search query (keywords, FTS5 syntax supported: AND, OR, NOT, phrases)",
+                    },
+                    "channel_id": {
+                        "type": "string",
+                        "description": "Optional: limit search to a specific channel ID",
+                    },
+                    "start_date": {
+                        "type": "string",
+                        "description": "Start date (YYYY-MM-DD). Default: 7 days ago",
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "description": "End date (YYYY-MM-DD). Default: today",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max results to return (default 50, max 200)",
+                        "default": 50,
+                    },
+                },
+                "required": ["query"],
+            },
+        ),
+        Tool(
+            name="slack_channel_summary",
+            description=(
+                "Generate a structured summary of a Slack channel's activity. "
+                "Returns message count, participant list, thread count, and "
+                "sample messages for a given date or time window."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "channel_id": {
+                        "type": "string",
+                        "description": "Slack channel ID to summarize",
+                    },
+                    "date": {
+                        "type": "string",
+                        "description": "Date to summarize (YYYY-MM-DD). Default: today",
+                    },
+                    "hours": {
+                        "type": "integer",
+                        "description": "Hours of history to include (default 24). If >24, spans multiple days.",
+                        "default": 24,
+                    },
+                },
+                "required": ["channel_id"],
+            },
+        ),
+        Tool(
+            name="slack_thread_summary",
+            description=(
+                "Summarize a specific Slack thread. Returns all messages in "
+                "the thread with participants and message count."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "channel_id": {
+                        "type": "string",
+                        "description": "Channel containing the thread",
+                    },
+                    "thread_ts": {
+                        "type": "string",
+                        "description": "Thread root timestamp (Slack ts format: epoch.sequence)",
+                    },
+                },
+                "required": ["channel_id", "thread_ts"],
+            },
+        ),
+        Tool(
+            name="slack_status",
+            description=(
+                "Get Slack Connector status: connection state, account type, "
+                "monitored channels, events logged today, log size, and "
+                "trigger rules loaded. No arguments required."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {},
+            },
+        ),
+    ]
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    """Dispatch tool calls to handlers."""
+    dispatch = {
+        "slack_log_search": _handle_slack_log_search,
+        "slack_channel_summary": _handle_slack_channel_summary,
+        "slack_thread_summary": _handle_slack_thread_summary,
+        "slack_status": _handle_slack_status,
+    }
+
+    handler = dispatch.get(name)
+    if handler is None:
+        return [TextContent(type="text", text=f"Unknown tool: {name}")]
+
+    try:
+        result = handler(arguments)
+        return [TextContent(type="text", text=result)]
+    except Exception as e:
+        log.error("Tool %s failed: %s", name, e, exc_info=True)
+        return [TextContent(type="text", text=json.dumps({"error": str(e)}))]
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+async def main():
+    """Run the Slack Connector MCP server over stdio."""
+    log.info("Starting slack-connector MCP server")
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream, write_stream, server.create_initialization_options()
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lobster-shop/slack-connector/tests/test_mcp_server.py
+++ b/lobster-shop/slack-connector/tests/test_mcp_server.py
@@ -1,0 +1,474 @@
+"""
+Tests for Slack Connector MCP Server.
+
+Tests the pure helper functions and tool handlers independently.
+Uses temp directories to avoid touching real log files.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add the skill src/ directory to path
+_SKILL_SRC = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(_SKILL_SRC))
+
+from mcp_server import (
+    _build_channel_summary,
+    _build_status,
+    _build_thread_summary,
+    _count_events_today,
+    _count_trigger_rules,
+    _date_n_days_ago,
+    _filter_messages_by_query,
+    _format_message_for_display,
+    _group_by_thread,
+    _last_event_timestamp,
+    _log_size_mb,
+    _parse_date_or_default,
+    _handle_slack_log_search,
+    _handle_slack_channel_summary,
+    _handle_slack_thread_summary,
+    _handle_slack_status,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def log_root(tmp_path):
+    """Create a temporary log root with sample data."""
+    channels_dir = tmp_path / "channels" / "C001"
+    channels_dir.mkdir(parents=True)
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    log_file = channels_dir / f"{today}.jsonl"
+
+    messages = [
+        {
+            "schema": 1,
+            "ts": "1743724800.001",
+            "channel_id": "C001",
+            "channel_name": "engineering",
+            "user_id": "U001",
+            "username": "alice",
+            "display_name": "Alice Smith",
+            "text": "Has anyone looked at the deploy issue?",
+            "thread_ts": None,
+            "logged_at": "2026-04-03T14:00:00Z",
+        },
+        {
+            "schema": 1,
+            "ts": "1743724801.002",
+            "channel_id": "C001",
+            "channel_name": "engineering",
+            "user_id": "U002",
+            "username": "bob",
+            "display_name": "Bob Jones",
+            "text": "Yes, the deploy pipeline is failing on staging",
+            "thread_ts": "1743724800.001",
+            "logged_at": "2026-04-03T14:01:00Z",
+        },
+        {
+            "schema": 1,
+            "ts": "1743724802.003",
+            "channel_id": "C001",
+            "channel_name": "engineering",
+            "user_id": "U001",
+            "username": "alice",
+            "display_name": "Alice Smith",
+            "text": "I'll fix the staging config by EOD",
+            "thread_ts": "1743724800.001",
+            "logged_at": "2026-04-03T14:02:00Z",
+        },
+        {
+            "schema": 1,
+            "ts": "1743724810.004",
+            "channel_id": "C001",
+            "channel_name": "engineering",
+            "user_id": "U003",
+            "username": "charlie",
+            "display_name": "Charlie Davis",
+            "text": "Anyone up for lunch?",
+            "thread_ts": None,
+            "logged_at": "2026-04-03T14:05:00Z",
+        },
+    ]
+
+    with open(log_file, "w") as f:
+        for msg in messages:
+            f.write(json.dumps(msg) + "\n")
+
+    return tmp_path
+
+
+@pytest.fixture
+def config_dir(tmp_path):
+    """Create a temporary config directory with sample rule files."""
+    config = tmp_path / "config"
+    rules_dir = config / "rules"
+    rules_dir.mkdir(parents=True)
+
+    # Create sample rule files
+    (rules_dir / "keyword-alert.toml").write_text("[rule]\nname = 'test-rule'\n")
+    (rules_dir / "mention-handler.toml").write_text("[rule]\nname = 'mention'\n")
+
+    return config
+
+
+@pytest.fixture
+def state_dir(tmp_path):
+    """Create a temporary state directory."""
+    state = tmp_path / "state"
+    state.mkdir(parents=True)
+    return state
+
+
+@pytest.fixture
+def fts_index(state_dir):
+    """Create a FTS5 keyword index with sample data."""
+    db_path = state_dir / "keyword_index.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""
+        CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+            ts, channel_id, user_id, text,
+            tokenize='porter ascii'
+        );
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS index_cursors (
+            channel_id TEXT PRIMARY KEY,
+            last_ts TEXT NOT NULL
+        );
+    """)
+    conn.executemany(
+        "INSERT INTO messages_fts(ts, channel_id, user_id, text) VALUES (?, ?, ?, ?);",
+        [
+            ("1743724800.001", "C001", "U001", "Has anyone looked at the deploy issue?"),
+            ("1743724801.002", "C001", "U002", "Yes, the deploy pipeline is failing on staging"),
+            ("1743724802.003", "C001", "U001", "I'll fix the staging config by EOD"),
+            ("1743724810.004", "C001", "U003", "Anyone up for lunch?"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestPureHelpers:
+    """Tests for pure functions with no I/O."""
+
+    def test_parse_date_or_default_valid(self):
+        assert _parse_date_or_default("2026-04-03", "2026-01-01") == "2026-04-03"
+
+    def test_parse_date_or_default_invalid(self):
+        assert _parse_date_or_default("not-a-date", "2026-01-01") == "2026-01-01"
+
+    def test_parse_date_or_default_none(self):
+        assert _parse_date_or_default(None, "2026-01-01") == "2026-01-01"
+
+    def test_parse_date_or_default_empty(self):
+        assert _parse_date_or_default("", "2026-01-01") == "2026-01-01"
+
+    def test_date_n_days_ago(self):
+        result = _date_n_days_ago(0)
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        assert result == today
+
+    def test_filter_messages_single_term(self):
+        messages = [
+            {"text": "deploy issue found"},
+            {"text": "lunch time!"},
+            {"text": "deploy pipeline failing"},
+        ]
+        result = _filter_messages_by_query(messages, "deploy")
+        assert len(result) == 2
+
+    def test_filter_messages_multiple_terms(self):
+        messages = [
+            {"text": "deploy issue found"},
+            {"text": "deploy pipeline failing"},
+        ]
+        result = _filter_messages_by_query(messages, "deploy pipeline")
+        assert len(result) == 1
+        assert "pipeline" in result[0]["text"]
+
+    def test_filter_messages_case_insensitive(self):
+        messages = [{"text": "DEPLOY ISSUE"}]
+        result = _filter_messages_by_query(messages, "deploy")
+        assert len(result) == 1
+
+    def test_filter_messages_empty_text(self):
+        messages = [{"text": ""}, {}]
+        result = _filter_messages_by_query(messages, "deploy")
+        assert len(result) == 0
+
+    def test_format_message_for_display(self):
+        msg = {
+            "ts": "123.456",
+            "channel_id": "C001",
+            "channel_name": "eng",
+            "user_id": "U001",
+            "username": "alice",
+            "display_name": "Alice",
+            "text": "hello",
+            "thread_ts": "100.001",
+            "raw": {"some": "data"},
+            "files": [],
+        }
+        result = _format_message_for_display(msg)
+        assert "raw" not in result
+        assert "files" not in result
+        assert result["username"] == "alice"
+        assert result["thread_ts"] == "100.001"
+
+    def test_group_by_thread(self):
+        messages = [
+            {"text": "root", "thread_ts": None},
+            {"text": "reply1", "thread_ts": "100.001"},
+            {"text": "reply2", "thread_ts": "100.001"},
+            {"text": "standalone", "thread_ts": None},
+        ]
+        groups = _group_by_thread(messages)
+        assert len(groups[None]) == 2
+        assert len(groups["100.001"]) == 2
+
+    def test_build_channel_summary_empty(self):
+        result = _build_channel_summary([], "C001", "2026-04-03")
+        assert result["message_count"] == 0
+        assert result["participants"] == []
+        assert "No messages" in result["summary"]
+
+    def test_build_channel_summary_with_messages(self):
+        messages = [
+            {"username": "alice", "text": "hello", "thread_ts": "100.001", "ts": "100.001"},
+            {"username": "bob", "text": "hi", "thread_ts": "100.001", "ts": "100.002"},
+            {"username": "alice", "text": "standalone", "thread_ts": None, "ts": "100.003"},
+        ]
+        result = _build_channel_summary(messages, "C001", "2026-04-03")
+        assert result["message_count"] == 3
+        assert "alice" in result["participants"]
+        assert "bob" in result["participants"]
+        assert result["threads"] == 1  # one thread with 2+ messages
+
+    def test_build_thread_summary(self):
+        messages = [
+            {"ts": "100.001", "thread_ts": None, "username": "alice", "text": "root"},
+            {"ts": "100.002", "thread_ts": "100.001", "username": "bob", "text": "reply"},
+            {"ts": "200.001", "thread_ts": None, "username": "charlie", "text": "other"},
+        ]
+        result = _build_thread_summary(messages, "C001", "100.001")
+        assert result["message_count"] == 2  # root + reply
+        assert "alice" in result["participants"]
+        assert "bob" in result["participants"]
+        assert "charlie" not in result["participants"]
+
+    def test_build_thread_summary_empty(self):
+        result = _build_thread_summary([], "C001", "999.999")
+        assert result["message_count"] == 0
+        assert result["participants"] == []
+
+
+# ---------------------------------------------------------------------------
+# I/O helper tests (read-only, use temp dirs)
+# ---------------------------------------------------------------------------
+
+
+class TestIOHelpers:
+    """Tests for read-only I/O helpers."""
+
+    def test_count_events_today(self, log_root):
+        count = _count_events_today(log_root)
+        assert count == 4
+
+    def test_count_events_today_no_dir(self, tmp_path):
+        count = _count_events_today(tmp_path / "nonexistent")
+        assert count == 0
+
+    def test_log_size_mb(self, log_root):
+        size = _log_size_mb(log_root)
+        # Files are small but should register as non-negative
+        assert size >= 0.0
+        # Verify there are actual files to measure
+        jsonl_files = list(log_root.rglob("*.jsonl"))
+        assert len(jsonl_files) > 0
+
+    def test_log_size_mb_no_dir(self, tmp_path):
+        size = _log_size_mb(tmp_path / "nonexistent")
+        assert size == 0.0
+
+    def test_last_event_timestamp(self, log_root):
+        ts = _last_event_timestamp(log_root)
+        assert ts is not None
+        assert "2026-04-03" in ts
+
+    def test_last_event_timestamp_empty(self, tmp_path):
+        ts = _last_event_timestamp(tmp_path)
+        assert ts is None
+
+    def test_count_trigger_rules(self, config_dir):
+        count = _count_trigger_rules(config_dir)
+        assert count == 2
+
+    def test_count_trigger_rules_no_dir(self, tmp_path):
+        count = _count_trigger_rules(tmp_path / "nonexistent")
+        assert count == 0
+
+
+class TestBuildStatus:
+    """Tests for the status builder."""
+
+    def test_build_status(self, log_root, config_dir, state_dir):
+        channels = ["C001", "C002"]
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = type("R", (), {"stdout": "inactive"})()
+            status = _build_status(log_root, config_dir, state_dir, channels)
+
+        assert status["connected"] is False
+        assert status["channels_monitored"] == 2
+        assert status["channel_ids"] == ["C001", "C002"]
+        assert status["events_logged_today"] == 4
+        assert status["log_size_mb"] >= 0.0
+        assert status["trigger_rules_loaded"] == 2
+
+    def test_build_status_connected(self, log_root, config_dir, state_dir):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = type("R", (), {"stdout": "active"})()
+            status = _build_status(log_root, config_dir, state_dir, [])
+
+        assert status["connected"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tool handler tests (integration-level, use temp dirs)
+# ---------------------------------------------------------------------------
+
+
+class TestToolHandlers:
+    """Tests for MCP tool handler functions."""
+
+    def test_slack_log_search_empty_query(self):
+        result = json.loads(_handle_slack_log_search({"query": ""}))
+        assert "error" in result
+
+    def test_slack_log_search_jsonl_fallback(self, log_root):
+        """Test JSONL scan fallback when FTS5 is unavailable."""
+        with (
+            patch("mcp_server._get_keyword_index", return_value=None),
+            patch("mcp_server._LOG_ROOT", log_root),
+        ):
+            result = json.loads(_handle_slack_log_search({
+                "query": "deploy",
+                "channel_id": "C001",
+            }))
+            assert result["source"] == "jsonl_scan"
+            assert result["result_count"] >= 1
+
+    def test_slack_log_search_fts5(self, log_root, fts_index, state_dir):
+        """Test FTS5 search when index is available."""
+        with (
+            patch("mcp_server._LOG_ROOT", log_root),
+            patch("mcp_server._STATE_DIR", state_dir),
+        ):
+            from keyword_index import KeywordIndex
+            idx = KeywordIndex(state_dir=state_dir)
+            with patch("mcp_server._get_keyword_index", return_value=idx):
+                result = json.loads(_handle_slack_log_search({
+                    "query": "deploy",
+                }))
+                assert result["source"] == "fts5"
+                assert result["result_count"] >= 1
+
+    def test_slack_channel_summary_missing_channel(self):
+        result = json.loads(_handle_slack_channel_summary({"channel_id": ""}))
+        assert "error" in result
+
+    def test_slack_channel_summary(self, log_root):
+        with patch("mcp_server._LOG_ROOT", log_root):
+            result = json.loads(_handle_slack_channel_summary({
+                "channel_id": "C001",
+            }))
+            assert result["message_count"] == 4
+            assert "alice" in result["participants"]
+
+    def test_slack_thread_summary_missing_params(self):
+        result = json.loads(_handle_slack_thread_summary({}))
+        assert "error" in result
+
+    def test_slack_thread_summary(self, log_root):
+        """Thread summary uses ts to derive date, so create logs at that date too."""
+        # The fixture logs are at today's date. Create a ts that maps to today.
+        today_epoch = datetime.now(timezone.utc).replace(
+            hour=14, minute=0, second=0, microsecond=0
+        ).timestamp()
+        thread_ts = f"{today_epoch:.3f}"
+
+        # Create messages with this thread_ts in the fixture
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        log_file = log_root / "channels" / "C001" / f"{today}.jsonl"
+        with open(log_file, "a") as f:
+            f.write(json.dumps({
+                "ts": thread_ts,
+                "channel_id": "C001",
+                "username": "alice",
+                "text": "thread root",
+                "thread_ts": None,
+            }) + "\n")
+            f.write(json.dumps({
+                "ts": f"{today_epoch + 1:.3f}",
+                "channel_id": "C001",
+                "username": "bob",
+                "text": "reply in thread",
+                "thread_ts": thread_ts,
+            }) + "\n")
+
+        with patch("mcp_server._LOG_ROOT", log_root):
+            result = json.loads(_handle_slack_thread_summary({
+                "channel_id": "C001",
+                "thread_ts": thread_ts,
+            }))
+            assert result["message_count"] >= 1
+
+    def test_slack_status(self, log_root, config_dir, state_dir):
+        with (
+            patch("mcp_server._LOG_ROOT", log_root),
+            patch("mcp_server._CONFIG_DIR", config_dir),
+            patch("mcp_server._STATE_DIR", state_dir),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = type("R", (), {"stdout": "active"})()
+            result = json.loads(_handle_slack_status({}))
+            assert result["connected"] is True
+            assert result["events_logged_today"] == 4
+
+
+class TestSearchLimitCap:
+    """Verify the limit parameter is capped at 200."""
+
+    def test_limit_capped(self, log_root):
+        with (
+            patch("mcp_server._get_keyword_index", return_value=None),
+            patch("mcp_server._LOG_ROOT", log_root),
+        ):
+            result = json.loads(_handle_slack_log_search({
+                "query": "deploy",
+                "limit": 500,
+            }))
+            # The result count should be limited even if 500 was requested
+            assert result["result_count"] <= 200


### PR DESCRIPTION
## Summary

Slack Connector capabilities are now accessible as MCP tools, enabling the dispatcher (and subagents) to search logs, summarize channels/threads, and check status without any Slack API calls — everything reads from the local JSONL log store and SQLite FTS5 index.

**Problem solved:** Before this change, querying Slack logs required manual file reads or custom scripts. Users had no way to ask Lobster "search slack logs for deploy" or "summarize #engineering today" through the standard command interface.

**What's new:**
- `slack_log_search` — full-text search with FTS5→JSONL automatic fallback
- `slack_channel_summary` — structured channel activity for a date/time window
- `slack_thread_summary` — all messages in a specific thread
- `slack_status` — connection state, channels monitored, events logged today, log size, trigger rules

**Functional patterns used:** Pure query functions with no side effects (data in, data out), lazy imports for resilience, composition of small transforms (`_filter_messages_by_query`, `_group_by_thread`, `_build_channel_summary`), I/O isolated at handler boundaries.

**What was NOT changed:** The existing ingress logger, log store, channel config, keyword index, and trigger engine are untouched. This phase only adds a read-only MCP interface on top of them.

### Command flow (after this change)

```
User: "/slack-status"
  → Dispatcher detects trigger, loads skill context
  → behavior/system.md instructs: call slack_status()
  → MCP server reads local files + systemd state
  → Returns JSON: {connected, channels_monitored, events_logged_today, ...}
  → Dispatcher formats and replies

User: "search slack logs for deploy"
  → slack_log_search(query="deploy")
  → Tries FTS5 index first → falls back to JSONL scan if unavailable
  → Returns matching messages with timestamps, authors, text
```

### install.sh change

Step 8 now registers the `slack-connector` MCP server in `~/.claude.json`. Idempotent — skips if already registered, prints manual instructions if `~/.claude.json` doesn't exist.

## Tests run
- [x] `uv run pytest lobster-shop/slack-connector/tests/test_mcp_server.py -v` — 34 passed, 0 failed
- [x] `uv run pytest lobster-shop/slack-connector/tests/ -v` — 234 passed (all existing + new), 0 failed
- [ ] Live MCP server startup test — skipped: requires active Claude Code session with MCP transport
- [ ] Live Slack integration test — skipped: requires active Slack workspace with tokens configured

**Blocked items needing attention before merge:** none

## Manual test
N/A — this change adds a read-only MCP server over local files. No systemd units, cron entries, or external service calls are modified. The install.sh MCP registration is idempotent JSON editing with safe fallback to manual instructions.

Relates to BIS-272

🤖 Generated with [Claude Code](https://claude.com/claude-code)