### PR TITLE
fix: standardize health-check-v3.sh to use uv run python3 throughout

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -435,7 +435,7 @@ read_lobster_mode() {
         echo "unknown"
         return
     fi
-    python3 -c "
+    uv run python3 -c "
 import json, sys
 try:
     d = json.load(open('$LOBSTER_STATE_FILE'))
@@ -476,7 +476,7 @@ is_compaction_recent() {
         return 1
     fi
     local compacted_at
-    compacted_at=$(python3 -c "
+    compacted_at=$(uv run python3 -c "
 import json, sys
 try:
     d = json.load(open('$LOBSTER_STATE_FILE'))
@@ -539,7 +539,7 @@ is_boot_grace_period() {
         return 1
     fi
     local booted_at
-    booted_at=$(python3 -c "
+    booted_at=$(uv run python3 -c "
 import json, sys
 try:
     d = json.load(open('$LOBSTER_STATE_FILE'))
@@ -598,7 +598,7 @@ write_boot_timestamp() {
     fi
     local now
     now=$(date -Iseconds)
-    python3 -c "
+    uv run python3 -c "
 import json, sys
 path = '$LOBSTER_STATE_FILE'
 now = '$now'
@@ -1040,7 +1040,7 @@ check_auth_token() {
         claude auth status 2>/dev/null)
 
     local logged_in auth_method
-    logged_in=$(echo "$auth_json" | python3 -c "
+    logged_in=$(echo "$auth_json" | uv run python3 -c "
 import json, sys
 try:
     d = json.load(sys.stdin)
@@ -1048,7 +1048,7 @@ try:
 except:
     print('unknown')
 " 2>/dev/null)
-    auth_method=$(echo "$auth_json" | python3 -c "
+    auth_method=$(echo "$auth_json" | uv run python3 -c "
 import json, sys
 try:
     d = json.load(sys.stdin)


### PR DESCRIPTION
## Summary

- Replaces all bare `python3 -c` calls in `scripts/health-check-v3.sh` with `uv run python3 -c`
- The only remaining `python3` reference is the dashboard server startup at line 1203 which uses the explicit venv path (`$install_dir/.venv/bin/python3`) — that is intentional and correct
- The `count_active_subagents()` function already used `uv run python3` correctly; this change makes all other functions consistent

Fixes #827

## Test plan
- [ ] Run `scripts/health-check-v3.sh` and verify it completes without Python errors
- [ ] Check that state file reads (mode, booted_at, compacted_at, etc.) still return expected values
- [ ] Check that auth token check still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)