### PR TITLE
fix: PID-based session-lost guard (#1429) + context-monitor WARN logging (#1430)

### DIFF
--- a/hooks/context-monitor.py
+++ b/hooks/context-monitor.py
@@ -8,6 +8,15 @@ so the dispatcher can enter wind-down mode and trigger a graceful restart.
 
 Dedup: once a warning is written, /tmp/lobster-context-warning-sent is touched
 so subsequent hook firings skip the write until the flag is cleared on restart.
+
+Issue #1430: Claude Code does NOT populate context_window in PostToolUse payloads
+for MCP tool calls — only for built-in tools like Bash.  Previously the hook
+silently returned when context_window was None, making "hook fired, no data"
+indistinguishable from "hook never fired."
+
+Fix: when context_window is absent, log a WARN entry so the log records that the
+hook fired.  The hook matcher in settings.json was also broadened to include Bash
+(which does carry context_window), ensuring real usage data is captured.
 """
 import json
 import sys
@@ -38,6 +47,21 @@ def _build_log_entry(tool_name: str, used_pct: float, remaining_pct: float, cont
     }
 
 
+def _build_absent_context_entry(tool_name: str) -> dict:
+    """Return a WARN log entry for when context_window is absent from the payload.
+
+    This makes 'hook fired, no data' distinguishable from 'hook never fired'.
+    Claude Code only populates context_window for built-in tools (e.g. Bash),
+    not for MCP tool calls.
+    """
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "tool": tool_name,
+        "context_window_absent": True,
+        "warn": f"[WARN] context_window absent in payload for tool: {tool_name}",
+    }
+
+
 def _build_warning_message(used_pct: float) -> dict:
     """Return the context_warning inbox message payload."""
     return {
@@ -58,32 +82,60 @@ def _write_warning_to_inbox(inbox_dir: Path, message: dict) -> None:
     (inbox_dir / filename).write_text(json.dumps(message, indent=2))
 
 
+def _handle_payload(
+    data: dict,
+    log_dir: Path | None = None,
+    inbox_dir: Path | None = None,
+) -> None:
+    """Process a single PostToolUse payload.
+
+    Accepts log_dir and inbox_dir as injectable parameters so tests can verify
+    behavior without touching the real filesystem.  When not provided, defaults
+    to the standard runtime paths.
+    """
+    if log_dir is None:
+        log_dir = Path.home() / "lobster-workspace" / "logs"
+    if inbox_dir is None:
+        inbox_dir = Path.home() / "messages" / "inbox"
+
+    tool_name = data.get("tool_name", "unknown")
+    context = data.get("context_window")
+
+    if context is None:
+        # Hook fired but Claude Code did not provide context_window data.
+        # Log a WARN entry so the log shows the hook is running even when no
+        # usage data is available (distinguishes "no data" from "not firing").
+        entry = _build_absent_context_entry(tool_name)
+        _log_usage(log_dir, entry)
+        return
+
+    used_pct = context.get("used_percentage")
+    remaining_pct = context.get("remaining_percentage")
+
+    if used_pct is None:
+        entry = _build_absent_context_entry(tool_name)
+        _log_usage(log_dir, entry)
+        return
+
+    entry = _build_log_entry(tool_name, used_pct, remaining_pct, context)
+    _log_usage(log_dir, entry)
+
+    if used_pct < WARNING_THRESHOLD:
+        return
+
+    # At or above threshold — write a context_warning to inbox (once per session)
+    if DEDUP_FLAG.exists():
+        return
+
+    message = _build_warning_message(used_pct)
+    _write_warning_to_inbox(inbox_dir, message)
+    DEDUP_FLAG.touch()
+
+
 def main() -> None:
     try:
         data = json.load(sys.stdin)
-        context = data.get("context_window", {})
-        used_pct = context.get("used_percentage")
-        remaining_pct = context.get("remaining_percentage")
-
-        if used_pct is None:
-            return
-
-        log_dir = Path.home() / "lobster-workspace" / "logs"
-        entry = _build_log_entry(data.get("tool_name", "unknown"), used_pct, remaining_pct, context)
-        _log_usage(log_dir, entry)
-
-        if used_pct < WARNING_THRESHOLD:
-            return
-
-        # At or above threshold — write a context_warning to inbox (once per session)
-        if DEDUP_FLAG.exists():
-            return
-
-        inbox_dir = Path.home() / "messages" / "inbox"
-        message = _build_warning_message(used_pct)
-        _write_warning_to_inbox(inbox_dir, message)
-        DEDUP_FLAG.touch()
-
+        _handle_payload(data)
     except Exception:
         pass  # Never block tool use
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2393,6 +2393,36 @@ CREATE TABLE IF NOT EXISTS dispatcher_lock (
         migrated=$((migrated + 1))
     fi
 
+    # Migration 68: Broaden context-monitor PostToolUse hook matcher to include Bash
+    # (issue #1430). Claude Code only populates context_window in PostToolUse payloads
+    # for built-in tools like Bash, not for MCP tool calls. The previous matcher
+    # "mcp__lobster-inbox__|Agent" caused the hook to fire but always see no data.
+    # Adding "Bash|" to the front ensures the hook receives context_window data.
+    if [ -f "$CLAUDE_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
+        local has_bash_in_matcher
+        has_bash_in_matcher=$(jq -r '
+            [.hooks.PostToolUse[]? | select(.hooks[]?.command | contains("context-monitor")) | .matcher]
+            | map(select(startswith("Bash|")))
+            | length
+        ' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+        if [ "${has_bash_in_matcher:-0}" = "0" ] || [ "${has_bash_in_matcher:-0}" = "" ]; then
+            TMP_SETTINGS=$(mktemp)
+            jq '
+                .hooks.PostToolUse = [
+                    .hooks.PostToolUse[]? |
+                    if (.hooks[]?.command | contains("context-monitor"))
+                    then .matcher = ("Bash|" + .matcher)
+                    else .
+                    end
+                ]
+            ' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+            substep "Broadened context-monitor hook matcher to include Bash (issue #1430)"
+            migrated=$((migrated + 1))
+        else
+            substep "context-monitor hook matcher already includes Bash — skipping"
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -663,6 +663,13 @@ HEARTBEAT_FILE = _WORKSPACE / "logs" / "claude-heartbeat"
 # Hibernation state file - tracks whether Lobster is active or hibernating
 LOBSTER_STATE_FILE = CONFIG_DIR / "lobster-state.json"
 
+# Dispatcher PID file — written by claude-persistent.sh when it exec-replaces
+# itself with the claude binary.  The file contains the PID of the running
+# claude process.  Used by _is_dispatcher_alive() to distinguish a true
+# mid-session MCP reconnect (dispatcher alive) from a real session loss
+# (dispatcher dead or absent).  See issue #1429.
+DISPATCHER_PID_FILE = CONFIG_DIR / "dispatcher.pid"
+
 # Reset state to "active" on startup — this is the fix for the critical bug where
 # state was never reset after waking from hibernation.
 # The bot issues systemctl restart → Claude starts → this module loads → state resets.
@@ -682,6 +689,38 @@ LOBSTER_STATE_FILE = CONFIG_DIR / "lobster-state.json"
 # check about session age and causing unnecessary restarts (issue #910).
 _TRANSIENT_MODES = {"hibernate", "starting", "restarting", "waking"}
 _RECONNECT_GRACE_SECONDS = 30 * 60  # 30 minutes
+
+
+def _is_dispatcher_alive() -> bool:
+    """Return True if the dispatcher process recorded in dispatcher.pid is alive.
+
+    Reads DISPATCHER_PID_FILE (written by claude-persistent.sh via exec-replace).
+    Uses kill -0 to test liveness without sending a signal.
+
+    Returns False when:
+    - The file is absent (first boot, or cleaned up on clean exit)
+    - The file is empty or contains a non-numeric value (corrupt)
+    - The PID is 0 or negative (invalid)
+    - kill -0 raises PermissionError or ProcessLookupError (dead process)
+
+    A True return means the claude process is still alive → this MCP restart
+    is a mid-session reconnect, NOT a real session loss.
+
+    A False return means the dispatcher is dead → write the session-lost-reminder.
+    """
+    try:
+        if not DISPATCHER_PID_FILE.exists():
+            return False
+        raw = DISPATCHER_PID_FILE.read_text().strip()
+        if not raw:
+            return False
+        pid = int(raw)
+        if pid <= 0:
+            return False
+        os.kill(pid, 0)  # kill -0: raises if process does not exist
+        return True
+    except (ValueError, ProcessLookupError, OSError):
+        return False
 
 
 def _reset_state_on_startup():
@@ -950,10 +989,15 @@ def _write_session_lost_reminder() -> None:
     reconnects and calls wait_for_messages, it immediately receives a prompt
     to re-orient and resume the main loop.
 
-    Guard: skipped when the lobster-state file indicates a mid-session MCP
-    reconnect (mode=active AND file age < 30 min).  That pattern means Claude
-    Code auto-updated or the HTTP transport briefly cycled — the dispatcher was
-    NOT blocked in a dead session and does not need to re-orient.
+    Guard: skipped when the dispatcher PID (from dispatcher.pid) is alive.  A
+    live PID means Claude Code auto-updated or the HTTP transport briefly
+    cycled — the dispatcher process is still running and does not need to
+    re-orient.  A dead or absent PID means real session loss.
+
+    Previous guard (issue #1429 — removed): checked lobster-state.json mtime
+    < 30 min.  This produced false negatives when cron jobs touched the state
+    file seconds before an MCP restart, making a real session loss look like a
+    reconnect.
 
     Idempotent: writing an extra compact-reminder during a real restart is
     harmless; the dispatcher processes it as a routine self-check message.
@@ -966,20 +1010,22 @@ def _write_session_lost_reminder() -> None:
         log.info("[session-lost] LOBSTER_DEV_MODE active — skipping session-lost-reminder")
         return
     try:
-        # Same reconnect-detection guard used by _reset_state_on_startup.
-        if LOBSTER_STATE_FILE.exists():
-            try:
-                state_data = json.loads(LOBSTER_STATE_FILE.read_text())
-                mode = state_data.get("mode", "active")
-                file_age = time.time() - LOBSTER_STATE_FILE.stat().st_mtime
-                if mode not in _TRANSIENT_MODES and file_age < _RECONNECT_GRACE_SECONDS:
-                    log.info(
-                        "[session-lost] Skipping session-lost-reminder: mid-session MCP "
-                        f"reconnect detected (mode={mode!r}, age={file_age:.0f}s)"
-                    )
-                    return
-            except Exception:  # noqa: BLE001
-                pass  # Can't read state — fall through and write the reminder
+        # PID-based reconnect guard (issue #1429).
+        #
+        # Previous guard (broken): checked lobster-state.json mtime < 30 min.
+        # Problem: cron jobs can touch lobster-state.json moments before an MCP
+        # restart, making the file look fresh even when the dispatcher is dead.
+        #
+        # New guard: check whether the dispatcher PID (from dispatcher.pid) is
+        # still alive via kill -0.  A live PID means Claude Code auto-updated
+        # its transport layer — the dispatcher is still running.  A dead or
+        # absent PID means the dispatcher process is gone — real session loss.
+        if _is_dispatcher_alive():
+            log.info(
+                "[session-lost] Skipping session-lost-reminder: dispatcher PID is alive "
+                f"(pid_file={DISPATCHER_PID_FILE})"
+            )
+            return
 
         now_utc = datetime.now(timezone.utc)
         reminder_id = f"session-lost-{int(now_utc.timestamp())}"

--- a/tests/unit/test_hooks/test_context_monitor.py
+++ b/tests/unit/test_hooks/test_context_monitor.py
@@ -1,0 +1,210 @@
+"""
+Unit tests for hooks/context-monitor.py (issue #1430).
+
+Root cause: the hook silently returned when context_window was None (typical for
+MCP tool PostToolUse payloads).  This made "hook fired, no data" indistinguishable
+from "hook never fired."
+
+Fixes verified:
+1. When context_window is absent, the hook logs a WARN entry to context-monitor.log
+   instead of silently returning.
+2. The hook continues to log usage and write warnings when context_window is present.
+3. The WARN log entry contains the tool name and indicates context_window was absent.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from datetime import datetime, timezone
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "context-monitor.py"
+
+# Named constant matching the spec — the log line prefix is load-bearing
+# for any downstream log parser.
+WARN_PREFIX_ABSENT_CONTEXT = "[WARN] context_window absent"
+
+
+def _load_hook():
+    """Load context-monitor as a module without executing main()."""
+    spec = importlib.util.spec_from_file_location("context_monitor", _HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _read_log(log_dir: Path) -> list[dict]:
+    log_file = log_dir / "context-monitor.log"
+    if not log_file.exists():
+        return []
+    return [json.loads(line) for line in log_file.read_text().splitlines() if line.strip()]
+
+
+class TestContextMonitorAbsentContextWindow:
+    """When context_window is absent, hook must log a WARN rather than silently return."""
+
+    def test_logs_warn_when_context_window_is_none(self, tmp_path, monkeypatch):
+        """Payload with no context_window key → WARN written to log."""
+        mod = _load_hook()
+        monkeypatch.setattr(mod.Path, "home", lambda: tmp_path)
+
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True)
+
+        payload = {"tool_name": "mcp__lobster-inbox__wait_for_messages"}
+        mod._handle_payload(payload, log_dir=log_dir)
+
+        entries = _read_log(log_dir)
+        assert len(entries) == 1, f"Expected 1 log entry, got {len(entries)}: {entries}"
+        entry = entries[0]
+        assert "context_window_absent" in entry or WARN_PREFIX_ABSENT_CONTEXT in str(entry), (
+            f"Expected warn entry for absent context_window, got: {entry}"
+        )
+        assert entry.get("tool") == "mcp__lobster-inbox__wait_for_messages"
+
+    def test_warn_entry_includes_tool_name(self, tmp_path, monkeypatch):
+        """WARN log entry must record which tool triggered the missing context_window."""
+        mod = _load_hook()
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True)
+
+        payload = {"tool_name": "Bash"}
+        mod._handle_payload(payload, log_dir=log_dir)
+
+        entries = _read_log(log_dir)
+        assert len(entries) >= 1
+        entry = entries[0]
+        assert entry.get("tool") == "Bash", (
+            f"Expected tool='Bash' in warn entry, got: {entry}"
+        )
+
+    def test_no_inbox_message_written_when_context_absent(self, tmp_path, monkeypatch):
+        """Missing context_window should never trigger a context_warning inbox message."""
+        mod = _load_hook()
+        inbox_dir = tmp_path / "messages" / "inbox"
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True)
+
+        payload = {"tool_name": "mcp__lobster-inbox__mark_processed"}
+        mod._handle_payload(payload, log_dir=log_dir, inbox_dir=inbox_dir)
+
+        inbox_files = list(inbox_dir.glob("*.json"))
+        assert len(inbox_files) == 0, (
+            f"No inbox message should be written for absent context_window, "
+            f"but found: {inbox_files}"
+        )
+
+
+class TestContextMonitorNormalOperation:
+    """When context_window is present, existing behavior must be preserved."""
+
+    def test_logs_usage_below_threshold(self, tmp_path):
+        """context_window present, below threshold → usage entry logged."""
+        mod = _load_hook()
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True)
+
+        payload = {
+            "tool_name": "Bash",
+            "context_window": {
+                "used_percentage": 45.0,
+                "remaining_percentage": 55.0,
+            },
+        }
+        mod._handle_payload(payload, log_dir=log_dir)
+
+        entries = _read_log(log_dir)
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["used_percentage"] == 45.0
+        assert entry["tool"] == "Bash"
+        # Should NOT have context_window_absent flag
+        assert not entry.get("context_window_absent", False)
+
+    def test_writes_inbox_warning_at_threshold(self, tmp_path):
+        """At or above WARNING_THRESHOLD → context_warning written to inbox."""
+        mod = _load_hook()
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        inbox_dir = tmp_path / "messages" / "inbox"
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        dedup_flag = tmp_path / "lobster-context-warning-sent"
+
+        # Patch paths
+        original_dedup = mod.DEDUP_FLAG
+        mod.DEDUP_FLAG = dedup_flag
+
+        try:
+            payload = {
+                "tool_name": "Bash",
+                "context_window": {
+                    "used_percentage": 75.0,
+                    "remaining_percentage": 25.0,
+                },
+            }
+            mod._handle_payload(payload, log_dir=log_dir, inbox_dir=inbox_dir)
+        finally:
+            mod.DEDUP_FLAG = original_dedup
+
+        inbox_files = list(inbox_dir.glob("context-warning-*.json"))
+        assert len(inbox_files) == 1
+        msg = json.loads(inbox_files[0].read_text())
+        assert msg["type"] == "context_warning"
+        assert msg["used_percentage"] == 75.0
+
+    def test_dedup_suppresses_second_warning(self, tmp_path):
+        """Dedup flag present → second warning is not written."""
+        mod = _load_hook()
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        inbox_dir = tmp_path / "messages" / "inbox"
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        dedup_flag = tmp_path / "lobster-context-warning-sent"
+        dedup_flag.touch()  # Already flagged
+
+        original_dedup = mod.DEDUP_FLAG
+        mod.DEDUP_FLAG = dedup_flag
+        try:
+            payload = {
+                "tool_name": "Bash",
+                "context_window": {
+                    "used_percentage": 80.0,
+                    "remaining_percentage": 20.0,
+                },
+            }
+            mod._handle_payload(payload, log_dir=log_dir, inbox_dir=inbox_dir)
+        finally:
+            mod.DEDUP_FLAG = original_dedup
+
+        inbox_files = list(inbox_dir.glob("context-warning-*.json"))
+        assert len(inbox_files) == 0, "Dedup flag should suppress second warning"
+
+
+class TestContextMonitorHandlePayloadSignature:
+    """_handle_payload() must accept log_dir and inbox_dir as parameters.
+
+    This verifies the hook is refactored to accept injected paths (enabling
+    the tests above) rather than hardcoding Path.home().
+    """
+
+    def test_handle_payload_accepts_log_dir_kwarg(self, tmp_path):
+        """_handle_payload() must accept a log_dir keyword argument."""
+        mod = _load_hook()
+        import inspect
+        sig = inspect.signature(mod._handle_payload)
+        assert "log_dir" in sig.parameters, (
+            "_handle_payload() must accept log_dir= for testability"
+        )
+
+    def test_handle_payload_accepts_inbox_dir_kwarg(self, tmp_path):
+        """_handle_payload() must accept an inbox_dir keyword argument."""
+        mod = _load_hook()
+        import inspect
+        sig = inspect.signature(mod._handle_payload)
+        assert "inbox_dir" in sig.parameters, (
+            "_handle_payload() must accept inbox_dir= for testability"
+        )

--- a/tests/unit/test_session_lost_reminder_pid_guard.py
+++ b/tests/unit/test_session_lost_reminder_pid_guard.py
@@ -1,0 +1,275 @@
+"""
+Unit tests for the PID-based reconnect guard in _write_session_lost_reminder()
+(issue #1429).
+
+Root cause: the old guard checked lobster-state.json mtime (< 30 min) to detect
+mid-session MCP reconnects.  Cron jobs that update the state file seconds before
+an MCP restart caused false negatives — the guard saw a fresh file and suppressed
+the session-lost reminder even though the dispatcher was actually dead.
+
+Fix: check whether the dispatcher PID (from ~/messages/config/dispatcher.pid) is
+alive via kill -0.  If the PID is alive → true reconnect → suppress.  If the PID
+is absent or dead → real session loss → write the reminder.
+
+These tests exercise _is_dispatcher_alive() in isolation (by loading the function
+from inbox_server.py source) and verify the full _write_session_lost_reminder()
+flow via the inbox_server module (using a minimal patched environment).
+"""
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers to extract _is_dispatcher_alive() from inbox_server.py source
+# ---------------------------------------------------------------------------
+
+_SRC_MCP_DIR = Path(__file__).parents[2] / "src" / "mcp"
+_SERVER_PATH = _SRC_MCP_DIR / "inbox_server.py"
+
+# Named constant matching the spec.
+DISPATCHER_PID_FILENAME = "dispatcher.pid"
+
+
+def _extract_is_dispatcher_alive(dispatcher_pid_path: Path):
+    """Extract _is_dispatcher_alive() from inbox_server.py source into a callable.
+
+    Returns a namespace dict containing the function.
+    """
+    src = _SERVER_PATH.read_text()
+
+    start_marker = "def _is_dispatcher_alive("
+    start_idx = src.find(start_marker)
+    assert start_idx != -1, "_is_dispatcher_alive() not found in inbox_server.py"
+
+    # Find the next top-level def/class after this function
+    lines = src[start_idx:].split("\n")
+    end_line = len(lines)
+    for i, line in enumerate(lines[1:], 1):
+        if line and line[0] not in (" ", "\t", "\n", "#", ""):
+            end_line = i
+            break
+
+    snippet = "\n".join(lines[:end_line])
+
+    ns = {
+        "os": os,
+        "Path": Path,
+        "DISPATCHER_PID_FILE": dispatcher_pid_path,
+        "log": _FakeLogger(),
+    }
+    exec(compile(snippet, "<is_dispatcher_alive>", "exec"), ns)
+    return ns
+
+
+class _FakeLogger:
+    def info(self, *a, **kw): pass
+    def warning(self, *a, **kw): pass
+    def debug(self, *a, **kw): pass
+
+
+# ---------------------------------------------------------------------------
+# Tests for _is_dispatcher_alive()
+# ---------------------------------------------------------------------------
+
+class TestIsDispatcherAlive:
+    """_is_dispatcher_alive() — pure function tests."""
+
+    def test_returns_false_when_pid_file_absent(self, tmp_path):
+        """No dispatcher.pid → treat as real session loss → return False."""
+        pid_file = tmp_path / DISPATCHER_PID_FILENAME
+        # File does not exist
+        ns = _extract_is_dispatcher_alive(pid_file)
+        assert ns["_is_dispatcher_alive"]() is False
+
+    def test_returns_true_when_pid_is_alive(self, tmp_path):
+        """PID file contains a live process PID → true reconnect → return True."""
+        pid_file = tmp_path / DISPATCHER_PID_FILENAME
+        # os.getpid() is always alive
+        pid_file.write_text(str(os.getpid()))
+        ns = _extract_is_dispatcher_alive(pid_file)
+        assert ns["_is_dispatcher_alive"]() is True
+
+    def test_returns_false_when_pid_is_dead(self, tmp_path):
+        """PID file contains a dead process PID → real session loss → return False."""
+        pid_file = tmp_path / DISPATCHER_PID_FILENAME
+        proc = subprocess.Popen(["true"])
+        proc.wait()
+        dead_pid = proc.pid
+        pid_file.write_text(str(dead_pid))
+        ns = _extract_is_dispatcher_alive(pid_file)
+        assert ns["_is_dispatcher_alive"]() is False
+
+    def test_returns_false_when_pid_file_is_empty(self, tmp_path):
+        """Empty PID file → cannot parse → treat as dead → return False."""
+        pid_file = tmp_path / DISPATCHER_PID_FILENAME
+        pid_file.write_text("")
+        ns = _extract_is_dispatcher_alive(pid_file)
+        assert ns["_is_dispatcher_alive"]() is False
+
+    def test_returns_false_when_pid_file_has_non_numeric_content(self, tmp_path):
+        """Corrupt PID file → cannot parse → treat as dead → return False."""
+        pid_file = tmp_path / DISPATCHER_PID_FILENAME
+        pid_file.write_text("not-a-pid\n")
+        ns = _extract_is_dispatcher_alive(pid_file)
+        assert ns["_is_dispatcher_alive"]() is False
+
+    def test_returns_false_when_pid_file_has_zero(self, tmp_path):
+        """PID 0 is invalid — kill -0 0 is unsafe → return False."""
+        pid_file = tmp_path / DISPATCHER_PID_FILENAME
+        pid_file.write_text("0")
+        ns = _extract_is_dispatcher_alive(pid_file)
+        assert ns["_is_dispatcher_alive"]() is False
+
+
+# ---------------------------------------------------------------------------
+# Tests for _write_session_lost_reminder() via inbox_server module
+# Uses a lightweight approach: patch the module-level globals to inject test paths.
+# ---------------------------------------------------------------------------
+
+def _call_write_session_lost_reminder(
+    *,
+    inbox_dir: Path,
+    dispatcher_pid_path: Path,
+    state_file: Path,
+    dev_mode: str = "",
+):
+    """Call _write_session_lost_reminder() with injected test paths.
+
+    Patches INBOX_DIR, DISPATCHER_PID_FILE, and LOBSTER_STATE_FILE at the
+    module level for the duration of the call.
+    """
+    import sys
+    import importlib
+
+    # Set or clear LOBSTER_DEV_MODE
+    old_dev = os.environ.get("LOBSTER_DEV_MODE")
+    if dev_mode:
+        os.environ["LOBSTER_DEV_MODE"] = dev_mode
+    else:
+        os.environ.pop("LOBSTER_DEV_MODE", None)
+
+    try:
+        # We need to import the module but it may be already imported.
+        # Find it in sys.modules if present.
+        mod = sys.modules.get("inbox_server")
+        if mod is None:
+            # Not loaded — add the src/mcp path and import
+            sys.path.insert(0, str(_SRC_MCP_DIR))
+            mod = importlib.import_module("inbox_server")
+
+        # Patch the module-level globals
+        with (
+            patch.object(mod, "INBOX_DIR", inbox_dir),
+            patch.object(mod, "DISPATCHER_PID_FILE", dispatcher_pid_path),
+            patch.object(mod, "LOBSTER_STATE_FILE", state_file),
+        ):
+            mod._write_session_lost_reminder()
+    finally:
+        if old_dev is None:
+            os.environ.pop("LOBSTER_DEV_MODE", None)
+        else:
+            os.environ["LOBSTER_DEV_MODE"] = old_dev
+
+
+class TestSessionLostReminderPidGuard:
+    """_write_session_lost_reminder() — PID-based suppression guard (issue #1429)."""
+
+    def test_writes_reminder_when_dispatcher_pid_absent(self, tmp_path):
+        """No dispatcher.pid → real session loss → reminder written to inbox."""
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        pid_file = tmp_path / DISPATCHER_PID_FILENAME
+        state_file = tmp_path / "lobster-state.json"
+        state_file.write_text(json.dumps({"mode": "active"}))
+        # PID file absent — dispatcher is dead
+
+        _call_write_session_lost_reminder(
+            inbox_dir=inbox_dir,
+            dispatcher_pid_path=pid_file,
+            state_file=state_file,
+        )
+
+        reminder_files = list(inbox_dir.glob("session-lost-*.json"))
+        assert len(reminder_files) == 1, "Expected exactly one session-lost reminder"
+        reminder = json.loads(reminder_files[0].read_text())
+        assert reminder["type"] == "compact-reminder"
+        assert "SESSION LOST" in reminder["text"]
+
+    def test_suppresses_reminder_when_dispatcher_alive(self, tmp_path):
+        """Live dispatcher PID → mid-session reconnect → reminder suppressed."""
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        pid_file = tmp_path / DISPATCHER_PID_FILENAME
+        pid_file.write_text(str(os.getpid()))  # current process — definitely alive
+        state_file = tmp_path / "lobster-state.json"
+        # State file recently touched (simulating cron-job update — old bug trigger)
+        state_file.write_text(json.dumps({"mode": "active"}))
+
+        _call_write_session_lost_reminder(
+            inbox_dir=inbox_dir,
+            dispatcher_pid_path=pid_file,
+            state_file=state_file,
+        )
+
+        reminder_files = list(inbox_dir.glob("session-lost-*.json"))
+        assert len(reminder_files) == 0, (
+            "Reminder was written despite dispatcher being alive — "
+            "this is a false positive that would disrupt an active session"
+        )
+
+    def test_writes_reminder_when_dispatcher_pid_is_dead(self, tmp_path):
+        """Dead PID in dispatcher.pid + fresh state file → reminder written.
+
+        This is exactly the cron-job false-negative scenario from issue #1429:
+        a cron job touches lobster-state.json seconds before MCP restarts.
+        The old mtime-based guard would suppress the reminder here.
+        The new PID-based guard correctly writes it.
+        """
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        pid_file = tmp_path / DISPATCHER_PID_FILENAME
+        proc = subprocess.Popen(["true"])
+        proc.wait()
+        pid_file.write_text(str(proc.pid))  # definitely dead now
+        state_file = tmp_path / "lobster-state.json"
+        # State file is fresh — old guard would see this as a reconnect
+        state_file.write_text(json.dumps({"mode": "active"}))
+        # mtime = now (within last few seconds, well within old 30-min window)
+
+        _call_write_session_lost_reminder(
+            inbox_dir=inbox_dir,
+            dispatcher_pid_path=pid_file,
+            state_file=state_file,
+        )
+
+        reminder_files = list(inbox_dir.glob("session-lost-*.json"))
+        assert len(reminder_files) == 1, (
+            "Expected reminder for dead dispatcher despite fresh state file — "
+            "the cron-job false-negative scenario from issue #1429"
+        )
+
+    def test_suppresses_reminder_in_dev_mode(self, tmp_path):
+        """LOBSTER_DEV_MODE=true → always suppress regardless of PID status."""
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        pid_file = tmp_path / DISPATCHER_PID_FILENAME
+        # No PID file — would normally trigger a reminder
+        state_file = tmp_path / "lobster-state.json"
+        state_file.write_text(json.dumps({"mode": "active"}))
+
+        _call_write_session_lost_reminder(
+            inbox_dir=inbox_dir,
+            dispatcher_pid_path=pid_file,
+            state_file=state_file,
+            dev_mode="true",
+        )
+
+        reminder_files = list(inbox_dir.glob("session-lost-*.json"))
+        assert len(reminder_files) == 0, "Dev mode should always suppress session-lost reminder"


### PR DESCRIPTION
## What this fixes

Two bugs that caused silent failures in the dispatcher's recovery and context monitoring systems.

### Bug #1429 — session-lost-reminder false negative

The dispatcher was blocked unrecovered for ~59 minutes on 2026-04-04 because the session-lost-reminder was suppressed during a real session loss.

**Root cause:** `_write_session_lost_reminder()` used `lobster-state.json` mtime < 30 min as a proxy for "mid-session MCP reconnect." This is wrong: cron jobs (lobstertalk-unified, any `mark_processed` call) routinely touch the state file. On 2026-04-04, the poller updated the file at 06:00:16Z and MCP restarted at 06:00:17Z — 1 second apart — triggering the false negative.

**Fix:** Replace the mtime check with `kill -0` on the PID in `~/messages/config/dispatcher.pid` (already written by `claude-persistent.sh` via exec-replace). A live PID → true reconnect → suppress. Dead or absent PID → real session loss → write the reminder. The new `_is_dispatcher_alive()` function is pure and fully testable.

The mtime-based guard still exists in `_reset_state_on_startup()` (a different function) and is correct there — it prevents rewriting `booted_at`/`woke_at` on CC auto-updates.

### Bug #1430 — context-monitor hook produces no log entries

`~/lobster-workspace/logs/context-monitor.log` had 4 entries from 2026-03-18 and nothing since, despite thousands of tool calls. The hook was firing but silently exiting.

**Root cause:** Claude Code does not populate `context_window` in PostToolUse payloads for MCP tool calls — only for built-in tools like Bash. The hook returned early with no log entry when `context_window` was `None`, making "hook fired, no data" indistinguishable from "hook never fired."

**Fix:**
1. Log a WARN entry when `context_window` is absent so the log records hook activity even when no usage data arrives.
2. Refactor `main()` into `_handle_payload(data, log_dir=..., inbox_dir=...)` with injectable paths for testability.
3. Migration 68 in `upgrade.sh` broadens the hook matcher from `mcp__lobster-inbox__|Agent` to `Bash|mcp__lobster-inbox__|Agent` — Bash tool calls do carry `context_window` and will now produce real usage measurements.

Note: `~/.claude/settings.json` is not in the repo. The settings change ships as upgrade.sh Migration 68, which is idempotent and updates the live settings on next `./scripts/upgrade.sh` run.

## Before / after (session-lost guard)

```
Before:
MCP restart → read lobster-state.json mtime
  file < 30 min old AND mode=active → SUPPRESS (false negative if cron touched file)
  otherwise → write reminder

After:
MCP restart → read dispatcher.pid → kill -0 <pid>
  process alive → SUPPRESS (true reconnect: Claude Code auto-update)
  process dead or PID file absent → write reminder (real session loss)
```

## Functional patterns

- `_is_dispatcher_alive()`: pure function — no side effects, all inputs via injected `DISPATCHER_PID_FILE` path
- `_handle_payload()` in context-monitor: accepts injectable path args, enabling test isolation without monkeypatching `Path.home()`
- Both changes use named constants (`DISPATCHER_PID_FILENAME`, `WARN_PREFIX_ABSENT_CONTEXT`) for testability

## Tests run

- [x] `uv run pytest tests/unit/test_session_lost_reminder_pid_guard.py tests/unit/test_hooks/test_context_monitor.py tests/unit/test_inbox_server_reconnect_guard.py -v` — 27 passed, 0 failed
- [x] `uv run pytest tests/unit/ -q` — 2330 passed, 80 failed (same 80 failures pre-exist on main — verified), 6 errors (pre-existing)

## Manual test

N/A — these fixes affect MCP startup behavior and hook file processing. The logic is fully covered by unit tests. The settings.json change (matcher broadening) cannot be verified without a real MCP restart; the migration is idempotent.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A for both changes (pure logic + file I/O, no external services)
- [x] User-visible outcome — not directly user-visible; prevents 59-minute recovery gaps and blind-spot in context monitoring
- [x] Side-effect audit: no floods, no unscoped writes; session-lost reminder writes are idempotent
- [x] External service calls — none

Closes #1429
Closes #1430

🤖🦞 Lobster (engineer): Claude Sonnet 4.6