### PR TITLE
feat(timezone): comprehensive UTC storage + owner-adaptive display

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -110,6 +110,45 @@ You can also use the existing update script's rollback feature:
 The upgrade script automatically shows you what's changed since your last update,
 written in plain language. You can also read the full list in `~/lobster/WHATSNEW`.
 
+## Migration Notes
+
+### April 2026 — Timezone-aware timestamps (`feat/tz-comprehensive`)
+
+**What changed:**
+
+- New module `src/utils/timezone.py` provides a central timezone API:
+  `utcnow()`, `to_utc()`, `to_user_tz()`, `format_for_user()`, `format_iso_for_user()`,
+  and `format_with_utc_and_local()`.
+- All `datetime.utcnow()` calls (which return naive/timezone-less datetimes) have been
+  replaced with `datetime.now(timezone.utc)` across all subsystems — bot, routers,
+  user model, and MCP server. This is the correct, future-proof approach per PEP 615.
+- Inbox and report timestamps now display in the owner's local timezone rather than
+  always showing UTC or hardcoded Eastern Time.
+- `config/owner.toml.example` documents the new `timezone` field.
+
+**Action required (optional):**
+
+Add your IANA timezone to `~/lobster-config/owner.toml`:
+
+```toml
+[owner]
+timezone = "America/New_York"   # replace with your timezone
+```
+
+Common values: `America/Los_Angeles`, `America/Chicago`, `Europe/London`,
+`Europe/Berlin`, `Asia/Tokyo`, `Asia/Kolkata`, `Australia/Sydney`.
+
+If you skip this, Lobster defaults to UTC — all functionality is intact, times just
+display in UTC rather than your local time.
+
+**Breaking changes:** None. The internal storage format is unchanged (UTC). Existing
+data is not affected. The only behavioral difference is that displayed timestamps now
+adapt to your timezone instead of showing UTC or Eastern Time.
+
+**Windows users:** The `zoneinfo` stdlib module on Windows requires `tzdata` from PyPI.
+Run `pip install tzdata` inside your venv if you see `zoneinfo.ZoneInfoNotFoundError`.
+On Linux and macOS the system timezone database is used automatically.
+
 ## Troubleshooting
 
 ### Playwright install fails

--- a/WHATSNEW
+++ b/WHATSNEW
@@ -2,6 +2,25 @@
 
 Each entry describes what changed for you as a user — not implementation details.
 
+## April 2026
+
+### Timestamps now show your local time
+
+Lobster has always stored timestamps in UTC internally. Now it also displays them
+in your local timezone. Inbox messages, reports, and digest entries all show the
+time in your configured timezone (e.g. "7:30 AM PDT") alongside the UTC reference.
+
+To enable this, add one line to your `~/lobster-config/owner.toml`:
+
+```toml
+[owner]
+timezone = "America/New_York"   # or your IANA timezone name
+```
+
+Run `lobster identity` if you're not sure how to find your IANA timezone name.
+If you leave this unset, Lobster defaults to UTC — everything still works, times
+just display in UTC.
+
 ## February 2026
 
 ### Browse past conversations

--- a/config/owner.toml.example
+++ b/config/owner.toml.example
@@ -26,6 +26,12 @@
 # Falls back to `gh api user --jq '.login'` if not set and gh CLI is authenticated
 # github_username = "your-github-username"
 
+# Timezone for display (IANA format).  All internal timestamps are stored in UTC;
+# this setting controls how times are shown to you in Telegram messages and reports.
+# Examples: "America/New_York", "America/Los_Angeles", "Europe/London", "Asia/Tokyo"
+# Defaults to "UTC" if not set.
+# timezone = "America/New_York"
+
 [instance]
 # Unique instance identifier (auto-generated for managed instances)
 # id = "lobster-self-hosted-1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,12 @@ dependencies = [
 dashboard = [
     # websockets moved to core deps (required by python-telegram-bot)
 ]
+windows = [
+    # zoneinfo (stdlib, Python 3.9+) needs this package on Windows
+    # because Windows ships without the IANA timezone database.
+    # Linux and macOS use the system tzdata and do not need this.
+    "tzdata>=2024.1",
+]
 browser = [
     "playwright>=1.40.0",
 ]

--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -990,7 +990,7 @@ async def handle_callback_query(update: Update, context: ContextTypes.DEFAULT_TY
         "text": f"[Button pressed: {query.data}]",
         "callback_data": query.data,
         "original_message_text": query.message.text or query.message.caption or "",
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
     inbox_file = INBOX_DIR / f"{msg_id}.json"
@@ -1037,7 +1037,7 @@ async def handle_photo_message(update: Update, context: ContextTypes.DEFAULT_TYP
             "user_name": user.first_name,
             "text": caption if caption else "[Photo message]",
             "image_file": str(image_path),
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         direct_inv = False
         engaged = False
@@ -1147,7 +1147,7 @@ async def handle_document_message(update: Update, context: ContextTypes.DEFAULT_
             "document_mime_type": document.mime_type,
             "document_file_size": document.file_size,
             "file_id": document.file_id,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         direct_inv = False
         engaged = False
@@ -1346,7 +1346,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "username": user.username,
         "user_name": user.first_name,
         "text": text,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
     if _is_group:
         msg_data["group_chat_id"] = chat.id
@@ -1443,7 +1443,7 @@ async def handle_edited_message(update: Update, context: ContextTypes.DEFAULT_TY
         "username": user.username,
         "user_name": user.first_name,
         "text": text,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "_edit_of_telegram_id": original_tg_id,
     }
     if _is_group:
@@ -1647,7 +1647,7 @@ async def handle_audio_message(
             "audio_duration": audio_obj.duration,
             "audio_mime_type": audio_obj.mime_type or ("audio/ogg" if is_voice else "audio/mpeg"),
             "file_id": audio_obj.file_id,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         direct_inv = False
         engaged = False
@@ -1715,7 +1715,7 @@ async def _flush_media_group(media_group_id: str, chat_id: int) -> None:
         "text": caption if caption else f"[{len(buf.image_paths)} photos]",
         "image_files": buf.image_paths,
         "image_file": buf.image_paths[0],  # backward compat: primary image
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
     if buf.reply_ctx:

--- a/src/bot/onboarding.py
+++ b/src/bot/onboarding.py
@@ -55,10 +55,10 @@ def is_user_onboarded(user_id: int) -> bool:
 
 def mark_user_onboarded(user_id: int) -> None:
     """Mark a user as onboarded and persist to disk."""
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     data = _load_onboarded_users()
-    data[str(user_id)] = datetime.utcnow().isoformat()
+    data[str(user_id)] = datetime.now(timezone.utc).isoformat()
     _save_onboarded_users(data)
     log.info(f"Marked user {user_id} as onboarded")
 

--- a/src/bot/slack_router.py
+++ b/src/bot/slack_router.py
@@ -17,7 +17,7 @@ from logging.handlers import RotatingFileHandler
 import os
 import re
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from threading import Thread
 
@@ -317,7 +317,7 @@ def handle_message_events(body, say, logger):
         "username": username,
         "user_name": display_name,
         "text": cleaned_text,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "slack_ts": ts,
         "channel_name": channel_name,
         "is_dm": is_dm,

--- a/src/bot/sms_router.py
+++ b/src/bot/sms_router.py
@@ -18,7 +18,7 @@ import json
 import logging
 import os
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 import sys as _sys
 _SRC_DIR = str(Path(__file__).resolve().parent.parent)
@@ -218,7 +218,7 @@ def build_text_message(form: dict) -> dict:
         "user_name": from_number,
         "text": body,
         "twilio_message_sid": msg_sid,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
 

--- a/src/bot/whatsapp_router.py
+++ b/src/bot/whatsapp_router.py
@@ -21,7 +21,7 @@ import json
 import logging
 import os
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from twilio.request_validator import RequestValidator
@@ -221,7 +221,7 @@ def build_text_message(form: dict) -> dict:
         "user_name": profile_name or from_number,
         "text": body,
         "twilio_message_sid": msg_sid,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
 

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -375,21 +375,37 @@ _REPLY_TRACK_MAX = 100
 
 
 # ---------------------------------------------------------------------------
-# Timezone utility — reads owner timezone from owner.toml for display
+# Timezone utility — delegates to utils.timezone for all display/conversion
+# ---------------------------------------------------------------------------
+#
+# The canonical implementation lives in utils/timezone.py.  Local wrappers
+# are kept here for backwards-compatibility with existing call sites inside
+# this file so that no other lines need to change.
+#
+# _format_ts_with_et has been renamed to _format_ts_for_user and now uses
+# the owner's configured timezone instead of hardcoding Eastern Time.
 # ---------------------------------------------------------------------------
 
-def _get_display_tz():
-    """Return the owner's local timezone for display purposes.
+try:
+    from utils.timezone import (
+        format_for_user as _tz_format_for_user,
+        format_iso_for_user as _tz_format_iso_for_user,
+        format_with_utc_and_local as _tz_format_with_utc_and_local,
+        get_owner_zoneinfo as _tz_get_owner_zoneinfo,
+    )
+    _TZ_UTIL_AVAILABLE = True
+except ImportError:
+    _TZ_UTIL_AVAILABLE = False
 
-    Reads the 'timezone' field from owner.toml (e.g. 'America/Los_Angeles').
-    Falls back to UTC if not set or if zoneinfo cannot load the zone.
-    Always returns a zoneinfo.ZoneInfo-compatible object.
-    """
+
+def _get_display_tz():
+    """Return the owner's local timezone (ZoneInfo) for display purposes."""
+    if _TZ_UTIL_AVAILABLE:
+        return _tz_get_owner_zoneinfo()
     import zoneinfo as _zoneinfo
     try:
         from user_model.owner import get_owner_timezone as _get_owner_tz
-        tz_name = _get_owner_tz()
-        return _zoneinfo.ZoneInfo(tz_name)
+        return _zoneinfo.ZoneInfo(_get_owner_tz())
     except Exception:
         return _zoneinfo.ZoneInfo("UTC")
 
@@ -397,23 +413,19 @@ def _get_display_tz():
 def _format_display_ts(dt: "datetime", fmt: str = "%Y-%m-%d %I:%M %p %Z") -> str:
     """Convert a datetime to the owner's local timezone and format it for display.
 
-    Args:
-        dt:  A datetime object (naive datetimes are assumed UTC).
-        fmt: strftime format string. Default produces e.g. '2026-03-19 02:18 AM PST'.
-
-    Returns a formatted string in the owner's local time.
+    Naive datetimes are assumed UTC.
     """
+    if _TZ_UTIL_AVAILABLE:
+        return _tz_format_for_user(dt, fmt=fmt)
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
-    local_dt = dt.astimezone(_get_display_tz())
-    return local_dt.strftime(fmt)
+    return dt.astimezone(_get_display_tz()).strftime(fmt)
 
 
 def _format_iso_for_display(iso_str: str, fmt: str = "%Y-%m-%d %I:%M %p %Z") -> str:
-    """Parse an ISO 8601 string and format it in the owner's local timezone.
-
-    Falls back to the raw string if parsing fails.
-    """
+    """Parse an ISO 8601 string and format it in the owner's local timezone."""
+    if _TZ_UTIL_AVAILABLE:
+        return _tz_format_iso_for_user(iso_str, fmt=fmt)
     try:
         dt = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
         return _format_display_ts(dt, fmt)
@@ -421,26 +433,23 @@ def _format_iso_for_display(iso_str: str, fmt: str = "%Y-%m-%d %I:%M %p %Z") -> 
         return iso_str
 
 
-_ET_ZONE = ZoneInfo("America/New_York")
-
-
 def _format_ts_with_et(ts_str: str) -> str:
-    """Format a timestamp string as 'YYYY-MM-DDTHH:MM:SS UTC (H:MM AM/PM ET)'.
+    """Format a timestamp as 'YYYY-MM-DDTHH:MM:SS UTC (H:MM AM/PM <owner-tz>)'.
 
-    Parses the ISO 8601 timestamp, appends the Eastern Time equivalent
-    (EDT or EST depending on DST), and keeps the UTC value for auditability.
+    Previously hardcoded to Eastern Time; now uses the owner's configured
+    timezone from owner.toml so display matches the owner's actual locale.
     Falls back to the raw string if parsing fails.
     """
+    if _TZ_UTIL_AVAILABLE:
+        return _tz_format_with_utc_and_local(ts_str)
     try:
         dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
-        # Strip sub-second precision for cleaner display
         utc_str = dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
-        et_dt = dt.astimezone(_ET_ZONE)
-        # %Z returns 'EDT' or 'EST' automatically via zoneinfo DST rules
-        et_str = et_dt.strftime("%-I:%M %p %Z")
-        return f"{utc_str} ({et_str})"
+        local_dt = dt.astimezone(_get_display_tz())
+        local_str = local_dt.strftime("%-I:%M %p %Z")
+        return f"{utc_str} ({local_str})"
     except Exception:
         return ts_str
 

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -448,7 +448,7 @@ def _format_ts_with_et(ts_str: str) -> str:
             dt = dt.replace(tzinfo=timezone.utc)
         utc_str = dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
         local_dt = dt.astimezone(_get_display_tz())
-        local_str = local_dt.strftime("%-I:%M %p %Z")
+        local_str = local_dt.strftime("%I:%M %p %Z").lstrip("0")
         return f"{utc_str} ({local_str})"
     except Exception:
         return ts_str

--- a/src/mcp/user_model/__init__.py
+++ b/src/mcp/user_model/__init__.py
@@ -52,8 +52,8 @@ class UserModel:
                 "SELECT value FROM um_metadata WHERE key = 'created_at'"
             ).fetchone()
             if not row:
-                from datetime import datetime
-                set_metadata_value(self._conn, "created_at", datetime.utcnow().isoformat())
+                from datetime import datetime, timezone
+                set_metadata_value(self._conn, "created_at", datetime.now(timezone.utc).isoformat())
             # Seed bootstrap from owner.toml (non-critical)
             try:
                 from .seed import reseed_if_needed

--- a/src/mcp/user_model/bridges.py
+++ b/src/mcp/user_model/bridges.py
@@ -12,7 +12,7 @@ Depends on: schema.py, db.py, narrative.py, prediction.py only.
 
 import re
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -161,7 +161,7 @@ def sync_projects_to_arcs(
                 themes=proj.get("themes") or existing.themes,
                 status=proj["status"],
                 started_at=existing.started_at,
-                last_updated=datetime.utcnow(),
+                last_updated=datetime.now(timezone.utc),
                 resolution=existing.resolution,
             )
             upsert_narrative_arc(conn, arc)
@@ -174,8 +174,8 @@ def sync_projects_to_arcs(
                 description=proj["description"],
                 themes=proj.get("themes", []),
                 status=proj["status"],
-                started_at=datetime.utcnow(),
-                last_updated=datetime.utcnow(),
+                started_at=datetime.now(timezone.utc),
+                last_updated=datetime.now(timezone.utc),
             )
             upsert_narrative_arc(conn, arc)
             created += 1
@@ -219,7 +219,7 @@ def sync_priorities_to_attention(
             context="priorities",
             source="canonical_priorities",
             metadata={"rank": rank + 1},
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
         )
         upsert_attention_item(conn, att)
         injected += 1
@@ -307,7 +307,7 @@ def write_context_cache(
         content = "# User Model Context\n\n*No data yet — model is still learning.*\n"
     else:
         header = "# User Model Context\n"
-        header += f"*Auto-generated {datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')} — do not edit*\n"
+        header += f"*Auto-generated {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')} — do not edit*\n"
         content = header + "\n".join(sections) + "\n"
 
     # Atomic write

--- a/src/mcp/user_model/db.py
+++ b/src/mcp/user_model/db.py
@@ -336,7 +336,12 @@ def _now_iso() -> str:
 def _parse_dt(s: str | None) -> datetime | None:
     if not s:
         return None
-    return datetime.fromisoformat(s)
+    dt = datetime.fromisoformat(s)
+    # Rows written before the tz-aware migration are naive UTC strings.
+    # Attach UTC so comparisons with datetime.now(timezone.utc) never raise TypeError.
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
 
 
 # ---------------------------------------------------------------------------
@@ -426,7 +431,7 @@ def _row_to_observation(row: sqlite3.Row) -> Observation:
         confidence=row["confidence"],
         context=row["context"],
         metadata=json.loads(row["metadata"]),
-        observed_at=datetime.fromisoformat(row["observed_at"]),
+        observed_at=_parse_dt(row["observed_at"]),
         processed=bool(row["processed"]),
     )
 
@@ -563,8 +568,8 @@ def _row_to_preference_node(row: sqlite3.Row) -> PreferenceNode:
         description=row["description"],
         evidence_count=row["evidence_count"],
         last_observed=_parse_dt(row["last_observed"]),
-        created_at=datetime.fromisoformat(row["created_at"]),
-        updated_at=datetime.fromisoformat(row["updated_at"]),
+        created_at=_parse_dt(row["created_at"]),
+        updated_at=_parse_dt(row["updated_at"]),
         decay_rate=row["decay_rate"],
     )
 
@@ -630,7 +635,7 @@ def get_recent_emotional_states(
             dominance=r["dominance"],
             trigger=r["trigger"],
             context=r["context"],
-            recorded_at=datetime.fromisoformat(r["recorded_at"]),
+            recorded_at=_parse_dt(r["recorded_at"]),
             confidence=r["confidence"],
         )
         for r in rows
@@ -682,7 +687,7 @@ def get_blind_spots(
             evidence=r["evidence"],
             surfaced=bool(r["surfaced"]),
             confidence=r["confidence"],
-            created_at=datetime.fromisoformat(r["created_at"]),
+            created_at=_parse_dt(r["created_at"]),
         )
         for r in rows
     ]
@@ -729,7 +734,7 @@ def get_active_contradictions(conn: sqlite3.Connection) -> list[Contradiction]:
             tension_score=r["tension_score"],
             resolved=bool(r["resolved"]),
             resolution=r["resolution"],
-            detected_at=datetime.fromisoformat(r["detected_at"]),
+            detected_at=_parse_dt(r["detected_at"]),
         )
         for r in rows
     ]
@@ -780,8 +785,8 @@ def get_active_narrative_arcs(conn: sqlite3.Connection) -> list[NarrativeArc]:
             description=r["description"],
             themes=json.loads(r["themes"]),
             status=r["status"],
-            started_at=datetime.fromisoformat(r["started_at"]),
-            last_updated=datetime.fromisoformat(r["last_updated"]),
+            started_at=_parse_dt(r["started_at"]),
+            last_updated=_parse_dt(r["last_updated"]),
             resolution=r["resolution"],
         )
         for r in rows
@@ -835,8 +840,8 @@ def get_active_life_patterns(conn: sqlite3.Connection) -> list[LifePattern]:
             stage=r["stage"],
             evidence_count=r["evidence_count"],
             confidence=r["confidence"],
-            first_seen=datetime.fromisoformat(r["first_seen"]),
-            last_seen=datetime.fromisoformat(r["last_seen"]),
+            first_seen=_parse_dt(r["first_seen"]),
+            last_seen=_parse_dt(r["last_seen"]),
         )
         for r in rows
     ]
@@ -897,7 +902,7 @@ def get_attention_stack(
             context=r["context"],
             source=r["source"],
             metadata=json.loads(r["metadata"]),
-            created_at=datetime.fromisoformat(r["created_at"]),
+            created_at=_parse_dt(r["created_at"]),
             expires_at=_parse_dt(r["expires_at"]),
         )
         for r in rows
@@ -931,7 +936,7 @@ def get_model_metadata(conn: sqlite3.Connection) -> ModelMetadata:
     return ModelMetadata(
         schema_version=int(_get("schema_version") or "0"),
         owner_id=_get("owner_id"),
-        created_at=datetime.fromisoformat(created_str) if created_str else datetime.now(timezone.utc),
+        created_at=_parse_dt(created_str) if created_str else datetime.now(timezone.utc),
         last_observation_at=_parse_dt(last_obs_str),
         last_consolidation_at=_parse_dt(last_consol_str),
         observation_count=obs_count,
@@ -1004,7 +1009,7 @@ def get_snapshots_since(conn: sqlite3.Connection, days: int = 30) -> list:
 def _row_to_snapshot(row: sqlite3.Row) -> TemporalSnapshot:
     return TemporalSnapshot(
         id=row["id"],
-        snapshot_at=datetime.fromisoformat(row["snapshot_at"]),
+        snapshot_at=_parse_dt(row["snapshot_at"]),
         week_number=row["week_number"],
         year=row["year"],
         data=json.loads(row["data"]),
@@ -1061,7 +1066,7 @@ def get_unsurfaced_drifts(conn: sqlite3.Connection) -> list:
 def _row_to_drift(row: sqlite3.Row) -> DriftRecord:
     return DriftRecord(
         id=row["id"],
-        detected_at=datetime.fromisoformat(row["detected_at"]),
+        detected_at=_parse_dt(row["detected_at"]),
         snapshot_a_id=row["snapshot_a_id"],
         snapshot_b_id=row["snapshot_b_id"],
         drift_type=row["drift_type"],
@@ -1131,7 +1136,7 @@ def get_activity_rhythm(conn: sqlite3.Connection) -> list:
             total_length=r["total_length"],
             total_latency=r["total_latency"],
             latency_count=r["latency_count"],
-            updated_at=datetime.fromisoformat(r["updated_at"]),
+            updated_at=_parse_dt(r["updated_at"]),
         )
         for r in rows
     ]

--- a/src/mcp/user_model/db.py
+++ b/src/mcp/user_model/db.py
@@ -10,7 +10,7 @@ Schema migration strategy: versioned, idempotent, forward-only.
 import json
 import sqlite3
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -330,7 +330,7 @@ def _new_id() -> str:
 
 
 def _now_iso() -> str:
-    return datetime.utcnow().isoformat()
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _parse_dt(s: str | None) -> datetime | None:
@@ -394,7 +394,7 @@ def get_recent_observations(
     limit: int = 100,
 ) -> list[Observation]:
     """Get recent observations, optionally filtered by signal type."""
-    cutoff = datetime.utcnow()
+    cutoff = datetime.now(timezone.utc)
     cutoff_iso = cutoff.replace(
         hour=cutoff.hour - min(hours, cutoff.hour),
     ).isoformat()
@@ -439,7 +439,7 @@ def upsert_preference_node(conn: sqlite3.Connection, node: PreferenceNode) -> st
     """Insert or update a preference node. Returns node ID."""
     if not node.id:
         node.id = _new_id()
-    node.updated_at = datetime.utcnow()
+    node.updated_at = datetime.now(timezone.utc)
     conn.execute(
         """INSERT INTO um_preference_nodes
            (id, name, node_type, strength, flexibility, contexts, source,
@@ -743,7 +743,7 @@ def upsert_narrative_arc(conn: sqlite3.Connection, arc: NarrativeArc) -> str:
     """Insert or update a narrative arc. Returns ID."""
     if not arc.id:
         arc.id = _new_id()
-    arc.last_updated = datetime.utcnow()
+    arc.last_updated = datetime.now(timezone.utc)
     conn.execute(
         """INSERT INTO um_narrative_arcs
            (id, title, description, themes, status, started_at, last_updated, resolution)
@@ -796,7 +796,7 @@ def upsert_life_pattern(conn: sqlite3.Connection, pattern: LifePattern) -> str:
     """Insert or update a life pattern. Returns ID."""
     if not pattern.id:
         pattern.id = _new_id()
-    pattern.last_seen = datetime.utcnow()
+    pattern.last_seen = datetime.now(timezone.utc)
     conn.execute(
         """INSERT INTO um_life_patterns
            (id, name, description, stage, evidence_count, confidence, first_seen, last_seen)
@@ -931,7 +931,7 @@ def get_model_metadata(conn: sqlite3.Connection) -> ModelMetadata:
     return ModelMetadata(
         schema_version=int(_get("schema_version") or "0"),
         owner_id=_get("owner_id"),
-        created_at=datetime.fromisoformat(created_str) if created_str else datetime.utcnow(),
+        created_at=datetime.fromisoformat(created_str) if created_str else datetime.now(timezone.utc),
         last_observation_at=_parse_dt(last_obs_str),
         last_consolidation_at=_parse_dt(last_consol_str),
         observation_count=obs_count,
@@ -1182,7 +1182,7 @@ def set_cached_inference(
     """Cache an inference result with TTL. Returns cache entry ID."""
     from datetime import timedelta
     entry_id = _new_id()
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     expires = now + timedelta(minutes=ttl_minutes)
     conn.execute(
         """INSERT INTO um_inference_cache

--- a/src/mcp/user_model/emotional_model.py
+++ b/src/mcp/user_model/emotional_model.py
@@ -10,7 +10,7 @@ Depends on: schema.py, db.py only.
 """
 
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from .db import (
@@ -107,7 +107,7 @@ def record_emotional_state(
         dominance=dominance,
         trigger=trigger,
         context=context,
-        recorded_at=datetime.utcnow(),
+        recorded_at=datetime.now(timezone.utc),
         confidence=confidence,
     )
     return insert_emotional_state(conn, state)

--- a/src/mcp/user_model/infer.py
+++ b/src/mcp/user_model/infer.py
@@ -15,7 +15,7 @@ Depends on: schema.py, db.py, emotional_model.py, rhythm.py only.
 import re
 import sqlite3
 import zlib
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from .db import (
@@ -52,7 +52,7 @@ def estimate_mood(
     """
     recent_states = get_recent_emotional_states(conn, limit=5)
     # Filter to recent_hours
-    cutoff = datetime.utcnow() - timedelta(hours=recent_hours)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=recent_hours)
     recent_states = [s for s in recent_states if s.recorded_at > cutoff]
 
     baseline = get_emotional_baseline(conn, days=30)
@@ -135,7 +135,7 @@ def infer_response_style(
 
     Returns: {"preferred_length": str, "tone": str, "include_rationale": bool, "confidence": float}
     """
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     hour = now.hour
 
     # Defaults
@@ -393,7 +393,7 @@ def _compute_cache_key(
 ) -> str:
     """Compute a stable cache key for the given context."""
     sorted_ctx = ",".join(sorted(contexts))
-    hour = datetime.utcnow().hour
+    hour = datetime.now(timezone.utc).hour
     recent = get_recent_observations(conn, hours=1, limit=5)
     obs_ids = "|".join(o.id or "" for o in recent)
     obs_hash = zlib.crc32(obs_ids.encode()) & 0xFFFFFFFF
@@ -445,7 +445,7 @@ def run_inference(
         "response_style": response_style,
         "likely_next": likely_next,
         "context_used": contexts,
-        "computed_at": datetime.utcnow().isoformat(),
+        "computed_at": datetime.now(timezone.utc).isoformat(),
         "cached": False,
     }
 
@@ -458,7 +458,7 @@ def run_inference(
     # Shorten TTL if data is thin (low confidence)
     if mood.get("confidence", 0) < 0.4:
         ttl = 15
-    expires = datetime.utcnow() + timedelta(minutes=ttl)
+    expires = datetime.now(timezone.utc) + timedelta(minutes=ttl)
     result["expires_at"] = expires.isoformat()
     cacheable["expires_at"] = expires.isoformat()
 

--- a/src/mcp/user_model/inference.py
+++ b/src/mcp/user_model/inference.py
@@ -17,7 +17,7 @@ Depends on: all other user_model modules.
 """
 
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from .db import (
@@ -41,7 +41,7 @@ def run_consolidation(
     Returns a summary dict.
     """
     summary: dict[str, Any] = {
-        "started_at": datetime.utcnow().isoformat(),
+        "started_at": datetime.now(timezone.utc).isoformat(),
         "steps": [],
     }
 
@@ -158,7 +158,7 @@ def run_consolidation(
             summary["steps"].append({"step": "context_cache", "error": str(e)})
 
     # Step 9: Update metadata
-    now_iso = datetime.utcnow().isoformat()
+    now_iso = datetime.now(timezone.utc).isoformat()
     set_metadata_value(conn, "last_consolidation_at", now_iso)
     summary["completed_at"] = now_iso
 

--- a/src/mcp/user_model/inquiry.py
+++ b/src/mcp/user_model/inquiry.py
@@ -15,7 +15,7 @@ Depends on: schema.py, db.py only.
 """
 
 import sqlite3
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from .db import (
@@ -43,14 +43,14 @@ def should_ask_question(
     if not row:
         return True
     last_inquiry = datetime.fromisoformat(row["value"])
-    return datetime.utcnow() - last_inquiry > timedelta(hours=budget_hours)
+    return datetime.now(timezone.utc) - last_inquiry > timedelta(hours=budget_hours)
 
 
 def record_inquiry(conn: sqlite3.Connection) -> None:
     """Record that a question was asked (update budget tracker)."""
     conn.execute(
         "INSERT OR REPLACE INTO um_metadata (key, value) VALUES ('last_inquiry_at', ?)",
-        (datetime.utcnow().isoformat(),),
+        (datetime.now(timezone.utc).isoformat(),),
     )
     conn.commit()
 
@@ -130,7 +130,7 @@ def _pick_blind_spot_question(conn: sqlite3.Connection) -> str | None:
 def _pick_fading_arc_question(conn: sqlite3.Connection) -> str | None:
     """Ask about narrative arcs that are going cold."""
     arcs = get_active_narrative_arcs(conn)
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     fading = [
         arc for arc in arcs
@@ -194,7 +194,7 @@ def get_inquiry_status(conn: sqlite3.Connection) -> dict[str, Any]:
         hours_remaining = 0.0
     else:
         last = datetime.fromisoformat(row["value"])
-        elapsed = datetime.utcnow() - last
+        elapsed = datetime.now(timezone.utc) - last
         can_ask = elapsed > timedelta(hours=_DEFAULT_BUDGET_HOURS)
         hours_remaining = max(0, _DEFAULT_BUDGET_HOURS - elapsed.total_seconds() / 3600)
 

--- a/src/mcp/user_model/inquiry.py
+++ b/src/mcp/user_model/inquiry.py
@@ -43,6 +43,10 @@ def should_ask_question(
     if not row:
         return True
     last_inquiry = datetime.fromisoformat(row["value"])
+    # Rows written before the tz-aware migration are naive; attach UTC so the
+    # subtraction below never raises TypeError on an upgraded installation.
+    if last_inquiry.tzinfo is None:
+        last_inquiry = last_inquiry.replace(tzinfo=timezone.utc)
     return datetime.now(timezone.utc) - last_inquiry > timedelta(hours=budget_hours)
 
 
@@ -194,6 +198,8 @@ def get_inquiry_status(conn: sqlite3.Connection) -> dict[str, Any]:
         hours_remaining = 0.0
     else:
         last = datetime.fromisoformat(row["value"])
+        if last.tzinfo is None:
+            last = last.replace(tzinfo=timezone.utc)
         elapsed = datetime.now(timezone.utc) - last
         can_ask = elapsed > timedelta(hours=_DEFAULT_BUDGET_HOURS)
         hours_remaining = max(0, _DEFAULT_BUDGET_HOURS - elapsed.total_seconds() / 3600)

--- a/src/mcp/user_model/markdown_sync.py
+++ b/src/mcp/user_model/markdown_sync.py
@@ -23,7 +23,7 @@ Depends on: schema.py, db.py, emotional_model.py, narrative.py, self_knowledge.p
 
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -139,7 +139,7 @@ def sync_index(conn: Any, base: Path) -> bool:
     lines = [
         "# User Model Index",
         "",
-        f"*Last synced: {datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')}*",
+        f"*Last synced: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}*",
         "",
         "## Model Stats",
         "",
@@ -280,7 +280,7 @@ def sync_all(
         "base_dir": str(base),
         "files_written": files_written,
         "errors": errors,
-        "synced_at": datetime.utcnow().isoformat(),
+        "synced_at": datetime.now(timezone.utc).isoformat(),
     }
 
 

--- a/src/mcp/user_model/narrative.py
+++ b/src/mcp/user_model/narrative.py
@@ -10,7 +10,7 @@ Depends on: schema.py, db.py only.
 
 import re
 import sqlite3
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from .db import (
@@ -35,8 +35,8 @@ def create_arc(
         description=description,
         themes=themes or [],
         status=status,
-        started_at=datetime.utcnow(),
-        last_updated=datetime.utcnow(),
+        started_at=datetime.now(timezone.utc),
+        last_updated=datetime.now(timezone.utc),
     )
     return upsert_narrative_arc(conn, arc)
 
@@ -62,7 +62,7 @@ def update_arc(
         themes=json.loads(rows["themes"]),
         status=status or rows["status"],
         started_at=datetime.fromisoformat(rows["started_at"]),
-        last_updated=datetime.utcnow(),
+        last_updated=datetime.now(timezone.utc),
         resolution=resolution or rows["resolution"],
     )
     upsert_narrative_arc(conn, arc)
@@ -96,7 +96,7 @@ def refresh_arcs_from_observations(
 
     warmed = 0
     cooled = 0
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     for arc in arcs:
         # Build keyword set from arc title and themes
@@ -162,7 +162,7 @@ def format_active_arcs_markdown(conn: sqlite3.Connection) -> str:
         lines.append("*No active arcs tracked yet.*")
         return "\n".join(lines)
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     for arc in arcs:
         themes_str = ", ".join(arc.themes) if arc.themes else "none"
         staleness = (now - arc.last_updated).days

--- a/src/mcp/user_model/observation.py
+++ b/src/mcp/user_model/observation.py
@@ -12,7 +12,7 @@ Depends on: schema.py, db.py only.
 
 import re
 import sqlite3
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from .db import insert_observation, set_metadata_value
@@ -64,7 +64,7 @@ def extract_signals(
     signals = []
     text = message_text.strip()
     words = set(re.findall(r"\b\w+\b", text.lower()))
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     meta = metadata or {}
 
     # --- Sentiment ---
@@ -241,7 +241,7 @@ def observe_message(
             message_ts = datetime.fromisoformat(message_ts)
         except (ValueError, TypeError):
             message_ts = None
-    ts = message_ts or datetime.utcnow()
+    ts = message_ts or datetime.now(timezone.utc)
     reply_length = len(message_text)
     signals = extract_signals(message_text, message_id, context, metadata)
 
@@ -392,7 +392,7 @@ def extract_latency_signal(
         confidence=confidence,
         context=context,
         metadata={"latency_ms": latency_ms},
-        observed_at=datetime.utcnow(),
+        observed_at=datetime.now(timezone.utc),
     )
 
 
@@ -427,7 +427,7 @@ def extract_length_signal(
         confidence=confidence,
         context=context,
         metadata={"char_count": length},
-        observed_at=datetime.utcnow(),
+        observed_at=datetime.now(timezone.utc),
     )
 
 
@@ -502,5 +502,5 @@ def extract_topic_shift_signal(
         confidence=0.65,
         context=context,
         metadata={"from_topic": previous_topic, "to_topic": current_topic},
-        observed_at=current_ts or datetime.utcnow(),
+        observed_at=current_ts or datetime.now(timezone.utc),
     )

--- a/src/mcp/user_model/prediction.py
+++ b/src/mcp/user_model/prediction.py
@@ -12,7 +12,7 @@ Depends on: schema.py, db.py only.
 """
 
 import sqlite3
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from .db import (
@@ -72,7 +72,7 @@ def build_attention_stack(
     - Unresolved contradictions
     """
     items = []
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     contexts = contexts or []
 
     # --- From narrative arcs ---

--- a/src/mcp/user_model/preference_graph.py
+++ b/src/mcp/user_model/preference_graph.py
@@ -11,7 +11,7 @@ Depends on: schema.py, db.py only.
 """
 
 import sqlite3
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from .db import (
@@ -146,9 +146,9 @@ def add_preference(
         confidence=confidence,
         description=description,
         evidence_count=1,
-        last_observed=datetime.utcnow(),
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        last_observed=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
     )
     node_id = upsert_preference_node(conn, node)
 
@@ -177,8 +177,8 @@ def reinforce_preference(
         return
     node.evidence_count += 1
     node.confidence = min(1.0, node.confidence + confidence_delta)
-    node.last_observed = datetime.utcnow()
-    node.updated_at = datetime.utcnow()
+    node.last_observed = datetime.now(timezone.utc)
+    node.updated_at = datetime.now(timezone.utc)
     upsert_preference_node(conn, node)
 
 
@@ -200,7 +200,7 @@ def apply_correction(
     node.description = corrected_description
     if corrected_strength is not None:
         node.strength = corrected_strength
-    node.updated_at = datetime.utcnow()
+    node.updated_at = datetime.now(timezone.utc)
     upsert_preference_node(conn, node)
 
 
@@ -218,7 +218,7 @@ def apply_decay(
     Returns the number of nodes affected.
     """
     all_nodes = get_all_preference_nodes(conn)
-    cutoff = datetime.utcnow() - timedelta(days=7)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=7)
     affected = 0
     for node in all_nodes:
         if node.source == NodeSource.CORRECTED:
@@ -228,7 +228,7 @@ def apply_decay(
             decay = node.decay_rate * days_since_last_run
             node.confidence = max(0.1, node.confidence - decay)
             node.strength = max(0.1, node.strength - decay * 0.5)
-            node.updated_at = datetime.utcnow()
+            node.updated_at = datetime.now(timezone.utc)
             upsert_preference_node(conn, node)
             affected += 1
     return affected

--- a/src/mcp/user_model/rhythm.py
+++ b/src/mcp/user_model/rhythm.py
@@ -9,7 +9,7 @@ Depends on: schema.py, db.py only.
 """
 
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from .db import get_activity_rhythm, get_peak_activity_hours, update_activity_rhythm
@@ -48,7 +48,7 @@ def get_current_activity_level(
 
     relative_level: 'very_high' | 'high' | 'normal' | 'low' | 'unknown'
     """
-    now = now or datetime.utcnow()
+    now = now or datetime.now(timezone.utc)
     hour = now.hour
     day = now.weekday()
 

--- a/src/mcp/user_model/schema.py
+++ b/src/mcp/user_model/schema.py
@@ -6,9 +6,18 @@ These are the shared data types used across all user_model modules.
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
+
+
+def _utcnow() -> datetime:
+    """Return the current UTC time as a timezone-aware datetime.
+
+    Used as the default_factory for datetime fields in dataclasses, replacing
+    the deprecated (and tz-naive) ``datetime.utcnow``.
+    """
+    return datetime.now(timezone.utc)
 
 
 # ---------------------------------------------------------------------------
@@ -80,8 +89,8 @@ class PreferenceNode:
     last_observed: datetime | None = None
     parent_ids: list[str] = field(default_factory=list)   # Parent nodes (derives from)
     override_ids: list[str] = field(default_factory=list) # Nodes this overrides
-    created_at: datetime = field(default_factory=datetime.utcnow)
-    updated_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=_utcnow)
+    updated_at: datetime = field(default_factory=_utcnow)
     decay_rate: float = 0.01  # Per-day decay when not reinforced
 
 
@@ -95,7 +104,7 @@ class Observation:
     confidence: float       # 0.0–1.0
     context: str            # Active context(s) at observation time
     metadata: dict[str, Any] = field(default_factory=dict)
-    observed_at: datetime = field(default_factory=datetime.utcnow)
+    observed_at: datetime = field(default_factory=_utcnow)
     processed: bool = False  # Has inference pipeline consumed this?
 
 
@@ -108,7 +117,7 @@ class EmotionalState:
     dominance: float         # 0.0 (submissive/uncertain) to 1.0 (confident/in-control)
     trigger: str | None      # What triggered this state (optional)
     context: str             # Active context
-    recorded_at: datetime = field(default_factory=datetime.utcnow)
+    recorded_at: datetime = field(default_factory=_utcnow)
     confidence: float = 0.7
 
 
@@ -121,7 +130,7 @@ class BlindSpot:
     evidence: str           # Supporting evidence
     surfaced: bool = False  # Has this been shown to the user?
     confidence: float = 0.6
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=_utcnow)
 
 
 @dataclass
@@ -134,7 +143,7 @@ class Contradiction:
     tension_score: float    # 0.0–1.0, how strong the contradiction is
     resolved: bool = False
     resolution: str | None = None
-    detected_at: datetime = field(default_factory=datetime.utcnow)
+    detected_at: datetime = field(default_factory=_utcnow)
 
 
 @dataclass
@@ -145,8 +154,8 @@ class NarrativeArc:
     description: str        # Summary of the arc
     themes: list[str]       # Associated themes/topics
     status: str             # "active", "resolved", "paused"
-    started_at: datetime = field(default_factory=datetime.utcnow)
-    last_updated: datetime = field(default_factory=datetime.utcnow)
+    started_at: datetime = field(default_factory=_utcnow)
+    last_updated: datetime = field(default_factory=_utcnow)
     resolution: str | None = None
 
 
@@ -159,8 +168,8 @@ class LifePattern:
     stage: str              # "forming", "active", "declining", "broken"
     evidence_count: int = 0
     confidence: float = 0.6
-    first_seen: datetime = field(default_factory=datetime.utcnow)
-    last_seen: datetime = field(default_factory=datetime.utcnow)
+    first_seen: datetime = field(default_factory=_utcnow)
+    last_seen: datetime = field(default_factory=_utcnow)
 
 
 @dataclass
@@ -174,7 +183,7 @@ class AttentionItem:
     context: str             # What context this is relevant in
     source: str              # Where this item came from
     metadata: dict[str, Any] = field(default_factory=dict)
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=_utcnow)
     expires_at: datetime | None = None
 
 
@@ -230,7 +239,7 @@ class ActivityRhythm:
     total_length: int = 0    # cumulative chars, for avg computation
     total_latency: float = 0.0  # cumulative ms, for avg computation
     latency_count: int = 0   # samples with latency data
-    updated_at: datetime = field(default_factory=datetime.utcnow)
+    updated_at: datetime = field(default_factory=_utcnow)
 
 
 @dataclass

--- a/src/mcp/user_model/seed.py
+++ b/src/mcp/user_model/seed.py
@@ -87,7 +87,7 @@ def _upsert_seeded_node(
     If a node with this name already exists, update its description and mark as seeded.
     Returns the node ID.
     """
-    from datetime import datetime
+    from datetime import datetime, timezone
     import json
 
     # Check if a node with this name already exists
@@ -109,7 +109,7 @@ def _upsert_seeded_node(
             description=description,
             evidence_count=existing["evidence_count"],
             created_at=datetime.fromisoformat(existing["created_at"]),
-            updated_at=datetime.utcnow(),
+            updated_at=datetime.now(timezone.utc),
             decay_rate=0.01,
         )
         # Set v2 columns via direct SQL (they may not exist in PreferenceNode dataclass yet)

--- a/src/mcp/user_model/self_knowledge.py
+++ b/src/mcp/user_model/self_knowledge.py
@@ -7,7 +7,7 @@ Depends on: schema.py, db.py only.
 """
 
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from .db import (
@@ -61,7 +61,7 @@ def detect_contradictions(conn: sqlite3.Connection) -> list[Contradiction]:
                     node_id_b=node_b.id,
                     description=desc,
                     tension_score=tension,
-                    detected_at=datetime.utcnow(),
+                    detected_at=datetime.now(timezone.utc),
                 )
                 new_contradictions.append(c)
 
@@ -138,7 +138,7 @@ def add_blind_spot(
         evidence=evidence,
         surfaced=False,
         confidence=confidence,
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc),
     )
     return insert_blind_spot(conn, spot)
 
@@ -177,7 +177,7 @@ def record_life_pattern(
             evidence_count=row["evidence_count"] + 1,
             confidence=min(1.0, confidence + 0.05),
             first_seen=datetime.fromisoformat(row["first_seen"]),
-            last_seen=datetime.utcnow(),
+            last_seen=datetime.now(timezone.utc),
         )
     else:
         pattern = LifePattern(
@@ -187,8 +187,8 @@ def record_life_pattern(
             stage=stage,
             evidence_count=1,
             confidence=confidence,
-            first_seen=datetime.utcnow(),
-            last_seen=datetime.utcnow(),
+            first_seen=datetime.now(timezone.utc),
+            last_seen=datetime.now(timezone.utc),
         )
     return upsert_life_pattern(conn, pattern)
 

--- a/src/mcp/user_model/temporal.py
+++ b/src/mcp/user_model/temporal.py
@@ -9,7 +9,7 @@ Depends on: schema.py, db.py only.
 """
 
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from .db import (
@@ -42,7 +42,7 @@ def take_weekly_snapshot_if_due(conn: sqlite3.Connection) -> str | None:
     """
     latest = get_latest_snapshot(conn)
     if latest:
-        days_since = (datetime.utcnow() - latest.snapshot_at).days
+        days_since = (datetime.now(timezone.utc) - latest.snapshot_at).days
         if days_since < 6:
             return None
 
@@ -79,7 +79,7 @@ def _capture_snapshot(conn: sqlite3.Connection) -> str:
         "active_pattern_names": [p.name for p in patterns],
     }
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     iso_cal = now.isocalendar()
     snapshot = TemporalSnapshot(
         id=None,
@@ -123,7 +123,7 @@ def detect_drift_since_last_snapshot(conn: sqlite3.Connection) -> list[DriftReco
     previous_snap = snapshots[1]
 
     records: list[DriftRecord] = []
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     # Build index of previous state
     prev_prefs = {p["id"]: p for p in previous_snap.data.get("preferences", [])}

--- a/src/mcp/user_model/tools.py
+++ b/src/mcp/user_model/tools.py
@@ -342,7 +342,7 @@ def handle_model_observe(conn: sqlite3.Connection, args: dict, workspace_path: s
         # Record an explicit observation directly
         from .db import insert_observation
         from .schema import Observation, ObservationSignalType
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         type_map = {
             "preference": ObservationSignalType.PREFERENCE,
@@ -361,7 +361,7 @@ def handle_model_observe(conn: sqlite3.Connection, args: dict, workspace_path: s
             content=explicit_observation,
             confidence=confidence,
             context=context,
-            observed_at=datetime.utcnow(),
+            observed_at=datetime.now(timezone.utc),
         )
         obs_id = insert_observation(conn, obs, user_id=user_id)
         result = {"success": True, "mode": "explicit", "obs_id": obs_id, "signal_type": observation_type}

--- a/src/utils/timezone.py
+++ b/src/utils/timezone.py
@@ -197,7 +197,7 @@ def format_with_utc_and_local(
         utc_dt = to_utc(dt)
         utc_str = utc_dt.strftime("%Y-%m-%dT%H:%M:%S UTC")
         local_dt = to_user_tz(utc_dt, user_tz)
-        local_str = local_dt.strftime("%-I:%M %p %Z")
+        local_str = local_dt.strftime("%I:%M %p %Z").lstrip("0")
         return f"{utc_str} ({local_str})"
     except Exception:
         return ts_str

--- a/src/utils/timezone.py
+++ b/src/utils/timezone.py
@@ -1,0 +1,203 @@
+"""
+Central timezone utility for Lobster.
+
+Rules:
+  - All internal storage uses UTC (timezone-aware datetimes).
+  - All display/output to users adapts to the owner's timezone, read from
+    owner.toml (field: owner.timezone).
+  - Falls back to UTC if no timezone is configured.
+
+Public API
+----------
+  utcnow()                          -> datetime (UTC-aware)
+  to_utc(dt)                        -> datetime (UTC-aware)
+  to_user_tz(dt, user_tz=None)      -> datetime (user-tz-aware)
+  format_for_user(dt, fmt=..., user_tz=None) -> str
+  format_iso_for_user(iso_str, fmt=..., user_tz=None) -> str
+  get_owner_tz_name()               -> str  (IANA name, e.g. 'America/Los_Angeles')
+  get_owner_zoneinfo()              -> ZoneInfo
+
+Per-user timezone overrides
+---------------------------
+  Pass ``user_tz`` (IANA string or ZoneInfo) to any ``to_user_tz`` /
+  ``format_for_user`` call.  The owner.toml timezone is the default; per-user
+  overrides are stored in the user model (observation key "timezone") and can be
+  passed through by callers who have already resolved the preference.
+
+  Example::
+
+      from utils.timezone import format_for_user
+      display = format_for_user(dt, user_tz="Europe/London")
+
+Stdlib-only — no third-party dependencies required.
+"""
+
+from __future__ import annotations
+
+import zoneinfo
+from datetime import datetime, timezone as _tz_utc
+from typing import Union
+
+# Type alias accepted by public helpers
+_TZish = Union[str, zoneinfo.ZoneInfo, None]
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _load_zoneinfo(name: str) -> zoneinfo.ZoneInfo:
+    """Load a ZoneInfo by IANA name, falling back to UTC on any error."""
+    try:
+        return zoneinfo.ZoneInfo(name)
+    except Exception:
+        return zoneinfo.ZoneInfo("UTC")
+
+
+def _resolve_tz(user_tz: _TZish) -> zoneinfo.ZoneInfo:
+    """
+    Resolve *user_tz* to a ZoneInfo object.
+
+    Priority:
+      1. Explicit *user_tz* argument (str or ZoneInfo).
+      2. Owner timezone from owner.toml.
+      3. UTC fallback.
+    """
+    if user_tz is not None:
+        if isinstance(user_tz, zoneinfo.ZoneInfo):
+            return user_tz
+        if isinstance(user_tz, str) and user_tz:
+            return _load_zoneinfo(user_tz)
+    return get_owner_zoneinfo()
+
+
+# ---------------------------------------------------------------------------
+# Owner timezone resolution
+# ---------------------------------------------------------------------------
+
+def get_owner_tz_name() -> str:
+    """
+    Return the owner's IANA timezone string from owner.toml.
+
+    Falls back to 'UTC' if not configured or on any error.
+    """
+    try:
+        from user_model.owner import get_owner_timezone as _get
+        name = _get()
+        return name if name else "UTC"
+    except Exception:
+        pass
+    # Secondary fallback: try importing via package path
+    try:
+        from mcp.user_model.owner import get_owner_timezone as _get2
+        name = _get2()
+        return name if name else "UTC"
+    except Exception:
+        return "UTC"
+
+
+def get_owner_zoneinfo() -> zoneinfo.ZoneInfo:
+    """Return a ZoneInfo for the owner's configured timezone."""
+    return _load_zoneinfo(get_owner_tz_name())
+
+
+# ---------------------------------------------------------------------------
+# UTC helpers (for internal storage)
+# ---------------------------------------------------------------------------
+
+def utcnow() -> datetime:
+    """
+    Return the current time as a timezone-aware UTC datetime.
+
+    Drop-in replacement for ``datetime.utcnow()`` that is actually tz-aware.
+    """
+    return datetime.now(_tz_utc.utc)
+
+
+def to_utc(dt: datetime) -> datetime:
+    """
+    Ensure *dt* is a UTC-aware datetime.
+
+    - If *dt* is already tz-aware, convert it to UTC.
+    - If *dt* is naive, assume UTC and attach the UTC tzinfo.
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=_tz_utc.utc)
+    return dt.astimezone(_tz_utc.utc)
+
+
+# ---------------------------------------------------------------------------
+# Display helpers (for user-facing output)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_FMT = "%Y-%m-%d %I:%M %p %Z"
+
+
+def to_user_tz(dt: datetime, user_tz: _TZish = None) -> datetime:
+    """
+    Convert *dt* to the user's local timezone.
+
+    Naive datetimes are assumed to be UTC.
+    """
+    return to_utc(dt).astimezone(_resolve_tz(user_tz))
+
+
+def format_for_user(
+    dt: datetime,
+    fmt: str = _DEFAULT_FMT,
+    user_tz: _TZish = None,
+) -> str:
+    """
+    Convert *dt* to the user's timezone and return a formatted string.
+
+    Args:
+        dt:      Datetime to format (naive assumed UTC).
+        fmt:     strftime format string.  Default: '%Y-%m-%d %I:%M %p %Z'
+                 which produces e.g. '2026-04-10 09:30 AM PDT'.
+        user_tz: Override timezone (IANA string or ZoneInfo).  Defaults to
+                 the owner's configured timezone from owner.toml.
+
+    Returns:
+        Formatted string in the user's local time.
+    """
+    local_dt = to_user_tz(dt, user_tz)
+    return local_dt.strftime(fmt)
+
+
+def format_iso_for_user(
+    iso_str: str,
+    fmt: str = _DEFAULT_FMT,
+    user_tz: _TZish = None,
+) -> str:
+    """
+    Parse an ISO 8601 string and format it in the user's timezone.
+
+    Handles trailing 'Z' for UTC.  Falls back to the raw string on parse error.
+    """
+    try:
+        dt = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
+        return format_for_user(dt, fmt=fmt, user_tz=user_tz)
+    except Exception:
+        return iso_str
+
+
+def format_with_utc_and_local(
+    ts_str: str,
+    user_tz: _TZish = None,
+) -> str:
+    """
+    Format a timestamp as 'YYYY-MM-DDTHH:MM:SS UTC (H:MM AM/PM TZ)'.
+
+    This is the canonical display format for inbox timestamps: keeps the UTC
+    value for auditability and appends the owner's local time in parentheses.
+
+    Example output: '2026-04-10T14:30:00 UTC (7:30 AM PDT)'
+    """
+    try:
+        dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+        utc_dt = to_utc(dt)
+        utc_str = utc_dt.strftime("%Y-%m-%dT%H:%M:%S UTC")
+        local_dt = to_user_tz(utc_dt, user_tz)
+        local_str = local_dt.strftime("%-I:%M %p %Z")
+        return f"{utc_str} ({local_str})"
+    except Exception:
+        return ts_str


### PR DESCRIPTION
## Summary

This PR delivers a comprehensive timezone overhaul across all Lobster subsystems. All internal storage is now correctly tz-aware UTC; all user-facing display adapts to the instance owner's configured timezone from `owner.toml`.

### What changed

- **New `src/utils/timezone.py`** — central timezone API with pure functions:
  - `utcnow()` — drop-in replacement for the deprecated `datetime.utcnow()`, returns tz-aware UTC datetime
  - `to_utc(dt)` — normalises any datetime to UTC-aware
  - `to_user_tz(dt, user_tz=None)` — converts to owner tz (or explicit per-user override)
  - `format_for_user(dt, fmt, user_tz=None)` — one-call formatting in local time
  - `format_iso_for_user(iso_str, ...)` — parses ISO 8601 + formats for display
  - `format_with_utc_and_local(ts_str)` — canonical inbox format: `2026-04-10T14:30:00 UTC (7:30 AM PDT)`
  - `get_owner_tz_name()` / `get_owner_zoneinfo()` — reads `owner.toml`, falls back to UTC

- **`src/mcp/inbox_server.py`** — removes hardcoded `_ET_ZONE` (Eastern Time). Timestamp formatting now calls `timezone.format_with_utc_and_local()`, so PDT/BST/JST/etc. users see their correct local time.

- **`src/mcp/user_model/schema.py`** — `datetime.utcnow` bare factory replaced with a tz-aware `_utcnow()` wrapper; `timezone` import added.

- **All `datetime.utcnow()` call sites** replaced with `datetime.now(timezone.utc)` across:
  `bot/lobster_bot.py`, `bot/sms_router.py`, `bot/slack_router.py`, `bot/whatsapp_router.py`, `bot/onboarding.py`, and all 17 `user_model/` modules (bridges, db, emotional_model, infer, inference, inquiry, markdown_sync, narrative, observation, prediction, preference_graph, rhythm, seed, self_knowledge, temporal, tools, `__init__`).

- **`config/owner.toml.example`** — documents the new `timezone` field with examples.

- **`pyproject.toml`** — adds optional `[windows]` extra (`tzdata>=2024.1`) for Windows users who need the IANA database via PyPI.

- **`WHATSNEW`** — user-facing description of the local-time display feature.

- **`UPGRADE.md`** — April 2026 migration note with full upgrade instructions.

### Functional patterns used

- All timezone helpers are pure functions — no global mutable state, no side effects inside formatters.
- `_resolve_tz()` implements a priority chain (explicit arg → owner config → UTC) declaratively.
- `to_utc()` and `to_user_tz()` compose to build all formatting helpers, keeping the logic in one place.
- The `get_owner_tz_name()` helper isolates the one I/O side effect (config file read) at the boundary.

### Upgrade instructions for other Lobster users

**No action required for existing installations to keep working.** Lobster defaults to UTC if no timezone is set.

To see times in your local timezone, add one line to `~/lobster-config/owner.toml`:

```toml
[owner]
timezone = "America/New_York"   # use your IANA timezone
```

Common values: `America/Los_Angeles`, `America/Chicago`, `Europe/London`, `Europe/Berlin`, `Asia/Tokyo`.

Windows users only: run `pip install tzdata` inside your venv if you see `ZoneInfoNotFoundError`.

### Breaking changes

None. Internal storage format (UTC) is unchanged. Existing data is unaffected.

### Files changed summary

| Area | Files |
|------|-------|
| New timezone module | `src/utils/timezone.py` |
| MCP server | `src/mcp/inbox_server.py` |
| User model | `src/mcp/user_model/schema.py` + 16 other modules |
| Bot routers | `bot/lobster_bot.py`, `bot/sms_router.py`, `bot/slack_router.py`, `bot/whatsapp_router.py`, `bot/onboarding.py` |
| Config example | `config/owner.toml.example` |
| Deps | `pyproject.toml` (windows extra) |
| Docs | `UPGRADE.md`, `WHATSNEW` |

26 files changed, 360 insertions(+), 133 deletions(−) for the core commit; docs/deps added in follow-up commit.