### PR TITLE
feat(dispatcher): deferred-question tracking via task system, no handoff.md dependency (#1312)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1183,7 +1183,7 @@ Users can run `lobster update` to pull the latest code and apply pending migrati
 
 ### At session start
 
-After reading handoff and user model, call `list_tasks(status="pending")` to recover in-progress work. If tasks exist, they are the starting point. Mention open tasks briefly in initial orientation.
+After reading handoff and user model, call `list_tasks(status="pending")` to recover in-progress work. If tasks exist, they are the starting point. Mention open tasks briefly in initial orientation. Tasks whose subject starts with `DEFERRED:` are unanswered user questions from prior sessions — surface these to the user proactively ("You asked X last session and I didn't get to it — want me to pick that up?").
 
 ### When user gives a task
 
@@ -1306,7 +1306,9 @@ If fewer than 2 trackable questions are present, apply no special handling — r
 
 ## Commitment Durability
 
-A **commitment** is created when you tell the user you will answer something or do something later — not just note it. Commitments must survive session boundaries. Session notes do not survive compaction reliably; `rolling-summary.md` is the designated cross-session truth and is read at every session start.
+A **commitment** is created when you tell the user you will answer something or do something later — not just note it. Commitments must survive session boundaries and compaction.
+
+**Storage: use the task system.** Deferred questions and commitments are stored as tasks with the subject prefix `DEFERRED:`. This requires no markdown file dependency and no background subagent — the task system is a first-class MCP tool that persists independently.
 
 **Trigger:** You defer a response with language like:
 - "I'll check on that"
@@ -1315,26 +1317,21 @@ A **commitment** is created when you tell the user you will answer something or 
 - "Checking now" (when spawning a subagent that may not complete before compaction)
 - Any explicit question from the user that you cannot answer inline AND you do not answer within the same session turn
 
-**Required action:** Immediately after sending the deferral reply, spawn a background subagent to write the deferred commitment to `rolling-summary.md`:
+**Required action:** Immediately after sending the deferral reply, call `create_task` directly:
 
-```
-Task(
-    subagent_type="lobster-generalist",
-    run_in_background=True,
-    prompt=(
-        "---\ntask_id: commitment-capture-<slug>\nchat_id: 0\nsource: system\n---\n\n"
-        "Capture an open commitment in rolling-summary.md.\n\n"
-        "1. Read ~/lobster-user-config/memory/canonical/rolling-summary.md\n"
-        "2. Find the '## Open Threads / Commitments' section. "
-           "If the section does not exist, add it after '## Active PRs & Decisions'.\n"
-        "3. Add this line if it is not already present (check for substring match to avoid duplicates):\n"
-        "   - **ANSWER the user**: <exact question text> (asked <HH:MM ET>, deferred — needs answer)\n"
-        "4. Write the file back.\n"
-        "5. Call write_result with task_id='commitment-capture-<slug>', chat_id=0, source='system'."
-    ),
+```python
+task_id = create_task(
+    subject="DEFERRED: <exact question text>",
+    description="Asked at <HH:MM ET>. Context: <one-sentence summary of what the user needs>."
 )
 ```
 
-**Idempotency:** Before adding the line, check that no existing line in the file already captures the same question (substring match is sufficient). Do not add duplicates.
+No background subagent is needed — `create_task` is a synchronous MCP call.
+
+**At session start:** `list_tasks(status="pending")` (already called at startup) surfaces all pending tasks including deferred questions. Any task whose subject starts with `DEFERRED:` is a commitment that needs follow-up. Mention these to the user if they appear in the startup scan.
+
+**When the commitment is fulfilled:** Call `update_task(task_id, status="done")` immediately after sending the answer. If the task_id was not recorded (session boundary), search `list_tasks()` for the matching `DEFERRED:` subject line.
+
+**Idempotency:** Before creating a deferred task, check `list_tasks()` for an existing task with the same `DEFERRED:` subject. Do not create duplicates.
 
 **Scope:** Only direct questions or explicit commitments from the user. Do not apply to internal system events, subagent status queries, or rhetorical questions.


### PR DESCRIPTION
## Summary

Deferred user questions (commitments the assistant makes mid-conversation to follow up later) previously required spawning a background subagent to write an entry into `rolling-summary.md`. This had three problems: subagent failure silently dropped the commitment; it added latency (a spawn + file write); and it created a soft dependency on rolling-summary.md which is itself subject to migration pressure (see #1384).

This replaces that mechanism with a direct `create_task()` call using a `DEFERRED:` subject prefix convention. The task system is already the primary persistence layer for in-flight work, is backed by the memory DB (not a markdown file), and is already scanned at every session start via `list_tasks(status="pending")`.

## What changed

**Commitment Durability section** — the required action after a deferral is now:
```python
task_id = create_task(
    subject="DEFERRED: <exact question text>",
    description="Asked at <HH:MM ET>. Context: <one-sentence summary>."
)
```
No background subagent. No rolling-summary.md write. One synchronous MCP call.

**Fulfillment** — when the commitment is answered: `update_task(task_id, status="done")`. If the task_id wasn't recorded across a session boundary, `list_tasks()` lets the dispatcher search by the `DEFERRED:` subject prefix.

**Startup** — the existing `list_tasks(status="pending")` call at session start already surfaces deferred questions. Added an explicit note: tasks with `DEFERRED:` subject prefix are prior-session commitments to surface proactively to the user.

## Before/after flow

Before:
```
deferral reply sent
  → spawn lobster-generalist subagent
    → subagent reads rolling-summary.md
    → subagent writes commitment line
    → subagent calls write_result
    (if subagent fails: commitment silently lost)
startup:
  → read rolling-summary.md (already in startup flow)
```

After:
```
deferral reply sent
  → create_task(subject="DEFERRED: ...", description="...")
    (synchronous, no subagent, backed by DB)
startup:
  → list_tasks(status="pending") (already in startup flow)
    → tasks with DEFERRED: prefix surfaced to user
```

## Functional patterns

Pure declarative change — agent instruction update only, no code or schema modified. The `DEFERRED:` prefix convention is a deterministic naming rule (no LLM judgment needed to identify deferred questions at startup).

## Open PR conflicts checked

6 open PRs touch `sys.dispatcher.bootup.md` (PRs #1540, #1543, #1546, #1547, #1549, #1561). All of them modify sections in the first ~950 lines of the file. This PR modifies only the Task System section (line ~1183) and the Commitment Durability section (lines ~1307-1341) at the end of the file. No merge conflicts expected.

## Tests run

- [x] `git diff` reviewed — correct sections modified, no unintended changes
- [ ] Live session test — not applicable; dispatcher instruction change only

## Manual test

N/A — this is a change to dispatcher instructions only. The `create_task` MCP call described is a synchronous call the dispatcher makes inline; it is not a code path in this repo.

## Definition of Done

- [x] No dependency on handoff.md or rolling-summary.md for commitment storage
- [x] Reuses existing infrastructure (task system + DB)
- [x] Startup surfacing covered by existing list_tasks(status="pending") call
- [x] Fulfillment and idempotency documented
- [x] No new tools or services required

Closes #1312