### PR TITLE
feat(write_result): add reply_text field — separate user reply from dispatcher summary (#1490)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -488,7 +488,11 @@ Background subagents call `write_result(task_id, chat_id, text, ...)`, which dro
        # --- RELAY ---
        # Never call Read(artifact_path) on the main thread — it violates the 7-second rule.
        # Delegate artifact reading and large-text composition to a relay subagent.
-       reply_text = msg["text"]
+       #
+       # reply_text split: if the subagent provided reply_text, use it for the user-facing
+       # relay and keep text as dispatcher-only context. If reply_text is absent, fall back
+       # to text (backward-compat). This reduces main-thread context burn.
+       relay_content = msg.get("reply_text") or msg["text"]
 
        if msg.get("artifacts"):
            # Artifacts present: delegate reading and composition to relay subagent
@@ -505,8 +509,8 @@ Background subagents call `write_result(task_id, chat_id, text, ...)`, which dro
                    f"Artifacts:\n" + "\n".join(f"- {p}" for p in msg["artifacts"])
                ),
            )
-       elif len(reply_text) > 500:
-           # Large text: relay subagent composes and sends directly
+       elif len(relay_content) > 500:
+           # Large relay content: relay subagent composes and sends directly
            # IMPORTANT: relay must call send_reply then write_result(sent_reply_to_user=True)
            # to prevent an infinite relay loop (dispatcher would re-check len on re-delivery)
            Task(
@@ -518,14 +522,14 @@ Background subagents call `write_result(task_id, chat_id, text, ...)`, which dro
                    f"Compose a clear, mobile-friendly reply from the result text below. "
                    f"Call send_reply(chat_id={msg['chat_id']}, ...) directly, then call "
                    f"write_result(sent_reply_to_user=True) so the dispatcher does not relay again.\n\n"
-                   f"Result:\n{msg['text']}"
+                   f"Result:\n{relay_content}"
                ),
            )
        else:
-           # Short text — send inline
+           # Short content — send inline
            send_reply(
                chat_id=msg["chat_id"],
-               text=reply_text,
+               text=relay_content,
                source=msg.get("source", "telegram"),
                thread_ts=msg.get("thread_ts"),
                reply_to_message_id=msg.get("telegram_message_id"),
@@ -533,7 +537,7 @@ Background subagents call `write_result(task_id, chat_id, text, ...)`, which dro
        mark_processed(message_id)
 ```
 
-**Key fields:** `task_id`, `chat_id`, `text`, `source`, `status`, `sent_reply_to_user`, `artifacts`, `thread_ts`.
+**Key fields:** `task_id`, `chat_id`, `text`, `reply_text` (optional user-facing text; if present, dispatcher relays this instead of `text`), `source`, `status`, `sent_reply_to_user`, `artifacts`, `thread_ts`.
 
 **When type is `subagent_error`:**
 ```

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -123,6 +123,25 @@ mcp__lobster-inbox__write_result(
 
 The dispatcher will read your result and decide what (if anything) to relay to the user.
 
+**reply_text — separate user reply from dispatcher summary:**
+
+When the dispatcher should relay a short user-facing message while you provide a longer internal summary, use `reply_text`:
+
+```python
+mcp__lobster-inbox__write_result(
+    task_id="<task-id>",
+    chat_id=<chat_id>,
+    # text = full context for dispatcher (decisions made, URLs, details)
+    text="Filed issue #42 in SiderealPress/lobster. Label: enhancement. URL: https://github.com/.../issues/42",
+    # reply_text = trimmed mobile-friendly message shown to user
+    reply_text="Filed: https://github.com/SiderealPress/lobster/issues/42",
+    source="telegram",
+    sent_reply_to_user=False,
+)
+```
+
+When `reply_text` is present: dispatcher relays `reply_text` to the user; `text` stays in dispatcher context only. When absent: dispatcher relays `text` (backward-compatible). Ignored if `sent_reply_to_user=True`.
+
 **Signal convention note:** This only works if the dispatcher (or whoever spawns you) actually includes the signal phrase ("do NOT call send_reply" or "Use write_result only") in your task prompt. The dispatcher is responsible for adding this signal when spawning internal subagents. If you receive a task prompt without this signal, treat it as user-facing.
 
 **For user-facing tasks (the default):**

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -2185,7 +2185,8 @@ async def list_tools() -> list[Tool]:
                 "Subagents should call send_reply directly first (crash-safe delivery), then call "
                 "this with sent_reply_to_user=True so the dispatcher marks the message processed "
                 "without re-sending. On failure, call this with status='error' (no prior send_reply) "
-                "so the main thread can notify the user gracefully."
+                "so the main thread can notify the user gracefully. "
+                "Use reply_text to separate the user-facing reply from the dispatcher summary in text."
             ),
             inputSchema={
                 "type": "object",
@@ -2204,13 +2205,28 @@ async def list_tools() -> list[Tool]:
                     "text": {
                         "type": "string",
                         "description": (
-                            "The result text to deliver to the user. "
+                            "Dispatcher-internal summary of what the subagent did. "
+                            "The dispatcher reads this for orientation. "
+                            "If reply_text is also provided, this is NEVER relayed to the user — "
+                            "only reply_text is sent. "
+                            "If reply_text is absent, this is relayed to the user (backward-compat). "
                             "Keep this to a concise summary (ideally under ~4KB / ~500 words). "
                             "For large outputs — reports, diffs, full analysis — write the content "
                             "to ~/lobster-workspace/reports/<task_id>.md and pass the path in "
-                            "`artifacts` instead. The dispatcher reads artifact files and inlines "
-                            "their content in the reply. Never put raw file paths in text — they "
+                            "`artifacts` instead. Never put raw file paths in text — they "
                             "are server-side references that are useless to mobile users."
+                        ),
+                    },
+                    "reply_text": {
+                        "type": "string",
+                        "description": (
+                            "Optional user-facing reply text. "
+                            "When present, the dispatcher sends this to the user instead of `text`. "
+                            "Use this to keep the user reply short and mobile-friendly while "
+                            "keeping the full context in `text` for the dispatcher. "
+                            "Example: text='Filed issue #42 in SiderealPress/lobster. Label: enhancement. URL: https://...', "
+                            "reply_text='Filed: https://github.com/SiderealPress/lobster/issues/42'. "
+                            "Ignored if sent_reply_to_user=True (subagent already sent directly)."
                         ),
                     },
                     "source": {
@@ -6796,6 +6812,10 @@ async def handle_write_result(args: dict) -> list[TextContent]:
     task_id = args.get("task_id", "").strip()
     chat_id = args.get("chat_id")
     text = args.get("text", "").strip()
+    # reply_text: optional user-facing text. When present, dispatcher relays this
+    # instead of `text`, keeping `text` as dispatcher-only internal summary.
+    reply_text_raw = args.get("reply_text")
+    reply_text = reply_text_raw.strip() if isinstance(reply_text_raw, str) else None
     source = args.get("source", "telegram").strip() or "telegram"
     status = args.get("status", "success")
     artifacts = args.get("artifacts") or []
@@ -6868,6 +6888,11 @@ async def handle_write_result(args: dict) -> list[TextContent]:
         "sent_reply_to_user": bool(sent_reply_to_user),
         "timestamp": now.isoformat(),
     }
+    # reply_text: user-facing text separate from the dispatcher summary.
+    # When present and sent_reply_to_user is False, the dispatcher relays reply_text
+    # instead of text, keeping `text` as dispatcher-only internal context.
+    if reply_text and not sent_reply_to_user:
+        message["reply_text"] = reply_text
     if msg_type == "subagent_notification":
         message["warning"] = "User already received the subagent's reply. Don't summarize it. If you respond, add new value only — a question, a correction, missing context."
     if artifacts:

--- a/tests/unit/test_mcp_server/test_write_result_reply_text.py
+++ b/tests/unit/test_mcp_server/test_write_result_reply_text.py
@@ -1,0 +1,266 @@
+"""
+Unit tests for the reply_text field in write_result (issue #1490).
+
+When a subagent provides reply_text, the dispatcher should relay reply_text to
+the user instead of text, keeping text as dispatcher-only internal context.
+When reply_text is absent, text is used (backward-compat).
+
+Test cases:
+  1. reply_text present → stored in inbox message under key "reply_text"
+  2. reply_text absent → "reply_text" key not in inbox message (backward-compat)
+  3. reply_text present + sent_reply_to_user=True → reply_text NOT stored
+     (subagent already delivered; no relay needed)
+  4. reply_text empty string → treated as absent (not stored)
+  5. reply_text present → text still stored as-is (dispatcher summary unchanged)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+_ROOT = Path(__file__).parents[4]
+for _p in [str(_ROOT / "src" / "mcp"), str(_ROOT / "src" / "agents"),
+           str(_ROOT / "src"), str(_ROOT / "src" / "utils")]:
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import src.mcp.inbox_server  # noqa: F401 — pre-load so patch.multiple resolves it
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_dirs(tmp_path: Path):
+    """Return (inbox, outbox, sent, sent_replies) directories under tmp_path."""
+    inbox = tmp_path / "inbox"
+    outbox = tmp_path / "outbox"
+    sent = tmp_path / "sent"
+    sent_replies = tmp_path / "sent-replies"
+    for d in (inbox, outbox, sent, sent_replies):
+        d.mkdir(parents=True, exist_ok=True)
+    return inbox, outbox, sent, sent_replies
+
+
+def _mock_session_store() -> MagicMock:
+    store = MagicMock()
+    store.session_end.return_value = None
+    store.set_notified.return_value = None
+    return store
+
+
+def _read_inbox_message(inbox: Path) -> dict:
+    files = list(inbox.glob("*.json"))
+    assert len(files) == 1, f"Expected 1 inbox file, got {len(files)}"
+    return json.loads(files[0].read_text())
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+class TestReplyTextField:
+    """reply_text is stored in the inbox message when provided."""
+
+    def test_reply_text_stored_when_provided(self, tmp_path):
+        """When reply_text is provided, it appears in the inbox message."""
+        inbox, outbox, sent, sent_replies = _make_dirs(tmp_path)
+        mock_store = _mock_session_store()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox,
+            OUTBOX_DIR=outbox,
+            SENT_DIR=sent,
+            SENT_REPLIES_DIR=sent_replies,
+            _session_store=mock_store,
+        ):
+            from src.mcp.inbox_server import handle_write_result
+
+            asyncio.run(handle_write_result({
+                "task_id": "test-reply-text",
+                "chat_id": 12345,
+                "text": "Filed issue #42 in SiderealPress/lobster. Label: enhancement. URL: https://github.com/SiderealPress/lobster/issues/42",
+                "reply_text": "Filed: https://github.com/SiderealPress/lobster/issues/42",
+                "source": "telegram",
+            }))
+
+        msg = _read_inbox_message(inbox)
+        assert "reply_text" in msg, "reply_text must appear in inbox message when provided"
+        assert msg["reply_text"] == "Filed: https://github.com/SiderealPress/lobster/issues/42"
+
+    def test_reply_text_absent_when_not_provided(self, tmp_path):
+        """When reply_text is not provided, it does not appear in the inbox message."""
+        inbox, outbox, sent, sent_replies = _make_dirs(tmp_path)
+        mock_store = _mock_session_store()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox,
+            OUTBOX_DIR=outbox,
+            SENT_DIR=sent,
+            SENT_REPLIES_DIR=sent_replies,
+            _session_store=mock_store,
+        ):
+            from src.mcp.inbox_server import handle_write_result
+
+            asyncio.run(handle_write_result({
+                "task_id": "test-no-reply-text",
+                "chat_id": 12345,
+                "text": "Done. PR is open at https://github.com/SiderealPress/lobster/pull/99",
+                "source": "telegram",
+            }))
+
+        msg = _read_inbox_message(inbox)
+        assert "reply_text" not in msg, "reply_text must NOT appear when not provided (backward-compat)"
+
+    def test_text_always_stored_regardless_of_reply_text(self, tmp_path):
+        """text is always stored in the inbox message even when reply_text is present."""
+        inbox, outbox, sent, sent_replies = _make_dirs(tmp_path)
+        mock_store = _mock_session_store()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox,
+            OUTBOX_DIR=outbox,
+            SENT_DIR=sent,
+            SENT_REPLIES_DIR=sent_replies,
+            _session_store=mock_store,
+        ):
+            from src.mcp.inbox_server import handle_write_result
+
+            asyncio.run(handle_write_result({
+                "task_id": "test-text-preserved",
+                "chat_id": 12345,
+                "text": "Full dispatcher context: filed issue #42, applied label enhancement, set milestone v2.0",
+                "reply_text": "Filed #42",
+                "source": "telegram",
+            }))
+
+        msg = _read_inbox_message(inbox)
+        assert msg["text"] == "Full dispatcher context: filed issue #42, applied label enhancement, set milestone v2.0"
+        assert msg["reply_text"] == "Filed #42"
+
+    def test_reply_text_not_stored_when_sent_reply_to_user_true(self, tmp_path):
+        """When sent_reply_to_user=True, reply_text is NOT stored (subagent already delivered)."""
+        inbox, outbox, sent, sent_replies = _make_dirs(tmp_path)
+        mock_store = _mock_session_store()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox,
+            OUTBOX_DIR=outbox,
+            SENT_DIR=sent,
+            SENT_REPLIES_DIR=sent_replies,
+            _session_store=mock_store,
+        ):
+            from src.mcp.inbox_server import handle_write_result
+
+            asyncio.run(handle_write_result({
+                "task_id": "test-already-sent",
+                "chat_id": 12345,
+                "text": "Summary for dispatcher: completed filing of issue #42.",
+                "reply_text": "Filed #42",
+                "source": "telegram",
+                "sent_reply_to_user": True,
+            }))
+
+        msg = _read_inbox_message(inbox)
+        # When sent_reply_to_user=True, reply_text should NOT be stored
+        # (the relay path is suppressed; reply_text would never be used)
+        assert "reply_text" not in msg, (
+            "reply_text must NOT be stored when sent_reply_to_user=True — "
+            "the subagent already sent the reply directly"
+        )
+
+    def test_reply_text_empty_string_treated_as_absent(self, tmp_path):
+        """An empty reply_text is treated as absent — not stored in inbox message."""
+        inbox, outbox, sent, sent_replies = _make_dirs(tmp_path)
+        mock_store = _mock_session_store()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox,
+            OUTBOX_DIR=outbox,
+            SENT_DIR=sent,
+            SENT_REPLIES_DIR=sent_replies,
+            _session_store=mock_store,
+        ):
+            from src.mcp.inbox_server import handle_write_result
+
+            asyncio.run(handle_write_result({
+                "task_id": "test-empty-reply-text",
+                "chat_id": 12345,
+                "text": "Done.",
+                "reply_text": "",
+                "source": "telegram",
+            }))
+
+        msg = _read_inbox_message(inbox)
+        assert "reply_text" not in msg, "Empty reply_text must be treated as absent"
+
+    def test_reply_text_whitespace_only_treated_as_absent(self, tmp_path):
+        """A whitespace-only reply_text is treated as absent — not stored."""
+        inbox, outbox, sent, sent_replies = _make_dirs(tmp_path)
+        mock_store = _mock_session_store()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox,
+            OUTBOX_DIR=outbox,
+            SENT_DIR=sent,
+            SENT_REPLIES_DIR=sent_replies,
+            _session_store=mock_store,
+        ):
+            from src.mcp.inbox_server import handle_write_result
+
+            asyncio.run(handle_write_result({
+                "task_id": "test-whitespace-reply-text",
+                "chat_id": 12345,
+                "text": "Done.",
+                "reply_text": "   ",
+                "source": "telegram",
+            }))
+
+        msg = _read_inbox_message(inbox)
+        assert "reply_text" not in msg, "Whitespace-only reply_text must be treated as absent"
+
+    def test_message_type_is_subagent_result_not_notification(self, tmp_path):
+        """reply_text with sent_reply_to_user=False still creates subagent_result type."""
+        inbox, outbox, sent, sent_replies = _make_dirs(tmp_path)
+        mock_store = _mock_session_store()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            INBOX_DIR=inbox,
+            OUTBOX_DIR=outbox,
+            SENT_DIR=sent,
+            SENT_REPLIES_DIR=sent_replies,
+            _session_store=mock_store,
+        ):
+            from src.mcp.inbox_server import handle_write_result
+
+            asyncio.run(handle_write_result({
+                "task_id": "test-type-check",
+                "chat_id": 12345,
+                "text": "Full context for dispatcher.",
+                "reply_text": "Short reply for user.",
+                "source": "telegram",
+                "sent_reply_to_user": False,
+            }))
+
+        msg = _read_inbox_message(inbox)
+        assert msg["type"] == "subagent_result", (
+            f"Message type must be subagent_result when sent_reply_to_user=False, got: {msg['type']}"
+        )
+        assert "reply_text" in msg


### PR DESCRIPTION
## Summary

- Adds optional `reply_text` field to `write_result` so subagents can provide a terse mobile-friendly user reply separately from the full internal summary in `text`
- When `reply_text` is present and `sent_reply_to_user=False`, the dispatcher relays `reply_text` to the user and keeps `text` as dispatcher-only context, reducing main-thread context burn
- Fully backward-compatible: absence of `reply_text` falls back to current behavior (dispatcher relays `text`)

## Changes

**`src/mcp/inbox_server.py`**
- `write_result` tool schema: adds `reply_text` (optional string) with clear documentation of the split pattern
- Updates `text` description to clarify it is now dispatcher-internal when `reply_text` is provided
- `handle_write_result`: parses `reply_text`, stores it in the inbox message when non-empty and `sent_reply_to_user=False`

**`.claude/sys.dispatcher.bootup.md`**
- Relay section: uses `relay_content = msg.get("reply_text") or msg["text"]` so the dispatcher sends the user-facing text, not the full summary
- Updates key fields documentation to include `reply_text`

**`.claude/sys.subagent.bootup.md`**
- Adds `reply_text` usage pattern with example to the "For internal tasks" section

**`tests/unit/test_mcp_server/test_write_result_reply_text.py`** (new file)
- 7 tests covering: reply_text stored when provided, absent when not provided, text always preserved, not stored when sent_reply_to_user=True, empty/whitespace treated as absent, message type unaffected

## Test plan
- [x] All 7 new `test_write_result_reply_text.py` tests pass
- [x] All 54 existing `test_write_result_set_notified.py` + `test_message_tools.py` tests pass (no regressions)

Fixes #1490

🤖 Generated with [Claude Code](https://claude.com/claude-code)