### PR TITLE
feat: implement contextual skill activation mode (#1054)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1001,7 +1001,9 @@ Never break out of this loop on a "Hibernating" or "EXIT" signal. Never pass `ti
 
 ## Skill System
 
-At message processing start (when skills are enabled), call `get_skill_context` to load assembled context from all active skills. Apply returned instructions alongside base context.
+At message processing start (when skills are enabled), call `get_skill_context_for_message` with the incoming message text to load assembled context from all active skills — including any skills with `activation_mode = "contextual"` whose `context_patterns` match the message. Apply returned instructions alongside base context.
+
+If message text is not yet available (e.g. system messages), fall back to `get_skill_context` (no message argument).
 
 **Commands:**
 - `/shop` / `/shop list` → `list_skills`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Skills are rich four-dimensional units (behavior + context + preferences + tooli
 - `triggered` — Skill activates when its triggers (commands/keywords) are detected
 - `contextual` — Skill activates when message context matches its patterns
 
-**Skill MCP tools:** `get_skill_context`, `list_skills`, `activate_skill`, `deactivate_skill`, `get_skill_preferences`, `set_skill_preference`
+**Skill MCP tools:** `get_skill_context_for_message` (preferred — evaluates contextual skills), `get_skill_context` (fallback — always-active only), `list_skills`, `activate_skill`, `deactivate_skill`, `get_skill_preferences`, `set_skill_preference`
 
 > **Dispatcher-only:** skill loading at message start and `/shop`/`/skill` command handling are documented in `.claude/sys.dispatcher.bootup.md`.
 

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -101,6 +101,7 @@ from claims import AtomicClaimDB as _AtomicClaimDB
 from skill_manager import (
     list_available_skills as _list_available_skills,
     get_skill_context as _get_skill_context,
+    get_skill_context_for_message as _get_skill_context_for_message,
     activate_skill as _activate_skill,
     deactivate_skill as _deactivate_skill,
     get_skill_preferences as _get_skill_preferences,
@@ -3004,6 +3005,20 @@ async def list_tools() -> list[Tool]:
             },
         ),
         Tool(
+            name="get_skill_context_for_message",
+            description="Get assembled context from all active skills, including contextual skills that match the current message. Pass the incoming message text to activate skills with activation_mode='contextual' whose context_patterns match. Use this instead of get_skill_context when you have message text available (at message processing start).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "message_text": {
+                        "type": "string",
+                        "description": "The incoming message text to evaluate contextual skill patterns against.",
+                    },
+                },
+                "required": ["message_text"],
+            },
+        ),
+        Tool(
             name="list_skills",
             description="List available skills in the Lobster Shop. Shows install/active status for each skill.",
             inputSchema={
@@ -3531,6 +3546,8 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[TextConte
     # Skill Management Tools
     elif name == "get_skill_context":
         return await handle_get_skill_context(arguments)
+    elif name == "get_skill_context_for_message":
+        return await handle_get_skill_context_for_message(arguments)
     elif name == "list_skills":
         return await handle_list_skills(arguments)
     elif name == "activate_skill":
@@ -8493,6 +8510,21 @@ async def handle_get_skill_context(args: dict) -> list[TextContent]:
         return [TextContent(type="text", text=context)]
     except Exception as e:
         log.error(f"get_skill_context failed: {e}", exc_info=True)
+        return [TextContent(type="text", text=f"Error: {e}")]
+
+
+async def handle_get_skill_context_for_message(args: dict) -> list[TextContent]:
+    """Return assembled context from active skills, including contextual skill matching."""
+    message_text = args.get("message_text", "").strip()
+    if not message_text:
+        return [TextContent(type="text", text="Error: message_text is required.")]
+    try:
+        context = _get_skill_context_for_message(message_text)
+        if not context:
+            return [TextContent(type="text", text="No active skills.")]
+        return [TextContent(type="text", text=context)]
+    except Exception as e:
+        log.error(f"get_skill_context_for_message failed: {e}", exc_info=True)
         return [TextContent(type="text", text=f"Error: {e}")]
 
 

--- a/src/mcp/inbox_server_http.py
+++ b/src/mcp/inbox_server_http.py
@@ -109,6 +109,7 @@ READONLY_TOOLS = frozenset({
     "transcribe_audio",
     # Skill reading
     "get_skill_context",
+    "get_skill_context_for_message",
     "list_skills",
     "get_skill_preferences",
 })

--- a/src/mcp/skill_manager.py
+++ b/src/mcp/skill_manager.py
@@ -27,6 +27,7 @@ Design principles (following tracker.py patterns):
 import fcntl
 import json
 import os
+import re
 import tempfile
 import tomllib
 from datetime import datetime, timezone
@@ -385,6 +386,139 @@ def get_skill_context(
             skill_dirs[name] = skill_dir
 
     return _assemble_context(skill_dirs, active, state)
+
+
+def _pattern_matches_message(pattern: str, message_text: str) -> bool:
+    """Check if a context_pattern matches the given message text.
+
+    Patterns are natural-language descriptions like "when user asks about X".
+    Matching strategy: extract meaningful keywords from the pattern and check
+    if the message contains them (case-insensitive). This avoids LLM calls
+    while still catching the most common cases.
+
+    For patterns starting with "when user asks about/to/for ...", we extract
+    the subject and look for it in the message.
+    """
+    if not pattern or not message_text:
+        return False
+
+    message_lower = message_text.lower()
+    pattern_lower = pattern.lower()
+
+    # Strip common preamble phrases to get subject keywords
+    strip_prefixes = [
+        r"^when (?:the )?user (?:asks?|wants?|mentions?|requests?|says?|tells?|needs?)"
+        r"(?: to| about| for| if| whether| that| how| when| what|'s| regarding)?:?\s*",
+        r"^when (?:discussing|reviewing|working on|checking|looking at)\s+",
+        r"^when lobster (?:confirms?|starts?|begins?|is|has)\s+",
+        r"^when (?:the )?message (?:contains?|mentions?|includes?|is about)\s*",
+        r"^when\s+",
+    ]
+
+    subject = pattern_lower
+    for prefix_re in strip_prefixes:
+        subject = re.sub(prefix_re, "", subject)
+
+    # Remove filler words to get content words
+    filler = {"a", "an", "the", "their", "its", "some", "any", "or", "and", "to", "in",
+               "on", "at", "of", "for", "with", "by", "from", "is", "are", "be", "been"}
+    words = [w for w in re.findall(r"[a-z0-9][\w-]*", subject) if w not in filler and len(w) > 2]
+
+    if not words:
+        return False
+
+    # Match if at least half the content words appear in the message
+    # (minimum 1 word must match)
+    matches = sum(1 for w in words if w in message_lower)
+    threshold = max(1, len(words) // 2)
+    return matches >= threshold
+
+
+def _get_contextual_skills_data(
+    repo_dir: Path,
+    config_dir: str,
+    state_path: Path,
+) -> list[tuple[str, Path, list[str], int]]:
+    """Return (name, dir, patterns, priority) for installed+active contextual skills."""
+    state = _read_store(state_path)
+    skill_dirs_map: dict[str, Path] = {}
+    for skill_dir in _resolve_skill_dirs(repo_dir, config_dir):
+        manifest = _parse_manifest(skill_dir)
+        if manifest:
+            name = _extract_skill_name(manifest, skill_dir.name)
+            skill_dirs_map[name] = skill_dir
+
+    result = []
+    for name, info in state.get("skills", {}).items():
+        if not info.get("active", False):
+            continue
+        if info.get("activation_mode", "always") != "contextual":
+            continue
+        if name not in skill_dirs_map:
+            continue
+        skill_dir = skill_dirs_map[name]
+        manifest = _parse_manifest(skill_dir)
+        if not manifest:
+            continue
+        patterns = manifest.get("activation", {}).get("context_patterns", [])
+        priority = info.get("priority", 50)
+        result.append((name, skill_dir, patterns, priority))
+    return result
+
+
+def get_skill_context_for_message(
+    message_text: str,
+    repo_dir: Path | None = None,
+    config_dir: str | None = None,
+    state_path: Path = _DEFAULT_STATE_PATH,
+) -> str:
+    """Assemble context from active skills, including contextual skills that match the message.
+
+    For skills with activation_mode='always' or 'triggered': included if active.
+    For skills with activation_mode='contextual': included only if a context_pattern
+    matches the message text.
+
+    Returns markdown string ready for injection into Claude's context.
+    Empty string if no skills are active/matched.
+    """
+    repo_dir = repo_dir or _REPO_DIR
+    config_dir = config_dir or _CONFIG_DIR
+
+    state = _read_store(state_path)
+
+    # Collect always-active and triggered skills (standard path)
+    standard_active = [
+        name for name, info in state.get("skills", {}).items()
+        if info.get("active", False) and info.get("activation_mode", "always") != "contextual"
+    ]
+
+    # Evaluate contextual skills against the message
+    contextual_matches: list[str] = []
+    for name, skill_dir, patterns, priority in _get_contextual_skills_data(
+        repo_dir, config_dir, state_path
+    ):
+        if any(_pattern_matches_message(p, message_text) for p in patterns):
+            contextual_matches.append(name)
+
+    all_active = standard_active + contextual_matches
+    if not all_active:
+        return ""
+
+    # Build name -> dir mapping
+    skill_dirs: dict[str, Path] = {}
+    for skill_dir in _resolve_skill_dirs(repo_dir, config_dir):
+        manifest = _parse_manifest(skill_dir)
+        if manifest:
+            name = _extract_skill_name(manifest, skill_dir.name)
+            skill_dirs[name] = skill_dir
+
+    result = _assemble_context(skill_dirs, all_active, state)
+
+    if contextual_matches:
+        note = "\n\n> **Contextual skills activated for this message:** " + ", ".join(contextual_matches)
+        result = result + note
+
+    return result
 
 
 def activate_skill(

--- a/tests/unit/test_skill_manager.py
+++ b/tests/unit/test_skill_manager.py
@@ -516,3 +516,210 @@ class TestGracefulDegradation:
         )
         # Still returns empty since no content to assemble
         assert result == ""
+
+
+# =============================================================================
+# Contextual Skill Activation
+# =============================================================================
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src" / "mcp"))
+from skill_manager import (
+    _pattern_matches_message,
+    get_skill_context_for_message,
+)
+
+
+class TestPatternMatchesMessage:
+    def test_simple_keyword_match(self):
+        """Pattern keywords are found in the message."""
+        assert _pattern_matches_message(
+            "when user asks about email",
+            "Can you check my email for me?",
+        )
+
+    def test_no_match_unrelated_message(self):
+        """Unrelated message does not match."""
+        assert not _pattern_matches_message(
+            "when user asks about email",
+            "What is the weather like today?",
+        )
+
+    def test_empty_pattern_no_match(self):
+        """Empty pattern never matches."""
+        assert not _pattern_matches_message("", "Some message")
+
+    def test_empty_message_no_match(self):
+        """Empty message never matches."""
+        assert not _pattern_matches_message("when user asks about email", "")
+
+    def test_case_insensitive(self):
+        """Matching is case-insensitive."""
+        assert _pattern_matches_message(
+            "when user asks about CALENDAR",
+            "Add something to my calendar",
+        )
+
+    def test_partial_word_match(self):
+        """Short filler words are excluded, content words match."""
+        assert _pattern_matches_message(
+            "when user wants to schedule a meeting",
+            "I need to schedule a team meeting",
+        )
+
+    def test_real_hibernation_pattern(self):
+        """Hibernation skill context patterns match expected messages."""
+        pattern = "when wait_for_messages returns a timeout with hibernate_on_timeout=True"
+        assert _pattern_matches_message(
+            pattern,
+            "wait_for_messages returned timeout hibernate_on_timeout=True",
+        )
+
+    def test_real_gmail_pattern(self):
+        """Gmail skill pattern matches email-related messages."""
+        assert _pattern_matches_message(
+            "when user asks to check their email",
+            "Can you check my email inbox?",
+        )
+
+
+class TestGetSkillContextForMessage:
+    def _create_contextual_skill(self, shop_dir: Path, name: str, patterns: list[str], behavior_text: str):
+        """Helper to create a contextual skill with behavior content."""
+        skill_dir = shop_dir / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+
+        patterns_toml = "\n".join(f'    "{p}",' for p in patterns)
+        toml = f"""[skill]
+name = "{name}"
+version = "1.0.0"
+description = "Test contextual skill"
+category = "behavioral"
+
+[activation]
+mode = "contextual"
+context_patterns = [
+{patterns_toml}
+]
+
+[layering]
+priority = 50
+merge_strategy = "append"
+"""
+        (skill_dir / "skill.toml").write_text(toml)
+        behavior_dir = skill_dir / "behavior"
+        behavior_dir.mkdir()
+        (behavior_dir / "main.md").write_text(behavior_text)
+
+    def test_contextual_skill_activates_on_match(self, tmp_path):
+        """Contextual skill is included when its pattern matches the message."""
+        shop_dir = tmp_path / "lobster-shop"
+        self._create_contextual_skill(
+            shop_dir, "test-contextual",
+            patterns=["when user asks about calendar"],
+            behavior_text="## Calendar behavior",
+        )
+
+        state_path = tmp_path / "state.json"
+        # Activate the skill in contextual mode (already set in toml, but we need state entry)
+        activate_skill("test-contextual", mode="contextual", state_path=state_path, repo_dir=tmp_path)
+
+        result = get_skill_context_for_message(
+            "Can you add this to my calendar?",
+            repo_dir=tmp_path,
+            state_path=state_path,
+        )
+        assert "Calendar behavior" in result
+        assert "test-contextual" in result
+
+    def test_contextual_skill_skipped_on_no_match(self, tmp_path):
+        """Contextual skill is NOT included when pattern doesn't match."""
+        shop_dir = tmp_path / "lobster-shop"
+        self._create_contextual_skill(
+            shop_dir, "test-contextual",
+            patterns=["when user asks about calendar"],
+            behavior_text="## Calendar behavior",
+        )
+
+        state_path = tmp_path / "state.json"
+        activate_skill("test-contextual", mode="contextual", state_path=state_path, repo_dir=tmp_path)
+
+        result = get_skill_context_for_message(
+            "What is the weather today?",
+            repo_dir=tmp_path,
+            state_path=state_path,
+        )
+        assert "Calendar behavior" not in result
+
+    def test_always_skill_always_included(self, tmp_path):
+        """Always-mode skill is always included regardless of message."""
+        shop_dir = tmp_path / "lobster-shop"
+        skill_dir = shop_dir / "always-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "skill.toml").write_text("""[skill]
+name = "always-skill"
+version = "1.0.0"
+description = "Always active"
+category = "behavioral"
+
+[activation]
+mode = "always"
+
+[layering]
+priority = 50
+merge_strategy = "append"
+""")
+        (skill_dir / "behavior").mkdir()
+        (skill_dir / "behavior" / "main.md").write_text("## Always present behavior")
+
+        state_path = tmp_path / "state.json"
+        activate_skill("always-skill", mode="always", state_path=state_path, repo_dir=tmp_path)
+
+        result = get_skill_context_for_message(
+            "Random unrelated message",
+            repo_dir=tmp_path,
+            state_path=state_path,
+        )
+        assert "Always present behavior" in result
+
+    def test_both_always_and_contextual_combined(self, tmp_path):
+        """Always skill and matching contextual skill both appear."""
+        shop_dir = tmp_path / "lobster-shop"
+
+        # Always skill
+        always_dir = shop_dir / "always-skill"
+        always_dir.mkdir(parents=True, exist_ok=True)
+        (always_dir / "skill.toml").write_text("""[skill]
+name = "always-skill"
+version = "1.0.0"
+description = "Always active"
+category = "behavioral"
+
+[activation]
+mode = "always"
+
+[layering]
+priority = 40
+merge_strategy = "append"
+""")
+        (always_dir / "behavior").mkdir()
+        (always_dir / "behavior" / "main.md").write_text("## Always present")
+
+        # Contextual skill
+        self._create_contextual_skill(
+            shop_dir, "ctx-skill",
+            patterns=["when user mentions email"],
+            behavior_text="## Email context",
+        )
+
+        state_path = tmp_path / "state.json"
+        activate_skill("always-skill", mode="always", state_path=state_path, repo_dir=tmp_path)
+        activate_skill("ctx-skill", mode="contextual", state_path=state_path, repo_dir=tmp_path)
+
+        result = get_skill_context_for_message(
+            "Check my email please",
+            repo_dir=tmp_path,
+            state_path=state_path,
+        )
+        assert "Always present" in result
+        assert "Email context" in result


### PR DESCRIPTION
## Summary

- Implements `activation_mode = 'contextual'` for skills — was previously silently ignored
- Adds `get_skill_context_for_message(text)` to skill_manager.py with keyword-based pattern matching
- Registers new MCP tool `get_skill_context_for_message` in inbox_server.py and the HTTP read-only allowlist
- Updates dispatcher bootup doc to call the new tool at message processing start

## How it works

Pattern matching extracts content keywords from natural-language `context_patterns` (e.g. "when user asks about calendar") and checks for majority keyword presence in the incoming message text. No LLM call is required — purely regex/string-based.

The dispatcher uses `get_skill_context_for_message` which internally combines:
- Standard always/triggered skills (included if active)
- Contextual skills (included only if a pattern matches the message)

## Test plan
- [ ] `tests/unit/test_skill_manager.py::TestPatternMatchesMessage` — 8 new unit tests for pattern matching logic
- [ ] `tests/unit/test_skill_manager.py::TestGetSkillContextForMessage` — 4 new integration-style tests
- [ ] Existing skill manager tests still pass (2 pre-existing failures from user-config env pollution, unrelated to this PR)

Fixes #1054

🤖 Generated with [Claude Code](https://claude.com/claude-code)