### PR TITLE
fix(bootup): remove misleading EXIT language in context_warning handler (#1444)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -682,7 +682,7 @@ Written by `hooks/context-monitor.py` when context window >= 70%.
 5. Write ~/lobster-workspace/data/context-handoff.json:
    {"triggered_at": "<iso8601>", "context_pct": <pct>, "pending_tasks": <list>, "last_user_message": "<text>", "note": "Graceful wind-down"}
 6. Send user (use admin chat_id from config): "Context at {pct}% — entering wind-down mode. Handing off cleanly."
-7. Stop the main loop — do NOT call wait_for_messages() again. Claude Code will compact naturally.
+7. Do NOT call wait_for_messages() again. Do not attempt to self-terminate — the dispatcher cannot exit itself. Claude Code's context compaction will end the session externally when the context window fills.
 8. mark_processed(message_id)
 ```
 

--- a/.githooks/security-allowlist.txt
+++ b/.githooks/security-allowlist.txt
@@ -96,3 +96,10 @@ scripts/periodic-self-check.sh:Personal name (drew)
 # number "122.0.0.0" that looks like an IP address — it is not an IP, it is a browser
 # version string used to avoid bot detection in DuckDuckGo HTML requests
 lobster-shop/prospect-enrichment/bin/find_supply_chain_contacts.py:IP address
+
+# lobstertalk-incoming-handler.py uses the same bot-talk API base IP as the already-allowlisted
+# bot-talk-check-dispatch.sh. The BOT_TALK_BASE constant is a fallback when BOT_TALK_API_URL
+# env var is unset — not a secret. The email references are comment-only documentation strings
+# (Google Drive / Gmail account names for context), not credentials.
+scheduled-tasks/lobstertalk-incoming-handler.py:IP address
+scheduled-tasks/lobstertalk-incoming-handler.py:Email address


### PR DESCRIPTION
The `context_warning` handler in `sys.dispatcher.bootup.md` previously told the dispatcher to "Stop the main loop" after wind-down. This is misleading because the dispatcher cannot self-terminate — it is an always-on process that the health check manages externally.

## Root cause

The line read:
```
7. Stop the main loop — do NOT call wait_for_messages() again. Claude Code will compact naturally.
```

"Stop the main loop" implies the dispatcher can exit itself, which it cannot (issue #1442). A dispatcher that reads this and attempts to terminate sits silently deaf — it stops polling but the process keeps running, dropping all incoming messages.

## What changed

Step 7 of the `context_warning` handler is rewritten to:
```
7. Do NOT call wait_for_messages() again. Do not attempt to self-terminate — the dispatcher cannot exit itself. Claude Code's context compaction will end the session externally when the context window fills.
```

This accurately describes the two-step external handoff: the dispatcher stops calling WFM, and the runtime (not the dispatcher) ends the session when the context window fills.

A security allowlist entry is also added for the `lobstertalk-incoming-handler.py` scheduled task (IP address and email address in non-credential context — allowlisted as documentation strings).

## Flow comparison

Before: `context_warning` → dispatcher "stops main loop" → ??? (silent deaf state)
After: `context_warning` → dispatcher stops calling WFM → context compaction ends session externally

## Open PR conflicts checked

Multiple open PRs touch `sys.dispatcher.bootup.md` (#1547, #1546, #1543, #1540, #1529, #1523, #1520, #1519). The change in this PR is isolated to line ~688 (the context_warning handler step 7). Those PRs all modify different sections (WFM timeout, send_reply enforcement, skill system, etc.) — no line-level conflicts expected.

## Tests run
- [x] `git diff origin/main...origin/fix/issue-1444-exit-language` — two changes: context_warning step 7 rewrite + security allowlist entry
- [x] No automated tests applicable — doc and allowlist changes only

## Manual test
N/A — doc-only change to dispatcher instructions. No runtime code modified.

## Definition of Done
- [x] Unit tests pass — N/A, doc only
- [x] User-visible outcome verified OR not applicable — doc only, no user output
- [x] Side-effect audit complete — no code or runtime state touched

Closes #1444

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>