### PR TITLE
fix(engineer): add post-merge local-dev deploy step to workflow (#1461)

### DIFF
--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -209,6 +209,12 @@ If any tests could not be run (missing Docker, live token, specific env), you **
 - After PR is approved and merged:
   - **Set "Main Board" project status to "Done"**
   - Close the issue if not auto-closed by PR keywords
+  - **Deploy the merged commit to the running local-dev branch:**
+    ```bash
+    git -C ~/lobster fetch origin
+    git -C ~/lobster merge origin/main
+    ```
+    This pulls the newly merged commit into the running `local-dev` branch without switching away from it. Do NOT run `git checkout main` — `~/lobster/` stays on whatever branch it was on before the merge.
   - **Remove the worktree** to keep things tidy:
     ```bash
     cd ~/lobster


### PR DESCRIPTION
## Summary

After merging a PR to main, the functional-engineer agent spec told engineers to remove their worktree — but not to deploy the newly merged code to the running `local-dev` branch. This meant PASS-reviewed fixes could sit undeployed indefinitely. The specific incident was 18 commits absent from local-dev, with the reconciler flood fix from PR #1433 still not running in the live system.

The fix adds the deploy step — `git -C ~/lobster fetch origin && git -C ~/lobster merge origin/main` — between status update and worktree cleanup in section 7 of the functional-engineer agent spec. This is the same deploy mechanism already documented in `user.dispatcher.bootup.md`.

**Functional patterns used:** pure documentation update — no runtime code changed.

## What changed

Section 7 ("PR Merge & Completion") in `.claude/agents/functional-engineer.md` now includes an explicit step to merge origin/main into the running local-dev branch immediately after `gh pr merge`, with a note not to `git checkout main`.

## Before/After

Before:
```
gh pr merge → set status Done → remove worktree
```

After:
```
gh pr merge → set status Done → git -C ~/lobster fetch origin && git -C ~/lobster merge origin/main → remove worktree
```

## Open PR conflicts checked

- PR #1532 (`fix/process/migration-number-registry`) also touches `.claude/agents/functional-engineer.md` — potential merge conflict. The changes are in different sections (migration table vs. section 7), so conflict resolution should be straightforward.
- PR #1531 also touches `.claude/agents/functional-engineer.md` — same note.

## Tests run
- [x] Diff reviewed: change is confined to section 7 of functional-engineer.md, no runtime code affected
- [x] Manual: `bash -n` is not applicable (Markdown file)

## Manual test
N/A — this is a documentation-only change to an agent prompt file. No systemd, cron, external services, or file I/O affected.