### PR TITLE
feat: append Eastern Time to inbox timestamps

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -25,6 +25,7 @@ import httpx
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from zoneinfo import ZoneInfo
 
 # Ensure src/mcp/ is on sys.path so log_utils (a sibling module) can be
 # imported when this script is run directly (same guard used by
@@ -418,6 +419,30 @@ def _format_iso_for_display(iso_str: str, fmt: str = "%Y-%m-%d %I:%M %p %Z") -> 
         return _format_display_ts(dt, fmt)
     except Exception:
         return iso_str
+
+
+_ET_ZONE = ZoneInfo("America/New_York")
+
+
+def _format_ts_with_et(ts_str: str) -> str:
+    """Format a timestamp string as 'YYYY-MM-DDTHH:MM:SS UTC (H:MM AM/PM ET)'.
+
+    Parses the ISO 8601 timestamp, appends the Eastern Time equivalent
+    (EDT or EST depending on DST), and keeps the UTC value for auditability.
+    Falls back to the raw string if parsing fails.
+    """
+    try:
+        dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        # Strip sub-second precision for cleaner display
+        utc_str = dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
+        et_dt = dt.astimezone(_ET_ZONE)
+        # %Z returns 'EDT' or 'EST' automatically via zoneinfo DST rules
+        et_str = et_dt.strftime("%-I:%M %p %Z")
+        return f"{utc_str} ({et_str})"
+    except Exception:
+        return ts_str
 
 
 def _track_reply(chat_id: Any) -> None:
@@ -4239,7 +4264,7 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
         tg_msg_id = msg.get("telegram_message_id")
         if tg_msg_id:
             output += f"Telegram Message ID: `{tg_msg_id}` (pass as reply_to_message_id to send_reply to thread your reply)\n"
-        output += f"Time: {ts}\n"
+        output += f"Time: {_format_ts_with_et(ts)}\n"
         # dispatcher_hint: structural signals for the dispatcher to route correctly
         if msg_type == "subagent_notification":
             output += "dispatcher_hint: SUBAGENT_NOTIFICATION — user already received the subagent's reply. Don't summarize it. If you respond, add new value only — a question, a correction, missing context. Call mark_processed when done.\n"

--- a/tests/unit/test_mcp_server/test_format_ts_with_et.py
+++ b/tests/unit/test_mcp_server/test_format_ts_with_et.py
@@ -1,0 +1,71 @@
+"""
+Tests for _format_ts_with_et — the ET timestamp formatter added to handle_check_inbox output.
+
+Verifies that:
+- Naive UTC timestamps get the ET equivalent appended (EDT in summer, EST in winter)
+- Explicit UTC timestamps (with +00:00) are handled correctly
+- Microseconds are stripped for cleaner display
+- Bad/malformed timestamps fall back to the raw string unchanged
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_MCP_DIR = Path(__file__).parent.parent.parent.parent / "src" / "mcp"
+if str(_MCP_DIR) not in sys.path:
+    sys.path.insert(0, str(_MCP_DIR))
+
+from inbox_server import _format_ts_with_et  # noqa: E402
+
+
+class TestFormatTsWithEt:
+    def test_summer_timestamp_shows_edt(self):
+        # April is EDT (UTC-4): 14:32 UTC -> 10:32 AM EDT
+        result = _format_ts_with_et("2026-04-10T14:32:18.059908")
+        assert result == "2026-04-10T14:32:18 UTC (10:32 AM EDT)"
+
+    def test_winter_timestamp_shows_est(self):
+        # January is EST (UTC-5): 20:00 UTC -> 3:00 PM EST
+        result = _format_ts_with_et("2026-01-15T20:00:00")
+        assert result == "2026-01-15T20:00:00 UTC (3:00 PM EST)"
+
+    def test_explicit_utc_offset_handled(self):
+        # Explicit +00:00 suffix should produce the same result as naive UTC
+        result = _format_ts_with_et("2026-04-10T14:32:18+00:00")
+        assert result == "2026-04-10T14:32:18 UTC (10:32 AM EDT)"
+
+    def test_microseconds_stripped_from_utc_portion(self):
+        # Sub-second precision should be stripped in the displayed UTC part
+        result = _format_ts_with_et("2026-04-10T14:32:18.123456")
+        assert ".123456" not in result
+        assert "14:32:18 UTC" in result
+
+    def test_midnight_utc_formats_correctly(self):
+        # Midnight UTC in summer -> 8:00 PM EDT previous day (UTC-4)
+        result = _format_ts_with_et("2026-06-01T00:00:00")
+        assert result == "2026-06-01T00:00:00 UTC (8:00 PM EDT)"
+
+    def test_malformed_timestamp_returns_raw_string(self):
+        bad = "not-a-timestamp"
+        result = _format_ts_with_et(bad)
+        assert result == bad
+
+    def test_empty_string_returns_empty_string(self):
+        result = _format_ts_with_et("")
+        assert result == ""
+
+    def test_utc_label_always_present(self):
+        result = _format_ts_with_et("2026-04-10T14:32:18")
+        assert " UTC " in result
+
+    def test_et_label_always_present(self):
+        # Result contains EDT (summer) or EST (winter) — both end in T
+        result = _format_ts_with_et("2026-04-10T14:32:18")
+        assert "EDT" in result or "EST" in result
+
+    def test_format_contains_parenthesized_et(self):
+        result = _format_ts_with_et("2026-04-10T14:32:18")
+        assert result.startswith("2026-04-10T14:32:18 UTC (")
+        assert result.endswith(")")


### PR DESCRIPTION
## What this solves

The dispatcher reads timestamps like `2026-04-10T14:32:18.059908` from `check_inbox` / `wait_for_messages` output. Converting raw UTC to ET mentally adds friction when reasoning about message age and timing urgency. The system prompt says to always display times in ET, but this was only applied to user-facing replies — not to the internal tool output the dispatcher reads.

## What changed

Timestamps in `handle_check_inbox` output now read:

```
Time: 2026-04-10T14:32:18 UTC (10:32 AM EDT)
```

instead of:

```
Time: 2026-04-10T14:32:18.059908
```

Both UTC and ET are shown — UTC preserved for auditability. Sub-second precision is stripped (irrelevant for dispatch decisions). EDT vs EST is handled automatically by the `America/New_York` tz database rule.

## Implementation

- Added `_format_ts_with_et(ts_str)` — a pure function using `zoneinfo.ZoneInfo("America/New_York")` (Python 3.9+ stdlib, no new dependencies). DST transitions are handled by the tz database, not by manual offset math.
- `_ET_ZONE` is a module-level singleton to avoid repeated `ZoneInfo` construction on every message.
- Graceful fallback: malformed or empty timestamps return the raw string unchanged.
- The only call-site change is line 4267 in `handle_check_inbox`: `f"Time: {ts}\n"` → `f"Time: {_format_ts_with_et(ts)}\n"`.

`wait_for_messages` returns directly through `handle_check_inbox`, so it picks up this change too.

**Functional patterns used:** pure function with no side effects, module-level immutable constant (`_ET_ZONE`), explicit fallback in `except` clause rather than letting exceptions surface.

## Scope

Only `handle_check_inbox` timestamp display is changed. No changes to message storage format, no changes to `since_ts` comparison logic, no changes to user-facing reply formatting.

## Tests run
- [x] `uv run pytest tests/unit/test_mcp_server/test_format_ts_with_et.py -v` — 10 passed, 0 failed (new tests covering EDT, EST, explicit UTC offset, microsecond stripping, midnight rollover, malformed input)
- [x] `uv run pytest tests/unit/test_mcp_server/ -q` — same pass/fail count as on `main` before this change; no regressions introduced
- [x] Pre-existing failures confirmed against `main` baseline (8 inbox-related failures exist on `main` unrelated to this change)

## Manual test

N/A — this change is entirely internal (tool output text formatting, not Telegram/user-facing messages). The MCP server restart is not required for the PR to be reviewed; it will be applied after merge.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (internal tool output only)
- [x] User-visible outcome — N/A (dispatcher-internal, not surfaced to Telegram)
- [x] Side-effect audit: read-only formatting change, no state written, no external calls
- [x] External service calls: none