### PR TITLE
fix: wire bot_talk_mirror into send/receive paths and fix event severity

### DIFF
--- a/src/mcp/bot_talk_mirror.py
+++ b/src/mcp/bot_talk_mirror.py
@@ -246,7 +246,7 @@ def _emit_event_bus(direction: str, from_: str, to: str, content: str) -> None:
         from event_bus import get_event_bus, LobsterEvent  # type: ignore[import]
         event = LobsterEvent(
             event_type="bot_talk.message",
-            severity="info",
+            severity="debug",
             source="bot_talk_mirror",
             payload={
                 "direction": direction,

--- a/src/mcp/event_bus.py
+++ b/src/mcp/event_bus.py
@@ -19,6 +19,8 @@ import json
 import logging
 import os
 import threading
+
+log = logging.getLogger(__name__)
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
 try:
@@ -156,7 +158,21 @@ class EventBus:
         running (e.g. tests, scripts), runs the emit coroutine synchronously.
 
         Never blocks the caller beyond scheduling overhead.
+
+        Logs a warning if no listeners are registered — this indicates
+        init_event_bus() was not called at server startup and events will be
+        silently dropped.
         """
+        with self._lock:
+            no_listeners = len(self._listeners) == 0
+        if no_listeners:
+            log.warning(
+                "EventBus.emit_sync called with no listeners registered — "
+                "init_event_bus() was not called at startup; event will be dropped: "
+                "event_type=%s source=%s",
+                event.event_type,
+                event.source,
+            )
         try:
             loop = asyncio.get_running_loop()
             loop.create_task(self.emit(event))
@@ -358,14 +374,21 @@ _EVENT_BUS: EventBus | None = None
 _BUS_LOCK = threading.Lock()
 
 
+_INIT_CALLED = False  # set to True by init_event_bus(); checked by get_event_bus()
+
+
 def get_event_bus() -> EventBus:
     """
     Return the module-level EventBus singleton.
 
     Thread-safe double-checked locking. The bus is created on first call with
     no listeners registered. Listeners are added by init_event_bus() at server
-    startup. Calling get_event_bus() before init_event_bus() is safe — events
-    emitted before listeners are registered are silently dropped.
+    startup.
+
+    Emitting events before init_event_bus() is called means no listeners are
+    registered and all events are silently dropped. To make this misconfiguration
+    visible, a warning is logged when emit() or emit_sync() is called on a bus
+    with no listeners.
     """
     global _EVENT_BUS
     if _EVENT_BUS is None:

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -4310,7 +4310,7 @@ async def handle_send_reply(args: dict) -> list[TextContent]:
             from bot_talk_mirror import mirror_outbound  # type: ignore[import]
             mirror_outbound(text, source, chat_id)
         except Exception as _bt_exc:
-            log.debug(f"bot-talk mirror_outbound failed (non-fatal): {_bt_exc}")
+            log.warning(f"bot-talk mirror_outbound failed (non-fatal): {_bt_exc}")
 
     # Atomic mark_processed: if message_id provided, move message to processed/ in same call
     mark_info = ""

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -4091,6 +4091,21 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
                     # inbox by bot_talk_mirror.log_inbound_cross_lobster() with source="bot-talk".
                     # We no longer mirror owner Telegram messages to bot-talk from here —
                     # only actual cross-Lobster exchanges belong in bot-talk (issue #1350).
+                    # Emit EventBus event for inbound bot-talk messages so TelegramOutboxListener
+                    # can forward them as debug notifications (issue #1425). The message is
+                    # already in the inbox so we only emit to EventBus, not route again.
+                    if msg.get("source") == "bot-talk" and msg.get("direction") == "INBOUND":
+                        try:
+                            from bot_talk_mirror import _spawn_mirror  # type: ignore[import]
+                            _spawn_mirror(
+                                content=msg.get("text", ""),
+                                genre="status-update",
+                                direction="INBOUND",
+                                from_=msg.get("from", msg.get("user_name", "unknown")),
+                                to=msg.get("to", ""),
+                            )
+                        except Exception as _bt_exc:
+                            log.debug(f"bot-talk EventBus inbound emit failed (non-fatal): {_bt_exc}")
                     if len(messages) >= limit:
                         break
             except Exception as e:
@@ -4287,6 +4302,15 @@ async def handle_send_reply(args: dict) -> list[TextContent]:
         log.debug(f"Recorded task_id dedup for task={task_id_param!r} chat={chat_id}")
 
     log.info(f"Reply sent to {source} chat {chat_id}")
+
+    # Mirror outbound bot-talk messages to the EventBus so TelegramOutboxListener
+    # can forward them as debug notifications. Fire-and-forget: non-blocking.
+    if source == "bot-talk":
+        try:
+            from bot_talk_mirror import mirror_outbound  # type: ignore[import]
+            mirror_outbound(text, source, chat_id)
+        except Exception as _bt_exc:
+            log.debug(f"bot-talk mirror_outbound failed (non-fatal): {_bt_exc}")
 
     # Atomic mark_processed: if message_id provided, move message to processed/ in same call
     mark_info = ""

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -297,3 +297,15 @@ class TestSingleton:
             bus2 = init_event_bus(jsonl_path=path)
             assert bus1 is bus2
             assert len(bus2._listeners) == listener_count_after_first
+
+    def test_emit_sync_warns_when_no_listeners_registered(self, caplog):
+        """emit_sync on a bus with no listeners logs a warning — missing init_event_bus() call."""
+        import logging
+        bus = EventBus()
+        event = make_event(event_type="bot_talk.message", source="bot_talk_mirror")
+        with caplog.at_level(logging.WARNING, logger="event_bus"):
+            bus.emit_sync(event)
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("init_event_bus" in msg for msg in warning_messages), (
+            "Expected a warning mentioning init_event_bus when no listeners are registered"
+        )

--- a/tests/unit/test_mcp_server/test_bot_talk_mirror.py
+++ b/tests/unit/test_mcp_server/test_bot_talk_mirror.py
@@ -323,7 +323,7 @@ class TestEmitEventBus:
         assert len(captured_events) == 1
         event_kwargs = captured_events[0]
         assert event_kwargs["event_type"] == "bot_talk.message"
-        assert event_kwargs["severity"] == "info"
+        assert event_kwargs["severity"] == "debug"
         payload = event_kwargs["payload"]
         assert payload["direction"] == "OUTBOUND"
         assert payload["from"] == "SaharLobster"
@@ -574,3 +574,56 @@ class TestSpawnMirror:
             called.wait(timeout=2.0)
 
         assert called.is_set(), "_do_mirror was not called within 2 seconds"
+
+
+# ---------------------------------------------------------------------------
+# Severity: bot_talk.message events must be emitted at debug (not info)
+# ---------------------------------------------------------------------------
+
+class TestEventSeverity:
+    def test_emit_event_bus_uses_debug_severity(self):
+        """bot_talk.message events must be emitted at debug severity (issue #1425).
+
+        TelegramOutboxListener is gated on LOBSTER_DEBUG=true and only forwards
+        warn, error, and debug events. info events are silently dropped.
+        Severity must be 'debug' for the existing listener to pick them up.
+        """
+        captured_events = []
+
+        mock_event_class = MagicMock(side_effect=lambda **kw: kw)
+        mock_bus = MagicMock()
+        mock_bus.emit_sync.side_effect = lambda e: captured_events.append(e)
+
+        with patch.dict("sys.modules", {
+            "event_bus": MagicMock(
+                get_event_bus=MagicMock(return_value=mock_bus),
+                LobsterEvent=mock_event_class,
+            )
+        }):
+            btm._emit_event_bus("OUTBOUND", "SaharLobster", "AlbertLobster", "test")
+
+        assert len(captured_events) == 1
+        assert captured_events[0]["severity"] == "debug", (
+            f"Expected severity='debug', got {captured_events[0]['severity']!r}. "
+            "TelegramOutboxListener only handles debug/warn/error; info is silently dropped."
+        )
+
+    def test_emit_event_bus_does_not_use_info_severity(self):
+        """info severity must no longer be used — it bypasses TelegramOutboxListener."""
+        captured_events = []
+
+        mock_event_class = MagicMock(side_effect=lambda **kw: kw)
+        mock_bus = MagicMock()
+        mock_bus.emit_sync.side_effect = lambda e: captured_events.append(e)
+
+        with patch.dict("sys.modules", {
+            "event_bus": MagicMock(
+                get_event_bus=MagicMock(return_value=mock_bus),
+                LobsterEvent=mock_event_class,
+            )
+        }):
+            btm._emit_event_bus("INBOUND", "AlbertLobster", "SaharLobster", "test")
+
+        assert captured_events[0]["severity"] != "info", (
+            "Severity must not be 'info' — TelegramOutboxListener drops info events."
+        )


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

Closes #1425

## What was broken

Bot-talk EventBus notifications never fired. The root cause was a single gap in the wiring: `mirror_outbound()` and the inbound EventBus emit were never called from `inbox_server.py`. Bot-talk messages bypassed the EventBus entirely.

**Gap 1 (blocker):** `mirror_outbound()` and the inbound EventBus emit were never called from `inbox_server.py`. Bot-talk messages (in both directions) bypassed the EventBus entirely. This is the only gap that prevented notifications from firing.

**Gap 2 (harmless cleanup):** `_emit_event_bus()` used `severity="info"`. `TelegramOutboxListener` accepts `debug`, `warn`, and `error` events. Info events would have been dropped — but this gap was never reached because Gap 1 prevented any EventBus emit from occurring. Changing to `severity="debug"` is a correctness fix but did not unblock anything on its own.

## What changed

**`bot_talk_mirror.py`** — one line: `severity="info"` → `severity="debug"` in `_emit_event_bus()`. No other changes to this file.

**`inbox_server.py`** — three call sites changed/added:

- **Outbound:** after the atomic write in `handle_send_reply`, when `source == "bot-talk"`, calls `mirror_outbound(text, source, chat_id)`. Fire-and-forget; exceptions are caught and logged at WARNING (not debug) so failures surface in production logs.

- **Inbound:** in `check_inbox`, after reading a message with `source="bot-talk"` and `direction="INBOUND"`, calls `_spawn_mirror()` directly (not `log_inbound_cross_lobster`) to emit to EventBus. The message is already in the inbox at this point — calling `log_inbound_cross_lobster` would also invoke `_route_to_inbox` and create a duplicate inbox entry.

- **Startup guard exception log level:** `mirror_outbound` failure catch changed from `log.debug` to `log.warning` so failures are visible in production.

**`event_bus.py`** — `emit_sync()` now logs a WARNING if called with no listeners registered, making it immediately visible if `init_event_bus()` was not called at server startup and all events would silently drop.

**`test_bot_talk_mirror.py`** — existing severity assertion updated from `"info"` to `"debug"`; new `TestEventSeverity` class added.

**`test_event_bus.py`** — new test `test_emit_sync_warns_when_no_listeners_registered` verifies the startup guard.

## Flow after this change

```
Outbound (Lobster → bot-talk):
  send_reply(source="bot-talk")
    → atomic write to outbox
    → mirror_outbound(text, source, chat_id)   ← NEW
        → _spawn_mirror (daemon thread)
        → _do_mirror → _emit_event_bus (severity=debug)  ← FIXED
        → TelegramOutboxListener fires → Telegram notification

Inbound (bot-talk → Lobster):
  lobstertalk-unified writes to inbox with source="bot-talk", direction="INBOUND"
  check_inbox reads message
    → _spawn_mirror(INBOUND, from, to)   ← NEW
        → _do_mirror → _emit_event_bus (severity=debug)  ← FIXED
        → TelegramOutboxListener fires → Telegram notification
```

## Functional patterns

Pure functions (`_build_http_payload`, `_build_ssh_log_line`, `_build_auth_headers`) are unchanged. The new call sites follow the existing fire-and-forget pattern: exceptions are caught at the boundary, never propagating into the message delivery path. Side effects are isolated to daemon threads.

## What is NOT changed

- `log_inbound_cross_lobster()` public API is unchanged
- `_route_to_inbox()` behavior is unchanged
- `TelegramOutboxListener` is unchanged (no new listener needed)
- The hourly lobstertalk-unified cron job is unchanged
- All existing behavior for non-bot-talk sources is unaffected

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_bot_talk_mirror.py -v` — 47 passed, 0 failed
- [x] `uv run pytest tests/unit/test_event_bus.py -v` — 26 passed, 0 failed (includes new startup-guard test)
- [x] `uv run pytest tests/unit/test_mcp_server/ -q` — 647 passed, 65 failed (65 pre-existing failures in `test_debug_alerts.py` and `test_write_observation.py` confirmed on both base branch and this branch — not caused by this PR)

## Manual test

N/A — this change wires EventBus calls that fire only when `LOBSTER_DEBUG=true` is set and a bot-talk message is processed. No change to production message delivery; no external service calls in the new code paths. The actual Telegram notification path (TelegramOutboxListener) is unchanged and was already covered by its own tests.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (no external service calls in changed paths)
- [x] User-visible outcome: Telegram debug notifications for bot-talk will fire once LOBSTER_DEBUG=true; not testable without a live bot-talk partner
- [x] Side-effect audit: fire-and-forget daemon threads, exceptions caught, no floods or shared state writes
- [x] External service calls: mocked in tests; no new production calls introduced