### PR TITLE
fix: reviewer subagents use chat_id=0 in librarian mode (#1406)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -453,10 +453,13 @@ Background subagents call `write_result(task_id, chat_id, text, ...)`, which dro
            if any(s.get("task_id") == reviewer_task_id or str(pr_number) in str(s.get("description", "")) for s in active):
                mark_processed(message_id)
            else:
-               # Preserve librarian mode: if the engineer result had chat_id=0 (system/autonomous),
-               # the reviewer must also use chat_id=0 so its result is dropped silently rather
-               # than routed to the user's Telegram. (Fixes issue #1406.)
-               reviewer_chat_id = msg["chat_id"] if msg["chat_id"] != 0 else 0
+               # Preserve librarian mode: engineer subagents spawned in autonomous/system context
+               # (source="system" or chat_id=0) must not route their reviewer results to the user.
+               # Use chat_id=0 for the reviewer so its write_result is dropped silently.
+               # Note: checking only msg["chat_id"]==0 is insufficient — in librarian mode the
+               # engineer is sometimes spawned with the user's chat_id but source="system".
+               # Checking source is the reliable signal. (Fixes issue #1406.)
+               reviewer_chat_id = 0 if msg.get("chat_id") == 0 or msg.get("source") == "system" else msg["chat_id"]
                Task(
                    subagent_type="lobster-generalist",
                    run_in_background=True,

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -453,11 +453,15 @@ Background subagents call `write_result(task_id, chat_id, text, ...)`, which dro
            if any(s.get("task_id") == reviewer_task_id or str(pr_number) in str(s.get("description", "")) for s in active):
                mark_processed(message_id)
            else:
+               # Preserve librarian mode: if the engineer result had chat_id=0 (system/autonomous),
+               # the reviewer must also use chat_id=0 so its result is dropped silently rather
+               # than routed to the user's Telegram. (Fixes issue #1406.)
+               reviewer_chat_id = msg["chat_id"] if msg["chat_id"] != 0 else 0
                Task(
                    subagent_type="lobster-generalist",
                    run_in_background=True,
                    prompt=(
-                       f"---\ntask_id: {reviewer_task_id}\nchat_id: {msg['chat_id']}\n"
+                       f"---\ntask_id: {reviewer_task_id}\nchat_id: {reviewer_chat_id}\n"
                        f"source: {msg.get('source', 'telegram')}\n---\n\n"
                        f"Review PR {pr_url} and post findings as a GitHub comment.\n\n"
                        f"REVIEWER PROCESS (follow this order exactly):\n"


### PR DESCRIPTION
## Summary

- Fixes #1406: reviewer subagents were inheriting `msg["chat_id"]` from the engineer result, which could be the user's Telegram chat_id from a prior interactive session
- When an engineer result arrives with `chat_id=0` (librarian/autonomous mode), the spawned reviewer now correctly uses `chat_id=0` so its result is dropped silently instead of being routed to the user's Telegram
- Fix is a single-line change in the engineer→reviewer routing block in `sys.dispatcher.bootup.md`

## Root cause

The dispatcher's ENGINEER → REVIEWER routing spawned the reviewer with chat_id unconditionally from msg["chat_id"]. In librarian mode, the engineer subagent that produced the result could carry the user's chat_id from a prior interactive session, causing the reviewer's result to be delivered to the user's Telegram unexpectedly.

## Test plan

- [ ] Trigger an engineer subagent during librarian mode (chat_id=0 task)
- [ ] Verify reviewer is spawned with chat_id=0 in its prompt header
- [ ] Verify reviewer result is dropped silently (not relayed to Telegram)
- [ ] Interactive mode (non-zero chat_id): verify reviewer still inherits the correct user chat_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)