### PR TITLE
fix(hooks): auto-register-agent builds meaningful descriptions (#894)

### DIFF
--- a/hooks/auto-register-agent.py
+++ b/hooks/auto-register-agent.py
@@ -120,8 +120,47 @@ def _extract_task_id_from_text(prompt: str) -> str | None:
     return match.group(1) if match else None
 
 
+def _build_description(task_id: str | None, prompt: str) -> str:
+    """Build a human-readable description for this agent session.
+
+    Priority:
+    1. If task_id is present, use it as the base (e.g. "my-task-id").
+    2. Append a brief excerpt from the first non-empty, non-frontmatter line of
+       the prompt so the dispatcher can tell what the agent was asked to do.
+    3. Fall back to a generic label only when there is truly nothing useful.
+
+    The result is capped at 120 characters.
+    """
+    # Skip past YAML frontmatter block (--- ... ---) to find the first real line
+    body = prompt.lstrip()
+    if body.startswith("---"):
+        rest = body[3:]
+        end = rest.find("\n---")
+        if end != -1:
+            body = rest[end + 4:].lstrip()  # text after closing ---
+
+    # Grab the first non-empty line as the task excerpt
+    first_line = ""
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped:
+            first_line = stripped
+            break
+
+    if task_id and first_line:
+        desc = f"{task_id}: {first_line}"
+    elif task_id:
+        desc = task_id
+    elif first_line:
+        desc = first_line
+    else:
+        desc = "subagent (no description)"
+
+    return desc[:120]
+
+
 def extract_metadata(prompt: str) -> dict:
-    """Return a dict with task_id, chat_id, source, reply_to_message_id from prompt.
+    """Return a dict with task_id, chat_id, source, reply_to_message_id, description from prompt.
 
     Tries YAML frontmatter first. Falls back to text parsing for task_id.
     All values are strings (or None if absent).
@@ -132,6 +171,7 @@ def extract_metadata(prompt: str) -> dict:
     chat_id = fm.get("chat_id")
     source = fm.get("source", "telegram")
     reply_to_message_id = fm.get("reply_to_message_id")
+    description = _build_description(task_id, prompt)
 
     return {
         "task_id": task_id,
@@ -140,6 +180,7 @@ def extract_metadata(prompt: str) -> dict:
         "reply_to_message_id": (
             str(reply_to_message_id) if reply_to_message_id is not None else None
         ),
+        "description": description,
     }
 
 
@@ -197,6 +238,7 @@ def insert_agent_session(
     session_id: str,
     output_file: str | None,
     input_summary: str | None,
+    description: str,
 ) -> None:
     """Insert a 'running' row into agent_sessions.db.
 
@@ -246,12 +288,13 @@ def insert_agent_session(
                 (id, task_id, agent_type, description, chat_id, source,
                  status, output_file, input_summary, spawned_at)
             VALUES
-                (?, ?, 'subagent', 'auto-registered by PostToolUse hook', ?, ?,
+                (?, ?, 'subagent', ?, ?, ?,
                  'running', ?, ?, ?)
             """,
             (
                 agent_id,
                 task_id,
+                description,
                 chat_id if chat_id is not None else "0",
                 source,
                 output_file,
@@ -306,6 +349,7 @@ def main() -> None:
             session_id=session_id,
             output_file=output_file,
             input_summary=input_summary,
+            description=metadata["description"],
         )
 
     except Exception as exc:  # noqa: BLE001

--- a/tests/unit/test_hooks/test_auto_register_agent.py
+++ b/tests/unit/test_hooks/test_auto_register_agent.py
@@ -43,6 +43,7 @@ _mod = _load_module()
 extract_metadata = _mod.extract_metadata
 extract_agent_id = _mod.extract_agent_id
 extract_output_file = _mod.extract_output_file
+_build_description = _mod._build_description
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +162,66 @@ class TestExtractMetadata:
         meta = extract_metadata(prompt)
         # Frontmatter parse fails, legacy text used
         assert meta["task_id"] == "textid"
+
+
+# ---------------------------------------------------------------------------
+# _build_description: pure function tests (#894)
+# ---------------------------------------------------------------------------
+
+class TestBuildDescription:
+    def test_task_id_and_first_line(self):
+        """task_id + first prompt line are combined."""
+        desc = _build_description("my-task", "---\ntask_id: my-task\n---\nDo some work.")
+        assert desc == "my-task: Do some work."
+
+    def test_task_id_only_no_body(self):
+        """Frontmatter with no body after closing --- uses task_id alone."""
+        desc = _build_description("slim-task", "---\ntask_id: slim-task\n---\n")
+        assert desc == "slim-task"
+
+    def test_no_task_id_uses_first_line(self):
+        """Without task_id, the first non-empty prompt line is used."""
+        desc = _build_description(None, "Fix the bug in the scheduler.")
+        assert desc == "Fix the bug in the scheduler."
+
+    def test_empty_prompt_fallback(self):
+        """Empty prompt and no task_id falls back to generic label."""
+        desc = _build_description(None, "")
+        assert desc == "subagent (no description)"
+
+    def test_truncated_to_120_chars(self):
+        """Descriptions longer than 120 chars are truncated."""
+        long_line = "A" * 200
+        desc = _build_description("t", long_line)
+        assert len(desc) <= 120
+
+    def test_skips_frontmatter_lines_for_excerpt(self):
+        """Lines inside the frontmatter block are not used as the excerpt."""
+        prompt = "---\ntask_id: myid\nchat_id: 123\n---\nActual task body here."
+        desc = _build_description("myid", prompt)
+        assert "chat_id" not in desc
+        assert "Actual task body here." in desc
+
+    def test_description_in_extract_metadata(self):
+        """extract_metadata includes a 'description' key."""
+        prompt = "---\ntask_id: t-desc\n---\nCheck the logs."
+        meta = extract_metadata(prompt)
+        assert "description" in meta
+        assert meta["description"] == "t-desc: Check the logs."
+
+    def test_description_stored_in_db(self, tmp_path):
+        """Integration: description from prompt ends up in the DB row."""
+        prompt = "---\ntask_id: t-db-desc\nchat_id: 777\n---\nVerify the deployment."
+        hook_input = _make_hook_input(
+            prompt=prompt,
+            tool_response={"agentId": "agent-db-desc"},
+        )
+        exit_code, _, _ = _run_hook(hook_input, tmp_path)
+        assert exit_code == 0
+
+        row = _get_row(tmp_path, "agent-db-desc")
+        assert row is not None
+        assert row["description"] == "t-db-desc: Verify the deployment."
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

After a restart, `get_active_sessions()` returns running subagents with the description `"auto-registered by PostToolUse hook"`. This is opaque — the dispatcher cannot tell what a running agent was tasked with, making it impossible to answer user questions about in-progress work.

## Fix

Added `_build_description()` to `auto-register-agent.py` that derives a meaningful description from the agent prompt:

1. **task_id + first body line** (primary): e.g. `"my-task-id: Fix the bug in the scheduler."`
2. **task_id alone** if there's no body text after the frontmatter
3. **First non-frontmatter line** if there's no task_id
4. **Generic fallback**: `"subagent (no description)"` only when there's truly nothing

Result is capped at 120 characters.

The description is now stored in `agent_sessions.db` instead of the generic placeholder.

## Tests

Added 8 unit tests covering:
- `_build_description()` pure function (task_id+line, task_id only, no task_id, empty, truncation, frontmatter skip)
- `extract_metadata()` now includes `description` key
- Integration: description value ends up in the DB row

## Before / After

Before: `"auto-registered by PostToolUse hook"`
After: `"librarian-batch-17: You are working in autonomous librarian mode..."`

Fixes #894

## Test plan
- [x] Run `uv run pytest tests/unit/test_hooks/test_auto_register_agent.py` — 8 new tests pass, no regressions
- [ ] After deploy, verify `get_active_sessions()` shows meaningful descriptions for new subagents