### PR TITLE
fix(reconciler): drain stale startup notifications instead of flooding inbox

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -931,7 +931,7 @@ One session note file per session. Lives in `~/lobster-user-config/memory/canoni
 
 **Creating (startup step 2a):**
 1. List the directory, find highest sequence number for today. If none, start at 001.
-2. Copy `session.template.md` to the new path.
+2. Copy `~/lobster-user-config/memory/canonical/sessions/session.template.md` to the new path.
 3. Replace `Started` placeholder with current UTC ISO timestamp.
 4. Replace `Messages processed` placeholder with `0`.
 5. Replace `End reason` placeholder with `active`.


### PR DESCRIPTION
## Summary

On fresh dispatcher restart after a multi-minute outage, the reconciler's startup sweep re-enqueues all sessions that completed while the server was offline — typically 10–30 entries — before any real user messages can be processed. On the observed incident (2026-04-01), approximately 30 stale entries required 3 full WFM cycles to drain.

The root cause: the startup sweep has a 24-hour lookback with no staleness check. Every session with `notified_at IS NULL` from the past day gets re-enqueued, even sessions that completed 30+ minutes ago when no crash-before-notify race is possible.

## Fix

Adds a 10-minute stale-drain threshold (`STALE_NOTIFICATION_THRESHOLD_MINUTES = 10`) applied in the startup sweep. Sessions with `completed_at` older than 10 minutes are silently marked notified without being enqueued in the inbox. Only sessions completed within the threshold window are re-enqueued (the genuine crash-before-notify race window, which takes <60 seconds).

## Before / After

```
Before (any restart after multi-minute outage):
  startup sweep → 30 unnotified sessions → 30 inbox files → 3+ WFM cycles to drain
  [real user messages blocked until backlog clears]

After:
  startup sweep → 30 unnotified sessions → 29 stale (silently drained) + 1 fresh (enqueued)
  [real user messages processed on next WFM cycle]
```

## Implementation details

- `_is_stale_for_startup(session)` — pure function; sessions missing `completed_at` are treated as fresh (safe default)
- `_startup_sweep()` — for each stale session: calls `set_notified()` (prevents re-flood on next restart) and continues without enqueuing
- Stale drain count logged at INFO level for observability
- The existing idempotency guard (`_inbox_already_has_agent`) runs after the stale check — fresh sessions still benefit from it

## Out of scope

The 24-hour lookback window in `get_unnotified_completed` is unchanged — the fix is applied in the sweep loop, not the query. This preserves the ability to inspect history while eliminating the inbox flood.

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_startup_sweep_stale_drain.py -v` — 15 passed, 0 failed (new tests for this fix)
- [x] `uv run pytest tests/unit/test_mcp_server/test_ghost_session_fixes.py tests/unit/test_mcp_server/test_reconciler_mtime_gate.py tests/unit/test_mcp_server/test_reconciler_timeout.py tests/unit/test_mcp_server/test_write_result_set_notified.py` — 100 passed, 0 failed (existing reconciler tests unaffected)
- [x] `uv run python -m py_compile src/mcp/inbox_server.py` — clean

## Manual test

N/A — this change is entirely internal to the MCP server's startup sequence. The observable behavior change (no inbox flood on restart) requires a live restart with stale sessions in the DB, which cannot be safely reproduced against the production system. Unit tests cover all branches including the mixed stale+fresh case.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, change is internal; unit tests cover behavior
- [x] User-visible outcome verified — N/A (internal fix; user benefit is messages processed without delay after restart)
- [x] Side-effect audit complete: no floods, no unscoped writes; stale sessions are silently drained (set_notified only)
- [x] External service calls: none

Closes #1355