### PR TITLE
fix: enable lobster-transcription.service so voice messages route to inbox (#1470)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2620,6 +2620,13 @@ else
         info "Observability server service installed (enable manually with: sudo systemctl enable lobster-observability)"
     fi
 
+    # Install and enable the voice transcription service (whisper.cpp pipeline)
+    if [ -f "$INSTALL_DIR/services/lobster-transcription.service" ]; then
+        sudo cp "$INSTALL_DIR/services/lobster-transcription.service" /etc/systemd/system/
+        sudo systemctl enable lobster-transcription 2>/dev/null || true
+        success "Voice transcription service installed and enabled (lobster-transcription)"
+    fi
+
     sudo systemctl daemon-reload
     success "Services installed"
 fi
@@ -2793,6 +2800,11 @@ if [[ ! $REPLY =~ ^[Nn]$ ]]; then
     sleep 2
     sudo systemctl start lobster-claude
 
+    # Start voice transcription service if installed
+    if systemctl is-enabled --quiet lobster-transcription 2>/dev/null; then
+        sudo systemctl start lobster-transcription 2>/dev/null || true
+    fi
+
     sleep 3
 
     echo ""
@@ -2806,6 +2818,12 @@ if [[ ! $REPLY =~ ^[Nn]$ ]]; then
         success "Claude session: running in tmux"
     else
         warn "Claude session: not running (check with: lobster attach)"
+    fi
+
+    if systemctl is-active --quiet lobster-transcription 2>/dev/null; then
+        success "Voice transcription: running"
+    elif systemctl is-enabled --quiet lobster-transcription 2>/dev/null; then
+        warn "Voice transcription: not running (check: sudo journalctl -u lobster-transcription)"
     fi
 
     # Start dashboard server if not already running

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2442,6 +2442,32 @@ CREATE TABLE IF NOT EXISTS dispatcher_lock (
         substep "wfm-watchdog.sh cron entry already present — skipping"
     fi
 
+    # Migration 70: Enable and start lobster-transcription.service (voice message pipeline).
+    # The service file was present in prior installs but never enabled, leaving voice
+    # messages stuck in pending-transcription/ indefinitely. (Issue #1470.)
+    local transcription_svc="lobster-transcription"
+    if [ -f "/etc/systemd/system/${transcription_svc}.service" ]; then
+        if ! systemctl is-enabled --quiet "$transcription_svc" 2>/dev/null; then
+            substep "Enabling $transcription_svc service (issue #1470)..."
+            sudo systemctl enable "$transcription_svc" 2>/dev/null || true
+            sudo systemctl start  "$transcription_svc" 2>/dev/null || true
+            substep "Voice transcription service enabled and started"
+            migrated=$((migrated + 1))
+        else
+            substep "$transcription_svc already enabled — skipping"
+        fi
+    elif [ -f "$LOBSTER_DIR/services/${transcription_svc}.service" ]; then
+        substep "Installing $transcription_svc service file..."
+        sudo cp "$LOBSTER_DIR/services/${transcription_svc}.service" /etc/systemd/system/
+        sudo systemctl daemon-reload 2>/dev/null || true
+        sudo systemctl enable "$transcription_svc" 2>/dev/null || true
+        sudo systemctl start  "$transcription_svc" 2>/dev/null || true
+        substep "Voice transcription service installed, enabled, and started"
+        migrated=$((migrated + 1))
+    else
+        substep "WARN: lobster-transcription.service not found — skipping (voice transcription unavailable)"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## Summary

- Voice messages sent to the bot were silently stuck in `~/messages/pending-transcription/` because `lobster-transcription.service` was installed on disk but never enabled or started by `install.sh`
- The whisper.cpp transcription worker never ran, so messages never arrived in `~/messages/inbox/` and the dispatcher never saw them

## Changes

**`install.sh`**
- Copies `lobster-transcription.service` to `/etc/systemd/system/` and enables it with `systemctl enable` (alongside the existing mcp-local enable)
- Starts the service in the "Start services now?" block alongside `lobster-router` and `lobster-claude`
- Adds a status line in the post-start summary ("Voice transcription: running / not running")

**`scripts/upgrade.sh`** — Migration 70
- Detects if `lobster-transcription.service` is installed but not enabled on existing installs
- Installs the service file from the repo if not yet in `/etc/systemd/system/`
- Enables and starts the service

## Test plan
- [ ] Fresh install: verify `lobster-transcription.service` is active after install
- [ ] Existing install: run `upgrade.sh` and verify Migration 70 enables the service
- [ ] Send a voice message and verify it transitions from `pending-transcription/` to `inbox/` and dispatcher processes it

Closes #1470

🤖 Generated with [Claude Code](https://claude.com/claude-code)