### PR TITLE
fix: create session file stub at dispatcher startup (#1086)

### DIFF
--- a/hooks/on-fresh-start.py
+++ b/hooks/on-fresh-start.py
@@ -83,6 +83,7 @@ on every SessionStart; ordering matters only for the marker file dependency.)
 
 import json
 import os
+import re
 import sqlite3
 import subprocess
 import sys
@@ -321,22 +322,21 @@ def _create_session_file_stub() -> None:
                 f"## Open Threads\n\n## Open Tasks\n\n## Open Subagents\n\n## Notable Events\n"
             )
 
-        # Substitute template placeholders.
+        # Substitute template placeholders using flexible regex patterns so
+        # that future edits to example values in the template (e.g. a new
+        # sample date) do not cause silent substitution failures.
         stub = template_content
         stub = stub.replace("# Session YYYYMMDD-NNN", f"# Session {session_id}")
-        stub = stub.replace(
-            "<ISO timestamp, e.g. 2026-03-25T14:32:00Z>", ts_iso
-        )
-        stub = stub.replace('<ISO timestamp or "active">', "active")
-        # Replace Messages processed placeholder if present.
-        stub = stub.replace(
-            '<count or "unknown">',
-            "0",
-        )
-        stub = stub.replace(
-            '<"active" | "graceful wind-down" | "context_warning" | "short session" | "crash">',
-            "active",
-        )
+        # Matches the Ended field: <ISO timestamp or "active"> — must run BEFORE
+        # the general ISO timestamp replacement to avoid being consumed by it.
+        stub = re.sub(r'<ISO timestamp or "active"[^>]*>', "active", stub)
+        # Matches the Started field: <ISO timestamp, e.g. 2026-03-25T14:32:00Z>
+        # (any example date — the "or" variant was already handled above).
+        stub = re.sub(r"<ISO timestamp[^>]*>", ts_iso, stub)
+        # Matches: <count or "unknown"> (the Messages processed field)
+        stub = re.sub(r'<count or "unknown"[^>]*>', "0", stub)
+        # Matches: <"active" | ...> (the End reason field — any pipe-separated options)
+        stub = re.sub(r'<"active"[^>]*>', "active", stub)
 
         # Write session file atomically.
         tmp_path = session_path.with_suffix(".tmp")

--- a/hooks/on-fresh-start.py
+++ b/hooks/on-fresh-start.py
@@ -233,6 +233,131 @@ def _has_recent_session_file() -> bool:
         return False
 
 
+def _create_session_file_stub() -> None:
+    """Create a stub session file for this dispatcher session if one doesn't already exist.
+
+    This is the hook-level safety net for issue #1086. The dispatcher bootup doc
+    instructs the LLM to create a session file inline (step 2a), and compact-catchup
+    fills in Phase 2. But if both fail (e.g. compact-catchup doesn't run, or the LLM
+    skips step 2a), no session file is written — leaving the next restart with no context.
+
+    This function runs at SessionStart (fresh restart only, not compaction) and creates
+    a minimal stub session file if today has no file or the existing one is a fresh stub.
+    The stub has the start timestamp filled in and End reason: active, so it is
+    immediately recoverable even if the session ends before anything writes to it.
+
+    Writes the file path to CURRENT_SESSION_FILE_POINTER (/tmp/lobster-current-session-file)
+    so the dispatcher and compact-catchup can find it.
+
+    Never raises — all errors are logged to stderr and the hook continues.
+    """
+    import datetime
+
+    try:
+        now_utc = datetime.datetime.now(datetime.timezone.utc)
+        today_str = now_utc.strftime("%Y%m%d")
+        ts_iso = now_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # Determine sessions directory.
+        sessions_dir = Path(os.path.expanduser(
+            "~/lobster-user-config/memory/canonical/sessions"
+        ))
+
+        # If the pointer file already has a valid today session file, respect it.
+        if CURRENT_SESSION_FILE_POINTER.exists():
+            existing_path_str = CURRENT_SESSION_FILE_POINTER.read_text().strip()
+            if existing_path_str:
+                existing_path = Path(existing_path_str)
+                if (
+                    existing_path.exists()
+                    and existing_path.name.startswith(today_str)
+                    and existing_path.stat().st_size > 0
+                ):
+                    print(
+                        f"[on-fresh-start] session file stub already exists: {existing_path}",
+                        file=sys.stderr,
+                    )
+                    return
+
+        # Find next sequence number for today.
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        existing_today = sorted(sessions_dir.glob(f"{today_str}-???.md"))
+        if existing_today:
+            last_seq_str = existing_today[-1].stem.split("-")[-1]
+            next_seq = int(last_seq_str) + 1
+        else:
+            next_seq = 1
+        seq_str = f"{next_seq:03d}"
+        session_id = f"{today_str}-{seq_str}"
+        session_filename = f"{session_id}.md"
+        session_path = sessions_dir / session_filename
+
+        # Read template — prefer user-config version, fall back to repo version.
+        user_template = Path(os.path.expanduser(
+            "~/lobster-user-config/memory/canonical/sessions/session.template.md"
+        ))
+        repo_template = Path(os.path.expanduser(
+            "~/lobster/memory/canonical-templates/sessions/session.template.md"
+        ))
+
+        template_content: str | None = None
+        for template_path in (user_template, repo_template):
+            if template_path.exists():
+                try:
+                    template_content = template_path.read_text(encoding="utf-8")
+                    break
+                except OSError:
+                    continue
+
+        if template_content is None:
+            # Minimal inline fallback.
+            template_content = (
+                f"# Session YYYYMMDD-NNN\n\n"
+                f"**Started:** <ISO timestamp, e.g. 2026-03-25T14:32:00Z>\n"
+                f"**Ended:** <ISO timestamp or \"active\">\n"
+                f"**Messages processed:** 0\n"
+                f"**End reason:** active\n\n"
+                f"## Summary\n(nothing to report this session)\n\n"
+                f"## Open Threads\n\n## Open Tasks\n\n## Open Subagents\n\n## Notable Events\n"
+            )
+
+        # Substitute template placeholders.
+        stub = template_content
+        stub = stub.replace("# Session YYYYMMDD-NNN", f"# Session {session_id}")
+        stub = stub.replace(
+            "<ISO timestamp, e.g. 2026-03-25T14:32:00Z>", ts_iso
+        )
+        stub = stub.replace('<ISO timestamp or "active">', "active")
+        # Replace Messages processed placeholder if present.
+        stub = stub.replace(
+            '<count or "unknown">',
+            "0",
+        )
+        stub = stub.replace(
+            '<"active" | "graceful wind-down" | "context_warning" | "short session" | "crash">',
+            "active",
+        )
+
+        # Write session file atomically.
+        tmp_path = session_path.with_suffix(".tmp")
+        tmp_path.write_text(stub, encoding="utf-8")
+        tmp_path.rename(session_path)
+
+        # Write the pointer.
+        CURRENT_SESSION_FILE_POINTER.write_text(str(session_path))
+
+        print(
+            f"[on-fresh-start] created session file stub: {session_path}",
+            file=sys.stderr,
+        )
+
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[on-fresh-start] failed to create session file stub: {exc}",
+            file=sys.stderr,
+        )
+
+
 def _compact_reminder_already_queued() -> bool:
     """Return True if a compact-reminder message is already in inbox/ or processing/.
 
@@ -487,6 +612,13 @@ def main() -> None:
     # Skip subagent sessions — only the dispatcher should run this.
     if not session_role.is_dispatcher(data):
         sys.exit(0)
+
+    # Safety net for issue #1086: create a stub session file for this session.
+    # The dispatcher bootup doc instructs the LLM to create a session file inline
+    # (step 2a), but this is unreliable if the LLM skips the step or compact-catchup
+    # doesn't run. Creating the stub here guarantees there is always a session file
+    # from the moment the dispatcher starts, even if it ends immediately.
+    _create_session_file_stub()
 
     if not AGENT_MONITOR.exists():
         print(

--- a/tests/unit/test_hooks/test_on_fresh_start_catchup.py
+++ b/tests/unit/test_hooks/test_on_fresh_start_catchup.py
@@ -553,3 +553,181 @@ class TestClearStaleClaim:
 
         # Stale processing file must have been removed
         assert not stale_file.exists()
+
+
+# =============================================================================
+# _create_session_file_stub tests (issue #1086 safety net)
+# =============================================================================
+
+class TestCreateSessionFileStub:
+    """Tests for the hook-level session file stub creation."""
+
+    def _make_template(self, sessions_dir: Path) -> Path:
+        """Write a minimal session template to sessions_dir."""
+        template = sessions_dir / "session.template.md"
+        template.write_text(
+            "# Session YYYYMMDD-NNN\n\n"
+            "**Started:** <ISO timestamp, e.g. 2026-03-25T14:32:00Z>\n"
+            '**Ended:** <ISO timestamp or "active">\n'
+            '**Messages processed:** <count or "unknown">\n'
+            '**End reason:** <"active" | "graceful wind-down" | "context_warning" | "short session" | "crash">\n\n'
+            "## Summary\n(nothing to report this session)\n\n"
+            "## Open Threads\n\n## Open Tasks\n\n## Open Subagents\n\n## Notable Events\n"
+        )
+        return template
+
+    def test_creates_stub_file(self, tmp_path):
+        """A new session file is created when none exists."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        self._make_template(sessions_dir)
+
+        pointer = tmp_path / "lobster-current-session-file"
+
+        mod = _load_on_fresh_start()
+        mod.CURRENT_SESSION_FILE_POINTER = pointer
+
+        # Patch the user-config path to tmp_path
+        import datetime
+        today_str = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d")
+
+        # Override the hardcoded user-config path by monkeypatching os.path.expanduser
+        original_expanduser = os.path.expanduser
+
+        def fake_expanduser(p):
+            if "lobster-user-config/memory/canonical/sessions" in p:
+                return str(sessions_dir)
+            if "lobster/memory/canonical-templates/sessions" in p:
+                return str(sessions_dir)
+            return original_expanduser(p)
+
+        import builtins
+        original_import = builtins.__import__
+        mod_os = __import__("os")
+        original_mod_expanduser = mod_os.path.expanduser
+        mod_os.path.expanduser = fake_expanduser
+
+        try:
+            mod._create_session_file_stub()
+        finally:
+            mod_os.path.expanduser = original_mod_expanduser
+
+        # Pointer should now exist
+        assert pointer.exists()
+        session_path_str = pointer.read_text().strip()
+        session_path = Path(session_path_str)
+        assert session_path.exists()
+
+        # File name starts with today
+        assert session_path.name.startswith(today_str)
+        assert session_path.name.endswith("-001.md")
+
+        # File content has start time filled in (not a placeholder)
+        content = session_path.read_text()
+        assert "YYYYMMDD-NNN" not in content
+        assert "<ISO timestamp, e.g." not in content
+        assert today_str[:4] in content  # year present
+
+    def test_increments_sequence_number(self, tmp_path):
+        """If a session file already exists for today, creates -002."""
+        import datetime
+        today_str = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d")
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        self._make_template(sessions_dir)
+
+        # Pre-create -001
+        existing = sessions_dir / f"{today_str}-001.md"
+        existing.write_text("# existing\n")
+
+        pointer = tmp_path / "lobster-current-session-file"
+
+        mod = _load_on_fresh_start()
+        mod.CURRENT_SESSION_FILE_POINTER = pointer
+
+        original_expanduser = os.path.expanduser
+
+        def fake_expanduser(p):
+            if "lobster-user-config/memory/canonical/sessions" in p:
+                return str(sessions_dir)
+            if "lobster/memory/canonical-templates/sessions" in p:
+                return str(sessions_dir)
+            return original_expanduser(p)
+
+        import os as real_os
+        orig = real_os.path.expanduser
+        real_os.path.expanduser = fake_expanduser
+        try:
+            mod._create_session_file_stub()
+        finally:
+            real_os.path.expanduser = orig
+
+        session_path_str = pointer.read_text().strip()
+        session_path = Path(session_path_str)
+        assert session_path.name == f"{today_str}-002.md"
+
+    def test_noop_if_valid_pointer_exists(self, tmp_path):
+        """Does not create a new file if the pointer already points to a valid today file."""
+        import datetime
+        today_str = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d")
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+
+        existing = sessions_dir / f"{today_str}-001.md"
+        existing.write_text("# existing content\n")
+
+        pointer = tmp_path / "lobster-current-session-file"
+        pointer.write_text(str(existing))
+
+        mod = _load_on_fresh_start()
+        mod.CURRENT_SESSION_FILE_POINTER = pointer
+
+        original_expanduser = os.path.expanduser
+
+        def fake_expanduser(p):
+            if "lobster-user-config/memory/canonical/sessions" in p:
+                return str(sessions_dir)
+            if "lobster/memory/canonical-templates/sessions" in p:
+                return str(sessions_dir)
+            return original_expanduser(p)
+
+        import os as real_os
+        orig = real_os.path.expanduser
+        real_os.path.expanduser = fake_expanduser
+        try:
+            mod._create_session_file_stub()
+        finally:
+            real_os.path.expanduser = orig
+
+        # Pointer still points to the original file
+        assert pointer.read_text().strip() == str(existing)
+        # No new files created
+        files = list(sessions_dir.glob(f"{today_str}-*.md"))
+        assert len(files) == 1
+
+    def test_graceful_on_error(self, tmp_path):
+        """Never raises even if sessions dir cannot be created."""
+        pointer = tmp_path / "nonexistent_deep" / "pointer"
+
+        mod = _load_on_fresh_start()
+        mod.CURRENT_SESSION_FILE_POINTER = pointer
+
+        # Point expanduser to a read-only path to trigger an error
+        import os as real_os
+        orig = real_os.path.expanduser
+
+        def fake_expanduser(p):
+            if "lobster-user-config/memory/canonical/sessions" in p:
+                return "/proc/lobster-fake-readonly-path"  # will fail to mkdir
+            if "lobster/memory/canonical-templates/sessions" in p:
+                return "/proc/lobster-fake-readonly-path"
+            return orig(p)
+
+        real_os.path.expanduser = fake_expanduser
+        try:
+            # Must not raise
+            mod._create_session_file_stub()
+        finally:
+            real_os.path.expanduser = orig


### PR DESCRIPTION
## Summary

- Adds `_create_session_file_stub()` to `hooks/on-fresh-start.py` — runs at every fresh dispatcher SessionStart
- Creates a sequenced `YYYYMMDD-NNN.md` session file with start timestamp filled in, even before the dispatcher processes any messages
- Writes path to `/tmp/lobster-current-session-file` for compact-catchup to find
- Skips if a valid today-dated session file is already pointed to by the pointer file
- Never raises — errors logged to stderr, hook continues

## Problem

The dispatcher bootup doc instructs the LLM to create a session file inline (step 2a), but this proved unreliable. If the LLM skipped the step or compact-catchup didn't run, sessions could end with no session file written — leaving the next restart with no context to recover from.

## Test plan
- [ ] `tests/unit/test_hooks/test_on_fresh_start_catchup.py::TestCreateSessionFileStub` — 4 new tests
  - Creates stub when none exists
  - Increments sequence number when prior file exists  
  - No-ops if valid pointer already exists
  - Graceful on errors (no raise)
- [ ] Existing on-fresh-start tests still pass (verified)

Fixes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)