### PR TITLE
fix(cli): env set writes to correct config dir and updates config.env for service vars (#1454)

### DIFF
--- a/src/cli
+++ b/src/cli
@@ -466,8 +466,13 @@ cmd_ps() {
 }
 
 cmd_env() {
-    local config_dir="${LOBSTER_CONFIG_DIR:-$HOME/lobster-user-config}"
+    # LOBSTER_CONFIG_DIR holds service-critical config (config.env, global.env).
+    # Default matches install.sh: $HOME/lobster-config.
+    # Previously this defaulted to lobster-user-config, which caused lobster env set
+    # to write to a directory the services never read. (#1454)
+    local config_dir="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
     local env_file="$config_dir/global.env"
+    local config_env_file="$config_dir/config.env"
     local subcmd="${1:-}"
 
     case "$subcmd" in
@@ -479,20 +484,32 @@ cmd_env() {
                 exit 1
             fi
             mkdir -p "$config_dir"
-            touch "$env_file" && chmod 600 "$env_file"
+
+            # If the key already exists in config.env (even as an empty stub), update
+            # it there. Service EnvironmentFiles are loaded in order; an empty stub in
+            # config.env previously silenced the value in global.env. Updating config.env
+            # directly removes the ambiguity and ensures the correct value is used
+            # regardless of load order.
+            local target_file="$env_file"
+            if grep -qE "^${key}=" "$config_env_file" 2>/dev/null; then
+                target_file="$config_env_file"
+                echo -e "(key found in config.env — updating there instead of global.env)"
+            fi
+
+            touch "$target_file" && chmod 600 "$target_file"
             # Update existing key in place, or append if not present
-            if grep -qF "^${key}=" "$env_file" 2>/dev/null; then
+            if grep -qF "^${key}=" "$target_file" 2>/dev/null; then
                 # Use a temp file to avoid sed -i portability issues
                 local tmp
                 tmp=$(mktemp)
                 chmod 600 "$tmp"
-                grep -vF "^${key}=" "$env_file" > "$tmp"
+                grep -vF "^${key}=" "$target_file" > "$tmp"
                 echo "${key}=${value}" >> "$tmp"
-                mv "$tmp" "$env_file"
-                echo -e "${GREEN}Updated${NC} $key"
+                mv "$tmp" "$target_file"
+                echo -e "${GREEN}Updated${NC} $key in $(basename "$target_file")"
             else
-                echo "${key}=${value}" >> "$env_file"
-                echo -e "${GREEN}Set${NC} $key"
+                echo "${key}=${value}" >> "$target_file"
+                echo -e "${GREEN}Set${NC} $key in $(basename "$target_file")"
             fi
             ;;
         get)
@@ -501,18 +518,21 @@ cmd_env() {
                 echo "Usage: lobster env get KEY"
                 exit 1
             fi
-            if [ ! -f "$env_file" ]; then
-                echo -e "${RED}No env file found at $env_file${NC}"
-                exit 1
+            # Search config.env first (higher priority for service-critical vars),
+            # then global.env. This mirrors the effective precedence after #1454.
+            local found_in=""
+            local val=""
+            if grep -qE "^${key}=" "$config_env_file" 2>/dev/null; then
+                found_in="$config_env_file"
+                val=$(grep -E "^${key}=" "$config_env_file" | cut -d= -f2-)
+            elif grep -qF "^${key}=" "$env_file" 2>/dev/null; then
+                found_in="$env_file"
+                val=$(grep -F "^${key}=" "$env_file" | cut -d= -f2-)
             fi
-            # Check key existence first (separate from value extraction) so that
-            # an empty value is not misreported as "key not found"
-            if ! grep -qF "^${key}=" "$env_file" 2>/dev/null; then
+            if [ -z "$found_in" ]; then
                 echo -e "${RED}Key not found: $key${NC}"
                 exit 1
             fi
-            local val
-            val=$(grep -F "^${key}=" "$env_file" | cut -d= -f2-)
             echo "$val"
             ;;
         list)

--- a/tests/unit/test_cli/test_commands.py
+++ b/tests/unit/test_cli/test_commands.py
@@ -314,3 +314,108 @@ class TestServiceStatusTmuxAwareness:
         assert '"lobster-claude"' in source or "'lobster-claude'" in source, (
             "The tmux guard must be scoped to the lobster-claude service specifically"
         )
+
+
+class TestEnvCommand:
+    """Tests for lobster env set/get — verifies fix for #1454.
+
+    The bug: cmd_env defaulted LOBSTER_CONFIG_DIR to ~/lobster-user-config but
+    services read from ~/lobster-config. Tokens written to the wrong directory
+    were never seen by systemd EnvironmentFile.
+
+    The fix: default changed to ~/lobster-config (matching install.sh), and
+    env set now writes to config.env when the key already exists there (to avoid
+    empty-stub override).
+    """
+
+    # Default lobster config dir — matches install.sh and service EnvironmentFile paths
+    EXPECTED_DEFAULT_CONFIG_DIR = "lobster-config"
+
+    @pytest.fixture
+    def cli_path(self) -> Path:
+        """Get path to CLI script."""
+        return Path(__file__).parent.parent.parent.parent / "src" / "cli"
+
+    def test_env_set_writes_to_lobster_config_not_user_config(self, cli_path: Path):
+        """cmd_env must default to ~/lobster-config, not ~/lobster-user-config.
+
+        Services load EnvironmentFile from lobster-config/. Writes to
+        lobster-user-config/ are silently ignored by systemd.
+        """
+        source = cli_path.read_text()
+        # The default fallback must reference lobster-config
+        assert "lobster-config" in source, (
+            "cmd_env must default LOBSTER_CONFIG_DIR to ~/lobster-config "
+            "so tokens written by 'lobster env set' land where services read them"
+        )
+        # Must NOT default to the wrong directory (user-config is for agent behavior, not service env)
+        # Check that the old wrong default is not the primary fallback
+        assert 'lobster-user-config"' not in source or source.count('lobster-user-config"') == 0, (
+            "cmd_env must not default to lobster-user-config — "
+            "that directory is not read by systemd EnvironmentFile"
+        )
+
+    def test_env_set_updates_config_env_when_key_exists_there(self, cli_path: Path, tmp_path: Path):
+        """If a key already exists in config.env (even as empty stub), set must update config.env.
+
+        This prevents the empty stub in config.env from silencing the value in global.env.
+        """
+        config_dir = tmp_path / "lobster-config"
+        config_dir.mkdir()
+        config_env = config_dir / "config.env"
+        global_env = config_dir / "global.env"
+
+        # Write empty stub to config.env (simulates non-interactive installer output)
+        config_env.write_text("TELEGRAM_ALLOWED_USERS=\n")
+        global_env.write_text("")
+
+        env = os.environ.copy()
+        env["LOBSTER_CONFIG_DIR"] = str(config_dir)
+        # Override HOME so the fallback path doesn't interfere
+        env["HOME"] = str(tmp_path)
+
+        result = subprocess.run(
+            ["bash", str(cli_path), "env", "set", "TELEGRAM_ALLOWED_USERS", "12345"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0, f"env set failed: {result.stderr}"
+
+        # The value must land in config.env (where the stub was), not global.env
+        config_content = config_env.read_text()
+        assert "TELEGRAM_ALLOWED_USERS=12345" in config_content, (
+            "env set must write to config.env when the key already exists there as an empty stub"
+        )
+        # global.env must NOT have the value (it wasn't there before)
+        global_content = global_env.read_text()
+        assert "TELEGRAM_ALLOWED_USERS" not in global_content, (
+            "env set must not write to global.env when config.env already has the key"
+        )
+
+    def test_env_set_falls_back_to_global_env_for_new_keys(self, cli_path: Path, tmp_path: Path):
+        """Keys not in config.env should be written to global.env as before."""
+        config_dir = tmp_path / "lobster-config"
+        config_dir.mkdir()
+        config_env = config_dir / "config.env"
+        global_env = config_dir / "global.env"
+
+        config_env.write_text("# no GITHUB_TOKEN here\n")
+        global_env.write_text("")
+
+        env = os.environ.copy()
+        env["LOBSTER_CONFIG_DIR"] = str(config_dir)
+        env["HOME"] = str(tmp_path)
+
+        result = subprocess.run(
+            ["bash", str(cli_path), "env", "set", "GITHUB_TOKEN", "ghp_abc123"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0, f"env set failed: {result.stderr}"
+
+        global_content = global_env.read_text()
+        assert "GITHUB_TOKEN=ghp_abc123" in global_content, (
+            "env set must write new keys (not in config.env) to global.env"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -902,6 +902,9 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
 ]
+windows = [
+    { name = "tzdata" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -928,11 +931,12 @@ requires-dist = [
     { name = "sqlite-vec", specifier = ">=0.1.7a1" },
     { name = "starlette", specifier = ">=0.37.0" },
     { name = "twilio", specifier = ">=9.0.0" },
+    { name = "tzdata", marker = "extra == 'windows'", specifier = ">=2024.1" },
     { name = "uvicorn", specifier = ">=0.29.0" },
     { name = "watchdog", specifier = ">=4.0.0" },
     { name = "websockets", specifier = ">=13.0" },
 ]
-provides-extras = ["dashboard", "browser", "slack", "test"]
+provides-extras = ["dashboard", "windows", "browser", "slack", "test"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2351,6 +2355,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`lobster env set TELEGRAM_ALLOWED_USERS <id>` silently failed to configure the router service. Two bugs combined to cause this.

## Root cause

**Bug 1 — Wrong default directory.** `cmd_env` in `src/cli` defaulted `LOBSTER_CONFIG_DIR` to `~/lobster-user-config`. Services load `EnvironmentFile` from `~/lobster-config`. When running `lobster env set` in a shell where `LOBSTER_CONFIG_DIR` is not exported (the common case for interactive use), tokens were written to `~/lobster-user-config/global.env` — a directory no service ever reads.

**Bug 2 — Empty-stub override.** The non-interactive installer writes service-critical vars as empty stubs in `~/lobster-config/config.env` (e.g., `TELEGRAM_ALLOWED_USERS=`). Even if the token landed in the right `global.env`, the empty stub in `config.env` would shadow it: if service EnvironmentFiles are loaded in an order where config.env comes after global.env for a given key, the empty value wins. Writing the value directly into `config.env` (where the stub lives) removes the ambiguity entirely.

## What changed

**`src/cli` — `cmd_env`**

- Default for `LOBSTER_CONFIG_DIR` changed from `~/lobster-user-config` to `~/lobster-config` (matches `install.sh` line 146 and the service `Environment=LOBSTER_CONFIG_DIR=...` line).
- `env set` now checks whether the key already exists in `config.env`. If it does (even as an empty stub `KEY=`), the value is written to `config.env` instead of `global.env`. If the key is not in `config.env`, behavior is unchanged: value goes to `global.env`.
- `env get` now checks `config.env` before `global.env`, matching the effective precedence for service-critical vars.
- Both `set` and `get` reference a new `config_env_file` local variable (`$config_dir/config.env`).

## Before / after

```
Before:
  lobster env set TELEGRAM_ALLOWED_USERS 12345
    → writes to ~/lobster-user-config/global.env  (never read by services)
    → lobster-router reads config.env stub: TELEGRAM_ALLOWED_USERS=
    → bot fails to start: ValueError: TELEGRAM_ALLOWED_USERS required

After:
  lobster env set TELEGRAM_ALLOWED_USERS 12345
    → detects stub in ~/lobster-config/config.env
    → writes to ~/lobster-config/config.env: TELEGRAM_ALLOWED_USERS=12345
    → lobster-router reads config.env: TELEGRAM_ALLOWED_USERS=12345
    → bot starts correctly
```

## Functional patterns used

Pure function logic for file routing: the target file is selected declaratively based on where the key already lives, rather than always writing to a fixed path. The selection is a single conditional read with no mutation before the decision is made.

## Open PR conflicts checked

No open PRs touch `src/cli` or `tests/unit/test_cli/test_commands.py`.

## Tests run

- [x] `uv run pytest tests/unit/test_cli/test_commands.py -v` — 18 passed, 0 failed
- [x] `uv run pytest tests/unit/ -x -q` — 547 passed, 1 pre-existing failure in `test_hibernation.py::TestWaitForMessagesHibernation::test_timeout_without_hibernate_flag_does_not_write_state` (confirmed present on main before this branch; unrelated to cli changes)
- [x] `bash -n src/cli` — syntax check clean

## Manual test

N/A — this change affects how `lobster env set` routes writes, not any external service call. The fix is verified by the three new unit tests that exercise the routing logic with a real temp directory and the actual CLI script.

Workaround noted in the issue ("edit config.env directly") is no longer needed after this fix.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (no external service touched)
- [x] User-visible outcome verified — verified via unit tests simulating the exact scenario from the issue
- [x] Side-effect audit complete: change is scoped to file writes in the user's config dir
- [x] External service calls: none

Closes #1454