### PR TITLE
fix: enable lobster-transcription.service and correct compact-ack path

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -40,11 +40,11 @@ When you first start (or after reading this file), follow these steps:
 **Selecting the ack message** (used in step 2d above and in compact-reminder step 2.5 below):
 ```python
 import json, random, os
-ack_path = os.path.expanduser("~/.claude/compact-ack-messages.json")
+ack_path = os.path.expanduser("~/lobster/.claude/compact-ack-messages.json")
 with open(ack_path) as f:
     ack_msg = random.choice(json.load(f)["messages"])
 ```
-The symlink `~/.claude/` resolves to `~/lobster/.claude/` on standard installs.
+Note: `~/.claude/` is Claude Code's own config directory, NOT the repo. The ack messages file lives in `~/lobster/.claude/` (also accessible via `~/lobster-workspace/.claude/` which is a symlink).
 
 3. Run `~/lobster/scripts/record-catchup-state.sh start` (suppresses WFM freshness check for 15 min).
 3b. **Claim any pending user messages immediately** to stop the health-check staleness clock:
@@ -248,7 +248,7 @@ After a context compaction you lose situational awareness of the last ~30 minute
 1. mark_processing(message_id)  <- compact-reminder ONLY, not other messages
 2. Read the compact-reminder text to re-orient (identity, main loop, key files)
 2.5. Send a random ack message to admin chat (see **Selecting the ack message** in the Startup Behavior section):
-   - Pick with `random.choice()` from `~/.claude/compact-ack-messages.json`
+   - Pick with `random.choice()` from `~/lobster/.claude/compact-ack-messages.json`
    - This is the user-visible signal that the lobster is back and gathering context
    - Use ADMIN_CHAT_ID from `lobster.conf` or the compact-reminder context
 3. Spawn session-note-polish subagent (run_in_background=True, subagent_type: "lobster-generalist"):

--- a/install.sh
+++ b/install.sh
@@ -2620,6 +2620,14 @@ else
         info "Observability server service installed (enable manually with: sudo systemctl enable lobster-observability)"
     fi
 
+    # Install transcription worker service (voice message pipeline)
+    # This service is a hard requirement: whisper.cpp was built above, so we enable it unconditionally.
+    if [ -f "$INSTALL_DIR/services/lobster-transcription.service" ]; then
+        sudo cp "$INSTALL_DIR/services/lobster-transcription.service" /etc/systemd/system/
+        sudo systemctl enable lobster-transcription 2>/dev/null || true
+        success "Transcription worker service installed and enabled (lobster-transcription)"
+    fi
+
     sudo systemctl daemon-reload
     success "Services installed"
 fi
@@ -2792,6 +2800,7 @@ if [[ ! $REPLY =~ ^[Nn]$ ]]; then
     sudo systemctl start lobster-router
     sleep 2
     sudo systemctl start lobster-claude
+    sudo systemctl start lobster-transcription 2>/dev/null || true
 
     sleep 3
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2442,6 +2442,24 @@ CREATE TABLE IF NOT EXISTS dispatcher_lock (
         substep "wfm-watchdog.sh cron entry already present — skipping"
     fi
 
+    # Migration 70: Enable and start lobster-transcription.service.
+    # The service was installed by install.sh but was not enabled, so voice messages
+    # accumulated in ~/messages/pending-transcription/ and were never processed.
+    # See issue #1470.
+    if systemctl list-unit-files lobster-transcription.service >/dev/null 2>&1; then
+        if ! systemctl is-enabled --quiet lobster-transcription 2>/dev/null; then
+            substep "Enabling and starting lobster-transcription.service..."
+            sudo systemctl enable lobster-transcription 2>/dev/null || true
+            sudo systemctl start lobster-transcription 2>/dev/null || true
+            substep "lobster-transcription.service enabled and started"
+            migrated=$((migrated + 1))
+        else
+            substep "lobster-transcription.service already enabled — skipping"
+        fi
+    else
+        substep "lobster-transcription.service not installed — skipping"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## Summary

- **Fixes #1470**: `lobster-transcription.service` was installed by `install.sh` but never enabled or started, causing all voice messages to accumulate in `~/messages/pending-transcription/` and never reach the dispatcher inbox. Added install and enable steps in `install.sh`, a `systemctl start` when starting services interactively, and **Migration 70** in `upgrade.sh` to enable the service on existing installs.

- **Fixes #1419**: `sys.dispatcher.bootup.md` referenced `~/.claude/compact-ack-messages.json` and claimed `~/.claude/` is a symlink to `~/lobster/.claude/`. On real installs, `~/.claude/` is Claude Code's own config directory — not a symlink. The file actually lives at `~/lobster/.claude/compact-ack-messages.json`. Fixed both references (line 43 code block and line 251 bullet) and corrected the symlink note.

## Changes

- `install.sh`: Copy, enable, and (on interactive start) start `lobster-transcription.service`
- `scripts/upgrade.sh`: Migration 70 — enable + start `lobster-transcription` on existing installs where it was disabled
- `.claude/sys.dispatcher.bootup.md`: Correct `compact-ack-messages.json` path and symlink note

## Test plan

- [ ] Fresh install: `lobster-transcription.service` shows as enabled and active after install
- [ ] Upgrade on existing install: Migration 70 runs and enables the service
- [ ] Voice message sent to bot → JSON written to `pending-transcription/` → worker picks it up → message appears in inbox → dispatcher processes it
- [ ] Dispatcher startup ack message lookup reads from `~/lobster/.claude/compact-ack-messages.json` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)