### PR TITLE
fix: prevent bot-talk mirror from posting real messages during tests (#1341)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,6 +206,38 @@ def isolate_inbox_server_paths(tmp_path: Path):
         yield dirs_result
 
 
+@pytest.fixture(autouse=True)
+def isolate_bot_talk_mirror():
+    """Prevent tests from making real network calls to the bot-talk service (issue #1341).
+
+    inbox_server.py imports bot_talk_mirror inline (inside function bodies) and
+    calls mirror_outbound / _spawn_mirror when BOT_TALK_HTTP_URL is configured.
+    If a developer has BOT_TALK_HTTP_URL set in config.env, running the test
+    suite will post hundreds of spurious messages to the shared bot-talk network.
+
+    Fix: zero out the URL constants in bot_talk_mirror (if the module is importable)
+    so that all HTTP and SSH sending paths are immediately skipped. This does NOT
+    replace the real module — tests that directly import and test bot_talk_mirror
+    still work against the real module, and per-test mocks of httpx/subprocess are
+    unaffected.
+
+    This fixture is autouse=True so it applies to every test in the suite.
+    """
+    import importlib
+
+    try:
+        btm = importlib.import_module("bot_talk_mirror")
+        with patch.multiple(
+            btm,
+            BOT_TALK_HTTP_URL="",
+            BOT_TALK_SSH_HOST="",
+        ):
+            yield
+    except (ImportError, ModuleNotFoundError):
+        # bot_talk_mirror not available (e.g. fresh install without optional dep).
+        yield
+
+
 @pytest.fixture
 def inbox_server_dirs(isolate_inbox_server_paths):
     """Expose the redirected inbox_server paths for tests that need to verify them.


### PR DESCRIPTION
## Summary

- Adds autouse fixture `isolate_bot_talk_mirror` to `tests/conftest.py`
- Patches `BOT_TALK_HTTP_URL = ""` and `BOT_TALK_SSH_HOST = ""` in the `bot_talk_mirror` module for every test
- Both HTTP and SSH sending paths immediately short-circuit when URL/host is empty
- Tests that directly test `bot_talk_mirror` are unaffected — they mock `httpx`/`subprocess` themselves

## Problem

The test suite was posting real HTTP messages to the bot-talk network. When `BOT_TALK_HTTP_URL` was set in `config.env`, running tests caused 943 spurious messages to be posted (875 in a single day).

## How it works

`inbox_server.py` imports bot_talk_mirror inline:
```python
from bot_talk_mirror import _spawn_mirror
from bot_talk_mirror import mirror_outbound
```

By patching the URL constants to `""` in the module, both `try_http()` and `try_ssh()` return `False` immediately without any network activity.

## Test plan
- [ ] `test_bot_talk_mirror.py` — same 5 pre-existing failures (BOT_TALK_SENDER rename issue), 42 still pass, 0 new failures
- [ ] All other tests still run normally

Fixes #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)