### PR TITLE
fix: nightly-consolidation.sh silent failure when LOBSTER_DEV_MODE absent

### DIFF
--- a/scripts/nightly-consolidation.sh
+++ b/scripts/nightly-consolidation.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 # bothered while testing. Real user messages are never affected by this flag.
 _LOBSTER_CONFIG="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}/config.env"
 if [ -f "$_LOBSTER_CONFIG" ]; then
-    _DEV_MODE=$(grep -m1 '^LOBSTER_DEV_MODE=' "$_LOBSTER_CONFIG" 2>/dev/null | cut -d= -f2)
+    _DEV_MODE=$(grep -m1 '^LOBSTER_DEV_MODE=' "$_LOBSTER_CONFIG" 2>/dev/null | cut -d= -f2 || true)
     if [ "$_DEV_MODE" = "true" ] || [ "$_DEV_MODE" = "1" ]; then
         exit 0
     fi


### PR DESCRIPTION
## Summary

- Fixes #1571: `nightly-consolidation.sh` aborts silently on any install where `LOBSTER_DEV_MODE` is not present in `config.env`
- Root cause: `grep` inside a command substitution on line 22 exits with code 1 (no match) when the key is absent; `set -euo pipefail` propagates this exit and kills the script before any log is written
- Fix: append `|| true` to the pipeline so an absent key yields an empty string instead of a fatal error

## Test plan

- [ ] Verify the script runs to completion on an install where `config.env` exists but does not contain `LOBSTER_DEV_MODE`
- [ ] Verify `DEV_MODE=true` still causes early exit when the key is present and set to `true`
- [ ] Verify consolidation inbox message is written when `LOBSTER_DEV_MODE` is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)