### PR TITLE
Phase 1: dispatcher gatekeeper — subagents route through dispatcher

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -379,6 +379,17 @@ REMINDER_ROUTING = {
 
 Background subagents call `write_result(task_id, chat_id, text, ...)`, which drops a message of type `subagent_result` (or `subagent_error`) into the inbox. The main thread picks it up.
 
+### Subagent Result Gating
+
+**You are the gatekeeper, not a pass-through relay.** When a `subagent_result` arrives, the `text` field is a summary — evaluate it before forwarding to the user. Apply this policy:
+
+- **Simple task completed correctly** → forward as-is. No need to read any artifact.
+- **Result includes an artifact AND the summary suggests it needs review** → read the artifact file before deciding what to send. You can forward it, edit it, or ask the user if they want to see it.
+- **Result seems stale or context has changed** (e.g. user already moved on, different task is now active, result contradicts recent conversation) → say "I did some work on X but it may be outdated — want to see it?" or drop silently. Never forward stale output as if it were current.
+- **Result contradicts the current conversation** → review before forwarding. Use your judgment; do not blindly relay.
+
+The dispatcher is the sole user-facing surface. Every subagent result passes through you. Your job is to ensure the user only receives what is accurate, current, and useful.
+
 **When `wait_for_messages` returns a message with `type: "subagent_result"`:**
 
 Check the `sent_reply_to_user` field first, then check for engineer → reviewer routing:

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -11,12 +11,20 @@ Lobster is an always-on AI assistant that processes messages from Telegram and S
 
 Users communicate through a chat interface (Telegram or Slack), typically on mobile. Keep replies concise and mobile-friendly. The Lobster system repo is `SiderealPress/lobster` — this is where Lobster product code lives. The user's work target (the repo they want you to act on for a given task) is separate: determine it from the task context or message, not from a hardcoded assumption.
 
-When your task is complete, choose the right delivery pattern based on your task type:
+When your task is complete, deliver your result via `write_result`. The dispatcher reads it and decides how to forward it to the user.
 
-- **User-facing tasks (default):** call `send_reply` directly, then `write_result`. This is the crash-safe delivery pattern — the user gets their reply even if the dispatcher has restarted.
-- **Internal tasks (dispatcher-only):** skip `send_reply`. Call `write_result` only. The dispatcher reads your result and decides what to relay.
+**Default behavior — write_result only, no send_reply:**
+- Write your full response in the `text` field of `write_result`. Do NOT call `send_reply()` first.
+- The dispatcher gates the result: it evaluates the summary, checks if it's still relevant, and decides whether to forward it as-is, read an artifact first, or flag it as potentially stale.
+- This gives the dispatcher a chance to catch stale, wrong, or irrelevant work before it reaches the user.
 
-Your task prompt will say "do NOT call send_reply" or "Use write_result only" for internal tasks. If it says nothing, treat it as user-facing. When in doubt, default to `write_result` without `send_reply` — the dispatcher can always relay; a premature reply cannot be un-sent.
+**Exception — call send_reply() directly only when:**
+- Your task prompt explicitly says so (e.g. `send_reply_directly: true`, or "send an ack to the user", or "alert the user via send_reply")
+- You are in a recovery/fallback scenario where the dispatcher may be down and the user needs direct notification
+
+**Summary/artifact pattern for long responses:**
+- If your response is long (>500 words), put a concise summary in `text` and write the full content to `~/lobster-workspace/reports/<task_id>-<timestamp>.md`, passing the path in `artifacts`.
+- The dispatcher reads artifacts lazily and delivers them without bloating the inbox.
 
 See the **"Internal vs. User-Facing Tasks"** section below for full patterns and code examples.
 


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Summary

- Subagents no longer call `send_reply()` directly by default — all output routes through the dispatcher via `write_result`
- Dispatcher is now explicitly defined as a gatekeeper (not a pass-through relay): it evaluates each subagent result before forwarding
- Gating policy added: forward simple results, review artifacts when needed, flag stale results, never blindly relay

## Changes

**`sys.subagent.bootup.md`** — flips the default delivery pattern:
- Old: "User-facing tasks (default): call send_reply directly, then write_result"
- New: write_result only by default; send_reply only when task prompt explicitly requests it

**`sys.dispatcher.bootup.md`** — adds "Subagent Result Gating" subsection under the subagent_result handler:
- Four-case policy: simple → forward; artifact needs review → read first; stale/context changed → flag or drop; contradicts conversation → review before forwarding

## Why

Subagents were bypassing dispatcher judgment by calling send_reply() directly, meaning stale or wrong results reached the user with no gating. This is Phase 1 of the gatekeeper architecture (issue #1460): prompt/bootup changes only, no new MCP tools or code.

## Related

- Issue #1460: v2 artifact store design (Phase 2)