### PR TITLE
feat: introduce LOBSTER_NAME as canonical instance identity

### DIFF
--- a/config/config.env.example
+++ b/config/config.env.example
@@ -111,10 +111,16 @@ LOBSTER_INSTANCE_URL=
 # GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE=$HOME/.config/gws/credentials.json
 # GOOGLE_WORKSPACE_CLI_KEYRING_BACKEND=file
 
+# Lobster instance identity — used as the sender name in bot-talk messages
+# and anywhere else the instance needs to identify itself by name.
+# BOT_TALK_SENDER (below) overrides this for bot-talk specifically.
+# LOBSTER_NAME=MyLobster
+
 # Bot-talk mirroring — shared message channel between Lobster instances
 # Set BOT_TALK_HTTP_URL to the /message endpoint of the shared bot-talk server.
 # BOT_TALK_SSH_HOST is the SSH alias for the fallback log write (default: sharedLobster).
 # BOT_TALK_SSH_LOG_PATH is the remote log file path (default: /home/shared/bot-talk/log.txt).
+# BOT_TALK_SENDER overrides LOBSTER_NAME for bot-talk (useful in multi-instance setups).
 # If BOT_TALK_HTTP_URL is empty, mirroring is silently disabled.
 # BOT_TALK_HTTP_URL=http://your-bot-talk-server:4242/message
 # BOT_TALK_SSH_HOST=sharedLobster

--- a/scheduled-tasks/tasks/lobstertalk-incoming-handler.md
+++ b/scheduled-tasks/tasks/lobstertalk-incoming-handler.md
@@ -12,7 +12,7 @@
 
 ## Context
 
-You are SaharLobster, handling incoming bot-talk messages from AlbertLobster or other lobsters.
+You are $LOBSTER_NAME (read from environment), handling incoming bot-talk messages from AlbertLobster or other lobsters.
 Your primary function for the LobsterTalk demo: when Albert's lobster asks "what do you know about X?",
 look up X in available data sources and reply with relevant context.
 
@@ -166,7 +166,7 @@ Send the reply via bot-talk:
 ```
 POST http://46.224.41.108:4242/message
 {
-  "sender": "SaharLobster",
+  "sender": "$LOBSTER_NAME",
   "recipient": "AlbertLobster",
   "content": "<reply>",
   "genre": "acknowledgment",

--- a/src/mcp/bot_talk_mirror.py
+++ b/src/mcp/bot_talk_mirror.py
@@ -117,6 +117,8 @@ BOT_TALK_TOKEN: str = (
 BOT_TALK_SENDER: str = (
     os.environ.get("BOT_TALK_SENDER")
     or _read_config_env("BOT_TALK_SENDER")
+    or os.environ.get("LOBSTER_NAME")
+    or _read_config_env("LOBSTER_NAME")
     or "SaharLobster"
 )
 BOT_TALK_HTTP_TIMEOUT = 3.0   # seconds


### PR DESCRIPTION
## What problem this solves

Every Lobster instance previously had its identity hardcoded as \"SaharLobster\" in two places: the bot-talk sender field in `bot_talk_mirror.py` and the deprecated `lobstertalk-incoming-handler.md` task spec. A second instance (AlbertLobster, or any future deploy) would silently impersonate SaharLobster in all bot-talk traffic unless the operator knew to set the undocumented `BOT_TALK_SENDER` override.

`LOBSTER_NAME` is the single place to declare an instance's identity. Everything that needs a name reads from it.

## What changed

**`config/config.env.example`** — adds a `LOBSTER_NAME=MyLobster` placeholder with a doc comment explaining the precedence hierarchy. Updates the `BOT_TALK_SENDER` comment to clarify it overrides `LOBSTER_NAME` (still supported for multi-instance scenarios where the bot-talk identity differs from the general instance name).

**`src/mcp/bot_talk_mirror.py`** — the `BOT_TALK_SENDER` resolution chain now reads:
1. `BOT_TALK_SENDER` env var (unchanged — highest priority)
2. `BOT_TALK_SENDER` from config.env (unchanged)
3. `LOBSTER_NAME` env var (new)
4. `LOBSTER_NAME` from config.env (new)
5. hardcoded `"SaharLobster"` (last resort, unchanged)

No behavior change for any existing install that has `BOT_TALK_SENDER` set. An install with only `LOBSTER_NAME` set now gets the right identity automatically.

**`scheduled-tasks/tasks/lobstertalk-incoming-handler.md`** — replaces two hardcoded `"SaharLobster"` string literals with `$LOBSTER_NAME` references so the task spec stays consistent with the env-var approach. (This file is marked DEPRECATED but is still in the repo and read by operators.)

## What is out of scope

`LOBSTER_NAME` is not yet wired into any other subsystems (Telegram bot display name, memory labels, etc.). This PR scopes it strictly to bot-talk identity resolution.

## Functional pattern

The resolution chain uses pure sequential `or` composition — no mutation, each fallback is an independent read. Consistent with the existing pattern used for `BOT_TALK_HTTP_URL` and `BOT_TALK_TOKEN`.

## Tests run
- [x] Static review of resolution chain — logic is identical to the existing `BOT_TALK_TOKEN` fallback pattern, no new branching
- [ ] Live bot-talk round-trip — skipped: requires a second running Lobster instance; no behavior change for existing installs with `BOT_TALK_SENDER` already set

## Manual test
N/A — this change is entirely within config resolution at module load time. No systemd, no external service calls, no file I/O at runtime. The only observable effect is which sender name appears in bot-talk HTTP payloads, which requires a live bot-talk server to verify.

## Definition of Done
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none added; existing bot-talk calls unchanged