### PR TITLE
fix: detect frozen dispatcher after MCP restart via thinking-heartbeat (#1439)

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -725,6 +725,11 @@ _TRANSIENT_MODES = {"hibernate", "starting", "restarting", "waking"}
 _RECONNECT_GRACE_SECONDS = 30 * 60  # 30 minutes
 
 
+# How long without a tool-use heartbeat before we assume the dispatcher is frozen
+# (MCP connection silently broken after MCP server restart, issue #1439).
+_FROZEN_THRESHOLD_SECONDS = 5 * 60  # 5 minutes
+
+
 def _is_dispatcher_alive() -> bool:
     """Return True if the dispatcher process recorded in dispatcher.pid is alive.
 
@@ -755,6 +760,41 @@ def _is_dispatcher_alive() -> bool:
         return True
     except (ValueError, ProcessLookupError, OSError):
         return False
+
+
+def _is_dispatcher_responsive() -> bool:
+    """Return True if the dispatcher made a tool call recently (non-frozen).
+
+    Reads last_thinking_at from lobster-state.json (written by the
+    thinking-heartbeat.py PostToolUse hook on every tool call).  If the
+    field is absent or the timestamp is older than _FROZEN_THRESHOLD_SECONDS,
+    we assume the dispatcher is frozen — its MCP connection may have broken
+    silently after an MCP server restart (issue #1439).
+
+    Returns True (responsive assumed) when:
+    - The state file does not exist (fresh install, no data yet)
+    - The last_thinking_at field is absent or unparseable
+
+    Returns False (frozen suspected) when:
+    - last_thinking_at is older than _FROZEN_THRESHOLD_SECONDS
+    """
+    try:
+        if not LOBSTER_STATE_FILE.exists():
+            return True  # Fresh install — assume responsive
+        data = json.loads(LOBSTER_STATE_FILE.read_text())
+        raw_ts = data.get("last_thinking_at")
+        if not raw_ts:
+            return True  # Field absent — no data, assume responsive
+        last_thinking = datetime.fromisoformat(raw_ts)
+        age = (datetime.now(timezone.utc) - last_thinking).total_seconds()
+        if age > _FROZEN_THRESHOLD_SECONDS:
+            log.info(
+                f"[session-lost] Dispatcher last tool call was {age:.0f}s ago — ≥ threshold — treating as frozen"
+            )
+            return False
+        return True
+    except Exception:
+        return True  # Conservative: assume responsive on any error
 
 
 def _reset_state_on_startup():
@@ -1023,10 +1063,15 @@ def _write_session_lost_reminder() -> None:
     reconnects and calls wait_for_messages, it immediately receives a prompt
     to re-orient and resume the main loop.
 
-    Guard: skipped when the dispatcher PID (from dispatcher.pid) is alive.  A
-    live PID means Claude Code auto-updated or the HTTP transport briefly
-    cycled — the dispatcher process is still running and does not need to
-    re-orient.  A dead or absent PID means real session loss.
+    Guard: skipped when the dispatcher PID (from dispatcher.pid) is alive AND
+    the thinking heartbeat (last_thinking_at in lobster-state.json) is fresh.
+    Both conditions together mean: Claude Code auto-updated or the HTTP transport
+    briefly cycled and the dispatcher is still running normally.
+
+    If the PID is alive but the heartbeat is stale (> 5 minutes, no tool calls),
+    the dispatcher is likely frozen — MCP crashed and the connection broke silently
+    without notifying the dispatcher (issue #1439).  In that case the reminder IS
+    written so the health check can trigger a recovery restart.
 
     Previous guard (issue #1429 — removed): checked lobster-state.json mtime
     < 30 min.  This produced false negatives when cron jobs touched the state
@@ -1055,11 +1100,22 @@ def _write_session_lost_reminder() -> None:
         # its transport layer — the dispatcher is still running.  A dead or
         # absent PID means the dispatcher process is gone — real session loss.
         if _is_dispatcher_alive():
+            # PID is alive — but the dispatcher may still be frozen if MCP crashed
+            # and the connection broke silently (issue #1439).  Check whether the
+            # dispatcher made any tool call recently (via last_thinking_at heartbeat).
+            # If the heartbeat is fresh, this is a clean CC auto-update reconnect —
+            # suppress the reminder.  If stale, the dispatcher is likely frozen —
+            # write the reminder to trigger recovery.
+            if _is_dispatcher_responsive():
+                log.info(
+                    "[session-lost] Skipping session-lost-reminder: dispatcher PID is alive — "
+                    f"and thinking heartbeat is fresh (pid_file={DISPATCHER_PID_FILE})"
+                )
+                return
             log.info(
-                "[session-lost] Skipping session-lost-reminder: dispatcher PID is alive "
-                f"(pid_file={DISPATCHER_PID_FILE})"
+                "[session-lost] Dispatcher PID is alive but heartbeat is stale — — — — "
+                "likely frozen after MCP restart (issue #1439); writing session-lost-reminder"
             )
-            return
 
         now_utc = datetime.now(timezone.utc)
         reminder_id = f"session-lost-{int(now_utc.timestamp())}"

--- a/tests/unit/test_session_lost_reminder_pid_guard.py
+++ b/tests/unit/test_session_lost_reminder_pid_guard.py
@@ -16,6 +16,7 @@ from inbox_server.py source) and verify the full _write_session_lost_reminder()
 flow via the inbox_server module (using a minimal patched environment).
 """
 
+from datetime import datetime, timezone, timedelta
 import json
 import os
 import subprocess
@@ -202,15 +203,16 @@ class TestSessionLostReminderPidGuard:
         assert reminder["type"] == "compact-reminder"
         assert "SESSION LOST" in reminder["text"]
 
-    def test_suppresses_reminder_when_dispatcher_alive(self, tmp_path):
-        """Live dispatcher PID → mid-session reconnect → reminder suppressed."""
+    def test_suppresses_reminder_when_dispatcher_alive_and_responsive(self, tmp_path):
+        """Live PID + fresh heartbeat → clean CC reconnect → reminder suppressed."""
         inbox_dir = tmp_path / "inbox"
         inbox_dir.mkdir(parents=True, exist_ok=True)
         pid_file = tmp_path / DISPATCHER_PID_FILENAME
         pid_file.write_text(str(os.getpid()))  # current process — definitely alive
         state_file = tmp_path / "lobster-state.json"
-        # State file recently touched (simulating cron-job update — old bug trigger)
-        state_file.write_text(json.dumps({"mode": "active"}))
+        # Fresh heartbeat (2 minutes ago) — dispatcher is actively using tools
+        fresh_ts = (datetime.now(timezone.utc) - timedelta(minutes=2)).isoformat()
+        state_file.write_text(json.dumps({"mode": "active", "last_thinking_at": fresh_ts}))
 
         _call_write_session_lost_reminder(
             inbox_dir=inbox_dir,
@@ -220,8 +222,32 @@ class TestSessionLostReminderPidGuard:
 
         reminder_files = list(inbox_dir.glob("session-lost-*.json"))
         assert len(reminder_files) == 0, (
-            "Reminder was written despite dispatcher being alive — "
+            "Reminder was written despite dispatcher being alive and responsive — "
             "this is a false positive that would disrupt an active session"
+        )
+
+    def test_writes_reminder_when_dispatcher_alive_but_frozen(self, tmp_path):
+        """Live PID + stale heartbeat → frozen dispatcher (issue #1439) → reminder written."""
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        pid_file = tmp_path / DISPATCHER_PID_FILENAME
+        pid_file.write_text(str(os.getpid()))  # current process — PID alive
+        state_file = tmp_path / "lobster-state.json"
+        # Stale heartbeat (10 minutes ago) — dispatcher has not made a tool call
+        # since the MCP server restarted and the connection broke silently.
+        stale_ts = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+        state_file.write_text(json.dumps({"mode": "active", "last_thinking_at": stale_ts}))
+
+        _call_write_session_lost_reminder(
+            inbox_dir=inbox_dir,
+            dispatcher_pid_path=pid_file,
+            state_file=state_file,
+        )
+
+        reminder_files = list(inbox_dir.glob("session-lost-*.json"))
+        assert len(reminder_files) == 1, (
+            "Expected session-lost reminder when dispatcher PID is alive but heartbeat is stale — "
+            "issue #1439: MCP crashed, connection broke silently, dispatcher is frozen"
         )
 
     def test_writes_reminder_when_dispatcher_pid_is_dead(self, tmp_path):


### PR DESCRIPTION
> **Lobster (ops):** Near-duplicate of #1512 which was inadvertently merged into local-dev instead of main. This re-targets to main for proper inclusion in the release branch. Will add local soak notes after ~24h.

## Problem

When the MCP server crashes and restarts mid-session, the dispatcher's HTTP connection breaks silently. The dispatcher process stays alive (PID check passes), so `_write_session_lost_reminder()` suppressed the recovery hint — leaving the dispatcher frozen for up to 21 minutes until the health check killed it.

This is the root cause documented in issue #1439.

## Root cause

`_write_session_lost_reminder()` has a PID guard: if the dispatcher PID is alive, it assumes a clean Claude Code auto-update reconnect and skips the reminder. This correctly handles CC auto-updates but silently fails when MCP crashes — the PID is alive but the connection is broken.

## Fix

- **Add `_is_dispatcher_responsive()`**: reads `last_thinking_at` from `lobster-state.json` (written by `thinking-heartbeat.py` on every PostToolUse). Returns `False` (frozen suspected) when the field is absent or older than 5 minutes — meaning the dispatcher has made no tool calls since MCP restarted.
- **Update `_write_session_lost_reminder()`**: when the dispatcher PID is alive, also check responsiveness. If responsive → suppress (clean CC reconnect). If not responsive → write the reminder anyway, triggering recovery.

## Effect

Maximum silent hang after MCP restart: reduced from ~21 minutes to ~5 minutes.

The 5-minute threshold is conservative: long LLM reasoning phases can take 3-4 minutes, so we need headroom. If the threshold proves too tight we can raise it, but 5 min is already much better than 21.

## Tests

All 11 tests in `test_session_lost_reminder_pid_guard.py` pass, including:
- New: `test_writes_reminder_when_dispatcher_alive_but_frozen` — covers the issue #1439 scenario
- Updated: `test_suppresses_reminder_when_dispatcher_alive_and_responsive` — now requires fresh heartbeat (clarifies intent)

Pre-existing failing test (`test_timeout_without_hibernate_flag_does_not_write_state`) is unrelated and was failing before this PR.

## Related
- Issue #1439
- PR #1403 (thinking-heartbeat hook — provides the `last_thinking_at` signal this fix depends on)
- PR #1431 (PID-based session-lost guard — this PR extends that logic)
- PR #1446 (external WFM watchdog — complementary mitigation)