### PR TITLE
fix(tests): add autouse bot-talk mirror isolation to prevent network pollution

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,17 @@ Do NOT add per-test mocks for:
     SCHEDULED_TASKS_LOGS_DIR, LOG_DIR
 
 These are all redirected automatically.
+
+Bot-talk mirror isolation
+--------------------------
+The ``isolate_bot_talk_mirror`` fixture (autouse=True) prevents tests from
+posting real HTTP messages to the bot-talk network. It patches
+``bot_talk_mirror.mirror_outbound`` and ``bot_talk_mirror._spawn_mirror``
+to no-ops for every test. This matches the approach described in issue #1341.
+
+Without this, tests that exercise ``handle_send_reply`` or ``handle_check_inbox``
+would fire real HTTP POSTs to ``BOT_TALK_HTTP_URL`` if it is configured in
+``~/messages/config/config.env``, polluting the shared bot-talk network.
 """
 
 import asyncio
@@ -59,6 +70,58 @@ from tests.fixtures.generators import (
     ScheduledJobGenerator,
     FixtureLoader,
 )
+
+
+# =============================================================================
+# Bot-talk Mirror Isolation (autouse — prevents network pollution in every test)
+# =============================================================================
+
+@pytest.fixture(autouse=True)
+def isolate_bot_talk_mirror():
+    """Prevent tests from posting real messages to the bot-talk network.
+
+    The bot_talk_mirror module is imported dynamically inside inbox_server.py
+    function bodies (``from bot_talk_mirror import mirror_outbound`` /
+    ``_spawn_mirror``).  Patching at the module level covers all code paths
+    regardless of where bot_talk_mirror is imported from.
+
+    This fixture is autouse so every test is protected without any explicit
+    decoration. Tests that intentionally want to verify bot-talk calls can
+    request the ``isolate_bot_talk_mirror`` fixture explicitly and inspect
+    the returned MagicMock objects:
+
+        def test_something(isolate_bot_talk_mirror):
+            mocks = isolate_bot_talk_mirror
+            # ... mocks["mirror_outbound"], mocks["_spawn_mirror"]
+
+    Issue: #1341 — 943 spurious bot-talk messages posted during test runs.
+    """
+    # Ensure bot_talk_mirror is importable before patching.
+    _MCP_DIR = str(SRC_DIR / "mcp")
+    if _MCP_DIR not in sys.path:
+        sys.path.insert(0, _MCP_DIR)
+
+    try:
+        import importlib
+        btm = importlib.import_module("bot_talk_mirror")
+    except Exception:
+        # If bot_talk_mirror is not importable (missing deps, etc.), yield
+        # without patching — the HTTP calls will fail silently anyway since
+        # the module can't be loaded.
+        yield {}
+        return
+
+    mock_mirror_outbound = MagicMock()
+    mock_spawn_mirror = MagicMock()
+
+    with (
+        patch.object(btm, "mirror_outbound", mock_mirror_outbound),
+        patch.object(btm, "_spawn_mirror", mock_spawn_mirror),
+    ):
+        yield {
+            "mirror_outbound": mock_mirror_outbound,
+            "_spawn_mirror": mock_spawn_mirror,
+        }
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Adds `isolate_bot_talk_mirror` autouse fixture to `tests/conftest.py` that patches `bot_talk_mirror.mirror_outbound` and `bot_talk_mirror._spawn_mirror` to no-ops for every test
- Prevents real HTTP POSTs to `BOT_TALK_HTTP_URL` when tests exercise `handle_send_reply` or `handle_check_inbox`
- Tests that want to assert on bot-talk calls can request the fixture explicitly and inspect the returned `MagicMock` objects

## Root cause

The `bot_talk_mirror` functions are imported dynamically inside `inbox_server.py` function bodies. When `BOT_TALK_HTTP_URL` is configured in `~/messages/config/config.env`, every test that exercises those code paths fires a real HTTP POST to the shared bot-talk network. This caused 943 spurious messages (875 in a single day) as documented in #1341.

## Test plan

- [x] `tests/unit/test_mcp_server/test_message_tools.py` — all 46 tests pass with the new fixture in place
- [x] Existing bot-talk tests in `test_bot_talk_mirror.py` are unaffected (the pre-existing failure there is about a missing `BOT_TALK_SENDER` attribute, unrelated to this change)
- [x] Fixture gracefully degrades if `bot_talk_mirror` is not importable

Closes #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)