### PR TITLE
fix(hooks): set sent_reply_to_user=false in recovery fallback

### DIFF
--- a/hooks/require-write-result.py
+++ b/hooks/require-write-result.py
@@ -422,7 +422,7 @@ def _write_synthetic_inbox_message(
             "text": text,
             "task_id": task_id,
             "status": "recovered",
-            "sent_reply_to_user": True,  # chat_id is unknown; dispatcher must not relay via send_reply
+            "sent_reply_to_user": False,  # dispatcher must relay this; user has NOT been notified
             "timestamp": now.isoformat(),
             "recovered": True,
         }


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Summary

The fallback path in `require-write-result.py` emits a synthetic `subagent_result` when an agent exceeds `MAX_HOOK_FIRES` without calling `write_result`. This message had `sent_reply_to_user: true` hardcoded — a signal the dispatcher reads to mean "user was already notified, skip delivery."

Under Phase 1 gatekeeper architecture (PR #1478), subagents no longer call `send_reply` directly. Delivery is always the dispatcher's responsibility. So the hardcoded `true` caused the dispatcher to silently drop these recovered messages, leaving the user with no notification at all.

The fix: change `sent_reply_to_user` to `false` so the dispatcher correctly routes the recovered content to the user.

The original comment ("dispatcher must not relay via send_reply") reflected pre-gatekeeper logic where the unknown `chat_id` (0) was the reason to suppress delivery. Under the gatekeeper model, the dispatcher handles the chat_id routing decision — it should receive the message and decide, not be pre-suppressed by the hook.

No other paths in the hook are affected.

## Functional patterns

Pure data transformation — the fix is a single value change in the message dict assembled by `_write_synthetic_inbox_message`. No control flow changes.

## Tests run

- [x] `grep -n sent_reply_to_user hooks/require-write-result.py` — confirms single occurrence, now `false`
- [ ] End-to-end fallback trigger test — skipped: requires a live agent session that exhausts MAX_HOOK_FIRES; safe to merge as the change is a single boolean

**Blocked items needing attention before merge:** none