### PR TITLE
feat(granola): raw ingest system for Granola meeting notes (BIS-434)

### DIFF
--- a/scheduled-tasks/granola_backfill.py
+++ b/scheduled-tasks/granola_backfill.py
@@ -1,0 +1,202 @@
+"""
+Granola Backfill — Slice 5
+
+One-time (re-runnable) script to import all historical Granola notes.
+Uses the same NoteStorage layer (idempotent writes), so re-running
+safely skips already-present notes.
+
+Does NOT touch the incremental state file — backfill is decoupled
+from the regular ingest cursor.
+
+Usage:
+    uv run granola_backfill.py
+    uv run granola_backfill.py --since 2025-01-01
+    uv run granola_backfill.py --dry-run
+    uv run granola_backfill.py --since 2025-06-01 --dry-run
+
+Exit codes:
+  0 — success
+  1 — partial failure (some writes failed)
+  2 — configuration error
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap
+# ---------------------------------------------------------------------------
+_THIS_DIR = Path(__file__).parent.resolve()
+if str(_THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(_THIS_DIR))
+
+from granola_client import GranolaClient, GranolaAPIError  # noqa: E402
+from granola_storage import NoteStorage  # noqa: E402
+
+
+NOTES_ROOT = Path.home() / "lobster-workspace" / "granola-notes"
+PROGRESS_INTERVAL = 50  # print progress every N notes
+
+
+# ---------------------------------------------------------------------------
+# Load config.env
+# ---------------------------------------------------------------------------
+
+def _load_config_env() -> None:
+    config_dir = os.environ.get("LOBSTER_CONFIG_DIR", str(Path.home() / "lobster-config"))
+    config_path = Path(config_dir) / "config.env"
+    if not config_path.exists():
+        return
+    with config_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip()
+            if key and key not in os.environ:
+                os.environ[key] = value
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Backfill all historical Granola notes into lobster-workspace.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--since",
+        metavar="YYYY-MM-DD",
+        help="Only import notes created on or after this date (UTC).",
+        default=None,
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be written without writing anything.",
+    )
+    return parser.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    args = _parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%SZ",
+        stream=sys.stdout,
+    )
+    log = logging.getLogger("granola_backfill")
+
+    _load_config_env()
+
+    api_key = os.environ.get("GRANOLA_API_KEY")
+    if not api_key:
+        log.error("GRANOLA_API_KEY not set. Set it in ~/lobster-config/config.env.")
+        return 2
+
+    # Parse --since date into ISO timestamp
+    created_after: str | None = None
+    if args.since:
+        try:
+            d = date.fromisoformat(args.since)
+            created_after = datetime(d.year, d.month, d.day, tzinfo=timezone.utc).isoformat()
+        except ValueError:
+            log.error("--since must be in YYYY-MM-DD format, got: %s", args.since)
+            return 2
+
+    if args.dry_run:
+        log.info("DRY RUN — no files will be written")
+
+    client = GranolaClient(api_key=api_key)
+    storage = NoteStorage(root=NOTES_ROOT)
+
+    written = 0
+    skipped = 0
+    errors = 0
+    total_seen = 0
+    cursor: str | None = None
+
+    log.info(
+        "Starting backfill%s%s",
+        f" since {args.since}" if args.since else " (all time)",
+        " [dry-run]" if args.dry_run else "",
+    )
+
+    try:
+        while True:
+            result = client.list_notes(created_after=created_after, cursor=cursor)
+
+            if not result.notes:
+                break
+
+            for note in result.notes:
+                total_seen += 1
+
+                if args.dry_run:
+                    # Check if it would be a new write
+                    exists = storage.note_exists(
+                        note.id, created_at=note.created_at
+                    )
+                    if exists:
+                        skipped += 1
+                        log.debug("[dry-run] SKIP %s (already present)", note.id)
+                    else:
+                        written += 1
+                        log.debug("[dry-run] WOULD WRITE %s (%s)", note.id, note.title)
+                else:
+                    try:
+                        path, was_new = storage.write_note(note.raw)
+                        if was_new:
+                            written += 1
+                            log.debug("Wrote %s → %s", note.id, path)
+                        else:
+                            skipped += 1
+                    except Exception as exc:  # noqa: BLE001
+                        errors += 1
+                        log.warning("Failed to write %s: %s", note.id, exc)
+
+                if total_seen % PROGRESS_INTERVAL == 0:
+                    log.info(
+                        "Progress: %d notes processed (written=%d, skipped=%d, errors=%d)",
+                        total_seen, written, skipped, errors,
+                    )
+
+            if not result.has_more:
+                break
+            cursor = result.cursor
+
+    except GranolaAPIError as exc:
+        log.error("API error during backfill: %s", exc)
+        log.info("Partial — written=%d, skipped=%d, errors=%d", written, skipped, errors)
+        return 1
+
+    log.info(
+        "Backfill complete%s: %d notes written, %d skipped (already present)%s",
+        " [dry-run]" if args.dry_run else "",
+        written,
+        skipped,
+        f", {errors} errors" if errors else "",
+    )
+    return 0 if errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scheduled-tasks/granola_client.py
+++ b/scheduled-tasks/granola_client.py
@@ -1,0 +1,192 @@
+"""
+Granola API Client — Slice 1
+
+Thin, typed wrapper around the Granola public REST API.
+No LLM calls. No heavy dependencies — only stdlib + urllib.
+
+API base: https://public-api.granola.ai/v1
+Auth:     Authorization: Bearer <GRANOLA_API_KEY>
+Rate:     5 req/sec (300/min), burst 25 in 5s; 429 → retry with backoff
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+GRANOLA_API_BASE = "https://public-api.granola.ai/v1"
+_DEFAULT_MAX_RETRIES = 3
+_DEFAULT_RETRY_BACKOFF_BASE = 1.0  # seconds, doubled each attempt
+
+
+@dataclass
+class GranolaNote:
+    """Minimal typed wrapper around a raw Granola note dict."""
+
+    id: str
+    title: str
+    created_at: str  # ISO 8601 string
+    raw: dict = field(repr=False)  # full original JSON for storage
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "GranolaNote":
+        return cls(
+            id=d["id"],
+            title=d.get("title", ""),
+            created_at=d.get("created_at", ""),
+            raw=d,
+        )
+
+
+@dataclass
+class ListNotesResult:
+    notes: list[GranolaNote]
+    has_more: bool
+    cursor: Optional[str]
+
+
+class GranolaAPIError(Exception):
+    """Raised on non-2xx responses that are not retried."""
+
+    def __init__(self, status: int, body: str):
+        self.status = status
+        self.body = body
+        super().__init__(f"Granola API error {status}: {body}")
+
+
+class GranolaRateLimitError(GranolaAPIError):
+    """Raised when 429 is returned and retries are exhausted."""
+
+
+class GranolaClient:
+    """
+    Thin HTTP client for the Granola public API.
+
+    Usage::
+
+        client = GranolaClient()               # reads GRANOLA_API_KEY from env
+        result = client.list_notes()
+        for note in result.notes:
+            print(note.id, note.title)
+
+        note = client.get_note("abc123", include_transcript=True)
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = GRANOLA_API_BASE,
+        max_retries: int = _DEFAULT_MAX_RETRIES,
+        retry_backoff_base: float = _DEFAULT_RETRY_BACKOFF_BASE,
+    ):
+        self._api_key = api_key or os.environ.get("GRANOLA_API_KEY")
+        if not self._api_key:
+            raise ValueError(
+                "GRANOLA_API_KEY not set. Export it or pass api_key= to GranolaClient()."
+            )
+        self._base_url = base_url.rstrip("/")
+        self._max_retries = max_retries
+        self._retry_backoff_base = retry_backoff_base
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def list_notes(
+        self,
+        created_after: Optional[str] = None,
+        cursor: Optional[str] = None,
+    ) -> ListNotesResult:
+        """
+        Fetch one page of notes.
+
+        Args:
+            created_after: ISO 8601 timestamp; only return notes created after this.
+            cursor:         Opaque pagination cursor from a previous response.
+
+        Returns:
+            ListNotesResult with notes list, has_more flag, and next cursor.
+        """
+        params: dict[str, str] = {}
+        if created_after:
+            params["created_after"] = created_after
+        if cursor:
+            params["cursor"] = cursor
+
+        data = self._get("/notes", params=params)
+
+        notes = [GranolaNote.from_dict(n) for n in data.get("notes", [])]
+        return ListNotesResult(
+            notes=notes,
+            has_more=data.get("hasMore", False),
+            cursor=data.get("cursor"),
+        )
+
+    def get_note(
+        self,
+        note_id: str,
+        include_transcript: bool = False,
+    ) -> dict:
+        """
+        Fetch a single note by ID.
+
+        Args:
+            note_id:             Granola note UUID.
+            include_transcript:  If True, include the transcript array in the response.
+
+        Returns:
+            Raw dict as returned by the API.
+        """
+        params: dict[str, str] = {}
+        if include_transcript:
+            params["include"] = "transcript"
+        return self._get(f"/notes/{note_id}", params=params)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get(self, path: str, params: Optional[dict] = None) -> Any:
+        url = self._base_url + path
+        if params:
+            query = "&".join(
+                f"{k}={urllib.request.quote(str(v))}" for k, v in params.items()
+            )
+            url = f"{url}?{query}"
+
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Accept": "application/json",
+            },
+        )
+
+        last_error: Optional[Exception] = None
+        for attempt in range(self._max_retries):
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    body = resp.read().decode("utf-8")
+                    return json.loads(body)
+            except urllib.error.HTTPError as exc:
+                if exc.code == 429:
+                    if attempt < self._max_retries - 1:
+                        wait = self._retry_backoff_base * (2 ** attempt)
+                        time.sleep(wait)
+                        last_error = exc
+                        continue
+                    else:
+                        body = exc.read().decode("utf-8") if exc.fp else ""
+                        raise GranolaRateLimitError(exc.code, body) from exc
+                else:
+                    body = exc.read().decode("utf-8") if exc.fp else ""
+                    raise GranolaAPIError(exc.code, body) from exc
+
+        # Should not reach here but satisfy type checker
+        raise GranolaRateLimitError(429, "Max retries exceeded") from last_error

--- a/scheduled-tasks/granola_ingest.py
+++ b/scheduled-tasks/granola_ingest.py
@@ -1,0 +1,154 @@
+"""
+Granola Ingest — Main Entry Point (Slices 1-4)
+
+Incremental ingest of Granola meeting notes into the versioned folder
+hierarchy. Designed to run every 15 minutes from cron.
+
+Exit codes:
+  0 — success (including 0 new notes)
+  1 — partial failure (API error, some notes may not have been written)
+  2 — fatal / configuration error (missing API key, etc.)
+
+Logs are written to ~/lobster-workspace/granola-notes/ingest.log
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap: ensure we can import sibling modules regardless of cwd
+# ---------------------------------------------------------------------------
+_THIS_DIR = Path(__file__).parent.resolve()
+if str(_THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(_THIS_DIR))
+
+from granola_client import GranolaClient, GranolaAPIError  # noqa: E402
+from granola_state import IncrementalFetcher, StateManager  # noqa: E402
+from granola_storage import NoteStorage  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+NOTES_ROOT = Path.home() / "lobster-workspace" / "granola-notes"
+LOG_PATH = NOTES_ROOT / "ingest.log"
+
+
+def _setup_logging() -> logging.Logger:
+    NOTES_ROOT.mkdir(parents=True, exist_ok=True)
+    logger = logging.getLogger("granola_ingest")
+    logger.setLevel(logging.DEBUG)
+
+    fmt = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%SZ",
+    )
+    # File handler (append)
+    fh = logging.FileHandler(LOG_PATH, encoding="utf-8")
+    fh.setFormatter(fmt)
+    logger.addHandler(fh)
+
+    # Stdout handler
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setFormatter(fmt)
+    logger.addHandler(sh)
+
+    return logger
+
+
+# ---------------------------------------------------------------------------
+# Load config.env into environment
+# ---------------------------------------------------------------------------
+
+def _load_config_env() -> None:
+    """Source ~/lobster-config/config.env into os.environ if not already set."""
+    config_dir = os.environ.get("LOBSTER_CONFIG_DIR", str(Path.home() / "lobster-config"))
+    config_path = Path(config_dir) / "config.env"
+    if not config_path.exists():
+        return
+    with config_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip()
+            if key and key not in os.environ:
+                os.environ[key] = value
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    log = _setup_logging()
+    log.info("=== Granola ingest started ===")
+
+    _load_config_env()
+
+    # Validate API key
+    api_key = os.environ.get("GRANOLA_API_KEY")
+    if not api_key:
+        log.error(
+            "GRANOLA_API_KEY not set. Set it in ~/lobster-config/config.env "
+            "or export it before running."
+        )
+        return 2
+
+    try:
+        client = GranolaClient(api_key=api_key)
+        state_manager = StateManager(state_path=NOTES_ROOT / ".state.json")
+        storage = NoteStorage(root=NOTES_ROOT)
+        fetcher = IncrementalFetcher(client=client, state_manager=state_manager)
+    except ValueError as exc:
+        log.error("Configuration error: %s", exc)
+        return 2
+
+    written = 0
+    skipped = 0
+    errors = 0
+
+    try:
+        for note in fetcher.fetch_new():
+            try:
+                path, was_new = storage.write_note(note.raw)
+                if was_new:
+                    written += 1
+                    log.debug("Wrote note %s → %s", note.id, path)
+                else:
+                    skipped += 1
+                    log.debug("Skipped (identical) note %s", note.id)
+            except Exception as exc:  # noqa: BLE001
+                errors += 1
+                log.warning("Failed to write note %s: %s", note.id, exc)
+
+    except GranolaAPIError as exc:
+        log.error("Granola API error: %s", exc)
+        log.info(
+            "Partial run — wrote %d, skipped %d, errors %d",
+            written, skipped, errors,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        log.error("Unexpected error during fetch: %s", exc, exc_info=True)
+        return 1
+
+    state = state_manager.load()
+    cursor = state.get("cursor", "null")
+    log.info(
+        "Ingest complete — wrote %d new, skipped %d identical, errors %d; cursor=%s",
+        written, skipped, errors, cursor,
+    )
+    return 0 if errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scheduled-tasks/granola_state.py
+++ b/scheduled-tasks/granola_state.py
@@ -1,0 +1,172 @@
+"""
+Granola Incremental Fetch + Cursor State Management — Slice 2
+
+Manages the state file that tracks where the last ingest run left off.
+Implements incremental fetching by paginating until hasMore=false and
+atomically persisting the final cursor after each page.
+
+State file: ~/lobster-workspace/granola-notes/.state.json
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator, Optional
+
+from granola_client import GranolaClient, GranolaNote, ListNotesResult
+
+
+# ---------------------------------------------------------------------------
+# State schema
+# ---------------------------------------------------------------------------
+
+# {
+#   "cursor": str | null,       -- cursor to pass to next list_notes() call
+#   "last_run": ISO8601 str,    -- when the last successful run completed
+#   "last_note_id": str | null  -- id of most recently fetched note (informational)
+# }
+
+DEFAULT_STATE: dict = {"cursor": None, "last_run": None, "last_note_id": None}
+
+
+class StateManager:
+    """
+    Reads and writes the ingest state file.
+
+    Writes are atomic: data is written to a .tmp file then renamed,
+    so a crash mid-write never corrupts the existing state.
+    """
+
+    def __init__(self, state_path: Optional[Path] = None):
+        if state_path is None:
+            state_path = (
+                Path.home() / "lobster-workspace" / "granola-notes" / ".state.json"
+            )
+        self._path = Path(state_path)
+        self._tmp_path = self._path.with_suffix(".json.tmp")
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def load(self) -> dict:
+        """Return the current state dict. Returns DEFAULT_STATE if file absent."""
+        if not self._path.exists():
+            return dict(DEFAULT_STATE)
+        try:
+            with self._path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            # Merge with defaults so new keys are always present
+            return {**DEFAULT_STATE, **data}
+        except (json.JSONDecodeError, OSError):
+            # Corrupt state — start fresh
+            return dict(DEFAULT_STATE)
+
+    def save(
+        self,
+        cursor: Optional[str],
+        last_note_id: Optional[str] = None,
+    ) -> None:
+        """
+        Atomically persist updated state.
+
+        Args:
+            cursor:       The cursor value returned by the last list_notes page.
+            last_note_id: The id of the last note seen (for diagnostics).
+        """
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        state = {
+            "cursor": cursor,
+            "last_run": datetime.now(timezone.utc).isoformat(),
+            "last_note_id": last_note_id,
+        }
+        with self._tmp_path.open("w", encoding="utf-8") as f:
+            json.dump(state, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.rename(self._tmp_path, self._path)
+
+
+# ---------------------------------------------------------------------------
+# Incremental fetcher
+# ---------------------------------------------------------------------------
+
+
+class IncrementalFetcher:
+    """
+    Wraps GranolaClient + StateManager to yield only new notes on each run.
+
+    Usage::
+
+        fetcher = IncrementalFetcher()
+        for note in fetcher.fetch_new():
+            storage.write_note(note.raw)
+    """
+
+    def __init__(
+        self,
+        client: Optional[GranolaClient] = None,
+        state_manager: Optional[StateManager] = None,
+    ):
+        self._client = client or GranolaClient()
+        self._state = state_manager or StateManager()
+
+    def fetch_new(self) -> Iterator[GranolaNote]:
+        """
+        Yield all notes that are new since the last saved cursor.
+
+        After each page, the cursor is atomically saved so a mid-run
+        crash won't re-fetch already-processed pages on restart.
+
+        Yields GranolaNote objects in API-returned order.
+        """
+        state = self._state.load()
+        cursor: Optional[str] = state.get("cursor")
+
+        last_note_id: Optional[str] = None
+        any_fetched = False
+
+        while True:
+            result: ListNotesResult = self._client.list_notes(cursor=cursor)
+
+            if not result.notes:
+                # No new notes; no state update needed if we had no results
+                if not any_fetched:
+                    return
+                break
+
+            for note in result.notes:
+                last_note_id = note.id
+                any_fetched = True
+                yield note
+
+            # Save cursor after each page (atomic write)
+            self._state.save(
+                cursor=result.cursor,
+                last_note_id=last_note_id,
+            )
+
+            if not result.has_more:
+                break
+
+            cursor = result.cursor
+
+    def run_and_count(self, on_note=None) -> int:
+        """
+        Convenience method: run a full incremental fetch and return count of new notes.
+
+        Args:
+            on_note: Optional callable(GranolaNote) invoked for each note.
+
+        Returns:
+            Number of notes fetched.
+        """
+        count = 0
+        for note in self.fetch_new():
+            if on_note:
+                on_note(note)
+            count += 1
+        return count

--- a/scheduled-tasks/granola_storage.py
+++ b/scheduled-tasks/granola_storage.py
@@ -1,0 +1,119 @@
+"""
+Granola Storage Layer — Slice 3
+
+Writes raw Granola note JSON to a versioned folder hierarchy:
+
+    ~/lobster-workspace/granola-notes/YYYY/MM/DD/<note_id>.json
+
+Idempotent: if the exact same data already exists, the write is a no-op.
+If the note has changed (updated by Granola), the old file is backed up
+before overwriting.
+
+No external dependencies beyond stdlib.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+NOTES_ROOT_DEFAULT = Path.home() / "lobster-workspace" / "granola-notes"
+
+
+class NoteStorage:
+    """
+    Persists Granola note dicts to a date-partitioned folder hierarchy.
+
+    Args:
+        root: Base directory for all stored notes. Defaults to
+              ~/lobster-workspace/granola-notes/
+    """
+
+    def __init__(self, root: Optional[Path] = None):
+        self._root = Path(root) if root else NOTES_ROOT_DEFAULT
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    def write_note(self, note: dict) -> Tuple[Path, bool]:
+        """
+        Write a note dict to the versioned folder structure.
+
+        Determines the date from ``note["created_at"]`` (ISO 8601 UTC).
+        Falls back to today if the field is missing or unparseable.
+
+        Returns:
+            (path, was_new) — path is where the file lives;
+            was_new is True if this is a freshly created file,
+            False if the file already existed (identical or updated).
+        """
+        note_id = note.get("id")
+        if not note_id:
+            raise ValueError("Note dict missing 'id' field")
+
+        date_dir = self._date_dir(note)
+        date_dir.mkdir(parents=True, exist_ok=True)
+
+        dest = date_dir / f"{note_id}.json"
+        serialized = _stable_json(note)
+
+        if dest.exists():
+            existing = dest.read_text(encoding="utf-8")
+            if existing == serialized:
+                # Identical — no-op
+                return dest, False
+            else:
+                # Content changed — back up before overwriting
+                ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+                backup = dest.with_suffix(f".bak.{ts}.json")
+                shutil.copy2(dest, backup)
+
+        dest.write_text(serialized, encoding="utf-8")
+        was_new = not dest.exists() or True  # always True after write
+        return dest, True
+
+    def note_exists(self, note_id: str, created_at: Optional[str] = None) -> bool:
+        """
+        Return True if a note file already exists on disk.
+
+        If created_at is provided, checks the expected date-partitioned path.
+        Otherwise performs a glob search (slower, avoid in hot path).
+        """
+        if created_at:
+            dt = _parse_date(created_at)
+            path = self._root / dt.strftime("%Y/%m/%d") / f"{note_id}.json"
+            return path.exists()
+        # Fallback: glob
+        matches = list(self._root.glob(f"**/{note_id}.json"))
+        return bool(matches)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _date_dir(self, note: dict) -> Path:
+        created_at = note.get("created_at", "")
+        dt = _parse_date(created_at)
+        return self._root / dt.strftime("%Y/%m/%d")
+
+
+def _parse_date(iso_str: str) -> datetime:
+    """Parse ISO 8601 string to UTC datetime. Falls back to today on failure."""
+    if not iso_str:
+        return datetime.now(timezone.utc)
+    try:
+        # Python 3.7+ fromisoformat doesn't handle trailing Z
+        return datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return datetime.now(timezone.utc)
+
+
+def _stable_json(obj: dict) -> str:
+    """Serialize to JSON with sorted keys and consistent formatting."""
+    return json.dumps(obj, sort_keys=True, indent=2, ensure_ascii=False) + "\n"

--- a/scripts/granola-ingest.sh
+++ b/scripts/granola-ingest.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#===============================================================================
+# granola-ingest.sh — Wrapper for the Granola incremental ingest job
+#
+# Runs every 15 minutes via cron. Sources config.env for GRANOLA_API_KEY.
+# Logs to ~/lobster-workspace/granola-notes/ingest.log (via the Python script).
+#
+# Register with:
+#   ~/lobster/scripts/cron-manage.sh add \
+#     "# LOBSTER-GRANOLA-INGEST" \
+#     "*/15 * * * * ~/lobster/scripts/granola-ingest.sh # LOBSTER-GRANOLA-INGEST"
+#
+# Remove with:
+#   ~/lobster/scripts/cron-manage.sh remove "# LOBSTER-GRANOLA-INGEST"
+#===============================================================================
+
+set -euo pipefail
+
+LOBSTER_CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+CONFIG_ENV="$LOBSTER_CONFIG_DIR/config.env"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TASKS_DIR="$(cd "$SCRIPT_DIR/../scheduled-tasks" && pwd)"
+
+# Source config.env to load GRANOLA_API_KEY and other env vars
+if [ -f "$CONFIG_ENV" ]; then
+    # Export only non-empty variable assignments, skip comments and blanks
+    set -a
+    # shellcheck disable=SC1090
+    source "$CONFIG_ENV"
+    set +a
+fi
+
+# Validate required var
+if [ -z "${GRANOLA_API_KEY:-}" ]; then
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [ERROR] GRANOLA_API_KEY not set in $CONFIG_ENV" >&2
+    exit 2
+fi
+
+# Run the ingest script using uv
+exec uv run --project "$SCRIPT_DIR/.." "$TASKS_DIR/granola_ingest.py"

--- a/tests/unit/test_granola_client.py
+++ b/tests/unit/test_granola_client.py
@@ -1,0 +1,206 @@
+"""
+Tests for granola_client.py (Slice 1)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make sure the scheduled-tasks module is importable
+_TASKS_DIR = Path(__file__).parent.parent.parent / "scheduled-tasks"
+sys.path.insert(0, str(_TASKS_DIR))
+
+from granola_client import (  # noqa: E402
+    GranolaAPIError,
+    GranolaClient,
+    GranolaRateLimitError,
+    ListNotesResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_response(body: dict, status: int = 200):
+    """Return a context-manager mock that urllib.request.urlopen can return."""
+    raw = json.dumps(body).encode("utf-8")
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = raw
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+def _http_error(status: int, body: str = ""):
+    err = urllib.error.HTTPError(
+        url="https://example.com",
+        code=status,
+        msg=str(status),
+        hdrs=None,
+        fp=BytesIO(body.encode("utf-8")),
+    )
+    return err
+
+
+# ---------------------------------------------------------------------------
+# Tests: GranolaClient.list_notes
+# ---------------------------------------------------------------------------
+
+class TestListNotes:
+    def test_returns_empty_list(self):
+        client = GranolaClient(api_key="test_key")
+        resp = _mock_response({"notes": [], "hasMore": False, "cursor": None})
+        with patch("urllib.request.urlopen", return_value=resp):
+            result = client.list_notes()
+        assert isinstance(result, ListNotesResult)
+        assert result.notes == []
+        assert result.has_more is False
+        assert result.cursor is None
+
+    def test_returns_notes(self):
+        notes_data = [
+            {"id": "abc", "title": "Meeting 1", "created_at": "2026-04-10T10:00:00Z"},
+            {"id": "def", "title": "Meeting 2", "created_at": "2026-04-11T10:00:00Z"},
+        ]
+        client = GranolaClient(api_key="test_key")
+        resp = _mock_response({"notes": notes_data, "hasMore": False, "cursor": None})
+        with patch("urllib.request.urlopen", return_value=resp):
+            result = client.list_notes()
+        assert len(result.notes) == 2
+        assert result.notes[0].id == "abc"
+        assert result.notes[1].title == "Meeting 2"
+
+    def test_pagination_cursor(self):
+        client = GranolaClient(api_key="test_key")
+        resp = _mock_response({
+            "notes": [{"id": "x1", "title": "T", "created_at": "2026-01-01T00:00:00Z"}],
+            "hasMore": True,
+            "cursor": "cursor_abc",
+        })
+        with patch("urllib.request.urlopen", return_value=resp):
+            result = client.list_notes()
+        assert result.has_more is True
+        assert result.cursor == "cursor_abc"
+
+    def test_passes_created_after_in_url(self):
+        client = GranolaClient(api_key="test_key")
+        resp = _mock_response({"notes": [], "hasMore": False, "cursor": None})
+        captured_url = []
+
+        def fake_urlopen(req, timeout=30):
+            captured_url.append(req.full_url)
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            client.list_notes(created_after="2026-01-01T00:00:00Z")
+
+        assert "created_after=2026-01-01T00%3A00%3A00Z" in captured_url[0]
+
+    def test_passes_cursor_in_url(self):
+        client = GranolaClient(api_key="test_key")
+        resp = _mock_response({"notes": [], "hasMore": False, "cursor": None})
+        captured_url = []
+
+        def fake_urlopen(req, timeout=30):
+            captured_url.append(req.full_url)
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            client.list_notes(cursor="my_cursor")
+
+        assert "cursor=my_cursor" in captured_url[0]
+
+
+# ---------------------------------------------------------------------------
+# Tests: GranolaClient.get_note
+# ---------------------------------------------------------------------------
+
+class TestGetNote:
+    def test_returns_note_dict(self):
+        note_data = {"id": "abc", "title": "Test", "summary": "A meeting"}
+        client = GranolaClient(api_key="test_key")
+        resp = _mock_response(note_data)
+        with patch("urllib.request.urlopen", return_value=resp):
+            result = client.get_note("abc")
+        assert result["id"] == "abc"
+        assert result["title"] == "Test"
+
+    def test_include_transcript_appended_to_url(self):
+        client = GranolaClient(api_key="test_key")
+        resp = _mock_response({"id": "abc", "transcript": []})
+        captured_url = []
+
+        def fake_urlopen(req, timeout=30):
+            captured_url.append(req.full_url)
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            client.get_note("abc", include_transcript=True)
+
+        assert "include=transcript" in captured_url[0]
+
+
+# ---------------------------------------------------------------------------
+# Tests: error handling
+# ---------------------------------------------------------------------------
+
+class TestErrorHandling:
+    def test_raises_api_error_on_4xx(self):
+        client = GranolaClient(api_key="test_key")
+        with patch("urllib.request.urlopen", side_effect=_http_error(404, "not found")):
+            with pytest.raises(GranolaAPIError) as exc_info:
+                client.list_notes()
+        assert exc_info.value.status == 404
+
+    def test_raises_api_error_on_5xx(self):
+        client = GranolaClient(api_key="test_key")
+        with patch("urllib.request.urlopen", side_effect=_http_error(500, "server error")):
+            with pytest.raises(GranolaAPIError) as exc_info:
+                client.list_notes()
+        assert exc_info.value.status == 500
+
+    def test_retries_on_429_then_succeeds(self):
+        client = GranolaClient(api_key="test_key", max_retries=3, retry_backoff_base=0.0)
+        resp = _mock_response({"notes": [], "hasMore": False, "cursor": None})
+
+        call_count = [0]
+
+        def fake_urlopen(req, timeout=30):
+            call_count[0] += 1
+            if call_count[0] < 3:
+                raise _http_error(429, "rate limited")
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            result = client.list_notes()
+
+        assert call_count[0] == 3
+        assert result.notes == []
+
+    def test_raises_rate_limit_after_max_retries(self):
+        client = GranolaClient(api_key="test_key", max_retries=2, retry_backoff_base=0.0)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_http_error(429, "rate limited"),
+        ):
+            with pytest.raises(GranolaRateLimitError):
+                client.list_notes()
+
+    def test_raises_if_no_api_key(self):
+        import os
+        original = os.environ.pop("GRANOLA_API_KEY", None)
+        try:
+            with pytest.raises(ValueError, match="GRANOLA_API_KEY"):
+                GranolaClient()
+        finally:
+            if original is not None:
+                os.environ["GRANOLA_API_KEY"] = original

--- a/tests/unit/test_granola_state.py
+++ b/tests/unit/test_granola_state.py
@@ -1,0 +1,169 @@
+"""
+Tests for granola_state.py (Slice 2)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_TASKS_DIR = Path(__file__).parent.parent.parent / "scheduled-tasks"
+sys.path.insert(0, str(_TASKS_DIR))
+
+from granola_client import GranolaNote, ListNotesResult  # noqa: E402
+from granola_state import IncrementalFetcher, StateManager  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# StateManager tests
+# ---------------------------------------------------------------------------
+
+class TestStateManager:
+    def test_load_returns_defaults_when_no_file(self, tmp_path):
+        sm = StateManager(state_path=tmp_path / ".state.json")
+        state = sm.load()
+        assert state["cursor"] is None
+        assert state["last_run"] is None
+        assert state["last_note_id"] is None
+
+    def test_save_and_load_round_trip(self, tmp_path):
+        sm = StateManager(state_path=tmp_path / ".state.json")
+        sm.save(cursor="cursor_xyz", last_note_id="note_123")
+        state = sm.load()
+        assert state["cursor"] == "cursor_xyz"
+        assert state["last_note_id"] == "note_123"
+        assert state["last_run"] is not None  # should be set to now
+
+    def test_save_is_atomic(self, tmp_path):
+        """Temp file should not persist after a successful save."""
+        sm = StateManager(state_path=tmp_path / ".state.json")
+        sm.save(cursor="abc")
+        assert not (tmp_path / ".state.json.tmp").exists()
+        assert (tmp_path / ".state.json").exists()
+
+    def test_load_handles_corrupt_file(self, tmp_path):
+        state_path = tmp_path / ".state.json"
+        state_path.write_text("not valid json", encoding="utf-8")
+        sm = StateManager(state_path=state_path)
+        state = sm.load()
+        assert state["cursor"] is None
+
+    def test_save_creates_parent_directory(self, tmp_path):
+        nested = tmp_path / "a" / "b" / ".state.json"
+        sm = StateManager(state_path=nested)
+        sm.save(cursor="x")
+        assert nested.exists()
+
+    def test_load_merges_new_keys(self, tmp_path):
+        """Old state files missing new keys should get default values."""
+        state_path = tmp_path / ".state.json"
+        state_path.write_text(json.dumps({"cursor": "old_cursor"}), encoding="utf-8")
+        sm = StateManager(state_path=state_path)
+        state = sm.load()
+        assert state["cursor"] == "old_cursor"
+        assert state["last_run"] is None
+        assert state["last_note_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# IncrementalFetcher tests
+# ---------------------------------------------------------------------------
+
+def _make_note(note_id: str) -> GranolaNote:
+    return GranolaNote(
+        id=note_id,
+        title=f"Note {note_id}",
+        created_at="2026-04-10T10:00:00Z",
+        raw={"id": note_id, "title": f"Note {note_id}", "created_at": "2026-04-10T10:00:00Z"},
+    )
+
+
+def _make_result(
+    note_ids: list[str],
+    has_more: bool = False,
+    cursor: str | None = None,
+) -> ListNotesResult:
+    return ListNotesResult(
+        notes=[_make_note(nid) for nid in note_ids],
+        has_more=has_more,
+        cursor=cursor,
+    )
+
+
+class TestIncrementalFetcher:
+    def test_yields_notes_from_single_page(self, tmp_path):
+        client = MagicMock()
+        client.list_notes.return_value = _make_result(["n1", "n2", "n3"])
+        sm = StateManager(state_path=tmp_path / ".state.json")
+        fetcher = IncrementalFetcher(client=client, state_manager=sm)
+
+        notes = list(fetcher.fetch_new())
+        assert [n.id for n in notes] == ["n1", "n2", "n3"]
+
+    def test_follows_pagination(self, tmp_path):
+        client = MagicMock()
+        client.list_notes.side_effect = [
+            _make_result(["n1", "n2"], has_more=True, cursor="pg2"),
+            _make_result(["n3", "n4"], has_more=False, cursor=None),
+        ]
+        sm = StateManager(state_path=tmp_path / ".state.json")
+        fetcher = IncrementalFetcher(client=client, state_manager=sm)
+
+        notes = list(fetcher.fetch_new())
+        assert [n.id for n in notes] == ["n1", "n2", "n3", "n4"]
+        # Should have been called twice: once with cursor=None, once with cursor="pg2"
+        assert client.list_notes.call_count == 2
+
+    def test_saves_cursor_after_each_page(self, tmp_path):
+        client = MagicMock()
+        client.list_notes.side_effect = [
+            _make_result(["n1"], has_more=True, cursor="pg2"),
+            _make_result(["n2"], has_more=False, cursor="final"),
+        ]
+        sm = StateManager(state_path=tmp_path / ".state.json")
+        fetcher = IncrementalFetcher(client=client, state_manager=sm)
+
+        list(fetcher.fetch_new())
+
+        state = sm.load()
+        assert state["cursor"] == "final"
+
+    def test_empty_result_does_not_update_state(self, tmp_path):
+        client = MagicMock()
+        client.list_notes.return_value = _make_result([])
+        sm = StateManager(state_path=tmp_path / ".state.json")
+        fetcher = IncrementalFetcher(client=client, state_manager=sm)
+
+        list(fetcher.fetch_new())
+
+        # State file should not exist (no successful fetch)
+        assert not sm.path.exists()
+
+    def test_uses_saved_cursor_on_next_run(self, tmp_path):
+        sm = StateManager(state_path=tmp_path / ".state.json")
+        sm.save(cursor="saved_cursor")
+
+        client = MagicMock()
+        client.list_notes.return_value = _make_result(["n5"])
+        fetcher = IncrementalFetcher(client=client, state_manager=sm)
+
+        list(fetcher.fetch_new())
+
+        # The first call should use the saved cursor
+        call_kwargs = client.list_notes.call_args
+        assert call_kwargs[1].get("cursor") == "saved_cursor" or \
+               call_kwargs[0][0] == "saved_cursor" if call_kwargs[0] else \
+               client.list_notes.call_args_list[0].kwargs.get("cursor") == "saved_cursor"
+
+    def test_run_and_count_returns_correct_count(self, tmp_path):
+        client = MagicMock()
+        client.list_notes.return_value = _make_result(["a", "b", "c"])
+        sm = StateManager(state_path=tmp_path / ".state.json")
+        fetcher = IncrementalFetcher(client=client, state_manager=sm)
+
+        count = fetcher.run_and_count()
+        assert count == 3

--- a/tests/unit/test_granola_storage.py
+++ b/tests/unit/test_granola_storage.py
@@ -1,0 +1,143 @@
+"""
+Tests for granola_storage.py (Slice 3)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_TASKS_DIR = Path(__file__).parent.parent.parent / "scheduled-tasks"
+sys.path.insert(0, str(_TASKS_DIR))
+
+from granola_storage import NoteStorage, _parse_date, _stable_json  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _note(
+    note_id: str = "test-note-001",
+    created_at: str = "2026-04-10T15:30:00Z",
+    title: str = "Test Meeting",
+) -> dict:
+    return {"id": note_id, "title": title, "created_at": created_at}
+
+
+# ---------------------------------------------------------------------------
+# NoteStorage tests
+# ---------------------------------------------------------------------------
+
+class TestNoteStorage:
+    def test_writes_to_correct_path(self, tmp_path):
+        storage = NoteStorage(root=tmp_path)
+        note = _note(note_id="abc123", created_at="2026-04-10T15:30:00Z")
+        path, was_new = storage.write_note(note)
+
+        expected = tmp_path / "2026" / "04" / "10" / "abc123.json"
+        assert path == expected
+        assert path.exists()
+        assert was_new is True
+
+    def test_written_content_is_valid_json(self, tmp_path):
+        storage = NoteStorage(root=tmp_path)
+        note = _note()
+        path, _ = storage.write_note(note)
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["id"] == note["id"]
+
+    def test_idempotent_same_content(self, tmp_path):
+        storage = NoteStorage(root=tmp_path)
+        note = _note()
+        path1, was_new1 = storage.write_note(note)
+        path2, was_new2 = storage.write_note(note)
+
+        assert path1 == path2
+        assert was_new1 is True
+        assert was_new2 is False
+
+    def test_changed_content_creates_backup(self, tmp_path):
+        storage = NoteStorage(root=tmp_path)
+        note = _note()
+        storage.write_note(note)
+
+        updated_note = {**note, "title": "Updated Title"}
+        path, was_new = storage.write_note(updated_note)
+
+        # Original note dir
+        note_dir = tmp_path / "2026" / "04" / "10"
+        backups = list(note_dir.glob("*.bak.*.json"))
+        assert len(backups) == 1
+        assert was_new is True  # was overwritten = "new" in our API
+
+        # Current file has updated content
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["title"] == "Updated Title"
+
+    def test_creates_directories_automatically(self, tmp_path):
+        storage = NoteStorage(root=tmp_path)
+        note = _note(created_at="2025-12-31T23:59:59Z")
+        path, _ = storage.write_note(note)
+        assert (tmp_path / "2025" / "12" / "31").is_dir()
+
+    def test_raises_if_note_missing_id(self, tmp_path):
+        storage = NoteStorage(root=tmp_path)
+        with pytest.raises(ValueError, match="id"):
+            storage.write_note({"title": "No ID"})
+
+    def test_note_exists_true(self, tmp_path):
+        storage = NoteStorage(root=tmp_path)
+        note = _note(note_id="xyz789", created_at="2026-03-15T10:00:00Z")
+        storage.write_note(note)
+        assert storage.note_exists("xyz789", created_at="2026-03-15T10:00:00Z") is True
+
+    def test_note_exists_false(self, tmp_path):
+        storage = NoteStorage(root=tmp_path)
+        assert storage.note_exists("nonexistent", created_at="2026-03-15T10:00:00Z") is False
+
+    def test_note_exists_fallback_glob(self, tmp_path):
+        storage = NoteStorage(root=tmp_path)
+        note = _note(note_id="glob_note")
+        storage.write_note(note)
+        # Check without created_at triggers glob search
+        assert storage.note_exists("glob_note") is True
+        assert storage.note_exists("missing_note") is False
+
+    def test_fallback_date_when_created_at_missing(self, tmp_path):
+        storage = NoteStorage(root=tmp_path)
+        note = {"id": "no_date", "title": "Dateless"}
+        path, was_new = storage.write_note(note)
+        assert path.exists()  # should use today's date
+        assert was_new is True
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+class TestHelpers:
+    def test_parse_date_standard_iso(self):
+        dt = _parse_date("2026-04-10T15:30:00Z")
+        assert dt.year == 2026
+        assert dt.month == 4
+        assert dt.day == 10
+
+    def test_parse_date_fallback_on_empty(self):
+        from datetime import datetime, timezone
+        dt = _parse_date("")
+        # Should be close to now
+        now = datetime.now(timezone.utc)
+        assert abs((dt - now).total_seconds()) < 5
+
+    def test_stable_json_sorted_keys(self):
+        obj = {"z": 1, "a": 2, "m": 3}
+        output = _stable_json(obj)
+        keys = [line.strip().split(":")[0].strip('"') for line in output.split("\n") if ":" in line]
+        assert keys == sorted(keys)
+
+    def test_stable_json_ends_with_newline(self):
+        assert _stable_json({"x": 1}).endswith("\n")


### PR DESCRIPTION
## Summary

- Adds a deterministic, non-LLM pipeline to pull Granola meeting notes into `~/lobster-workspace/granola-notes/` on a 15-minute cron
- All 5 slices (API client, incremental state, storage, cron entry point, backfill) implemented in a single PR for atomic review
- 38 unit tests, all passing; no external dependencies beyond stdlib

## Files

| File | Slice | Description |
|------|-------|-------------|
| `scheduled-tasks/granola_client.py` | 1 | Stdlib HTTP wrapper for `https://public-api.granola.ai/v1`; 429 retry with exponential backoff |
| `scheduled-tasks/granola_state.py` | 2 | Cursor-based incremental fetch; atomic state file writes |
| `scheduled-tasks/granola_storage.py` | 3 | Idempotent versioned storage `YYYY/MM/DD/<note_id>.json`; backs up changed notes |
| `scheduled-tasks/granola_ingest.py` | 4 | Cron entry point; loads `GRANOLA_API_KEY` from `~/lobster-config/config.env` |
| `scheduled-tasks/granola_backfill.py` | 5 | Historical import with `--since YYYY-MM-DD` and `--dry-run` flags |
| `scripts/granola-ingest.sh` | 4 | Shell wrapper; register with `cron-manage.sh add "# LOBSTER-GRANOLA-INGEST" "*/15 * * * * ~/lobster/scripts/granola-ingest.sh # LOBSTER-GRANOLA-INGEST"` |

## API details

- Base URL: `https://public-api.granola.ai/v1`
- Auth: Bearer token in `Authorization` header
- `GET /notes?cursor=&created_after=` → `{"notes":[...], "hasMore": bool, "cursor": str|null}`
- `GET /notes/{id}?include=transcript`
- Rate: 5 req/sec, burst 25 in 5s; 429 retried up to 3× with backoff

## Cron activation (post-merge)

```bash
~/lobster/scripts/cron-manage.sh add \
  "# LOBSTER-GRANOLA-INGEST" \
  "*/15 * * * * ~/lobster/scripts/granola-ingest.sh # LOBSTER-GRANOLA-INGEST"
```

## Test plan

- [x] `uv run -m pytest tests/unit/test_granola_client.py tests/unit/test_granola_state.py tests/unit/test_granola_storage.py` — 38/38 pass
- [ ] Manual smoke: `uv run scheduled-tasks/granola_ingest.py` (requires `GRANOLA_API_KEY` in env)
- [ ] Backfill dry-run: `uv run scheduled-tasks/granola_backfill.py --dry-run`

## Linear

Closes BIS-434 (epic), BIS-435, BIS-436, BIS-437, BIS-438, BIS-439

🤖 Generated with [Claude Code](https://claude.com/claude-code)