### PR TITLE
feat(session-notes): add Dead Ends section to prevent re-investigation (#1111)

### DIFF
--- a/.claude/agents/session-note-appender.md
+++ b/.claude/agents/session-note-appender.md
@@ -52,14 +52,19 @@ The `activity` context may also include:
 
    Keep each bullet to one line. No nested bullets. No prose paragraphs.
 
-4. Append the snapshot entry to the end of the session file, after all existing content.
+4. If the `activity` context contains any explicitly invalidated findings (e.g., "X was tried but rejected because Y"), add them to the **Dead Ends** section of the session file:
+   - Append a bullet under `## Dead Ends` in the format: `- <Approach> — rejected because <reason>. Evidence: <test/log/observation>.`
+   - Only add entries when the invalidation is explicit in the activity context — do not infer.
+   - If there is no `## Dead Ends` section in the file, skip this step (session-note-polish will add it on the next compaction).
+
+5. Append the snapshot entry to the end of the session file, after all existing content.
    - Do NOT overwrite or restructure the existing content.
-   - Do NOT modify the header, Summary, Open Threads, Open Tasks, Open Subagents, or Notable Events sections.
+   - Do NOT modify the header, Summary, Open Threads, Open Tasks, Open Subagents, Dead Ends, or Notable Events sections.
    - Simply append the new `## Snapshot [timestamp]` block at the bottom.
 
-5. Write the updated file back to the same path.
+6. Write the updated file back to the same path.
 
-6. Call `write_result` to signal completion.
+7. Call `write_result` to signal completion.
 
 ## Snapshot format example
 

--- a/.claude/agents/session-note-polish.md
+++ b/.claude/agents/session-note-polish.md
@@ -22,7 +22,12 @@ When summarizing recent activity, cover the last **30 minutes OR 25 messages, wh
 
 2. Call `get_active_sessions()` to get currently running agents.
 
-3. Rewrite the file in place as a clean, dense handoff summary in **decision-log format**:
+3. **Superseded findings check (run before writing the polished output):** Scan the full note for findings that are contradicted or invalidated by later entries in the same note. For each such finding:
+   - Mark it as superseded inline using `[SUPERSEDED by: <brief explanation>]` — e.g., `~~agent_id is the signal~~ [SUPERSEDED by: agent_id not present in SessionStart payloads per 02:03 UTC test]`
+   - Do NOT delete the finding — preserve it for audit trail, just mark it clearly
+   - Only mark a finding superseded when the note itself contains explicit contradictory evidence, not when you infer it from outside knowledge
+
+4. Rewrite the file in place as a clean, dense handoff summary in **decision-log format**:
 
    **Summary** — Write 1-3 sentences in decision-log narrative style, not changelog style:
    - Focus on: what we started working on, what we discovered or decided, what is still in progress.
@@ -56,9 +61,9 @@ When summarizing recent activity, cover the last **30 minutes OR 25 messages, wh
    - Remove all `## Snapshot [timestamp]` blocks — these are raw log entries that have been incorporated into the polished sections above.
    - Keep all six section headings (including Dead Ends). Do not delete any section.
 
-4. Write the polished content back to the same file path.
+5. Write the polished content back to the same file path.
 
-5. Call `write_result` to signal completion.
+6. Call `write_result` to signal completion.
 
 ## Rules
 

--- a/.claude/agents/session-note-polish.md
+++ b/.claude/agents/session-note-polish.md
@@ -43,13 +43,18 @@ When summarizing recent activity, cover the last **30 minutes OR 25 messages, wh
 
    **Notable Events** — Trim to the 3-5 most significant entries across the whole session.
 
+   **Dead Ends** — Consolidate invalidated findings from Snapshot blocks and the existing Dead Ends section:
+   - Collect all entries from `## Dead Ends` plus any "rejected because" / "invalidated" entries found in Snapshot blocks.
+   - De-duplicate (same approach name = one entry).
+   - Write the consolidated list under `## Dead Ends`. If no dead ends exist, write `- (none)`.
+
    **File cleanup:**
    - Set the Ended field to the current UTC timestamp.
    - Before stripping Snapshot blocks, scan each one for `In-flight:` bullets and `Pending response to:` bullets:
      - Any `In-flight: <task_id>` found should be added to the Open Subagents section if not already present.
      - Any `Pending response to: <description>` found should be added to the Open Threads section if not already present.
    - Remove all `## Snapshot [timestamp]` blocks — these are raw log entries that have been incorporated into the polished sections above.
-   - Keep all five section headings. Do not delete any section.
+   - Keep all six section headings (including Dead Ends). Do not delete any section.
 
 4. Write the polished content back to the same file path.
 

--- a/memory/canonical-templates/sessions/session.template.md
+++ b/memory/canonical-templates/sessions/session.template.md
@@ -46,5 +46,15 @@
 ## Open Subagents
 <Subagents spawned this session that may not have written results yet. Include task_id and brief description.>
 
+## Dead Ends
+
+<!--
+  Findings that were investigated and invalidated during this session.
+  Format: "Approach X — rejected because Y. Evidence: Z."
+  Add one entry per invalidated direction so future sessions don't re-investigate.
+-->
+
+- (none)
+
 ## Notable Events
 <Significant things that happened this session: user decisions, system changes, errors, unexpected outcomes, etc.>


### PR DESCRIPTION
## Summary

- Adds a `## Dead Ends` section to the session template so invalidated findings are explicitly recorded rather than silently retained as stale truths
- Updates `session-note-appender` to populate Dead Ends when the activity context contains explicit invalidations
- Updates `session-note-polish` to consolidate Dead Ends entries from Snapshot blocks during compaction

## Problem solved

Session notes retained invalidated findings without marking them as such. This caused re-investigation from scratch in later sessions (e.g., the `agent_id` re-investigation that cost 20+ minutes in the is_dispatcher work).

## Changes

**`memory/canonical-templates/sessions/session.template.md`**
- Adds `## Dead Ends` section between Open Subagents and Notable Events, with format guidance and `- (none)` default

**`.claude/agents/session-note-appender.md`**
- Step 4 (new): checks activity context for explicit invalidations and appends them to Dead Ends section
- Step 5 (was 4): updated to list Dead Ends as a protected section
- Steps renumbered 4→5, 5→6, 6→7

**`.claude/agents/session-note-polish.md`**
- New Dead Ends consolidation step: collects entries from existing Dead Ends section and Snapshot blocks, de-duplicates, writes consolidated list
- File cleanup: updated to keep all six section headings (was five)

## Conflict note

This PR modifies `session-note-polish.md` which is also modified by open PR #1539. The changes are in different areas (superseded-findings check vs Dead Ends consolidation) but both renumber steps — a minor merge conflict is expected.

## Test plan
- [x] Pre-existing test failures confirmed as pre-existing (not introduced by this PR)
- [x] Template renders correctly with new section
- [x] No regressions in passing tests

Fixes #1111

🤖 Generated with [Claude Code](https://claude.com/claude-code)