### PR TITLE
fix(install): unconditionally enable lobster-claude service on install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2728,7 +2728,12 @@ else
     fi
 
     sudo systemctl daemon-reload
-    success "Services installed"
+
+    # Enable services for autostart unconditionally. This is separate from
+    # "start now" — autostart on boot should always be configured regardless
+    # of whether the user wants to start the services interactively right now.
+    sudo systemctl enable lobster-router lobster-claude
+    success "Services installed and enabled for autostart"
 fi
 
 #===============================================================================
@@ -2895,7 +2900,6 @@ else
 fi
 
 if [[ ! $REPLY =~ ^[Nn]$ ]]; then
-    sudo systemctl enable lobster-router lobster-claude
     sudo systemctl start lobster-router
     sleep 2
     sudo systemctl start lobster-claude

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2562,6 +2562,26 @@ CREATE TABLE IF NOT EXISTS dispatcher_lock (
         substep "No LOBSTER-SCHEDULED crontab entries found — skipping"
     fi
 
+    # Migration 72: Enable lobster-claude and lobster-router for autostart on existing installs.
+    # Non-interactive installs (NON_INTERACTIVE=true) prior to this fix skipped the
+    # `systemctl enable` call entirely, leaving the services installed but not enabled.
+    # After any reboot the services would not start automatically, causing ~4 min downtime
+    # until the health check detected and restarted the missing session. Fix: enable
+    # unconditionally if the service unit is present but not enabled. (issue #1603)
+    for _m72_svc in lobster-router lobster-claude; do
+        if systemctl list-unit-files --quiet "${_m72_svc}.service" 2>/dev/null | grep -q "^${_m72_svc}"; then
+            if ! systemctl is-enabled --quiet "${_m72_svc}" 2>/dev/null; then
+                sudo systemctl enable "${_m72_svc}" 2>/dev/null || true
+                substep "Enabled ${_m72_svc} for autostart"
+                migrated=$((migrated + 1))
+            else
+                substep "${_m72_svc} already enabled — skipping"
+            fi
+        else
+            substep "${_m72_svc}.service not found — skipping"
+        fi
+    done
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## Summary

After a non-interactive install (`NON_INTERACTIVE=true`), `lobster-claude.service` and `lobster-router.service` were installed but never enabled for autostart. The `systemctl enable` call was inside the "Start services now?" prompt block, which is skipped entirely in non-interactive mode. After any reboot, the services would not start automatically — the health check had to detect the missing session and restart it (~4 min downtime).

The fix separates two independent concerns that were incorrectly coupled:
- **Autostart on boot** (`systemctl enable`) — should always happen when the service is installed
- **Start immediately now** (`systemctl start`) — correctly gated on user confirmation / `NON_INTERACTIVE`

`systemctl enable lobster-router lobster-claude` is moved to run unconditionally after `daemon-reload`, before the interactive start prompt. Only the `systemctl start` calls remain inside the prompt block.

## Migration

`upgrade.sh` Migration 72 enables the services on existing installs where a prior non-interactive install left them in the disabled state. The migration is idempotent — it checks `systemctl is-enabled` before calling enable and skips if already enabled.

## Flow before / after

```
Before:
  daemon-reload
  +- Start now? [Y/n] -------------------------------------------+
  |  systemctl enable lobster-router lobster-claude  <- was here  |
  |  systemctl start lobster-router                               |
  |  systemctl start lobster-claude                               |
  +---------------------------------------------------------------+
  NON_INTERACTIVE -> skips entire block -> services not enabled

After:
  daemon-reload
  systemctl enable lobster-router lobster-claude  <- unconditional
  +- Start now? [Y/n] -------------------------------------------+
  |  systemctl start lobster-router                               |
  |  systemctl start lobster-claude                               |
  +---------------------------------------------------------------+
  NON_INTERACTIVE -> skips start block -> services still enabled for boot
```

Nothing else in the start flow is changed. Interactive installs see identical behavior (enable + start both happen as before).

## Tests run

- [x] `bash -n install.sh` — syntax check passes
- [x] `bash -n scripts/upgrade.sh` — syntax check passes
- [x] Manual diff review — confirmed `enable` lifted above prompt block and removed from the `if [[ ! $REPLY =~ ^[Nn]$ ]]` block
- [ ] Live service enable/start test — not run; requires root on a fresh install with systemd available

## Manual test

N/A for automated testing. The change is straightforward shell restructuring with no external service calls. The behavior is verified by code inspection: `systemctl enable` now runs unconditionally inside the service-install block, and the start block no longer contains an enable call.

## Definition of Done

- [x] User-visible outcome: services now survive reboots without a ~4 min health-check recovery window
- [x] Side-effect audit: change adds one enable call that was already expected to run in the common case; no unexpected volume or state writes
- [x] External service calls: none

Closes #1603