### PR TITLE
feat(gmail): use caller chat_id instead of read_owner() for multi-user support

### DIFF
--- a/lobster-shop/gmail/behavior/system.md
+++ b/lobster-shop/gmail/behavior/system.md
@@ -11,11 +11,25 @@ import sys
 import os
 sys.path.insert(0, os.path.expanduser("~/lobster/src"))
 from integrations.gmail.token_store import load_token
-from mcp.user_model.owner import read_owner
 
-owner = read_owner()
-OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
-token = load_token(OWNER_USER_ID)
+# MULTI-USER: always prefer chat_id from the incoming message context.
+# Fall back to read_owner() only for single-user / legacy installs where
+# the message doesn't carry a chat_id (e.g. scheduled jobs).
+#
+# In the Lobster dispatcher the message looks like:
+#   message["chat_id"]  — Telegram chat_id of the user who sent the message
+#
+# Usage pattern (the subagent receives chat_id as a parameter):
+#   USER_ID = message_chat_id or _fallback_to_owner()
+def _fallback_to_owner() -> str:
+    from mcp.user_model.owner import read_owner
+    owner = read_owner()
+    return owner.get("owner", {}).get("telegram_chat_id", "")
+
+# Prefer caller's chat_id; fall back to owner for single-user installs.
+# `message_chat_id` must be passed in from the dispatcher context.
+USER_ID = str(message_chat_id) if message_chat_id else _fallback_to_owner()
+token = load_token(USER_ID)
 is_authenticated = token is not None
 ```
 
@@ -73,12 +87,20 @@ import sys
 import os
 sys.path.insert(0, os.path.expanduser("~/lobster/src"))
 from integrations.gmail.client import get_recent_emails
-from mcp.user_model.owner import read_owner
 
-owner = read_owner()
-OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
+# MULTI-USER: use the chat_id from the message that triggered this subagent.
+# The dispatcher must pass it as a parameter when spawning the subagent.
+# Fall back to read_owner() only for single-user / legacy installs.
+def _get_user_id(message_chat_id=None) -> str:
+    if message_chat_id:
+        return str(message_chat_id)
+    from mcp.user_model.owner import read_owner
+    owner = read_owner()
+    return owner.get("owner", {}).get("telegram_chat_id", "")
 
-emails = get_recent_emails(user_id=OWNER_USER_ID, max_results=5)
+USER_ID = _get_user_id(message_chat_id)  # pass chat_id from dispatcher context
+
+emails = get_recent_emails(user_id=USER_ID, max_results=5)
 if not emails:
     reply = "No recent emails in your inbox, or Gmail is not connected."
 else:
@@ -97,13 +119,19 @@ import sys
 import os
 sys.path.insert(0, os.path.expanduser("~/lobster/src"))
 from integrations.gmail.client import search_emails
-from mcp.user_model.owner import read_owner
 
-owner = read_owner()
-OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
+# MULTI-USER: use the chat_id from the message that triggered this subagent.
+def _get_user_id(message_chat_id=None) -> str:
+    if message_chat_id:
+        return str(message_chat_id)
+    from mcp.user_model.owner import read_owner
+    owner = read_owner()
+    return owner.get("owner", {}).get("telegram_chat_id", "")
+
+USER_ID = _get_user_id(message_chat_id)  # pass chat_id from dispatcher context
 
 # query is the Gmail search string derived from user's message
-emails = search_emails(user_id=OWNER_USER_ID, query=query, max_results=5)
+emails = search_emails(user_id=USER_ID, query=query, max_results=5)
 if not emails:
     reply = f"No emails found matching \"{query}\"."
 else:

--- a/lobster-shop/gmail/context/reference.md
+++ b/lobster-shop/gmail/context/reference.md
@@ -7,11 +7,18 @@ import sys
 import os
 sys.path.insert(0, os.path.expanduser("~/lobster/src"))
 from integrations.gmail.token_store import load_token
-from mcp.user_model.owner import read_owner
 
-owner = read_owner()
-OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
-token = load_token(OWNER_USER_ID)
+# MULTI-USER: prefer chat_id from the incoming message context.
+# Fall back to read_owner() only for single-user / legacy installs.
+def _get_user_id(message_chat_id=None) -> str:
+    if message_chat_id:
+        return str(message_chat_id)
+    from mcp.user_model.owner import read_owner
+    owner = read_owner()
+    return owner.get("owner", {}).get("telegram_chat_id", "")
+
+USER_ID = _get_user_id(message_chat_id)  # pass chat_id from dispatcher context
+token = load_token(USER_ID)
 is_authenticated = token is not None
 ```
 
@@ -42,7 +49,7 @@ except Exception as exc:
 ```python
 from integrations.gmail.client import get_recent_emails
 
-emails = get_recent_emails(user_id=OWNER_USER_ID, max_results=10)
+emails = get_recent_emails(user_id=USER_ID, max_results=10)
 # Returns List[EmailMessage] — empty list on auth failure or API error
 
 # EmailMessage fields:
@@ -57,7 +64,7 @@ emails = get_recent_emails(user_id=OWNER_USER_ID, max_results=10)
 ```python
 from integrations.gmail.client import search_emails
 
-emails = search_emails(user_id=OWNER_USER_ID, query="from:boss@example.com is:unread")
+emails = search_emails(user_id=USER_ID, query="from:boss@example.com is:unread")
 # Returns List[EmailMessage] — empty list on auth failure or no results
 ```
 
@@ -67,8 +74,11 @@ Gmail search operators work as-is (from:, subject:, is:unread, after:, label:, e
 
 ### User ID convention
 
-The owner's `user_id` is their Telegram chat_id as a string, read from
-`~/lobster-config/owner.toml`.
+For multi-user (myownlobster.ai) deployments, `user_id` is the **caller's
+Telegram `chat_id`** passed in from the message context — not the owner's ID.
+Fall back to `read_owner()` only for single-user / legacy installs where no
+`chat_id` is available in context.
+
 All Gmail token files live in `~/messages/config/gmail-tokens/{user_id}.json`.
 
 ---


### PR DESCRIPTION
## Summary

- Updates Gmail skill behavior docs to use `message_chat_id` (the caller's Telegram chat_id) instead of hardcoded `read_owner()` when fetching Gmail tokens
- Maintains backward compatibility via fallback to `read_owner()` for single-user / legacy installs where no `chat_id` is in context
- Fixes silent failures for myownlobster.ai users who aren't the owner — their tokens exist in `gmail-tokens/{chat_id}.json` but the skill was always loading the owner's token file instead

## Files changed

- `lobster-shop/gmail/behavior/system.md` — auth check, `get_recent_emails`, `search_emails` patterns updated
- `lobster-shop/gmail/context/reference.md` — same pattern + clarified user ID convention

## Why this matters

The VPS Gmail client (`client.py`) and token store (`token_store.py`) already support per-user tokens keyed by `chat_id`. Only the skill behavior documentation was hardcoding `read_owner()`. This change unblocks multi-user Gmail on any myownlobster.ai instance.

## Test plan

- [ ] As owner: verify "check my email" still works (fallback path)
- [ ] As non-owner authed user: verify their own Gmail token is used, not owner's
- [ ] As unauthenticated user: verify consent link is generated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)