### PR TITLE
feat: send voice notes via TTS (piper + Telegram sendVoice)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2356,6 +2356,112 @@ else
 fi
 
 #===============================================================================
+# Voice TTS Setup (piper + lessac-medium model)
+#
+# Installs piper TTS for local, offline text-to-speech. Required for the
+# send_voice_note MCP tool. This is a soft requirement — failure emits a
+# warning but does not abort the install (TTS falls back to text replies).
+#===============================================================================
+
+step "Voice TTS Setup (piper)..."
+
+# Detect architecture for piper binary download
+ARCH="$(uname -m)"
+case "$ARCH" in
+    x86_64)   PIPER_ARCH="amd64" ;;
+    aarch64)  PIPER_ARCH="aarch64" ;;
+    armv7l)   PIPER_ARCH="armv7" ;;
+    *)
+        warn "Unsupported architecture for piper: $ARCH — skipping TTS setup"
+        PIPER_ARCH=""
+        ;;
+esac
+
+PIPER_BIN="/usr/local/bin/piper"
+PIPER_MODELS_DIR="${WORKSPACE_DIR}/piper-models"
+PIPER_MODEL_NAME="en_US-lessac-medium"
+PIPER_MODEL_FILE="${PIPER_MODELS_DIR}/${PIPER_MODEL_NAME}.onnx"
+PIPER_MODEL_URL="https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/en/en_US/lessac/medium/${PIPER_MODEL_NAME}.onnx"
+PIPER_MODEL_JSON_URL="https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/en/en_US/lessac/medium/${PIPER_MODEL_NAME}.onnx.json"
+
+if [ -n "$PIPER_ARCH" ]; then
+    mkdir -p "$PIPER_MODELS_DIR"
+
+    # Install piper binary
+    if [ ! -x "$PIPER_BIN" ] && ! command -v piper &>/dev/null; then
+        info "Downloading piper TTS binary (${PIPER_ARCH})..."
+        PIPER_RELEASE_API="https://api.github.com/repos/rhasspy/piper/releases/latest"
+        PIPER_TARBALL_URL="$(curl -fsSL "$PIPER_RELEASE_API" 2>/dev/null | \
+            python3 -c "import sys,json; \
+            data=json.load(sys.stdin); \
+            urls=[a['browser_download_url'] for a in data.get('assets',[]) \
+                  if 'linux_${PIPER_ARCH}' in a['name'] and a['name'].endswith('.tar.gz')]; \
+            print(urls[0] if urls else '')" 2>/dev/null || true)"
+
+        if [ -n "$PIPER_TARBALL_URL" ]; then
+            PIPER_TMP="$(mktemp -d)"
+            if curl -fsSL -o "${PIPER_TMP}/piper.tar.gz" "$PIPER_TARBALL_URL"; then
+                tar -xzf "${PIPER_TMP}/piper.tar.gz" -C "$PIPER_TMP"
+                PIPER_EXTRACTED="$(find "$PIPER_TMP" -type f -name "piper" | head -1)"
+                if [ -n "$PIPER_EXTRACTED" ]; then
+                    PIPER_EXTRACT_DIR="$(dirname "$PIPER_EXTRACTED")"
+                    sudo cp "$PIPER_EXTRACTED" "$PIPER_BIN"
+                    sudo chmod +x "$PIPER_BIN"
+                    # Copy shared libraries required by piper
+                    for lib in libonnxruntime.so.* libpiper_phonemize.so.* libespeak-ng.so.*; do
+                        lib_path="$(find "$PIPER_EXTRACT_DIR" -name "$lib" -type f | head -1)"
+                        if [ -n "$lib_path" ]; then
+                            sudo cp "$lib_path" /usr/local/lib/
+                        fi
+                    done
+                    sudo ldconfig 2>/dev/null || true
+                    # Install bundled espeak-ng-data (piper phoneme tables)
+                    if [ -d "${PIPER_EXTRACT_DIR}/espeak-ng-data" ]; then
+                        sudo cp -r "${PIPER_EXTRACT_DIR}/espeak-ng-data" /usr/share/ 2>/dev/null || true
+                    fi
+                    success "piper installed to $PIPER_BIN"
+                else
+                    warn "piper binary not found in tarball — TTS will not be available"
+                fi
+            else
+                warn "Failed to download piper tarball from $PIPER_TARBALL_URL — TTS will not be available"
+            fi
+            rm -rf "$PIPER_TMP"
+        else
+            warn "Could not find piper release for linux_${PIPER_ARCH} — TTS will not be available"
+        fi
+    else
+        success "piper already installed"
+    fi
+
+    # Download lessac-medium voice model (~30MB)
+    if [ ! -f "$PIPER_MODEL_FILE" ]; then
+        info "Downloading piper voice model: ${PIPER_MODEL_NAME} (~30MB)..."
+        if curl -fsSL -o "$PIPER_MODEL_FILE" "$PIPER_MODEL_URL" && \
+           curl -fsSL -o "${PIPER_MODEL_FILE}.json" "$PIPER_MODEL_JSON_URL"; then
+            success "piper voice model downloaded: ${PIPER_MODEL_FILE}"
+        else
+            warn "Failed to download piper voice model — TTS will not be available"
+            rm -f "$PIPER_MODEL_FILE" "${PIPER_MODEL_FILE}.json"
+        fi
+    else
+        success "piper voice model already present: ${PIPER_MODEL_FILE}"
+    fi
+
+    # Quick smoke test
+    if command -v piper &>/dev/null || [ -x "$PIPER_BIN" ]; then
+        PIPER_CMD="${PIPER_BIN:-piper}"
+        if "$PIPER_CMD" --help &>/dev/null 2>&1; then
+            success "piper TTS verified"
+        else
+            warn "piper binary present but --help failed — TTS may not work correctly"
+        fi
+    fi
+else
+    info "Skipping piper TTS setup (unsupported architecture: $ARCH)"
+fi
+
+#===============================================================================
 # Authentication Method (OAuth-first)
 #===============================================================================
 

--- a/scripts/send-voice-note.sh
+++ b/scripts/send-voice-note.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# send-voice-note.sh — Send a TTS voice note to a Telegram chat
+#
+# Usage:
+#   scripts/send-voice-note.sh <chat_id> "<text>"
+#
+# Examples:
+#   scripts/send-voice-note.sh 8305714125 "Good morning! Here is your briefing."
+#   scripts/send-voice-note.sh 8305714125 "$(cat /tmp/message.txt)"
+#
+# Requires:
+#   - piper binary at /usr/local/bin/piper or ~/.local/bin/piper
+#   - en_US-lessac-medium.onnx model in ~/lobster-workspace/piper-models/
+#   - ffmpeg available in PATH
+#   - TELEGRAM_BOT_TOKEN environment variable (or sourced from config)
+#   - Lobster installed at ~/lobster/
+#
+# The script generates an OGG/Opus voice file using piper + ffmpeg, then sends
+# it via the Telegram Bot API using curl. It does not rely on the running
+# Lobster dispatcher — useful for scripted/cron usage.
+#
+# Exit codes:
+#   0 — voice note sent successfully
+#   1 — argument error (missing chat_id or text)
+#   2 — TTS synthesis failed (piper or ffmpeg error)
+#   3 — Telegram API send failed
+#   4 — configuration error (missing token or binary)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+INSTALL_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
+WORKSPACE_DIR="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-user-config}"
+
+PIPER_BIN="${PIPER_BIN:-}"
+if [ -z "$PIPER_BIN" ]; then
+    if [ -x "/usr/local/bin/piper" ]; then
+        PIPER_BIN="/usr/local/bin/piper"
+    elif [ -x "$HOME/.local/bin/piper" ]; then
+        PIPER_BIN="$HOME/.local/bin/piper"
+    elif command -v piper &>/dev/null; then
+        PIPER_BIN="$(command -v piper)"
+    fi
+fi
+
+PIPER_MODELS_DIR="${PIPER_MODELS_DIR:-$WORKSPACE_DIR/piper-models}"
+PIPER_MODEL="${PIPER_MODEL:-$PIPER_MODELS_DIR/en_US-lessac-medium.onnx}"
+TELEGRAM_API_URL="https://api.telegram.org"
+
+# Load TELEGRAM_BOT_TOKEN from config if not set
+if [ -z "${TELEGRAM_BOT_TOKEN:-}" ]; then
+    config_file="${LOBSTER_CONFIG_FILE:-$HOME/lobster-user-config/config.env}"
+    if [ -f "$config_file" ]; then
+        # shellcheck disable=SC1090
+        source "$config_file" 2>/dev/null || true
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <chat_id> \"<text>\"" >&2
+    echo "Example: $0 8305714125 \"Good morning! Here is your briefing.\"" >&2
+    exit 1
+fi
+
+CHAT_ID="$1"
+TEXT="$2"
+
+if [ -z "$CHAT_ID" ]; then
+    echo "Error: chat_id cannot be empty" >&2
+    exit 1
+fi
+
+if [ -z "$TEXT" ]; then
+    echo "Error: text cannot be empty" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Pre-flight checks
+# ---------------------------------------------------------------------------
+
+if [ -z "${TELEGRAM_BOT_TOKEN:-}" ]; then
+    echo "Error: TELEGRAM_BOT_TOKEN is not set. Source your config or export the variable." >&2
+    exit 4
+fi
+
+if [ -z "$PIPER_BIN" ]; then
+    echo "Error: piper binary not found. Install via install.sh or set PIPER_BIN." >&2
+    exit 4
+fi
+
+if [ ! -f "$PIPER_MODEL" ]; then
+    echo "Error: piper model not found at $PIPER_MODEL" >&2
+    echo "Install via install.sh or set PIPER_MODEL=/path/to/model.onnx" >&2
+    exit 4
+fi
+
+if ! command -v ffmpeg &>/dev/null; then
+    echo "Error: ffmpeg not found in PATH. Install ffmpeg." >&2
+    exit 4
+fi
+
+# ---------------------------------------------------------------------------
+# TTS synthesis
+# ---------------------------------------------------------------------------
+
+TMP_DIR="$(mktemp -d --tmpdir lobster-tts-XXXXXX)"
+WAV_FILE="$TMP_DIR/voice.wav"
+OGG_FILE="$TMP_DIR/voice.ogg"
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+echo "Synthesizing voice note ($(echo -n "$TEXT" | wc -c) chars)..."
+
+# Run piper: text → WAV
+if ! echo "$TEXT" | "$PIPER_BIN" \
+        --model "$PIPER_MODEL" \
+        --output_file "$WAV_FILE" 2>&1; then
+    echo "Error: piper synthesis failed" >&2
+    exit 2
+fi
+
+if [ ! -s "$WAV_FILE" ]; then
+    echo "Error: piper produced an empty WAV file" >&2
+    exit 2
+fi
+
+# Convert WAV → OGG/Opus (Telegram voice format)
+if ! ffmpeg -y -i "$WAV_FILE" \
+        -c:a libopus -b:a 24k -ar 24000 -ac 1 \
+        -vbr on -compression_level 10 \
+        "$OGG_FILE" 2>&1 | tail -3; then
+    echo "Error: ffmpeg OGG conversion failed" >&2
+    exit 2
+fi
+
+if [ ! -s "$OGG_FILE" ]; then
+    echo "Error: ffmpeg produced an empty OGG file" >&2
+    exit 2
+fi
+
+OGG_SIZE="$(wc -c < "$OGG_FILE")"
+echo "Voice note generated: ${OGG_SIZE} bytes"
+
+# ---------------------------------------------------------------------------
+# Send via Telegram Bot API
+# ---------------------------------------------------------------------------
+
+echo "Sending voice note to chat ${CHAT_ID}..."
+
+RESPONSE="$(curl -s -X POST \
+    "${TELEGRAM_API_URL}/bot${TELEGRAM_BOT_TOKEN}/sendVoice" \
+    -F "chat_id=${CHAT_ID}" \
+    -F "voice=@${OGG_FILE};type=audio/ogg")"
+
+if echo "$RESPONSE" | python3 -c "import sys, json; d=json.load(sys.stdin); sys.exit(0 if d.get('ok') else 1)" 2>/dev/null; then
+    echo "Voice note sent successfully to chat ${CHAT_ID}."
+    exit 0
+else
+    echo "Error: Telegram API returned an error:" >&2
+    echo "$RESPONSE" >&2
+    exit 3
+fi

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2442,6 +2442,76 @@ CREATE TABLE IF NOT EXISTS dispatcher_lock (
         substep "wfm-watchdog.sh cron entry already present — skipping"
     fi
 
+    # Migration 70: Install piper TTS and lessac-medium voice model for send_voice_note.
+    # Soft requirement: failure warns but does not abort upgrade.
+    local PIPER_BIN_PATH="/usr/local/bin/piper"
+    local PIPER_MODELS_TARGET="${WORKSPACE_DIR}/piper-models"
+    local PIPER_MODEL_FILE="${PIPER_MODELS_TARGET}/en_US-lessac-medium.onnx"
+    mkdir -p "$PIPER_MODELS_TARGET"
+
+    if [ ! -x "$PIPER_BIN_PATH" ] && ! command -v piper &>/dev/null; then
+        substep "Installing piper TTS binary for send_voice_note..."
+        local _arch
+        _arch="$(uname -m)"
+        local _piper_arch=""
+        case "$_arch" in
+            x86_64)   _piper_arch="amd64" ;;
+            aarch64)  _piper_arch="aarch64" ;;
+            armv7l)   _piper_arch="armv7" ;;
+        esac
+        if [ -n "$_piper_arch" ]; then
+            local _piper_url
+            _piper_url="$(curl -fsSL https://api.github.com/repos/rhasspy/piper/releases/latest 2>/dev/null | \
+                python3 -c "import sys,json; \
+                data=json.load(sys.stdin); \
+                urls=[a['browser_download_url'] for a in data.get('assets',[]) \
+                      if 'linux_${_piper_arch}' in a['name'] and a['name'].endswith('.tar.gz')]; \
+                print(urls[0] if urls else '')" 2>/dev/null || true)"
+            if [ -n "$_piper_url" ]; then
+                local _ptmp
+                _ptmp="$(mktemp -d)"
+                if curl -fsSL -o "${_ptmp}/piper.tar.gz" "$_piper_url" && \
+                   tar -xzf "${_ptmp}/piper.tar.gz" -C "$_ptmp"; then
+                    local _bin
+                    _bin="$(find "$_ptmp" -type f -name "piper" | head -1)"
+                    if [ -n "$_bin" ]; then
+                        local _bin_dir
+                        _bin_dir="$(dirname "$_bin")"
+                        sudo cp "$_bin" "$PIPER_BIN_PATH"
+                        sudo chmod +x "$PIPER_BIN_PATH"
+                        # Copy shared libraries
+                        for _lib in libonnxruntime.so.* libpiper_phonemize.so.* libespeak-ng.so.*; do
+                            _lib_path="$(find "$_bin_dir" -name "$_lib" -type f | head -1)"
+                            [ -n "$_lib_path" ] && sudo cp "$_lib_path" /usr/local/lib/ 2>/dev/null || true
+                        done
+                        sudo ldconfig 2>/dev/null || true
+                        # Install bundled espeak-ng-data
+                        if [ -d "${_bin_dir}/espeak-ng-data" ]; then
+                            sudo cp -r "${_bin_dir}/espeak-ng-data" /usr/share/ 2>/dev/null || true
+                        fi
+                        substep "piper TTS installed to $PIPER_BIN_PATH"
+                        migrated=$((migrated + 1))
+                    fi
+                fi
+                rm -rf "$_ptmp"
+            fi
+        fi
+    fi
+
+    if [ ! -f "$PIPER_MODEL_FILE" ]; then
+        substep "Downloading piper lessac-medium voice model (~30MB)..."
+        local _model_url="https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/en/en_US/lessac/medium/en_US-lessac-medium.onnx"
+        local _model_json_url="https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/en/en_US/lessac/medium/en_US-lessac-medium.onnx.json"
+        if curl -fsSL -o "$PIPER_MODEL_FILE" "$_model_url" && \
+           curl -fsSL -o "${PIPER_MODEL_FILE}.json" "$_model_json_url"; then
+            substep "piper voice model downloaded"
+            migrated=$((migrated + 1))
+        else
+            warn "piper voice model download failed — send_voice_note will fall back to text"
+            rm -f "$PIPER_MODEL_FILE" "${PIPER_MODEL_FILE}.json"
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -1876,7 +1876,52 @@ class OutboxHandler(FileSystemEventHandler):
 
             # Handle voice note messages (from TTS / send_voice_note MCP tool)
             voice_path = reply.get('voice_path', '')
-            if reply_type == 'voice' and voice_path and chat_id and bot_app:
+            if reply_type == 'voice':
+                # Helper: clean up the OGG temp file if it exists.
+                def _cleanup_ogg(path):
+                    if path:
+                        try:
+                            os.remove(path)
+                        except OSError:
+                            pass
+
+                # Helper: send a text fallback so the user always gets something.
+                async def _send_voice_fallback(reason):
+                    fallback_text = text or "[Voice note could not be delivered]"
+                    log.warning(
+                        f"voice note to {chat_id}: {reason} — "
+                        f"falling back to text (has_text={bool(text)})"
+                    )
+                    if chat_id and bot_app:
+                        try:
+                            await bot_app.bot.send_message(chat_id=chat_id, text=fallback_text)
+                            log.info(f"Sent voice fallback text to {chat_id}")
+                        except Exception as fb_err:
+                            log.error(
+                                f"Voice fallback text send also failed for {chat_id}: {fb_err}"
+                            )
+                    else:
+                        log.error(
+                            f"voice note to {chat_id}: cannot send fallback "
+                            f"(bot_app={bot_app!r}) — message will be lost"
+                        )
+
+                # Guard: bot must be running to send anything via Telegram.
+                if not bot_app or not chat_id:
+                    log.error(
+                        f"voice note dropped: bot_app={bot_app!r} chat_id={chat_id!r} — "
+                        "cleaning up OGG and removing outbox file"
+                    )
+                    _cleanup_ogg(voice_path)
+                    os.remove(filepath)
+                    return
+
+                # Guard: voice_path must be present; fall back to text if missing.
+                if not voice_path:
+                    await _send_voice_fallback("voice_path is missing from outbox message")
+                    os.remove(filepath)
+                    return
+
                 try:
                     from telegram import InputFile as _InputFile
                     with open(voice_path, 'rb') as audio_f:
@@ -1885,22 +1930,14 @@ class OutboxHandler(FileSystemEventHandler):
                             voice=_InputFile(audio_f),
                         )
                     log.info(f"Sent voice note to {chat_id}: {voice_path}")
-                    # Delete the OGG temp file now that it's been sent
-                    try:
-                        os.remove(voice_path)
-                    except OSError:
-                        pass
+                    # Delete the OGG temp file now that it's been sent.
+                    _cleanup_ogg(voice_path)
                     os.remove(filepath)
                     return
                 except Exception as e:
                     log.warning(f"send_voice failed for {chat_id}: {e} — falling back to text")
-                    # Fall back to text so the user receives something
-                    if text:
-                        try:
-                            await bot_app.bot.send_message(chat_id=chat_id, text=text)
-                            log.info(f"Sent voice fallback text to {chat_id}")
-                        except Exception as e2:
-                            log.error(f"Voice fallback text send also failed for {chat_id}: {e2}")
+                    _cleanup_ogg(voice_path)
+                    await _send_voice_fallback(str(e))
                     os.remove(filepath)
                     return
 

--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -1874,6 +1874,36 @@ class OutboxHandler(FileSystemEventHandler):
             caption = reply.get('caption', '')
             reply_to_id = reply.get('reply_to_message_id')
 
+            # Handle voice note messages (from TTS / send_voice_note MCP tool)
+            voice_path = reply.get('voice_path', '')
+            if reply_type == 'voice' and voice_path and chat_id and bot_app:
+                try:
+                    from telegram import InputFile as _InputFile
+                    with open(voice_path, 'rb') as audio_f:
+                        await bot_app.bot.send_voice(
+                            chat_id=chat_id,
+                            voice=_InputFile(audio_f),
+                        )
+                    log.info(f"Sent voice note to {chat_id}: {voice_path}")
+                    # Delete the OGG temp file now that it's been sent
+                    try:
+                        os.remove(voice_path)
+                    except OSError:
+                        pass
+                    os.remove(filepath)
+                    return
+                except Exception as e:
+                    log.warning(f"send_voice failed for {chat_id}: {e} — falling back to text")
+                    # Fall back to text so the user receives something
+                    if text:
+                        try:
+                            await bot_app.bot.send_message(chat_id=chat_id, text=text)
+                            log.info(f"Sent voice fallback text to {chat_id}")
+                        except Exception as e2:
+                            log.error(f"Voice fallback text send also failed for {chat_id}: {e2}")
+                    os.remove(filepath)
+                    return
+
             # Handle photo messages (from image-generation skill or other sources)
             if reply_type == 'photo' and photo_url and chat_id and bot_app:
                 try:

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -2063,6 +2063,36 @@ async def list_tools() -> list[Tool]:
                 "required": ["message_id"],
             },
         ),
+        # TTS Voice Note Tool
+        Tool(
+            name="send_voice_note",
+            description=(
+                "Synthesize text to speech and send as a Telegram voice note using local piper TTS. "
+                "Runs entirely locally — no cloud API or API key needed. "
+                "Requires piper binary and lessac-medium voice model (installed by install.sh). "
+                "Falls back to send_reply with text if TTS is unavailable. "
+                "Use for responses that benefit from an audio/voice delivery."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "chat_id": {
+                        "type": "string",
+                        "description": "The chat ID to send the voice note to (Telegram chat ID).",
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "The text to synthesize into a voice note. Keep under ~500 words for best results.",
+                    },
+                    "source": {
+                        "type": "string",
+                        "description": "Message source channel. Defaults to 'telegram'. Voice notes are only sent for Telegram; other sources fall back to text.",
+                        "default": "telegram",
+                    },
+                },
+                "required": ["chat_id", "text"],
+            },
+        ),
         # Headless Browser Fetch Tool
         Tool(
             name="fetch_page",
@@ -3497,6 +3527,8 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[TextConte
         return await handle_update_rule(arguments)
     elif name == "transcribe_audio":
         return await handle_transcribe_audio(arguments)
+    elif name == "send_voice_note":
+        return await handle_send_voice_note(arguments)
     # Headless Browser Fetch
     elif name == "fetch_page":
         return await handle_fetch_page(arguments)
@@ -6356,6 +6388,74 @@ async def handle_transcribe_audio(args: dict) -> list[TextContent]:
 
     except Exception as e:
         return [TextContent(type="text", text=f"Error during transcription: {str(e)}")]
+
+
+# =============================================================================
+# TTS Voice Note Handler
+# =============================================================================
+
+async def handle_send_voice_note(args: dict) -> list[TextContent]:
+    """Synthesize text to a voice note and send via Telegram.
+
+    Uses piper TTS locally (no cloud). Falls back to a text send_reply if TTS
+    or the Telegram voice send fails, so the user always gets a response.
+    """
+    chat_id = str(args.get("chat_id", "")).strip()
+    text = str(args.get("text", "")).strip()
+    source = str(args.get("source", "telegram")).strip() or "telegram"
+
+    if not chat_id:
+        return [TextContent(type="text", text="Error: chat_id is required.")]
+    if not text:
+        return [TextContent(type="text", text="Error: text is required.")]
+
+    # Non-Telegram sources: voice notes are not supported; fall back to text.
+    if source != "telegram":
+        log.info(f"send_voice_note: source={source!r} is not telegram — falling back to text")
+        fallback_args = {"chat_id": chat_id, "text": text, "source": source}
+        return await handle_send_reply(fallback_args)
+
+    # Import TTS module lazily so missing piper doesn't crash the server.
+    try:
+        from tts.piper import text_to_voice_file  # type: ignore[import]
+    except ImportError as e:
+        log.warning(f"send_voice_note: tts module not importable ({e}) — falling back to text")
+        return await handle_send_reply({"chat_id": chat_id, "text": text, "source": source})
+
+    # Generate OGG voice file
+    tts_result = text_to_voice_file(text)
+    if not tts_result.ok:
+        log.warning(f"send_voice_note: TTS failed ({tts_result.error}) — falling back to text")
+        tts_result.cleanup()
+        return await handle_send_reply({"chat_id": chat_id, "text": text, "source": source})
+
+    ogg_path = tts_result.ogg_path
+    try:
+        # Write a voice-type outbox message pointing to the OGG file.
+        # The Telegram bot's outbox handler reads this and calls bot.send_voice().
+        import time as _time
+        reply_id = f"{int(_time.time() * 1000)}_telegram_voice"
+        reply_data = {
+            "id": reply_id,
+            "source": "telegram",
+            "chat_id": chat_id,
+            "type": "voice",
+            "voice_path": str(ogg_path),
+            "text": text,  # kept as fallback caption / for sent-messages history
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        outbox_file = OUTBOX_DIR / f"{reply_id}.json"
+        atomic_write_json(outbox_file, reply_data)
+        # Save to sent directory for conversation history
+        sent_file = SENT_DIR / f"{reply_id}.json"
+        atomic_write_json(sent_file, reply_data)
+
+        log.info(f"send_voice_note: queued voice note to {chat_id} ({ogg_path})")
+        return [TextContent(type="text", text=f"Voice note queued for delivery to chat {chat_id}.")]
+    except Exception as e:
+        log.error(f"send_voice_note: failed to queue voice note ({e}) — falling back to text")
+        tts_result.cleanup()
+        return await handle_send_reply({"chat_id": chat_id, "text": text, "source": source})
 
 
 # =============================================================================

--- a/src/tts/__init__.py
+++ b/src/tts/__init__.py
@@ -1,0 +1,24 @@
+"""Text-to-speech synthesis for Lobster.
+
+Provides local TTS using piper (neural TTS, high quality, no cloud dependency).
+Falls back gracefully when the binary or model is unavailable.
+"""
+from .piper import (
+    PiperConfig,
+    TtsResult,
+    find_piper_binary,
+    find_voice_model,
+    synthesize_wav,
+    convert_wav_to_ogg,
+    text_to_voice_file,
+)
+
+__all__ = [
+    "PiperConfig",
+    "TtsResult",
+    "find_piper_binary",
+    "find_voice_model",
+    "synthesize_wav",
+    "convert_wav_to_ogg",
+    "text_to_voice_file",
+]

--- a/src/tts/piper.py
+++ b/src/tts/piper.py
@@ -1,0 +1,356 @@
+"""Piper TTS integration for Lobster.
+
+Pure functions for text-to-speech synthesis using piper (https://github.com/rhasspy/piper).
+
+Flow:
+    text → piper CLI → WAV file → ffmpeg → OGG/Opus file → Telegram send_voice
+
+All functions are pure and side-effect-free except for file I/O. Callers manage
+temporary file lifetimes using TtsResult.cleanup().
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration constants (named after spec requirements)
+# ---------------------------------------------------------------------------
+
+# Default voice model: lessac-medium — natural quality, moderate size (~30MB)
+DEFAULT_VOICE_MODEL_NAME = "en_US-lessac-medium"
+
+# Piper model file extension
+PIPER_MODEL_EXTENSION = ".onnx"
+
+# Search paths for the piper binary (in priority order)
+PIPER_BINARY_SEARCH_PATHS = [
+    "/usr/local/bin/piper",
+    os.path.expanduser("~/.local/bin/piper"),
+]
+
+# Search paths for voice models (in priority order)
+PIPER_MODEL_SEARCH_DIRS = [
+    os.path.expanduser("~/lobster-workspace/piper-models"),
+    os.path.expanduser("~/.local/share/piper"),
+    "/usr/local/share/piper",
+]
+
+# Subprocess timeout for piper synthesis (seconds)
+PIPER_SYNTHESIS_TIMEOUT_S = 30
+
+# Subprocess timeout for ffmpeg OGG conversion (seconds)
+FFMPEG_CONVERT_TIMEOUT_S = 30
+
+# OGG/Opus codec settings for Telegram voice notes
+# Telegram requires OGG/Opus; 24kbps is intelligible and small
+FFMPEG_OPUS_BITRATE = "24k"
+FFMPEG_OPUS_SAMPLE_RATE = "24000"
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PiperConfig:
+    """Resolved piper configuration (binary + model paths).
+
+    Produced by find_piper_binary() + find_voice_model(). Immutable after
+    construction so it can be passed through pure function chains safely.
+    """
+    piper_binary: Path
+    model_path: Path
+
+    def is_usable(self) -> bool:
+        """Return True if both binary and model file exist and are executable."""
+        return (
+            self.piper_binary.exists()
+            and os.access(str(self.piper_binary), os.X_OK)
+            and self.model_path.exists()
+        )
+
+
+@dataclass
+class TtsResult:
+    """Result of a TTS synthesis pipeline run.
+
+    On success: ogg_path points to the generated OGG/Opus file.
+    On failure: error contains a human-readable message; ogg_path is None.
+
+    Callers are responsible for calling cleanup() to delete the temp file.
+    """
+    ok: bool
+    ogg_path: Optional[Path] = None
+    error: Optional[str] = None
+    _cleanup_paths: list = field(default_factory=list, repr=False)
+
+    def cleanup(self) -> None:
+        """Delete any temporary files created during synthesis."""
+        for p in self._cleanup_paths:
+            try:
+                path = Path(p)
+                if path.exists():
+                    path.unlink()
+            except OSError as e:
+                log.warning(f"TtsResult.cleanup: failed to delete {p}: {e}")
+        self._cleanup_paths.clear()
+
+
+# ---------------------------------------------------------------------------
+# Discovery functions
+# ---------------------------------------------------------------------------
+
+def find_piper_binary() -> Optional[Path]:
+    """Return the path to the piper binary, or None if not found.
+
+    Searches PIPER_BINARY_SEARCH_PATHS in order, then falls back to PATH.
+    Pure: reads the filesystem but has no side effects.
+    """
+    for candidate in PIPER_BINARY_SEARCH_PATHS:
+        p = Path(candidate)
+        if p.exists() and os.access(str(p), os.X_OK):
+            log.debug(f"piper binary found at {p}")
+            return p
+
+    # Fall back to shutil.which (searches PATH)
+    found = shutil.which("piper")
+    if found:
+        log.debug(f"piper binary found via PATH at {found}")
+        return Path(found)
+
+    log.warning(
+        "piper binary not found. "
+        f"Searched: {PIPER_BINARY_SEARCH_PATHS} and PATH. "
+        "Install piper to /usr/local/bin/piper or ~/.local/bin/piper."
+    )
+    return None
+
+
+def find_voice_model(model_name: str = DEFAULT_VOICE_MODEL_NAME) -> Optional[Path]:
+    """Return the path to a piper voice model file, or None if not found.
+
+    Searches PIPER_MODEL_SEARCH_DIRS for a file named <model_name>.onnx.
+    Pure: reads the filesystem but has no side effects.
+    """
+    filename = model_name + PIPER_MODEL_EXTENSION
+    for search_dir in PIPER_MODEL_SEARCH_DIRS:
+        candidate = Path(search_dir) / filename
+        if candidate.exists():
+            log.debug(f"piper model found at {candidate}")
+            return candidate
+
+    log.warning(
+        f"piper voice model '{filename}' not found. "
+        f"Searched: {PIPER_MODEL_SEARCH_DIRS}. "
+        "Download from https://huggingface.co/rhasspy/piper-voices"
+    )
+    return None
+
+
+def resolve_piper_config(
+    model_name: str = DEFAULT_VOICE_MODEL_NAME,
+) -> Optional[PiperConfig]:
+    """Resolve binary + model into a PiperConfig, or None if either is missing.
+
+    Composition of find_piper_binary() + find_voice_model().
+    Pure: no side effects.
+    """
+    binary = find_piper_binary()
+    if binary is None:
+        return None
+    model = find_voice_model(model_name)
+    if model is None:
+        return None
+    cfg = PiperConfig(piper_binary=binary, model_path=model)
+    if not cfg.is_usable():
+        log.warning(f"PiperConfig not usable: binary={binary} model={model}")
+        return None
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Synthesis functions
+# ---------------------------------------------------------------------------
+
+def synthesize_wav(
+    text: str,
+    config: PiperConfig,
+    output_path: Path,
+) -> Optional[str]:
+    """Run piper to synthesize text into a WAV file at output_path.
+
+    Returns None on success, or an error message string on failure.
+    Side effect: writes a WAV file at output_path.
+    """
+    if not text.strip():
+        return "Empty text provided for TTS synthesis"
+
+    if not config.is_usable():
+        return f"PiperConfig not usable: binary={config.piper_binary} model={config.model_path}"
+
+    cmd = [
+        str(config.piper_binary),
+        "--model", str(config.model_path),
+        "--output_file", str(output_path),
+    ]
+
+    log.debug(f"synthesize_wav: running {cmd!r} with text len={len(text)}")
+
+    try:
+        result = subprocess.run(
+            cmd,
+            input=text,
+            capture_output=True,
+            text=True,
+            timeout=PIPER_SYNTHESIS_TIMEOUT_S,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            return f"piper exited with code {result.returncode}: {stderr}"
+        if not output_path.exists() or output_path.stat().st_size == 0:
+            return f"piper produced no output at {output_path}"
+        log.debug(f"synthesize_wav: success, WAV size={output_path.stat().st_size} bytes")
+        return None
+    except subprocess.TimeoutExpired:
+        return f"piper timed out after {PIPER_SYNTHESIS_TIMEOUT_S}s synthesizing {len(text)} chars"
+    except FileNotFoundError:
+        return f"piper binary not found at {config.piper_binary}"
+    except OSError as e:
+        return f"piper subprocess error: {e}"
+
+
+def convert_wav_to_ogg(wav_path: Path, ogg_path: Path) -> Optional[str]:
+    """Convert a WAV file to OGG/Opus format using ffmpeg.
+
+    Telegram voice notes require OGG/Opus. This function wraps ffmpeg with
+    settings appropriate for voice (24kHz, 24kbps Opus).
+
+    Returns None on success, or an error message string on failure.
+    Side effect: writes an OGG file at ogg_path.
+    """
+    if not wav_path.exists():
+        return f"WAV file not found: {wav_path}"
+
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        return "ffmpeg not found in PATH — required for OGG/Opus conversion"
+
+    cmd = [
+        ffmpeg,
+        "-y",                          # overwrite output without asking
+        "-i", str(wav_path),           # input WAV
+        "-c:a", "libopus",             # Opus codec
+        "-b:a", FFMPEG_OPUS_BITRATE,   # bitrate
+        "-ar", FFMPEG_OPUS_SAMPLE_RATE,  # sample rate
+        "-ac", "1",                    # mono
+        "-vbr", "on",                  # variable bitrate (better quality)
+        "-compression_level", "10",    # max compression
+        str(ogg_path),
+    ]
+
+    log.debug(f"convert_wav_to_ogg: running ffmpeg WAV→OGG")
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=FFMPEG_CONVERT_TIMEOUT_S,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.strip()[-500:]  # last 500 chars of ffmpeg stderr
+            return f"ffmpeg exited with code {result.returncode}: {stderr}"
+        if not ogg_path.exists() or ogg_path.stat().st_size == 0:
+            return f"ffmpeg produced no output at {ogg_path}"
+        log.debug(f"convert_wav_to_ogg: success, OGG size={ogg_path.stat().st_size} bytes")
+        return None
+    except subprocess.TimeoutExpired:
+        return f"ffmpeg timed out after {FFMPEG_CONVERT_TIMEOUT_S}s"
+    except FileNotFoundError:
+        return "ffmpeg binary not found"
+    except OSError as e:
+        return f"ffmpeg subprocess error: {e}"
+
+
+def text_to_voice_file(
+    text: str,
+    model_name: str = DEFAULT_VOICE_MODEL_NAME,
+) -> TtsResult:
+    """Full TTS pipeline: text → OGG/Opus file ready for Telegram.
+
+    Composes resolve_piper_config() + synthesize_wav() + convert_wav_to_ogg()
+    into a single call. Creates temporary files managed by the returned TtsResult.
+
+    On failure at any stage, returns TtsResult(ok=False, error=...) without
+    raising. Caller must call result.cleanup() after use.
+
+    Args:
+        text: Text to synthesize. Must be non-empty.
+        model_name: Piper voice model name (default: lessac-medium).
+
+    Returns:
+        TtsResult with ok=True and ogg_path set on success,
+        or ok=False and error set on failure.
+    """
+    result = TtsResult(ok=False)
+
+    # Resolve piper config
+    config = resolve_piper_config(model_name)
+    if config is None:
+        result.error = (
+            "TTS unavailable: piper binary or voice model not found. "
+            "Run install.sh to install piper and the lessac-medium model."
+        )
+        return result
+
+    # Create temp directory for intermediate files
+    tmp_dir = Path(tempfile.mkdtemp(prefix="lobster-tts-"))
+    result._cleanup_paths.append(str(tmp_dir / "voice.wav"))
+    result._cleanup_paths.append(str(tmp_dir / "voice.ogg"))
+
+    wav_path = tmp_dir / "voice.wav"
+    ogg_path = tmp_dir / "voice.ogg"
+
+    # Step 1: synthesize WAV
+    err = synthesize_wav(text, config, wav_path)
+    if err:
+        result.error = f"TTS synthesis failed: {err}"
+        # Clean up tmp_dir itself
+        try:
+            import shutil as _shutil
+            _shutil.rmtree(str(tmp_dir), ignore_errors=True)
+        except Exception:
+            pass
+        result._cleanup_paths.clear()
+        return result
+
+    # Step 2: convert WAV → OGG/Opus
+    err = convert_wav_to_ogg(wav_path, ogg_path)
+    if err:
+        result.error = f"OGG conversion failed: {err}"
+        try:
+            import shutil as _shutil
+            _shutil.rmtree(str(tmp_dir), ignore_errors=True)
+        except Exception:
+            pass
+        result._cleanup_paths.clear()
+        return result
+
+    # Clean WAV (no longer needed), keep OGG
+    try:
+        wav_path.unlink()
+    except OSError:
+        pass
+    result._cleanup_paths = [str(ogg_path)]
+
+    result.ok = True
+    result.ogg_path = ogg_path
+    return result

--- a/tests/unit/test_bot/test_outbox_watcher.py
+++ b/tests/unit/test_bot/test_outbox_watcher.py
@@ -199,6 +199,229 @@ class TestOutboxHandler:
             mock_run.assert_not_called()
 
 
+class TestVoiceNoteHandling:
+    """Tests for voice note outbox handling in process_reply.
+
+    Covers the two issues fixed in PR #1576:
+    1. Silent message loss when voice_path is missing — user must always get text fallback.
+    2. OGG temp file leak when bot is not running — OGG must be cleaned up even if bot_app is None.
+    """
+
+    @pytest.fixture
+    def mock_bot_app(self):
+        app = MagicMock()
+        app.bot.send_voice = AsyncMock()
+        app.bot.send_message = AsyncMock()
+        return app
+
+    @pytest.fixture
+    def bot_module(self):
+        return get_bot_module()
+
+    @pytest.mark.asyncio
+    async def test_voice_note_sent_successfully(self, tmp_path, temp_messages_dir, mock_bot_app, bot_module):
+        """Happy path: OGG file exists, bot is running — voice note is sent and OGG is cleaned up."""
+        outbox = temp_messages_dir / "outbox"
+        ogg_file = tmp_path / "voice.ogg"
+        ogg_file.write_bytes(b"fake ogg data")
+
+        reply = {
+            "chat_id": 123456,
+            "type": "voice",
+            "voice_path": str(ogg_file),
+            "text": "Hello in voice",
+        }
+        reply_file = outbox / "voice_1.json"
+        reply_file.write_text(json.dumps(reply))
+
+        handler = bot_module.OutboxHandler()
+        original_bot_app = bot_module.bot_app
+        bot_module.bot_app = mock_bot_app
+        loop = asyncio.new_event_loop()
+        bot_module.main_loop = loop
+
+        try:
+            await handler.process_reply(str(reply_file))
+            mock_bot_app.bot.send_voice.assert_called_once()
+            mock_bot_app.bot.send_message.assert_not_called()
+            assert not ogg_file.exists(), "OGG temp file should be cleaned up after successful send"
+            assert not reply_file.exists()
+        finally:
+            bot_module.bot_app = original_bot_app
+            loop.close()
+
+    @pytest.mark.asyncio
+    async def test_voice_note_missing_voice_path_sends_text_fallback(
+        self, temp_messages_dir, mock_bot_app, bot_module
+    ):
+        """If voice_path is absent from the outbox message, the user receives the text fallback."""
+        outbox = temp_messages_dir / "outbox"
+
+        reply = {
+            "chat_id": 123456,
+            "type": "voice",
+            # voice_path intentionally omitted
+            "text": "This is the fallback text",
+        }
+        reply_file = outbox / "voice_no_path.json"
+        reply_file.write_text(json.dumps(reply))
+
+        handler = bot_module.OutboxHandler()
+        original_bot_app = bot_module.bot_app
+        bot_module.bot_app = mock_bot_app
+        loop = asyncio.new_event_loop()
+        bot_module.main_loop = loop
+
+        try:
+            await handler.process_reply(str(reply_file))
+            mock_bot_app.bot.send_voice.assert_not_called()
+            mock_bot_app.bot.send_message.assert_called_once()
+            call_text = mock_bot_app.bot.send_message.call_args.kwargs.get("text", "")
+            assert "fallback text" in call_text
+            assert not reply_file.exists()
+        finally:
+            bot_module.bot_app = original_bot_app
+            loop.close()
+
+    @pytest.mark.asyncio
+    async def test_voice_note_missing_voice_path_no_text_sends_placeholder(
+        self, temp_messages_dir, mock_bot_app, bot_module
+    ):
+        """If both voice_path and text are absent, a placeholder message is sent — no silent drop."""
+        outbox = temp_messages_dir / "outbox"
+
+        reply = {
+            "chat_id": 123456,
+            "type": "voice",
+            # voice_path and text both absent
+        }
+        reply_file = outbox / "voice_no_path_no_text.json"
+        reply_file.write_text(json.dumps(reply))
+
+        handler = bot_module.OutboxHandler()
+        original_bot_app = bot_module.bot_app
+        bot_module.bot_app = mock_bot_app
+        loop = asyncio.new_event_loop()
+        bot_module.main_loop = loop
+
+        try:
+            await handler.process_reply(str(reply_file))
+            mock_bot_app.bot.send_voice.assert_not_called()
+            mock_bot_app.bot.send_message.assert_called_once()
+            # Should receive a placeholder, not silence
+            call_text = mock_bot_app.bot.send_message.call_args.kwargs.get("text", "")
+            assert len(call_text) > 0, "Expected a non-empty placeholder message, got silence"
+            assert not reply_file.exists()
+        finally:
+            bot_module.bot_app = original_bot_app
+            loop.close()
+
+    @pytest.mark.asyncio
+    async def test_voice_note_bot_not_running_cleans_up_ogg(
+        self, tmp_path, temp_messages_dir, bot_module
+    ):
+        """If bot_app is None (bot not running), the OGG temp file is still cleaned up."""
+        outbox = temp_messages_dir / "outbox"
+        ogg_file = tmp_path / "voice.ogg"
+        ogg_file.write_bytes(b"fake ogg data")
+
+        reply = {
+            "chat_id": 123456,
+            "type": "voice",
+            "voice_path": str(ogg_file),
+            "text": "Hello in voice",
+        }
+        reply_file = outbox / "voice_bot_down.json"
+        reply_file.write_text(json.dumps(reply))
+
+        handler = bot_module.OutboxHandler()
+        original_bot_app = bot_module.bot_app
+        bot_module.bot_app = None  # Simulate bot not running
+        loop = asyncio.new_event_loop()
+        bot_module.main_loop = loop
+
+        try:
+            await handler.process_reply(str(reply_file))
+            assert not ogg_file.exists(), "OGG temp file must be cleaned up even when bot is not running"
+            assert not reply_file.exists()
+        finally:
+            bot_module.bot_app = original_bot_app
+            loop.close()
+
+    @pytest.mark.asyncio
+    async def test_voice_send_failure_sends_text_fallback(
+        self, tmp_path, temp_messages_dir, mock_bot_app, bot_module
+    ):
+        """If send_voice raises an exception, the user receives a text fallback."""
+        outbox = temp_messages_dir / "outbox"
+        ogg_file = tmp_path / "voice.ogg"
+        ogg_file.write_bytes(b"fake ogg data")
+
+        reply = {
+            "chat_id": 123456,
+            "type": "voice",
+            "voice_path": str(ogg_file),
+            "text": "Voice content as text fallback",
+        }
+        reply_file = outbox / "voice_fail.json"
+        reply_file.write_text(json.dumps(reply))
+
+        mock_bot_app.bot.send_voice.side_effect = Exception("Telegram API error")
+
+        handler = bot_module.OutboxHandler()
+        original_bot_app = bot_module.bot_app
+        bot_module.bot_app = mock_bot_app
+        loop = asyncio.new_event_loop()
+        bot_module.main_loop = loop
+
+        try:
+            await handler.process_reply(str(reply_file))
+            mock_bot_app.bot.send_message.assert_called_once()
+            call_text = mock_bot_app.bot.send_message.call_args.kwargs.get("text", "")
+            assert "Voice content as text fallback" in call_text
+            assert not ogg_file.exists(), "OGG temp file must be cleaned up after send_voice failure"
+            assert not reply_file.exists()
+        finally:
+            bot_module.bot_app = original_bot_app
+            loop.close()
+
+    @pytest.mark.asyncio
+    async def test_voice_send_failure_no_text_sends_placeholder(
+        self, tmp_path, temp_messages_dir, mock_bot_app, bot_module
+    ):
+        """If send_voice fails AND text is empty, a placeholder is sent — never silent drop."""
+        outbox = temp_messages_dir / "outbox"
+        ogg_file = tmp_path / "voice.ogg"
+        ogg_file.write_bytes(b"fake ogg data")
+
+        reply = {
+            "chat_id": 123456,
+            "type": "voice",
+            "voice_path": str(ogg_file),
+            "text": "",  # empty text — would silently drop in original code
+        }
+        reply_file = outbox / "voice_fail_no_text.json"
+        reply_file.write_text(json.dumps(reply))
+
+        mock_bot_app.bot.send_voice.side_effect = Exception("Telegram API error")
+
+        handler = bot_module.OutboxHandler()
+        original_bot_app = bot_module.bot_app
+        bot_module.bot_app = mock_bot_app
+        loop = asyncio.new_event_loop()
+        bot_module.main_loop = loop
+
+        try:
+            await handler.process_reply(str(reply_file))
+            mock_bot_app.bot.send_message.assert_called_once()
+            call_text = mock_bot_app.bot.send_message.call_args.kwargs.get("text", "")
+            assert len(call_text) > 0, "Expected placeholder message, got silence"
+            assert not reply_file.exists()
+        finally:
+            bot_module.bot_app = original_bot_app
+            loop.close()
+
+
 class TestSplitMessage:
     """Tests for the split_message function.
 

--- a/tests/unit/test_tts/test_piper.py
+++ b/tests/unit/test_tts/test_piper.py
@@ -1,0 +1,454 @@
+"""Tests for src/tts/piper.py
+
+Tests are derived from the feature spec (issue #1575):
+- piper binary + lessac-medium model as the TTS pipeline
+- WAV synthesis → OGG/Opus conversion → TtsResult
+- Fallback: TtsResult.ok=False when binary/model missing
+- Failure propagation: synthesis error → TtsResult.ok=False
+- Failure propagation: ffmpeg error → TtsResult.ok=False
+- Cleanup: TtsResult.cleanup() deletes temp files
+
+All tests mock subprocess.run and filesystem to avoid requiring piper/ffmpeg
+to be installed during unit testing.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent / "src"))
+
+from tts.piper import (
+    PiperConfig,
+    TtsResult,
+    DEFAULT_VOICE_MODEL_NAME,
+    PIPER_SYNTHESIS_TIMEOUT_S,
+    FFMPEG_CONVERT_TIMEOUT_S,
+    find_piper_binary,
+    find_voice_model,
+    resolve_piper_config,
+    synthesize_wav,
+    convert_wav_to_ogg,
+    text_to_voice_file,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_piper_config(tmp_path: Path) -> PiperConfig:
+    """Create a PiperConfig pointing to real temp files for testing."""
+    binary = tmp_path / "piper"
+    binary.write_text("#!/bin/sh\necho fake piper\n")
+    binary.chmod(0o755)
+    model = tmp_path / f"{DEFAULT_VOICE_MODEL_NAME}.onnx"
+    model.write_bytes(b"fake model data")
+    return PiperConfig(piper_binary=binary, model_path=model)
+
+
+# ---------------------------------------------------------------------------
+# PiperConfig.is_usable
+# ---------------------------------------------------------------------------
+
+class TestPiperConfigIsUsable:
+    def test_usable_when_binary_and_model_exist(self, tmp_path):
+        cfg = _fake_piper_config(tmp_path)
+        assert cfg.is_usable() is True
+
+    def test_not_usable_when_binary_missing(self, tmp_path):
+        model = tmp_path / f"{DEFAULT_VOICE_MODEL_NAME}.onnx"
+        model.write_bytes(b"x")
+        cfg = PiperConfig(
+            piper_binary=tmp_path / "nonexistent_piper",
+            model_path=model,
+        )
+        assert cfg.is_usable() is False
+
+    def test_not_usable_when_model_missing(self, tmp_path):
+        binary = tmp_path / "piper"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        cfg = PiperConfig(
+            piper_binary=binary,
+            model_path=tmp_path / "nonexistent_model.onnx",
+        )
+        assert cfg.is_usable() is False
+
+    def test_not_usable_when_binary_not_executable(self, tmp_path):
+        binary = tmp_path / "piper"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o644)  # not executable
+        model = tmp_path / f"{DEFAULT_VOICE_MODEL_NAME}.onnx"
+        model.write_bytes(b"x")
+        cfg = PiperConfig(piper_binary=binary, model_path=model)
+        assert cfg.is_usable() is False
+
+
+# ---------------------------------------------------------------------------
+# TtsResult.cleanup
+# ---------------------------------------------------------------------------
+
+class TestTtsResultCleanup:
+    def test_cleanup_deletes_ogg_file(self, tmp_path):
+        ogg = tmp_path / "voice.ogg"
+        ogg.write_bytes(b"fake ogg data")
+        result = TtsResult(ok=True, ogg_path=ogg, _cleanup_paths=[str(ogg)])
+
+        assert ogg.exists()
+        result.cleanup()
+        assert not ogg.exists()
+
+    def test_cleanup_is_idempotent(self, tmp_path):
+        ogg = tmp_path / "voice.ogg"
+        ogg.write_bytes(b"fake ogg data")
+        result = TtsResult(ok=True, ogg_path=ogg, _cleanup_paths=[str(ogg)])
+
+        result.cleanup()
+        result.cleanup()  # second call should not raise
+
+    def test_cleanup_clears_paths_list(self, tmp_path):
+        ogg = tmp_path / "voice.ogg"
+        ogg.write_bytes(b"x")
+        result = TtsResult(ok=True, ogg_path=ogg, _cleanup_paths=[str(ogg)])
+        result.cleanup()
+        assert result._cleanup_paths == []
+
+
+# ---------------------------------------------------------------------------
+# find_piper_binary
+# ---------------------------------------------------------------------------
+
+class TestFindPiperBinary:
+    def test_finds_binary_at_first_search_path(self, tmp_path):
+        binary = tmp_path / "piper"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+
+        with patch("tts.piper.PIPER_BINARY_SEARCH_PATHS", [str(binary)]):
+            result = find_piper_binary()
+        assert result == binary
+
+    def test_returns_none_when_not_found(self):
+        with patch("tts.piper.PIPER_BINARY_SEARCH_PATHS", ["/nonexistent/piper"]):
+            with patch("shutil.which", return_value=None):
+                result = find_piper_binary()
+        assert result is None
+
+    def test_falls_back_to_path(self, tmp_path):
+        binary = tmp_path / "piper"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+
+        with patch("tts.piper.PIPER_BINARY_SEARCH_PATHS", ["/nonexistent/piper"]):
+            with patch("shutil.which", return_value=str(binary)):
+                result = find_piper_binary()
+        assert result == binary
+
+
+# ---------------------------------------------------------------------------
+# find_voice_model
+# ---------------------------------------------------------------------------
+
+class TestFindVoiceModel:
+    def test_finds_model_in_search_dir(self, tmp_path):
+        model = tmp_path / f"{DEFAULT_VOICE_MODEL_NAME}.onnx"
+        model.write_bytes(b"model data")
+
+        with patch("tts.piper.PIPER_MODEL_SEARCH_DIRS", [str(tmp_path)]):
+            result = find_voice_model()
+        assert result == model
+
+    def test_returns_none_when_model_missing(self, tmp_path):
+        with patch("tts.piper.PIPER_MODEL_SEARCH_DIRS", [str(tmp_path)]):
+            result = find_voice_model()
+        assert result is None
+
+    def test_custom_model_name(self, tmp_path):
+        custom_name = "en_US-amy-low"
+        model = tmp_path / f"{custom_name}.onnx"
+        model.write_bytes(b"model data")
+
+        with patch("tts.piper.PIPER_MODEL_SEARCH_DIRS", [str(tmp_path)]):
+            result = find_voice_model(model_name=custom_name)
+        assert result == model
+
+
+# ---------------------------------------------------------------------------
+# synthesize_wav
+# ---------------------------------------------------------------------------
+
+class TestSynthesizeWav:
+    def test_success_returns_none_error(self, tmp_path):
+        cfg = _fake_piper_config(tmp_path)
+        output_wav = tmp_path / "out.wav"
+
+        def fake_run(cmd, **kwargs):
+            # Simulate piper writing the output file
+            output_wav.write_bytes(b"RIFF" + b"\x00" * 100)
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stderr = ""
+            return mock
+
+        with patch("subprocess.run", side_effect=fake_run):
+            err = synthesize_wav("Hello world", cfg, output_wav)
+
+        assert err is None
+        assert output_wav.exists()
+
+    def test_returns_error_on_nonzero_exit(self, tmp_path):
+        cfg = _fake_piper_config(tmp_path)
+        output_wav = tmp_path / "out.wav"
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "model error"
+
+        with patch("subprocess.run", return_value=mock_result):
+            err = synthesize_wav("Hello world", cfg, output_wav)
+
+        assert err is not None
+        assert "piper exited with code 1" in err
+        assert "model error" in err
+
+    def test_returns_error_on_timeout(self, tmp_path):
+        import subprocess
+        cfg = _fake_piper_config(tmp_path)
+        output_wav = tmp_path / "out.wav"
+
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=["piper"], timeout=30)):
+            err = synthesize_wav("Hello world", cfg, output_wav)
+
+        assert err is not None
+        assert "timed out" in err
+
+    def test_returns_error_for_empty_text(self, tmp_path):
+        cfg = _fake_piper_config(tmp_path)
+        output_wav = tmp_path / "out.wav"
+
+        err = synthesize_wav("", cfg, output_wav)
+        assert err is not None
+        assert "Empty text" in err
+
+    def test_returns_error_when_config_not_usable(self, tmp_path):
+        cfg = PiperConfig(
+            piper_binary=tmp_path / "nonexistent",
+            model_path=tmp_path / "nonexistent.onnx",
+        )
+        output_wav = tmp_path / "out.wav"
+
+        err = synthesize_wav("Hello", cfg, output_wav)
+        assert err is not None
+        assert "not usable" in err
+
+    def test_returns_error_when_output_empty(self, tmp_path):
+        cfg = _fake_piper_config(tmp_path)
+        output_wav = tmp_path / "out.wav"
+
+        # piper exits 0 but writes nothing
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+
+        with patch("subprocess.run", return_value=mock_result):
+            err = synthesize_wav("Hello world", cfg, output_wav)
+
+        assert err is not None
+        assert "no output" in err
+
+
+# ---------------------------------------------------------------------------
+# convert_wav_to_ogg
+# ---------------------------------------------------------------------------
+
+class TestConvertWavToOgg:
+    def test_success_returns_none_error(self, tmp_path):
+        wav = tmp_path / "voice.wav"
+        wav.write_bytes(b"RIFF" + b"\x00" * 100)
+        ogg = tmp_path / "voice.ogg"
+
+        def fake_run(cmd, **kwargs):
+            ogg.write_bytes(b"OggS" + b"\x00" * 200)
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stderr = ""
+            return mock
+
+        with patch("shutil.which", return_value="/usr/bin/ffmpeg"):
+            with patch("subprocess.run", side_effect=fake_run):
+                err = convert_wav_to_ogg(wav, ogg)
+
+        assert err is None
+        assert ogg.exists()
+
+    def test_returns_error_when_wav_missing(self, tmp_path):
+        wav = tmp_path / "nonexistent.wav"
+        ogg = tmp_path / "voice.ogg"
+
+        err = convert_wav_to_ogg(wav, ogg)
+        assert err is not None
+        assert "not found" in err
+
+    def test_returns_error_when_ffmpeg_missing(self, tmp_path):
+        wav = tmp_path / "voice.wav"
+        wav.write_bytes(b"RIFF" + b"\x00" * 100)
+        ogg = tmp_path / "voice.ogg"
+
+        with patch("shutil.which", return_value=None):
+            err = convert_wav_to_ogg(wav, ogg)
+
+        assert err is not None
+        assert "ffmpeg not found" in err
+
+    def test_returns_error_on_ffmpeg_nonzero_exit(self, tmp_path):
+        wav = tmp_path / "voice.wav"
+        wav.write_bytes(b"RIFF" + b"\x00" * 100)
+        ogg = tmp_path / "voice.ogg"
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "Invalid data found"
+
+        with patch("shutil.which", return_value="/usr/bin/ffmpeg"):
+            with patch("subprocess.run", return_value=mock_result):
+                err = convert_wav_to_ogg(wav, ogg)
+
+        assert err is not None
+        assert "ffmpeg exited with code 1" in err
+
+    def test_returns_error_on_timeout(self, tmp_path):
+        import subprocess
+        wav = tmp_path / "voice.wav"
+        wav.write_bytes(b"RIFF" + b"\x00" * 100)
+        ogg = tmp_path / "voice.ogg"
+
+        with patch("shutil.which", return_value="/usr/bin/ffmpeg"):
+            with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=["ffmpeg"], timeout=30)):
+                err = convert_wav_to_ogg(wav, ogg)
+
+        assert err is not None
+        assert "timed out" in err
+
+
+# ---------------------------------------------------------------------------
+# text_to_voice_file (full pipeline)
+# ---------------------------------------------------------------------------
+
+class TestTextToVoiceFile:
+    def test_returns_ok_result_with_ogg_path_on_success(self, tmp_path):
+        """Full pipeline produces TtsResult.ok=True with a non-None ogg_path."""
+        def fake_run(cmd, **kwargs):
+            # Determine which tool is being called from the command
+            if "piper" in str(cmd[0]):
+                # Find output_file arg and write WAV there
+                idx = cmd.index("--output_file")
+                Path(cmd[idx + 1]).write_bytes(b"RIFF" + b"\x00" * 100)
+            else:
+                # ffmpeg: write OGG to last arg
+                Path(cmd[-1]).write_bytes(b"OggS" + b"\x00" * 200)
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stderr = ""
+            return mock
+
+        with patch("tts.piper.resolve_piper_config") as mock_cfg, \
+             patch("shutil.which", return_value="/usr/bin/ffmpeg"), \
+             patch("subprocess.run", side_effect=fake_run):
+            cfg = _fake_piper_config(tmp_path)
+            mock_cfg.return_value = cfg
+            result = text_to_voice_file("Hello world")
+
+        assert result.ok is True
+        assert result.ogg_path is not None
+        assert result.error is None
+        result.cleanup()
+
+    def test_returns_failed_result_when_piper_not_available(self):
+        """When piper config cannot be resolved, TtsResult.ok=False."""
+        with patch("tts.piper.resolve_piper_config", return_value=None):
+            result = text_to_voice_file("Hello world")
+
+        assert result.ok is False
+        assert result.error is not None
+        assert "TTS unavailable" in result.error
+
+    def test_returns_failed_result_when_synthesis_fails(self, tmp_path):
+        """When piper synthesis fails, TtsResult.ok=False with error."""
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "model load error"
+
+        with patch("tts.piper.resolve_piper_config") as mock_cfg, \
+             patch("subprocess.run", return_value=mock_result):
+            cfg = _fake_piper_config(tmp_path)
+            mock_cfg.return_value = cfg
+            result = text_to_voice_file("Hello world")
+
+        assert result.ok is False
+        assert result.error is not None
+        assert "synthesis failed" in result.error
+
+    def test_returns_failed_result_when_ogg_conversion_fails(self, tmp_path):
+        """When ffmpeg conversion fails, TtsResult.ok=False with error."""
+        def fake_run(cmd, **kwargs):
+            if "piper" in str(cmd[0]):
+                idx = cmd.index("--output_file")
+                Path(cmd[idx + 1]).write_bytes(b"RIFF" + b"\x00" * 100)
+                mock = MagicMock()
+                mock.returncode = 0
+                mock.stderr = ""
+                return mock
+            else:
+                # ffmpeg fails
+                mock = MagicMock()
+                mock.returncode = 1
+                mock.stderr = "codec not found"
+                return mock
+
+        with patch("tts.piper.resolve_piper_config") as mock_cfg, \
+             patch("shutil.which", return_value="/usr/bin/ffmpeg"), \
+             patch("subprocess.run", side_effect=fake_run):
+            cfg = _fake_piper_config(tmp_path)
+            mock_cfg.return_value = cfg
+            result = text_to_voice_file("Hello world")
+
+        assert result.ok is False
+        assert result.error is not None
+        assert "OGG conversion failed" in result.error
+
+    def test_cleanup_removes_ogg_file(self, tmp_path):
+        """After cleanup, the OGG temp file should be deleted."""
+        ogg_path = None
+
+        def fake_run(cmd, **kwargs):
+            if "piper" in str(cmd[0]):
+                idx = cmd.index("--output_file")
+                Path(cmd[idx + 1]).write_bytes(b"RIFF" + b"\x00" * 100)
+            else:
+                # Write OGG to last arg
+                Path(cmd[-1]).write_bytes(b"OggS" + b"\x00" * 200)
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stderr = ""
+            return mock
+
+        with patch("tts.piper.resolve_piper_config") as mock_cfg, \
+             patch("shutil.which", return_value="/usr/bin/ffmpeg"), \
+             patch("subprocess.run", side_effect=fake_run):
+            cfg = _fake_piper_config(tmp_path)
+            mock_cfg.return_value = cfg
+            result = text_to_voice_file("Hello world")
+
+        assert result.ok is True
+        ogg_path = result.ogg_path
+        assert ogg_path.exists()
+
+        result.cleanup()
+        assert not ogg_path.exists()


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

Closes #1575

## What problem this solves

Lobster could receive and transcribe voice notes from Telegram but had no way to send them. This adds the complete outbound path: text → piper TTS → OGG/Opus → Telegram `sendVoice`. The result is a conversational voice channel that works entirely locally with no cloud API or billing.

## TTS engine: Piper

Piper was chosen over espeak-ng and festival for these reasons:
- **Quality**: Neural VITS model (lessac-medium) produces natural-sounding speech vs. robotic espeak-ng output
- **Local + offline**: No cloud dependency, no API key, no billing
- **aarch64 support**: Pre-built binary available for the deployment architecture
- **Fast inference**: ~0.12x real-time factor on aarch64 (1.9s audio synthesized in 0.23s)

espeak-ng was the alternative. It would work but sounds robotic; for a personal assistant, voice quality matters.

## How it works

```
MCP send_voice_note(chat_id, text)
         │
         ▼
   src/tts/piper.py: text_to_voice_file()
         │
   piper CLI: text → WAV (lessac-medium model, ~0.23s for short phrases)
         │
   ffmpeg: WAV → OGG/Opus (24kHz mono, 24kbps — Telegram voice format)
         │
   Outbox JSON: {type: "voice", voice_path: "/tmp/lobster-tts-.../voice.ogg"}
         │
   lobster_bot.py: bot.send_voice(InputFile(ogg_path))
         │
         ▼
   Telegram voice message delivered
```

**Failure handling**: If piper is unavailable, synthesis fails, or ffmpeg fails → falls back to `send_reply` with text silently. The user always receives a response.

**Non-Telegram sources**: Other sources (Slack, SMS) fall back to text immediately — voice notes are Telegram-specific.

## What changed

- **`src/tts/piper.py`** — New module. Pure functions: `find_piper_binary()`, `find_voice_model()`, `synthesize_wav()`, `convert_wav_to_ogg()`, `text_to_voice_file()`. Composable, no side effects except file I/O.
- **`src/mcp/inbox_server.py`** — New `send_voice_note` tool registered and dispatched to `handle_send_voice_note()`. Writes a `type=voice` outbox file rather than a text reply.
- **`src/bot/lobster_bot.py`** — New `type=voice` handler in `process_reply()`. Reads `voice_path` from the outbox file, calls `bot.send_voice()`, deletes the temp OGG, falls back to text on error.
- **`scripts/send-voice-note.sh`** — Standalone CLI wrapper: synthesizes and sends a voice note directly via curl + Telegram API. Works without the dispatcher running.
- **`install.sh`** — New piper TTS setup section after whisper.cpp: downloads piper binary, shared libs, espeak-ng-data, and the lessac-medium model (~63MB ONNX).
- **`scripts/upgrade.sh`** — Migration 70: installs piper + model on existing installs.

**What is NOT changed**: The inbound transcription path (whisper.cpp worker), all existing send_reply logic, the outbox file format for text/photo types, and all other MCP tools.

## Functional patterns used

- **Pure functions**: `synthesize_wav`, `convert_wav_to_ogg`, `find_piper_binary`, `find_voice_model` — no state, same inputs → same outputs
- **Composition**: `text_to_voice_file` composes discovery + synthesis + conversion in one pipeline call
- **Immutability**: `PiperConfig` is a frozen dataclass — safe to pass through call chains
- **Explicit error handling**: functions return `Optional[str]` error messages rather than raising; callers decide how to handle failures
- **Isolated side effects**: all file I/O confined to `synthesize_wav`, `convert_wav_to_ogg`, and `text_to_voice_file`; the `TtsResult.cleanup()` caller manages temp file lifetime

## Tests run

- [x] `uv run pytest tests/unit/test_tts/ -v` — 29 passed, 0 failed
- [x] `uv run pytest tests/unit/test_tts/ tests/unit/test_bot/ -v` — 217 passed, 2 failed (pre-existing `test_group_ack_policy` failures in main, unrelated)
- [x] Live piper synthesis: `echo "Voice notes working. Testing." | piper --model ... --output_file /tmp/test.wav` — 102KB WAV produced in 0.23s
- [x] ffmpeg WAV→OGG conversion: 6.2KB OGG/Opus output — correct
- [x] `uv run python3 -c "from tts.piper import text_to_voice_file; r = text_to_voice_file('Voice notes working. Testing.'); print(r.ok, r.ogg_path)"` — ok=True, 6171-byte OGG

## Manual test

Voice note sent to chat_id=8305714125 via `curl sendVoice` using the production bot token. Telegram API returned `ok: true, message_id: 23669`. This is the live test message "Voice notes working. Testing." delivered via the actual piper+ffmpeg pipeline.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — voice note delivered, Telegram API returned ok=true
- [x] User-visible outcome verified — voice note sent to chat_id=8305714125 (message_id: 23669)
- [x] Side-effect audit complete: single bounded send (1 message, explicit chat_id), no loops or floods, no shared state written
- [x] External service calls: mocked in tests; production send was single explicit call during manual test

## Known limitations

- Voice notes are Telegram-only (non-Telegram sources fall back to text)
- No caching: each call synthesizes fresh audio (acceptable for v1 — cache adds complexity without clear benefit)
- piper shared libraries are bundled in `/usr/local/lib/` — if a distro ships incompatible versions, `ldconfig` could cause conflicts (unlikely on Ubuntu 24.04)
- The lessac-medium model is ~63MB ONNX — install.sh download adds ~30s to setup time