### PR TITLE
feat(inbox): add offset pagination and total count to check_inbox (#1316)

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -1572,6 +1572,15 @@ async def list_tools() -> list[Tool]:
                         "description": "Maximum number of messages to return. Default 10.",
                         "default": 10,
                     },
+                    "offset": {
+                        "type": "integer",
+                        "description": (
+                            "Number of messages to skip before returning results. "
+                            "Use with limit to page through results when total > limit. "
+                            "Default 0 (start from beginning)."
+                        ),
+                        "default": 0,
+                    },
                     "since_ts": {
                         "type": "string",
                         "description": (
@@ -4317,15 +4326,21 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
 
     When since_ts is provided, scans both inbox/ and processed/ directories
     for messages with timestamp >= since_ts. This mode is designed for catch-up
-    agents that need to recover context after compaction. The limit still applies
-    to the combined result set.
+    agents that need to recover context after compaction.
+
+    Supports pagination via offset + limit. The response header always includes
+    the total count of matching messages so callers can detect truncation and
+    page through results:
+        check_inbox(limit=10, offset=0)  → messages 1-10 of N
+        check_inbox(limit=10, offset=10) → messages 11-20 of N
     """
     source_filter = args.get("source", "").lower()
     limit = args.get("limit", 10)
+    offset = max(0, args.get("offset", 0))
     since_ts_str = args.get("since_ts", "")
     since_epoch = _parse_iso_timestamp(since_ts_str) if since_ts_str else None
 
-    messages = []
+    all_messages: list = []
 
     if since_epoch is not None:
         # Historical scan mode: read from both processed/ and inbox/, sorted by timestamp.
@@ -4354,16 +4369,16 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
                     continue
                 msg["_filename"] = f.name
                 msg["_directory"] = f.parent.name  # "inbox" or "processed"
-                messages.append(msg)
-                if len(messages) >= limit:
-                    break
+                all_messages.append(msg)
             except Exception:
                 continue
 
-        if not messages:
+        if not all_messages:
             return [TextContent(type="text", text=f"📭 No messages found since {since_ts_str}.")]
 
-        log.info(f"check_inbox (since_ts={since_ts_str!r}) returning {len(messages)} message(s)")
+        total = len(all_messages)
+        messages = all_messages[offset: offset + limit]
+        log.info(f"check_inbox (since_ts={since_ts_str!r}) returning {len(messages)}/{total} message(s) (offset={offset})")
     else:
         # --- Priority-ordered inbox scan (issue #1079) ---
         # Two-pass approach: read and score all inbox files, then sort by
@@ -4410,7 +4425,7 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
                     except Exception as exc:
                         log.error(f"check_inbox: subagent_recovered pre-processor error: {exc}", exc_info=True)
                 msg["_filename"] = f.name  # type: ignore[union-attr]
-                messages.append(msg)
+                all_messages.append(msg)
                 # NOTE: Inbound cross-Lobster messages from bot-talk are routed to this
                 # inbox by bot_talk_mirror.log_inbound_cross_lobster() with source="bot-talk".
                 # We no longer mirror owner Telegram messages to bot-talk from here —
@@ -4430,18 +4445,30 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
                         )
                     except Exception as _bt_exc:
                         log.warning(f"bot-talk EventBus inbound emit failed (non-fatal): {_bt_exc}")
-                if len(messages) >= limit:
-                    break
             except Exception:
                 continue
 
-        if not messages:
+        if not all_messages:
             return [TextContent(type="text", text="📭 No new messages in inbox.")]
 
-        log.info(f"check_inbox returning {len(messages)} message(s)")
+        total = len(all_messages)
+        messages = all_messages[offset: offset + limit]
+        log.info(f"check_inbox returning {len(messages)}/{total} message(s) (offset={offset})")
+
+    # Build pagination info for the header
+    page_end = offset + len(messages)
+    if (total > limit or offset > 0) and len(messages) > 0:
+        pagination_info = f" (showing {offset + 1}–{page_end} of {total})"
+        if page_end < total:
+            remaining = total - page_end
+            pagination_info += f" — {remaining} more, use offset={page_end} to continue"
+    elif offset > 0 and len(messages) == 0:
+        pagination_info = f" (offset {offset} is past end of {total} total)"
+    else:
+        pagination_info = ""
 
     # Format messages nicely
-    output = f"📬 **{len(messages)} new message(s):**\n\n"
+    output = f"📬 **{len(messages)} new message(s){pagination_info}:**\n\n"
     for msg in messages:
         source = msg.get("source", "unknown").upper()
         user = msg.get("user_name", msg.get("username", "Unknown"))
@@ -4548,6 +4575,8 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
 
     output += "---\n"
     output += "Use `send_reply` to respond, `mark_processed` when done."
+    if page_end < total:
+        output += f"\n\n⚠️ **{total - page_end} more message(s) not shown.** Call `check_inbox(offset={page_end})` to fetch the next page."
 
     return [TextContent(type="text", text=output)]
 

--- a/tests/unit/test_mcp_server/test_check_inbox_pagination.py
+++ b/tests/unit/test_mcp_server/test_check_inbox_pagination.py
@@ -1,0 +1,170 @@
+"""
+Tests for check_inbox offset/pagination and total-count (#1316).
+
+Verifies that:
+- offset parameter skips the correct number of messages
+- total count is reported in the response header when messages are truncated
+- pagination hint appears in the footer when more messages remain
+- offset defaults to 0 (no skip)
+- limit + offset combination pages through results correctly
+- since_ts mode also respects offset and reports total
+"""
+
+import asyncio
+import json
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_MCP_DIR = Path(__file__).parent.parent.parent.parent / "src" / "mcp"
+if str(_MCP_DIR) not in sys.path:
+    sys.path.insert(0, str(_MCP_DIR))
+
+import src.mcp.inbox_server  # noqa: F401
+
+
+_BASE = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_msg(msg_id: str, offset_minutes: int = 0) -> dict:
+    ts = _BASE + timedelta(minutes=offset_minutes)
+    return {
+        "id": msg_id,
+        "source": "telegram",
+        "chat_id": 12345,
+        "user_id": 12345,
+        "username": "testuser",
+        "user_name": "Test",
+        "type": "text",
+        "text": f"message {msg_id}",
+        "timestamp": ts.strftime("%Y-%m-%dT%H:%M:%S.%f"),
+    }
+
+
+def _write_msgs(inbox_dir: Path, msgs: list[dict]) -> None:
+    for msg in msgs:
+        (inbox_dir / f"{msg['id']}.json").write_text(json.dumps(msg))
+
+
+@pytest.fixture
+def dirs(tmp_path):
+    inbox = tmp_path / "inbox"
+    processed = tmp_path / "processed"
+    inbox.mkdir()
+    processed.mkdir()
+    return {"inbox": inbox, "processed": processed}
+
+
+def _run(dirs, args):
+    with patch.multiple(
+        "src.mcp.inbox_server",
+        INBOX_DIR=dirs["inbox"],
+        PROCESSED_DIR=dirs["processed"],
+    ):
+        from src.mcp.inbox_server import handle_check_inbox
+        return asyncio.run(handle_check_inbox(args))
+
+
+class TestCheckInboxPagination:
+    """Tests for offset and total-count in regular inbox mode."""
+
+    def test_default_offset_returns_first_page(self, dirs):
+        """Without offset, returns first N messages (same as before)."""
+        msgs = [_make_msg(f"m{i}", i) for i in range(5)]
+        _write_msgs(dirs["inbox"], msgs)
+
+        result = _run(dirs, {"limit": 3})
+        text = result[0].text
+        # Shows first 3 out of 5
+        assert "3 new message" in text
+        assert "1–3 of 5" in text
+
+    def test_offset_skips_messages(self, dirs):
+        """offset=2 skips the first 2 messages."""
+        msgs = [_make_msg(f"m{i}", i) for i in range(5)]
+        _write_msgs(dirs["inbox"], msgs)
+
+        result = _run(dirs, {"limit": 2, "offset": 2})
+        text = result[0].text
+        # Shows messages 3-4 (indices 2-3)
+        assert "2 new message" in text
+        assert "3–4 of 5" in text
+
+    def test_offset_beyond_total_returns_empty(self, dirs):
+        """offset >= total with messages present returns empty."""
+        msgs = [_make_msg(f"m{i}", i) for i in range(3)]
+        _write_msgs(dirs["inbox"], msgs)
+
+        result = _run(dirs, {"limit": 10, "offset": 5})
+        text = result[0].text
+        # Offset beyond total — no messages in the slice, but total was 3
+        assert "0 new message" in text or "No new messages" in text
+
+    def test_no_pagination_info_when_all_fit(self, dirs):
+        """When all messages fit in limit, no pagination hint is shown."""
+        msgs = [_make_msg(f"m{i}", i) for i in range(3)]
+        _write_msgs(dirs["inbox"], msgs)
+
+        result = _run(dirs, {"limit": 10})
+        text = result[0].text
+        # No truncation: no "of N" or "more message" hint needed
+        assert "of 3" not in text
+        assert "more message" not in text.lower()
+
+    def test_footer_hint_when_truncated(self, dirs):
+        """Footer shows next-page hint when messages were truncated."""
+        msgs = [_make_msg(f"m{i}", i) for i in range(7)]
+        _write_msgs(dirs["inbox"], msgs)
+
+        result = _run(dirs, {"limit": 3})
+        text = result[0].text
+        # Should mention remaining count and offset to continue
+        assert "more message" in text.lower()
+        assert "offset=3" in text
+
+    def test_second_page_no_more_hint(self, dirs):
+        """When on the last page, no 'more messages' hint appears."""
+        msgs = [_make_msg(f"m{i}", i) for i in range(5)]
+        _write_msgs(dirs["inbox"], msgs)
+
+        result = _run(dirs, {"limit": 3, "offset": 3})
+        text = result[0].text
+        # Last page: 2 messages, no more hint
+        assert "more message" not in text.lower()
+
+    def test_total_count_reported_in_header(self, dirs):
+        """Total count appears in the header when messages are truncated."""
+        msgs = [_make_msg(f"m{i}", i) for i in range(8)]
+        _write_msgs(dirs["inbox"], msgs)
+
+        result = _run(dirs, {"limit": 5})
+        text = result[0].text
+        assert "of 8" in text
+
+
+class TestCheckInboxPaginationSinceTs:
+    """Tests for offset and total-count in since_ts (historical scan) mode."""
+
+    def test_since_ts_with_offset_skips_messages(self, dirs):
+        """offset works in since_ts mode too."""
+        for i in range(6):
+            msg = _make_msg(f"m{i}", i + 10)  # all after base
+            (dirs["processed"] / f"m{i}.json").write_text(json.dumps(msg))
+
+        result = _run(dirs, {"since_ts": "2026-01-01T12:00:00Z", "limit": 2, "offset": 2})
+        text = result[0].text
+        assert "2 new message" in text
+        assert "3–4 of 6" in text
+
+    def test_since_ts_total_in_header(self, dirs):
+        """Total appears in header for since_ts mode when truncated."""
+        for i in range(5):
+            msg = _make_msg(f"m{i}", i + 5)
+            (dirs["processed"] / f"m{i}.json").write_text(json.dumps(msg))
+
+        result = _run(dirs, {"since_ts": "2026-01-01T12:00:00Z", "limit": 2})
+        text = result[0].text
+        assert "of 5" in text


### PR DESCRIPTION
## Summary

- Add \`offset\` parameter to \`check_inbox\` (default 0) for cursor-based pagination
- Collect all matching messages before slicing, so total count is always known
- Report total and current slice in the response header: \"showing 1–10 of 47\"
- Add next-page hint in the footer when more messages remain: \`check_inbox(offset=10)\`
- Both regular inbox mode and \`since_ts\` historical scan mode support pagination
- 9 new unit tests in \`test_check_inbox_pagination.py\`; all 16 existing \`since_ts\` tests still pass

## Problem

\`check_inbox\` silently returned at most \`limit\` messages with no indication of how many total messages matched. Callers like \`compact-catchup\` could not tell if results were truncated. They resorted to time-window caps instead of correct pagination.

## Usage

\`\`\`
# Page through a large inbox
check_inbox(limit=10, offset=0)   # \"showing 1–10 of 47 — 37 more, use offset=10 to continue\"
check_inbox(limit=10, offset=10)  # \"showing 11–20 of 47 — 27 more, use offset=20 to continue\"
check_inbox(limit=10, offset=40)  # \"showing 41–47 of 47\"
\`\`\`

## Conflict resolution note

Rebased onto local-dev after merging #1079 (priority inbox queue). The inbox scan in the \`else\` branch was restructured in local-dev to use a two-pass priority sort (read+score all files, then iterate sorted). The resolution keeps the two-pass structure from local-dev intact and changes the accumulation from \`messages.append\` to \`all_messages.append\` (removing the early \`break\` at limit), so the full sorted set is available before the pagination slice is applied.

## Tests run

- [x] \`uv run pytest tests/unit/test_mcp_server/test_check_inbox_pagination.py -v\` — 9 passed, 0 failed
- [x] \`uv run pytest tests/unit/test_mcp_server/test_check_inbox_since_ts.py -v\` — 16 passed, 0 failed (no regressions)

## Manual test

N/A — change is internal to the MCP inbox server's message collection and pagination logic. No external service calls, file system side-effects, or Telegram output involved. Unit tests cover all pagination scenarios including boundary conditions.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, fully unit-testable
- [x] User-visible outcome verified — dispatcher sees pagination header/footer in check_inbox output; no Telegram output affected
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)