### PR TITLE
fix(bootup): correct compact-ack-messages.json path

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -40,11 +40,10 @@ When you first start (or after reading this file), follow these steps:
 **Selecting the ack message** (used in step 2d above and in compact-reminder step 2.5 below):
 ```python
 import json, random, os
-ack_path = os.path.expanduser("~/.claude/compact-ack-messages.json")
+ack_path = os.path.expanduser("~/lobster/.claude/compact-ack-messages.json")
 with open(ack_path) as f:
     ack_msg = random.choice(json.load(f)["messages"])
 ```
-The symlink `~/.claude/` resolves to `~/lobster/.claude/` on standard installs.
 
 3. Run `~/lobster/scripts/record-catchup-state.sh start` (suppresses WFM freshness check for 15 min).
 3b. **Claim any pending user messages immediately** to stop the health-check staleness clock:
@@ -248,7 +247,7 @@ After a context compaction you lose situational awareness of the last ~30 minute
 1. mark_processing(message_id)  <- compact-reminder ONLY, not other messages
 2. Read the compact-reminder text to re-orient (identity, main loop, key files)
 2.5. Send a random ack message to admin chat (see **Selecting the ack message** in the Startup Behavior section):
-   - Pick with `random.choice()` from `~/.claude/compact-ack-messages.json`
+   - Pick with `random.choice()` from `~/lobster/.claude/compact-ack-messages.json`
    - This is the user-visible signal that the lobster is back and gathering context
    - Use ADMIN_CHAT_ID from `lobster.conf` or the compact-reminder context
 3. Spawn session-note-polish subagent (run_in_background=True, subagent_type: "lobster-generalist"):


### PR DESCRIPTION
## Summary

The dispatcher bootup doc told the dispatcher to load `compact-ack-messages.json` from `~/.claude/`, which is Claude Code's own config directory. The file does not exist there — it lives at `~/lobster/.claude/`. This caused ack message lookups to fail silently on every dispatcher startup and compact-reminder cycle, as confirmed in the issue comments (reproduced again April 5).

The doc also claimed `~/.claude/` is a symlink to `~/lobster/.claude/` on standard installs. That symlink does not exist; `~/lobster-workspace/.claude` is the symlink to `~/lobster/.claude/`, not `~/.claude/`. The false note has been removed.

## Changes

- `.claude/sys.dispatcher.bootup.md` line 43: `~/.claude/compact-ack-messages.json` → `~/lobster/.claude/compact-ack-messages.json`
- `.claude/sys.dispatcher.bootup.md` line 251: same path fix in the compact-reminder step
- Removed the false note claiming `~/.claude/` resolves to `~/lobster/.claude/` on standard installs

No code changes — doc-only fix. No behavior change to any running service; this only affects what path the dispatcher uses when loading ack messages from instructions.

## Tests run
- [x] `grep -n "compact-ack-messages" .claude/sys.dispatcher.bootup.md` — confirmed both references now use `~/lobster/.claude/` path
- [x] `ls ~/lobster/.claude/compact-ack-messages.json` — file exists at the corrected path

## Manual test
N/A — this change is entirely internal to the bootup doc. The effect is that dispatcher startup no longer silently fails to find the ack message file. No Telegram output generated by this PR itself.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests) — N/A (doc-only)
- [x] Integration/manual test run — N/A
- [x] User-visible outcome verified — ack messages will now load correctly; could only be observed on next restart
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none

Fixes #1419