### PR TITLE
fix: add fallback inbox poll in WFM to wake on subagent_notification (#990)

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -694,6 +694,10 @@ def normalize_message_type(msg: dict) -> dict:
 # Heartbeat file for health monitoring
 HEARTBEAT_FILE = _WORKSPACE / "logs" / "claude-heartbeat"
 
+# How often (in seconds) wait_for_messages performs a fallback inbox poll.
+# Exposed as a module-level constant so tests can monkeypatch it.
+WAIT_HEARTBEAT_INTERVAL = 60
+
 # Hibernation state file - tracks whether Lobster is active or hibernating
 LOBSTER_STATE_FILE = CONFIG_DIR / "lobster-state.json"
 
@@ -3778,8 +3782,8 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
             touch_heartbeat()
             inbox_results = await handle_check_inbox({"limit": 10})
             return _prepend_sessions_prefix(sessions_prefix, inbox_results)
-        # Wait with periodic heartbeats (every 60 seconds)
-        heartbeat_interval = 60
+        # Wait with periodic heartbeats (every WAIT_HEARTBEAT_INTERVAL seconds)
+        heartbeat_interval = WAIT_HEARTBEAT_INTERVAL
         elapsed = 0
 
         while elapsed < timeout:

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -3797,6 +3797,15 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
             touch_heartbeat()
             elapsed += wait_time
 
+            # Fallback inbox poll: inotify can miss rename events under high load
+            # (IN_Q_OVERFLOW) or in edge cases with certain filesystem configurations.
+            # This periodic check ensures subagent_notification and other messages
+            # are detected within one heartbeat interval even if the file watcher
+            # missed the event (issue #990).
+            if list(INBOX_DIR.glob("*.json")):
+                message_arrived.set()
+                break
+
         if message_arrived.is_set():
             # Small delay to ensure file is fully written
             await asyncio.sleep(0.1)

--- a/tests/unit/test_mcp_server/test_wait_for_messages.py
+++ b/tests/unit/test_mcp_server/test_wait_for_messages.py
@@ -176,21 +176,15 @@ class TestSubagentNotificationWakesWFM:
         """Get inbox directory."""
         return temp_messages_dir / "inbox"
 
-    def test_fallback_poll_detects_subagent_notification_when_watcher_missed(
+    def test_precheck_detects_existing_inbox_files_before_wait(
         self, inbox_dir: Path
     ):
-        """WFM must detect a subagent_notification via the fallback inbox poll.
+        """WFM returns immediately when a subagent_notification is already in the inbox.
 
-        This test bypasses the file watcher by writing the message AFTER the
-        observer is started but preventing on_moved from firing (simulated by
-        writing the file directly, not via rename) — then verifies that the
-        heartbeat-loop poll detects it within a short window.
-
-        The key invariant: subagent_notification files written to INBOX_DIR
-        must wake WFM within heartbeat_interval seconds at most.
+        Validates the pre-check path: after the observer starts but before blocking,
+        WFM scans for existing files. Messages already present are detected without
+        waiting for any heartbeat interval or inotify event.
         """
-        import threading
-
         # Write a subagent_notification BEFORE WFM starts so the pre-check
         # picks it up immediately.  This validates that the pre-check path works.
         notification = {
@@ -214,7 +208,12 @@ class TestSubagentNotificationWakesWFM:
         ):
             from src.mcp.inbox_server import handle_wait_for_messages
 
-            result = asyncio.run(handle_wait_for_messages({"timeout": 2}))
+            start = time.time()
+            result = asyncio.run(handle_wait_for_messages({"timeout": 10}))
+            elapsed = time.time() - start
+
+            # Pre-check should return immediately (< 1 second)
+            assert elapsed < 1.0, f"Expected immediate return from pre-check, took {elapsed:.2f}s"
             text = result[0].text
             assert "subagent_notification" in text.lower() or "SUBAGENT NOTIFICATION" in text
 
@@ -225,31 +224,26 @@ class TestSubagentNotificationWakesWFM:
 
         Simulates the case where a subagent calls write_result(sent_reply_to_user=True)
         while the dispatcher is blocked in wait_for_messages.  Even if the file
-        watcher misses the inotify event, the fallback poll must detect the file.
+        watcher misses the inotify event, the fallback poll must detect the file
+        within WAIT_HEARTBEAT_INTERVAL seconds.
+
+        WAIT_HEARTBEAT_INTERVAL is patched to 1s so the fallback poll fires within
+        ~1.2s of the file being written — well before the 8s join timeout.
         """
         import threading
 
         results = []
         errors = []
 
-        # Use a short heartbeat to make the test fast
         def wait_thread():
             try:
                 with patch.multiple(
                     "src.mcp.inbox_server",
                     INBOX_DIR=inbox_dir,
+                    WAIT_HEARTBEAT_INTERVAL=1,  # Patch heartbeat to 1s so fallback fires quickly
                 ):
-                    # Patch heartbeat_interval to 1s so the fallback poll fires quickly.
-                    import src.mcp.inbox_server as _srv
-                    orig_handle = _srv.handle_wait_for_messages
-
-                    async def _fast_wfm(args):
-                        # Override timeout to 5s and rely on fallback poll
-                        args = dict(args)
-                        args["timeout"] = 5
-                        return await orig_handle(args)
-
-                    result = asyncio.run(_fast_wfm({"timeout": 5}))
+                    from src.mcp.inbox_server import handle_wait_for_messages
+                    result = asyncio.run(handle_wait_for_messages({"timeout": 5}))
                     results.append(result)
             except Exception as e:
                 errors.append(e)
@@ -274,6 +268,8 @@ class TestSubagentNotificationWakesWFM:
         notification_file = inbox_dir / f"{notification['id']}.json"
         notification_file.write_text(json.dumps(notification))
 
+        # With WAIT_HEARTBEAT_INTERVAL=1s and message written at 0.2s, the fallback
+        # poll should fire within ~1.2s — well before the 8s join timeout.
         thread.join(timeout=8)
 
         if errors:

--- a/tests/unit/test_mcp_server/test_wait_for_messages.py
+++ b/tests/unit/test_mcp_server/test_wait_for_messages.py
@@ -160,3 +160,127 @@ class TestWaitForMessagesIntegration:
         # Result should contain the message (not timeout)
         if results:
             assert "message" in results[0][0].text.lower()
+
+
+class TestSubagentNotificationWakesWFM:
+    """Tests that subagent_notification messages wake wait_for_messages (issue #990).
+
+    The file watcher (watchdog/inotify) can miss rename events under high load.
+    WFM must also periodically poll the inbox directory as a fallback so that
+    subagent_notification (and other message types) are detected within one
+    heartbeat interval even when the file-system event is missed.
+    """
+
+    @pytest.fixture
+    def inbox_dir(self, temp_messages_dir: Path) -> Path:
+        """Get inbox directory."""
+        return temp_messages_dir / "inbox"
+
+    def test_fallback_poll_detects_subagent_notification_when_watcher_missed(
+        self, inbox_dir: Path
+    ):
+        """WFM must detect a subagent_notification via the fallback inbox poll.
+
+        This test bypasses the file watcher by writing the message AFTER the
+        observer is started but preventing on_moved from firing (simulated by
+        writing the file directly, not via rename) — then verifies that the
+        heartbeat-loop poll detects it within a short window.
+
+        The key invariant: subagent_notification files written to INBOX_DIR
+        must wake WFM within heartbeat_interval seconds at most.
+        """
+        import threading
+
+        # Write a subagent_notification BEFORE WFM starts so the pre-check
+        # picks it up immediately.  This validates that the pre-check path works.
+        notification = {
+            "id": "1234567890_test_notify",
+            "type": "subagent_notification",
+            "source": "telegram",
+            "chat_id": 12345,
+            "text": "Subagent completed and already sent reply.",
+            "task_id": "test-task-123",
+            "status": "success",
+            "sent_reply_to_user": True,
+            "timestamp": "2026-01-01T12:00:00+00:00",
+            "warning": "User already received the subagent's reply.",
+        }
+        notification_file = inbox_dir / f"{notification['id']}.json"
+        notification_file.write_text(json.dumps(notification))
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox_dir,
+        ):
+            from src.mcp.inbox_server import handle_wait_for_messages
+
+            result = asyncio.run(handle_wait_for_messages({"timeout": 2}))
+            text = result[0].text
+            assert "subagent_notification" in text.lower() or "SUBAGENT NOTIFICATION" in text
+
+    def test_fallback_poll_detects_subagent_notification_written_during_wait(
+        self, inbox_dir: Path
+    ):
+        """WFM must detect a subagent_notification written while WFM is blocking.
+
+        Simulates the case where a subagent calls write_result(sent_reply_to_user=True)
+        while the dispatcher is blocked in wait_for_messages.  Even if the file
+        watcher misses the inotify event, the fallback poll must detect the file.
+        """
+        import threading
+
+        results = []
+        errors = []
+
+        # Use a short heartbeat to make the test fast
+        def wait_thread():
+            try:
+                with patch.multiple(
+                    "src.mcp.inbox_server",
+                    INBOX_DIR=inbox_dir,
+                ):
+                    # Patch heartbeat_interval to 1s so the fallback poll fires quickly.
+                    import src.mcp.inbox_server as _srv
+                    orig_handle = _srv.handle_wait_for_messages
+
+                    async def _fast_wfm(args):
+                        # Override timeout to 5s and rely on fallback poll
+                        args = dict(args)
+                        args["timeout"] = 5
+                        return await orig_handle(args)
+
+                    result = asyncio.run(_fast_wfm({"timeout": 5}))
+                    results.append(result)
+            except Exception as e:
+                errors.append(e)
+
+        thread = threading.Thread(target=wait_thread)
+        thread.start()
+
+        # Wait a short moment then write the notification directly (no rename,
+        # simulating a case where the file watcher might not fire).
+        time.sleep(0.2)
+        notification = {
+            "id": "9876543210_test_delayed_notify",
+            "type": "subagent_notification",
+            "source": "telegram",
+            "chat_id": 12345,
+            "text": "Subagent already sent reply to user.",
+            "task_id": "delayed-task",
+            "status": "success",
+            "sent_reply_to_user": True,
+            "timestamp": "2026-01-01T12:00:01+00:00",
+        }
+        notification_file = inbox_dir / f"{notification['id']}.json"
+        notification_file.write_text(json.dumps(notification))
+
+        thread.join(timeout=8)
+
+        if errors:
+            raise errors[0]
+
+        assert len(results) > 0, "WFM should have returned after subagent_notification was written"
+        text = results[0][0].text
+        assert "message" in text.lower() or "SUBAGENT" in text, (
+            f"Expected WFM to return messages, got: {text[:200]}"
+        )


### PR DESCRIPTION
## Summary

- `wait_for_messages` relies on the watchdog/inotify file watcher to detect new inbox messages. Under high load, inotify can emit `IN_Q_OVERFLOW` instead of individual rename events, causing the observer to miss the `on_moved` event for the `.json` file — leaving WFM blocked until its full timeout (up to 20 hours).
- `subagent_notification` messages (written by `write_result(sent_reply_to_user=True)`) were the primary trigger of this: the dispatcher appeared stalled after a subagent completed, causing the health check to see a stale WFM and trigger restarts. This caused the 2026-03-27 9-hour downtime incident.
- Adds a periodic fallback inbox poll inside the WFM heartbeat loop: after each 60-second heartbeat interval, check `INBOX_DIR.glob("*.json")`. If any files exist, set `message_arrived` and break. This guarantees any message is detected within one heartbeat interval even when the file watcher misses the event.
- Also adds two new unit tests verifying that `subagent_notification` is not filtered out by WFM, and that the fallback poll detects a file written without rename (simulating a missed inotify event).

## Test plan
- [ ] Run `uv run pytest tests/unit/test_mcp_server/test_wait_for_messages.py` — all 7 tests should pass
- [ ] Verify that the fallback poll test (`test_fallback_poll_detects_subagent_notification_written_during_wait`) passes, confirming that WFM returns within a few seconds even when the file is written without a rename event

🤖 Generated with [Claude Code](https://claude.com/claude-code)