### PR TITLE
fix(health-check): downgrade stale-inbox to YELLOW when dispatcher is actively busy (#1078 Fix B)

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -85,6 +85,9 @@ RESTART_COOLDOWN_SUPPRESS_SECONDS=240 # 4 minutes - suppress stale-inbox RED aft
 
 BOOT_GRACE_SECONDS=90                # 90s - skip stale-inbox, WFM, and process checks after a restart
 
+DISPATCHER_BUSY_SECONDS=90           # 90s - if last_thinking_at is this fresh, dispatcher is actively busy;
+                                     # downgrade stale-inbox from RED to YELLOW (issue #1078 Fix B)
+
 HIBERNATE_FRESH_SECONDS=30           # Ignore hibernate state younger than this — transient dispatcher hibernation
 
 WFM_STALE_SECONDS=1200               # 20 minutes - RED if wait_for_messages not called since this long ago (raised from 600 to accommodate long reasoning/subagent-spawning phases)
@@ -651,6 +654,42 @@ is_recent_restart() {
     local age=$((now - restart_epoch))
     if [[ $age -le $RESTART_COOLDOWN_SUPPRESS_SECONDS ]]; then
         log_info "Recent restart ${age}s ago (cooldown: ${RESTART_COOLDOWN_SUPPRESS_SECONDS}s) — stale-inbox RED suppressed"
+        return 0
+    fi
+    return 1
+}
+
+# Check if the dispatcher is actively busy — i.e. making tool calls right now.
+# If last_thinking_at is fresh (within DISPATCHER_BUSY_SECONDS), the dispatcher
+# is in the middle of processing and a stale inbox is a false alarm, not a stall.
+# This prevents restarts when a busy startup backlog causes user messages to age
+# while the dispatcher is legitimately working through lower-priority items.
+# (issue #1078 Fix B)
+#
+# Returns 0 (true) if dispatcher is actively busy, 1 otherwise.
+is_dispatcher_busy() {
+    if [[ ! -f "$LOBSTER_STATE_FILE" ]]; then
+        return 1
+    fi
+    local last_thinking_at
+    last_thinking_at=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open('$LOBSTER_STATE_FILE'))
+    print(d.get('last_thinking_at', ''))
+except Exception:
+    print('')
+" 2>/dev/null)
+    if [[ -z "$last_thinking_at" ]]; then
+        return 1
+    fi
+    local thinking_epoch
+    thinking_epoch=$(date -d "$last_thinking_at" +%s 2>/dev/null) || return 1
+    local now
+    now=$(date +%s)
+    local age=$((now - thinking_epoch))
+    if [[ $age -le $DISPATCHER_BUSY_SECONDS ]]; then
+        log_info "Dispatcher active: last tool call ${age}s ago (threshold: ${DISPATCHER_BUSY_SECONDS}s) — stale-inbox RED downgraded to YELLOW (issue #1078)"
         return 0
     fi
     return 1
@@ -1942,6 +1981,11 @@ main() {
                     local inbox_rc=$?
                     if [[ $inbox_rc -eq 2 ]]; then
                         if is_recent_restart; then
+                            [[ "$level" == "GREEN" ]] && level="YELLOW"
+                        elif is_dispatcher_busy; then
+                            # Dispatcher is actively making tool calls — a stale inbox means
+                            # it's processing a backlog, not stuck. Downgrade to YELLOW.
+                            # (issue #1078 Fix B: activity-aware health check)
                             [[ "$level" == "GREEN" ]] && level="YELLOW"
                         else
                             level="RED"

--- a/tests/smoke/test_health_check.py
+++ b/tests/smoke/test_health_check.py
@@ -516,3 +516,139 @@ def test_wfm_freshness_green_when_last_processed_absent_heartbeat_recent(
         "state files that predate issue #694.\n"
         f"stderr: {result.stderr!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# D6 — is_dispatcher_busy: activity-aware inbox staleness (issue #1078 Fix B)
+# ---------------------------------------------------------------------------
+#
+# When the dispatcher is actively making tool calls (fresh last_thinking_at),
+# a stale inbox is a false alarm — the dispatcher is processing a backlog, not
+# stuck. is_dispatcher_busy() detects this by reading last_thinking_at from
+# lobster-state.json and returning true if it's within DISPATCHER_BUSY_SECONDS.
+
+# Must match DISPATCHER_BUSY_SECONDS in health-check-v3.sh.
+DISPATCHER_BUSY_SECONDS = 90
+
+
+def _is_dispatcher_busy_script(state_file: Path, tmp_path: Path) -> str:
+    """
+    Build a self-contained bash fragment that calls is_dispatcher_busy()
+    and exits with its return code (0=busy, 1=not busy).
+    """
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "health-check.log"
+
+    fn_body = _extract_function("is_dispatcher_busy")
+
+    return f"""
+#!/bin/bash
+LOBSTER_STATE_FILE="{state_file}"
+DISPATCHER_BUSY_SECONDS={DISPATCHER_BUSY_SECONDS}
+LOG_FILE="{log_file}"
+mkdir -p "$(dirname "$LOG_FILE")"
+log()      {{ echo "[$(date -Iseconds)] [$1] $2" >> "$LOG_FILE"; }}
+log_info() {{ log "INFO" "$1"; }}
+
+{fn_body}
+
+is_dispatcher_busy
+exit $?
+"""
+
+
+def test_dispatcher_busy_returns_true_when_thinking_recent(tmp_path: Path) -> None:
+    """
+    D6a: is_dispatcher_busy() must return 0 (true) when last_thinking_at is
+    within DISPATCHER_BUSY_SECONDS.
+
+    Failure mode: if this returns false for a fresh last_thinking_at, a busy
+    dispatcher processing a backlog gets restarted while it's actively working
+    (the original issue #1078 false alarm scenario).
+    """
+    state_file = tmp_path / "lobster-state.json"
+    recent_ts = datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    state_file.write_text(json.dumps({"mode": "active", "last_thinking_at": recent_ts}))
+
+    fragment = _is_dispatcher_busy_script(state_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode == 0, (
+        "is_dispatcher_busy() returned false (non-zero) for a fresh last_thinking_at, "
+        "but should return true (0) when the dispatcher made a tool call within "
+        f"the last {DISPATCHER_BUSY_SECONDS}s.\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_dispatcher_busy_returns_false_when_thinking_stale(tmp_path: Path) -> None:
+    """
+    D6b: is_dispatcher_busy() must return 1 (false) when last_thinking_at is
+    older than DISPATCHER_BUSY_SECONDS.
+
+    Failure mode: if this returns true for a stale last_thinking_at, a genuinely
+    stuck dispatcher would never trigger a RED restart because the health check
+    would always think it's busy.
+    """
+    state_file = tmp_path / "lobster-state.json"
+    stale_epoch = time.time() - (DISPATCHER_BUSY_SECONDS + 120)
+    stale_ts = datetime.fromtimestamp(stale_epoch, tz=timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%S+00:00"
+    )
+    state_file.write_text(json.dumps({"mode": "active", "last_thinking_at": stale_ts}))
+
+    fragment = _is_dispatcher_busy_script(state_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode != 0, (
+        "is_dispatcher_busy() returned true (0) for a last_thinking_at that is "
+        f"{DISPATCHER_BUSY_SECONDS + 120}s old. A dispatcher that has been silent "
+        f"for >{DISPATCHER_BUSY_SECONDS}s is not busy — inbox staleness must still "
+        "trigger RED.\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_dispatcher_busy_returns_false_when_state_absent(tmp_path: Path) -> None:
+    """
+    D6c: is_dispatcher_busy() must return 1 (false) when lobster-state.json
+    does not exist.
+
+    Failure mode: if this returns true when the state file is missing, the health
+    check would never restart a stuck dispatcher on fresh installs or after the
+    state file is deleted.
+    """
+    missing_state_file = tmp_path / "nonexistent-state.json"
+    # Do NOT create the file.
+
+    fragment = _is_dispatcher_busy_script(missing_state_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode != 0, (
+        "is_dispatcher_busy() returned true (0) when lobster-state.json does not "
+        "exist. A missing state file cannot indicate activity — must return false.\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_dispatcher_busy_returns_false_when_thinking_absent(tmp_path: Path) -> None:
+    """
+    D6d: is_dispatcher_busy() must return 1 (false) when lobster-state.json
+    exists but has no last_thinking_at field.
+
+    Failure mode: if this returns true for a state file without last_thinking_at
+    (e.g. an older install that predates the thinking-heartbeat hook), the health
+    check would silently suppress all stale-inbox restarts.
+    """
+    state_file = tmp_path / "lobster-state.json"
+    state_file.write_text(json.dumps({"mode": "active"}))  # no last_thinking_at
+
+    fragment = _is_dispatcher_busy_script(state_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode != 0, (
+        "is_dispatcher_busy() returned true (0) when last_thinking_at is absent "
+        "from lobster-state.json. A missing field must not indicate activity.\n"
+        f"stderr: {result.stderr!r}"
+    )


### PR DESCRIPTION
## Summary

- Adds `is_dispatcher_busy()` to `health-check-v3.sh` which reads `last_thinking_at` from `lobster-state.json` (written by `hooks/thinking-heartbeat.py` on every PostToolUse event)
- When the dispatcher made a tool call within the last 90s (`DISPATCHER_BUSY_SECONDS`), a stale inbox is downgraded from RED to YELLOW — no restart triggered
- This prevents the 2026-03-28 false-alarm incident where a startup backlog caused user messages to age while cron tasks ran first, and the health check restarted a healthy dispatcher

## Fix B from issue #1078

The three fixes recommended in the issue:
- **Fix A** (user-message priority ordering): addressed by PR #1485 / issue #1079
- **Fix B** (activity-aware health check): this PR
- **Fix C** (boot grace period): already implemented before this issue

## Test plan

- [x] 4 new smoke tests added (`D6a-D6d` in `tests/smoke/test_health_check.py`)
- [x] `D6a`: returns true (busy) when `last_thinking_at` is fresh (within 90s)
- [x] `D6b`: returns false (not busy) when `last_thinking_at` is stale (>90s)
- [x] `D6c`: returns false when `lobster-state.json` does not exist
- [x] `D6d`: returns false when `last_thinking_at` is absent from state file
- [x] All 13 passing tests in `test_health_check.py` still pass
- [x] `bash -n` syntax check passes

Closes #1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)