### PR TITLE
fix(agent-status): treat stop_sequence and max_tokens as terminal states

### DIFF
--- a/scripts/agent-status.sh
+++ b/scripts/agent-status.sh
@@ -124,8 +124,10 @@ scan_agent_status() {
         local stop_reason
         stop_reason=$(_get_stop_reason "$filepath")
 
-        # Skip completed agents — self-check is only for active work
-        if [ "$stop_reason" = "end_turn" ]; then
+        # Skip completed agents — self-check is only for active work.
+        # Terminal stop reasons: end_turn (normal), stop_sequence (hit stop seq),
+        # max_tokens (hit token limit). All mean the agent is done.
+        if [ "$stop_reason" = "end_turn" ] || [ "$stop_reason" = "stop_sequence" ] || [ "$stop_reason" = "max_tokens" ]; then
             continue
         fi
 
@@ -244,11 +246,13 @@ scan_completed_tasks() {
             continue
         fi
 
-        # Check stop_reason — only "end_turn" means definitively done
+        # Check stop_reason — terminal states mean definitively done.
+        # end_turn: normal completion; stop_sequence: hit a stop sequence;
+        # max_tokens: hit token limit. All are terminal.
         local stop_reason
         stop_reason=$(_get_stop_reason "$filepath")
 
-        if [ "$stop_reason" = "end_turn" ]; then
+        if [ "$stop_reason" = "end_turn" ] || [ "$stop_reason" = "stop_sequence" ] || [ "$stop_reason" = "max_tokens" ]; then
             unreported_completed+=("$filepath")
         fi
     done


### PR DESCRIPTION
## Problem

Agents that finish with `stop_reason=stop_sequence` (hit a stop sequence) or `stop_reason=max_tokens` (hit token limit) were invisible to `agent-status.sh` as terminal. The script only recognized `end_turn` as "done", so these agents appeared permanently "running" in self-check output.

The self-check script runs every 3 minutes and reports active agents. Any agent finishing via stop_sequence or max_tokens would show up in every self-check cycle indefinitely, flooding the inbox with false "agent running" notifications.

## Fix

Both `scan_agent_status()` and `scan_completed_tasks()` now treat three stop reasons as terminal:

- `end_turn` — normal agent completion (was already handled)
- `stop_sequence` — agent hit a configured stop sequence (now handled)
- `max_tokens` — agent hit its token limit (now handled)

The comment block in `scan_agent_status()` was also updated to document why all three are terminal, matching the comment already present in `scan_completed_tasks()` after this change.

## Before / After

```
Before:
  stop_reason=end_turn      → skipped (done)       ✓
  stop_reason=stop_sequence → shown as "running"   ✗  (floods inbox every 3m)
  stop_reason=max_tokens    → shown as "running"   ✗  (floods inbox every 3m)

After:
  stop_reason=end_turn      → skipped (done)       ✓
  stop_reason=stop_sequence → skipped (done)       ✓
  stop_reason=max_tokens    → skipped (done)       ✓
```

No changes to the stale-agent detection logic, turn counting, or any other behavior.

## Tests run
- [ ] Automated unit tests — skipped: this script has no automated test suite covering the `stop_reason` branch logic. The fix is a two-line condition change in a shell script; correctness is verifiable directly from the diff.
- [ ] Manual test — N/A: reproducing requires an agent that finishes via stop_sequence in production. The fix is deterministic and verifiable from the diff alone.

## Manual test
N/A — this is an entirely internal change to a string comparison in a bash conditional. No external services, no file I/O beyond what the script already does, no Telegram output. The behavior change is: agents with `stop_reason=stop_sequence` or `max_tokens` are now skipped in the "running agents" loop rather than displayed. This is verifiable from the diff.

## Definition of Done
- [x] Fix is a targeted, minimal condition change — no unrelated behavior altered
- [x] Both functions (`scan_agent_status` and `scan_completed_tasks`) updated consistently
- [x] Comments updated to document all three terminal states
- [x] Side-effect audit: no floods, no unscoped writes, no unintended volume — this fix *reduces* inbox noise
- [x] External service calls: none

Closes #1567