### PR TITLE
Replace multi-signal health check with single dispatcher heartbeat sentinel

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -46,7 +46,7 @@ with open(ack_path) as f:
 ```
 The symlink `~/.claude/` resolves to `~/lobster/.claude/` on standard installs.
 
-3. Run `~/lobster/scripts/record-catchup-state.sh start` (suppresses WFM freshness check for 15 min).
+3. (Catchup suppression no longer required — the health check uses a 20-minute heartbeat threshold that covers catchup naturally. `record-catchup-state.sh` is no longer called. Skip this step.)
 3b. **Claim any pending user messages immediately** to stop the health-check staleness clock:
     - Call `check_inbox()` to get any messages currently waiting in the inbox
     - For each message that is NOT a system message (i.e. `chat_id != 0` and `source != "system"`): call `mark_processing(message_id)`
@@ -63,7 +63,7 @@ The symlink `~/.claude/` resolves to `~/lobster/.claude/` on standard installs.
 - New tasks: ack normally and spawn subagent. These are unambiguously new work.
 - Urgent messages: handle them. You have handoff.md for context.
 
-**When the startup catchup result arrives** (`task_id: "startup-catchup"`, `chat_id: 0`): read for situational awareness, update `handoff.md` if anything notable changed (failed subagents, open threads). Run `~/lobster/scripts/record-catchup-state.sh finish`. Do NOT relay to user — except if `LOBSTER_DEBUG=true`, send the post-bootup status message below. Then `mark_processed`.
+**When the startup catchup result arrives** (`task_id: "startup-catchup"`, `chat_id: 0`): read for situational awareness, update `handoff.md` if anything notable changed (failed subagents, open threads). Do NOT relay to user — except if `LOBSTER_DEBUG=true`, send the post-bootup status message below. Then `mark_processed`.
 
 **Post-bootup status message (LOBSTER_DEBUG=true only):** Send to ADMIN_CHAT_ID. Keep to 5-8 lines, mobile-friendly. Build it from `handoff.md` (just read for startup) and `msg["text"]` (the catchup summary). Format:
 
@@ -242,7 +242,7 @@ After a context compaction you lose situational awareness of the last ~30 minute
 
 > **MANDATORY: You MUST spawn compact-catchup before doing any other work after a compaction. Do not skip compact-catchup even if the in-conversation summary appears sufficient. The summary only covers pre-compaction context; compact-catchup also checks for in-flight subagent state and recently-returned results that the summary cannot know about.**
 
-> **CRITICAL — never batch the compact-reminder with other messages.** If `0_compact` arrives alongside other messages in the same WFM batch, handle the compact-reminder first (steps 1–7 below), return to `wait_for_messages()`, and the other messages will be waiting in the next cycle. Batching the compact-reminder with other work causes `record-catchup-state.sh start` to be skipped or forgotten, which disables WFM freshness suppression and causes a spurious health-check restart after ~10 minutes (issue #1283).
+> **CRITICAL — never batch the compact-reminder with other messages.** If `0_compact` arrives alongside other messages in the same WFM batch, handle the compact-reminder first (steps 1–7 below), return to `wait_for_messages()`, and the other messages will be waiting in the next cycle. Batching the compact-reminder with other work causes the catchup subagent to be spawned late, which may delay context recovery.
 
 ```
 1. mark_processing(message_id)  <- compact-reminder ONLY, not other messages
@@ -255,16 +255,15 @@ After a context compaction you lose situational awareness of the last ~30 minute
    - See .claude/agents/session-note-polish.md for the agent definition
    - Pass: task_id: "session-note-polish", chat_id: 0, source: "system", current_session_file: <path>, MESSAGE_COUNT: <current message count>
    - Do NOT wait for it — spawn and immediately proceed to step 4
-4. Run: ~/lobster/scripts/record-catchup-state.sh start  <- MANDATORY, arms WFM suppression
-5. Spawn compact_catchup subagent (subagent_type: "compact-catchup", run_in_background=True):
+4. Spawn compact_catchup subagent (subagent_type: "compact-catchup", run_in_background=True):
    - See .claude/agents/compact-catchup.md for the full prompt
    - Pass task_id: "compact-catchup", chat_id: 0, source: "system"
    - This step is MANDATORY — never skip it, regardless of how complete the in-conversation summary seems
-6. mark_processed(message_id)
-7. Resume wait_for_messages() loop — do NOT wait for either subagent result inline
+5. mark_processed(message_id)
+6. Resume wait_for_messages() loop — do NOT wait for either subagent result inline
 ```
 
-> **CRITICAL — do not wait inline.** The catchup subagent can take 10-12 minutes. If you wait before calling `wait_for_messages()`, the health check's WFM freshness threshold (600s) will fire and trigger an unnecessary restart.
+> **CRITICAL — do not wait inline.** The catchup subagent can take 10-12 minutes. Always return to `wait_for_messages()` immediately after spawning. The health check heartbeat covers the catchup window — no suppression needed.
 
 **When the compact_catchup result arrives** (`task_id: "compact-catchup"`, `chat_id: 0`):
 - Read `msg["text"]` to restore situational awareness
@@ -273,7 +272,6 @@ After a context compaction you lose situational awareness of the last ~30 minute
     `"🔄 Back online. Context recovered from [window_start] to [now]. [N messages] processed, [M subagents] were running."`
     (Fill in N and M from `msg["text"]`. ADMIN_CHAT_ID from `lobster.conf` or the compact-reminder context.)
     **Before composing this message, convert `[window_start]` and `[now]` from UTC ISO timestamps to ET (e.g. "5:29 AM ET"). Rule: EDT (UTC-4) mid-March through early November, EST (UTC-5) otherwise. Never send raw UTC ISO strings to the user.**
-- Run `~/lobster/scripts/record-catchup-state.sh finish`
 - `mark_processed`
 
 ---

--- a/hooks/thinking-heartbeat.py
+++ b/hooks/thinking-heartbeat.py
@@ -1,62 +1,64 @@
 #!/usr/bin/env python3
 """
-PostToolUse hook: thinking heartbeat.
+PostToolUse hook: dispatcher heartbeat.
 
-Writes last_thinking_at (ISO UTC timestamp) to lobster-state.json on every
-PostToolUse event. The health check reads this field and folds it into the
-effective freshness signal alongside the WFM heartbeat file and last_processed_at.
+Writes the current Unix epoch timestamp to a single heartbeat file on every
+PostToolUse event. The health check reads this file to determine whether the
+dispatcher is alive.
 
-Purpose: the dispatcher can spend 10+ minutes in a reasoning phase (thinking,
-composing responses, spawning subagents) without touching wait_for_messages or
-mark_processed. During this window the health check sees no activity and may
-incorrectly conclude the dispatcher is frozen. Any tool call at all means the
-dispatcher is alive — this hook captures that signal.
+Purpose: the dispatcher can spend 10+ minutes in a reasoning/catchup phase
+without touching wait_for_messages. Any tool call at all means the dispatcher
+is alive. This hook captures that signal via the simplest possible mechanism:
+a single file containing a single integer (epoch seconds).
 
 Design:
-- Unconditional: fires on every PostToolUse (no tool-name filtering needed)
+- Fires on every PostToolUse (no tool-name filtering needed)
 - Atomic write: write to .tmp, then os.rename() to avoid partial reads
-- Merge: read existing JSON, update last_thinking_at, write back — no overwrite
-- Silent on failure: health check degrades gracefully when field is absent
+- Single integer timestamp — no JSON parsing, no merging, no state file locking
+- Silent on failure: health check degrades gracefully when file is absent
+- Threshold-based: the health check uses a 20-minute window that naturally
+  covers compaction, catchup, and boot transitions without any suppression logic
+
+File location: ~/lobster-workspace/logs/dispatcher-heartbeat
+Content: single Unix epoch integer (e.g. "1713456789\n")
+
+Replaces the multi-signal approach (claude-heartbeat file + last_processed_at +
+last_thinking_at in lobster-state.json) with a single authoritative signal.
+See issue #1483.
 """
 
-import json
 import os
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 
 
-MESSAGES_DIR = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages"))
-STATE_FILE = Path(os.environ.get("LOBSTER_STATE_FILE_OVERRIDE", MESSAGES_DIR / "config" / "lobster-state.json"))
+WORKSPACE_DIR = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+HEARTBEAT_FILE = Path(
+    os.environ.get(
+        "LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE",
+        WORKSPACE_DIR / "logs" / "dispatcher-heartbeat",
+    )
+)
+
+# Sentinel threshold used in tests — not read here, but documents the expected value.
+# The health check uses DISPATCHER_HEARTBEAT_STALE_SECONDS = 1200 (20 minutes).
+DISPATCHER_HEARTBEAT_STALE_SECONDS = 1200
 
 
-def _read_state(path: Path) -> dict:
-    """Return existing state dict, or empty dict if file is absent or unparseable."""
-    try:
-        return json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
-        return {}
-
-
-def _write_state_atomic(path: Path, state: dict) -> None:
-    """Write state dict atomically: write to .tmp then rename."""
-    tmp = Path(str(path) + ".tmp")
-    tmp.write_text(json.dumps(state, indent=2) + "\n")
-    os.rename(str(tmp), str(path))
-
-
-def write_thinking_heartbeat(state_file: Path) -> None:
-    """Merge last_thinking_at into state_file, creating it if absent."""
-    state = _read_state(state_file)
-    state["last_thinking_at"] = datetime.now(timezone.utc).isoformat()
-    _write_state_atomic(state_file, state)
+def write_heartbeat(heartbeat_file: Path) -> None:
+    """Write current Unix epoch to heartbeat_file atomically."""
+    import time
+    heartbeat_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp = heartbeat_file.with_suffix(".tmp")
+    tmp.write_text(str(int(time.time())) + "\n")
+    os.rename(str(tmp), str(heartbeat_file))
 
 
 def main() -> None:
     try:
-        write_thinking_heartbeat(STATE_FILE)
+        write_heartbeat(HEARTBEAT_FILE)
     except Exception:
-        # Never block tool execution — health check degrades gracefully if field is absent
+        # Never block tool execution — health check degrades gracefully when file absent.
         pass
     sys.exit(0)
 

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -19,31 +19,33 @@
 #   stopped    - Wrapper received signal, shutting down
 #   waking     - Wrapper detected messages, about to launch Claude
 #
-# Compaction suppression:
+# Compaction suppression (inbox drain only):
 #   When Claude Code compacts its context, tool calls pause for 1-3+ minutes.
 #   During this window real user messages can age past STALE_THRESHOLD_SECONDS
 #   and trigger a false-positive restart. To prevent this, on-compact.py writes
 #   a compacted_at timestamp to lobster-state.json, and the stale-inbox check
 #   is skipped for COMPACTION_SUPPRESS_SECONDS after that timestamp.
+#   NOTE: Dispatcher liveness check (check_dispatcher_heartbeat) is NOT
+#   suppressed during compaction — the 20-minute threshold covers it naturally.
 #
-# Catchup suppression:
-#   After a compaction or restart, the dispatcher spawns a catchup subagent to
-#   recover situational awareness. This subagent can take 10-12 minutes. During
-#   this window the dispatcher IS calling wait_for_messages() but the catchup
-#   subagent delays return from the main loop. The dispatcher writes
-#   catchup_started_at to lobster-state.json before spawning the subagent, and
-#   catchup_finished_at when the result arrives. The WFM freshness check is
-#   suppressed for CATCHUP_SUPPRESS_SECONDS (15 min) after catchup_started_at,
-#   or immediately when catchup_finished_at is written.
+# Dispatcher liveness (replaces WFM freshness + catchup suppression):
+#   hooks/thinking-heartbeat.py writes a Unix epoch timestamp to
+#   ~/lobster-workspace/logs/dispatcher-heartbeat on every PostToolUse event.
+#   check_dispatcher_heartbeat() reads this single file and checks its age.
+#   The 1200s threshold covers compaction, catchup, and boot without any
+#   suppression logic. The dispatcher no longer needs to call
+#   record-catchup-state.sh to suppress false alarms. See issue #1483.
 #
 # Boot grace period:
 #   After any restart (health-check-initiated or manual), the new Claude session
 #   needs ~60-90s to initialize and begin draining the inbox. During this window
-#   the health-check skips stale-inbox, WFM freshness, and process/tmux checks
-#   to avoid false-positive restarts. The boot timestamp is written to
-#   lobster-state.json as booted_at by claude-persistent.sh (on first start) and
-#   by do_restart() (after each health-check-initiated restart). Resource checks
-#   (memory, disk, auth, outbox) still run during the grace period.
+#   the health-check skips stale-inbox and process/tmux checks to avoid
+#   false-positive restarts. The boot timestamp is written to lobster-state.json
+#   as booted_at by claude-persistent.sh (on first start) and by do_restart()
+#   (after each health-check-initiated restart). Resource checks (memory, disk,
+#   auth, outbox) still run during the grace period.
+#   NOTE: Dispatcher heartbeat check is NOT suppressed during boot grace — the
+#   20-minute threshold absorbs the 90s boot window naturally.
 #
 # Escalation ladder:
 #   GREEN  - All checks pass (or in expected transient state)
@@ -80,15 +82,22 @@ MAINTENANCE_EXPIRY_SECONDS=3600      # 1 hour - stale maintenance flag is auto-c
 
 COMPACTION_SUPPRESS_SECONDS=300      # 5 minutes - skip stale-inbox check after a compaction event
 COMPACT_GRACE_SECONDS=600            # 10 minutes - skip stale-inbox check after a compaction (last-compact.ts)
-CATCHUP_SUPPRESS_SECONDS=900         # 15 minutes - skip WFM freshness check while catchup subagent is running
+# CATCHUP_SUPPRESS_SECONDS removed (issue #1483): dispatcher heartbeat threshold covers catchup naturally
 RESTART_COOLDOWN_SUPPRESS_SECONDS=240 # 4 minutes - suppress stale-inbox RED after a recent restart
 
 BOOT_GRACE_SECONDS=90                # 90s - skip stale-inbox, WFM, and process checks after a restart
 
 HIBERNATE_FRESH_SECONDS=30           # Ignore hibernate state younger than this — transient dispatcher hibernation
 
-WFM_STALE_SECONDS=1200               # 20 minutes - RED if wait_for_messages not called since this long ago (raised from 600 to accommodate long reasoning/subagent-spawning phases)
-HEARTBEAT_FILE="$WORKSPACE_DIR/logs/claude-heartbeat"
+WFM_STALE_SECONDS=1200               # 20 minutes - kept for backward-compat references; superseded by DISPATCHER_HEARTBEAT_STALE_SECONDS
+HEARTBEAT_FILE="$WORKSPACE_DIR/logs/claude-heartbeat"   # legacy WFM-touch signal; superseded by dispatcher-heartbeat
+
+# Dispatcher heartbeat sentinel (issue #1483 simplification)
+# Written by hooks/thinking-heartbeat.py on every PostToolUse event.
+# Single file, single integer (Unix epoch seconds). No JSON parsing required.
+# Threshold is generous enough to cover compaction + catchup without suppression.
+DISPATCHER_HEARTBEAT_FILE="${LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE:-$WORKSPACE_DIR/logs/dispatcher-heartbeat}"
+DISPATCHER_HEARTBEAT_STALE_SECONDS=1200   # 20 min — covers compaction (~5m) + catchup (~12m) + margin
 
 OUTBOX_DIR="$MESSAGES_DIR/outbox"
 OUTBOX_STALE_THRESHOLD_SECONDS=900   # 15 min = RED
@@ -505,96 +514,10 @@ is_compact_grace_period() {
     return 1
 }
 
-# Check if a catchup subagent is actively running (or recently started).
-# Returns 0 (true) if the WFM freshness check should be suppressed, 1 otherwise.
-#
-# Primary path: the dispatcher writes catchup_started_at to lobster-state.json
-# before spawning either the startup-catchup or compact-catchup subagent, and
-# writes catchup_finished_at when the subagent result arrives.  If
-# catchup_finished_at is absent or older than catchup_started_at, the catchup
-# is still in flight.
-#
-# Fallback path (issue #1283): if the dispatcher forgot to call
-# record-catchup-state.sh (e.g. it batched the compact-reminder with other
-# messages), catchup_started_at is never updated.  In that case we fall back
-# to compacted_at: if a compaction is more recent than catchup_finished_at and
-# within CATCHUP_SUPPRESS_SECONDS, we treat catchup as in-flight.
-#
-# Suppression window: CATCHUP_SUPPRESS_SECONDS from the effective start time.
-# This caps suppression even if catchup_finished_at is never written (e.g. the
-# subagent crashed), preventing permanent suppression.
-is_catchup_active() {
-    if [[ ! -f "$LOBSTER_STATE_FILE" ]]; then
-        return 1
-    fi
-
-    local now
-    now=$(date +%s)
-
-    # Read all relevant timestamps in one python call for efficiency
-    local started_at finished_at compacted_at
-    read -r started_at finished_at compacted_at < <(python3 -c "
-import json, sys
-try:
-    d = json.load(open('$LOBSTER_STATE_FILE'))
-    print(d.get('catchup_started_at', ''), d.get('catchup_finished_at', ''), d.get('compacted_at', ''))
-except Exception:
-    print('', '', '')
-" 2>/dev/null)
-
-    local finished_epoch=0
-    if [[ -n "$finished_at" ]]; then
-        finished_epoch=$(date -d "$finished_at" +%s 2>/dev/null) || finished_epoch=0
-    fi
-
-    # --- Primary path: catchup_started_at is present ---
-    if [[ -n "$started_at" ]]; then
-        local started_epoch
-        started_epoch=$(date -d "$started_at" +%s 2>/dev/null) || started_epoch=0
-        if [[ $started_epoch -gt 0 ]]; then
-            local age=$(( now - started_epoch ))
-            # Hard cap: don't suppress longer than CATCHUP_SUPPRESS_SECONDS even if
-            # catchup_finished_at was never written (subagent crash, etc.)
-            if [[ $age -gt $CATCHUP_SUPPRESS_SECONDS ]]; then
-                log_info "Catchup suppression expired: started ${age}s ago (cap: ${CATCHUP_SUPPRESS_SECONDS}s)"
-                # Fall through to compacted_at fallback — maybe a new compaction
-                # occurred after the cap expired and a new catchup is in flight.
-            else
-                # Check if catchup has already finished
-                if [[ $finished_epoch -gt 0 && $finished_epoch -ge $started_epoch ]]; then
-                    log_info "Catchup complete: finished_at=$finished_at — WFM suppression lifted"
-                    return 1
-                fi
-                log_info "Catchup in flight: started ${age}s ago (cap: ${CATCHUP_SUPPRESS_SECONDS}s) — WFM freshness suppressed"
-                return 0
-            fi
-        fi
-    fi
-
-    # --- Fallback path: check compacted_at (issue #1283) ---
-    # If the dispatcher forgot to write catchup_started_at (e.g. it batched
-    # the compact-reminder with other messages), we fall back to compacted_at.
-    # A compaction that is more recent than catchup_finished_at implies that
-    # a new catchup should be in flight but was never registered.
-    if [[ -n "$compacted_at" ]]; then
-        local compacted_epoch
-        compacted_epoch=$(date -d "$compacted_at" +%s 2>/dev/null) || compacted_epoch=0
-        if [[ $compacted_epoch -gt 0 ]]; then
-            local compaction_age=$(( now - compacted_epoch ))
-            if [[ $compaction_age -le $CATCHUP_SUPPRESS_SECONDS ]]; then
-                # Compaction is recent — check if catchup finished AFTER the compaction
-                if [[ $finished_epoch -gt 0 && $finished_epoch -ge $compacted_epoch ]]; then
-                    log_info "Catchup complete (fallback): compacted_at=$compacted_at, finished_at=$finished_at — WFM suppression not needed"
-                    return 1
-                fi
-                log_warn "Catchup fallback active (issue #1283): compacted_at=${compaction_age}s ago, catchup_started_at missing or stale — WFM freshness suppressed"
-                return 0
-            fi
-        fi
-    fi
-
-    return 1
-}
+# is_catchup_active() removed (issue #1483).
+# The dispatcher heartbeat threshold (DISPATCHER_HEARTBEAT_STALE_SECONDS = 1200s)
+# covers catchup duration naturally. No per-catchup suppression needed.
+# The dispatcher no longer needs to call record-catchup-state.sh.
 
 # Check if a boot/restart occurred within the last BOOT_GRACE_SECONDS.
 # Returns 0 (true) if we are inside the grace window, 1 otherwise.
@@ -1002,94 +925,48 @@ check_outbox_drain() {
     fi
 }
 
-# Check 6: wait_for_messages freshness
-# The dispatcher is considered "fresh" if ANY of:
-#   (a) the claude-heartbeat file was touched recently — inbox_server.py touches
-#       it at the start of every wait_for_messages call, OR
-#   (b) last_processed_at in lobster-state.json was updated recently — written
-#       by inbox_server.py on every successful mark_processed call (issue #694), OR
-#   (c) last_thinking_at in lobster-state.json was updated recently — written by
-#       hooks/thinking-heartbeat.py on every PostToolUse event (issue #1401).
+# Check 6: Dispatcher heartbeat sentinel (issue #1483 simplification)
 #
-# Signals (b) and (c) together cover the full dispatcher lifecycle: (b) fires
-# during message processing batches; (c) fires during the reasoning phase (thinking,
-# composing, spawning subagents) when no WFM or mark_processed calls are made.
+# The dispatcher is considered alive if hooks/thinking-heartbeat.py has written
+# to DISPATCHER_HEARTBEAT_FILE within the last DISPATCHER_HEARTBEAT_STALE_SECONDS.
+# The hook fires on every PostToolUse event — any tool call resets the clock.
 #
-# The effective freshness timestamp is max(wfm_heartbeat_mtime, last_processed_at,
-# last_thinking_at).
+# This single-file check replaces the previous multi-signal approach
+# (claude-heartbeat file + last_processed_at + last_thinking_at in
+# lobster-state.json). The 20-minute threshold naturally covers:
+#   - Context compaction pause (1-3 minutes with no tool calls)
+#   - Startup catchup subagent (up to 10-12 minutes)
+#   - Boot grace period (60-90 seconds)
 #
-# Gracefully skips the check if the heartbeat file does not exist (fresh install).
-# Gracefully ignores missing or unparseable state file fields (backward compat).
+# No suppression logic needed — the threshold does the work.
+#
+# Gracefully skips the check if the heartbeat file does not exist (fresh install
+# or first run before the hook has fired).
 #
 # Returns: 0=GREEN (fresh or skipped), 2=RED (stale)
-check_wfm_freshness() {
-    if [[ ! -f "$HEARTBEAT_FILE" ]]; then
-        log_info "WFM freshness: heartbeat file not found — skipping check (fresh install?)"
+check_dispatcher_heartbeat() {
+    if [[ ! -f "$DISPATCHER_HEARTBEAT_FILE" ]]; then
+        log_info "Dispatcher heartbeat: file not found — skipping check (fresh install?)"
         return 0
     fi
 
-    local last_heartbeat
-    last_heartbeat=$(stat -c %Y "$HEARTBEAT_FILE" 2>/dev/null)
-    if [[ -z "$last_heartbeat" ]]; then
-        log_info "WFM freshness: cannot stat heartbeat file — skipping check"
+    local raw_ts
+    raw_ts=$(cat "$DISPATCHER_HEARTBEAT_FILE" 2>/dev/null | tr -d '[:space:]')
+    if [[ -z "$raw_ts" ]] || ! [[ "$raw_ts" =~ ^[0-9]+$ ]]; then
+        log_info "Dispatcher heartbeat: unreadable or non-integer content — skipping check"
         return 0
-    fi
-
-    # Read per-message heartbeat (mark_processed, issue #694) and PostToolUse
-    # thinking heartbeat (issue #1401) from lobster-state.json.
-    local last_processed_epoch=0
-    local last_thinking_epoch=0
-    if [[ -f "$LOBSTER_STATE_FILE" ]]; then
-        local last_processed_at last_thinking_at
-        last_processed_at=$(python3 -c "
-import json, sys
-try:
-    d = json.load(open('$LOBSTER_STATE_FILE'))
-    print(d.get('last_processed_at', ''))
-except Exception:
-    print('')
-" 2>/dev/null)
-        last_thinking_at=$(python3 -c "
-import json, sys
-try:
-    d = json.load(open('$LOBSTER_STATE_FILE'))
-    print(d.get('last_thinking_at', ''))
-except Exception:
-    print('')
-" 2>/dev/null)
-        if [[ -n "$last_processed_at" ]]; then
-            last_processed_epoch=$(date -d "$last_processed_at" +%s 2>/dev/null) || last_processed_epoch=0
-        fi
-        if [[ -n "$last_thinking_at" ]]; then
-            last_thinking_epoch=$(date -d "$last_thinking_at" +%s 2>/dev/null) || last_thinking_epoch=0
-        fi
-    fi
-
-    # Effective freshness = most recent of all three signals
-    local effective_last="$last_heartbeat"
-    local effective_source="WFM heartbeat"
-    if [[ "$last_processed_epoch" -gt "$effective_last" ]]; then
-        effective_last="$last_processed_epoch"
-        effective_source="last_processed_at"
-    fi
-    if [[ "$last_thinking_epoch" -gt "$effective_last" ]]; then
-        effective_last="$last_thinking_epoch"
-        effective_source="last_thinking_at"
-    fi
-    if [[ "$effective_source" != "WFM heartbeat" ]]; then
-        log_info "WFM freshness: using $effective_source signal (more recent than WFM heartbeat)"
     fi
 
     local now age
     now=$(date +%s)
-    age=$(( now - effective_last ))
+    age=$(( now - raw_ts ))
 
-    if [[ $age -gt $WFM_STALE_SECONDS ]]; then
-        log_error "RED: dispatcher stale — last activity ${age}s ago (threshold: ${WFM_STALE_SECONDS}s, wfm=${last_heartbeat}, last_processed=${last_processed_epoch}, last_thinking=${last_thinking_epoch})"
+    if [[ $age -gt $DISPATCHER_HEARTBEAT_STALE_SECONDS ]]; then
+        log_error "RED: dispatcher heartbeat stale — last tool use ${age}s ago (threshold: ${DISPATCHER_HEARTBEAT_STALE_SECONDS}s)"
         return 2
     fi
 
-    log_info "WFM freshness OK: last dispatcher activity ${age}s ago (via $effective_source)"
+    log_info "Dispatcher heartbeat OK: last tool use ${age}s ago (threshold: ${DISPATCHER_HEARTBEAT_STALE_SECONDS}s)"
     return 0
 }
 
@@ -1968,32 +1845,30 @@ main() {
         level="YELLOW"
     fi
 
-    # --- wait_for_messages freshness check ---
-    # Suppressed during hibernation (dispatcher isn't running), transient
-    # lifecycle states where Claude hasn't started yet (starting, restarting,
-    # waking, backoff, stopped), during the compaction grace period (tool
-    # calls pause while Claude compacts context), and while a catchup subagent
-    # is running (dispatcher may not call wait_for_messages for 10-12 minutes
-    # during startup-catchup or compact-catchup generation).
+    # --- Dispatcher heartbeat check (issue #1483 simplification) ---
+    # Single-file liveness check: hooks/thinking-heartbeat.py writes a Unix
+    # epoch timestamp to DISPATCHER_HEARTBEAT_FILE on every PostToolUse event.
+    # The 20-minute threshold covers compaction + catchup without suppression.
+    #
+    # Only suppressed during:
+    #   - Hibernation (dispatcher process is not running)
+    #   - Transient lifecycle states (starting/restarting/waking/backoff/stopped —
+    #     the wrapper hasn't even launched Claude yet)
+    # Boot grace and catchup suppression are no longer needed: the threshold
+    # absorbs them. The dispatcher no longer needs to call record-catchup-state.sh.
 
     if is_hibernating; then
-        log_info "WFM freshness suppressed (hibernating)"
+        log_info "Dispatcher heartbeat suppressed (hibernating)"
     elif [[ "$lobster_mode" == "starting" || "$lobster_mode" == "restarting" || \
             "$lobster_mode" == "waking"    || "$lobster_mode" == "backoff"    || \
             "$lobster_mode" == "stopped" ]]; then
-        log_info "WFM freshness suppressed (transient lifecycle state: $lobster_mode)"
-    elif [[ "$boot_grace" == "true" ]]; then
-        log_info "WFM freshness suppressed (boot grace period)"
-    elif [[ "$compaction_recent" == "true" ]]; then
-        log_info "WFM freshness suppressed (recent compaction)"
-    elif is_catchup_active; then
-        log_info "WFM freshness suppressed (catchup subagent in flight)"
+        log_info "Dispatcher heartbeat suppressed (transient lifecycle state: $lobster_mode)"
     else
-        check_wfm_freshness
-        local wfm_rc=$?
-        if [[ $wfm_rc -eq 2 ]]; then
+        check_dispatcher_heartbeat
+        local hb_rc=$?
+        if [[ $hb_rc -eq 2 ]]; then
             level="RED"
-            restart_reason="${restart_reason:+$restart_reason + }wait_for_messages stale (>${WFM_STALE_SECONDS}s)"
+            restart_reason="${restart_reason:+$restart_reason + }dispatcher heartbeat stale (>${DISPATCHER_HEARTBEAT_STALE_SECONDS}s)"
         fi
     fi
 

--- a/tests/test-health-check-dispatcher-heartbeat.sh
+++ b/tests/test-health-check-dispatcher-heartbeat.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+#===============================================================================
+# Test Suite: Health Check v3 - Dispatcher Heartbeat Sentinel (issue #1483)
+#
+# Tests for check_dispatcher_heartbeat() — the simplified single-file liveness check.
+#
+# Tests:
+#   1. Heartbeat file absent → GREEN (skipped, no false alarm on fresh install)
+#   2. Heartbeat file recent (< DISPATCHER_HEARTBEAT_STALE_SECONDS) → GREEN
+#   3. Heartbeat file stale (> DISPATCHER_HEARTBEAT_STALE_SECONDS) → RED (exit 2)
+#   4. Heartbeat file contains non-integer content → GREEN (graceful fallback)
+#   5. Heartbeat file exists but empty → GREEN (graceful fallback)
+#   6. LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE respected
+#   7. Stale by 1 second past threshold → RED (boundary condition)
+#   8. Fresh by 1 second before threshold → GREEN (boundary condition)
+#
+# Key behavioral assertion: the check uses a SINGLE file with a SINGLE epoch
+# timestamp. No lobster-state.json reads, no WFM heartbeat file, no multi-signal
+# aggregation.
+#
+# Usage: bash tests/test-health-check-dispatcher-heartbeat.sh
+#===============================================================================
+
+set -u
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts"
+HEALTH_SCRIPT="$SCRIPT_DIR/health-check-v3.sh"
+
+TEST_TMPDIR=$(mktemp -d /tmp/lobster-dispatcher-hb-test-XXXXXX)
+TEST_LOG_DIR="$TEST_TMPDIR/logs"
+DISPATCHER_HEARTBEAT_FILE="$TEST_LOG_DIR/dispatcher-heartbeat"
+
+cleanup() { rm -rf "$TEST_TMPDIR"; }
+trap cleanup EXIT
+
+mkdir -p "$TEST_LOG_DIR"
+
+begin_test() { TOTAL=$((TOTAL + 1)); test_name="$1"; }
+pass()  { PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC} $test_name"; }
+fail()  { FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC} $test_name: $1"; }
+
+assert_exit() {
+    local actual="$1" expected="$2"
+    if [[ "$actual" -eq "$expected" ]]; then pass; else fail "expected exit $expected, got $actual"; fi
+}
+
+# Source check_dispatcher_heartbeat() from the health check script once.
+LOG_FILE="$TEST_LOG_DIR/health-check.log"
+DISPATCHER_HEARTBEAT_STALE_SECONDS=1200
+
+log()       { echo "[$1] $2" >> "$LOG_FILE" 2>/dev/null; }
+log_info()  { log INFO "$1"; }
+log_warn()  { log WARN "$1"; }
+log_error() { log ERROR "$1"; }
+
+# Load the function definition from the health check script.
+eval "$(sed -n '/^check_dispatcher_heartbeat()/,/^}/p' "$HEALTH_SCRIPT")" 2>/dev/null
+
+# Run check_dispatcher_heartbeat() with the given heartbeat file.
+# Returns the function's exit code via $?.
+run_heartbeat_check() {
+    local hb_file="$1"
+    DISPATCHER_HEARTBEAT_FILE="$hb_file"
+    check_dispatcher_heartbeat
+    return $?
+}
+
+echo "=== Dispatcher Heartbeat Health Check Tests ==="
+echo ""
+
+# -------------------------------------------------------------------
+# Test 1: Heartbeat file absent → GREEN (skip, no false alarm)
+# -------------------------------------------------------------------
+begin_test "Absent heartbeat file → GREEN (skip)"
+rm -f "$DISPATCHER_HEARTBEAT_FILE"
+run_heartbeat_check "$DISPATCHER_HEARTBEAT_FILE" && rc=$? || rc=$?
+assert_exit "$rc" 0
+
+# -------------------------------------------------------------------
+# Test 2: Recent heartbeat (just now) → GREEN
+# -------------------------------------------------------------------
+begin_test "Recent heartbeat (5s ago) → GREEN"
+echo "$(( $(date +%s) - 5 ))" > "$DISPATCHER_HEARTBEAT_FILE"
+run_heartbeat_check "$DISPATCHER_HEARTBEAT_FILE" && rc=$? || rc=$?
+assert_exit "$rc" 0
+
+# -------------------------------------------------------------------
+# Test 3: Stale heartbeat (> 1200s ago) → RED
+# -------------------------------------------------------------------
+begin_test "Stale heartbeat (1500s ago) → RED"
+echo "$(( $(date +%s) - 1500 ))" > "$DISPATCHER_HEARTBEAT_FILE"
+run_heartbeat_check "$DISPATCHER_HEARTBEAT_FILE" && rc=$? || rc=$?
+assert_exit "$rc" 2
+
+# -------------------------------------------------------------------
+# Test 4: Heartbeat contains non-integer content → GREEN (graceful)
+# -------------------------------------------------------------------
+begin_test "Non-integer content → GREEN (graceful fallback)"
+echo "not-a-number" > "$DISPATCHER_HEARTBEAT_FILE"
+run_heartbeat_check "$DISPATCHER_HEARTBEAT_FILE" && rc=$? || rc=$?
+assert_exit "$rc" 0
+
+# -------------------------------------------------------------------
+# Test 5: Heartbeat file empty → GREEN (graceful fallback)
+# -------------------------------------------------------------------
+begin_test "Empty file → GREEN (graceful fallback)"
+echo "" > "$DISPATCHER_HEARTBEAT_FILE"
+run_heartbeat_check "$DISPATCHER_HEARTBEAT_FILE" && rc=$? || rc=$?
+assert_exit "$rc" 0
+
+# -------------------------------------------------------------------
+# Test 6: Custom override path is used
+# -------------------------------------------------------------------
+begin_test "Custom heartbeat path is used"
+custom_hb="$TEST_TMPDIR/custom-heartbeat"
+echo "$(( $(date +%s) - 5 ))" > "$custom_hb"
+run_heartbeat_check "$custom_hb" && rc=$? || rc=$?
+assert_exit "$rc" 0
+
+# -------------------------------------------------------------------
+# Test 7: Exactly 1 second past threshold → RED (boundary)
+# -------------------------------------------------------------------
+begin_test "1s past threshold (1201s ago) → RED"
+echo "$(( $(date +%s) - 1201 ))" > "$DISPATCHER_HEARTBEAT_FILE"
+run_heartbeat_check "$DISPATCHER_HEARTBEAT_FILE" && rc=$? || rc=$?
+assert_exit "$rc" 2
+
+# -------------------------------------------------------------------
+# Test 8: Exactly 1 second before threshold → GREEN (boundary)
+# -------------------------------------------------------------------
+begin_test "1s before threshold (1199s ago) → GREEN"
+echo "$(( $(date +%s) - 1199 ))" > "$DISPATCHER_HEARTBEAT_FILE"
+run_heartbeat_check "$DISPATCHER_HEARTBEAT_FILE" && rc=$? || rc=$?
+assert_exit "$rc" 0
+
+# -------------------------------------------------------------------
+# Summary
+# -------------------------------------------------------------------
+echo ""
+echo "Results: $PASS/$TOTAL passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tests/test-health-check-thinking-heartbeat.sh
+++ b/tests/test-health-check-thinking-heartbeat.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 #===============================================================================
-# Test Suite: Health Check v3 - Thinking Heartbeat (issue #1401)
+# [DEPRECATED] Test Suite: Health Check v3 - Thinking Heartbeat (issue #1401)
 #
-# Tests for check_wfm_freshness() with the last_thinking_at signal:
+# DEPRECATED as of issue #1483 (health check simplification).
+#
+# The multi-signal check_wfm_freshness() function was REMOVED from health-check-v3.sh
+# and replaced with check_dispatcher_heartbeat() — a single-file epoch-based check.
+# These tests now exercise a self-contained Python reimplementation of the old
+# three-signal logic embedded in this file. They do NOT test any current production code.
+#
+# Kept for historical reference only. See instead:
+#   tests/test-health-check-dispatcher-heartbeat.sh  (new single-signal check)
+#   tests/unit/test_hooks/test_thinking_heartbeat.py (new hook unit tests)
+#
+# Original purpose: Tests for check_wfm_freshness() with the last_thinking_at signal:
 #   1. last_thinking_at recent → GREEN (no restart)
 #   2. last_thinking_at stale, others also stale → RED
 #   3. last_thinking_at absent → behavior unchanged (falls back to wfm+processed)

--- a/tests/unit/test_hooks/test_thinking_heartbeat.py
+++ b/tests/unit/test_hooks/test_thinking_heartbeat.py
@@ -1,23 +1,27 @@
 """
 Unit tests for hooks/thinking-heartbeat.py
 
-Tests cover:
-- Normal write: last_thinking_at written and ISO UTC formatted
-- Merge semantics: existing fields in lobster-state.json are preserved
-- Creates state file if absent (state dir exists)
-- Atomic write: uses .tmp then rename
-- Env override: LOBSTER_STATE_FILE_OVERRIDE is respected
-- Malformed existing JSON is treated as empty (overwritten cleanly)
-- Exceptions during write do not propagate (hook exits 0 silently)
-- Hook exits 0 in all cases
+Tests cover the simplified sentinel design (issue #1483):
+- write_heartbeat() writes a Unix epoch integer to the heartbeat file
+- Atomic write: uses .tmp then rename, no .tmp left behind
+- Creates parent directory if absent
+- Overwrites existing content on each call
+- Timestamp is within a small window of time.time()
+- main() exits 0 on success
+- main() exits 0 even when write fails (silent failure — never block tool use)
+- LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE env var is respected
+
+Design change from the original (lobster-state.json merge):
+- No JSON parsing or merging
+- Single integer epoch value, not ISO timestamp
+- Single file — no other state touched
 """
 
 import importlib.util
-import json
 import os
 import sys
 import tempfile
-from datetime import datetime, timezone
+import time
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
@@ -27,14 +31,20 @@ import pytest
 _HOOKS_DIR = Path(__file__).parents[3] / "hooks"
 HOOK_PATH = _HOOKS_DIR / "thinking-heartbeat.py"
 
+# How close (in seconds) the written timestamp must be to now.
+TIMESTAMP_TOLERANCE_SECONDS = 5
+
+# The threshold documented in the hook (checked here to prevent silent drift).
+EXPECTED_STALE_THRESHOLD = 1200  # 20 minutes
+
 
 # ---------------------------------------------------------------------------
-# Module loader (fresh import each call to avoid state pollution)
+# Module loader
 # ---------------------------------------------------------------------------
 
-def _load_module(monkeypatch, state_file: Path):
-    """Load thinking-heartbeat as a fresh module with state file override."""
-    monkeypatch.setenv("LOBSTER_STATE_FILE_OVERRIDE", str(state_file))
+def _load_module(monkeypatch, heartbeat_file: Path):
+    """Load thinking-heartbeat as a fresh module with heartbeat file override."""
+    monkeypatch.setenv("LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE", str(heartbeat_file))
     spec = importlib.util.spec_from_file_location("thinking_heartbeat", HOOK_PATH)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
@@ -42,129 +52,88 @@ def _load_module(monkeypatch, state_file: Path):
 
 
 # ---------------------------------------------------------------------------
-# Pure function tests (no subprocess)
+# Pure function tests
 # ---------------------------------------------------------------------------
 
-class TestReadState:
-    def test_returns_empty_dict_when_file_absent(self, tmp_path):
-        mod = importlib.util.module_from_spec(
-            importlib.util.spec_from_file_location("th", HOOK_PATH)
-        )
-        importlib.util.spec_from_file_location("th", HOOK_PATH).loader.exec_module(mod)
-        result = mod._read_state(tmp_path / "nonexistent.json")
-        assert result == {}
-
-    def test_returns_parsed_dict(self, tmp_path):
-        mod = importlib.util.module_from_spec(
-            importlib.util.spec_from_file_location("th", HOOK_PATH)
-        )
-        importlib.util.spec_from_file_location("th", HOOK_PATH).loader.exec_module(mod)
-        f = tmp_path / "state.json"
-        f.write_text('{"mode": "active", "booted_at": "2024-01-01T00:00:00Z"}')
-        result = mod._read_state(f)
-        assert result == {"mode": "active", "booted_at": "2024-01-01T00:00:00Z"}
-
-    def test_returns_empty_dict_on_malformed_json(self, tmp_path):
-        mod = importlib.util.module_from_spec(
-            importlib.util.spec_from_file_location("th", HOOK_PATH)
-        )
-        importlib.util.spec_from_file_location("th", HOOK_PATH).loader.exec_module(mod)
-        f = tmp_path / "state.json"
-        f.write_text("not valid json {{{")
-        result = mod._read_state(f)
-        assert result == {}
-
-
-class TestWriteStateAtomic:
-    def test_writes_json_to_path(self, tmp_path):
-        mod = importlib.util.module_from_spec(
-            importlib.util.spec_from_file_location("th", HOOK_PATH)
-        )
-        importlib.util.spec_from_file_location("th", HOOK_PATH).loader.exec_module(mod)
-        target = tmp_path / "state.json"
-        mod._write_state_atomic(target, {"foo": "bar"})
-        assert target.exists()
-        data = json.loads(target.read_text())
-        assert data == {"foo": "bar"}
-
-    def test_no_tmp_file_left_behind(self, tmp_path):
-        mod = importlib.util.module_from_spec(
-            importlib.util.spec_from_file_location("th", HOOK_PATH)
-        )
-        importlib.util.spec_from_file_location("th", HOOK_PATH).loader.exec_module(mod)
-        target = tmp_path / "state.json"
-        mod._write_state_atomic(target, {"x": 1})
-        tmp = Path(str(target) + ".tmp")
-        assert not tmp.exists()
-
-
-class TestWriteThinkingHeartbeat:
-    def _load(self):
-        mod = importlib.util.module_from_spec(
-            importlib.util.spec_from_file_location("th", HOOK_PATH)
-        )
-        importlib.util.spec_from_file_location("th", HOOK_PATH).loader.exec_module(mod)
+class TestWriteHeartbeat:
+    def _load_raw(self):
+        """Load module without any env override (uses default paths internally)."""
+        spec = importlib.util.spec_from_file_location("th", HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
         return mod
 
-    def test_writes_last_thinking_at(self, tmp_path):
-        mod = self._load()
-        state_file = tmp_path / "lobster-state.json"
-        mod.write_thinking_heartbeat(state_file)
-        data = json.loads(state_file.read_text())
-        assert "last_thinking_at" in data
-        # Parseable ISO timestamp
-        ts = datetime.fromisoformat(data["last_thinking_at"])
-        assert ts.tzinfo is not None
+    def test_writes_integer_epoch_to_file(self, tmp_path):
+        mod = self._load_raw()
+        hb = tmp_path / "dispatcher-heartbeat"
+        before = int(time.time())
+        mod.write_heartbeat(hb)
+        after = int(time.time())
+        assert hb.exists()
+        content = hb.read_text().strip()
+        ts = int(content)
+        assert before <= ts <= after + 1  # allow 1s rounding
 
-    def test_preserves_existing_fields(self, tmp_path):
-        mod = self._load()
-        state_file = tmp_path / "lobster-state.json"
-        state_file.write_text(json.dumps({
-            "mode": "active",
-            "booted_at": "2024-01-01T00:00:00Z",
-            "last_processed_at": "2024-01-01T01:00:00Z",
-        }))
-        mod.write_thinking_heartbeat(state_file)
-        data = json.loads(state_file.read_text())
-        assert data["mode"] == "active"
-        assert data["booted_at"] == "2024-01-01T00:00:00Z"
-        assert data["last_processed_at"] == "2024-01-01T01:00:00Z"
-        assert "last_thinking_at" in data
+    def test_content_is_pure_integer_no_json(self, tmp_path):
+        mod = self._load_raw()
+        hb = tmp_path / "dispatcher-heartbeat"
+        mod.write_heartbeat(hb)
+        content = hb.read_text().strip()
+        # Must be parseable as int, not JSON
+        ts = int(content)
+        assert ts > 0
 
-    def test_creates_file_when_absent(self, tmp_path):
-        mod = self._load()
-        state_file = tmp_path / "subdir" / "lobster-state.json"
-        state_file.parent.mkdir(parents=True)
-        mod.write_thinking_heartbeat(state_file)
-        assert state_file.exists()
-        data = json.loads(state_file.read_text())
-        assert "last_thinking_at" in data
+    def test_no_tmp_file_left_behind(self, tmp_path):
+        mod = self._load_raw()
+        hb = tmp_path / "dispatcher-heartbeat"
+        mod.write_heartbeat(hb)
+        tmp = hb.with_suffix(".tmp")
+        assert not tmp.exists()
 
-    def test_overwrites_malformed_json_cleanly(self, tmp_path):
-        mod = self._load()
-        state_file = tmp_path / "lobster-state.json"
-        state_file.write_text("not json at all")
-        mod.write_thinking_heartbeat(state_file)
-        data = json.loads(state_file.read_text())
-        assert "last_thinking_at" in data
+    def test_creates_parent_directory(self, tmp_path):
+        mod = self._load_raw()
+        nested = tmp_path / "nested" / "deep" / "dispatcher-heartbeat"
+        mod.write_heartbeat(nested)
+        assert nested.exists()
 
-    def test_timestamp_is_utc(self, tmp_path):
-        mod = self._load()
-        state_file = tmp_path / "lobster-state.json"
-        mod.write_thinking_heartbeat(state_file)
-        data = json.loads(state_file.read_text())
-        ts = datetime.fromisoformat(data["last_thinking_at"])
-        # UTC offset should be +00:00
-        assert ts.utcoffset().total_seconds() == 0
+    def test_overwrites_previous_content(self, tmp_path):
+        mod = self._load_raw()
+        hb = tmp_path / "dispatcher-heartbeat"
+        hb.write_text("99999\n")
+        time.sleep(0.01)
+        mod.write_heartbeat(hb)
+        content = hb.read_text().strip()
+        ts = int(content)
+        # New timestamp should be recent (not the old 99999)
+        assert ts > 1000000000  # sanity: real epoch, not legacy value
+
+    def test_timestamp_within_tolerance_of_now(self, tmp_path):
+        mod = self._load_raw()
+        hb = tmp_path / "dispatcher-heartbeat"
+        before = time.time()
+        mod.write_heartbeat(hb)
+        after = time.time()
+        ts = int(hb.read_text().strip())
+        assert before - TIMESTAMP_TOLERANCE_SECONDS <= ts <= after + TIMESTAMP_TOLERANCE_SECONDS
+
+
+class TestStaleThresholdConstant:
+    """Verify the documented threshold matches the expected value (prevents silent drift)."""
+
+    def test_stale_threshold_is_1200_seconds(self):
+        spec = importlib.util.spec_from_file_location("th", HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        assert mod.DISPATCHER_HEARTBEAT_STALE_SECONDS == EXPECTED_STALE_THRESHOLD
 
 
 # ---------------------------------------------------------------------------
 # Hook main() integration tests
 # ---------------------------------------------------------------------------
 
-def _run_hook(monkeypatch, state_file: Path) -> tuple[int, str, str]:
+def _run_hook(monkeypatch, heartbeat_file: Path) -> tuple[int, str, str]:
     """Execute the hook's main() capturing exit code and stdio."""
-    monkeypatch.setenv("LOBSTER_STATE_FILE_OVERRIDE", str(state_file))
+    monkeypatch.setenv("LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE", str(heartbeat_file))
 
     spec = importlib.util.spec_from_file_location("thinking_heartbeat", HOOK_PATH)
     mod = importlib.util.module_from_spec(spec)
@@ -188,26 +157,54 @@ def _run_hook(monkeypatch, state_file: Path) -> tuple[int, str, str]:
 
 class TestHookMain:
     def test_exits_zero_on_success(self, monkeypatch, tmp_path):
-        state_file = tmp_path / "lobster-state.json"
-        code, _, _ = _run_hook(monkeypatch, state_file)
+        hb = tmp_path / "dispatcher-heartbeat"
+        code, _, _ = _run_hook(monkeypatch, hb)
         assert code == 0
 
     def test_writes_heartbeat_on_success(self, monkeypatch, tmp_path):
-        state_file = tmp_path / "lobster-state.json"
-        _run_hook(monkeypatch, state_file)
-        assert state_file.exists()
-        data = json.loads(state_file.read_text())
-        assert "last_thinking_at" in data
+        hb = tmp_path / "dispatcher-heartbeat"
+        _run_hook(monkeypatch, hb)
+        assert hb.exists()
+        ts = int(hb.read_text().strip())
+        assert ts > 0
 
     def test_exits_zero_even_when_write_fails(self, monkeypatch, tmp_path):
-        # Point state file at a non-writable path to simulate write failure
-        state_file = tmp_path / "readonly_dir" / "lobster-state.json"
+        """Hook must never block tool execution even if write fails."""
         readonly_dir = tmp_path / "readonly_dir"
         readonly_dir.mkdir()
         readonly_dir.chmod(0o444)  # read-only directory
+        hb = readonly_dir / "dispatcher-heartbeat"
 
         try:
-            code, _, _ = _run_hook(monkeypatch, state_file)
+            code, _, _ = _run_hook(monkeypatch, hb)
             assert code == 0
         finally:
             readonly_dir.chmod(0o755)  # restore for cleanup
+
+    def test_env_override_respected(self, monkeypatch, tmp_path):
+        """LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE must be used when set."""
+        custom = tmp_path / "custom-heartbeat"
+        code, _, _ = _run_hook(monkeypatch, custom)
+        assert code == 0
+        assert custom.exists()
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: the old lobster-state.json fields are NOT written
+# ---------------------------------------------------------------------------
+
+class TestNoLobsterStateWrites:
+    """The new hook must NOT write last_thinking_at to lobster-state.json.
+
+    The health check no longer reads lobster-state.json for liveness signals.
+    Writing it would be harmless but signals incorrect design intent.
+    """
+
+    def test_does_not_create_state_json(self, monkeypatch, tmp_path):
+        hb = tmp_path / "dispatcher-heartbeat"
+        # Point state file override at a location we can check
+        state_file = tmp_path / "lobster-state.json"
+        monkeypatch.setenv("LOBSTER_STATE_FILE_OVERRIDE", str(state_file))
+        _run_hook(monkeypatch, hb)
+        # The new hook should NOT write lobster-state.json
+        assert not state_file.exists(), "thinking-heartbeat.py must not write lobster-state.json"


### PR DESCRIPTION
Closes #1483

## Why this exists

The health check had accumulated three separate liveness signals for dispatcher
activity: the WFM heartbeat file (touched by `wait_for_messages`), `last_processed_at`,
and `last_thinking_at` in `lobster-state.json`. Keeping all three in sync required
the dispatcher to explicitly call `record-catchup-state.sh start/finish` during
catchup — and if it forgot, or if compaction happened mid-catchup, the health
check would fire a false-positive restart.

The core issue: a mechanism designed to prevent false alarms had become a source
of false alarms. Any signal that drifted out of sync looked like a dead dispatcher.

## What changed

**Single file, single threshold.** Every tool call fires the `thinking-heartbeat.py`
PostToolUse hook, which atomically writes the current Unix epoch to
`~/lobster-workspace/logs/dispatcher-heartbeat`. The health check reads that one
file and checks its age against a 1200-second (20-minute) threshold.

1200s is large enough to absorb compaction pauses (1–3 min), catchup subagent
runs (10–12 min), and boot transitions (90 s) without any suppression logic. If
the dispatcher is alive and using tools, the heartbeat is fresh. If it has been
silent for 20 minutes, something is actually wrong.

**Removed from the health check:**
- `check_wfm_freshness()` — 3-signal aggregation with JSON parsing
- `is_catchup_active()` — catchup suppression gate
- Compaction-freshness guard in the WFM liveness section
- 6-condition suppression chain → 2-condition chain (hibernating, transient lifecycle)

**Removed from the dispatcher:**
- All `record-catchup-state.sh start/finish` calls (no longer needed)

**What was NOT changed:**
- The hook file path and registration in settings.json (Migration 66, already deployed)
- `lobster-state.json` structure (still written by other signals; thinking-heartbeat no longer touches it)
- The boot grace period, inbox drain, or any other health check signal
- `record-catchup-state.sh` itself (still exists for potential use; just not called)

## Flow change

Before (6 suppression conditions, 3 aggregated signals):
```
WFM liveness check:
  if hibernating → skip
  elif compaction_recent → skip
  elif is_catchup_active → skip
  elif mode in [starting, restarting, waking, backoff, stopped] → skip
  elif boot_grace → skip
  else → check max(wfm_mtime, last_processed_at, last_thinking_at) vs 1200s
```

After (2 suppression conditions, 1 signal):
```
WFM liveness check:
  if hibernating → skip
  elif mode in [starting, restarting, waking, backoff, stopped] → skip
  else → check dispatcher-heartbeat epoch vs 1200s
```

## Tests run

- [x] `bash tests/test-health-check-dispatcher-heartbeat.sh` — 8/8 passed (new tests for `check_dispatcher_heartbeat()`)
- [x] `uv run pytest tests/unit/test_hooks/test_thinking_heartbeat.py -v` — 12/12 passed (new hook unit tests)
- [x] `bash tests/test-health-check-boot-grace.sh` — 8/8 passed (unaffected)
- [x] `bash tests/test-health-check-inbox-drain.sh` — 19/19 passed (unaffected)
- [x] `bash tests/test-health-check-thinking-heartbeat.sh` — 7/7 passed (tests its own inline Python reimplementation; marked deprecated since it no longer tests production code)
- [x] `bash -n scripts/health-check-v3.sh` — clean syntax check
- [x] `sudo docker compose -f tests/docker/docker-compose.test.yml up unit-tests` — 1975 passed, 91 failed (all 91 failures are pre-existing: `_DEBUG_MODE`, `sqlite_vec`, `fastembed`, `FileExistsError` in path_guard — verified identical failures on main)
- [x] `uv run pytest tests/unit/ -v` — same pre-existing failure profile; `test_thinking_heartbeat.py` 12/12 pass

## Manual test

Verified with direct invocation:

```
# Hook writes epoch integer:
LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE=/tmp/hb python3 hooks/thinking-heartbeat.py
# → exit 0, file contains "1776005118\n", age 0s

# Health check reads fresh file → GREEN:
check_dispatcher_heartbeat  # with DISPATCHER_HEARTBEAT_FILE=/tmp/hb (age 0s)
# → exit 0

# Health check reads stale file (1500s old) → RED:
echo "$(( $(date +%s) - 1500 ))" > /tmp/hb-stale
check_dispatcher_heartbeat  # with DISPATCHER_HEARTBEAT_FILE=/tmp/hb-stale
# → exit 2

# Health check with absent file → GREEN (no false alarm on fresh install):
check_dispatcher_heartbeat  # with DISPATCHER_HEARTBEAT_FILE=/tmp/nonexistent
# → exit 0
```

This change is entirely internal to the health check and the PostToolUse hook.
No user-visible output is produced. Dispatcher/Telegram behavior is unaffected.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Manual test run — see above
- [x] User-visible outcome: N/A — this is internal infrastructure (health check liveness detection)
- [x] Side-effect audit: no floods, no volume changes, no shared state writes beyond the single heartbeat file
- [x] External service calls: none

🤖🦞 Lobster (engineer) — issue #1483