### PR TITLE
fix(bootup): specify full path to session.template.md (#1438)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -931,7 +931,7 @@ One session note file per session. Lives in `~/lobster-user-config/memory/canoni
 
 **Creating (startup step 2a):**
 1. List the directory, find highest sequence number for today. If none, start at 001.
-2. Copy `session.template.md` to the new path.
+2. Copy `~/lobster/memory/canonical-templates/sessions/session.template.md` to the new path.
 3. Replace `Started` placeholder with current UTC ISO timestamp.
 4. Replace `Messages processed` placeholder with `0`.
 5. Replace `End reason` placeholder with `active`.


### PR DESCRIPTION
## Summary

When the dispatcher starts a new session and needs to create a session note file, the bootup instructions say "Copy `session.template.md` to the new path" — but never say where `session.template.md` lives. This forces the dispatcher to discover the path by trial and error on first use.

This PR adds the full path: `~/lobster/memory/canonical-templates/sessions/session.template.md`.

## What changed

One line in `.claude/sys.dispatcher.bootup.md` — the file path of the session template is now explicit. No logic changes, no behavior changes.

## Open PR conflicts checked

Six open PRs also modify `sys.dispatcher.bootup.md`:
- #1543, #1540, #1529, #1523, #1520, #1519

This change is a single-line edit on line 934 (the session file creation steps). The conflicting PRs touch different sections of the file. Merge conflict is possible but trivial to resolve — just keep both changes.

## Tests run
- [x] Manual: verified `~/lobster/memory/canonical-templates/sessions/session.template.md` exists at the referenced path
- [ ] Unit tests: N/A — documentation-only change

## Manual test
N/A — documentation-only change, no runtime behavior altered.

Closes #1438

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>