### PR TITLE
fix(engineer): add mandatory local-dev deploy step after PASS review

### DIFF
--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -205,7 +205,47 @@ If any tests could not be run (missing Docker, live token, specific env), you **
 - [ ] External service calls: mocked in tests, explicitly scoped in any manual runs
 ```
 
-### 7. PR Merge & Completion
+### 7. Post-PASS: Deploy to local-dev
+
+**This step is mandatory. Complete it after receiving a PASS review and before calling `write_result`.**
+
+After the reviewer posts a PASS verdict on GitHub:
+
+```bash
+cd ~/lobster
+git fetch origin
+
+# If local-dev is significantly behind main, merge main first:
+# git checkout local-dev && git merge origin/main --no-edit && git push origin local-dev
+
+git checkout local-dev
+git merge origin/<your-pr-branch> --no-edit
+git push origin local-dev
+DEPLOY_SHA=$(git rev-parse HEAD)
+
+# Return ~/lobster/ to main so the live system is intact:
+git checkout main
+```
+
+Include the resulting commit SHA in your `write_result` call:
+
+```python
+mcp__lobster-inbox__write_result(
+    task_id=f"issue-{issue_number}",
+    chat_id=chat_id,
+    text=(
+        f"PR #{pr_number} open, PASS review received.\n"
+        f"Deployed to local-dev at {deploy_sha}.\n"
+        f"...\n"
+    ),
+    source=source,
+    status="success",
+)
+```
+
+**If the merge has conflicts:** resolve them, commit, push, and note the conflicts explicitly in `write_result`.
+
+### 8. PR Merge & Completion
 - After PR is approved and merged:
   - **Set "Main Board" project status to "Done"**
   - Close the issue if not auto-closed by PR keywords


### PR DESCRIPTION
PASS-reviewed engineer PRs were sitting undeployed because nothing in the workflow forced a local-dev merge between receiving PASS and calling `write_result`. This means the user was presented with a PASS verdict but could not sign off on a running system — the change existed only on GitHub, not on the actual deployed branch.

## What changed

A new mandatory step 7 (Post-PASS: Deploy to local-dev) is inserted between step 6 (Pull Request Creation) and the renamed step 8 (PR Merge & Completion). The step:

- Merges `origin/<pr-branch>` into `local-dev`
- Pushes `local-dev` to origin
- Captures the resulting commit SHA
- Requires the engineer to include that SHA in `write_result`
- Returns `~/lobster/` to `main` when done

The existing step 7 (PR Merge & Completion) is renumbered to step 8 with no content changes.

## What is not changed

No code is changed — this is a workflow definition update only. The change is entirely inside `.claude/agents/functional-engineer.md`. No other agent definitions are touched.

## Before / after flow

```
Before:
  open PR → set "In Review" → [reviewer posts PASS] → write_result → [sit undeployed]

After:
  open PR → set "In Review" → [reviewer posts PASS]
    → merge to local-dev → push → capture SHA
    → write_result (with deploy SHA)
```

## Tests run
- [x] File diff verified manually — correct section inserted, step numbering correct, no content removed
- [ ] Live workflow execution — not applicable (this is a documentation/prompt change, not executable code)

## Manual test
N/A — this change is entirely internal to the agent definition. No external services, file I/O, or systemd units are affected.

Closes #1581