### PR TITLE
fix(dispatcher): prevent inline responses to CC terminal input and stop hook errors

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -104,6 +104,10 @@ while True:
 
 **WFM-always-next rule:** After any `mark_processed` call, the very next action is `wait_for_messages()`. No exceptions. No state assessment. No deliberation. This is enforced by a Stop hook (`hooks/require-wait-for-messages.py`) — if you end a turn without calling WFM, it blocks the stop (exit 2) and injects an error. The only correct response to that error is: call `wait_for_messages` immediately.
 
+**CC terminal input rule:** If the user types directly in the Claude Code interactive terminal (not via Telegram or the inbox), treat it identically to a Telegram message: compose a response, call `send_reply(chat_id=ADMIN_CHAT_ID, ...)` to deliver it to Telegram, then call `wait_for_messages`. Never respond inline as CC text output. The user communicates via Telegram — CC terminal input is an accident of session startup, not a different interaction mode.
+
+**Stop hook error rule:** If the `require-wait-for-messages.py` stop hook fires and injects an error (e.g. "WFM not called"), the ONLY correct response is: call `wait_for_messages()` immediately. Do NOT treat the injected error message as a user prompt. Do NOT respond to it inline. The hook's intent is to force WFM — honor it by calling WFM and nothing else.
+
 ---
 
 ## The 7-Second Rule


### PR DESCRIPTION
## What this fixes

The dispatcher had two behavioral gaps that caused it to respond inline as Claude Code text output instead of routing through `send_reply` to Telegram.

**Root cause 1 — CC terminal input:** When a user typed directly in the Claude Code interactive terminal (rather than sending a message via Telegram), the dispatcher had no rule saying this was the same interaction mode as Telegram. It responded inline, and the user never saw the reply in Telegram.

**Root cause 2 — Stop hook error handling:** The `require-wait-for-messages.py` stop hook injects an error when WFM is not called at end-of-turn. The dispatcher had no rule explicitly handling this case, so it sometimes treated the injected error text as a new user prompt and responded to it inline — compounding the problem rather than fixing it.

## Changes

Two rules added to the WFM section of `sys.dispatcher.bootup.md`, immediately after the existing `WFM-always-next rule`:

- **CC terminal input rule:** Treat CC terminal input identically to a Telegram message — compose a response, call `send_reply(chat_id=ADMIN_CHAT_ID, ...)`, then call `wait_for_messages`. Never respond inline.

- **Stop hook error rule:** When the stop hook fires with a "WFM not called" error, the only correct response is to call `wait_for_messages()` immediately. Do not treat the injected error as a user prompt. Do not respond inline.

Both rules are placed adjacent to the `WFM-always-next rule` so they are read together as a single coherent group governing end-of-turn behavior.

No other sections are changed.

## Tests run
- [x] Manual diff review — changes are purely additive, two new rule paragraphs inserted in the correct location
- [ ] Live dispatcher behavior — not testable without a running dispatcher session; the change is prompting rules only (no code), so the effect is behavioral

## Manual test
N/A — this change is entirely prompting text in a documentation/context file. No code paths are affected. No external services, systemd units, or file I/O involved.

## Definition of Done
- [x] No code changed — prompting rules only
- [x] Placed adjacent to the existing WFM-always-next rule for co-location
- [x] User-visible outcome: dispatcher will route replies to Telegram instead of inline CC output (verified by rule text; live verification requires a running dispatcher)
- [x] Side-effect audit: no floods, no shared state writes, no production data affected