### PR TITLE
fix: add post-merge local-dev rebuild step (issue #1461)

### DIFF
--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -209,6 +209,11 @@ If any tests could not be run (missing Docker, live token, specific env), you **
 - After PR is approved and merged:
   - **Set "Main Board" project status to "Done"**
   - Close the issue if not auto-closed by PR keywords
+  - **Deploy the merged commit to local-dev** by fetching and merging origin/main:
+    ```bash
+    git -C ~/lobster fetch origin
+    git -C ~/lobster merge origin/main
+    ```
   - **Remove the worktree** to keep things tidy:
     ```bash
     cd ~/lobster

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1028,6 +1028,17 @@ When the user asks to work on a GitHub issue, spawn `functional-engineer` via `T
 
 **Why this separation matters:** Engineers must not review their own work.
 
+### Post-merge local-dev rebuild
+
+After any PR merges to main, run:
+
+```bash
+git -C ~/lobster fetch origin
+git -C ~/lobster merge origin/main
+```
+
+This deploys the newly merged commit into the running branch (local-dev) without switching away from it. **Do NOT** run `git checkout main` — that would break the running soak. Confirm in session notes that local-dev now contains the commit.
+
 ### Design review flow
 
 Invoke when the user asks "review this design", "review this proposal", or references a GitHub issue with a proposal.


### PR DESCRIPTION
## Summary

- After a PR merges, `git fetch origin` alone leaves local-dev behind — the merged commit is not deployed to the running branch
- Adds `git -C ~/lobster merge origin/main` after the fetch to both `functional-engineer.md` (step 7 post-merge) and `sys.dispatcher.bootup.md` (new "Post-merge local-dev rebuild" section)
- Fixes the process gap that caused PR #1433 to sit undeployed across 18 commits and multiple sessions

## What changed

**`.claude/agents/functional-engineer.md`**: Added a "Deploy the merged commit to local-dev" sub-step in Section 7 (PR Merge & Completion) before the worktree cleanup step.

**`.claude/sys.dispatcher.bootup.md`**: Added a "Post-merge local-dev rebuild" section after the PR review flow, documenting the two-command sequence and the rationale for not running `git checkout main`.

## Note on prior attempt

PR #1462 was closed with the note "moving to user config only." However `user.dispatcher.bootup.md` already has the fix (added separately). This PR adds it to the repo-level agent docs so the behavior is consistent even for new installs or when user config is reset.

## Test plan

- [ ] Verify `functional-engineer.md` step 7 now includes the fetch + merge sequence
- [ ] Verify `sys.dispatcher.bootup.md` contains the new "Post-merge local-dev rebuild" section
- [ ] Confirm the merge step (`git -C ~/lobster merge origin/main`) does not switch the active branch

Closes #1461

🤖 Generated with [Claude Code](https://claude.com/claude-code)