### PR TITLE
fix: specify full path to session.template.md in bootup instructions

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -931,7 +931,7 @@ One session note file per session. Lives in `~/lobster-user-config/memory/canoni
 
 **Creating (startup step 2a):**
 1. List the directory, find highest sequence number for today. If none, start at 001.
-2. Copy `session.template.md` to the new path.
+2. Copy `~/lobster-user-config/memory/canonical/sessions/session.template.md` to the new path.
 3. Replace `Started` placeholder with current UTC ISO timestamp.
 4. Replace `Messages processed` placeholder with `0`.
 5. Replace `End reason` placeholder with `active`.


### PR DESCRIPTION
Fixes #1438. The session file creation step now references the full path `~/lobster-user-config/memory/canonical/sessions/session.template.md` instead of the bare filename, so the dispatcher can locate it without guessing.