### PR TITLE
fix: filter stale reconciler notifications from startup sweep (#1355)

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -9043,6 +9043,13 @@ def _inbox_already_has_agent(agent_id: str) -> bool:
     return False
 
 
+# Sessions that completed more than this many minutes before the MCP server
+# started are "stale" — the dispatcher that requested them is gone, and
+# injecting them would flood the inbox at startup (issue #1355).
+# These sessions are silently marked as notified rather than queued.
+_STARTUP_SWEEP_STALE_MINUTES = 10
+
+
 async def _startup_sweep() -> None:
     """Send missed notifications for sessions that completed while server was down.
 
@@ -9057,7 +9064,18 @@ async def _startup_sweep() -> None:
 
     An additional idempotency guard checks whether an inbox file for the agent
     already exists (handles the crash-after-write-before-set_notified race).
+
+    Staleness filter (issue #1355): sessions that completed more than
+    _STARTUP_SWEEP_STALE_MINUTES minutes before the server started are silently
+    marked as notified without being injected into the inbox. This prevents the
+    inbox from being flooded with stale completion notices at startup — which
+    would block real user messages for several WFM cycles.
     """
+    from datetime import timedelta
+
+    # _SERVER_START_TIME is recorded at module import time (~line 899).
+    stale_cutoff = _SERVER_START_TIME - timedelta(minutes=_STARTUP_SWEEP_STALE_MINUTES)
+
     try:
         unnotified = _session_store.get_unnotified_completed(since_hours=24)
         if unnotified:
@@ -9065,8 +9083,30 @@ async def _startup_sweep() -> None:
                 f"[reconciler] Startup sweep: found {len(unnotified)} unnotified "
                 f"completed/dead session(s) — re-enqueuing notifications"
             )
+        stale_count = 0
         for session in unnotified:
             agent_id = session.get("id", "")
+
+            # Staleness check: sessions that finished long before the server
+            # started are stale artifacts — silently acknowledge them.
+            completed_at_str = session.get("completed_at") or session.get("stopped_at")
+            if completed_at_str:
+                try:
+                    completed_at = datetime.fromisoformat(
+                        completed_at_str.replace("Z", "+00:00")
+                    )
+                    if completed_at < stale_cutoff:
+                        _session_store.set_notified(agent_id)
+                        stale_count += 1
+                        log.debug(
+                            "[reconciler] Startup sweep: skipping stale session %r "
+                            "(completed_at=%s, stale_cutoff=%s)",
+                            agent_id, completed_at_str, stale_cutoff.isoformat(),
+                        )
+                        continue
+                except (ValueError, TypeError):
+                    pass  # Unparseable timestamp — fall through to normal handling
+
             if _inbox_already_has_agent(agent_id):
                 log.debug(
                     "[reconciler] Startup sweep: inbox file already exists for "
@@ -9076,6 +9116,12 @@ async def _startup_sweep() -> None:
                 continue
             outcome = session.get("status", "completed")
             _enqueue_reconciler_notification(session, outcome=outcome)
+
+        if stale_count:
+            log.info(
+                f"[reconciler] Startup sweep: silently acknowledged {stale_count} "
+                f"stale session(s) (completed >{_STARTUP_SWEEP_STALE_MINUTES}min before server start)"
+            )
     except Exception as exc:
         log.error(f"[reconciler] Startup sweep error: {exc}", exc_info=True)
 

--- a/tests/unit/test_mcp_server/test_startup_sweep_staleness.py
+++ b/tests/unit/test_mcp_server/test_startup_sweep_staleness.py
@@ -1,0 +1,139 @@
+"""
+Unit tests for the reconciler startup sweep staleness filter (issue #1355).
+
+When the MCP server restarts, it may find unnotified completed sessions from
+the last 24 hours. If these sessions completed long before the server started
+(i.e. they are "stale"), injecting them into the inbox would flood it with
+irrelevant completion notices, blocking real user messages.
+
+The staleness filter silently marks sessions that completed more than
+_STARTUP_SWEEP_STALE_MINUTES before the server started as "notified" without
+queuing them.
+
+Strategy: extract the staleness check logic into standalone pure functions
+and test all branching cases without instantiating the async reconciler.
+"""
+
+import pytest
+from datetime import datetime, timezone, timedelta
+
+
+# ---------------------------------------------------------------------------
+# Pure helper — mirrors the staleness check in _startup_sweep()
+# ---------------------------------------------------------------------------
+
+STALE_MINUTES = 10  # mirrors _STARTUP_SWEEP_STALE_MINUTES
+
+
+def is_session_stale(
+    completed_at_str: str | None,
+    server_start_time: datetime,
+    stale_minutes: int = STALE_MINUTES,
+) -> bool:
+    """Return True if the session completed before the stale cutoff.
+
+    Mirrors the staleness check in _startup_sweep():
+        stale_cutoff = server_start_time - timedelta(minutes=stale_minutes)
+        if completed_at < stale_cutoff: return True
+    """
+    if not completed_at_str:
+        return False
+    try:
+        completed_at = datetime.fromisoformat(
+            completed_at_str.replace("Z", "+00:00")
+        )
+        stale_cutoff = server_start_time - timedelta(minutes=stale_minutes)
+        return completed_at < stale_cutoff
+    except (ValueError, TypeError):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestStartupSweepStalenessFilter:
+    """Tests for the staleness check applied during startup sweep."""
+
+    def _server_start(self, minutes_ago: float = 0) -> datetime:
+        """Return a fake server start time, optionally in the past."""
+        return datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+
+    def test_session_completed_before_cutoff_is_stale(self):
+        """Session completed 30 min ago is stale when server just started and threshold is 10 min."""
+        server_start = self._server_start(minutes_ago=0)
+        completed_at = (server_start - timedelta(minutes=30)).isoformat()
+        assert is_session_stale(completed_at, server_start) is True
+
+    def test_session_completed_just_after_cutoff_is_not_stale(self):
+        """Session completed 5 min ago is NOT stale (within the 10-min window)."""
+        server_start = self._server_start(minutes_ago=0)
+        completed_at = (server_start - timedelta(minutes=5)).isoformat()
+        assert is_session_stale(completed_at, server_start) is False
+
+    def test_session_completed_exactly_at_cutoff_is_not_stale(self):
+        """Session completed exactly at stale_cutoff is not stale (boundary exclusive)."""
+        server_start = self._server_start(minutes_ago=0)
+        completed_at = (server_start - timedelta(minutes=10)).isoformat()
+        # completed_at == stale_cutoff: not strictly less than, so not stale
+        assert is_session_stale(completed_at, server_start) is False
+
+    def test_session_completed_after_server_start_is_not_stale(self):
+        """Session that somehow completed after server start is not stale."""
+        server_start = self._server_start(minutes_ago=0)
+        completed_at = (server_start + timedelta(minutes=1)).isoformat()
+        assert is_session_stale(completed_at, server_start) is False
+
+    def test_missing_completed_at_is_not_stale(self):
+        """Session with no completed_at timestamp is not filtered (safety default)."""
+        server_start = self._server_start(minutes_ago=0)
+        assert is_session_stale(None, server_start) is False
+        assert is_session_stale("", server_start) is False
+
+    def test_malformed_timestamp_is_not_stale(self):
+        """Session with unparseable timestamp is not filtered (safety default)."""
+        server_start = self._server_start(minutes_ago=0)
+        assert is_session_stale("not-a-date", server_start) is False
+        assert is_session_stale("2026-99-99T25:00:00Z", server_start) is False
+
+    def test_z_suffix_timestamp_parsed_correctly(self):
+        """ISO timestamp with Z suffix is parsed correctly."""
+        server_start = self._server_start(minutes_ago=0)
+        completed_at = (server_start - timedelta(minutes=20)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        assert is_session_stale(completed_at, server_start) is True
+
+    def test_plus_offset_timestamp_parsed_correctly(self):
+        """ISO timestamp with +00:00 offset is parsed correctly."""
+        server_start = self._server_start(minutes_ago=0)
+        completed_at = (server_start - timedelta(minutes=20)).isoformat()
+        assert is_session_stale(completed_at, server_start) is True
+
+    def test_custom_stale_minutes(self):
+        """Custom stale_minutes threshold is respected."""
+        server_start = self._server_start(minutes_ago=0)
+        # Completed 3 min ago
+        completed_at = (server_start - timedelta(minutes=3)).isoformat()
+        # With default 10 min threshold: not stale
+        assert is_session_stale(completed_at, server_start, stale_minutes=10) is False
+        # With 2 min threshold: stale
+        assert is_session_stale(completed_at, server_start, stale_minutes=2) is True
+
+    def test_many_stale_sessions(self):
+        """All sessions from 24h ago are correctly identified as stale."""
+        server_start = self._server_start(minutes_ago=0)
+        stale_sessions = [
+            (server_start - timedelta(hours=h)).isoformat()
+            for h in [1, 3, 6, 12, 24]
+        ]
+        for ts in stale_sessions:
+            assert is_session_stale(ts, server_start) is True, f"Expected stale: {ts}"
+
+    def test_fresh_sessions_not_filtered(self):
+        """Sessions from the last few minutes are not stale."""
+        server_start = self._server_start(minutes_ago=0)
+        fresh_sessions = [
+            (server_start - timedelta(minutes=m)).isoformat()
+            for m in [1, 3, 5, 9]
+        ]
+        for ts in fresh_sessions:
+            assert is_session_stale(ts, server_start) is False, f"Expected not stale: {ts}"


### PR DESCRIPTION
## Summary

- Adds a staleness filter to the reconciler startup sweep that silently marks sessions older than 10 minutes as notified without injecting them into the inbox
- Uses the existing `_SERVER_START_TIME` module-level timestamp to compute the cutoff
- Sessions with missing or unparseable timestamps fall through to normal handling (safe default)

## Problem

On MCP server restart, `_startup_sweep()` re-queues all unnotified completed sessions from the last 24 hours. When the server was offline for a while, this floods the inbox with ~30+ stale completion notices that block real user messages for multiple WFM cycles.

## Implementation

```
stale_cutoff = _SERVER_START_TIME - timedelta(minutes=10)
if completed_at < stale_cutoff:
    set_notified(agent_id)  # silent ack, no inbox injection
    continue
```

## Test plan
- [ ] `tests/unit/test_mcp_server/test_startup_sweep_staleness.py` — 11 new unit tests covering:
  - Session completed before/after cutoff boundary
  - Session completed exactly at cutoff (not stale)
  - Missing/malformed timestamps (conservative default)
  - Z-suffix and +00:00 offset timestamp formats
  - Custom stale_minutes threshold
  - Bulk stale vs. fresh session discrimination

Fixes #1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)