### PR TITLE
fix(bootup): add two-pass read guidance for 10K token limit (#1353)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -6,6 +6,12 @@ You are the **Lobster dispatcher**. You run in an infinite main loop, processing
 
 This file restores full context after a compaction or restart. Read it top-to-bottom.
 
+> **Two-pass read required.** This file exceeds the Read tool's single-call token limit (~10K tokens / ~150 lines). You MUST read it in two passes before taking any action:
+> - **Pass 1:** `Read(".claude/sys.dispatcher.bootup.md", limit=150)` — startup steps, main loop, 7-second rule, delegation pattern, in-flight tracking
+> - **Pass 2:** `Read(".claude/sys.dispatcher.bootup.md", offset=150, limit=200)` — message handlers (compact-reminder, subagent_result, etc.), source handling, session management, remaining behavioral rules
+>
+> If you are reading this notice, Pass 1 is complete. Proceed to Pass 2 now before taking any startup action.
+
 You are not a passive relay. You are a vigilant dispatcher. You take initiative based on what you observe — both from external signals and from the passage of time. When something seems off — whether because a signal says so or because time has passed and nothing has arrived — use your judgment to follow up. Spawning a brief investigation subagent takes <1 second and is almost always the right call when uncertain.
 
 **After reading the sections below**, also check for and read user context files if they exist:


### PR DESCRIPTION
## Problem

`sys.dispatcher.bootup.md` is ~20K tokens but the Read tool's single-call limit is ~10K tokens (~150 lines). When the dispatcher re-reads this file after a compaction or restart, it only gets the first half — startup steps, main loop, and the 7-second rule — but never sees the second half: message handlers (compact-reminder, subagent_result, etc.), source routing, session management, and behavioral rules. The file has no indication that anything was missed.

This was observed on 2026-04-01: the dispatcher entered the main loop without having read past the midpoint of the file.

## What changed

Six lines added at the top of `.claude/sys.dispatcher.bootup.md`. The notice is self-referential: if you are reading it, Pass 1 is already done, so it tells the dispatcher to do Pass 2 immediately. It provides exact `Read()` parameters (offset=150, limit=200) and names which sections each pass covers.

No logic changes, no behavior changes.

## Functional patterns

Pure documentation change — no executable code.

## Open PR conflicts checked

Six open PRs also modify `sys.dispatcher.bootup.md`: #1549, #1547, #1546, #1543, #1540, #1529. This PR inserts 6 lines at the top of the "Who You Are" section. Merge conflicts are possible but trivial — keep both changes.

## Tests run
- [x] Manual review: confirmed block appears correctly in file
- [ ] No automated tests — doc-only change, N/A

## Manual test
N/A — purely textual change to an instruction file.

Closes #1353