### PR TITLE
fix(hooks): use Claude UUID state file in post-compact-gate dispatcher detection (#1151)

### DIFF
--- a/hooks/post-compact-gate.py
+++ b/hooks/post-compact-gate.py
@@ -25,16 +25,19 @@ Detection is performed by is_dispatcher_session(), which uses a layered strategy
    filesystem I/O required.  This is the primary check for the common case.
    See issue #1152.
 
-1. MCP state file: The running MCP server writes the dispatcher session ID to
-   ~/lobster-workspace/data/dispatcher-session-id.  NOTE: this file stores an
-   HTTP MCP session ID, not a CC UUID; it will never match the hook session_id
-   field in practice (namespace mismatch — see issue #1151).  Retained for
-   belt-and-suspenders; effectively a no-op in hook context.
+1. MCP Claude UUID state file (primary): The MCP server writes the dispatcher
+   Claude session UUID to ~/lobster-workspace/data/dispatcher-claude-session-id
+   when session_start(agent_type='dispatcher', claude_session_id=<uuid>) is
+   called.  This CC UUID matches hook_input["session_id"] directly.
+   Match → dispatcher.  Mismatch → subagent.  File absent → try next.
+   NOTE: The HTTP session state file (dispatcher-session-id) is NOT checked
+   here — it stores an MCP HTTP transport ID (32-char hex) which never matches
+   the CC UUID in hook_input["session_id"] (see issue #1151).
 
 2. Hook marker file (secondary): At dispatcher startup, write-dispatcher-session-id.py
    (a SessionStart hook) writes the session ID to
-   ~/messages/config/dispatcher-session-id.  This is the real primary
-   state-file signal for hooks (CC UUID on both sides).  Match → dispatcher.
+   ~/messages/config/dispatcher-session-id.  This is a CC UUID fallback for
+   the window before session_start is called.  Match → dispatcher.
 
 3. Process-tree fallback: If neither state file is present or gives a definitive
    answer, walk the process tree upward.  Two consecutive claude-like ancestors
@@ -218,22 +221,30 @@ def is_dispatcher_session(hook_input: dict) -> bool:
     removed in PR #1102 because JSONL transcript scanning was fragile and is
     now superseded by the MCP state file written by the running server.
     """
-    # Primary: MCP state file + hook marker file (via session_role).
-    # is_dispatcher() checks both files and returns False if neither is present
-    # or matches.  We need to distinguish "definitely subagent" (file exists,
-    # mismatch) from "no signal" (file absent) to know when to apply the
-    # process-tree fallback.  Probe both files directly.
+    # Primary: MCP Claude UUID state file + hook marker file (via session_role).
+    # We need to distinguish "definitely subagent" (file exists, mismatch) from
+    # "no signal" (file absent) to know when to apply the process-tree fallback.
+    # Probe both files directly.
+    #
+    # NOTE: We use _get_mcp_claude_session_file() (dispatcher-claude-session-id),
+    # NOT _get_mcp_session_state_file() (dispatcher-session-id).  The latter stores
+    # the HTTP MCP transport session ID (32-char hex), while hook_input["session_id"]
+    # is always a Claude Code UUID (36-char UUID4).  These namespaces never match, so
+    # using the HTTP session file would cause _check_state_file() to always return
+    # False when the file exists — short-circuiting before the hook marker file check
+    # and incorrectly treating the dispatcher as a subagent.  See issue #1151.
     from session_role import (
         _check_state_file,
-        _get_mcp_session_state_file,
+        _get_mcp_claude_session_file,
         get_session_id,
         DISPATCHER_SESSION_FILE,
     )
 
     session_id = get_session_id(hook_input)
 
-    # Check MCP state file first (written by the running MCP server).
-    mcp_result = _check_state_file(_get_mcp_session_state_file(), session_id)
+    # Check MCP Claude UUID state file first (written by MCP server on session_start).
+    # This file stores the same Claude UUID format as hook_input["session_id"].
+    mcp_result = _check_state_file(_get_mcp_claude_session_file(), session_id)
     if mcp_result is not None:
         return mcp_result
 

--- a/tests/smoke/test_post_compact_gate.py
+++ b/tests/smoke/test_post_compact_gate.py
@@ -76,20 +76,28 @@ def _run_gate(
     *,
     main_session: bool = True,
     agent_id: str | None = None,
+    session_id: str | None = None,
+    workspace: Path | None = None,
 ) -> subprocess.CompletedProcess:
     """Run the gate hook with the given tool call payload piped to stdin.
 
     HOME is overridden to home so the sentinel and log paths are isolated.
     agent_id, when provided, simulates a subagent PreToolUse payload.
+    session_id, when provided, is included in the hook payload.
+    workspace, when provided, overrides LOBSTER_WORKSPACE.
     """
     payload = {"tool_name": tool_name, "tool_input": tool_input or {}}
     if agent_id is not None:
         payload["agent_id"] = agent_id
+    if session_id is not None:
+        payload["session_id"] = session_id
     env = {
         **os.environ,
         "HOME": str(home),
         "LOBSTER_MAIN_SESSION": "1" if main_session else "0",
     }
+    if workspace is not None:
+        env["LOBSTER_WORKSPACE"] = str(workspace)
     return subprocess.run(
         [sys.executable, str(HOOK)],
         input=json.dumps(payload),
@@ -229,4 +237,62 @@ def test_subagent_passes_with_fresh_sentinel(tmp_path):
     assert result.returncode == 0, f"Hook exited non-zero: {result.stderr}"
     assert result.stdout.strip() == "", (
         f"Expected empty stdout (subagent fast-exit despite sentinel), got: {result.stdout!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# B6 — regression: HTTP session state file must not block gate for dispatcher
+# ---------------------------------------------------------------------------
+
+
+def test_dispatcher_not_blocked_by_http_session_state_file(tmp_path):
+    """B6 (Regression #1151): HTTP session state file must not cause dispatcher
+    to be misidentified as subagent.
+
+    Before fix: is_dispatcher_session() checked dispatcher-session-id (HTTP session
+    ID, 32-char hex) against hook_input["session_id"] (Claude UUID, 36-char UUID4).
+    These are different namespaces; _check_state_file() returned False (mismatch)
+    when the HTTP session file existed, causing the gate to pass the dispatcher as
+    if it were a subagent — bypassing the compact-pending sentinel enforcement.
+
+    After fix: is_dispatcher_session() uses dispatcher-claude-session-id (Claude UUID)
+    as the primary check, which matches the hook_input["session_id"] format correctly.
+    """
+    dispatcher_uuid = "b5b15385-5d9c-4755-8d7a-c5cfe3457b12"
+    http_session_id = "8221b9189a0a40f99a81d72bac452e5a"  # different format, never matches
+
+    # Set up workspace with BOTH state files (the HTTP one and the correct UUID one).
+    workspace = tmp_path / "lobster-workspace"
+    data_dir = workspace / "data"
+    data_dir.mkdir(parents=True)
+
+    # Write the HTTP session ID file (wrong namespace — should be ignored).
+    (data_dir / "dispatcher-session-id").write_text(http_session_id)
+    # Write the correct Claude UUID file (right namespace — should match).
+    (data_dir / "dispatcher-claude-session-id").write_text(dispatcher_uuid)
+
+    # Create a fresh sentinel so the gate would block if it detects dispatcher.
+    _make_sentinel(tmp_path)
+
+    # Run gate as the dispatcher (matching session_id = dispatcher UUID).
+    result = _run_gate(
+        tmp_path,
+        tool_name="some_other_tool",
+        session_id=dispatcher_uuid,
+        workspace=workspace,
+    )
+
+    assert result.returncode == 0, f"Hook exited non-zero: {result.stderr}"
+    output_text = result.stdout.strip()
+    assert output_text, (
+        "Expected gate to DENY (dispatcher with fresh sentinel should be blocked), "
+        f"but got empty output.\nstderr: {result.stderr!r}\n"
+        "This indicates the gate treated the dispatcher as a subagent due to the "
+        "HTTP session state file namespace mismatch (regression #1151)."
+    )
+    output = json.loads(output_text)
+    decision = output.get("hookSpecificOutput", {}).get("permissionDecision", "")
+    assert decision == "deny", (
+        f"Expected gate to deny dispatcher, got: {decision!r}\n"
+        "The HTTP session state file caused dispatcher to be misidentified as subagent."
     )


### PR DESCRIPTION
## Summary

- `post-compact-gate.py`'s `is_dispatcher_session()` was checking the HTTP MCP session state file (`dispatcher-session-id`, 32-char hex) against `hook_input["session_id"]` (Claude Code UUID, 36-char UUID4)
- These are different ID namespaces — the comparison always returns `False` when the file exists, silently treating the dispatcher as a subagent and bypassing sentinel enforcement
- Fix: use `_get_mcp_claude_session_file()` (`dispatcher-claude-session-id`) instead, which stores the Claude UUID written by the MCP server on `session_start` and matches the hook payload's `session_id` format

## Test plan

- [x] All 5 existing smoke tests in `test_post_compact_gate.py` pass
- [x] New regression test B6 (`test_dispatcher_not_blocked_by_http_session_state_file`) added — verifies that when both the HTTP session file and Claude UUID file are present, the gate correctly identifies the dispatcher and denies non-wait_for_messages tools
- [x] All 33 session_role state file unit tests pass

Fixes #1151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)