### PR TITLE
fix(history): raise get_conversation_history text limit from 500 to 4000 chars (#1106)

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -5229,6 +5229,9 @@ def _apply_filters_and_paginate(
     return filtered[offset: offset + limit], total
 
 
+_HISTORY_TEXT_DISPLAY_LIMIT = 4000  # Max chars shown per message in get_conversation_history
+
+
 def _format_history_output(
     paginated: list[dict],
     total_count: int,
@@ -5239,6 +5242,8 @@ def _format_history_output(
 
     Each dict must have _direction set to 'received' or 'sent'.
     Fields source, chat_id, timestamp, text, user_name, username are optional.
+    Messages longer than _HISTORY_TEXT_DISPLAY_LIMIT chars are shown with a
+    [truncated] suffix so the caller knows the content was cut.
     """
     showing_end = min(offset + limit, total_count)
     output = f"**Conversation History** (showing {offset + 1}-{showing_end} of {total_count}):\n\n"
@@ -5256,7 +5261,8 @@ def _format_history_output(
         except (ValueError, TypeError):
             ts_display = ts
 
-        truncated = text[:500] + ("..." if len(text) > 500 else "")
+        was_truncated = len(text) > _HISTORY_TEXT_DISPLAY_LIMIT
+        truncated = text[:_HISTORY_TEXT_DISPLAY_LIMIT] + (" [truncated]" if was_truncated else "")
         if msg["_direction"] == "received":
             user = msg.get("user_name", msg.get("username", "Unknown"))
             output += "---\n"

--- a/tests/unit/test_mcp_server/test_conversation_history_sql.py
+++ b/tests/unit/test_mcp_server/test_conversation_history_sql.py
@@ -326,19 +326,28 @@ class TestFormatHistoryOutput:
         assert "SENT" in output
 
     def test_truncates_long_text(self):
-        long_text = "x" * 600
+        # Text must exceed _HISTORY_TEXT_DISPLAY_LIMIT (4000 chars) to be truncated
+        long_text = "x" * 5000
         msgs = [_make_msg("m1", text=long_text)]
         output = _format_history_output(msgs, total_count=1, offset=0, limit=20)
-        assert "..." in output
-        # The rendered text block should not include all 600 chars
+        assert "[truncated]" in output
+        # The rendered text block should not include all 5000 chars
         assert long_text not in output
+
+    def test_medium_text_not_truncated(self):
+        # Text under 4000 chars (old 500-char limit was too short — e.g. JWT tokens ~600 chars)
+        medium_text = "x" * 600
+        msgs = [_make_msg("m1", text=medium_text)]
+        output = _format_history_output(msgs, total_count=1, offset=0, limit=20)
+        assert medium_text in output
+        assert "[truncated]" not in output
 
     def test_short_text_not_truncated(self):
         short_text = "short message"
         msgs = [_make_msg("m1", text=short_text)]
         output = _format_history_output(msgs, total_count=1, offset=0, limit=20)
         assert short_text in output
-        assert "..." not in output
+        assert "[truncated]" not in output
 
     def test_pagination_hint_shown_when_more(self):
         msgs = [_make_msg(f"m{i}") for i in range(5)]


### PR DESCRIPTION
## Summary

- `get_conversation_history` was truncating message text at 500 characters with `...`, silently cutting off long values like JWT tokens (~600 chars), long URLs, and base64 blobs
- Raised the display limit to 4000 characters (8x increase)
- Changed truncation marker from `...` to `[truncated]` so the caller knows content was cut rather than confusing it with normal text ending in `...`

## Root cause

`_format_history_output` in `inbox_server.py` had a hardcoded `text[:500]` truncation applied to every message before rendering. A 600-char JWT token would always be cut off, making it unreadable from history.

## Changes

- `src/mcp/inbox_server.py`: Added `_HISTORY_TEXT_DISPLAY_LIMIT = 4000` module-level constant; updated `_format_history_output` to use it with `[truncated]` marker
- `tests/unit/test_mcp_server/test_conversation_history_sql.py`: Updated test to use 5000-char text (above new limit), check for `[truncated]` marker, and added a regression test confirming 600-char messages are no longer cut

## Test plan

- [x] `uv run pytest tests/unit/test_mcp_server/test_conversation_history_sql.py` — all 38 tests pass
- [ ] Manually verify a long message (>500 chars) is now readable in full from `get_conversation_history`

Closes #1106

🤖 Generated with [Claude Code](https://claude.com/claude-code)