### PR TITLE
cleanup(health-check): remove dead hibernate mode handling, mark skill deprecated (#1448)

### DIFF
--- a/lobster-shop/hibernation/behavior/system.md
+++ b/lobster-shop/hibernation/behavior/system.md
@@ -1,47 +1,29 @@
-## Hibernation
+## Hibernation — DEPRECATED
 
-Lobster hibernates after a configurable idle timeout. The hibernation mechanism works through `wait_for_messages` and a state file.
+> **This skill is deprecated as of PR #1447.** The dispatcher no longer hibernates.
+> `wait_for_messages()` is called without `hibernate_on_timeout=True` and the main
+> loop never exits. Do NOT call `wait_for_messages(hibernate_on_timeout=True)`.
+>
+> If this skill activates, ignore its instructions. The dispatcher should continue
+> its normal `wait_for_messages()` loop without any hibernation logic.
 
-### How hibernation is triggered
+---
 
-Call `wait_for_messages` with `hibernate_on_timeout=True` when entering a low-activity idle period:
+### Why hibernation was removed
 
-```python
-result = wait_for_messages(timeout=1800, hibernate_on_timeout=True)
-```
+Hibernation (exiting the main dispatcher loop after an idle timeout) caused the
+dispatcher to go deaf to incoming messages. The WFM watchdog (PR #1446) replaced
+the recovery role that hibernation was intended to serve. The dispatcher now stays
+running indefinitely.
 
-When the timeout fires with `hibernate_on_timeout=True`, `wait_for_messages`:
-1. Writes `~/messages/config/lobster-state.json` with `{"mode": "hibernate"}`
-2. Returns a string containing "Hibernating" and "EXIT"
+### What to do if you see mode=hibernate in lobster-state.json
 
-### How to detect and break the loop
+This indicates a stale state file from before PR #1447. The health check now treats
+`mode=hibernate` as `mode=active` and applies full process/inbox checks. The value
+will be overwritten on the next state write.
 
-```python
-result = wait_for_messages(timeout=1800, hibernate_on_timeout=True)
-if isinstance(result, str) and ("Hibernating" in result or "EXIT" in result):
-    break  # Exit the main loop — do NOT call wait_for_messages again
-```
+### Do not use
 
-Breaking the loop ends the Claude session cleanly. The session is not restarted — the health check reads the state file and recognizes `"hibernate"` mode, suppressing the usual restart.
-
-### How hibernation ends
-
-The Telegram/Slack bot restarts Claude on the next incoming message. Once a message arrives:
-1. The bot clears the hibernate state file (or the health check does)
-2. A new Claude session starts
-3. Normal startup behavior runs (handoff read, catchup subagent, etc.)
-
-### State file
-
-Path: `~/messages/config/lobster-state.json`
-
-| `mode` value | Meaning |
-|---|---|
-| `"active"` | Normal operation (default) |
-| `"hibernate"` | Hibernating — health check must NOT restart |
-
-### Rules
-
-- Never call `send_reply` immediately before hibernating — there is no active user conversation
-- Always write a brief session note update before breaking the loop if notable work happened this session
-- The `hibernate_on_timeout=True` flag is the only supported hibernation trigger — do not write the state file directly
+- Do not call `wait_for_messages(timeout=1800, hibernate_on_timeout=True)`
+- Do not write `mode=hibernate` to `lobster-state.json` directly
+- Do not break the main dispatcher loop based on hibernation signals

--- a/lobster-shop/hibernation/skill.toml
+++ b/lobster-shop/hibernation/skill.toml
@@ -1,9 +1,10 @@
 [skill]
 name = "hibernation"
-version = "1.0.0"
-description = "Dispatcher hibernation — idle timeout behavior, state file semantics, and how to break the hibernation loop cleanly"
+version = "2.0.0"
+description = "DEPRECATED: Dispatcher hibernation is no longer supported (PR #1447). This skill warns against using hibernate_on_timeout."
 author = "Lobster"
 category = "behavioral"
+deprecated = true
 
 [activation]
 mode = "contextual"
@@ -12,6 +13,7 @@ context_patterns = [
     "when wait_for_messages returns a timeout with hibernate_on_timeout=True",
     "when the dispatcher has been idle and the health check should not restart it",
     "when lobster-state.json mode is set to hibernate",
+    "hibernate_on_timeout",
 ]
 
 [layering]

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -14,7 +14,8 @@
 #   active     - Claude is running (WAITING on wait_for_messages or PROCESSING)
 #   starting   - Wrapper is launching Claude (transient, < 30s)
 #   restarting - Wrapper is restarting after an exit (transient, < 60s)
-#   hibernate  - Claude exited cleanly, wrapper watching for inbox messages
+#   hibernate  - DEPRECATED: dispatcher no longer writes this state (PR #1447).
+#                If seen in a stale state file, treated as active (full checks apply).
 #   backoff    - Wrapper hit rapid-restart limit, cooling down
 #   stopped    - Wrapper received signal, shutting down
 #   waking     - Wrapper detected messages, about to launch Claude
@@ -85,7 +86,7 @@ RESTART_COOLDOWN_SUPPRESS_SECONDS=240 # 4 minutes - suppress stale-inbox RED aft
 
 BOOT_GRACE_SECONDS=90                # 90s - skip stale-inbox, WFM, and process checks after a restart
 
-HIBERNATE_FRESH_SECONDS=30           # Ignore hibernate state younger than this — transient dispatcher hibernation
+HIBERNATE_FRESH_SECONDS=30           # DEPRECATED — kept for reference; hibernate state is no longer written by dispatcher
 
 WFM_STALE_SECONDS=1200               # 20 minutes - RED if wait_for_messages not called since this long ago (raised from 600 to accommodate long reasoning/subagent-spawning phases)
 HEARTBEAT_FILE="$WORKSPACE_DIR/logs/claude-heartbeat"
@@ -409,7 +410,8 @@ record_restart() {
 #===============================================================================
 
 # Read the current Lobster mode from state file.
-# Returns one of: active, starting, restarting, hibernate, backoff, stopped, waking, unknown
+# Returns one of: active, starting, restarting, backoff, stopped, waking, unknown
+# May also return "hibernate" from stale state files — treated as active by check_claude_lifecycle()
 read_lobster_mode() {
     if [[ ! -f "$LOBSTER_STATE_FILE" ]]; then
         echo "unknown"
@@ -443,9 +445,9 @@ read_state_age() {
 }
 
 is_hibernating() {
-    local mode
-    mode=$(read_lobster_mode)
-    [[  "$mode" == "hibernate" ]]
+    # DEPRECATED: dispatcher no longer writes mode=hibernate (PR #1447).
+    # Always returns false — hibernation suppression is no longer applied.
+    return 1
 }
 
 # Check if a context compaction occurred within the last COMPACTION_SUPPRESS_SECONDS.
@@ -1705,70 +1707,16 @@ main() {
     # The persistent wrapper (claude-persistent.sh) manages Claude's lifecycle.
     # We need to check differently depending on the current phase:
     #
-    # hibernate:  Claude exited cleanly, wrapper is polling for new messages.
-    #             No Claude process expected. Only alert if stale user messages.
     # active:     Claude should be running. Full checks apply.
     # starting/restarting/waking: Transient states. Wrapper is handling it.
     # backoff:    Wrapper hit rapid-restart limit. Expected pause.
     # stopped:    Wrapper was stopped. Systemd should restart.
     # unknown:    No state file. Either first run or old-style wrapper.
+    # hibernate:  DEPRECATED (PR #1447) — dispatcher no longer writes this state.
+    #             Treated as active if seen in a stale state file.
     #
 
     case "$lobster_mode" in
-        hibernate)
-            log_info "HIBERNATE: Claude cleanly exited. Wrapper polling for new messages."
-
-            # Boot grace: skip process/tmux/inbox checks — session may not be fully up yet.
-            if [[ "$boot_grace" == "true" ]]; then
-                log_info "Process/inbox checks suppressed (boot grace period)"
-            else
-                # Fresh-state guard: ignore hibernate states younger than HIBERNATE_FRESH_SECONDS.
-                # The dispatcher briefly writes mode=hibernate after wait_for_messages times out,
-                # then immediately wakes if new messages arrive. A health check that fires within
-                # this window would see a momentarily-missing wrapper and false-positive into RED.
-                if [[ $state_age -lt $HIBERNATE_FRESH_SECONDS ]]; then
-                    log_info "Hibernate state is only ${state_age}s old (threshold: ${HIBERNATE_FRESH_SECONDS}s) — skipping process check (transient)"
-                elif ! check_tmux; then
-                    level="RED"
-                    restart_reason="tmux session missing (hibernate mode)"
-                elif [[ "$LOBSTER_DEBUG" == "true" ]]; then
-                    # Debug mode: no persistent wrapper is expected. Claude Code runs
-                    # directly in the tmux pane without claude-persistent.sh. Check for
-                    # the Claude process directly instead of checking for the wrapper.
-                    if ! check_claude_process; then
-                        level="RED"
-                        restart_reason="no Claude process in lobster tmux (debug mode, hibernate)"
-                    fi
-                elif ! check_wrapper_process; then
-                    # Wrapper died during hibernation — need systemd restart
-                    level="RED"
-                    restart_reason="wrapper process missing during hibernation"
-                fi
-
-                # Still check inbox: if user messages are sitting stale, the wrapper
-                # should have woken Claude by now. Give extra time (5 min) since
-                # the wrapper polls every 10s.
-                if [[ "$compaction_recent" == "true" ]]; then
-                    log_info "Inbox drain suppressed (recent compaction)"
-                else
-                    check_inbox_drain
-                    local hibernate_inbox_rc=$?
-                    if [[ $hibernate_inbox_rc -eq 2 ]]; then
-                        # Stale user messages during hibernation — wrapper may be stuck.
-                        # Suppress to YELLOW if a health-check restart just fired: the
-                        # MCP server recovers processing/ messages to inbox/ on startup,
-                        # which would otherwise trigger an immediate second restart.
-                        if is_recent_restart; then
-                            [[ "$level" == "GREEN" ]] && level="YELLOW"
-                        else
-                            level="RED"
-                            restart_reason="${restart_reason:+$restart_reason + }stale inbox during hibernation"
-                        fi
-                    fi
-                fi
-            fi
-            ;;
-
         starting|restarting|waking)
             # Boot grace: skip stale-transient escalation and inbox checks.
             if [[ "$boot_grace" == "true" ]]; then
@@ -1884,7 +1832,13 @@ main() {
             fi
             ;;
 
-        active|unknown|*)
+        hibernate|active|unknown|*)
+            # hibernate: DEPRECATED — dispatcher no longer writes this state (PR #1447).
+            # If seen in a stale state file, treat as active: full process and inbox checks apply.
+            if [[ "$lobster_mode" == "hibernate" ]]; then
+                log_warn "HIBERNATE: stale hibernate state found — dispatcher no longer uses hibernation (treating as active)"
+            fi
+
             # Boot grace: skip process/tmux/inbox checks — session may still be initializing.
             if [[ "$boot_grace" == "true" ]]; then
                 log_info "Process/inbox checks suppressed (boot grace period)"


### PR DESCRIPTION
Dispatcher hibernation was disabled in PR #1447 — the dispatcher now calls `wait_for_messages()` with no timeout and never breaks its main loop. This leaves three artifacts that still reference the old behavior: the health check's dedicated `hibernate` lifecycle case, the `is_hibernating()` helper, and the hibernation skill. This PR removes or marks all three as deprecated.

## What changed

**`scripts/health-check-v3.sh`**

The dedicated `hibernate)` case block is removed and `hibernate` is added to the `active|unknown|*` catch-all with a warning log. The logic was: when mode=hibernate, skip most process checks since Claude had exited cleanly. Now that the dispatcher never exits its loop, a stale `mode=hibernate` in a state file means the session is actually running — full active checks should apply.

`is_hibernating()` always returns `false` (was: `read_lobster_mode | grep hibernate`). This removes the WFM freshness suppression that fired during hibernation.

`HIBERNATE_FRESH_SECONDS` constant is retained with a deprecation comment so the variable name doesn't become a dangling reference if any external script reads it.

**`lobster-shop/hibernation/behavior/system.md`**

Rewritten as a deprecation notice. The old instructions told the dispatcher to call `wait_for_messages(hibernate_on_timeout=True)` and break the loop on "Hibernating"/"EXIT" — instructions that would cause the session to go deaf. The replacement explains why hibernation was removed and what to do instead.

**`lobster-shop/hibernation/skill.toml`**

Bumped to v2.0.0, `deprecated = true` added, `hibernate_on_timeout` added as a context trigger so the skill fires when the deprecated flag appears in context and immediately warns against it.

## What is NOT changed

`inbox_server.py` — per issue scope: the `hibernate_on_timeout` parameter remains as a safety valve until the WFM watchdog (PR #1446) is confirmed stable in production. This PR only removes the dead calling-side code.

## Open PR conflicts checked

PRs touching `scripts/health-check-v3.sh`: #1540, #1524.

- PR #1540 (`fix/issue-1483-dispatcher-heartbeat`): modifies constants and catchup-suppression logic in health-check-v3.sh but does not touch the `hibernate` case. Merge conflict likely around the `HIBERNATE_FRESH_SECONDS` line (both branches modify nearby constants). Logically non-overlapping.
- PR #1524: touches health-check-v3.sh for outbox dedup logic, different section.

No conflicts on `lobster-shop/hibernation/`.

## Tests run

- [x] `bash -n scripts/health-check-v3.sh` — syntax check clean
- [ ] `uv run pytest tests/unit/` — skipped: health-check-v3.sh has no pytest-level unit tests; bash syntax check is the available automated verification. The hibernate code path was dead at runtime (dispatcher never wrote mode=hibernate since PR #1447), so behavioral regression is not a concern.

## Manual test

N/A — this change removes dead code. The health check's hibernate branch was never reached after PR #1447 (dispatcher writes mode=active). The only observable difference: if a stale state file with mode=hibernate were present, the health check would now log a warning and run active checks instead of skipping process checks. This is the correct behavior.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run (if applicable) — N/A, dead code removal
- [x] User-visible outcome verified OR not applicable — not applicable (internal health check)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none in this change

Closes #1448