### PR TITLE
fix: add git merge origin/main to post-merge steps (issue #1461)

### DIFF
--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -209,6 +209,11 @@ If any tests could not be run (missing Docker, live token, specific env), you **
 - After PR is approved and merged:
   - **Set "Main Board" project status to "Done"**
   - Close the issue if not auto-closed by PR keywords
+  - **Deploy the merged commit to local-dev** by fetching and merging origin/main:
+    ```bash
+    git -C ~/lobster fetch origin
+    git -C ~/lobster merge origin/main
+    ```
   - **Remove the worktree** to keep things tidy:
     ```bash
     cd ~/lobster


### PR DESCRIPTION
## Summary

After a PR merges to main, the post-merge step `git -C ~/lobster fetch origin` only updates the remote-tracking ref — it does not deploy the merged commit into the running branch (local-dev). This left merged PRs undeployed indefinitely. Issue #1461 documents the specific case of PR #1433 (reconciler flood fix) sitting absent from local-dev across 18 commits and multiple sessions.

The fix: add `git -C ~/lobster merge origin/main` immediately after the fetch. This brings the running branch (local-dev or main) up to date with origin/main without switching away from it.

## What changed

**`.claude/agents/functional-engineer.md` — Step 7 (PR Merge & Completion):** Added a new "Deploy the merged commit to local-dev" sub-step with the two-command sequence before the worktree cleanup step.

**`~/lobster-user-config/agents/user.dispatcher.bootup.md` (private, not in repo):** Updated the "Post-merge cleanup" paragraph to document both commands. This file governs what the dispatcher does when handling post-merge sign-off — it now correctly specifies fetch + merge, not fetch alone.

**`memory/feedback_merge_branch_handling.md` (private memory file):** Updated the stored rule from "only `git -C ~/lobster fetch origin`" to the two-command form, with the rationale from issue #1461. This ensures future sessions loading from memory get the correct behavior.

## Functional pattern

Pure documentation/process change — no runtime code modified. The change is declarative: it adds a step to the post-merge protocol that was always safe to run but was never specified.

## Before / after

```
Before:
  gh pr merge → git -C ~/lobster fetch origin → [done]
                                                     ^
                                                     local-dev still missing merged commit

After:
  gh pr merge → git -C ~/lobster fetch origin → git -C ~/lobster merge origin/main → [done]
                                                                                          ^
                                                                                          local-dev now contains merged commit
```

## Tests run

- [x] `git diff HEAD~1` — diff verified correct, no unintended changes
- [ ] Live post-merge test — not applicable: this is a process document change, not runtime code. The commands themselves (`git fetch` + `git merge`) are standard git operations with no novel logic to test.

## Manual test

N/A — change is entirely to agent instructions and memory. No external service calls, no file system runtime state, no systemd units affected.

## Definition of Done
- [x] Unit tests pass with proper mocking — N/A (doc change)
- [x] Integration/manual test run — N/A (doc change)
- [x] User-visible outcome verified — future post-merge subagents will run the merge step. Updated files verified.
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none

Closes #1461