### PR TITLE
fix: reviewer prompt anchoring — diff-first, independent analysis before engineer briefing

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -455,10 +455,26 @@ Background subagents call `write_result(task_id, chat_id, text, ...)`, which dro
                    prompt=(
                        f"---\ntask_id: {reviewer_task_id}\nchat_id: {msg['chat_id']}\n"
                        f"source: {msg.get('source', 'telegram')}\n---\n\n"
-                       f"Review PR {pr_url} and post findings:\n"
-                       f"  gh pr review <N> --repo {pr_repo} --comment --body \"PASS/NEEDS-WORK/FAIL: ...\"\n"
-                       f"Use --comment only (never --approve or --request-changes — same token = self-review error).\n"
-                       f"After posting, call write_result with a short verdict (1-3 sentences).\n\n"
+                       f"Review PR {pr_url} and post findings as a GitHub comment.\n\n"
+                       f"REVIEWER PROCESS (follow this order exactly):\n"
+                       f"1. Run: gh pr diff {pr_number} --repo {pr_repo}\n"
+                       f"   Read the diff cold. Before reading anything else, note independently:\n"
+                       f"   - What could go wrong with this change?\n"
+                       f"   - What edge cases are not covered?\n"
+                       f"   - What would you want tested?\n\n"
+                       f"2. Then read the engineer's briefing below.\n"
+                       f"   Compare what you found against what the engineer flagged.\n"
+                       f"   A good review catches what the engineer didn't think of.\n\n"
+                       f"ALWAYS CHECK:\n"
+                       f"- For any store/DB/MCP method call: do the argument types match what the method actually expects?\n"
+                       f"- Test structure: duplicate class names? Any test classes unreachable due to shadowing?\n"
+                       f"- Do tests exercise the actual before-state, or just assert it in comments?\n"
+                       f"- \"N pre-existing failures\" claims: run `uv run pytest --tb=no -q` yourself and verify the count\n\n"
+                       f"POST your review as a GitHub comment:\n"
+                       f"  gh pr review {pr_number} --repo {pr_repo} --comment --body \"🤖🦞 Lobster (reviewer): PASS/NEEDS-WORK/FAIL: ...\"\n"
+                       f"  (Never --approve or --request-changes — same token = self-review error)\n\n"
+                       f"After posting, call write_result with a plain-English verdict (1-3 sentences).\n"
+                       f"Translate all findings — no function names, file paths, or code terms. State what each issue means operationally.\n\n"
                        f"Engineer's briefing:\n{msg['text']}"
                    ),
                )
@@ -741,10 +757,26 @@ If `reacted_to_text` is empty: use `get_conversation_history` to get context.
                    run_in_background=True,
                    prompt=(
                        f"---\ntask_id: {reviewer_task_id}\nchat_id: {chat_id}\nsource: {source}\n---\n\n"
-                       f"Review PR {pr_url} and post findings:\n"
-                       f"  gh pr review <N> --repo {pr_repo} --comment --body \"PASS/NEEDS-WORK/FAIL: ...\"\n"
-                       f"Use --comment only (never --approve or --request-changes).\n"
-                       f"After posting, call write_result with a short verdict (1-3 sentences).\n\n"
+                       f"Review PR {pr_url} and post findings as a GitHub comment.\n\n"
+                       f"REVIEWER PROCESS (follow this order exactly):\n"
+                       f"1. Run: gh pr diff {pr_number} --repo {pr_repo}\n"
+                       f"   Read the diff cold. Before reading anything else, note independently:\n"
+                       f"   - What could go wrong with this change?\n"
+                       f"   - What edge cases are not covered?\n"
+                       f"   - What would you want tested?\n\n"
+                       f"2. Then read the engineer's briefing below.\n"
+                       f"   Compare what you found against what the engineer flagged.\n"
+                       f"   A good review catches what the engineer didn't think of.\n\n"
+                       f"ALWAYS CHECK:\n"
+                       f"- For any store/DB/MCP method call: do the argument types match what the method actually expects?\n"
+                       f"- Test structure: duplicate class names? Any test classes unreachable due to shadowing?\n"
+                       f"- Do tests exercise the actual before-state, or just assert it in comments?\n"
+                       f"- \"N pre-existing failures\" claims: run `uv run pytest --tb=no -q` yourself and verify the count\n\n"
+                       f"POST your review as a GitHub comment:\n"
+                       f"  gh pr review {pr_number} --repo {pr_repo} --comment --body \"🤖🦞 Lobster (reviewer): PASS/NEEDS-WORK/FAIL: ...\"\n"
+                       f"  (Never --approve or --request-changes — same token = self-review error)\n\n"
+                       f"After posting, call write_result with a plain-English verdict (1-3 sentences).\n"
+                       f"Translate all findings — no function names, file paths, or code terms. State what each issue means operationally.\n\n"
                        f"Engineer\'s briefing:\n{parked[\'content\']}"
                    ),
                )
@@ -973,8 +1005,8 @@ When the user asks to work on a GitHub issue, spawn `functional-engineer` via `T
 
 1. Engineer's `write_result` arrives as `subagent_result` with a GitHub PR URL in `text`
 2. Dispatcher detects the URL (in `subagent_result` handler above), spawns reviewer, marks processed
-3. Reviewer reads the PR, posts findings with `gh pr review <N> --repo <owner/repo> --comment --body "PASS/NEEDS-WORK/FAIL: ..."` (never `--approve` or `--request-changes` — same token = self-review error)
-4. Reviewer calls `write_result` with a short verdict (1-3 sentences)
+3. Reviewer reads the diff cold first (before the briefing), then posts findings with `gh pr review <N> --repo <owner/repo> --comment --body "🤖🦞 Lobster (reviewer): PASS/NEEDS-WORK/FAIL: ..."` (never `--approve` or `--request-changes` — same token = self-review error)
+4. Reviewer calls `write_result` with a plain-English verdict (1-3 sentences) — no function names or file paths
 5. Dispatcher receives that result, relays the short verdict to the user
 
 **Why this separation matters:** Engineers must not review their own work.
@@ -1008,7 +1040,11 @@ When the user types `/re-review <PR URL or number>`, extract the PR reference an
 parts = msg["text"].strip().split(None, 1)
 pr_ref = parts[1].strip() if len(parts) > 1 else ""
 # Parse as full URL or bare number
-# Spawn review agent with re-review prompt
+# Spawn review agent with the same diff-first reviewer prompt used in ENGINEER→REVIEWER routing:
+#   - Step 1: gh pr diff {pr_number} --repo {pr_repo} (read cold, form independent view)
+#   - Step 2: (no engineer briefing for re-reviews — reviewer works entirely from the diff and PR description)
+#   - POST: gh pr review {pr_number} --repo {pr_repo} --comment --body "🤖🦞 Lobster (reviewer): PASS/NEEDS-WORK/FAIL: ..."
+#   - write_result: plain-English verdict, no code terms
 # send_reply: "On it — reviewing {pr_url}."
 ```
 


### PR DESCRIPTION
## Problem

Reviewer subagents were anchored to the engineer's framing. The prompt passed the engineer's briefing first, so reviewers read the PR description and then verified it — catching internal inconsistencies well but missing bugs the engineer didn't think of. This is a systematic bias: a reviewer who reads the conclusion before the evidence will unconsciously filter the evidence to match.

Identified through a meta-review of PR #1433. Fixes #1434.

## What changed

All three reviewer prompt call sites in `sys.dispatcher.bootup.md` are updated to enforce a diff-first reading order:

1. **ENGINEER→REVIEWER routing** (main subagent_result handler)
2. **Deletion-confirmed engineer→reviewer routing** (callback_data handler)
3. **`/re-review` command docs** (pseudocode + explanation)

The PR review flow description (step 3) is also updated to state that the reviewer reads the diff cold first.

## Before → After flow

```
BEFORE:
  Dispatcher spawns reviewer with:
    [engineer's briefing]
    [instruction to post gh pr review]
  Reviewer reads briefing → anchored frame → reads diff through that lens

AFTER:
  Dispatcher spawns reviewer with:
    [instruction to run gh pr diff and note findings independently]
    [checklist of things to always verify]
    [instruction to post gh pr review with plain-English verdict]
    [engineer's briefing — last]
  Reviewer forms independent view → then compares against engineer's claims
```

## Checklist added to every reviewer prompt

- Verify argument types on store/DB/MCP method calls
- Check for duplicate test class names / shadowing
- Verify tests exercise actual before-state (not just assert it in comments)
- Validate "N pre-existing failures" claims by running `uv run pytest --tb=no -q` directly

## Verdict format change

Reviewers are now required to post findings in plain English — no function names, file paths, or code terms. Each finding must state what it means operationally. This makes verdicts readable by the user on mobile without needing to cross-reference the diff.

## What is not changed

- No Python code changes. This is a prompt-only update.
- The `gh pr review --comment` constraint (never `--approve` or `--request-changes`) is preserved at all sites.
- The reviewer subagent type (`lobster-generalist`) is unchanged.
- The dedup check in the main routing block is unchanged.

## Tests run
- [x] Verified all four edit sites applied correctly via Python string-match assertions — 8/8 checks passed
- [ ] Live reviewer run — not applicable for this PR (prompt-only change; reviewer behavior is verified by reading the prompt, not by running a test suite against it)

## Manual test
N/A — this change is entirely internal to the dispatcher prompt. No external service calls, no file I/O affecting runtime state, no systemd units. The effect is observable only when the next engineer PR triggers the reviewer flow.

## Definition of Done
- [x] All three call sites updated to diff-first structure
- [x] Engineer's briefing appears last in every reviewer prompt
- [x] Plain-English verdict requirement added
- [x] `/re-review` docs updated to reference same approach
- [x] PR flow description updated
- [x] Side-effect audit: no floods, no writes, no external calls — prompt text only