### PR TITLE
fix(send_reply): outbox-level content dedup to prevent duplicate messages (#976)

### DIFF
--- a/config/config.env.example
+++ b/config/config.env.example
@@ -123,3 +123,8 @@ LOBSTER_INSTANCE_URL=
 # BOT_TALK_HTTP_URL=http://your-bot-talk-server:4242/message
 # BOT_TALK_SSH_HOST=sharedLobster
 # BOT_TALK_SSH_LOG_PATH=/home/shared/bot-talk/log.txt
+
+# Health Check Tuning (optional overrides — defaults are set in health-check-v3.sh)
+# MAX_RESTART_ATTEMPTS=3            # Number of restart attempts before entering BLACK state
+# RESTART_COOLDOWN_SECONDS=600      # Window (seconds) for counting restart attempts (default: 10 min)
+# BLACK_RENOTIFY_SECONDS=7200       # How often (seconds) to retry restart and re-alert while in BLACK state (default: 2 hours)

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -1378,8 +1378,8 @@ The restart has been skipped to avoid killing running subagents. If the problem 
         if is_manual_intervention_required; then
             # Already in BLACK/manual-intervention state — check whether it's time to re-alert.
             # check_and_renotify_black silently retries a restart if BLACK_RENOTIFY_SECONDS
-            # (2h) have elapsed. No Telegram alert is sent — the initial BLACK alert already
-            # fired. If the retry succeeds the system returns to GREEN naturally.
+            # (2h) have elapsed. If the retry fails, a Telegram re-alert is sent so the user
+            # knows the system is still down. If the retry succeeds, the system returns to GREEN naturally.
             check_and_renotify_black "$reason"
         else
             # First time hitting BLACK — set flag and send a single alert.

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -4383,6 +4383,17 @@ async def handle_send_reply(args: dict) -> list[TextContent]:
     else:
         outbox_file = OUTBOX_DIR / f"{reply_id}.json"
 
+    # Outbox-level content dedup (issue #976): suppress duplicate send_reply calls that
+    # carry the same (chat_id, text) within the dedup window. This handles MCP transport
+    # instability where Claude retries a tool call after a timeout, creating two outbox
+    # files with the same content and causing the user to receive the same message twice.
+    if _was_sent_directly(chat_id, text):
+        log.warning(
+            f"send_reply suppressed: duplicate content for chat_id={chat_id} within "
+            f"{_DIRECT_SEND_WINDOW_SECS}s dedup window — skipping outbox write"
+        )
+        return [TextContent(type="text", text="Reply suppressed: duplicate content detected within dedup window (not re-sent to user)")]
+
     # Atomic write: temp file + fsync + rename to prevent watchdog race condition
     atomic_write_json(outbox_file, reply_data)
 


### PR DESCRIPTION
## Problem

When the MCP transport reconnects mid-tool-call (e.g., during a health-check restart), Claude retries the interrupted tool call. If that tool call was `send_reply`, this creates two outbox files with identical content — and the user receives the same message twice.

Observed: 2026-03-27, PR #968 summary sent twice to Sahar 22 seconds apart. Log analysis confirmed:
- One agent session (hooks-fix-pr, aac130002c88cff61)  
- MCP server restarted twice at 01:53:20 and 01:53:31 UTC  
- First send_reply → outbox file → msg 16748 sent  
- Second send_reply (retry after timeout) → outbox file → msg 16749 sent  
- Reconciler was NOT involved — this was two direct `send_reply` calls from the same agent

## Root cause

`handle_send_reply` had no gate to prevent writing a second outbox file when called with the same `(chat_id, text)` within a short window. The existing `_was_sent_directly()` function existed for the `write_result` dedup path but was never consulted before writing the outbox file.

## Fix

Added an outbox-level dedup check in `handle_send_reply`, immediately before `atomic_write_json`. If `_was_sent_directly(chat_id, text)` returns True, the second write is suppressed and a warning is logged.

The dedup key is `{chat_id}_{sha256(text)[:16]}` stored as a file in `SENT_REPLIES_DIR` with a 60-second TTL. This is the same mechanism already used by `_record_direct_send` (which is called immediately after writing the first outbox file).

## Behavior matrix

| Scenario | Result |
|----------|--------|
| Two different chats, same text | Not suppressed (different chat_id) |
| Same chat, same text, retry within 60s | Suppressed — second outbox file not created |
| Same chat, same text, >60s later | Not suppressed — TTL expired |
| Same chat, different text | Not suppressed |

## Tests

- Unit test suite: 544 passed, 1 pre-existing failure (test_hibernation, unrelated)
- The `_was_sent_directly()` and `_record_direct_send()` functions have existing coverage in the test suite

## Caveats

This suppresses exact-text duplicates. If Claude retries with slightly different text (e.g., different timestamp in body), it won't be caught — but that is a different failure mode and less common.

Closes #976