### PR TITLE
feat(agents): add research methodology to lobster-generalist

### DIFF
--- a/.claude/agents/lobster-generalist.md
+++ b/.claude/agents/lobster-generalist.md
@@ -41,6 +41,18 @@ This two-step pattern ensures the user gets the reply even if the dispatcher ses
 
 If task_id or chat_id were not provided in your prompt, omit both calls — the dispatcher will handle routing.
 
+## Research Methodology
+
+When a task requires real-world information (current events, local searches, business hours, what exists near X, synagogues, restaurants, services, people, places, etc.):
+
+1. **SEARCH FIRST** — use WebSearch to discover the universe of options. Do not rely on training knowledge as the primary source.
+2. **Find authoritative directories first** — community org lists, official directories, neighborhood aggregators — before individual websites
+3. **Do NOT fill from latent knowledge and verify selectively** — this silently omits anything not in training data, producing incomplete results
+4. **Verify completion before delivering** — ask: "Could there be options I haven't found yet?" If no authoritative directory was found, keep searching
+5. **Disclose provenance** — if any result came from training knowledge rather than a live search, say so explicitly
+
+Latent knowledge tells you *what to search for*. It does not substitute for searching.
+
 ## Tooling Conventions
 
 - **Python**: always use `uv run` — never bare `python` or `python3`


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Problem

Subagents handling local-search tasks drew on latent training knowledge instead of using WebSearch. The failure mode: any entity not in training data is silently omitted. In one case this produced an incomplete synagogue search near 11238 — Union Temple and possibly others were missed.

Root cause: `lobster-generalist.md` had no explicit instruction to search first. Without that rule, the model defaults to what it knows from training, then may do selective verification — which cannot surface what it doesn't know to verify.

## Change

Adds a `## Research Methodology` section to `lobster-generalist.md` with five explicit rules:
1. Search first (WebSearch), never rely on latent knowledge as the primary source
2. Find authoritative directories before individual websites
3. Do not fill from latent knowledge and verify selectively
4. Verify completion before delivering ("could there be options I haven't found?")
5. Disclose provenance when any result came from training knowledge

## Scope

This is a shared system change — it applies to all users of the `lobster-generalist` agent. The same rule has already been added to the local `user.subagent.bootup.md` (which takes effect immediately without a PR).

*(This PR was opened by Lobster (subagent) on behalf of @sayhar.)*