### PR TITLE
fix: add log-cleanup.sh cron job to prune unbounded log directories (#1240)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1324,6 +1324,23 @@ chmod +x "$INSTALL_DIR/scheduled-tasks/export-logs.py" 2>/dev/null || true
 success "Log export configured (runs at 03:00 UTC daily)"
 
 #===============================================================================
+# Log Cleanup (issue #1240)
+#===============================================================================
+
+step "Setting up log cleanup cron..."
+
+# log-cleanup.sh prunes three directories that grow without bound:
+#   - ~/lobster-workspace/scheduled-jobs/logs/ (keep 14 days)
+#   - ~/messages/processed/                    (keep 30 days)
+#   - ~/messages/audio/                        (keep 7 days)
+# Runs at 04:00 UTC daily (one hour after nightly consolidation).
+chmod +x "$INSTALL_DIR/scripts/log-cleanup.sh" || true
+"$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-LOG-CLEANUP" \
+    "0 4 * * * $INSTALL_DIR/scripts/log-cleanup.sh >> $HOME/lobster-workspace/logs/log-cleanup.log 2>&1 # LOBSTER-LOG-CLEANUP"
+
+success "Log cleanup configured (runs at 04:00 UTC daily)"
+
+#===============================================================================
 # Ghost Detector (agent-monitor)
 #===============================================================================
 

--- a/install.sh
+++ b/install.sh
@@ -1336,7 +1336,7 @@ step "Setting up log cleanup cron..."
 # Runs at 04:00 UTC daily (one hour after nightly consolidation).
 chmod +x "$INSTALL_DIR/scripts/log-cleanup.sh" || true
 "$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-LOG-CLEANUP" \
-    "0 4 * * * $INSTALL_DIR/scripts/log-cleanup.sh >> $HOME/lobster-workspace/logs/log-cleanup.log 2>&1 # LOBSTER-LOG-CLEANUP"
+    "0 4 * * * $INSTALL_DIR/scripts/log-cleanup.sh # LOBSTER-LOG-CLEANUP"
 
 success "Log cleanup configured (runs at 04:00 UTC daily)"
 

--- a/scripts/log-cleanup.sh
+++ b/scripts/log-cleanup.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#===============================================================================
+# log-cleanup.sh
+#
+# Prune three directories that grow without bound (issue #1240):
+#
+#   1. ~/lobster-workspace/scheduled-jobs/logs/  — job run logs (keep 14 days)
+#   2. ~/messages/processed/                     — processed inbox messages (keep 30 days)
+#   3. ~/messages/audio/                         — voice audio files (keep 7 days)
+#
+# Designed to be safe and idempotent:
+#   - Skips deletion if the directory doesn't exist
+#   - Counts deleted files and logs the result
+#   - Never touches files newer than the retention window
+#
+# Usage (run by cron — see install.sh / upgrade.sh Migration 70):
+#   0 4 * * * ~/lobster/scripts/log-cleanup.sh >> ~/lobster-workspace/logs/log-cleanup.log 2>&1
+#
+# The cron entry fires at 04:00 UTC daily (one hour after nightly-consolidation).
+#===============================================================================
+
+set -euo pipefail
+
+LOBSTER_WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+MESSAGES_DIR="${LOBSTER_MESSAGES:-$HOME/messages}"
+LOG_DIR="$LOBSTER_WORKSPACE/logs"
+LOG_FILE="$LOG_DIR/log-cleanup.log"
+
+# Retention windows (days)
+SCHED_LOGS_DAYS=14
+PROCESSED_DAYS=30
+AUDIO_DAYS=7
+
+log() {
+    echo "[$(date -Iseconds)] $*" | tee -a "$LOG_FILE"
+}
+
+prune_dir() {
+    local label="$1"
+    local dir="$2"
+    local days="$3"
+
+    if [ ! -d "$dir" ]; then
+        log "SKIP $label: directory not found ($dir)"
+        return 0
+    fi
+
+    # Count files before deletion
+    local before
+    before=$(find "$dir" -maxdepth 1 -type f 2>/dev/null | wc -l)
+
+    # Delete files older than $days days
+    find "$dir" -maxdepth 1 -type f -mtime "+${days}" -delete 2>/dev/null || true
+
+    local after
+    after=$(find "$dir" -maxdepth 1 -type f 2>/dev/null | wc -l)
+    local deleted=$(( before - after ))
+
+    log "PRUNED $label: removed $deleted file(s) older than ${days}d (${after} remaining)"
+}
+
+mkdir -p "$LOG_DIR"
+
+log "log-cleanup.sh started"
+
+prune_dir "scheduled-jobs/logs" "$LOBSTER_WORKSPACE/scheduled-jobs/logs" "$SCHED_LOGS_DAYS"
+prune_dir "messages/processed"  "$MESSAGES_DIR/processed"               "$PROCESSED_DAYS"
+prune_dir "messages/audio"      "$MESSAGES_DIR/audio"                   "$AUDIO_DAYS"
+
+log "log-cleanup.sh complete"

--- a/scripts/log-cleanup.sh
+++ b/scripts/log-cleanup.sh
@@ -13,8 +13,12 @@
 #   - Counts deleted files and logs the result
 #   - Never touches files newer than the retention window
 #
-# Usage (run by cron — see install.sh / upgrade.sh Migration 70):
-#   0 4 * * * ~/lobster/scripts/log-cleanup.sh >> ~/lobster-workspace/logs/log-cleanup.log 2>&1
+# Usage (run by cron — see install.sh / upgrade.sh Migration 71):
+#   0 4 * * * ~/lobster/scripts/log-cleanup.sh # LOBSTER-LOG-CLEANUP
+#
+# Note: stdout redirect is NOT used in the cron entry. The log() function
+# inside this script appends directly to log-cleanup.log via tee -a, so
+# adding a cron redirect would double-log every line.
 #
 # The cron entry fires at 04:00 UTC daily (one hour after nightly-consolidation).
 #===============================================================================

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2442,7 +2442,7 @@ CREATE TABLE IF NOT EXISTS dispatcher_lock (
         substep "wfm-watchdog.sh cron entry already present — skipping"
     fi
 
-    # Migration 70: Add LOBSTER-LOG-CLEANUP cron entry (issue #1240).
+    # Migration 71: Add LOBSTER-LOG-CLEANUP cron entry (issue #1240).
     # Prunes scheduled-jobs/logs/ (14d), messages/processed/ (30d), messages/audio/ (7d).
     local LOG_CLEANUP_MARKER="# LOBSTER-LOG-CLEANUP"
     local log_cleanup_script="$LOBSTER_DIR/scripts/log-cleanup.sh"
@@ -2451,7 +2451,7 @@ CREATE TABLE IF NOT EXISTS dispatcher_lock (
             chmod +x "$log_cleanup_script" 2>/dev/null || true
             "$LOBSTER_DIR/scripts/cron-manage.sh" add \
                 "$LOG_CLEANUP_MARKER" \
-                "0 4 * * * $log_cleanup_script >> $HOME/lobster-workspace/logs/log-cleanup.log 2>&1 $LOG_CLEANUP_MARKER"
+                "0 4 * * * $log_cleanup_script $LOG_CLEANUP_MARKER"
             substep "Added log-cleanup.sh cron entry (daily at 04:00 UTC)"
             migrated=$((migrated + 1))
         else

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2442,6 +2442,25 @@ CREATE TABLE IF NOT EXISTS dispatcher_lock (
         substep "wfm-watchdog.sh cron entry already present — skipping"
     fi
 
+    # Migration 70: Add LOBSTER-LOG-CLEANUP cron entry (issue #1240).
+    # Prunes scheduled-jobs/logs/ (14d), messages/processed/ (30d), messages/audio/ (7d).
+    local LOG_CLEANUP_MARKER="# LOBSTER-LOG-CLEANUP"
+    local log_cleanup_script="$LOBSTER_DIR/scripts/log-cleanup.sh"
+    if ! crontab -l 2>/dev/null | grep -qF "$LOG_CLEANUP_MARKER"; then
+        if [[ -f "$log_cleanup_script" ]]; then
+            chmod +x "$log_cleanup_script" 2>/dev/null || true
+            "$LOBSTER_DIR/scripts/cron-manage.sh" add \
+                "$LOG_CLEANUP_MARKER" \
+                "0 4 * * * $log_cleanup_script >> $HOME/lobster-workspace/logs/log-cleanup.log 2>&1 $LOG_CLEANUP_MARKER"
+            substep "Added log-cleanup.sh cron entry (daily at 04:00 UTC)"
+            migrated=$((migrated + 1))
+        else
+            substep "WARN: log-cleanup.sh not found at $log_cleanup_script — skipping"
+        fi
+    else
+        substep "log-cleanup.sh cron entry already present — skipping"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## Summary

- Adds `scripts/log-cleanup.sh` — a daily cron job (04:00 UTC) that prunes three directories that were growing without bound
- `~/lobster-workspace/scheduled-jobs/logs/`: files older than 14 days (was ~40k files / 160 MB)
- `~/messages/processed/`: files older than 30 days (was ~17k files / 73 MB)  
- `~/messages/audio/`: files older than 7 days (was ~173 files / 71 MB)
- Adds the cron entry to `install.sh` for fresh installs
- Adds Migration 70 to `upgrade.sh` so existing installs get the cron entry on next upgrade

## Verification

Ran the script manually — removed 794 old job log files and 46 old audio files on first run. Script is safe: skips missing directories, counts deleted/remaining files, never touches recent files.

## Test plan

- [x] `bash -n scripts/log-cleanup.sh` — syntax check passes
- [x] Manual run: correctly pruned scheduled-jobs/logs (794 files removed, 919 remaining) and audio (46 files removed, 17 remaining)
- [x] messages/processed: 0 removed (none old enough, 11k files remain — 30d retention is deliberately conservative)
- [x] Script is idempotent: safe to run multiple times

Fixes #1240

🤖 Generated with [Claude Code](https://claude.com/claude-code)