### PR TITLE
fix: read owner timezone from owner.toml instead of hardcoding America/New_York

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -421,15 +421,12 @@ def _format_iso_for_display(iso_str: str, fmt: str = "%Y-%m-%d %I:%M %p %Z") -> 
         return iso_str
 
 
-_ET_ZONE = ZoneInfo("America/New_York")
+def _format_ts_with_local_tz(ts_str: str) -> str:
+    """Format a timestamp string as 'YYYY-MM-DDTHH:MM:SS UTC (H:MM AM/PM TZ)'.
 
-
-def _format_ts_with_et(ts_str: str) -> str:
-    """Format a timestamp string as 'YYYY-MM-DDTHH:MM:SS UTC (H:MM AM/PM ET)'.
-
-    Parses the ISO 8601 timestamp, appends the Eastern Time equivalent
-    (EDT or EST depending on DST), and keeps the UTC value for auditability.
-    Falls back to the raw string if parsing fails.
+    Parses the ISO 8601 timestamp, appends the owner's local time equivalent
+    (read from owner.toml; falls back to UTC if unset), and keeps the UTC value
+    for auditability.  Falls back to the raw string if parsing fails.
     """
     try:
         dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
@@ -437,10 +434,10 @@ def _format_ts_with_et(ts_str: str) -> str:
             dt = dt.replace(tzinfo=timezone.utc)
         # Strip sub-second precision for cleaner display
         utc_str = dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S UTC")
-        et_dt = dt.astimezone(_ET_ZONE)
-        # %Z returns 'EDT' or 'EST' automatically via zoneinfo DST rules
-        et_str = et_dt.strftime("%-I:%M %p %Z")
-        return f"{utc_str} ({et_str})"
+        local_dt = dt.astimezone(_get_display_tz())
+        # %Z returns the tz abbreviation automatically (EDT, EST, PDT, UTC, etc.)
+        local_str = local_dt.strftime("%-I:%M %p %Z")
+        return f"{utc_str} ({local_str})"
     except Exception:
         return ts_str
 
@@ -4264,7 +4261,7 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
         tg_msg_id = msg.get("telegram_message_id")
         if tg_msg_id:
             output += f"Telegram Message ID: `{tg_msg_id}` (pass as reply_to_message_id to send_reply to thread your reply)\n"
-        output += f"Time: {_format_ts_with_et(ts)}\n"
+        output += f"Time: {_format_ts_with_local_tz(ts)}\n"
         # dispatcher_hint: structural signals for the dispatcher to route correctly
         if msg_type == "subagent_notification":
             output += "dispatcher_hint: SUBAGENT_NOTIFICATION — user already received the subagent's reply. Don't summarize it. If you respond, add new value only — a question, a correction, missing context. Call mark_processed when done.\n"

--- a/tests/unit/test_mcp_server/test_format_ts_with_et.py
+++ b/tests/unit/test_mcp_server/test_format_ts_with_et.py
@@ -1,15 +1,19 @@
 """
-Tests for _format_ts_with_et — the ET timestamp formatter added to handle_check_inbox output.
+Tests for _format_ts_with_local_tz — the owner-tz-aware timestamp formatter
+used in handle_check_inbox output.
 
 Verifies that:
-- Naive UTC timestamps get the ET equivalent appended (EDT in summer, EST in winter)
-- Explicit UTC timestamps (with +00:00) are handled correctly
+- Timestamps are formatted using the owner's timezone from owner.toml
+- DST transitions work correctly (EDT in summer, EST in winter when set to NY)
+- UTC is the fallback when no timezone is configured in owner.toml
 - Microseconds are stripped for cleaner display
 - Bad/malformed timestamps fall back to the raw string unchanged
 """
 
 import sys
 from pathlib import Path
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -17,55 +21,69 @@ _MCP_DIR = Path(__file__).parent.parent.parent.parent / "src" / "mcp"
 if str(_MCP_DIR) not in sys.path:
     sys.path.insert(0, str(_MCP_DIR))
 
-from inbox_server import _format_ts_with_et  # noqa: E402
+from inbox_server import _format_ts_with_local_tz  # noqa: E402
 
 
-class TestFormatTsWithEt:
-    def test_summer_timestamp_shows_edt(self):
-        # April is EDT (UTC-4): 14:32 UTC -> 10:32 AM EDT
-        result = _format_ts_with_et("2026-04-10T14:32:18.059908")
+class TestFormatTsWithLocalTz:
+    def test_eastern_summer_shows_edt(self):
+        # With NY timezone: April is EDT (UTC-4), 14:32 UTC -> 10:32 AM EDT
+        with patch("inbox_server._get_display_tz", return_value=ZoneInfo("America/New_York")):
+            result = _format_ts_with_local_tz("2026-04-10T14:32:18.059908")
         assert result == "2026-04-10T14:32:18 UTC (10:32 AM EDT)"
 
-    def test_winter_timestamp_shows_est(self):
-        # January is EST (UTC-5): 20:00 UTC -> 3:00 PM EST
-        result = _format_ts_with_et("2026-01-15T20:00:00")
+    def test_eastern_winter_shows_est(self):
+        # With NY timezone: January is EST (UTC-5), 20:00 UTC -> 3:00 PM EST
+        with patch("inbox_server._get_display_tz", return_value=ZoneInfo("America/New_York")):
+            result = _format_ts_with_local_tz("2026-01-15T20:00:00")
         assert result == "2026-01-15T20:00:00 UTC (3:00 PM EST)"
+
+    def test_pacific_timezone_shows_pdt(self):
+        # With LA timezone: April is PDT (UTC-7), 14:32 UTC -> 7:32 AM PDT
+        with patch("inbox_server._get_display_tz", return_value=ZoneInfo("America/Los_Angeles")):
+            result = _format_ts_with_local_tz("2026-04-10T14:32:18")
+        assert result == "2026-04-10T14:32:18 UTC (7:32 AM PDT)"
+
+    def test_utc_fallback_when_no_timezone_set(self):
+        # With UTC (the fallback): time is identical, suffix is UTC
+        with patch("inbox_server._get_display_tz", return_value=ZoneInfo("UTC")):
+            result = _format_ts_with_local_tz("2026-04-10T14:32:18")
+        assert result == "2026-04-10T14:32:18 UTC (2:32 PM UTC)"
 
     def test_explicit_utc_offset_handled(self):
         # Explicit +00:00 suffix should produce the same result as naive UTC
-        result = _format_ts_with_et("2026-04-10T14:32:18+00:00")
+        with patch("inbox_server._get_display_tz", return_value=ZoneInfo("America/New_York")):
+            result = _format_ts_with_local_tz("2026-04-10T14:32:18+00:00")
         assert result == "2026-04-10T14:32:18 UTC (10:32 AM EDT)"
 
     def test_microseconds_stripped_from_utc_portion(self):
         # Sub-second precision should be stripped in the displayed UTC part
-        result = _format_ts_with_et("2026-04-10T14:32:18.123456")
+        with patch("inbox_server._get_display_tz", return_value=ZoneInfo("America/New_York")):
+            result = _format_ts_with_local_tz("2026-04-10T14:32:18.123456")
         assert ".123456" not in result
         assert "14:32:18 UTC" in result
 
     def test_midnight_utc_formats_correctly(self):
-        # Midnight UTC in summer -> 8:00 PM EDT previous day (UTC-4)
-        result = _format_ts_with_et("2026-06-01T00:00:00")
+        # Midnight UTC in summer with NY tz -> 8:00 PM EDT previous day (UTC-4)
+        with patch("inbox_server._get_display_tz", return_value=ZoneInfo("America/New_York")):
+            result = _format_ts_with_local_tz("2026-06-01T00:00:00")
         assert result == "2026-06-01T00:00:00 UTC (8:00 PM EDT)"
 
     def test_malformed_timestamp_returns_raw_string(self):
         bad = "not-a-timestamp"
-        result = _format_ts_with_et(bad)
+        result = _format_ts_with_local_tz(bad)
         assert result == bad
 
     def test_empty_string_returns_empty_string(self):
-        result = _format_ts_with_et("")
+        result = _format_ts_with_local_tz("")
         assert result == ""
 
     def test_utc_label_always_present(self):
-        result = _format_ts_with_et("2026-04-10T14:32:18")
+        with patch("inbox_server._get_display_tz", return_value=ZoneInfo("America/New_York")):
+            result = _format_ts_with_local_tz("2026-04-10T14:32:18")
         assert " UTC " in result
 
-    def test_et_label_always_present(self):
-        # Result contains EDT (summer) or EST (winter) — both end in T
-        result = _format_ts_with_et("2026-04-10T14:32:18")
-        assert "EDT" in result or "EST" in result
-
-    def test_format_contains_parenthesized_et(self):
-        result = _format_ts_with_et("2026-04-10T14:32:18")
+    def test_format_contains_parenthesized_local_time(self):
+        with patch("inbox_server._get_display_tz", return_value=ZoneInfo("America/New_York")):
+            result = _format_ts_with_local_tz("2026-04-10T14:32:18")
         assert result.startswith("2026-04-10T14:32:18 UTC (")
         assert result.endswith(")")


### PR DESCRIPTION
## Problem

PR #1472 (merged 2026-04-10) introduced `_format_ts_with_et()` which hardcodes `ZoneInfo("America/New_York")` for inbox timestamp display. Lobster is multi-user — the timezone must come from the instance owner's `owner.toml` config, not be baked into the code.

The merged code already contained the correct building block: `_get_display_tz()` (also added in #1472) reads `[owner].timezone` from `owner.toml` and falls back to UTC. `_format_ts_with_et` just wasn't wired to use it.

## What changed

- Removed `_ET_ZONE = ZoneInfo("America/New_York")` (the hardcoded constant)
- Renamed `_format_ts_with_et` to `_format_ts_with_local_tz` (name no longer implies Eastern Time)
- Wired the function to use `_get_display_tz()`, which reads `owner.toml` and falls back to UTC when no timezone is set
- Updated the call site in `handle_check_inbox`
- Updated tests: now mock `_get_display_tz` explicitly; added Pacific (PDT) and UTC-fallback cases

## owner.toml field

```toml
[owner]
timezone = "America/New_York"   # any IANA timezone string; omit for UTC
```

Read via `user_model.owner.get_owner_timezone()`, surfaced by `_get_display_tz()`.

## Before / After

```
Before (hardcoded):                   After (owner.toml):
_ET_ZONE = ZoneInfo(                  _get_display_tz() reads owner.toml
  "America/New_York")                   falls back to UTC

_format_ts_with_et(ts)               _format_ts_with_local_tz(ts)
  always shows EDT/EST                  shows PDT/EDT/BST/UTC/etc.
```

## Relation to PR #1473

PR #1473 (`feature/tz-comprehensive`) is a broader timezone overhaul that creates a central `src/utils/timezone.py` module. This PR is narrower — it fixes only the hardcoded timezone in the inbox formatter, using the helpers already present in the codebase. Both can land independently; #1473 will supersede this change when it merges.

## Functional patterns used

Pure function with no side effects; `_get_display_tz()` isolates the one I/O boundary (config file read) at the system edge.

## Tests run
- [x] `uv run pytest tests/unit/test_mcp_server/test_format_ts_with_et.py -v` — 11 passed, 0 failed (covers NY EDT/EST, Pacific PDT, UTC fallback, explicit offset, microsecond stripping, midnight rollover, malformed input)
- [x] `uv run pytest tests/unit/test_mcp_server/ -q` — same pre-existing failure baseline as `origin/main`; no regressions introduced

## Manual test
N/A — entirely internal change (MCP tool output formatting, not Telegram/user-facing messages). MCP server was NOT restarted; this PR is staged for user review only.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (internal tool output only)
- [x] User-visible outcome — N/A (dispatcher-internal, not surfaced to Telegram)
- [x] Side-effect audit: read-only formatting change; no state written, no external calls
- [x] External service calls: none