### PR TITLE
fix(session-note-polish): add superseded-findings consistency pass (#1112)

### DIFF
--- a/.claude/agents/session-note-polish.md
+++ b/.claude/agents/session-note-polish.md
@@ -22,7 +22,12 @@ When summarizing recent activity, cover the last **30 minutes OR 25 messages, wh
 
 2. Call `get_active_sessions()` to get currently running agents.
 
-3. Rewrite the file in place as a clean, dense handoff summary in **decision-log format**:
+3. **Superseded findings check (run before writing the polished output):** Scan the full note for findings that are contradicted or invalidated by later entries in the same note. For each such finding:
+   - Mark it as superseded inline using `[SUPERSEDED by: <brief explanation>]` — e.g., `~~agent_id is the signal~~ [SUPERSEDED by: agent_id not present in SessionStart payloads per 02:03 UTC test]`
+   - Do NOT delete the finding — preserve it for audit trail, just mark it clearly
+   - Only mark a finding superseded when the note itself contains explicit contradictory evidence, not when you infer it from outside knowledge
+
+4. Rewrite the file in place as a clean, dense handoff summary in **decision-log format**:
 
    **Summary** — Write 1-3 sentences in decision-log narrative style, not changelog style:
    - Focus on: what we started working on, what we discovered or decided, what is still in progress.
@@ -51,9 +56,9 @@ When summarizing recent activity, cover the last **30 minutes OR 25 messages, wh
    - Remove all `## Snapshot [timestamp]` blocks — these are raw log entries that have been incorporated into the polished sections above.
    - Keep all five section headings. Do not delete any section.
 
-4. Write the polished content back to the same file path.
+5. Write the polished content back to the same file path.
 
-5. Call `write_result` to signal completion.
+6. Call `write_result` to signal completion.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

- Add a new step 3 to `session-note-polish.md` that performs a superseded-findings consistency pass before writing polished output
- When a session note contains a finding that is explicitly contradicted by a later entry in the same note, the finding is marked inline as `~~finding~~ [SUPERSEDED by: <explanation>]`
- Findings are preserved (not deleted) for audit trail purposes
- Only marks findings superseded when the note itself contains explicit contradictory evidence — not based on outside knowledge

## Problem

The polish step ran and produced clean, well-formatted notes but left invalidated findings in place as if still current. The concrete example from the issue: a session note contained both "agent_id is the signal" (early finding) and evidence that agent_id is absent from SessionStart payloads (later test at 02:03 UTC). The contradiction was invisible to the next session.

## Changes

`.claude/agents/session-note-polish.md` — insert new step 3 (superseded findings check); renumber old steps 3→4 (rewrite file), 4→5 (write back), 5→6 (write_result).

## Test plan

- [ ] Read updated `session-note-polish.md` and verify step 3 appears between the `get_active_sessions()` call and the file-rewrite step
- [ ] Verify the `[SUPERSEDED by: ...]` inline format matches the issue's proposed convention
- [ ] Verify subsequent steps are renumbered correctly (4=rewrite, 5=write back, 6=write_result)
- [ ] Manually test against an is_dispatcher-style fixture: note with early finding contradicted later; polished output should show the finding as superseded

Fixes #1112

🤖 Generated with [Claude Code](https://claude.com/claude-code)