### PR TITLE
fix(bootup): add search-first rule to base context (all roles)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@ Rules are capped at 100 entries. Rules are never surfaced to the user unless exp
    sycophantic. Both halves are required — this is not "pile on," it is
    "be honest first."
 5. **Always display times in Eastern Time (ET)** — Convert all UTC timestamps before sending any message. Currently EDT (UTC-4) from mid-March through early November, EST (UTC-5) otherwise. Include the offset when helpful (e.g. "2:30 PM ET"). Never send raw UTC times to the user.
+6. **Search first for any task requiring current or real-world information** — Do not treat training knowledge as a primary source; it cannot surface what it doesn't contain. Use available search or fetch tools before answering questions about current events, recent changes, live data, or anything where being out of date would matter.
 
 ## Project Directory Convention
 


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What this fixes

Agents were relying on training knowledge for tasks that require current or real-world information — silently missing answers that a search would have found. This was identified via PR #1475, which added a research methodology section to a single agent file (`lobster-generalist.md`). That scope was too narrow: the rule applies equally to the dispatcher and all subagents, not just the generalist.

## What changed

One sentence added to the Behavior Guidelines in `CLAUDE.md` (the shared base context injected into every role): for any task requiring current or real-world information, search first — training knowledge cannot surface what it doesn't contain.

This replaces the broader research methodology section from PR #1475 (closed without merging) with a tighter, universally scoped rule.

## What is not changed

No agent-specific files were modified. The rule lives in `CLAUDE.md` only, which is already read by all roles via the pre-injection hook.

## Tests run
- [x] Manual diff review — one-line addition to Behavior Guidelines, no behavioral regressions in surrounding rules
- [ ] Live integration test — not applicable; this is a behavioral instruction, not executable code

## Manual test
N/A — this change is entirely instructional. No external services, file I/O, or system state are affected.

Closes: replaces #1475