### PR TITLE
feat(pr-template): add 'Alternatives considered' section (#1110)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,12 @@
 -
 -
 
+## Alternatives considered
+
+<!-- Required if this PR replaces a previous approach or changes an existing mechanism. -->
+<!-- For each rejected alternative: what was tried, why it was rejected, and any confirming test/error. -->
+<!-- For purely additive PRs (no existing approach replaced): "N/A — purely additive." -->
+
 ## Tests run
 
 Fill this in before opening the PR. Each checked item must show the exact command and a brief outcome. Each unchecked item must explain why it was skipped or blocked. No abstract category labels — just commands and results.


### PR DESCRIPTION
## Summary

- Adds an **Alternatives considered** section to the PR template, positioned between Summary and Tests run
- The section is required for PRs that replace an existing approach; for purely additive PRs, authors write "N/A — purely additive"
- Comments in the template explain exactly what to fill in (what was tried, why rejected, confirming test/error) — no ceremony for simple cases

## Alternatives considered

N/A — purely additive (no existing template section replaced, only a new section inserted).

## Why this section matters

Rejected approaches were not recorded anywhere durable. During the `is_dispatcher` work, two approaches (`agent_id` and `LOBSTER_MAIN_SESSION` env var) were investigated and rejected — but neither rejection was recorded in the PR description. Hours later, both were re-proposed and required 20+ minutes of re-investigation to re-reject. This section makes the cost of omission visible: a reviewer can ask "where's the Alternatives considered?" before approving.

The section is intentionally lightweight: one table or a few bullets suffices. For purely additive PRs, "N/A" is the entire entry. The goal is to force an explicit acknowledgment, not add ceremony.

## Tests run

- [x] Template renders correctly in GitHub PR creation flow — verified by reading file contents
- [ ] No automated tests applicable — this is a markdown template file

**Blocked items needing attention before merge:** none

## Functional patterns used

N/A — documentation-only change (markdown template).

## Breaking changes / migration notes

None.

## Open PR conflicts checked

No other open PR touches `.github/pull_request_template.md`.

Closes #1110