### PR TITLE
fix(sessions): separate system agents from user count in wait_for_messages (#983)

### DIFF
--- a/src/agents/session_store.py
+++ b/src/agents/session_store.py
@@ -829,27 +829,47 @@ def _elapsed_minutes_str(elapsed_seconds: int | None) -> str:
 def format_active_sessions_block(sessions: list[dict]) -> str:
     """Format a list of active sessions as a compact context block.
 
+    Distinguishes user-facing agents from system agents (chat_id=0 or None).
+    System agents are background tasks (scheduled jobs, startup-catchup, etc.)
+    that do not correspond to a user conversation in the IDE panel.
+
     Produces output like:
-        [2 agents running]
-        - functional-engineer: "Implement GSD phase plan for BIS-51" (chat: OWNER_CHAT_ID_PLACEHOLDER, 12m ago)
-        - general-purpose: "Archive link for the user" (chat: OWNER_CHAT_ID_PLACEHOLDER, 2m ago)
+        [1 agent running, 1 system]
+        - functional-engineer: "Implement GSD phase plan" (chat: 8305714125, 12m ago)
+        - subagent: "startup-catchup" (system, 3m ago)
 
     Returns an empty string if sessions is empty.
     """
     if not sessions:
         return ""
-    count = len(sessions)
-    label = "agent" if count == 1 else "agents"
-    lines = [f"[{count} {label} running]"]
-    for s in sessions:
+
+    # Split into user agents (real chat_id) and system agents (chat_id=0 or None)
+    user_sessions = [s for s in sessions if s.get("chat_id") not in (None, 0, "0", "")]
+    system_sessions = [s for s in sessions if s.get("chat_id") in (None, 0, "0", "")]
+
+    user_count = len(user_sessions)
+    system_count = len(system_sessions)
+
+    user_label = "agent" if user_count == 1 else "agents"
+    header = f"[{user_count} {user_label} running"
+    if system_count > 0:
+        sys_label = "system" if system_count == 1 else "system"
+        header += f", {system_count} {sys_label}"
+    header += "]"
+
+    lines = [header]
+    for s in user_sessions + system_sessions:
         agent_type = s.get("agent_type") or "agent"
         desc = s.get("description", "")
         # Truncate long descriptions
         if len(desc) > 60:
             desc = desc[:57] + "..."
-        chat_id = s.get("chat_id", "?")
+        chat_id = s.get("chat_id")
         elapsed = _elapsed_minutes_str(s.get("elapsed_seconds"))
-        lines.append(f'- {agent_type}: "{desc}" (chat: {chat_id}, {elapsed})')
+        if chat_id in (None, 0, "0", ""):
+            lines.append(f'- {agent_type}: "{desc}" (system, {elapsed})')
+        else:
+            lines.append(f'- {agent_type}: "{desc}" (chat: {chat_id}, {elapsed})')
     return "\n".join(lines)
 
 

--- a/src/agents/session_store.py
+++ b/src/agents/session_store.py
@@ -853,7 +853,7 @@ def format_active_sessions_block(sessions: list[dict]) -> str:
     user_label = "agent" if user_count == 1 else "agents"
     header = f"[{user_count} {user_label} running"
     if system_count > 0:
-        sys_label = "system" if system_count == 1 else "system"
+        sys_label = "system" if system_count == 1 else "systems"
         header += f", {system_count} {sys_label}"
     header += "]"
 

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -355,6 +355,19 @@ def test_format_system_agent_separated_from_user_count():
     assert "chat: 8305714125" in result
 
 
+def test_format_plural_system_agents():
+    """Two system agents should show '2 systems' (not '2 system')."""
+    sessions = [
+        {"agent_type": "subagent", "description": "startup-catchup",
+         "chat_id": "0", "elapsed_seconds": 60, "id": "s1"},
+        {"agent_type": "subagent", "description": "health-check",
+         "chat_id": 0, "elapsed_seconds": 30, "id": "s2"},
+    ]
+    result = session_store.format_active_sessions_block(sessions)
+    assert "2 systems" in result, f"Expected '2 systems' in output, got: {result!r}"
+    assert "2 system]" not in result, "Singular 'system' must not appear with count 2"
+
+
 def test_format_only_system_agents():
     """When only system agents are running, header shows 0 user agents + N system."""
     sessions = [

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -336,6 +336,36 @@ def test_format_truncates_long_description():
     assert "..." in result
 
 
+def test_format_system_agent_separated_from_user_count():
+    """System agents (chat_id=0) must not inflate the user-facing agent count."""
+    sessions = [
+        {"agent_type": "subagent", "description": "User task",
+         "chat_id": "8305714125", "elapsed_seconds": 300, "id": "u1"},
+        {"agent_type": "subagent", "description": "startup-catchup",
+         "chat_id": "0", "elapsed_seconds": 60, "id": "s1"},
+    ]
+    result = session_store.format_active_sessions_block(sessions)
+    # User count should be 1, not 2
+    assert "[1 agent running" in result
+    # System count annotation
+    assert "1 system" in result
+    # System agent shown with 'system' label, not chat_id
+    assert "(system," in result
+    # User agent shown with real chat_id
+    assert "chat: 8305714125" in result
+
+
+def test_format_only_system_agents():
+    """When only system agents are running, header shows 0 user agents + N system."""
+    sessions = [
+        {"agent_type": "subagent", "description": "startup-catchup",
+         "chat_id": 0, "elapsed_seconds": 60, "id": "s1"},
+    ]
+    result = session_store.format_active_sessions_block(sessions)
+    assert "[0 agents running, 1 system]" in result
+    assert "(system," in result
+
+
 # ---------------------------------------------------------------------------
 # Test: tracker.py adapter compatibility
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `[N agents running]` in `wait_for_messages` output was counting all sessions including system agents (chat_id=0, e.g. `startup-catchup`, scheduled job pollers), causing a consistent +1 mismatch with the IDE panel which only shows user-facing agents
- `format_active_sessions_block` now splits sessions into user agents (real chat_id) and system agents (chat_id=0/None/empty), displaying them separately

## New output format

```
[1 agent running, 1 system]
- subagent: "User task" (chat: 8305714125, 5m ago)
- subagent: "startup-catchup" (system, 1m ago)
```

Previously it would show `[2 agents running]` causing confusion.

## Changes

- `src/agents/session_store.py`: Updated `format_active_sessions_block` to partition sessions by whether `chat_id` is 0/None/empty (system) or a real user chat_id. System agents are shown with `(system, Xm ago)` instead of `(chat: 0, Xm ago)`.
- `tests/test_agent_sessions.py`: Added three new tests covering mixed user+system sessions, only-system sessions, and the header format.

## Test plan

- [x] `uv run pytest tests/test_agent_sessions.py` — all 38 tests pass
- [ ] Observe `wait_for_messages` output when a system agent (e.g. startup-catchup) is running — confirm count shows correctly

Closes #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)