### PR TITLE
fix(install): run Claude Code installer in non-interactive mode (#1452)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -855,36 +855,35 @@ fi
 #===============================================================================
 
 if [ "$CLAUDE_INSTALLED" = false ]; then
-    if [ "$NON_INTERACTIVE" = true ]; then
-        warn "Claude Code not found — skipping installation (non-interactive mode)."
-        info "Run the installer interactively or install Claude Code manually: curl -fsSL https://claude.ai/install.sh | bash"
-    else
-        step "Installing Claude Code..."
+    step "Installing Claude Code..."
 
-        curl -fsSL https://claude.ai/install.sh | bash
+    # The official Claude Code installer (curl -fsSL https://claude.ai/install.sh | bash)
+    # is itself non-interactive — it does not prompt for input. We can safely run it in
+    # both interactive and non-interactive modes. The previous behaviour of skipping the
+    # install in non-interactive mode left the lobster-claude service unable to start.
+    curl -fsSL https://claude.ai/install.sh | bash
 
-        # Add to PATH for current session and clear bash's command hash table so
-        # command -v picks up the newly installed binary immediately.
-        export PATH="$HOME/.local/bin:$PATH"
-        hash -r 2>/dev/null || true
+    # Add to PATH for current session and clear bash's command hash table so
+    # command -v picks up the newly installed binary immediately.
+    export PATH="$HOME/.local/bin:$PATH"
+    hash -r 2>/dev/null || true
 
-        # Persist ~/.local/bin to PATH in shell config files
-        PATH_LINE="export PATH=\"\$HOME/.local/bin:\$PATH\""
-        for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
-            if [ -f "$rc" ] && ! grep -q '\.local/bin' "$rc"; then
-                echo "" >> "$rc"
-                echo "# Added by Lobster installer" >> "$rc"
-                echo "$PATH_LINE" >> "$rc"
-                info "Added ~/.local/bin to PATH in $rc"
-            fi
-        done
-
-        if command -v claude &>/dev/null || [ -x "$HOME/.local/bin/claude" ]; then
-            success "Claude Code installed"
-        else
-            error "Claude Code installation failed"
-            exit 1
+    # Persist ~/.local/bin to PATH in shell config files
+    PATH_LINE="export PATH=\"\$HOME/.local/bin:\$PATH\""
+    for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+        if [ -f "$rc" ] && ! grep -q '\.local/bin' "$rc"; then
+            echo "" >> "$rc"
+            echo "# Added by Lobster installer" >> "$rc"
+            echo "$PATH_LINE" >> "$rc"
+            info "Added ~/.local/bin to PATH in $rc"
         fi
+    done
+
+    if command -v claude &>/dev/null || [ -x "$HOME/.local/bin/claude" ]; then
+        success "Claude Code installed"
+    else
+        error "Claude Code installation failed"
+        exit 1
     fi
 fi
 


### PR DESCRIPTION
## Problem

Fresh non-interactive installs (`install.sh --non-interactive`) finished without installing Claude Code. The `lobster-claude` tmux session then failed to start because `claude` was missing from PATH, leaving the system completely inoperative despite a successful install.

The root cause: the installer guarded the `curl -fsSL https://claude.ai/install.sh | bash` call behind an `if [ "$NON_INTERACTIVE" = false ]` check, reasoning that non-interactive mode should avoid prompts. But the Claude Code native installer is itself non-interactive — it downloads a binary and exits, with no prompts at any point. The guard was both incorrect and harmful.

## Change

The `NON_INTERACTIVE` branch is removed. The Claude Code install block now runs unconditionally when `claude` is not already present, in both interactive and non-interactive modes. A comment explains why the guard was wrong so it is not re-introduced.

No other behavior changes. The PATH extension logic, shell rc-file updates, and post-install verification are unchanged.

## Functional pattern

Pure removal of a dead conditional branch. No new state, no new side effects.

## Open PR conflicts checked

Multiple open PRs touch `install.sh` (PRs #1554, #1550, #1541, #1535, #1532, #1528). This change modifies the Claude Code install block (lines ~857-889), which is a distinct section from the service install block touched by those PRs. Merge conflicts are possible but the logical change is isolated.

## Tests run

- [x] `git diff main HEAD` verified — single coherent removal of the `NON_INTERACTIVE` guard
- [ ] Live non-interactive install — not run (requires a fresh VM); the change is a one-line conditional removal with obvious correctness

## Manual test

N/A for this change on this environment — the Claude Code installer cannot be re-run without side effects (it would overwrite the running binary). The change is a conditional removal with clear correctness: if `curl | bash` is safe to run interactively, it is safe to run non-interactively (same binary, no stdin interaction).

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests) — N/A, shell script change
- [ ] Integration/manual test run — blocked: requires fresh VM
- [x] User-visible outcome: non-interactive installs now have a working `claude` binary after install
- [x] Side-effect audit: change only removes a skip-guard; no new writes, no new network calls beyond the already-intended installer fetch
- [x] External service calls: the `curl | bash` was already present in the interactive path; no new external calls added

Closes #1452