### PR TITLE
fix(dispatcher): add subagent_recovered handler with user notification (#1035)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -562,6 +562,52 @@ The distinct type is a structural guarantee: the `subagent_result` branch (which
 
 ---
 
+### subagent_recovered (`type: "subagent_recovered"`)
+
+Written by `require-write-result.py` when a subagent exits without calling `write_result` after MAX_HOOK_FIRES (5) retry attempts. The hook salvages the last few transcript turns and writes them as a recovery message.
+
+**Key fields:** `task_id`, `chat_id` (0 if unknown), `text` (salvaged content), `recovered: True`.
+
+```
+1. mark_processing(message_id)
+
+2. if msg.get("chat_id", 0) == 0:
+       # System job with no known user — drop silently, nothing to relay.
+       mark_processed(message_id)
+       continue
+
+3. # Real user task: send a gentle failure notification.
+   # Do NOT relay the raw salvaged dump — it is noisy transcript content.
+   # Extract a brief summary (first sentence or two) from msg["text"] if present.
+   summary_marker = "Recovered content:\n\n"
+   raw_text = msg.get("text", "")
+   if summary_marker in raw_text:
+       salvaged = raw_text.split(summary_marker, 1)[1]
+       summary = salvaged[:200].strip()
+   else:
+       summary = "(No recoverable output found.)"
+   task_id = msg.get("task_id", "unknown")
+   send_reply(
+       chat_id=msg["chat_id"],
+       text=(
+           f"A background task ran into trouble and could not complete.\n\n"
+           f"Task: {task_id}\n"
+           f"Last known activity: {summary}\n\n"
+           "Let me know if you'd like me to retry."
+       ),
+       source=msg.get("source", "telegram"),
+   )
+
+4. mark_processed(message_id)
+```
+
+Rules:
+- Never relay raw salvaged transcript content — it is noisy and unhelpful. Summarize at most 200 chars.
+- If `chat_id == 0`, drop silently. There is no user to notify.
+- The dispatcher hint from check_inbox (`SUBAGENT_RECOVERED`) will specify whether to notify or drop.
+
+---
+
 ### subagent_observation (`type: "subagent_observation"`)
 
 Side-channel signals from subagents via `write_observation(chat_id, text, category, ...)`.

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -4278,7 +4278,18 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
         if msg_type == "subagent_notification":
             output += "dispatcher_hint: SUBAGENT_NOTIFICATION — user already received the subagent's reply. Don't summarize it. If you respond, add new value only — a question, a correction, missing context. Call mark_processed when done.\n"
         if msg_type == "subagent_recovered":
-            output += "dispatcher_hint: SUBAGENT_RECOVERED — agent exited without calling write_result; content was salvaged from transcript. The owner has been notified via inbox. Do NOT relay the raw dump to the user. Call mark_processed when done.\n"
+            _recovered_chat_id = msg.get("chat_id", 0)
+            if _recovered_chat_id and _recovered_chat_id != 0:
+                output += (
+                    "dispatcher_hint: SUBAGENT_RECOVERED — agent exited without calling write_result. "
+                    f"The originating user (chat_id={_recovered_chat_id}) has NOT been notified. "
+                    "Send them a brief, gentle message: "
+                    '"A background task ran into trouble and could not complete. Here\'s what it found: [brief summary from text]. '
+                    'Let me know if you\'d like me to retry." '
+                    "Do NOT relay the raw salvaged dump. call mark_processed when done.\n"
+                )
+            else:
+                output += "dispatcher_hint: SUBAGENT_RECOVERED — agent exited without calling write_result; content was salvaged from transcript. chat_id=0 means no known user — drop silently. Call mark_processed when done.\n"
         _has_file = msg_type in ("voice", "photo", "document") or bool(
             msg.get("image_file") or msg.get("image_files") or
             msg.get("file_path") or msg.get("audio_file")

--- a/tests/unit/test_mcp_server/test_dispatcher_hint.py
+++ b/tests/unit/test_mcp_server/test_dispatcher_hint.py
@@ -169,3 +169,86 @@ class TestDispatcherHint:
         # Count hint occurrences -- exactly one (for the voice message)
         hint_count = text.count("dispatcher_hint: HINT: file attached - use subagent")
         assert hint_count == 1
+
+
+class TestSubagentRecoveredDispatcherHint:
+    """Tests for subagent_recovered dispatcher_hint routing based on chat_id (issue #1035).
+
+    When a subagent exits without calling write_result, require-write-result.py
+    writes a subagent_recovered message to the inbox. The dispatcher_hint tells
+    the dispatcher whether to send a user-facing notification (chat_id != 0)
+    or drop silently (chat_id == 0).
+    """
+
+    @pytest.fixture
+    def inbox_dir(self, temp_messages_dir: Path) -> Path:
+        """Get inbox directory."""
+        return temp_messages_dir / "inbox"
+
+    def _check_inbox(self, inbox_dir: Path) -> str:
+        """Helper: run handle_check_inbox and return the result text."""
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox_dir,
+        ):
+            from src.mcp.inbox_server import handle_check_inbox
+            result = asyncio.run(handle_check_inbox({}))
+            return result[0].text
+
+    def _make_recovered_msg(self, chat_id: int) -> dict:
+        """Build a minimal subagent_recovered inbox message."""
+        return {
+            "id": f"1234567890_test_task_recovered",
+            "type": "subagent_recovered",
+            "source": "system",
+            "chat_id": chat_id,
+            "text": (
+                "Agent exited without calling write_result. "
+                "Content recovered from transcript after 5 hook fires.\n\n"
+                "Recovered content:\n\nSome partial work was done."
+            ),
+            "task_id": "test-task-123",
+            "status": "recovered",
+            "sent_reply_to_user": False,
+            "timestamp": "2026-01-01T12:00:00+00:00",
+            "recovered": True,
+        }
+
+    def test_real_chat_id_hint_instructs_dispatcher_to_notify_user(
+        self, inbox_dir: Path
+    ):
+        """subagent_recovered with a real chat_id must instruct dispatcher to notify the user."""
+        msg = self._make_recovered_msg(chat_id=987654321)
+        # Patch _enqueue_recovery_notification to avoid touching owner config
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox_dir,
+            _enqueue_recovery_notification=lambda m: None,
+        ):
+            (inbox_dir / f"{msg['id']}.json").write_text(json.dumps(msg))
+            text = self._check_inbox(inbox_dir)
+
+        # Should contain a hint telling the dispatcher to notify the user
+        assert "SUBAGENT_RECOVERED" in text
+        assert "chat_id=987654321" in text
+        assert "NOT been notified" in text
+        assert "gentle" in text.lower() or "gentle" in text
+
+    def test_zero_chat_id_hint_instructs_dispatcher_to_drop_silently(
+        self, inbox_dir: Path
+    ):
+        """subagent_recovered with chat_id=0 must instruct dispatcher to drop silently."""
+        msg = self._make_recovered_msg(chat_id=0)
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox_dir,
+            _enqueue_recovery_notification=lambda m: None,
+        ):
+            (inbox_dir / f"{msg['id']}.json").write_text(json.dumps(msg))
+            text = self._check_inbox(inbox_dir)
+
+        assert "SUBAGENT_RECOVERED" in text
+        # chat_id=0 path: should say to drop silently
+        assert "drop silently" in text or "chat_id=0" in text
+        # Must NOT instruct dispatcher to notify any user
+        assert "NOT been notified" not in text


### PR DESCRIPTION
## Summary

- Completes issue #1035 (dispatcher side). The hook side was fixed in PR #1517 (adding chat_id extraction to require-write-result.py).
- When a subagent dies after 5 hook retries, require-write-result.py writes a `subagent_recovered` message. Previously the dispatcher had no handler and the user was silently left without a response — even when the original chat_id was known.
- Updates `check_inbox` to emit a chat_id-aware `dispatcher_hint` for `subagent_recovered` messages:
  - `chat_id != 0`: instructs dispatcher to send a brief user-facing "task had trouble" message with a 200-char summary of salvaged content
  - `chat_id == 0`: instructs dispatcher to drop silently (no user to notify)
- Adds a `subagent_recovered` handler section to `sys.dispatcher.bootup.md` with step-by-step routing logic
- Adds 2 unit tests verifying the dispatcher_hint for both routing paths

## Test plan
- [ ] Run `uv run pytest tests/unit/test_mcp_server/test_dispatcher_hint.py` — all 12 tests should pass
- [ ] Verify that a subagent dying after 5 retries with a real chat_id produces a `subagent_recovered` message that instructs the dispatcher to notify the user
- [ ] Verify that a `subagent_recovered` with `chat_id=0` instructs the dispatcher to drop silently

## Dependencies
- Depends on PR #1517 for chat_id extraction in the hook (can be reviewed independently but should be merged together)

🤖 Generated with [Claude Code](https://claude.com/claude-code)