### PR TITLE
fix(config): move timezone preference from CLAUDE.md to user config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ Rules are capped at 100 entries. Rules are never surfaced to the user unless exp
    If you cannot articulate what is legitimately concerning, you are being
    sycophantic. Both halves are required — this is not "pile on," it is
    "be honest first."
-5. **Always display times in Eastern Time (ET)** — Convert all UTC timestamps before sending any message. Currently EDT (UTC-4) from mid-March through early November, EST (UTC-5) otherwise. Include the offset when helpful (e.g. "2:30 PM ET"). Never send raw UTC times to the user.
+5. **Always display times in the user's preferred timezone** — Convert all UTC timestamps before sending any message. The user's timezone preference is set in their user config (`user.base.bootup.md`). Never send raw UTC times.
 6. **Search first for any task requiring current or real-world information** — Do not treat training knowledge as a primary source; it cannot surface what it doesn't contain. Use available search or fetch tools before answering questions about current events, recent changes, live data, or anything where being out of date would matter.
 
 ## Project Directory Convention

--- a/install.sh
+++ b/install.sh
@@ -390,12 +390,19 @@ if [ "$CONTAINER_SETUP" = true ]; then
         done
     fi
 
-    # Create stub user-config agent files if they don't exist
+    # Create stub user-config agent files if they don't exist.
+    # Seed from canonical-templates if a matching template exists, otherwise create empty stub.
     for stub_file in "user.base.bootup.md" "user.base.context.md" "user.dispatcher.bootup.md" "user.subagent.bootup.md"; do
         stub_dest="$USER_CONFIG_DIR/agents/$stub_file"
         if [ ! -f "$stub_dest" ]; then
-            touch "$stub_dest"
-            info "  Created stub: agents/$stub_file"
+            stub_tmpl="$INSTALL_DIR/memory/canonical-templates/$stub_file"
+            if [ -f "$stub_tmpl" ]; then
+                cp "$stub_tmpl" "$stub_dest"
+                info "  Seeded user config: agents/$stub_file"
+            else
+                touch "$stub_dest"
+                info "  Created stub: agents/$stub_file"
+            fi
         fi
     done
 
@@ -1151,12 +1158,19 @@ if [ -f "$AUDIT_CONTEXT_SEED" ] && [ ! -f "$AUDIT_CONTEXT_DEST" ]; then
     info "  Seeded system-audit.context.md to user-config/agents/"
 fi
 
-# Create stub user-config agent files if they don't exist
+# Create stub user-config agent files if they don't exist.
+# Seed from canonical-templates if a matching template exists, otherwise create empty stub.
 for stub_file in "user.base.bootup.md" "user.base.context.md" "user.dispatcher.bootup.md" "user.subagent.bootup.md"; do
     stub_dest="$USER_CONFIG_DIR/agents/$stub_file"
     if [ ! -f "$stub_dest" ]; then
-        touch "$stub_dest"
-        info "  Created stub: agents/$stub_file"
+        stub_tmpl="$INSTALL_DIR/memory/canonical-templates/$stub_file"
+        if [ -f "$stub_tmpl" ]; then
+            cp "$stub_tmpl" "$stub_dest"
+            info "  Seeded user config: agents/$stub_file"
+        else
+            touch "$stub_dest"
+            info "  Created stub: agents/$stub_file"
+        fi
     fi
 done
 

--- a/memory/canonical-templates/user.base.bootup.md
+++ b/memory/canonical-templates/user.base.bootup.md
@@ -1,0 +1,23 @@
+# User Preferences — Lobster
+
+This file is injected into every Lobster session (dispatcher and all subagents).
+Edit it to customize Lobster's behavior for your install.
+
+## Timezone
+
+Always display times in **<YOUR_TIMEZONE>** in messages. For example:
+- Eastern Time: "ET" (EDT UTC-4 mid-March to early November, EST UTC-5 otherwise)
+- Pacific Time: "PT" (PDT UTC-7, PST UTC-8)
+- Central European Time: "CET" (CEST UTC+2, CET UTC+1)
+
+Replace <YOUR_TIMEZONE> with your preferred timezone abbreviation and offset.
+Include the offset in messages when helpful (e.g. "6:01 PM ET").
+Convert all UTC timestamps before sending. Never send raw UTC times.
+
+## Additional Preferences
+
+<!-- Add your behavioral preferences below. Examples:
+- Preferred language or communication style
+- Topics or domains you work in frequently
+- Notification preferences
+-->


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Summary

Closes #1464.

- Removes the hardcoded Eastern Time line from `CLAUDE.md` (the shared, committed repo file) and replaces it with a generic instruction that defers to the user's config file
- Adds a new `memory/canonical-templates/user.base.bootup.md` template with a `<YOUR_TIMEZONE>` placeholder and examples for ET, PT, and CET
- Updates `install.sh` (both stub-creation sites) to seed `user.base.bootup.md` from the canonical template on first install, instead of creating a blank file

**Impact:** New installs get a customizable timezone template. Existing installs are unaffected — the file already exists so it won't be overwritten. The ET preference itself is unchanged for current users (it lives in their `~/lobster-user-config/agents/user.base.bootup.md`).

## Test plan

- [ ] Fresh install: verify `~/lobster-user-config/agents/user.base.bootup.md` is created from the template (not empty)
- [ ] Upgrade on existing install: verify existing `user.base.bootup.md` is not overwritten
- [ ] Verify CLAUDE.md no longer mentions "Eastern Time" directly
- [ ] `bash -n install.sh` passes (syntax check)