### PR TITLE
fix(process): engineer PR awareness — in-flight conflicts and diff-first bodies

### DIFF
--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -123,6 +123,30 @@ If yes to any of the first three: run in test scope first, verify bounds, then s
 - Reference the issue in the PR description using keywords (Closes #XX, Fixes #XX, or Relates to #XX)
 - **Set "Main Board" project status to "In Review"** after PR is opened
 
+**In-flight PR awareness — required before opening any PR:**
+
+Before opening a PR, check whether any open PR already touches the same files you changed:
+
+```bash
+gh pr list --repo SiderealPress/lobster --state open --json number,title,files
+```
+
+Review the output. If any open PR touches the same files you are about to change:
+- Note those PRs in your PR body under a **"Conflicts with open PRs"** section (list their numbers and titles).
+- If 3 or more open PRs already touch the same file, consider whether your change can wait or whether you should rebase onto the most recent open branch to reduce merge complexity. If you proceed anyway, explain why in the PR body.
+
+This is not optional — undetected file conflicts create merge nightmares. Run the check, then act on what you find.
+
+**Diff-first body writing — required before writing the PR description:**
+
+Before writing the PR body, read the actual diff:
+
+```bash
+git diff main HEAD
+```
+
+Write the PR body from what you see in the diff — never from memory of the issue. The body must accurately describe what the code actually changes, not what you intended or remembered. If the diff shows something different from what the issue asked for, note the discrepancy. A PR body that cannot be verified against the diff is not acceptable.
+
 **Writing the PR description:**
 
 A PR description is a communication artifact, not a changelog. Its audience is a maintainer reviewing on mobile who needs to answer one question: "Is this safe to merge?" Write for that person.

--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -142,7 +142,7 @@ This is not optional — undetected file conflicts create merge nightmares. Run 
 Before writing the PR body, read the actual diff:
 
 ```bash
-git diff main HEAD
+git diff origin/local-dev...HEAD
 ```
 
 Write the PR body from what you see in the diff — never from memory of the issue. The body must accurately describe what the code actually changes, not what you intended or remembered. If the diff shows something different from what the issue asked for, note the discrepancy. A PR body that cannot be verified against the diff is not acceptable.


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

Engineers were opening PRs without knowing about conflicts with other in-flight PRs touching the same files, and were sometimes writing PR bodies from memory of the issue rather than from the actual diff. This created merge nightmares (12+ open PRs on the same file at once) and inaccurate PR descriptions (#1501 was caught writing a body from memory).

## What changed

Two mandatory pre-PR steps are now required in the engineer subagent workflow (`functional-engineer.md`), inserted immediately before the "Writing the PR description" section in the Pull Request Creation phase:

**Rule 1 — In-flight PR awareness:** Before opening a PR, the engineer must run `gh pr list --repo SiderealPress/lobster --state open --json number,title,files` and check for file-level conflicts with open PRs. Any conflicts must be noted in the PR body under "Conflicts with open PRs". For files with 3+ open PRs, the engineer must consider waiting or rebasing.

**Rule 2 — Diff-first body writing:** Before writing the PR body, the engineer must run `git diff main HEAD` and write the body from what the diff shows — never from memory of the issue. The body must be verifiable against the diff.

## What is not changed

No code changes. This is a process instruction update only, affecting the engineer subagent's behavioral protocol. All other sections of `functional-engineer.md` are unchanged.

## Tests run
- [x] Diff reviewed: changes are exactly the two new protocol blocks, no unintended edits
- [ ] Unit tests — N/A: documentation/instruction change only, no code modified

## Manual test
N/A — this change is entirely internal to subagent instructions, not a code or infrastructure change.

## Conflicts with open PRs
Checked: no other open PRs touch `.claude/agents/functional-engineer.md`.