### PR TITLE
feat(inbox): priority inbox queue — P0-P4 ordering in check_inbox

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -4089,6 +4089,77 @@ def _enqueue_recovery_notification(msg: dict) -> None:
         log.error(f"subagent_recovered: failed to enqueue recovery notification: {exc}", exc_info=True)
 
 
+# ---------------------------------------------------------------------------
+# Priority inbox queue — P0-P4 ordering (issue #1079)
+# ---------------------------------------------------------------------------
+
+# P0: dispatcher housekeeping — zero-cost, must run before everything else
+_INBOX_P0_TYPES: frozenset[str] = frozenset()
+_INBOX_P0_SUBTYPES: frozenset[str] = frozenset({"compact-reminder", "self_check"})
+_INBOX_P0_TEXT_PREFIXES: tuple[str, ...] = ("compact-reminder",)
+
+# P1: real-user messages — latency-sensitive
+_INBOX_P1_TYPES: frozenset[str] = frozenset({"text", "voice", "photo", "document"})
+
+# P2: completing in-flight work
+_INBOX_P2_TYPES: frozenset[str] = frozenset({"subagent_result", "subagent_error"})
+
+# P3: error recovery
+_INBOX_P3_TYPES: frozenset[str] = frozenset({"agent_failed"})
+
+# P4: background / cron — everything else
+_INBOX_P4_DEFAULT: int = 4
+
+
+def _inbox_priority(msg: dict) -> int:
+    """Return the priority tier (0=highest, 4=lowest) for an inbox message.
+
+    Priority is derived from message type and subtype at read time — nothing
+    is stored in the message file itself. Unrecognised types default to P4.
+    """
+    msg_type = msg.get("type", "")
+    msg_subtype = msg.get("subtype", "")
+    msg_text = msg.get("text", "")
+
+    # P0: dispatcher housekeeping
+    if msg_subtype in _INBOX_P0_SUBTYPES:
+        return 0
+    if msg_type in _INBOX_P0_TYPES:
+        return 0
+    # compact-reminder messages are sometimes typed as "text" with a specific prefix
+    if any(msg_text.startswith(p) for p in _INBOX_P0_TEXT_PREFIXES):
+        return 0
+
+    # P1: real-user messages
+    if msg_type in _INBOX_P1_TYPES:
+        return 1
+
+    # P2: completing in-flight subagent work
+    if msg_type in _INBOX_P2_TYPES:
+        return 2
+
+    # P3: error recovery
+    if msg_type in _INBOX_P3_TYPES:
+        return 3
+
+    # P4: everything else (scheduled_reminder, system_error, unknown, ...)
+    return _INBOX_P4_DEFAULT
+
+
+def _inbox_sort_key(
+    f_name: str, priority: int, ts_epoch: float | None
+) -> tuple[int, float, str]:
+    """Return (priority, timestamp_epoch, filename) for stable ordering.
+
+    Lower priority tier = earlier in queue.
+    Within a tier, older messages (smaller epoch) come first (FIFO).
+    Filename is the final tiebreaker for determinism.
+    """
+    # Use a large sentinel so unparseable timestamps sink to the back of their tier
+    epoch = ts_epoch if ts_epoch is not None else float("inf")
+    return (priority, epoch, f_name)
+
+
 def _parse_iso_timestamp(ts: str) -> float | None:
     """
     Parse an ISO 8601 UTC timestamp string to a Unix epoch float.
@@ -4167,54 +4238,74 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
 
         log.info(f"check_inbox (since_ts={since_ts_str!r}) returning {len(messages)} message(s)")
     else:
-        for f in sorted(INBOX_DIR.glob("*.json")):
+        # --- Priority-ordered inbox scan (issue #1079) ---
+        # Two-pass approach: read and score all inbox files, then sort by
+        # (priority, timestamp, filename) before processing. Unreadable files
+        # default to P4 so they never cause a crash or a skip.
+        _scored: list[tuple[tuple[int, float, str], object, dict]] = []
+        for f in INBOX_DIR.glob("*.json"):
             try:
                 with open(f) as fp:
                     msg = json.load(fp)
-                    if source_filter and msg.get("source", "").lower() != source_filter:
-                        continue
-                    # /report slash command pre-processor: handle automatically without
-                    # surfacing the raw message to the main dispatcher loop.
-                    msg_text = msg.get("text", "")
-                    if _is_report_command(msg_text):
-                        try:
-                            await _handle_report_slash_command(msg, f)
-                        except Exception as exc:
-                            log.error(f"check_inbox: /report pre-processor error: {exc}", exc_info=True)
-                        continue  # skip — already handled
-                    # subagent_recovered pre-processor: enqueue an owner notification so the
-                    # user is informed about the failed agent. The raw recovery message still
-                    # flows through to the dispatcher (with a dispatcher_hint) so it can call
-                    # mark_processed — but the salvaged dump is never relayed directly.
-                    if msg.get("type") == "subagent_recovered":
-                        try:
-                            _enqueue_recovery_notification(msg)
-                        except Exception as exc:
-                            log.error(f"check_inbox: subagent_recovered pre-processor error: {exc}", exc_info=True)
-                    msg["_filename"] = f.name
-                    messages.append(msg)
-                    # NOTE: Inbound cross-Lobster messages from bot-talk are routed to this
-                    # inbox by bot_talk_mirror.log_inbound_cross_lobster() with source="bot-talk".
-                    # We no longer mirror owner Telegram messages to bot-talk from here —
-                    # only actual cross-Lobster exchanges belong in bot-talk (issue #1350).
-                    # Emit EventBus event for inbound bot-talk messages so TelegramOutboxListener
-                    # can forward them as debug notifications (issue #1425). The message is
-                    # already in the inbox so we only emit to EventBus, not route again.
-                    if msg.get("source") == "bot-talk" and msg.get("direction") == "INBOUND":
-                        try:
-                            from bot_talk_mirror import _spawn_mirror  # type: ignore[import]
-                            _spawn_mirror(
-                                content=msg.get("text", ""),
-                                genre="status-update",
-                                direction="INBOUND",
-                                from_=msg.get("from", msg.get("user_name", "unknown")),
-                                to=msg.get("to", ""),
-                            )
-                        except Exception as _bt_exc:
-                            log.warning(f"bot-talk EventBus inbound emit failed (non-fatal): {_bt_exc}")
-                    if len(messages) >= limit:
-                        break
-            except Exception as e:
+                ts_epoch = _parse_iso_timestamp(msg.get("timestamp", ""))
+                priority = _inbox_priority(msg)
+                key = _inbox_sort_key(f.name, priority, ts_epoch)
+                _scored.append((key, f, msg))
+            except Exception:
+                # Unreadable file: assign worst possible key so it appears last
+                key = (_INBOX_P4_DEFAULT, float("inf"), f.name)
+                _scored.append((key, f, {}))
+
+        for _key, f, msg in sorted(_scored, key=lambda x: x[0]):
+            try:
+                if not msg:
+                    # Re-read files that failed the first pass (e.g. transient lock)
+                    with open(f) as fp:  # type: ignore[arg-type]
+                        msg = json.load(fp)
+                if source_filter and msg.get("source", "").lower() != source_filter:
+                    continue
+                # /report slash command pre-processor: handle automatically without
+                # surfacing the raw message to the main dispatcher loop.
+                msg_text = msg.get("text", "")
+                if _is_report_command(msg_text):
+                    try:
+                        await _handle_report_slash_command(msg, f)  # type: ignore[arg-type]
+                    except Exception as exc:
+                        log.error(f"check_inbox: /report pre-processor error: {exc}", exc_info=True)
+                    continue  # skip — already handled
+                # subagent_recovered pre-processor: enqueue an owner notification so the
+                # user is informed about the failed agent. The raw recovery message still
+                # flows through to the dispatcher (with a dispatcher_hint) so it can call
+                # mark_processed — but the salvaged dump is never relayed directly.
+                if msg.get("type") == "subagent_recovered":
+                    try:
+                        _enqueue_recovery_notification(msg)
+                    except Exception as exc:
+                        log.error(f"check_inbox: subagent_recovered pre-processor error: {exc}", exc_info=True)
+                msg["_filename"] = f.name  # type: ignore[union-attr]
+                messages.append(msg)
+                # NOTE: Inbound cross-Lobster messages from bot-talk are routed to this
+                # inbox by bot_talk_mirror.log_inbound_cross_lobster() with source="bot-talk".
+                # We no longer mirror owner Telegram messages to bot-talk from here —
+                # only actual cross-Lobster exchanges belong in bot-talk (issue #1350).
+                # Emit EventBus event for inbound bot-talk messages so TelegramOutboxListener
+                # can forward them as debug notifications (issue #1425). The message is
+                # already in the inbox so we only emit to EventBus, not route again.
+                if msg.get("source") == "bot-talk" and msg.get("direction") == "INBOUND":
+                    try:
+                        from bot_talk_mirror import _spawn_mirror  # type: ignore[import]
+                        _spawn_mirror(
+                            content=msg.get("text", ""),
+                            genre="status-update",
+                            direction="INBOUND",
+                            from_=msg.get("from", msg.get("user_name", "unknown")),
+                            to=msg.get("to", ""),
+                        )
+                    except Exception as _bt_exc:
+                        log.warning(f"bot-talk EventBus inbound emit failed (non-fatal): {_bt_exc}")
+                if len(messages) >= limit:
+                    break
+            except Exception:
                 continue
 
         if not messages:

--- a/tests/unit/test_mcp_server/test_priority_inbox_queue.py
+++ b/tests/unit/test_mcp_server/test_priority_inbox_queue.py
@@ -1,0 +1,254 @@
+"""
+Tests for priority inbox queue — P0-P4 ordering in check_inbox (issue #1079).
+
+Verifies that:
+- check_inbox returns messages in P0→P1→P2→P3→P4 order regardless of filename
+- Within each tier, messages are ordered by timestamp (FIFO, ascending)
+- Unrecognised or unparseable message types default to P4 (no crash, no skip)
+- No change to message schema — priority is derived at read time, not stored
+- The since_ts historical scan path is unaffected
+"""
+
+import asyncio
+import json
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_MCP_DIR = Path(__file__).parent.parent.parent.parent / "src" / "mcp"
+if str(_MCP_DIR) not in sys.path:
+    sys.path.insert(0, str(_MCP_DIR))
+
+import src.mcp.inbox_server  # noqa: F401
+
+# Priority constants — mirror the spec so tests break if the implementation drifts
+P0_COMPACT_REMINDER = 0
+P0_SELF_CHECK = 0
+P1_TEXT = 1
+P1_VOICE = 1
+P2_SUBAGENT_RESULT = 2
+P3_AGENT_FAILED = 3
+P4_SCHEDULED_REMINDER = 4
+P4_DEFAULT = 4
+
+_BASE_TS = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _make_msg(
+    msg_id: str,
+    msg_type: str = "text",
+    subtype: str | None = None,
+    offset_seconds: int = 0,
+    source: str = "telegram",
+    text: str | None = None,
+) -> dict:
+    ts = _BASE_TS + timedelta(seconds=offset_seconds)
+    msg: dict = {
+        "id": msg_id,
+        "source": source,
+        "type": msg_type,
+        "text": text if text is not None else f"message {msg_id}",
+        "timestamp": _iso(ts),
+        "chat_id": 12345,
+        "user_id": 12345,
+        "username": "testuser",
+        "user_name": "Test",
+    }
+    if subtype:
+        msg["subtype"] = subtype
+    return msg
+
+
+@pytest.fixture
+def inbox_dir(tmp_path):
+    d = tmp_path / "inbox"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def processed_dir(tmp_path):
+    d = tmp_path / "processed"
+    d.mkdir()
+    return d
+
+
+def _run_check_inbox(inbox_dir, processed_dir, args=None):
+    args = args or {}
+    with patch.multiple(
+        "src.mcp.inbox_server",
+        INBOX_DIR=inbox_dir,
+        PROCESSED_DIR=processed_dir,
+    ):
+        from src.mcp.inbox_server import handle_check_inbox
+        return asyncio.run(handle_check_inbox(args))
+
+
+def _write(inbox_dir: Path, filename: str, msg: dict) -> None:
+    (inbox_dir / filename).write_text(json.dumps(msg))
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _inbox_priority pure function
+# ---------------------------------------------------------------------------
+
+
+class TestInboxPriorityFunction:
+    """_inbox_priority returns the correct tier for each message class."""
+
+    def _priority(self, msg: dict) -> int:
+        from src.mcp.inbox_server import _inbox_priority
+        return _inbox_priority(msg)
+
+    def test_compact_reminder_subtype_is_p0(self):
+        assert self._priority({"type": "text", "subtype": "compact-reminder"}) == P0_COMPACT_REMINDER
+
+    def test_self_check_subtype_is_p0(self):
+        assert self._priority({"type": "text", "subtype": "self_check"}) == P0_SELF_CHECK
+
+    def test_compact_reminder_text_prefix_is_p0(self):
+        assert self._priority({"type": "text", "text": "compact-reminder extra"}) == P0_COMPACT_REMINDER
+
+    def test_text_message_is_p1(self):
+        assert self._priority({"type": "text"}) == P1_TEXT
+
+    def test_voice_message_is_p1(self):
+        assert self._priority({"type": "voice"}) == P1_VOICE
+
+    def test_photo_message_is_p1(self):
+        assert self._priority({"type": "photo"}) == 1
+
+    def test_document_message_is_p1(self):
+        assert self._priority({"type": "document"}) == 1
+
+    def test_subagent_result_is_p2(self):
+        assert self._priority({"type": "subagent_result"}) == P2_SUBAGENT_RESULT
+
+    def test_subagent_error_is_p2(self):
+        assert self._priority({"type": "subagent_error"}) == 2
+
+    def test_agent_failed_is_p3(self):
+        assert self._priority({"type": "agent_failed"}) == P3_AGENT_FAILED
+
+    def test_scheduled_reminder_is_p4(self):
+        assert self._priority({"type": "scheduled_reminder"}) == P4_SCHEDULED_REMINDER
+
+    def test_system_error_is_p4(self):
+        assert self._priority({"type": "system_error"}) == P4_DEFAULT
+
+    def test_unknown_type_defaults_to_p4(self):
+        assert self._priority({"type": "some_new_type_we_never_heard_of"}) == P4_DEFAULT
+
+    def test_empty_message_defaults_to_p4(self):
+        assert self._priority({}) == P4_DEFAULT
+
+    def test_priority_derived_from_fields_not_stored(self):
+        """Priority must NOT be a stored field — it is always re-derived."""
+        msg = {"type": "text", "priority": 99}
+        # The priority=99 field must be ignored; type=text → P1
+        assert self._priority(msg) == P1_TEXT
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for check_inbox ordering
+# ---------------------------------------------------------------------------
+
+
+class TestCheckInboxPriorityOrdering:
+    """check_inbox returns messages in P0→P4 order, FIFO within each tier."""
+
+    def test_p0_before_p1_before_p4_in_mixed_inbox(self, inbox_dir, processed_dir):
+        """A mixed inbox returns P0 first, then P1, then P4."""
+        # Written in reverse priority order to expose any filename-sorted fallback
+        _write(inbox_dir, "zzz_scheduled.json", _make_msg("sched", "scheduled_reminder", offset_seconds=1))
+        _write(inbox_dir, "mmm_text.json", _make_msg("usermsg", "text", offset_seconds=2))
+        _write(inbox_dir, "aaa_compact.json", _make_msg("compact", "text", subtype="compact-reminder", offset_seconds=3, source="system"))
+
+        result = _run_check_inbox(inbox_dir, processed_dir)
+        text = result[0].text
+
+        compact_pos = text.find("compact")
+        usermsg_pos = text.find("usermsg")
+        sched_pos = text.find("sched")
+
+        assert compact_pos < usermsg_pos, "P0 (compact-reminder) must appear before P1 (text)"
+        assert usermsg_pos < sched_pos, "P1 (text) must appear before P4 (scheduled_reminder)"
+
+    def test_within_tier_messages_are_fifo_by_timestamp(self, inbox_dir, processed_dir):
+        """Within the same priority tier, older messages appear first."""
+        # Both are P1 (text); older1 should appear before older2
+        _write(inbox_dir, "zzz_newer.json", _make_msg("newer", "text", offset_seconds=60))
+        _write(inbox_dir, "aaa_older.json", _make_msg("older", "text", offset_seconds=0))
+
+        result = _run_check_inbox(inbox_dir, processed_dir)
+        text = result[0].text
+
+        older_pos = text.find("older")
+        newer_pos = text.find("newer")
+        assert older_pos < newer_pos, "Older message must appear before newer message within same tier"
+
+    def test_unparseable_file_does_not_crash_and_defaults_to_p4(self, inbox_dir, processed_dir):
+        """An unreadable JSON file is silently skipped without crashing check_inbox."""
+        (inbox_dir / "bad.json").write_text("not valid json {{{{")
+        _write(inbox_dir, "good.json", _make_msg("good", "text"))
+
+        result = _run_check_inbox(inbox_dir, processed_dir)
+        text = result[0].text
+        assert "good" in text  # good message still returned
+        # No exception raised (test itself passing proves this)
+
+    def test_message_without_priority_field_still_sorted_correctly(self, inbox_dir, processed_dir):
+        """Messages that don't have a priority field are sorted by type (no stored priority)."""
+        _write(inbox_dir, "a.json", _make_msg("sr", "scheduled_reminder"))
+        _write(inbox_dir, "b.json", _make_msg("txt", "text"))
+
+        result = _run_check_inbox(inbox_dir, processed_dir)
+        text = result[0].text
+
+        txt_pos = text.find("txt")
+        sr_pos = text.find("sr")
+        assert txt_pos < sr_pos, "text (P1) must appear before scheduled_reminder (P4)"
+
+    def test_limit_applied_after_priority_sort(self, inbox_dir, processed_dir):
+        """With limit=1, the P0 message is returned, not the earliest filename."""
+        # zzz_ sorts last alphabetically — without priority sort this would be skipped
+        _write(inbox_dir, "aaa_sched.json", _make_msg("sched", "scheduled_reminder"))
+        _write(inbox_dir, "zzz_compact.json", _make_msg("compact", "text", subtype="compact-reminder", source="system"))
+
+        result = _run_check_inbox(inbox_dir, processed_dir, {"limit": 1})
+        text = result[0].text
+        assert "compact" in text, "With limit=1 the P0 message should be returned"
+        assert "sched" not in text, "P4 message should not appear when limit=1 cuts off after P0"
+
+    def test_all_p0_subtypes_sorted_before_p1(self, inbox_dir, processed_dir):
+        """self_check messages are also P0 and should precede P1 user messages."""
+        _write(inbox_dir, "zzz_self.json", _make_msg("selfchk", "text", subtype="self_check", source="system"))
+        _write(inbox_dir, "aaa_user.json", _make_msg("usermsg", "text"))
+
+        result = _run_check_inbox(inbox_dir, processed_dir)
+        text = result[0].text
+
+        selfchk_pos = text.find("selfchk")
+        usermsg_pos = text.find("usermsg")
+        assert selfchk_pos < usermsg_pos, "self_check (P0) must appear before user text (P1)"
+
+    def test_since_ts_path_unaffected_by_priority_change(self, inbox_dir, processed_dir):
+        """The since_ts historical scan path is not changed — it still reads processed/ too."""
+        ts_future = _BASE_TS + timedelta(hours=2)
+        msg = _make_msg("proc_msg", "text", offset_seconds=7200)
+        (processed_dir / "proc_msg.json").write_text(json.dumps(msg))
+
+        result = _run_check_inbox(
+            inbox_dir,
+            processed_dir,
+            {"since_ts": _iso(_BASE_TS)},
+        )
+        text = result[0].text
+        assert "proc_msg" in text, "since_ts path must still read from processed/ dir"


### PR DESCRIPTION
## What problem this solves

Closes #1079

The dispatcher processes messages in filename-sorted (arrival-time) order. This means a `compact-reminder` — which takes zero tokens to handle — can sit behind 3 queued `scheduled_reminder` messages that each spawn a full subagent, causing the dispatcher to take the expensive path first. Ordering was an LLM judgment call when it should be a code property.

## What changed

`check_inbox` now returns messages in P0→P1→P2→P3→P4 order, with FIFO by timestamp within each tier:

| Priority | Message types | Rationale |
|---|---|---|
| P0 | `compact-reminder`, `self_check` subtypes | Dispatcher housekeeping — zero-cost, must run first |
| P1 | `text`, `voice`, `photo`, `document` | Human in the loop — latency-sensitive |
| P2 | `subagent_result`, `subagent_error` | Completing in-flight work |
| P3 | `agent_failed` | Error recovery |
| P4 | `scheduled_reminder`, `system_error`, everything else | Background / cron |

Priority is derived at read time from `type` and `subtype` fields — nothing is stored in message files. Unreadable/unparseable files default to P4 silently.

The `since_ts` historical scan path is entirely unchanged — priority ordering only applies to the live inbox scan.

## Implementation

Two pure functions added before `handle_check_inbox`:
- `_inbox_priority(msg)` — maps message fields to tier 0-4
- `_inbox_sort_key(filename, priority, ts_epoch)` — returns `(priority, epoch, filename)` for stable sort

The live inbox scan becomes a two-pass approach: read all files and score them, sort by key, then process in priority order. The existing pre-processors (`/report` command handler, `subagent_recovered` notifier) are preserved intact in the processing pass.

**Functional patterns used:** pure functions for priority/sort-key derivation, immutable sort key tuple, separation of scoring from processing.

## Flow (before/after)

Before:
```
inbox files → sort by filename → process in arrival order
```

After:
```
inbox files → score each (priority + timestamp) → sort by (P, ts, filename) → process in priority order
```

No state transitions or message schema changes. This is purely a read-side ordering fix.

## Tests run
- [x] `uv run pytest tests/unit/test_mcp_server/test_priority_inbox_queue.py -v` — 22 passed, 0 failed
- [x] `uv run pytest tests/unit/test_mcp_server/ --tb=short` — 682 passed, 70 failed (all 70 are pre-existing `_DEBUG_MODE` attribute failures in `test_debug_alerts.py` and `test_write_observation.py` unrelated to this change)

## Manual test

N/A — this change is entirely internal to the read path of `check_inbox`. No external services, no file I/O side effects, no Telegram output. The dispatcher's observable behavior is that it processes compact-reminders before user messages before scheduled jobs — this is verifiable in logs if a mixed inbox occurs, but requires no production intervention to confirm correctness.