### PR TITLE
remove: /re-review command (pseudocode only, never implemented)

### DIFF
--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -85,13 +85,13 @@ If you find an existing PASS review or substantive comments, compare the timesta
 
 Call `write_result` with:
 ```
-Already reviewed at [timestamp] (no new commits since). Skipping re-review.
+Already reviewed at [timestamp] (no new commits since). Skipping.
 ```
 then exit.
 
 **This is discretion, not a hard gate.** Override the skip if:
 - The existing review has a NEEDS-WORK or FAIL verdict (the author may have addressed feedback)
-- You were explicitly asked to re-review
+- You were explicitly asked to review again
 - The existing comments look like housekeeping rather than real technical findings
 
 When in doubt, skip — a duplicate PASS is noise; a missed issue can be caught in a follow-up.
@@ -151,14 +151,12 @@ NEEDS-WORK: Scope mismatch — PR claims [stated scope] but has [N] files change
 
 This PR is too large relative to its stated purpose. A reviewer cannot safely approve a [M]-line change described as "[stated scope]" — the stated scope does not explain what the extra [M - expected] lines are doing.
 
-**Required before re-review:**
+**Required before merge:**
 - Split this PR: keep the stated fix in one PR, move unrelated changes to separate PRs
 - Or update the description to fully explain every file changed and why it belongs here
 
 Until the scope is clear, NEEDS-WORK is the only safe verdict.
 
----
-After pushing a fix, post `/re-review` as a comment on this PR to trigger re-review.
 ```
 
 **Override conditions** — do NOT flag as mismatch if:
@@ -201,8 +199,6 @@ Then include: a summary of what changed, specific findings with severity, test r
 **For NEEDS-WORK and FAIL verdicts**, append the following escape valve at the end of the review comment (after all findings):
 
 ```
----
-After pushing a fix, post `/re-review` as a comment on this PR to trigger re-review.
 ```
 
 This tells the author how to get a follow-up review once they have addressed the findings. Do not include this footer on PASS verdicts.


### PR DESCRIPTION
## What and why

The `/re-review` command was documented in `sys.dispatcher.bootup.md` as pseudocode — it described the intent but was never wired to actual dispatcher routing logic. Issue #885 tracked the incomplete wiring. Rather than implement it, Sahar decided to remove it entirely.

This PR removes the command definition and all downstream references:

- `sys.dispatcher.bootup.md`: removes the `### /re-review command` section (14 lines of pseudocode + the issue #885 note)
- `agents/review.md`: removes the `/re-review` footer from NEEDS-WORK/FAIL verdict templates, the "Required before re-review" label in the scope mismatch block, and incidental wording in the skip-detection section

No behavior changes — the command was never functional.

## Tests run
- [x] `grep -r "re-review" .claude/` — 0 matches after edits
- [ ] No unit tests applicable (doc-only change)

## Manual test
N/A — doc-only removal, no external service calls or runtime state affected.

## Definition of Done
- [x] Unit tests pass with proper mocking — N/A
- [x] Integration/manual test — N/A (doc-only)
- [x] User-visible outcome verified — N/A (no user-visible output)
- [x] Side-effect audit — no runtime effect; command was never dispatched
- [x] External service calls — none