### PR TITLE
refactor(eventbus): centralize MCP handler emit calls via _emit_mcp_event helper

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -303,6 +303,42 @@ def _resolve_debug_config() -> None:
     pass
 
 
+def _emit_mcp_event(
+    event_type: str,
+    payload: dict,
+    severity: str = "info",
+    chat_id: int | str | None = None,
+) -> None:
+    """
+    Centralized EventBus emission for MCP handler audit-trail events (issue #1459).
+
+    All 5 per-handler emit blocks (telegram.inbound, telegram.outbound,
+    inbox.processed, inbox.failed, job.completed) were identical except for
+    event_type, payload, severity, and chat_id.  This function extracts that
+    boilerplate into one place.
+
+    Callers pass only the semantically meaningful fields; this function handles
+    availability guard, LobsterEvent construction, emit_sync(), and
+    exception suppression so the main handler path is never blocked.
+
+    Adding a new event type = one call to _emit_mcp_event(), no copy-pasted
+    try/except block.
+    """
+    if not _EVENT_BUS_AVAILABLE:
+        return
+    try:
+        event = LobsterEvent(
+            event_type=event_type,
+            severity=severity,
+            source="inbox-server",
+            payload=payload,
+            chat_id=chat_id,
+        )
+        get_event_bus().emit_sync(event)
+    except Exception:
+        pass  # observability must never block the caller
+
+
 # ---------------------------------------------------------------------------
 # User model context injection heuristic
 # ---------------------------------------------------------------------------
@@ -4411,23 +4447,12 @@ async def handle_send_reply(args: dict) -> list[TextContent]:
 
     # Emit telegram.outbound to EventBus for audit trail (issue #1352).
     # Skipped for bot-talk — that source already emits via bot_talk_mirror.
-    # Fire-and-forget: swallows all exceptions so the reply path is never blocked.
-    if source != "bot-talk" and _EVENT_BUS_AVAILABLE:
-        try:
-            event = LobsterEvent(
-                event_type="telegram.outbound",
-                severity="info",
-                source="inbox-server",
-                payload={
-                    "source": source,
-                    "chat_id": chat_id,
-                    "text_len": len(text),
-                },
-                chat_id=chat_id,
-            )
-            get_event_bus().emit_sync(event)
-        except Exception:
-            pass  # never block on observability
+    if source != "bot-talk":
+        _emit_mcp_event(
+            "telegram.outbound",
+            {"source": source, "chat_id": chat_id, "text_len": len(text)},
+            chat_id=chat_id,
+        )
 
     # Mirror outbound bot-talk messages to the EventBus so TelegramOutboxListener
     # can forward them as debug notifications. Fire-and-forget: non-blocking.
@@ -4668,18 +4693,7 @@ async def handle_mark_processed(args: dict) -> list[TextContent]:
     )
 
     # Emit inbox.processed to EventBus for audit trail (issue #1352).
-    # Fire-and-forget: swallows all exceptions so the mark_processed path is never blocked.
-    if _EVENT_BUS_AVAILABLE:
-        try:
-            event = LobsterEvent(
-                event_type="inbox.processed",
-                severity="info",
-                source="inbox-server",
-                payload={"message_id": message_id},
-            )
-            get_event_bus().emit_sync(event)
-        except Exception:
-            pass  # never block on observability
+    _emit_mcp_event("inbox.processed", {"message_id": message_id})
 
     log.info(f"Message processed: {message_id}")
     return [TextContent(type="text", text=f"✅ Message marked as processed: {message_id}")]
@@ -4802,23 +4816,11 @@ async def handle_mark_processing(args: dict) -> list[TextContent]:
         pass  # non-fatal; stale recovery falls back to mtime
 
     # Emit telegram.inbound to EventBus for audit trail (issue #1352).
-    # Fire-and-forget: swallows all exceptions so the claim path is never blocked.
-    if _EVENT_BUS_AVAILABLE:
-        try:
-            event = LobsterEvent(
-                event_type="telegram.inbound",
-                severity="info",
-                source="inbox-server",
-                payload={
-                    "message_id": message_id,
-                    "source": msg_source,
-                    "msg_type": msg_type,
-                },
-                chat_id=msg_data.get("chat_id"),
-            )
-            get_event_bus().emit_sync(event)
-        except Exception:
-            pass  # never block on observability
+    _emit_mcp_event(
+        "telegram.inbound",
+        {"message_id": message_id, "source": msg_source, "msg_type": msg_type},
+        chat_id=msg_data.get("chat_id"),
+    )
 
     log.info(f"Message claimed for processing: {message_id}")
     return [TextContent(type="text", text=f"Message claimed: {message_id}{context_block}")]
@@ -4953,18 +4955,12 @@ async def handle_mark_failed(args: dict) -> list[TextContent]:
         # Update claim status to 'failed' (issue #1360)
         _claims_db.update_status(message_id, "failed")
         log.error(f"Message permanently failed after {max_retries} retries: {message_id} - {error}")
-        # Emit inbox.failed to EventBus for audit trail (issue #1352). Fire-and-forget.
-        if _EVENT_BUS_AVAILABLE:
-            try:
-                event = LobsterEvent(
-                    event_type="inbox.failed",
-                    severity="warn",
-                    source="inbox-server",
-                    payload={"message_id": message_id, "error": error, "permanent": True},
-                )
-                get_event_bus().emit_sync(event)
-            except Exception:
-                pass  # never block on observability
+        # Emit inbox.failed to EventBus for audit trail (issue #1352).
+        _emit_mcp_event(
+            "inbox.failed",
+            {"message_id": message_id, "error": error, "permanent": True},
+            severity="warn",
+        )
         return [TextContent(type="text", text=f"Message permanently failed after {max_retries} retries: {message_id}")]
 
     # Schedule retry with exponential backoff: 60s, 120s, 240s
@@ -4979,18 +4975,12 @@ async def handle_mark_failed(args: dict) -> list[TextContent]:
     # Release claim row so the message can be re-claimed on retry (issue #1360)
     _claims_db.release(message_id)
     log.warning(f"Message failed (retry {retry_count}/{max_retries}, next in {backoff}s): {message_id} - {error}")
-    # Emit inbox.failed to EventBus for audit trail (issue #1352). Fire-and-forget.
-    if _EVENT_BUS_AVAILABLE:
-        try:
-            event = LobsterEvent(
-                event_type="inbox.failed",
-                severity="warn",
-                source="inbox-server",
-                payload={"message_id": message_id, "error": error, "permanent": False},
-            )
-            get_event_bus().emit_sync(event)
-        except Exception:
-            pass  # never block on observability
+    # Emit inbox.failed to EventBus for audit trail (issue #1352).
+    _emit_mcp_event(
+        "inbox.failed",
+        {"message_id": message_id, "error": error, "permanent": False},
+        severity="warn",
+    )
     return [TextContent(type="text", text=f"Message queued for retry ({retry_count}/{max_retries}, backoff {backoff}s): {message_id}")]
 
 
@@ -6761,22 +6751,12 @@ async def handle_write_task_output(args: dict) -> list[TextContent]:
     with open(output_file, "w") as f:
         json.dump(output_data, f, indent=2)
 
-    # Emit job.completed to EventBus for audit trail (issue #1352). Fire-and-forget.
-    if _EVENT_BUS_AVAILABLE:
-        try:
-            event = LobsterEvent(
-                event_type="job.completed",
-                severity="warn" if status == "failed" else "info",
-                source="inbox-server",
-                payload={
-                    "job_name": job_name,
-                    "status": status,
-                    "output_len": len(output),
-                },
-            )
-            get_event_bus().emit_sync(event)
-        except Exception:
-            pass  # never block on observability
+    # Emit job.completed to EventBus for audit trail (issue #1352).
+    _emit_mcp_event(
+        "job.completed",
+        {"job_name": job_name, "status": status, "output_len": len(output)},
+        severity="warn" if status == "failed" else "info",
+    )
 
     return [TextContent(type="text", text=f"Output recorded for job '{job_name}'")]
 

--- a/tests/unit/test_eventbus_wiring.py
+++ b/tests/unit/test_eventbus_wiring.py
@@ -1,5 +1,5 @@
 """
-Unit tests for EventBus wiring of remaining event sources (issue #1352).
+Unit tests for EventBus wiring of remaining event sources (issues #1352, #1459).
 
 Verifies that the four event sources emit correctly-typed events to the bus:
 - telegram.inbound  — emitted in handle_mark_processing when a human message is claimed
@@ -14,6 +14,10 @@ Each test follows the same pattern as test_emit_event.py:
 - Assert the event fields match what the spec requires
 
 Tests are named after behavior, not mechanism.
+
+Issue #1459 added _emit_mcp_event() to centralize the 5 per-handler try/except
+emit blocks into a single helper. The handler-level tests below remain the
+behavioral contract; TestEmitMcpEventHelper covers the helper's own contract.
 """
 
 from __future__ import annotations
@@ -425,3 +429,76 @@ class TestJobCompletedEvent:
         ev = _events_of_type(listener, "job.completed")[0]
         assert ev.payload.get("status") == "failed"
         assert ev.severity == "warn"
+
+
+# ---------------------------------------------------------------------------
+# _emit_mcp_event helper — centralized emission contract (issue #1459)
+# ---------------------------------------------------------------------------
+
+class TestEmitMcpEventHelper:
+    """_emit_mcp_event is a no-op when bus unavailable and swallows exceptions."""
+
+    def test_no_emission_when_event_bus_unavailable(self):
+        """When _EVENT_BUS_AVAILABLE is False, _emit_mcp_event does nothing."""
+        bus, listener = _make_bus_with_listener()
+        import inbox_server
+        with patch.object(inbox_server, "_EVENT_BUS_AVAILABLE", False), \
+             patch("inbox_server.get_event_bus", return_value=bus):
+            inbox_server._emit_mcp_event(
+                "inbox.processed",
+                {"message_id": "test-msg"},
+            )
+        assert len(listener.received) == 0
+
+    def test_emission_reaches_bus_when_available(self):
+        """When _EVENT_BUS_AVAILABLE is True, _emit_mcp_event delivers the event."""
+        bus, listener = _make_bus_with_listener()
+        import inbox_server
+        with patch.object(inbox_server, "_EVENT_BUS_AVAILABLE", True), \
+             patch("inbox_server.get_event_bus", return_value=bus):
+            inbox_server._emit_mcp_event(
+                "inbox.processed",
+                {"message_id": "test-msg"},
+            )
+        events = _events_of_type(listener, "inbox.processed")
+        assert len(events) == 1
+        assert events[0].payload["message_id"] == "test-msg"
+        assert events[0].source == "inbox-server"
+
+    def test_exception_in_bus_is_swallowed(self):
+        """A broken bus does not propagate exceptions through _emit_mcp_event."""
+        broken_bus = MagicMock()
+        broken_bus.emit_sync.side_effect = RuntimeError("bus exploded")
+        import inbox_server
+        with patch.object(inbox_server, "_EVENT_BUS_AVAILABLE", True), \
+             patch("inbox_server.get_event_bus", return_value=broken_bus):
+            # Must not raise
+            inbox_server._emit_mcp_event("inbox.processed", {"message_id": "x"})
+
+    def test_severity_forwarded_to_event(self):
+        """severity parameter is passed through to the emitted event."""
+        bus, listener = _make_bus_with_listener()
+        import inbox_server
+        with patch.object(inbox_server, "_EVENT_BUS_AVAILABLE", True), \
+             patch("inbox_server.get_event_bus", return_value=bus):
+            inbox_server._emit_mcp_event(
+                "inbox.failed",
+                {"message_id": "bad-msg", "error": "oops", "permanent": True},
+                severity="warn",
+            )
+        ev = _events_of_type(listener, "inbox.failed")[0]
+        assert ev.severity == "warn"
+
+    def test_chat_id_forwarded_to_event(self):
+        """chat_id parameter is passed through to the emitted event."""
+        bus, listener = _make_bus_with_listener()
+        import inbox_server
+        with patch.object(inbox_server, "_EVENT_BUS_AVAILABLE", True), \
+             patch("inbox_server.get_event_bus", return_value=bus):
+            inbox_server._emit_mcp_event(
+                "telegram.outbound",
+                {"source": "telegram", "chat_id": 1234, "text_len": 10},
+                chat_id=1234,
+            )
+        ev = _events_of_type(listener, "telegram.outbound")[0]
+        assert ev.chat_id == 1234


### PR DESCRIPTION
Closes #1459

## What problem this solves

PR #1456 wired 5 event types to `logs/events.jsonl` by embedding a try/except emit block inside each of the 5 MCP handlers. Every block was structurally identical — availability guard, `LobsterEvent` construction, `emit_sync()`, exception suppression — differing only in `event_type`, `payload`, `severity`, and `chat_id`. Adding a sixth event type would mean copy-pasting that 10-line block again.

## What changed

A new `_emit_mcp_event(event_type, payload, severity, chat_id)` helper centralizes all five of those try/except blocks. Each handler now calls one line instead of ten. The helper owns the boilerplate: availability guard, `LobsterEvent` construction, `emit_sync()`, and exception suppression.

Before (each of 5 handlers):
```
if _EVENT_BUS_AVAILABLE:
    try:
        event = LobsterEvent(event_type=..., severity=..., source="inbox-server", payload={...}, ...)
        get_event_bus().emit_sync(event)
    except Exception:
        pass
```

After (each of 5 handlers):
```
_emit_mcp_event("inbox.processed", {"message_id": message_id})
```

Adding a new event type going forward = one `_emit_mcp_event()` call. No try/except, no availability guard, no boilerplate to get wrong.

## Design decision

The issue offered two options: a handler decorator or a post-dispatch hook. I chose a third option — a thin shared helper — for these reasons:

- The post-dispatch hook approach fails cleanly for `telegram.inbound` and `inbox.failed`: those payloads require handler-internal state (`msg_source`, `msg_type` from the parsed message file; the computed `permanent` flag) that isn't visible at dispatch time without a larger refactor.
- The decorator approach would require either passing that same state somehow or reading the message file twice.
- The helper achieves the issue's stated goals (one place for the boilerplate, one line per event type) without touching handler signatures or the dispatch table.

Functional patterns used: pure function (`_emit_mcp_event` has no side effects beyond the fire-and-forget bus emit), exception isolation at the boundary.

## What is not changed

- The 5 event types (`telegram.inbound`, `telegram.outbound`, `inbox.processed`, `inbox.failed`, `job.completed`) still fire exactly as before, with identical payloads and severities.
- The dispatch table is untouched.
- No behavior changes in any handler.

## Tests run

- [x] `uv run pytest tests/unit/test_eventbus_wiring.py tests/unit/test_event_bus.py -v` — 44 passed, 0 failed (run locally outside Docker)
- [x] `sudo docker compose -f tests/docker/docker-compose.test.yml up unit-tests` — Full suite run. The `test_eventbus_wiring.py` tests show as ERROR in Docker due to a pre-existing "too many open files" issue that affects ~200 tests equally on main; verified this baseline is unchanged by my PR.
- [x] `uv run pytest tests/unit/test_eventbus_wiring.py -v` — 18 passed (13 existing + 5 new helper tests), 0 failed

5 new tests added in `TestEmitMcpEventHelper`:
- no-op when bus unavailable
- event reaches bus when available
- broken bus exceptions are swallowed
- severity parameter forwarded
- chat_id parameter forwarded

## Manual test

N/A — this change is entirely internal. The `_emit_mcp_event` helper produces identical `LobsterEvent` objects with identical payloads to the blocks it replaces. No external service calls, no file I/O paths changed, no Telegram output affected.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — not applicable (purely internal refactor, no behavior change)
- [x] User-visible outcome verified — not applicable (observability infrastructure, no user-visible output)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: mocked in tests

🤖🦞 Lobster (engineer):