### PR TITLE
fix: preserve chat_id in subagent recovery fallback (require-write-result.py)

### DIFF
--- a/hooks/require-write-result.py
+++ b/hooks/require-write-result.py
@@ -376,6 +376,7 @@ def _write_synthetic_inbox_message(
     data: dict,
     content: str,
     task_id_hint: str,
+    chat_id: int = 0,
 ) -> None:
     """Write a synthetic subagent_result message to ~/messages/inbox/.
 
@@ -399,10 +400,8 @@ def _write_synthetic_inbox_message(
         safe_task_id = "".join(c if c.isalnum() or c in "-_" else "_" for c in task_id)[:40]
         message_id = f"{ts_ms}_{safe_task_id}_recovered"
 
-        # chat_id: we don't know the original chat_id when the agent didn't call
-        # write_result. Use 0 as the dispatcher system route so the dispatcher
-        # can decide what to do with the recovered result.
-        chat_id = 0
+        # chat_id: use the recovered value from the transcript header if available,
+        # otherwise fall back to 0 (the dispatcher system route for background agents).
 
         recovery_note = (
             "Agent exited without calling write_result. "
@@ -555,19 +554,32 @@ def main():
     if fire_count > MAX_HOOK_FIRES:
         # Give up blocking — extract the best pre-hook content and emit a
         # synthetic subagent_result so the dispatcher gets something.
+        import re
         task_id_hint = ""
-        # Try to extract a task_id hint from the prompt text in the transcript.
-        # A common pattern is "Your task_id is: <id>" injected by the dispatcher.
+        recovered_chat_id = 0
+        # Try to extract task_id and chat_id hints from the prompt text.
+        # The dispatcher injects a header block into every subagent prompt:
+        #   ---
+        #   task_id: <task-id>
+        #   chat_id: <chat-id>
+        #   source: telegram
+        #   ---
         for part in text_content_parts:
-            if "task_id" in part.lower():
-                import re
+            if not task_id_hint and "task_id" in part.lower():
                 m = re.search(r"task[_\s-]?id\s*(?:is\s*)?[:\-]?\s*([A-Za-z0-9_-]+)", part, re.IGNORECASE)
                 if m:
                     task_id_hint = m.group(1)
-                    break
+            if not recovered_chat_id and "chat_id" in part.lower():
+                m = re.search(r"chat[_\s-]?id\s*[:\-]\s*(\d+)", part, re.IGNORECASE)
+                if m:
+                    candidate = int(m.group(1))
+                    if candidate != 0:
+                        recovered_chat_id = candidate
+            if task_id_hint and recovered_chat_id:
+                break
 
         content = _extract_pre_hook_text(transcript, first_fire_ts, _FALLBACK_TURNS)
-        _write_synthetic_inbox_message(data, content, task_id_hint)
+        _write_synthetic_inbox_message(data, content, task_id_hint, chat_id=recovered_chat_id)
 
         # Clean up the fire-count temp file.
         key = _agent_key(data)

--- a/tests/unit/test_hooks/test_require_write_result.py
+++ b/tests/unit/test_hooks/test_require_write_result.py
@@ -723,3 +723,89 @@ class TestFallbackAfterNFires:
 
         assert "early" in result
         assert "late" not in result
+
+    def test_fallback_extracts_chat_id_from_prompt_header(self, monkeypatch, tmp_path):
+        """Fallback must extract chat_id from the dispatcher-injected header block."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        # Transcript includes the dispatcher header with a real chat_id.
+        prompt_with_header = (
+            "---\n"
+            "task_id: my-task-123\n"
+            "chat_id: 987654321\n"
+            "source: telegram\n"
+            "---\n\n"
+            "Do the task and call write_result."
+        )
+        transcript = [
+            {
+                "type": "human",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": prompt_with_header}],
+                },
+                "uuid": "uuid-prompt",
+                "sessionId": "test-session",
+            }
+        ]
+        transcript_file = tmp_path / "agent.jsonl"
+        _write_jsonl_transcript(transcript_file, transcript)
+
+        hook_input = _make_subagentstop_hook_input_with_agent_id(
+            str(transcript_file),
+            agent_id="test-agent-chatid",
+        )
+
+        fire_path = tmp_path / "lobster-hook-fires-test-agent-chatid"
+        monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
+
+        inbox_dir = tmp_path / "messages" / "inbox"
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        for _ in range(mod.MAX_HOOK_FIRES):
+            _run_hook(mod, hook_input)
+
+        _run_hook(mod, hook_input)  # fallback fire
+
+        inbox_files = list(inbox_dir.glob("*.json"))
+        assert len(inbox_files) == 1, f"Expected 1 inbox file, got {len(inbox_files)}"
+
+        msg = json.loads(inbox_files[0].read_text())
+        assert msg["type"] == "subagent_recovered"
+        assert msg["chat_id"] == 987654321, (
+            f"Expected recovered chat_id=987654321, got {msg['chat_id']}"
+        )
+
+    def test_fallback_chat_id_defaults_to_zero_when_not_found(self, monkeypatch, tmp_path):
+        """Fallback must default chat_id to 0 when no header is present."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        transcript_file = tmp_path / "agent.jsonl"
+        _write_jsonl_transcript(
+            transcript_file,
+            _make_transcript_with_text_turns(["I did some work"]),
+        )
+
+        hook_input = _make_subagentstop_hook_input_with_agent_id(
+            str(transcript_file),
+            agent_id="test-agent-no-chatid",
+        )
+
+        fire_path = tmp_path / "lobster-hook-fires-test-agent-no-chatid"
+        monkeypatch.setattr(mod, "_fire_count_path", lambda key: fire_path)
+
+        inbox_dir = tmp_path / "messages" / "inbox"
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        for _ in range(mod.MAX_HOOK_FIRES):
+            _run_hook(mod, hook_input)
+
+        _run_hook(mod, hook_input)  # fallback fire
+
+        inbox_files = list(inbox_dir.glob("*.json"))
+        assert len(inbox_files) == 1
+
+        msg = json.loads(inbox_files[0].read_text())
+        assert msg["chat_id"] == 0, f"Expected chat_id=0 (fallback), got {msg['chat_id']}"


### PR DESCRIPTION
## Summary

- When a subagent exhausts `MAX_HOOK_FIRES` without calling `write_result`, the fallback path now extracts the `chat_id` from the dispatcher-injected header block (`task_id`/`chat_id`/`source`) in the transcript text
- Previously the synthetic `subagent_recovered` message always had `chat_id=0`, causing the dispatcher's system-route fast-exit to silently drop it — the user got no notification
- Now, if a real `chat_id` is found, the recovered message is routed correctly and the dispatcher can notify the user of the partial result or failure
- Falls back to `chat_id=0` (existing behavior) if no header is present
- Added 2 new unit tests: one verifying extraction of a real `chat_id`, one verifying the `chat_id=0` fallback

Fixes #1035

## Test plan
- [ ] Run `uv run pytest tests/unit/test_hooks/test_require_write_result.py` — all 27 tests should pass
- [ ] Verify that a subagent that dies after MAX_HOOK_FIRES now produces a `subagent_recovered` message with the correct `chat_id` from its prompt header
- [ ] Verify that the dispatcher's `agent_failed` handler routes the message to the user instead of dropping it

🤖 Generated with [Claude Code](https://claude.com/claude-code)