### PR TITLE
docs(scheduling): migration guide — converting Claude-based jobs to code-first scripts

### DIFF
--- a/scheduled-tasks/HOW-TO-MIGRATE.md
+++ b/scheduled-tasks/HOW-TO-MIGRATE.md
@@ -1,0 +1,300 @@
+# How to Migrate a Scheduled Job to the New Architecture
+
+This guide covers converting a Claude-mediated (Kind 2) scheduled job to a
+code-first (Kind 1) polling script, and registering new jobs the right way
+using systemd timers.
+
+**Written against the live implementations in `#1081` (lobstertalk-unified) and
+`#1082` (lobstertalk-incoming-handler).** If the examples here contradict what
+you see in those files, the code is authoritative.
+
+---
+
+## The Three Job Kinds
+
+| Kind | Trigger | Runner | When to use |
+|------|---------|--------|-------------|
+| **Kind 1** | systemd timer → code | Python/shell script directly (no Claude) | Deterministic algorithm, fixed API, no open-ended reasoning. Examples: email poller, API watcher, git diff check. |
+| **Kind 2** | systemd timer → Claude | `dispatch-job.sh` → inbox → LLM subagent | Requires LLM judgment: formatting, routing decisions, multi-step reasoning. Examples: kanban watcher, SSH message router. |
+| **Kind 3** | External webhook / event | Direct inbox write | Triggered by an external system pushing a message in, not by a timer. |
+
+**The new default for new jobs is Kind 1 or Kind 2 backed by a systemd timer.**
+The old cron + `jobs.json` + `sync-crontab.sh` path is deprecated (see `dispatch-job.sh`
+header and issue #1083). Do not create new `# LOBSTER-SCHEDULED` crontab entries.
+
+---
+
+## When to Migrate a Claude Task to a Code-First Script
+
+Migrate from Kind 2 to Kind 1 when **all** of the following are true:
+
+- The job follows a deterministic algorithm: same input → same output, every time.
+- The job calls a fixed API with a known response schema (no need to parse free text).
+- The job's decisions can be written as explicit `if/else` logic, not prose instructions.
+- The job does not require multi-step reasoning, tone adjustment, or contextual judgment.
+- The job produces structured output (inbox message, log entry) rather than a narrative reply.
+
+**Do not migrate** if the job needs to decide *how* to present information, which of
+several actions to take, or when to escalate to a human. Keep it as Kind 2.
+
+Examples that are good Kind 1 candidates:
+- "Poll Linear, write inbox message if any new issues assigned to me since last check"
+- "Check if a GitHub PR has new review comments since last run"
+- "Read a file's mtime; if changed, write a notification"
+
+Examples that should stay Kind 2:
+- "Read the kanban board and write a concise summary with action items"
+- "Check SSH messages and route them with appropriate context to the right Lobster inbox"
+
+---
+
+## Step-by-Step: Converting a Kind 2 Job to Kind 1
+
+### 1. Write the Python poller script
+
+Create `~/lobster/scheduled-tasks/<job-name>.py`.
+
+**Anatomy of a Kind 1 poller:**
+
+```
+constants and configuration
+    ↓
+_load_state()         # read last watermark from state file
+    ↓
+_poll_api()           # call external service, return new items (pure function)
+    ↓
+_delta()              # compute what changed since last watermark (pure function)
+    ↓
+if delta is empty:
+    exit 0            # no LLM subagent spawned, zero cost
+else:
+    _write_inbox()    # write a structured message to ~/messages/inbox/
+    _write_state()    # advance watermark atomically
+    exit 0
+```
+
+Key invariants:
+- **Never advance the watermark before writing to the inbox.** If the process
+  crashes after advancing but before writing, you'll miss events permanently.
+- **Never invoke `claude` or the MCP server directly.** All LLM work is done
+  by the dispatcher when it reads the inbox message you wrote.
+- **Exit 0 always** (even on error — let the job log it and retry next cycle).
+  Non-zero exits cause systemd to mark the job as failed, which can suppress
+  future runs.
+- **Use atomic writes.** Write to a `.tmp` file, then `os.replace()`. This
+  prevents partial reads if the process is interrupted.
+
+See `scheduled-tasks/lobstertalk_unified.py` for a complete production example.
+
+### 2. State file location and schema
+
+Store state in `~/lobster-workspace/data/<job-name>-state.json`.
+
+Minimum schema:
+
+```json
+{
+  "last_check_ts": "2026-01-01T12:00:00+00:00"
+}
+```
+
+For cursor-based APIs (message IDs, page tokens):
+
+```json
+{
+  "last_seen_id": "msg_12345",
+  "last_check_ts": "2026-01-01T12:00:00+00:00"
+}
+```
+
+Read it with a helper that returns defaults on first run:
+
+```python
+def _load_state() -> dict:
+    if not STATE_FILE.exists():
+        return {"last_check_ts": (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()}
+    try:
+        return json.loads(STATE_FILE.read_text())
+    except Exception:
+        return {"last_check_ts": (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()}
+```
+
+Write atomically:
+
+```python
+def _write_state(state: dict) -> None:
+    tmp = Path(str(STATE_FILE) + ".tmp")
+    tmp.write_text(json.dumps(state, indent=2))
+    tmp.replace(STATE_FILE)
+```
+
+### 3. Writing inbox messages
+
+Write to `~/messages/inbox/<epoch_ms>_<job-name>.json`:
+
+```python
+def _write_inbox_message(items: list[dict], state: dict) -> None:
+    epoch_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    msg_id = f"{epoch_ms}_{JOB_NAME}"
+    msg = {
+        "id": msg_id,
+        "source": "system",
+        "type": "scheduled_reminder",
+        "chat_id": ADMIN_CHAT_ID,   # from env: LOBSTER_ADMIN_CHAT_ID
+        "user_id": ADMIN_CHAT_ID,
+        "username": "lobster-cron",
+        "user_name": "Cron",
+        "text": f"[{JOB_NAME}] {len(items)} new item(s) since {state.get('last_check_ts')}",
+        "job_name": JOB_NAME,
+        "items": items,             # structured payload for the dispatcher
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    tmp = INBOX_DIR / f"{msg_id}.tmp"
+    out = INBOX_DIR / f"{msg_id}.json"
+    tmp.write_text(json.dumps(msg, ensure_ascii=False, indent=2))
+    tmp.replace(out)
+```
+
+The dispatcher reads `job_name` and routes the message to a subagent configured
+for that job. The `items` payload is available in the task context.
+
+### 4. Creating the systemd timer
+
+Register the job via the `create_scheduled_job` MCP tool from within a Claude session:
+
+```
+create_scheduled_job(
+    name="my-job",
+    schedule="*/15 * * * *",    # standard cron syntax; the tool converts to systemd OnCalendar=
+    context="<path to task file or inline instructions>"
+)
+```
+
+For Kind 1 jobs where the script runs directly (no task file / no LLM), you
+can still use `create_scheduled_job` — just set the `context` to a note explaining
+the job exists. The underlying systemd service will call your script's full path.
+
+To create the systemd unit manually (for Kind 1 scripts that call no LLM):
+
+```bash
+# /etc/systemd/system/lobster-my-job.service
+[Unit]
+Description=My job description
+# LOBSTER-MANAGED
+
+[Service]
+Type=oneshot
+User=lobster
+ExecStart=/home/lobster/lobster/scheduled-tasks/my-job.py
+
+# /etc/systemd/system/lobster-my-job.timer
+[Unit]
+Description=My job description
+# LOBSTER-MANAGED
+
+[Timer]
+OnCalendar=*:0/15    # every 15 minutes
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Then:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now lobster-my-job.timer
+```
+
+### 5. Tombstoning the jobs.json entry
+
+If the job was previously registered in `~/lobster-workspace/scheduled-jobs/jobs.json`,
+disable it there to prevent any legacy path from re-firing:
+
+```bash
+cd ~/lobster-workspace/scheduled-jobs
+jq '.jobs["my-job"].enabled = false | .jobs["my-job"].tombstoned = "migrated to systemd timer — see #1083"' \
+  jobs.json > jobs.json.tmp && mv jobs.json.tmp jobs.json
+```
+
+Also remove any `# LOBSTER-SCHEDULED` crontab entry for the job. With the new
+architecture, upgrade.sh Migration 70 removes all such entries automatically.
+
+### 6. Testing checklist
+
+Before shipping:
+
+- [ ] Script runs standalone: `uv run ~/lobster/scheduled-tasks/my-job.py` exits 0
+- [ ] On first run (no state file), script exits 0 without crashing
+- [ ] On second run with no new data, script exits 0 and writes nothing to inbox
+- [ ] When new data exists, inbox message appears at `~/messages/inbox/` with correct schema
+- [ ] State file advances after inbox write, not before
+- [ ] State file uses atomic write (no partial reads during crash)
+- [ ] No direct `claude` invocations anywhere in the script
+- [ ] `systemctl status lobster-my-job.timer` shows `active (waiting)`
+
+---
+
+## Template: `scheduled-tasks/templates/poller.py.template`
+
+A copy-paste starting point for new Kind 1 Python pollers. See that file for the
+full annotated template.
+
+Quick summary of what the template provides:
+- Constants block (JOB_NAME, ADMIN_CHAT_ID, STATE_FILE, INBOX_DIR)
+- `_load_state()` and `_write_state()` with safe defaults
+- `_poll()` stub to fill in with your API call
+- `_write_inbox_message()` with atomic write
+- `main()` wiring it all together with try/except guard
+- Exit codes: always 0 (log errors, don't fail the systemd unit)
+
+---
+
+## Common Mistakes
+
+### 1. Advancing the watermark before writing to the inbox
+
+```python
+# WRONG — if _write_inbox_message crashes, events are lost forever
+_write_state({"last_check_ts": now})
+_write_inbox_message(new_items)
+
+# CORRECT — advance only after successful write
+_write_inbox_message(new_items)
+_write_state({"last_check_ts": now})
+```
+
+### 2. Forgetting `last_check_ts` on first run
+
+If `STATE_FILE` doesn't exist and your code does `state["last_check_ts"]` without
+a default, you'll get a `KeyError` on first run. Always use `_load_state()` with
+defaults.
+
+### 3. Advancing the watermark in the script instead of the subagent
+
+For Kind 2 jobs (LLM-mediated), the subagent must update the state file after
+successful processing. The pre-check script must not advance the watermark —
+it only reads it. If the script advances the cursor and the subagent never runs
+(inbox full, dispatcher busy), you permanently skip those events.
+
+For Kind 1 jobs (code-only), the script itself advances the watermark after
+writing to the inbox. This is correct because there is no subagent to do it.
+
+### 4. Non-zero exit on handled errors
+
+If your API is unreachable or returns 500, log the error and `sys.exit(0)`.
+A non-zero exit causes systemd to mark the job as failed, which may suppress
+future runs or trigger admin alerts for a transient issue.
+
+### 5. Creating a new `# LOBSTER-SCHEDULED` crontab entry
+
+The `# LOBSTER-SCHEDULED` cron layer is deprecated (issue #1083). All new
+jobs must use systemd timers via `create_scheduled_job` MCP tool. Do not
+write new entries to the crontab manually.
+
+### 6. Calling the MCP server or Claude directly from a scheduled script
+
+Scheduled scripts run outside the Claude session. They cannot call MCP tools.
+All LLM work must flow through the inbox: write a `scheduled_reminder` message,
+and let the dispatcher spawn a subagent to handle it.

--- a/scheduled-tasks/templates/poller.py.template
+++ b/scheduled-tasks/templates/poller.py.template
@@ -1,0 +1,243 @@
+#!/usr/bin/env -S uv run python3
+"""
+<SHORT_DESCRIPTION> — Lobster Kind 1 polling script.
+
+This is a code-first (Kind 1) scheduled job. It runs on a systemd timer,
+polls an external source, and writes to the Lobster inbox when new data is
+found. No LLM is invoked if nothing changed (zero token cost on empty polls).
+
+SETUP: Search for all YOUR_* placeholders and replace them before deploying.
+
+Architecture:
+  systemd timer fires → this script runs → if new data: writes inbox message
+  → dispatcher picks up message → (optionally) spawns Claude subagent
+
+For Kind 1 jobs, the subagent step may be omitted: the script can write a
+fully-formed notification directly and the dispatcher routes it.
+
+State file: ~/lobster-workspace/data/YOUR_JOB_NAME-state.json
+Inbox writes: ~/messages/inbox/<epoch_ms>_YOUR_JOB_NAME.json
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import uuid
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants — fill these in before deploying
+# ---------------------------------------------------------------------------
+
+JOB_NAME: str = "YOUR_JOB_NAME"  # must match the systemd unit name (lobster-<JOB_NAME>)
+
+# Admin chat ID: where inbox notifications are routed.
+# Read from env so this script works without hardcoded credentials.
+_admin_chat_id_str = os.environ.get("LOBSTER_ADMIN_CHAT_ID") or os.environ.get("ADMIN_CHAT_ID") or ""
+if not _admin_chat_id_str:
+    # Fail fast at startup, not silently mid-run
+    print(f"[{JOB_NAME}] ERROR: LOBSTER_ADMIN_CHAT_ID env var not set", file=sys.stderr)
+    sys.exit(0)  # exit 0 to avoid systemd marking the unit failed for a config issue
+ADMIN_CHAT_ID: int = int(_admin_chat_id_str)
+
+# File paths — convention: ~/lobster-workspace/data/<job-name>-state.json
+STATE_FILE = Path.home() / "lobster-workspace" / "data" / f"{JOB_NAME}-state.json"
+INBOX_DIR = Path.home() / "messages" / "inbox"
+
+# Logging
+log = logging.getLogger(JOB_NAME)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    stream=sys.stderr,
+)
+
+
+# ---------------------------------------------------------------------------
+# State management (pure transformation + atomic I/O)
+# ---------------------------------------------------------------------------
+
+def _default_state() -> dict[str, Any]:
+    """Return initial state for a first-run install (look back 1 hour)."""
+    return {
+        "last_check_ts": (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
+        # Add job-specific fields here, e.g.:
+        # "last_seen_id": None,
+    }
+
+
+def _load_state() -> dict[str, Any]:
+    """Read state file; return defaults if missing or corrupted."""
+    if not STATE_FILE.exists():
+        log.info("No state file found — using defaults (first run)")
+        return _default_state()
+    try:
+        data = json.loads(STATE_FILE.read_text())
+        # Forward-compat: ensure all expected keys exist
+        defaults = _default_state()
+        for key, val in defaults.items():
+            data.setdefault(key, val)
+        return data
+    except Exception as exc:
+        log.warning(f"State file corrupted ({exc}) — resetting to defaults")
+        return _default_state()
+
+
+def _write_state(state: dict[str, Any]) -> None:
+    """Write state atomically (tmp → replace) to prevent partial reads."""
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    tmp = Path(str(STATE_FILE) + ".tmp")
+    tmp.write_text(json.dumps(state, indent=2, ensure_ascii=False))
+    tmp.replace(STATE_FILE)
+
+
+# ---------------------------------------------------------------------------
+# External source polling (pure function — no I/O side effects)
+# Replace _poll() with your actual API call.
+# ---------------------------------------------------------------------------
+
+def _poll(state: dict[str, Any]) -> list[dict[str, Any]]:
+    """Fetch items from the external source that are new since state['last_check_ts'].
+
+    Returns a list of items (may be empty). Must not mutate state.
+    Raises on unrecoverable errors (caller wraps in try/except).
+
+    REPLACE THIS with your actual API call.
+
+    Example patterns:
+      - HTTP GET with ?since= query param
+      - Read a file and check mtime
+      - `gh api graphql` call
+      - Parse a JSONL file for new lines beyond a byte offset
+    """
+    last_ts = state.get("last_check_ts", "")
+    log.info(f"Polling YOUR_SOURCE since {last_ts}")
+
+    # --- YOUR API CALL HERE ---
+    # import urllib.request
+    # url = f"https://YOUR_API/items?since={last_ts}"
+    # with urllib.request.urlopen(url) as resp:
+    #     data = json.loads(resp.read())
+    # return data.get("items", [])
+
+    # Stub: return empty list (no-op until you fill this in)
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Delta computation (pure function)
+# ---------------------------------------------------------------------------
+
+def _is_new(item: dict[str, Any], state: dict[str, Any]) -> bool:
+    """Return True if this item is newer than what we've already seen.
+
+    Adjust the comparison to match your data model:
+      - timestamp-based: item["created_at"] > state["last_check_ts"]
+      - ID-based: item["id"] not in seen_ids
+      - sequence-based: item["seq"] > state["last_seq"]
+    """
+    item_ts = item.get("created_at") or item.get("timestamp") or ""
+    return item_ts > state.get("last_check_ts", "")
+
+
+def _compute_delta(
+    items: list[dict[str, Any]], state: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Filter items to only those that are new since the last recorded state."""
+    return [item for item in items if _is_new(item, state)]
+
+
+# ---------------------------------------------------------------------------
+# Inbox message writer (atomic I/O)
+# ---------------------------------------------------------------------------
+
+def _write_inbox_message(new_items: list[dict[str, Any]], state: dict[str, Any]) -> None:
+    """Write a structured scheduled_reminder to ~/messages/inbox/.
+
+    Uses epoch_ms prefix for filename to ensure FIFO ordering in the inbox.
+    Writes atomically via tmp → replace.
+    """
+    INBOX_DIR.mkdir(parents=True, exist_ok=True)
+    epoch_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    msg_id = f"{epoch_ms}_scheduled_{JOB_NAME}"
+    last_ts = state.get("last_check_ts", "")
+
+    msg: dict[str, Any] = {
+        "id": msg_id,
+        "source": "system",
+        "type": "scheduled_reminder",
+        "chat_id": ADMIN_CHAT_ID,
+        "user_id": ADMIN_CHAT_ID,
+        "username": "lobster-cron",
+        "user_name": "Cron",
+        "text": f"[{JOB_NAME}] {len(new_items)} new item(s) since {last_ts}",
+        "job_name": JOB_NAME,
+        # Structured payload — the dispatcher and any subagent can read this.
+        # Keep it compact: include only what the subagent needs to reason.
+        "items": new_items,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    out = INBOX_DIR / f"{msg_id}.json"
+    tmp = INBOX_DIR / f"{msg_id}.tmp"
+    tmp.write_text(json.dumps(msg, ensure_ascii=False, indent=2))
+    tmp.replace(out)
+    log.info(f"Wrote inbox message: {out.name}")
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    """Run one poll cycle.
+
+    Flow:
+      1. Load state (watermark + any cursors)
+      2. Poll external source
+      3. Compute delta vs watermark
+      4. If empty delta: log no-op, exit 0 (no inbox write, no LLM cost)
+      5. If new items: write inbox message, then advance watermark
+         (order matters: write first, then advance — see HOW-TO-MIGRATE.md)
+
+    Always exits 0. Errors are logged but do not fail the systemd unit.
+    """
+    try:
+        state = _load_state()
+
+        # Poll — may raise on network/API errors
+        all_items = _poll(state)
+
+        # Filter to what's genuinely new
+        new_items = _compute_delta(all_items, state)
+
+        if not new_items:
+            log.info(f"No new items — exiting without inbox write")
+            return  # exit 0
+
+        log.info(f"Found {len(new_items)} new item(s) — writing to inbox")
+
+        # Write inbox message BEFORE advancing the watermark.
+        # If we crash between these two lines, the next run will re-process
+        # the same items (safe duplication), rather than silently skipping them.
+        _write_inbox_message(new_items, state)
+
+        # Advance watermark: update last_check_ts to now (or to the max timestamp
+        # in new_items, depending on your data model).
+        new_state = dict(state)
+        new_state["last_check_ts"] = datetime.now(timezone.utc).isoformat()
+        # If your API uses IDs: new_state["last_seen_id"] = new_items[-1]["id"]
+        _write_state(new_state)
+
+    except Exception as exc:
+        # Log and exit 0 — do not let a transient error fail the systemd unit
+        log.error(f"Unhandled error in {JOB_NAME}: {exc}", exc_info=True)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_migration_guide.py
+++ b/tests/unit/test_migration_guide.py
@@ -1,0 +1,193 @@
+"""
+Tests for the scheduled job migration guide (issue #1084).
+
+Verifies that:
+1. HOW-TO-MIGRATE.md exists and covers all required sections
+2. poller.py.template is syntactically valid Python
+3. The template has no TODOs left in critical paths (only YOUR_* placeholders)
+4. The guide does not describe dispatch-job.sh or jobs.json as the "right way"
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_DIR = Path(__file__).parent.parent.parent
+HOW_TO_MIGRATE = REPO_DIR / "scheduled-tasks" / "HOW-TO-MIGRATE.md"
+POLLER_TEMPLATE = REPO_DIR / "scheduled-tasks" / "templates" / "poller.py.template"
+
+
+class TestHowToMigrateExists:
+    def test_file_exists(self):
+        assert HOW_TO_MIGRATE.exists(), "HOW-TO-MIGRATE.md must exist in scheduled-tasks/"
+
+    def test_file_is_not_empty(self):
+        assert HOW_TO_MIGRATE.stat().st_size > 500, "HOW-TO-MIGRATE.md must not be empty"
+
+
+class TestHowToMigrateSections:
+    """The guide must cover all five sections from the issue spec."""
+
+    @pytest.fixture(autouse=True)
+    def content(self):
+        self.text = HOW_TO_MIGRATE.read_text()
+
+    def test_covers_three_job_kinds(self):
+        """Section 1: The three job kinds (Kind 1/2/3) with descriptions."""
+        assert "Kind 1" in self.text, "Guide must describe Kind 1 jobs"
+        assert "Kind 2" in self.text, "Guide must describe Kind 2 jobs"
+
+    def test_covers_when_to_migrate_decision_criteria(self):
+        """Section 2: Decision criteria for migrating to Kind 1."""
+        # Should have guidance on when to migrate
+        assert "When to" in self.text or "when to" in self.text, (
+            "Guide must explain when to migrate a job"
+        )
+        assert "deterministic" in self.text.lower(), (
+            "Guide must mention determinism as a migration criterion"
+        )
+
+    def test_covers_step_by_step_conversion(self):
+        """Section 3: Step-by-step conversion guide."""
+        assert "Step" in self.text or "step" in self.text
+        assert "state" in self.text.lower(), "Guide must cover state file handling"
+        assert "watermark" in self.text.lower() or "last_check_ts" in self.text, (
+            "Guide must mention the watermark/last_check_ts pattern"
+        )
+
+    def test_covers_systemd_timer_creation(self):
+        """Section 3: Creating the systemd timer via create_scheduled_job MCP tool."""
+        assert "create_scheduled_job" in self.text, (
+            "Guide must mention the create_scheduled_job MCP tool"
+        )
+        assert "systemd" in self.text.lower(), "Guide must cover systemd timer creation"
+
+    def test_covers_tombstoning(self):
+        """Section 3: Tombstoning the jobs.json entry."""
+        assert "tombstone" in self.text.lower() or "jobs.json" in self.text, (
+            "Guide must cover tombstoning jobs.json entries"
+        )
+
+    def test_covers_testing_checklist(self):
+        """Section 3: Testing checklist."""
+        assert "checklist" in self.text.lower() or "- [ ]" in self.text, (
+            "Guide must include a testing checklist"
+        )
+
+    def test_covers_common_mistakes(self):
+        """Section 5: Common mistakes."""
+        assert "Common" in self.text and ("mistake" in self.text.lower() or "Mistake" in self.text), (
+            "Guide must have a Common Mistakes section"
+        )
+        assert "watermark" in self.text.lower() or "before writing" in self.text.lower(), (
+            "Guide must warn about advancing watermark before writing to inbox"
+        )
+
+    def test_no_dispatch_job_presented_as_right_way(self):
+        """Guide must not present dispatch-job.sh as the recommended new-job approach."""
+        lines_with_dispatch = [
+            ln for ln in self.text.splitlines()
+            if "dispatch-job.sh" in ln and "new job" in ln.lower()
+        ]
+        assert len(lines_with_dispatch) == 0, (
+            "Guide must not describe dispatch-job.sh as how to create new jobs. "
+            f"Found: {lines_with_dispatch}"
+        )
+
+    def test_no_lobster_scheduled_crontab_as_right_way(self):
+        """Guide must not instruct the reader to create LOBSTER-SCHEDULED crontab entries."""
+        assert "# LOBSTER-SCHEDULED" not in self.text or "deprecated" in self.text.lower() or "Do not" in self.text, (
+            "If guide mentions LOBSTER-SCHEDULED, it must also note that it is deprecated"
+        )
+
+
+class TestPollerPythonTemplate:
+    """poller.py.template must be syntactically valid and complete."""
+
+    @pytest.fixture(autouse=True)
+    def content(self):
+        self.raw = POLLER_TEMPLATE.read_text()
+
+    def test_template_file_exists(self):
+        assert POLLER_TEMPLATE.exists(), "poller.py.template must exist"
+
+    def test_template_is_valid_python(self):
+        """Template must parse as valid Python (minus the shebang line)."""
+        # Strip the shebang for the AST parser
+        lines = self.raw.splitlines()
+        code = "\n".join(lines[1:]) if lines[0].startswith("#!") else self.raw
+        try:
+            ast.parse(code)
+        except SyntaxError as e:
+            pytest.fail(f"poller.py.template has syntax error: {e}")
+
+    def test_template_has_job_name_constant(self):
+        assert "JOB_NAME" in self.raw, "Template must define JOB_NAME constant"
+
+    def test_template_has_state_file_constant(self):
+        assert "STATE_FILE" in self.raw, "Template must define STATE_FILE constant"
+
+    def test_template_has_inbox_dir_constant(self):
+        assert "INBOX_DIR" in self.raw, "Template must define INBOX_DIR constant"
+
+    def test_template_has_load_state_function(self):
+        assert "_load_state" in self.raw, "Template must include _load_state() function"
+
+    def test_template_has_write_state_function(self):
+        assert "_write_state" in self.raw, "Template must include _write_state() function"
+
+    def test_template_has_poll_function(self):
+        assert "_poll" in self.raw, "Template must include a polling function"
+
+    def test_template_has_write_inbox_function(self):
+        assert "_write_inbox" in self.raw, "Template must include inbox write function"
+
+    def test_template_has_main_function(self):
+        assert "def main" in self.raw, "Template must include main() function"
+
+    def test_template_watermark_write_before_state_advance(self):
+        """Template must write inbox message BEFORE advancing watermark."""
+        write_pos = self.raw.find("_write_inbox_message")
+        state_pos = self.raw.find("_write_state(new_state)")
+        assert write_pos != -1, "Template must call _write_inbox_message"
+        assert state_pos != -1, "Template must call _write_state to advance watermark"
+        assert write_pos < state_pos, (
+            "Template must call _write_inbox_message() BEFORE _write_state() "
+            "(watermark must not advance until inbox write succeeds)"
+        )
+
+    def test_template_uses_atomic_write(self):
+        """Template must use atomic tmp→replace pattern for writes."""
+        assert "tmp.replace" in self.raw or ".replace(" in self.raw, (
+            "Template must use atomic write: write to .tmp then os.replace/Path.replace"
+        )
+
+    def test_template_no_claude_invocation(self):
+        """Template must not invoke Claude directly."""
+        import re
+        claude_calls = re.findall(r'\bclaude\s+(-p|--print)', self.raw)
+        assert len(claude_calls) == 0, (
+            "Template must not invoke `claude -p` or `claude --print` directly"
+        )
+
+    def test_template_exits_zero_on_error(self):
+        """Template must exit 0 on errors to avoid failing the systemd unit."""
+        assert "sys.exit(0)" in self.raw, (
+            "Template must use sys.exit(0) in the error handler to prevent "
+            "systemd from marking the unit as failed on transient errors"
+        )
+
+    def test_template_no_leftover_todos(self):
+        """Template must have no TODO comments left in critical code paths."""
+        import re
+        # Allow TODOs in comments that are clearly instructions to the user
+        # Disallow TODOs inside function bodies where they'd cause a NameError
+        todo_lines = [
+            ln for ln in self.raw.splitlines()
+            if "TODO" in ln and not ln.strip().startswith("#")
+        ]
+        assert len(todo_lines) == 0, (
+            f"Template has TODO in non-comment lines: {todo_lines}"
+        )


### PR DESCRIPTION
## What problem this solves

Closes #1084

The Kind 1/2/3 job architecture is non-obvious the first time. Without a guide, every new poller gets re-invented by reading the full #1059 design doc or reverse-engineering an existing script. The pattern needs to be repeatable.

## What changed

Two new files in `scheduled-tasks/`:

**`HOW-TO-MIGRATE.md`** — a practical guide covering:
1. The three job kinds (Kind 1/2/3) with a decision table for when to use each
2. When to migrate from Kind 2 (Claude-mediated) to Kind 1 (code-first) — explicit criteria based on determinism, fixed API, no open-ended reasoning
3. Step-by-step conversion: script anatomy, state file location and schema, inbox message format, systemd timer registration via `create_scheduled_job` MCP tool, tombstoning `jobs.json`, testing checklist
4. Template reference to `poller.py.template`
5. Common mistakes: watermark-before-write bug, missing `last_check_ts` default, advancing watermark in the wrong layer, non-zero exits on transient errors, creating new `LOBSTER-SCHEDULED` crontab entries

**`scheduled-tasks/templates/poller.py.template`** — a copy-paste starting point for Kind 1 Python pollers. All critical paths are implemented (not stubbed with TODOs). The template demonstrates:
- Named constants for all configurable values
- `_load_state()` / `_write_state()` with safe defaults and atomic I/O
- `_poll()` stub for the API call
- `_compute_delta()` pure function
- `_write_inbox_message()` with atomic tmp→replace write
- `main()` wiring with try/except guard and `sys.exit(0)` on errors
- Correct ordering: inbox write before watermark advance

The guide is written against the real `lobstertalk-unified` implementation (PR #1081) — it is accurate, not aspirational.

**Functional patterns used:** pure functions for `_is_new`/`_compute_delta`, immutable state dict (read → transform → write), I/O isolated to named functions, separation of polling from delta computation from side effects.

## What is NOT changed

- No runtime code changed
- No existing scheduled scripts modified
- No systemd units or cron entries added

## Tests run
- [x] `uv run pytest tests/unit/test_migration_guide.py -v` — 26 passed, 0 failed
  - Template syntax checked via `ast.parse`
  - All 5 required sections verified present in HOW-TO-MIGRATE.md
  - Watermark ordering verified (inbox write before state advance)
  - No TODOs in non-comment lines
  - Template confirmed not to invoke `claude` directly

## Manual test

N/A — this is documentation and a Python template. No external services, no systemd units, no file I/O side effects at runtime.