### PR TITLE
fix(health-check): remove invalid auth flag; make apt GPG failures self-healing

### DIFF
--- a/scripts/daily-health-check.sh
+++ b/scripts/daily-health-check.sh
@@ -111,12 +111,64 @@ update_system_packages() {
 
     if command -v apt-get &>/dev/null; then
         log "INFO: update_system_packages: using apt-get"
-        if ${sudo_prefix}apt-get update -q &>>"$LOG_FILE" && \
-           ${sudo_prefix}apt-get upgrade -y -q &>>"$LOG_FILE"; then
-            log "OK: system packages updated (apt-get)"
-        else
-            log "ERROR: system packages update failed (apt-get)"
-            FAILURES+=("system-packages-apt-get")
+        # Run apt-get update and capture output so we can inspect it for GPG
+        # key errors before deciding whether to fail the health check.
+        local apt_update_out
+        apt_update_out=$(${sudo_prefix}apt-get update -q 2>&1 | tee -a "$LOG_FILE")
+        local apt_update_rc=${PIPESTATUS[0]}
+
+        # Detect untrusted GPG key errors (NO_PUBKEY / not signed).
+        # A stale or corrupt third-party keyring (e.g. cli.github.com) causes
+        # apt-get update to exit non-zero but does not mean the system is
+        # unhealthy — it just means one repo's key needs refreshing.
+        # Strategy:
+        #   1. If NO_PUBKEY is reported for the GitHub CLI repo, attempt to
+        #      refresh the keyring automatically and retry apt-get update.
+        #   2. If update still fails only due to GPG errors (not package
+        #      conflicts or network outages), log a warning but do not fail the
+        #      health check — GPG issues are a configuration matter, not a
+        #      system outage.
+        #   3. If update fails for non-GPG reasons, fail as usual.
+        if echo "$apt_update_out" | grep -q "NO_PUBKEY"; then
+            log "WARN: apt-get update reported untrusted GPG key(s) — checking for known fixable repos"
+            # Self-heal: refresh GitHub CLI keyring if that specific repo is affected
+            if echo "$apt_update_out" | grep -q "cli.github.com"; then
+                log "INFO: Attempting to refresh GitHub CLI apt keyring..."
+                local keyring_path="/etc/apt/keyrings/githubcli-archive-keyring.gpg"
+                if ${sudo_prefix}curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+                       | ${sudo_prefix}dd of="$keyring_path" 2>/dev/null; then
+                    log "INFO: GitHub CLI keyring refreshed — retrying apt-get update"
+                    apt_update_out=$(${sudo_prefix}apt-get update -q 2>&1 | tee -a "$LOG_FILE")
+                    apt_update_rc=${PIPESTATUS[0]}
+                else
+                    log "WARN: Could not refresh GitHub CLI keyring (no network or permission issue)"
+                fi
+            fi
+        fi
+
+        if [ $apt_update_rc -ne 0 ]; then
+            # Check if remaining failures are ALL GPG-related (NO_PUBKEY / not signed).
+            # If so, treat as a warning — apt-get upgrade can still update packages
+            # from repos whose keys ARE trusted. Extract only E: lines, then check
+            # whether any of them are NOT about GPG key trust issues.
+            local non_gpg_errors
+            non_gpg_errors=$(echo "$apt_update_out" | grep "^E:" | grep -vE "NO_PUBKEY|not signed" || true)
+            if [ -z "$non_gpg_errors" ]; then
+                log "WARN: apt-get update has GPG key warnings only — proceeding with upgrade for trusted repos"
+                apt_update_rc=0
+            else
+                log "ERROR: apt-get update failed (non-GPG error): $non_gpg_errors"
+                FAILURES+=("system-packages-apt-get-update")
+            fi
+        fi
+
+        if [ $apt_update_rc -eq 0 ]; then
+            if ${sudo_prefix}apt-get upgrade -y -q &>>"$LOG_FILE"; then
+                log "OK: system packages updated (apt-get)"
+            else
+                log "ERROR: apt-get upgrade failed"
+                FAILURES+=("system-packages-apt-get")
+            fi
         fi
     elif command -v dnf &>/dev/null; then
         log "INFO: update_system_packages: using dnf"

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -1054,7 +1054,7 @@ check_disk() {
 #
 # Auth is managed via CLAUDE_CODE_OAUTH_TOKEN env var in lobster-config/config.env.
 # The token is passed directly to Claude Code — no credentials file is involved.
-# `claude auth status --output-format json` is the authoritative check regardless
+# `claude auth status` is the authoritative check regardless
 # of how the token was provisioned.
 #
 # RESTART GUARD: When AUTH RED is detected, do NOT restart Claude — restarting
@@ -1071,9 +1071,13 @@ check_auth_token() {
     # Single check: `claude auth status` is the authoritative source of truth.
     # Auth is managed via CLAUDE_CODE_OAUTH_TOKEN env var in config.env.
     # Unset CLAUDECODE/CLAUDE_CODE_ENTRYPOINT to avoid nested-session errors.
+    #
+    # NOTE: `claude auth status` outputs JSON by default. Do NOT pass
+    # --output-format json — that flag does not exist and causes an error,
+    # leaving auth_json empty and making the parse return "unknown" every run.
     local auth_json
     auth_json=$(env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT \
-        claude auth status --output-format json 2>/dev/null)
+        claude auth status 2>/dev/null)
 
     local logged_in auth_method
     logged_in=$(echo "$auth_json" | python3 -c "


### PR DESCRIPTION
## What's broken

Two persistent health check alerts with no actionable signal:

### 1. AUTH YELLOW (every 4 minutes)

`check_auth_token()` called `claude auth status --output-format json`, but that flag doesn't exist — the command exits with `error: unknown option '--output-format'`, leaving `auth_json` empty. The JSON parser then returns `"unknown"`, which fires YELLOW on every health check cycle.

**Root cause:** `claude auth status` already outputs JSON by default. The `--output-format json` flag was written speculatively but was never valid.

**Fix:** Remove the flag. `claude auth status 2>/dev/null` returns valid JSON. Also updated the stale comment in the section header.

### 2. Daily apt GPG failure (`cli.github.com` key `23F3D4EA75716059`)

The GitHub CLI keyring at `/etc/apt/keyrings/githubcli-archive-keyring.gpg` was corrupt (gpg reports "Invalid packet"), causing `apt-get update` to exit non-zero and the daily health check to report a hard failure every morning.

**Root cause:** The keyring file is binary and can be corrupted silently. The previous code had no GPG error handling — any `apt-get update` failure was a hard health check failure.

**Fix:** Three-layer response:
1. **Auto-detect:** capture `apt-get update` output; check for `NO_PUBKEY`
2. **Self-heal:** if the GitHub CLI repo is affected, automatically refresh the keyring via `curl` and retry `apt-get update`
3. **Graceful degradation:** if update still fails but only for GPG reasons (no non-GPG `E:` lines), treat as a warning and continue with `apt-get upgrade` for trusted repos. Non-GPG failures still fail the check.

Also refreshed the live keyring directly (`gpg` now shows valid key expires 2026-09-05).

## Design notes

Both bugs share a pattern: **fragile output parsing of external tools**. The auth check assumed a CLI flag existed without testing it. The apt check assumed any non-zero exit = hard failure without inspecting why.

No other design inconsistencies requiring fixes were found in this pass. The duplicated state tracking (`booted_at` written by both `claude-persistent.sh` and `health-check-v3.sh`) is intentional and correct. The restart/hibernation race condition was already fixed in #1426.

## Test plan

- [ ] Run `env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT claude auth status` — should return JSON with `loggedIn: true`
- [ ] Confirm next health check cycle shows AUTH GREEN, not YELLOW
- [ ] Run `sudo apt-get update` — should succeed without GPG errors
- [ ] Run `daily-health-check.sh` manually — should show OK for system packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)