### PR TITLE
feat(hooks): enforce reply_to_message_id on Telegram send_reply (#1168)

### DIFF
--- a/hooks/require-reply-to-message-id.py
+++ b/hooks/require-reply-to-message-id.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook: enforce reply_to_message_id on Telegram send_reply calls.
+
+Without reply_to_message_id, Telegram replies are sent standalone (not threaded
+to the original message). This hook blocks send_reply calls that target Telegram
+but omit or set reply_to_message_id=0.
+
+Exemptions (always allowed):
+  - Non-Telegram sources (slack, sms, whatsapp, bot-talk, system, ...)
+  - System/proactive sends where chat_id == 0 (no incoming message context)
+  - Calls where reply_to_message_id is already set to a positive integer
+
+Exit codes:
+  0 - Allow the call
+  2 - Block the call (Claude Code shows stderr message to Claude)
+
+Issue: #1168
+"""
+
+import json
+import sys
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        # Unparseable input — allow rather than block (fail-open)
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+
+    # Only check send_reply calls
+    if tool_name != "mcp__lobster-inbox__send_reply":
+        sys.exit(0)
+
+    tool_input = data.get("tool_input", {})
+    source = (tool_input.get("source") or "telegram").lower()
+
+    # Only enforce on Telegram (source absent defaults to telegram per API contract)
+    if source != "telegram":
+        sys.exit(0)
+
+    # Exempt proactive/system sends: chat_id == 0 means no originating user message
+    chat_id = tool_input.get("chat_id")
+    try:
+        if int(chat_id) == 0:
+            sys.exit(0)
+    except (TypeError, ValueError):
+        # chat_id absent or non-numeric — cannot determine, allow
+        sys.exit(0)
+
+    # Check reply_to_message_id: must be present and a positive integer
+    reply_to = tool_input.get("reply_to_message_id")
+    try:
+        if reply_to is not None and int(reply_to) > 0:
+            sys.exit(0)  # Properly set — allow
+    except (TypeError, ValueError):
+        pass  # Non-integer value — fall through to block
+
+    # Block: reply_to_message_id is missing or not a positive integer
+    print(
+        "BLOCKED: Telegram send_reply is missing reply_to_message_id.\n"
+        "Every Telegram reply must include reply_to_message_id (the integer\n"
+        "Telegram message ID shown in wait_for_messages output as\n"
+        "'pass as reply_to_message_id') to thread the reply correctly.\n\n"
+        "If this is a proactive/system send with no originating message,\n"
+        "pass chat_id=0 to exempt this check.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/install.sh
+++ b/install.sh
@@ -1437,6 +1437,27 @@ else
     info "Skipping link enforcement hook (settings.json not yet created)"
 fi
 
+# Set up Claude Code PreToolUse hook to enforce reply_to_message_id on Telegram send_reply (#1168)
+chmod +x "$INSTALL_DIR/hooks/require-reply-to-message-id.py" || true
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.PreToolUse[]? | select(.hooks[]?.command | test("require-reply-to-message-id"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+            "matcher": "mcp__lobster-inbox__send_reply",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 '"$INSTALL_DIR"'/hooks/require-reply-to-message-id.py",
+                "timeout": 5
+            }]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "Telegram reply_to_message_id enforcement hook installed"
+    else
+        info "reply_to_message_id enforcement hook already configured in Claude Code settings"
+    fi
+else
+    info "Skipping reply_to_message_id enforcement hook (settings.json not yet created)"
+fi
+
 # Set up Claude Code PreToolUse hook to block generic Agent calls without subagent_type
 chmod +x "$INSTALL_DIR/hooks/require-subagent-type.py" || true
 if [ -f "$CLAUDE_SETTINGS" ]; then

--- a/tests/unit/test_hooks/test_require_reply_to_message_id.py
+++ b/tests/unit/test_hooks/test_require_reply_to_message_id.py
@@ -1,0 +1,143 @@
+"""
+Unit tests for hooks/require-reply-to-message-id.py
+
+Tests cover:
+- Non-send_reply tool calls pass through (exit 0)
+- Telegram send_reply with reply_to_message_id > 0 passes (exit 0)
+- Telegram send_reply missing reply_to_message_id is blocked (exit 2)
+- Telegram send_reply with reply_to_message_id=0 is blocked (exit 2)
+- Non-Telegram source passes through (exit 0)
+- chat_id=0 (proactive/system send) passes through (exit 0)
+- Absent source defaults to telegram enforcement (exit 2 when no reply_to_message_id)
+- Malformed input passes through (exit 0 fail-open)
+- Block message contains actionable text in stderr
+
+Issue: #1168
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+HOOK_PATH = HOOKS_DIR / "require-reply-to-message-id.py"
+
+
+def _run(tool_input: dict, tool_name: str = "mcp__lobster-inbox__send_reply") -> tuple[int, str, str]:
+    """Run the hook with the given input; return (exit_code, stdout, stderr)."""
+    payload = {"tool_name": tool_name, "tool_input": tool_input}
+    result = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+class TestRequireReplyToMessageId:
+
+    def test_non_send_reply_tool_is_allowed(self):
+        """Non-send_reply tool calls are not checked."""
+        rc, _, _ = _run({"chat_id": 123456}, tool_name="mcp__lobster-inbox__mark_processed")
+        assert rc == 0
+
+    def test_telegram_with_valid_reply_to_message_id_allowed(self):
+        """Telegram send_reply with a positive reply_to_message_id passes."""
+        rc, _, _ = _run({
+            "source": "telegram",
+            "chat_id": 123456,
+            "text": "Hello!",
+            "reply_to_message_id": 99,
+        })
+        assert rc == 0
+
+    def test_telegram_missing_reply_to_message_id_blocked(self):
+        """Telegram send_reply without reply_to_message_id is blocked."""
+        rc, _, stderr = _run({
+            "source": "telegram",
+            "chat_id": 123456,
+            "text": "Hello!",
+        })
+        assert rc == 2
+        assert "reply_to_message_id" in stderr
+
+    def test_telegram_zero_reply_to_message_id_blocked(self):
+        """Telegram send_reply with reply_to_message_id=0 is blocked."""
+        rc, _, stderr = _run({
+            "source": "telegram",
+            "chat_id": 123456,
+            "text": "Hello!",
+            "reply_to_message_id": 0,
+        })
+        assert rc == 2
+        assert "reply_to_message_id" in stderr
+
+    def test_absent_source_defaults_to_telegram_enforcement(self):
+        """When source is absent, it defaults to telegram — enforce reply_to_message_id."""
+        rc, _, stderr = _run({
+            "chat_id": 123456,
+            "text": "Hello!",
+        })
+        assert rc == 2
+        assert "reply_to_message_id" in stderr
+
+    def test_slack_source_bypasses_enforcement(self):
+        """Slack send_reply without reply_to_message_id is allowed."""
+        rc, _, _ = _run({
+            "source": "slack",
+            "chat_id": 123456,
+            "text": "Hello!",
+        })
+        assert rc == 0
+
+    def test_system_source_bypasses_enforcement(self):
+        """System messages are not Telegram — allowed without reply_to_message_id."""
+        rc, _, _ = _run({
+            "source": "system",
+            "chat_id": 123456,
+            "text": "System alert",
+        })
+        assert rc == 0
+
+    def test_proactive_send_chat_id_zero_is_exempt(self):
+        """chat_id=0 means no originating message — proactive send is allowed."""
+        rc, _, _ = _run({
+            "source": "telegram",
+            "chat_id": 0,
+            "text": "Good morning!",
+        })
+        assert rc == 0
+
+    def test_malformed_input_fails_open(self):
+        """Unparseable JSON input allows the call rather than blocking it."""
+        result = subprocess.run(
+            [sys.executable, str(HOOK_PATH)],
+            input="not-valid-json{{{",
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+
+    def test_telegram_uppercase_source_is_normalised(self):
+        """Source comparison is case-insensitive."""
+        rc, _, _ = _run({
+            "source": "Telegram",
+            "chat_id": 123456,
+            "text": "Hello!",
+            "reply_to_message_id": 42,
+        })
+        assert rc == 0
+
+    def test_telegram_missing_id_blocked_stderr_has_guidance(self):
+        """Stderr message explains how to exempt proactive sends."""
+        rc, _, stderr = _run({
+            "source": "telegram",
+            "chat_id": 123456,
+            "text": "Hello!",
+        })
+        assert rc == 2
+        assert "chat_id=0" in stderr


### PR DESCRIPTION
## Summary

- Add `hooks/require-reply-to-message-id.py`: a PreToolUse hook that blocks `send_reply` calls targeting Telegram when `reply_to_message_id` is absent or zero
- Register the hook in `install.sh` so it is wired automatically on fresh installs and upgrades
- Add 11 unit tests covering all enforcement paths and exemptions

## Problem

Without `reply_to_message_id`, Telegram replies are sent standalone — not threaded to the original message. The CLAUDE.md docs say to pass it, but docs are advisory. LLMs forget. A hook makes this structural.

## How it works

- Only fires on `mcp__lobster-inbox__send_reply` calls
- Only enforces when `source == "telegram"` (or source is absent, which defaults to telegram per API contract)
- Exemptions that always pass:
  - Non-Telegram sources (slack, system, sms, whatsapp, bot-talk)
  - `chat_id == 0` — proactive/system sends with no originating message
  - `reply_to_message_id` is a positive integer — already correct

## Test plan

- [x] 11 unit tests pass: all allow/block paths, exemptions, case normalization, malformed input fail-open
- [ ] Deploy to local-dev and verify a Telegram send_reply without `reply_to_message_id` is blocked

Fixes #1168

🤖 Generated with [Claude Code](https://claude.com/claude-code)