### PR TITLE
fix(bootup): correct compact-ack-messages.json path to ~/lobster/.claude/ (#1419)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -40,11 +40,10 @@ When you first start (or after reading this file), follow these steps:
 **Selecting the ack message** (used in step 2d above and in compact-reminder step 2.5 below):
 ```python
 import json, random, os
-ack_path = os.path.expanduser("~/.claude/compact-ack-messages.json")
+ack_path = os.path.expanduser("~/lobster/.claude/compact-ack-messages.json")
 with open(ack_path) as f:
     ack_msg = random.choice(json.load(f)["messages"])
 ```
-The symlink `~/.claude/` resolves to `~/lobster/.claude/` on standard installs.
 
 3. Run `~/lobster/scripts/record-catchup-state.sh start` (suppresses WFM freshness check for 15 min).
 3b. **Claim any pending user messages immediately** to stop the health-check staleness clock:
@@ -248,7 +247,7 @@ After a context compaction you lose situational awareness of the last ~30 minute
 1. mark_processing(message_id)  <- compact-reminder ONLY, not other messages
 2. Read the compact-reminder text to re-orient (identity, main loop, key files)
 2.5. Send a random ack message to admin chat (see **Selecting the ack message** in the Startup Behavior section):
-   - Pick with `random.choice()` from `~/.claude/compact-ack-messages.json`
+   - Pick with `random.choice()` from `~/lobster/.claude/compact-ack-messages.json`
    - This is the user-visible signal that the lobster is back and gathering context
    - Use ADMIN_CHAT_ID from `lobster.conf` or the compact-reminder context
 3. Spawn session-note-polish subagent (run_in_background=True, subagent_type: "lobster-generalist"):


### PR DESCRIPTION
## Summary

The dispatcher bootup doc referenced `~/.claude/compact-ack-messages.json` for reading the ack message list. But `~/.claude` is Claude Code's own config directory — not the lobster repo. The file actually lives at `~/lobster/.claude/compact-ack-messages.json`.

The doc also claimed `~/.claude/` is a symlink to `~/lobster/.claude/` on standard installs, which is false: `~/.claude` is a real directory (Claude Code's config store), not a symlink. The symlink is `~/lobster-workspace/.claude` → `~/lobster/.claude/`, not `~/.claude`.

This PR corrects both the path reference and removes the incorrect symlink note.

## What changed

Two lines in `.claude/sys.dispatcher.bootup.md`:
- `~/.claude/compact-ack-messages.json` → `~/lobster/.claude/compact-ack-messages.json` (two occurrences)
- Removed the false claim that `~/.claude/` is a symlink to `~/lobster/.claude/`

No logic changes. Documentation only.

## Open PR conflicts checked

Seven open PRs also modify `sys.dispatcher.bootup.md`:
- #1546, #1543, #1540, #1529, #1523, #1520, #1519

This change is on lines 43-47 (startup ack message block) and line 250 (compact-reminder section). Merge conflicts are possible but trivial to resolve.

## Tests run
- [x] Manual: verified `~/lobster/.claude/compact-ack-messages.json` exists (6485 bytes)
- [x] Manual: verified `~/.claude` is NOT a symlink — it is Claude Code's real config directory
- [ ] Unit tests: N/A — documentation-only change

## Manual test
N/A — documentation-only change. Verified the correct path exists on disk.

Closes #1419

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>