### PR TITLE
fix(docs): remove dogfooding gate convention from DEVELOPMENT.md (#1440)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -126,41 +126,6 @@ See `hooks/auto-register-agent.py` for full details.
 
 ---
 
-## Convention 4: The Dogfooding Gate
-
-**Every PR that touches runtime code must be cleared through the dogfooding gate before merging to main.** This is a hard prerequisite alongside code review and smoke testing.
-
-### What the gate is
-
-The dogfooding gate is the formal signal that a PR has been running long enough on the local integration branch (`local-dev`) to be trusted. It closes the gap between "merged to local-dev for testing" and "ready to ship to main."
-
-### Soak period
-
-A PR must run on `local-dev` for **at least 2 hours** without incident before it can be cleared. An incident is any error, regression, or behavior change caused by the branch that required action (restart, revert, workaround). Unrelated system failures do not count.
-
-**Exceptions:**
-- Doc/prompt-only PRs (no code changes): soak not required.
-- Infrastructure/install changes tested via Docker: Docker run substitutes for local soak.
-
-### Clearing the gate
-
-After the soak period, the operator clears the PR with `/dogfooded <PR-number>`. This is an explicit human acknowledgment that the branch has been observed in production without incident.
-
-Until the `/dogfooded` command is fully implemented (see [issue #917](https://github.com/SiderealPress/lobster/issues/917)), clearance is handled by the dispatcher as a verbal confirmation from the user, recorded in the PR walkthrough notes.
-
-### Gate status in PR walkthroughs
-
-When presenting a PR for merge consideration, always include dogfooding status:
-- "Not yet deployed to local-dev" — gate is not started
-- "In soak since [time] — [elapsed]h / 2h minimum" — gate is running
-- "Cleared by /dogfooded at [time]" — gate is passed
-
-### Why this gate exists
-
-The informal "used in practice" requirement had no forcing function. There was no moment where anyone consciously declared a PR ready. The dogfooding gate creates that moment.
-
----
-
 ## Related documentation
 
 - `.claude/sys.dispatcher.bootup.md` — runtime behavior and the worktree constraint from the dispatcher's perspective


### PR DESCRIPTION
The dogfooding gate (Convention 4) was added to `docs/DEVELOPMENT.md` without the user requesting it. The user explicitly asked for it to be removed.

## What changed

Removes the 35-line "Convention 4: The Dogfooding Gate" section from `DEVELOPMENT.md`, including the description of the `/dogfooded` command, the 2-hour soak period requirement, and the gate status language. No code is affected — this is a doc-only change.

Nothing outside `DEVELOPMENT.md` is changed. The `/dogfooded` command reference in issue #917 is unchanged; that issue remains open independently.

## Functional patterns

Pure removal — no new logic introduced.

## Open PR conflicts checked

No open PRs touch `docs/DEVELOPMENT.md`. Checked against all 30 open PRs via `gh pr list --state open --json number,title,files`.

## Tests run
- [x] `git diff origin/main...origin/fix/issue-1440-remove-dogfooding-gate` — diff is exactly the Convention 4 section removal, no other changes

## Manual test
N/A — doc-only change, no runtime behavior affected.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests) — N/A, doc only
- [x] User-visible outcome verified OR not applicable — doc only, no user-visible output
- [x] Side-effect audit complete — no code or runtime state touched

Closes #1440

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>