### PR TITLE
docs: add two-pass read guidance to dispatcher bootup doc (#1353)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -4,7 +4,12 @@
 
 You are the **Lobster dispatcher**. You run in an infinite main loop, processing messages from users as they arrive. You are always-on — you never exit, never stop, never pause.
 
-This file restores full context after a compaction or restart. Read it top-to-bottom.
+This file restores full context after a compaction or restart. Read it in **two passes** — the file exceeds the Read tool single-call limit (~750 lines per call):
+
+1. First call: Read this file with no offset — reads lines 1-750 (startup, main loop, all message handlers)
+2. Second call: Read this file with offset=750 — reads lines 751-end (source handling, hooks, session mgmt, skills, GitHub, voice, calendar, context recovery)
+
+**Do not skip the second read.** Critical session file management and context recovery rules are in the second half.
 
 You are not a passive relay. You are a vigilant dispatcher. You take initiative based on what you observe — both from external signals and from the passage of time. When something seems off — whether because a signal says so or because time has passed and nothing has arrived — use your judgment to follow up. Spawning a brief investigation subagent takes <1 second and is almost always the right call when uncertain.
 

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -6,8 +6,8 @@ You are the **Lobster dispatcher**. You run in an infinite main loop, processing
 
 This file restores full context after a compaction or restart. Read it in **two passes** — the file exceeds the Read tool single-call limit (~750 lines per call):
 
-1. First call: Read this file with no offset — reads lines 1-750 (startup, main loop, all message handlers)
-2. Second call: Read this file with offset=750 — reads lines 751-end (source handling, hooks, session mgmt, skills, GitHub, voice, calendar, context recovery)
+1. First call: Read this file with limit=750 — reads lines 1-750 (startup, main loop, message handlers through early source handling)
+2. Second call: Read this file with offset=870 — reads lines 870-end (hooks, message flow, session mgmt, IFTTT rules, skills, GitHub, voice, calendar, context recovery)
 
 **Do not skip the second read.** Critical session file management and context recovery rules are in the second half.
 


### PR DESCRIPTION
## Summary

- `sys.dispatcher.bootup.md` is ~1340 lines (~18K tokens), exceeding the Read tool's single-call limit (~750 lines / ~10K tokens)
- When the dispatcher reads the file during startup or post-compaction context recovery, it silently sees only the first half and misses session file management, source handling, hooks, GitHub flows, voice notes, calendar, and context recovery rules
- This was observed on 2026-04-01: the dispatcher entered the main loop having never read sections past the midpoint

## Change

Replaced the opening "Read it top-to-bottom" line with explicit two-pass read instructions:

```
Read it in **two passes** — the file exceeds the Read tool single-call limit (~750 lines per call):

1. First call: Read this file with no offset — reads lines 1-750 (startup, main loop, all message handlers)
2. Second call: Read this file with offset=750 — reads lines 751-end (source handling, hooks, session mgmt, skills, GitHub, voice, calendar, context recovery)

**Do not skip the second read.** Critical session file management and context recovery rules are in the second half.
```

## Why not split the file?

Splitting requires updating the SessionStart hook injection logic and deploy coordination. The multi-read guidance is the lowest-risk fix: zero runtime changes, immediately effective for future startups.

## Test plan
- [ ] After compaction, verify the dispatcher issues two Read calls for the bootup file
- [ ] Verify session file management section (line ~928) is included in working context after startup

Closes #1353

🤖 Generated with [Claude Code](https://claude.com/claude-code)