### PR TITLE
feat(eventbus): wire remaining event sources to central EventBus

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -4375,6 +4375,26 @@ async def handle_send_reply(args: dict) -> list[TextContent]:
 
     log.info(f"Reply sent to {source} chat {chat_id}")
 
+    # Emit telegram.outbound to EventBus for audit trail (issue #1352).
+    # Skipped for bot-talk — that source already emits via bot_talk_mirror.
+    # Fire-and-forget: swallows all exceptions so the reply path is never blocked.
+    if source != "bot-talk" and _EVENT_BUS_AVAILABLE:
+        try:
+            event = LobsterEvent(
+                event_type="telegram.outbound",
+                severity="info",
+                source="inbox-server",
+                payload={
+                    "source": source,
+                    "chat_id": chat_id,
+                    "text_len": len(text),
+                },
+                chat_id=chat_id,
+            )
+            get_event_bus().emit_sync(event)
+        except Exception:
+            pass  # never block on observability
+
     # Mirror outbound bot-talk messages to the EventBus so TelegramOutboxListener
     # can forward them as debug notifications. Fire-and-forget: non-blocking.
     if source == "bot-talk":
@@ -4613,6 +4633,20 @@ async def handle_mark_processed(args: dict) -> list[TextContent]:
         {"last_processed_at": datetime.now(timezone.utc).isoformat()}
     )
 
+    # Emit inbox.processed to EventBus for audit trail (issue #1352).
+    # Fire-and-forget: swallows all exceptions so the mark_processed path is never blocked.
+    if _EVENT_BUS_AVAILABLE:
+        try:
+            event = LobsterEvent(
+                event_type="inbox.processed",
+                severity="info",
+                source="inbox-server",
+                payload={"message_id": message_id},
+            )
+            get_event_bus().emit_sync(event)
+        except Exception:
+            pass  # never block on observability
+
     log.info(f"Message processed: {message_id}")
     return [TextContent(type="text", text=f"✅ Message marked as processed: {message_id}")]
 
@@ -4732,6 +4766,25 @@ async def handle_mark_processing(args: dict) -> list[TextContent]:
         atomic_write_json(dest, msg_data)
     except Exception:
         pass  # non-fatal; stale recovery falls back to mtime
+
+    # Emit telegram.inbound to EventBus for audit trail (issue #1352).
+    # Fire-and-forget: swallows all exceptions so the claim path is never blocked.
+    if _EVENT_BUS_AVAILABLE:
+        try:
+            event = LobsterEvent(
+                event_type="telegram.inbound",
+                severity="info",
+                source="inbox-server",
+                payload={
+                    "message_id": message_id,
+                    "source": msg_source,
+                    "msg_type": msg_type,
+                },
+                chat_id=msg_data.get("chat_id"),
+            )
+            get_event_bus().emit_sync(event)
+        except Exception:
+            pass  # never block on observability
 
     log.info(f"Message claimed for processing: {message_id}")
     return [TextContent(type="text", text=f"Message claimed: {message_id}{context_block}")]
@@ -4866,6 +4919,18 @@ async def handle_mark_failed(args: dict) -> list[TextContent]:
         # Update claim status to 'failed' (issue #1360)
         _claims_db.update_status(message_id, "failed")
         log.error(f"Message permanently failed after {max_retries} retries: {message_id} - {error}")
+        # Emit inbox.failed to EventBus for audit trail (issue #1352). Fire-and-forget.
+        if _EVENT_BUS_AVAILABLE:
+            try:
+                event = LobsterEvent(
+                    event_type="inbox.failed",
+                    severity="warn",
+                    source="inbox-server",
+                    payload={"message_id": message_id, "error": error, "permanent": True},
+                )
+                get_event_bus().emit_sync(event)
+            except Exception:
+                pass  # never block on observability
         return [TextContent(type="text", text=f"Message permanently failed after {max_retries} retries: {message_id}")]
 
     # Schedule retry with exponential backoff: 60s, 120s, 240s
@@ -4880,6 +4945,18 @@ async def handle_mark_failed(args: dict) -> list[TextContent]:
     # Release claim row so the message can be re-claimed on retry (issue #1360)
     _claims_db.release(message_id)
     log.warning(f"Message failed (retry {retry_count}/{max_retries}, next in {backoff}s): {message_id} - {error}")
+    # Emit inbox.failed to EventBus for audit trail (issue #1352). Fire-and-forget.
+    if _EVENT_BUS_AVAILABLE:
+        try:
+            event = LobsterEvent(
+                event_type="inbox.failed",
+                severity="warn",
+                source="inbox-server",
+                payload={"message_id": message_id, "error": error, "permanent": False},
+            )
+            get_event_bus().emit_sync(event)
+        except Exception:
+            pass  # never block on observability
     return [TextContent(type="text", text=f"Message queued for retry ({retry_count}/{max_retries}, backoff {backoff}s): {message_id}")]
 
 
@@ -6649,6 +6726,23 @@ async def handle_write_task_output(args: dict) -> list[TextContent]:
     output_file = TASK_OUTPUTS_DIR / f"{timestamp_str}-{job_name}.json"
     with open(output_file, "w") as f:
         json.dump(output_data, f, indent=2)
+
+    # Emit job.completed to EventBus for audit trail (issue #1352). Fire-and-forget.
+    if _EVENT_BUS_AVAILABLE:
+        try:
+            event = LobsterEvent(
+                event_type="job.completed",
+                severity="warn" if status == "failed" else "info",
+                source="inbox-server",
+                payload={
+                    "job_name": job_name,
+                    "status": status,
+                    "output_len": len(output),
+                },
+            )
+            get_event_bus().emit_sync(event)
+        except Exception:
+            pass  # never block on observability
 
     return [TextContent(type="text", text=f"Output recorded for job '{job_name}'")]
 

--- a/tests/unit/test_eventbus_wiring.py
+++ b/tests/unit/test_eventbus_wiring.py
@@ -1,0 +1,427 @@
+"""
+Unit tests for EventBus wiring of remaining event sources (issue #1352).
+
+Verifies that the four event sources emit correctly-typed events to the bus:
+- telegram.inbound  — emitted in handle_mark_processing when a human message is claimed
+- telegram.outbound — emitted in handle_send_reply when a reply is sent
+- job.started / job.completed — emitted in handle_write_task_output
+- inbox.processed   — emitted in handle_mark_processed
+- inbox.failed      — emitted in handle_mark_failed
+
+Each test follows the same pattern as test_emit_event.py:
+- Install a collecting listener on the module-level bus
+- Patch _EVENT_BUS_AVAILABLE + get_event_bus to inject the bus
+- Assert the event fields match what the spec requires
+
+Tests are named after behavior, not mechanism.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src" / "mcp"))
+
+from event_bus import EventBus, EventFilter, LobsterEvent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _CollectingListener:
+    """Collects every event it receives."""
+
+    name = "collecting"
+
+    def __init__(self) -> None:
+        self.received: list[LobsterEvent] = []
+
+    def accepts(self, event: LobsterEvent) -> bool:
+        return True
+
+    async def deliver(self, event: LobsterEvent) -> None:
+        self.received.append(event)
+
+
+def _make_bus_with_listener() -> tuple[EventBus, _CollectingListener]:
+    """Return a fresh EventBus with a collecting listener attached."""
+    import event_bus as _eb
+    _eb._EVENT_BUS = None
+    bus = _eb.get_event_bus()
+    listener = _CollectingListener()
+    bus.register(listener)
+    return bus, listener
+
+
+def _events_of_type(listener: _CollectingListener, event_type: str) -> list[LobsterEvent]:
+    return [e for e in listener.received if e.event_type == event_type]
+
+
+# ---------------------------------------------------------------------------
+# telegram.outbound — emitted when send_reply delivers a message
+# ---------------------------------------------------------------------------
+
+class TestTelegramOutboundEvent:
+    """send_reply emits a telegram.outbound event to the bus."""
+
+    def _run_send_reply(self, bus: EventBus, outbox_dir: Path) -> None:
+        import inbox_server
+        # Patch everything that send_reply depends on for filesystem I/O
+        with patch.object(inbox_server, "_EVENT_BUS_AVAILABLE", True), \
+             patch("inbox_server.get_event_bus", return_value=bus), \
+             patch.object(inbox_server, "OUTBOX_DIR", outbox_dir), \
+             patch.object(inbox_server, "SENT_DIR", outbox_dir), \
+             patch.object(inbox_server, "BISQUE_OUTBOX_DIR", outbox_dir), \
+             patch.object(inbox_server, "_db_persist_outbound", None), \
+             patch.object(inbox_server, "_track_reply", MagicMock()), \
+             patch.object(inbox_server, "_record_direct_send", MagicMock()), \
+             patch.object(inbox_server, "_record_task_replied", MagicMock()):
+            asyncio.run(inbox_server.handle_send_reply({
+                "chat_id": 9999,
+                "text": "Hello from Lobster",
+                "source": "telegram",
+            }))
+
+    def test_send_reply_emits_telegram_outbound_event(self):
+        bus, listener = _make_bus_with_listener()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._run_send_reply(bus, Path(tmpdir))
+        events = _events_of_type(listener, "telegram.outbound")
+        assert len(events) == 1, f"Expected 1 telegram.outbound event, got {len(events)}"
+
+    def test_telegram_outbound_event_has_required_fields(self):
+        bus, listener = _make_bus_with_listener()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._run_send_reply(bus, Path(tmpdir))
+        ev = _events_of_type(listener, "telegram.outbound")[0]
+        assert ev.source == "inbox-server"
+        assert "chat_id" in ev.payload
+        assert ev.payload["chat_id"] == 9999
+        assert "text_len" in ev.payload
+
+    def test_telegram_outbound_event_severity_is_info(self):
+        bus, listener = _make_bus_with_listener()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._run_send_reply(bus, Path(tmpdir))
+        ev = _events_of_type(listener, "telegram.outbound")[0]
+        assert ev.severity == "info"
+
+    def test_send_reply_does_not_emit_outbound_for_bot_talk_source(self):
+        """bot-talk messages already go through bot_talk_mirror — no duplicate event."""
+        bus, listener = _make_bus_with_listener()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outbox_dir = Path(tmpdir)
+            import inbox_server
+            # bot_talk_mirror is imported locally inside handle_send_reply, so we
+            # patch at the module level inside the bot_talk_mirror module itself.
+            with patch.object(inbox_server, "_EVENT_BUS_AVAILABLE", True), \
+                 patch("inbox_server.get_event_bus", return_value=bus), \
+                 patch.object(inbox_server, "OUTBOX_DIR", outbox_dir), \
+                 patch.object(inbox_server, "SENT_DIR", outbox_dir), \
+                 patch.object(inbox_server, "BISQUE_OUTBOX_DIR", outbox_dir), \
+                 patch.object(inbox_server, "_db_persist_outbound", None), \
+                 patch.object(inbox_server, "_track_reply", MagicMock()), \
+                 patch.object(inbox_server, "_record_direct_send", MagicMock()), \
+                 patch.object(inbox_server, "_record_task_replied", MagicMock()), \
+                 patch("bot_talk_mirror.mirror_outbound", MagicMock()):
+                asyncio.run(inbox_server.handle_send_reply({
+                    "chat_id": "AlbertLobster",
+                    "text": "Hi from bot-talk",
+                    "source": "bot-talk",
+                }))
+        # telegram.outbound should NOT be emitted for bot-talk
+        events = _events_of_type(listener, "telegram.outbound")
+        assert len(events) == 0, "telegram.outbound must not be emitted for bot-talk source"
+
+
+# ---------------------------------------------------------------------------
+# telegram.inbound — emitted when mark_processing claims a human message
+# ---------------------------------------------------------------------------
+
+class TestTelegramInboundEvent:
+    """mark_processing emits a telegram.inbound event for human messages."""
+
+    def _write_inbox_message(self, inbox_dir: Path, msg_id: str, msg_type: str = "text", source: str = "telegram") -> None:
+        msg = {
+            "id": msg_id,
+            "type": msg_type,
+            "source": source,
+            "chat_id": 7777,
+            "text": "Hello Lobster",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+        }
+        (inbox_dir / f"{msg_id}.json").write_text(json.dumps(msg))
+
+    def test_mark_processing_emits_telegram_inbound_for_user_message(self):
+        bus, listener = _make_bus_with_listener()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            inbox_dir = Path(tmpdir) / "inbox"
+            processing_dir = Path(tmpdir) / "processing"
+            inbox_dir.mkdir()
+            processing_dir.mkdir()
+            msg_id = "1234567890_telegram"
+            self._write_inbox_message(inbox_dir, msg_id, msg_type="text", source="telegram")
+
+            import inbox_server
+            with patch.object(inbox_server, "_EVENT_BUS_AVAILABLE", True), \
+                 patch("inbox_server.get_event_bus", return_value=bus), \
+                 patch.object(inbox_server, "INBOX_DIR", inbox_dir), \
+                 patch.object(inbox_server, "PROCESSING_DIR", processing_dir), \
+                 patch.object(inbox_server, "_claims_db") as mock_claims, \
+                 patch.object(inbox_server, "_queue_observation", MagicMock()), \
+                 patch.object(inbox_server, "_user_model", None), \
+                 patch.object(inbox_server, "_tick_user_message_counter", MagicMock()), \
+                 patch.object(inbox_server, "_get_current_http_session_id", return_value=None):
+                mock_claims.claim.return_value = True
+                asyncio.run(inbox_server.handle_mark_processing({"message_id": msg_id}))
+
+        events = _events_of_type(listener, "telegram.inbound")
+        assert len(events) == 1, f"Expected 1 telegram.inbound event, got {len(events)}"
+
+    def test_telegram_inbound_event_has_required_fields(self):
+        bus, listener = _make_bus_with_listener()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            inbox_dir = Path(tmpdir) / "inbox"
+            processing_dir = Path(tmpdir) / "processing"
+            inbox_dir.mkdir()
+            processing_dir.mkdir()
+            msg_id = "1234567890_telegram"
+            self._write_inbox_message(inbox_dir, msg_id)
+
+            import inbox_server
+            with patch.object(inbox_server, "_EVENT_BUS_AVAILABLE", True), \
+                 patch("inbox_server.get_event_bus", return_value=bus), \
+                 patch.object(inbox_server, "INBOX_DIR", inbox_dir), \
+                 patch.object(inbox_server, "PROCESSING_DIR", processing_dir), \
+                 patch.object(inbox_server, "_claims_db") as mock_claims, \
+                 patch.object(inbox_server, "_queue_observation", MagicMock()), \
+                 patch.object(inbox_server, "_user_model", None), \
+                 patch.object(inbox_server, "_tick_user_message_counter", MagicMock()), \
+                 patch.object(inbox_server, "_get_current_http_session_id", return_value=None):
+                mock_claims.claim.return_value = True
+                asyncio.run(inbox_server.handle_mark_processing({"message_id": msg_id}))
+
+        ev = _events_of_type(listener, "telegram.inbound")[0]
+        assert "message_id" in ev.payload
+        assert "source" in ev.payload
+        assert "msg_type" in ev.payload
+        assert ev.severity == "info"
+
+
+# ---------------------------------------------------------------------------
+# inbox.processed — emitted when mark_processed moves a message to processed/
+# ---------------------------------------------------------------------------
+
+class TestInboxProcessedEvent:
+    """mark_processed emits an inbox.processed event."""
+
+    def _write_processing_message(self, processing_dir: Path, msg_id: str) -> None:
+        msg = {
+            "id": msg_id,
+            "type": "text",
+            "source": "telegram",
+            "chat_id": 5555,
+            "text": "Done",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+        }
+        (processing_dir / f"{msg_id}.json").write_text(json.dumps(msg))
+
+    def test_mark_processed_emits_inbox_processed_event(self):
+        bus, listener = _make_bus_with_listener()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            processing_dir = Path(tmpdir) / "processing"
+            processed_dir = Path(tmpdir) / "processed"
+            processing_dir.mkdir()
+            processed_dir.mkdir()
+            msg_id = "9876543210_telegram"
+            self._write_processing_message(processing_dir, msg_id)
+
+            import inbox_server
+            with patch.object(inbox_server, "_EVENT_BUS_AVAILABLE", True), \
+                 patch("inbox_server.get_event_bus", return_value=bus), \
+                 patch.object(inbox_server, "PROCESSING_DIR", processing_dir), \
+                 patch.object(inbox_server, "INBOX_DIR", processing_dir), \
+                 patch.object(inbox_server, "PROCESSED_DIR", processed_dir), \
+                 patch.object(inbox_server, "_claims_db") as mock_claims, \
+                 patch.object(inbox_server, "_db_persist_inbound", None), \
+                 patch.object(inbox_server, "_update_lobster_state_fields", MagicMock()), \
+                 patch.object(inbox_server, "_recent_replies", {}):
+                mock_claims.update_status = MagicMock()
+                asyncio.run(inbox_server.handle_mark_processed({"message_id": msg_id, "force": True}))
+
+        events = _events_of_type(listener, "inbox.processed")
+        assert len(events) == 1, f"Expected 1 inbox.processed event, got {len(events)}"
+
+    def test_inbox_processed_event_has_message_id_in_payload(self):
+        bus, listener = _make_bus_with_listener()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            processing_dir = Path(tmpdir) / "processing"
+            processed_dir = Path(tmpdir) / "processed"
+            processing_dir.mkdir()
+            processed_dir.mkdir()
+            msg_id = "9876543210_telegram"
+            self._write_processing_message(processing_dir, msg_id)
+
+            import inbox_server
+            with patch.object(inbox_server, "_EVENT_BUS_AVAILABLE", True), \
+                 patch("inbox_server.get_event_bus", return_value=bus), \
+                 patch.object(inbox_server, "PROCESSING_DIR", processing_dir), \
+                 patch.object(inbox_server, "INBOX_DIR", processing_dir), \
+                 patch.object(inbox_server, "PROCESSED_DIR", processed_dir), \
+                 patch.object(inbox_server, "_claims_db") as mock_claims, \
+                 patch.object(inbox_server, "_db_persist_inbound", None), \
+                 patch.object(inbox_server, "_update_lobster_state_fields", MagicMock()), \
+                 patch.object(inbox_server, "_recent_replies", {}):
+                mock_claims.update_status = MagicMock()
+                asyncio.run(inbox_server.handle_mark_processed({"message_id": msg_id, "force": True}))
+
+        ev = _events_of_type(listener, "inbox.processed")[0]
+        assert ev.payload.get("message_id") == msg_id
+        assert ev.severity == "info"
+
+
+# ---------------------------------------------------------------------------
+# inbox.failed — emitted when mark_failed moves a message to failed/
+# ---------------------------------------------------------------------------
+
+class TestInboxFailedEvent:
+    """mark_failed emits an inbox.failed event."""
+
+    def _write_processing_message(self, processing_dir: Path, msg_id: str) -> None:
+        msg = {
+            "id": msg_id,
+            "type": "text",
+            "source": "telegram",
+            "chat_id": 4444,
+            "text": "oops",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+        }
+        (processing_dir / f"{msg_id}.json").write_text(json.dumps(msg))
+
+    def test_mark_failed_emits_inbox_failed_event(self):
+        bus, listener = _make_bus_with_listener()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            processing_dir = Path(tmpdir) / "processing"
+            failed_dir = Path(tmpdir) / "failed"
+            processing_dir.mkdir()
+            failed_dir.mkdir()
+            msg_id = "1111111111_telegram"
+            self._write_processing_message(processing_dir, msg_id)
+
+            import inbox_server
+            with patch.object(inbox_server, "_EVENT_BUS_AVAILABLE", True), \
+                 patch("inbox_server.get_event_bus", return_value=bus), \
+                 patch.object(inbox_server, "PROCESSING_DIR", processing_dir), \
+                 patch.object(inbox_server, "INBOX_DIR", processing_dir), \
+                 patch.object(inbox_server, "FAILED_DIR", failed_dir), \
+                 patch.object(inbox_server, "_claims_db") as mock_claims:
+                mock_claims.update_status = MagicMock()
+                mock_claims.release = MagicMock()
+                asyncio.run(inbox_server.handle_mark_failed({
+                    "message_id": msg_id,
+                    "error": "test error",
+                    "max_retries": 0,  # force permanent failure immediately
+                }))
+
+        events = _events_of_type(listener, "inbox.failed")
+        assert len(events) == 1, f"Expected 1 inbox.failed event, got {len(events)}"
+
+    def test_inbox_failed_event_contains_error_info(self):
+        bus, listener = _make_bus_with_listener()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            processing_dir = Path(tmpdir) / "processing"
+            failed_dir = Path(tmpdir) / "failed"
+            processing_dir.mkdir()
+            failed_dir.mkdir()
+            msg_id = "1111111111_telegram"
+            self._write_processing_message(processing_dir, msg_id)
+
+            import inbox_server
+            with patch.object(inbox_server, "_EVENT_BUS_AVAILABLE", True), \
+                 patch("inbox_server.get_event_bus", return_value=bus), \
+                 patch.object(inbox_server, "PROCESSING_DIR", processing_dir), \
+                 patch.object(inbox_server, "INBOX_DIR", processing_dir), \
+                 patch.object(inbox_server, "FAILED_DIR", failed_dir), \
+                 patch.object(inbox_server, "_claims_db") as mock_claims:
+                mock_claims.update_status = MagicMock()
+                mock_claims.release = MagicMock()
+                asyncio.run(inbox_server.handle_mark_failed({
+                    "message_id": msg_id,
+                    "error": "my error message",
+                    "max_retries": 0,
+                }))
+
+        ev = _events_of_type(listener, "inbox.failed")[0]
+        assert ev.payload.get("message_id") == msg_id
+        assert "error" in ev.payload
+        assert ev.severity == "warn"
+
+
+# ---------------------------------------------------------------------------
+# job.completed — emitted when write_task_output records a job result
+# ---------------------------------------------------------------------------
+
+class TestJobCompletedEvent:
+    """write_task_output emits a job.completed event carrying job_name and status."""
+
+    def test_write_task_output_emits_job_completed_event(self):
+        bus, listener = _make_bus_with_listener()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outputs_dir = Path(tmpdir)
+            import inbox_server
+            with patch.object(inbox_server, "_EVENT_BUS_AVAILABLE", True), \
+                 patch("inbox_server.get_event_bus", return_value=bus), \
+                 patch.object(inbox_server, "TASK_OUTPUTS_DIR", outputs_dir):
+                asyncio.run(inbox_server.handle_write_task_output({
+                    "job_name": "nightly-check",
+                    "output": "All systems green",
+                    "status": "success",
+                }))
+
+        events = _events_of_type(listener, "job.completed")
+        assert len(events) == 1, f"Expected 1 job.completed event, got {len(events)}"
+
+    def test_job_completed_event_has_job_name_and_status(self):
+        bus, listener = _make_bus_with_listener()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outputs_dir = Path(tmpdir)
+            import inbox_server
+            with patch.object(inbox_server, "_EVENT_BUS_AVAILABLE", True), \
+                 patch("inbox_server.get_event_bus", return_value=bus), \
+                 patch.object(inbox_server, "TASK_OUTPUTS_DIR", outputs_dir):
+                asyncio.run(inbox_server.handle_write_task_output({
+                    "job_name": "nightly-check",
+                    "output": "All systems green",
+                    "status": "success",
+                }))
+
+        ev = _events_of_type(listener, "job.completed")[0]
+        assert ev.payload.get("job_name") == "nightly-check"
+        assert ev.payload.get("status") == "success"
+        assert ev.severity == "info"
+
+    def test_job_completed_event_severity_is_warn_on_failure(self):
+        bus, listener = _make_bus_with_listener()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outputs_dir = Path(tmpdir)
+            import inbox_server
+            with patch.object(inbox_server, "_EVENT_BUS_AVAILABLE", True), \
+                 patch("inbox_server.get_event_bus", return_value=bus), \
+                 patch.object(inbox_server, "TASK_OUTPUTS_DIR", outputs_dir):
+                asyncio.run(inbox_server.handle_write_task_output({
+                    "job_name": "nightly-check",
+                    "output": "Something went wrong",
+                    "status": "failed",
+                }))
+
+        ev = _events_of_type(listener, "job.completed")[0]
+        assert ev.payload.get("status") == "failed"
+        assert ev.severity == "warn"


### PR DESCRIPTION
Closes #1352

## What this solves

Before this PR, `logs/events.jsonl` captured bot-talk messages and agent lifecycle events, but the four highest-volume flows through Lobster — inbound Telegram messages, outbound replies, inbox state transitions, and scheduled job completions — were invisible to the audit trail. Retrospective debugging required reading individual inbox/processing/processed files.

## What changed

Five new event types are now emitted to the EventBus on every call to the relevant MCP handlers:

| Event type | Emitted in | Payload fields |
|---|---|---|
| `telegram.inbound` | `handle_mark_processing` | `message_id`, `source`, `msg_type` |
| `telegram.outbound` | `handle_send_reply` (non-bot-talk) | `source`, `chat_id`, `text_len` |
| `inbox.processed` | `handle_mark_processed` | `message_id` |
| `inbox.failed` | `handle_mark_failed` (both retry and permanent paths) | `message_id`, `error`, `permanent` |
| `job.completed` | `handle_write_task_output` | `job_name`, `status`, `output_len` |

`telegram.outbound` is skipped for `source="bot-talk"` — that channel already emits to the bus via `bot_talk_mirror._emit_event_bus`. Agent lifecycle (`agent.spawn`, `agent.complete`) was already wired in `handle_register_agent`/`handle_unregister_agent` — no change there.

All new events use the direct `LobsterEvent(payload={...})` pattern (not `_emit_event`) so the payload carries structured fields queryable without content-marker heuristics. Every emit is wrapped in `try/except _EVENT_BUS_AVAILABLE` — the calling code path is never blocked.

## Functional patterns

Pure construction of immutable `LobsterEvent` dataclasses, fire-and-forget emission via `emit_sync`, `try/except` isolation at each callsite.

## Before/after flow

The state transition flow is unchanged. The only addition is a side-channel emission after each state transition:

```
inbox/ → [mark_processing] → processing/   + emit telegram.inbound
                 ↓
         [send_reply]       → outbox/       + emit telegram.outbound
                 ↓
         [mark_processed]   → processed/    + emit inbox.processed
         [mark_failed]      → failed/       + emit inbox.failed

[write_task_output]         → task-outputs/ + emit job.completed
```

## Tests run

- [x] `uv run pytest tests/unit/test_eventbus_wiring.py tests/unit/test_event_bus.py tests/unit/test_emit_event.py -q` — 44 passed, 0 failed
- [x] Pre-existing test suite: 2427 passed, 80 pre-existing failures in unrelated test files (test_write_observation, test_memory, test_reliability, test_skill_manager) — none caused by this change (verified by running same set on main before changes)

## Manual test

N/A — all changes are internal MCP handler instrumentation. No systemd units, cron, external services, or file I/O pattern changes. Events emit to the same `events.jsonl` path already used by bot-talk events.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (internal instrumentation only)
- [x] User-visible outcome verified — N/A (audit log, not user-facing)
- [x] Side-effect audit complete: fire-and-forget emissions; no floods, no shared-state writes beyond the existing events.jsonl append path
- [x] External service calls: none