### PR TITLE
fix: clean up two nits from PR #1427 review

### DIFF
--- a/src/mcp/event_bus.py
+++ b/src/mcp/event_bus.py
@@ -374,8 +374,6 @@ _EVENT_BUS: EventBus | None = None
 _BUS_LOCK = threading.Lock()
 
 
-_INIT_CALLED = False  # set to True by init_event_bus(); checked by get_event_bus()
-
 
 def get_event_bus() -> EventBus:
     """

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -4105,7 +4105,7 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
                                 to=msg.get("to", ""),
                             )
                         except Exception as _bt_exc:
-                            log.debug(f"bot-talk EventBus inbound emit failed (non-fatal): {_bt_exc}")
+                            log.warning(f"bot-talk EventBus inbound emit failed (non-fatal): {_bt_exc}")
                     if len(messages) >= limit:
                         break
             except Exception as e:


### PR DESCRIPTION
Both fixes are one-liners with no behavior change outside of log visibility.

**Nit 1 — inbound log level raised to warning**

The outbound `mirror_outbound` exception path already logs at `log.warning`. The inbound EventBus emit failure at line 4108 was logging at `log.debug`, making it invisible in prod unless debug logging was enabled. This asymmetry meant a broken inbound mirror would produce no signal in a standard deployment. Raised to `log.warning` to match.

**Nit 2 — removed unused `_INIT_CALLED` variable**

`event_bus.py` declared `_INIT_CALLED = False` with a comment claiming it was set by `init_event_bus()` and checked by `get_event_bus()`. Neither was true — the variable was never written after declaration and never read. The startup warning (emitted when `emit()` is called with no listeners registered) works by checking `len(self._listeners) == 0`, not by consulting this flag. The variable and its misleading comment are removed.

**Functional patterns:** both changes are purely imperative cleanup — no functional patterns involved. No logic altered.

## Tests run
- [x] `uv run pytest tests/unit/test_mcp_server/test_bot_talk_mirror.py tests/unit/test_event_bus.py -v` — 73 passed, 0 failed

## Manual test
N/A — change is entirely internal (log level adjustment and dead code removal; no external service calls, no file I/O, no systemd/cron).

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A, see above
- [x] User-visible outcome — not applicable; log level changes are operator-visible only
- [x] Side-effect audit complete: no floods, no writes, no unintended volume
- [x] External service calls: none in this change

Relates to #1427