### PR TITLE
fix(startup): skip systemd-managed MCP processes in orphan reaper (#1455)

### DIFF
--- a/scripts/claude-persistent.sh
+++ b/scripts/claude-persistent.sh
@@ -374,6 +374,15 @@ kill_orphaned_mcp_processes() {
             continue
         fi
 
+        # Skip systemd-managed services — they are independently lifecycle-managed,
+        # not orphans. Killing them causes a restart race where Claude initializes
+        # before the MCP server comes back up, leaving the session without MCP tools.
+        if systemctl status --pid "$pid" >/dev/null 2>&1; then
+            log "CLEANUP: MCP PID $pid is a systemd-managed service — skipping"
+            skipped=$((skipped + 1))
+            continue
+        fi
+
         local is_ours=false
         if [[ -n "$tmux_panes" ]]; then
             local check_pid="$pid"


### PR DESCRIPTION
## Summary

On every restart, `kill_orphaned_mcp_processes` was killing the `lobster-mcp-local.service` — the systemd-managed MCP server. Because systemd restarts it with a delay and Claude Code initializes in between, the dispatcher started every session without MCP tools (no `wait_for_messages`, no `send_reply`, no inbox access). A workaround (`RestartSec=0`) narrowed the race but did not eliminate it.

The fix is a single guard: before the tmux ancestry walk, check if the process belongs to an active systemd service. If it does, skip it — it is not an orphan, it is independently lifecycle-managed.

## Root cause

`lobster-mcp-local.service` has PPID=1 (systemd). The ancestry walk stops at PPID=1 without finding a tmux pane, so the process falls through to the kill branch on every invocation.

## What changed

`scripts/claude-persistent.sh`: in the `kill_orphaned_mcp_processes` per-pid loop, added a `systemctl status --pid` check before the tmux ancestry walk. If the check succeeds (process is a systemd service), the pid is logged and skipped. The rest of the kill/skip logic is unchanged.

## Flow comparison

Before:
```
pgrep inbox_server.py → pid found → tmux ancestry walk → PPID=1, no tmux pane found → SIGTERM → systemd restart race → session starts without MCP tools
```

After:
```
pgrep inbox_server.py → pid found → systemctl status --pid check → service detected → skip → tmux ancestry walk never runs for this pid
```

## Open PR conflicts checked

- **PR#1535** touches `scripts/claude-persistent.sh` and `install.sh` — adds a separate `scripts/reap-orphaned-mcp.sh` and modifies `kill_orphaned_mcp_processes` in a different block (the MCP pid collection section, not the per-pid loop). Line-level conflict is possible depending on what exactly PR#1535 changes in the per-pid section. Reviewer should verify merge order.

## Tests run

- [x] `git diff origin/main HEAD -- scripts/claude-persistent.sh` — diff reviewed, guard is correctly placed before ancestry walk, skipped count is properly incremented
- [ ] Live restart test — not run; this is a startup script path that requires a real system restart to exercise. The fix is a 9-line addition with no behavior change for non-systemd processes.

## Manual test

The fix addresses a runtime startup condition (kill happens before Claude initializes). Proper verification requires watching logs during a system restart. The workaround (`RestartSec=0`) should be removed after this merges and the fix is confirmed working in production.

The `systemctl status --pid` command is safe to run (read-only, zero side effects) and will return non-zero for any non-systemd process, leaving the existing kill logic intact.

## Definition of Done

- [x] Unit tests pass — not applicable (bash script)
- [ ] Integration/manual test — requires live system restart with log observation
- [x] User-visible outcome: MCP tools available at session start (cannot self-verify without production restart)
- [x] Side-effect audit: read-only systemctl check, no writes, no floods
- [x] External service calls: none

Closes #1455