### PR TITLE
fix(bootup): strengthen inline catchup guard at startup step 4

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -53,7 +53,12 @@ The symlink `~/.claude/` resolves to `~/lobster/.claude/` on standard installs.
     - Do NOT process, reply to, or act on these messages yet — just claim them
     - They will be returned by `wait_for_messages()` at step 5 and processed normally
     - Rationale: `mark_processing()` moves messages from `inbox/` to `processing/`, stopping the health check's inbox-age clock. Without this step, messages that arrived during a long bootup sequence (compact-catchup can take 4–10 min) will exceed the 240s staleness threshold and trigger a false-positive health-check restart.
-4. Spawn the `compact-catchup` agent in the background with `task_id: startup-catchup` and `chat_id: 0`. See agent definition at `.claude/agents/compact-catchup.md` for the full prompt — pass it with `task_id: startup-catchup` instead of `compact-catchup`. **Never do catchup inline — it violates the 7-second rule.**
+4. Spawn the `compact-catchup` agent in the background with `task_id: startup-catchup` and `chat_id: 0`. See agent definition at `.claude/agents/compact-catchup.md` for the full prompt — pass it with `task_id: startup-catchup` instead of `compact-catchup`.
+
+   > **NEVER DO CATCHUP INLINE. THIS IS A HARD RULE WITH NO EXCEPTIONS.**
+   > Startup catchup involves file I/O, inbox scanning, and summarization. On the main thread this blocks ALL new messages for 10–15 minutes. The health check's WFM freshness threshold is 600 seconds — inline catchup WILL trigger an unnecessary restart.
+   > If you find yourself calling `check_inbox`, `Read`, `Bash`, or any file-reading tool to do catchup on the main thread during startup, STOP. You are about to block for 10+ minutes. Spawn the subagent instead.
+   > There is no situation — not "many queued messages", not "faster this way", not "simpler" — where inline catchup is correct. Spawn the background subagent and proceed to step 5.
 5. Call `wait_for_messages()` to start listening.
 6. **Triage before acting on queued messages at startup**: read ALL queued messages first, identify anything risky (e.g. large audio transcription that could cause OOM), skip or defer those, then process safe ones.
 7. Resume the main loop.

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -55,10 +55,9 @@ The symlink `~/.claude/` resolves to `~/lobster/.claude/` on standard installs.
     - Rationale: `mark_processing()` moves messages from `inbox/` to `processing/`, stopping the health check's inbox-age clock. Without this step, messages that arrived during a long bootup sequence (compact-catchup can take 4–10 min) will exceed the 240s staleness threshold and trigger a false-positive health-check restart.
 4. Spawn the `compact-catchup` agent in the background with `task_id: startup-catchup` and `chat_id: 0`. See agent definition at `.claude/agents/compact-catchup.md` for the full prompt — pass it with `task_id: startup-catchup` instead of `compact-catchup`.
 
-   > **NEVER DO CATCHUP INLINE. THIS IS A HARD RULE WITH NO EXCEPTIONS.**
-   > Startup catchup involves file I/O, inbox scanning, and summarization. On the main thread this blocks ALL new messages for 10–15 minutes. The health check's WFM freshness threshold is 600 seconds — inline catchup WILL trigger an unnecessary restart.
-   > If you find yourself calling `check_inbox`, `Read`, `Bash`, or any file-reading tool to do catchup on the main thread during startup, STOP. You are about to block for 10+ minutes. Spawn the subagent instead.
-   > There is no situation — not "many queued messages", not "faster this way", not "simpler" — where inline catchup is correct. Spawn the background subagent and proceed to step 5.
+   > **NEVER DO CATCHUP INLINE. NO EXCEPTIONS.**
+   > Startup catchup is long-running work. Running it on the main thread blocks all message handling and will trigger a watchdog restart.
+   > If you are about to call any tool to do catchup work on the main thread — stop. That is the violation. Spawn the background subagent and proceed to step 5.
 5. Call `wait_for_messages()` to start listening.
 6. **Triage before acting on queued messages at startup**: read ALL queued messages first, identify anything risky (e.g. large audio transcription that could cause OOM), skip or defer those, then process safe ones.
 7. Resume the main loop.


### PR DESCRIPTION
The prior single-line WARNING at startup step 4 was not strong enough — the dispatcher rationalized past it when under load. The first fix (the original PR commit) added a more emphatic block, but that block named specific tool call lists, time thresholds, and internal mechanism details that will become stale as the system evolves.

This PR replaces the verbose block with a three-line warning that states the prohibition, the consequence (in terms of effect, not implementation), and the "if you are about to do X — stop" redirect. No hardcoded tool names, no numeric thresholds, no quoted rationalizations.

## What changed

**Before:** 4-line block naming `check_inbox`/`Read`/`Bash`, citing the 600-second WFM freshness threshold and 10–15 minute blocking estimates, closing three specific rationalizations by name.

**After:** 3-line block — prohibition, consequence (blocks message handling, triggers watchdog restart), redirect (if you're about to call any tool for catchup on the main thread, stop; spawn the subagent instead).

The "if you are doing X, that's wrong" pattern is preserved. The implementation-specific detail that will rot is removed.

## Tests run
- [x] Documentation-only change — no automated tests applicable
- [x] Verified diff reads correctly and warning block parses as intended Markdown

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)