### PR TITLE
cleanup: remove unused IdempotencyTracker and CircuitBreaker instances from inbox_server (#1335)

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -73,7 +73,7 @@ from utils.ifttt_rules import (
 )
 import uuid as _uuid_mod
 
-# Reliability utilities (atomic writes, validation, audit logging, circuit breaker)
+# Reliability utilities (atomic writes, validation, audit logging)
 from reliability import (
     atomic_write_json,
     validate_send_reply_args,
@@ -81,8 +81,6 @@ from reliability import (
     ValidationError,
     init_audit_log,
     audit_log,
-    IdempotencyTracker,
-    CircuitBreaker,
 )
 
 # Self-update system
@@ -870,14 +868,6 @@ _seed_canonical_templates()
 
 # Initialize audit log for structured observability
 init_audit_log(LOG_DIR)
-
-# Initialize idempotency tracker to prevent duplicate reply sends
-# TODO: Wire into send_reply and outbox processing paths
-_reply_idempotency = IdempotencyTracker(ttl_seconds=300)
-
-# Circuit breaker for outbox delivery (Telegram/Slack API)
-# TODO: Wire into lobster_bot.py outbox delivery to short-circuit when Telegram is down
-_outbox_breaker = CircuitBreaker("outbox_delivery", failure_threshold=5, cooldown_seconds=120)
 
 # OpenAI configuration for Whisper transcription
 # Try environment first, then fall back to config file


### PR DESCRIPTION
## Summary

- Removes `_reply_idempotency` (IdempotencyTracker) and `_outbox_breaker` (CircuitBreaker) module-level instances from `inbox_server.py` — they were instantiated but never used anywhere in the code path
- Removes their corresponding imports from the `from reliability import (...)` block
- Clears the two wired TODO comments that had been flagged in audit issue #1335

## Why these are safe to remove

- `_reply_idempotency`: The send_reply path already has reply deduplication via `_record_direct_send()` and `_record_task_replied()`. An additional in-memory IdempotencyTracker would be redundant.
- `_outbox_breaker`: Was intended to wire into `lobster_bot.py` (a separate process), but cross-process wiring never happened. The CircuitBreaker class remains in `reliability.py` for future use.

## Classes are preserved

`IdempotencyTracker` and `CircuitBreaker` remain implemented and tested in `src/mcp/reliability.py`. Only the unused module-level instantiations in `inbox_server.py` are removed.

## Test plan

- [x] `pytest tests/unit/test_mcp_server/test_message_tools.py` — all 46 tests pass
- [x] Verified no other module references `_reply_idempotency` or `_outbox_breaker`

Closes #1335

🤖 Generated with [Claude Code](https://claude.com/claude-code)