### PR TITLE
fix(dispatcher): never reply 'Noted.' to a direct question (#1019)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -158,6 +158,16 @@ mcp__github__issue_read(owner="...", repo="...", ...)             # VIOLATION
 - **Send a brief ack** if the task will take >~4 seconds: "On it.", "Looking into this.", "Writing that up."
 - **Skip the ack** for fast inline responses, button callbacks, reaction messages, or system messages.
 
+**Critical ack gate — questions require answers, not acks:**
+If the message contains a **direct question**, the ack policy does not apply. The response must answer the question, even if brief. "Noted." is never an acceptable response to a direct question.
+
+Signals that a message is a question:
+- Contains a `?`
+- Starts or contains: "does that mean", "are you", "will you", "did you", "what does", "what is", "what are", "how do", "can you explain", "is that", "do you"
+- Imperative requests for status or explanation: "tell me", "explain", "clarify"
+
+For questions that require investigation (e.g., "what is the current state of X?"), spawn a subagent to find the answer — never reply "Noted." and never skip the question.
+
 Note: The Telegram bot sends "📨 Message received. Processing..." automatically at the transport layer. Your ack is a second, dispatcher-level signal that work is underway.
 
 **Preferred pattern (use `claim_and_ack` for long tasks):**


### PR DESCRIPTION
## Problem

When a user followed up a behavior correction with a direct question ("does that mean you won't take action or are you spinning up a subagent?"), the dispatcher replied "Noted." — treating a question as a task-initiation message and applying the ack policy instead of answering.

The 7-second rule creates exit pressure that, combined with a message pattern-matching "behavioral note from user", produces the path of least resistance: "Noted." → mark_processed → wait_for_messages. No gate checked whether the message was actually a question.

## Fix

Added a **Critical ack gate** section to `sys.dispatcher.bootup.md`, immediately after the existing ack policy rules:

> If the message contains a direct question, the ack policy does not apply. The response must answer the question, even if brief. "Noted." is never an acceptable response to a direct question.

The rule lists concrete signals: `?` in the message, interrogative phrases ("does that mean", "are you", "will you", "did you", "what is", "how do", etc.), and imperative requests for status/explanation ("tell me", "explain", "clarify").

For questions requiring investigation, the dispatcher must spawn a subagent to find the answer rather than sending an ack.

## Why a bootup rule (not a hook)

The issue proposes two options: (1) dispatcher bootup rule or (2) PreToolUse hook blocking mark_processed when message is a question and reply is 1-3 words. This PR implements option 1.

A hook approach would catch the symptom but not the cause. The dispatcher should not even reach the "should I ack?" decision when the message is a question — the rule needs to fire at message-classification time. A bootup rule forces that check before any ack is composed.

## Test plan

- [ ] Read the diff — the new rule appears in the ack policy section of sys.dispatcher.bootup.md
- [ ] Manual test: send a question after a behavioral correction ("does that mean you'll do X?") — dispatcher should answer directly, not reply "Noted."
- [ ] No code changes, so no unit test needed

Closes #1019