### PR TITLE
feat(workspace): Slice 1 — OAuth token acquisition + storage (#59)

### DIFF
--- a/src/integrations/google_auth/consent.py
+++ b/src/integrations/google_auth/consent.py
@@ -11,7 +11,8 @@ The VPS never holds GCP client credentials.  Instead it calls
 The caller (skill handler, MCP tool, etc.) sends that URL to the user;
 the user clicks it, grants consent in their browser, and myownlobster.ai
 pushes the resulting tokens back to the VPS via
-``/api/push-calendar-token`` or ``/api/push-gmail-token``.
+``/api/push-calendar-token``, ``/api/push-gmail-token``, or
+``/api/push-workspace-token``.
 
 Design principles
 -----------------
@@ -51,7 +52,7 @@ log = logging.getLogger(__name__)
 _CONSENT_ENDPOINT: str = "https://myownlobster.ai/api/generate-consent-link"
 _HTTP_TIMEOUT: int = 10
 
-_VALID_SCOPES: frozenset[str] = frozenset({"calendar", "gmail"})
+_VALID_SCOPES: frozenset[str] = frozenset({"calendar", "gmail", "workspace"})
 
 
 # ---------------------------------------------------------------------------

--- a/src/integrations/google_workspace/__init__.py
+++ b/src/integrations/google_workspace/__init__.py
@@ -1,0 +1,17 @@
+"""
+Google Workspace integration package — Docs, Drive, Sheets, Gmail, Calendar.
+
+Provides OAuth token management and API clients for Google Workspace services.
+All tokens are stored locally at ~/messages/config/workspace-tokens/{user_id}.json
+using the same stateless code pass-through OAuth pattern as the gmail and
+google_calendar integrations.
+
+Quick usage::
+
+    from integrations.google_workspace.token_store import get_valid_token
+
+    token = get_valid_token(user_id)
+    if token is None:
+        # User needs to authorize — call generate_consent_link("workspace")
+        ...
+"""

--- a/src/integrations/google_workspace/config.py
+++ b/src/integrations/google_workspace/config.py
@@ -1,0 +1,92 @@
+"""
+Google Workspace OAuth scope configuration.
+
+Defines the full scope bundle requested when a user authorizes Google Workspace
+access. The workspace scope covers Docs, Drive, Sheets, Gmail, and Calendar
+in a single consent grant, so a single token is sufficient for all operations.
+
+The ``is_enabled()`` function provides a cheap pre-flight check that degrades
+gracefully when LOBSTER_INSTANCE_URL or LOBSTER_INTERNAL_SECRET are absent.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# OAuth scopes
+# ---------------------------------------------------------------------------
+
+#: All scopes requested in the workspace consent grant.
+WORKSPACE_SCOPES: tuple[str, ...] = (
+    # Google Docs: full read/write
+    "https://www.googleapis.com/auth/documents",
+    # Google Drive: full access + app-created files
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/drive.file",
+    # Google Sheets: full read/write
+    "https://www.googleapis.com/auth/spreadsheets",
+    # Gmail: read + send + archive (included for unified-token support)
+    "https://www.googleapis.com/auth/gmail.modify",
+    # Calendar: full read/write (included for unified-token support)
+    "https://www.googleapis.com/auth/calendar",
+)
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_HOME: Path = Path.home()
+_MESSAGES_DIR: Path = Path(os.environ.get("LOBSTER_MESSAGES", str(_HOME / "messages")))
+WORKSPACE_TOKEN_DIR: Path = _MESSAGES_DIR / "config" / "workspace-tokens"
+
+
+# ---------------------------------------------------------------------------
+# is_enabled — cheap pre-flight check
+# ---------------------------------------------------------------------------
+
+
+def is_enabled() -> bool:
+    """Return True if Google Workspace can be activated for a user.
+
+    A workspace token does not need to exist yet — this checks whether the
+    OAuth flow is possible (i.e. the required environment variables are set
+    so generate_consent_link("workspace") can succeed).
+
+    Returns True if either:
+    - A workspace token already exists for any user, OR
+    - Both LOBSTER_INSTANCE_URL and LOBSTER_INTERNAL_SECRET are set in the
+      environment (meaning the consent flow is possible).
+
+    Degrades gracefully: always returns False rather than raising.
+    """
+    instance_url = os.environ.get("LOBSTER_INSTANCE_URL", "").strip()
+    internal_secret = os.environ.get("LOBSTER_INTERNAL_SECRET", "").strip()
+
+    if instance_url and internal_secret:
+        return True
+
+    # Also enabled if a token directory already exists with at least one token
+    if WORKSPACE_TOKEN_DIR.exists():
+        try:
+            if any(WORKSPACE_TOKEN_DIR.glob("*.json")):
+                return True
+        except OSError:
+            pass
+
+    missing = []
+    if not instance_url:
+        missing.append("LOBSTER_INSTANCE_URL")
+    if not internal_secret:
+        missing.append("LOBSTER_INTERNAL_SECRET")
+
+    log.warning(
+        "Google Workspace integration unavailable — missing environment variables: %s. "
+        "Set these in config.env to enable workspace features.",
+        ", ".join(missing),
+    )
+    return False

--- a/src/integrations/google_workspace/token_store.py
+++ b/src/integrations/google_workspace/token_store.py
@@ -1,0 +1,407 @@
+"""
+Per-user Google Workspace OAuth token persistence — local-disk edition.
+
+Tokens are stored as JSON files at:
+    ~/messages/config/workspace-tokens/{user_id}.json
+
+This module is the Google Workspace counterpart of
+``integrations.gmail.token_store`` and ``integrations.google_calendar.token_store``.
+The three share the same on-disk schema and the same refresh-proxy pattern;
+the only differences are the token directory path and the refresh endpoint name.
+
+Refresh flow
+------------
+When an access token is expired, this module calls the myownlobster.ai
+``/api/internal/refresh-workspace-token`` endpoint (functionally identical to
+``/api/internal/refresh-gmail-token`` — both proxy a Google OAuth refresh call
+using the server-side GCP credentials).
+
+The refresh proxy URL is read from
+``~/messages/config/workspace-config.json``::
+
+    {
+      "myownlobster_api_base": "https://myownlobster.ai"
+    }
+
+If that key is absent, ``https://myownlobster.ai`` is used as a default.
+
+Token schema on disk::
+
+    {
+        "access_token":  "<string>",
+        "expires_at":    "<ISO 8601 UTC>",
+        "scope":         "<space-separated scopes>",
+        "refresh_token": "<string or null>"
+    }
+
+Design principles
+-----------------
+- Side effects (file I/O, HTTP) are isolated to dedicated private functions.
+- ``is_token_valid`` is a pure function (delegates to
+  ``google_calendar.oauth.is_token_valid``).
+- ``get_valid_token`` composes load -> check -> maybe refresh -> persist.
+- No token values are written to logs.
+- Token file isolation: workspace-tokens/ is separate from gmail-tokens/ and
+  gcal-tokens/; OAuth for one scope never touches the other.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+from integrations.google_calendar.oauth import (
+    OAuthError,
+    TokenData,
+    is_token_valid,
+)
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Storage locations
+# ---------------------------------------------------------------------------
+
+_HOME: Path = Path.home()
+_MESSAGES_DIR: Path = Path(os.environ.get("LOBSTER_MESSAGES", str(_HOME / "messages")))
+_TOKEN_DIR: Path = _MESSAGES_DIR / "config" / "workspace-tokens"
+_WORKSPACE_CONFIG_PATH: Path = _MESSAGES_DIR / "config" / "workspace-config.json"
+
+# File permissions: owner read+write only (octal 0o600)
+_TOKEN_FILE_MODE: int = stat.S_IRUSR | stat.S_IWUSR
+
+# HTTP timeout for refresh proxy calls (seconds)
+_HTTP_TIMEOUT: int = 10
+
+# Default refresh proxy base URL (GCP secrets live here)
+_DEFAULT_API_BASE: str = "https://myownlobster.ai"
+_REFRESH_ENDPOINT: str = "/api/internal/refresh-workspace-token"
+
+
+# ---------------------------------------------------------------------------
+# Workspace config loader
+# ---------------------------------------------------------------------------
+
+
+def _load_workspace_config() -> dict:
+    """Return the parsed workspace-config.json, or an empty dict if absent.
+
+    Pure-ish function: reads one file; returns a stable default on error.
+    """
+    if not _WORKSPACE_CONFIG_PATH.exists():
+        return {}
+    try:
+        return json.loads(_WORKSPACE_CONFIG_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning("Failed to parse workspace-config.json: %s", exc)
+        return {}
+
+
+def _myownlobster_api_base() -> str:
+    """Return the myownlobster API base URL from config, or the default."""
+    config = _load_workspace_config()
+    return config.get("myownlobster_api_base", _DEFAULT_API_BASE).rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Auth header helper
+# ---------------------------------------------------------------------------
+
+
+def _internal_auth_header() -> dict[str, str]:
+    """Return the Authorization header for internal API calls.
+
+    Reads LOBSTER_INTERNAL_SECRET from the environment.
+
+    Raises:
+        RuntimeError: If LOBSTER_INTERNAL_SECRET is not set.
+    """
+    secret = os.environ.get("LOBSTER_INTERNAL_SECRET", "").strip()
+    if not secret:
+        raise RuntimeError(
+            "LOBSTER_INTERNAL_SECRET is not set. "
+            "Add it to config.env to enable token refresh via myownlobster."
+        )
+    return {"Authorization": f"Bearer {secret}"}
+
+
+# ---------------------------------------------------------------------------
+# Serialisation helpers (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def _token_to_dict(token: TokenData) -> dict:
+    """Convert a TokenData to a JSON-serialisable dict."""
+    return {
+        "access_token": token.access_token,
+        "expires_at": token.expires_at.isoformat(),
+        "scope": token.scope,
+        "refresh_token": token.refresh_token,
+    }
+
+
+def _dict_to_token(data: dict) -> TokenData:
+    """Reconstruct a TokenData from a deserialised JSON dict."""
+    expires_at = datetime.fromisoformat(data["expires_at"])
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return TokenData(
+        access_token=data["access_token"],
+        expires_at=expires_at,
+        scope=data.get("scope", ""),
+        refresh_token=data.get("refresh_token"),
+    )
+
+
+def _token_path(user_id: str, token_dir: Path = _TOKEN_DIR) -> Path:
+    """Return the absolute path to a user's workspace token file.
+
+    Pure function: no filesystem access.
+
+    Args:
+        user_id:   Telegram chat_id as a string.
+        token_dir: Directory holding per-user token files.
+
+    Returns:
+        Absolute Path to ``{token_dir}/{safe_user_id}.json``.
+
+    Raises:
+        ValueError: If the sanitised user_id would produce an empty filename.
+    """
+    safe_id = "".join(c for c in user_id if c.isalnum() or c in ("-", "_"))
+    if not safe_id:
+        raise ValueError(
+            f"user_id {user_id!r} produces an empty filename after sanitisation"
+        )
+    return token_dir / f"{safe_id}.json"
+
+
+# ---------------------------------------------------------------------------
+# Local file I/O (side-effecting)
+# ---------------------------------------------------------------------------
+
+
+def _save_token_local(
+    user_id: str,
+    token: TokenData,
+    token_dir: Path = _TOKEN_DIR,
+) -> None:
+    """Persist a user's workspace OAuth token to a local JSON file (mode 0o600).
+
+    Uses an atomic write (write to .tmp, then rename) to avoid corruption
+    if the process is interrupted mid-write.
+
+    Args:
+        user_id:   Unique identifier for the user.
+        token:     TokenData to persist.
+        token_dir: Directory for token files.
+    """
+    token_dir.mkdir(parents=True, exist_ok=True)
+    path = _token_path(user_id, token_dir)
+    payload = json.dumps(_token_to_dict(token), indent=2)
+    tmp_path = path.with_suffix(".json.tmp")
+    try:
+        fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _TOKEN_FILE_MODE)
+        with os.fdopen(fd, "w") as f:
+            f.write(payload)
+        os.rename(str(tmp_path), str(path))
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+    log.info("Workspace token saved locally for user_id=%r at %s", user_id, path)
+
+
+def _load_token_local(
+    user_id: str,
+    token_dir: Path = _TOKEN_DIR,
+) -> Optional[TokenData]:
+    """Load a user's workspace token from the local JSON file.
+
+    Args:
+        user_id:   Unique identifier for the user.
+        token_dir: Directory for token files.
+
+    Returns:
+        TokenData if the file exists and is valid JSON, else None.
+    """
+    path = _token_path(user_id, token_dir)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return _dict_to_token(data)
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        log.warning("Failed to parse local workspace token for user_id=%r: %s", user_id, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Refresh proxy (calls myownlobster.ai — side-effecting)
+# ---------------------------------------------------------------------------
+
+
+def _refresh_token_via_proxy(refresh_token: str) -> Optional[TokenData]:
+    """Obtain a new workspace access token by calling the myownlobster refresh proxy.
+
+    myownlobster.ai holds the GCP client_id + client_secret and proxies the
+    refresh call to Google, returning only the new access_token and expires_in.
+
+    Args:
+        refresh_token: The long-lived refresh token.
+
+    Returns:
+        A new TokenData (refresh_token preserved from caller), or None on error.
+    """
+    api_base = _myownlobster_api_base()
+    url = f"{api_base}{_REFRESH_ENDPOINT}"
+
+    try:
+        headers = _internal_auth_header()
+    except RuntimeError as exc:
+        log.error("Workspace token refresh proxy: %s", exc)
+        return None
+
+    try:
+        resp = requests.post(
+            url,
+            json={"refresh_token": refresh_token},
+            headers=headers,
+            timeout=_HTTP_TIMEOUT,
+        )
+    except requests.exceptions.RequestException as exc:
+        log.warning("Workspace token refresh proxy unreachable: %s", exc)
+        return None
+
+    if not resp.ok:
+        log.warning(
+            "Workspace token refresh proxy returned %d: %s",
+            resp.status_code,
+            resp.text[:200],
+        )
+        return None
+
+    try:
+        data = resp.json()
+        access_token = data["access_token"]
+        expires_in = int(data["expires_in"])
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        log.warning("Workspace token refresh proxy returned unexpected payload: %s", exc)
+        return None
+
+    expires_at = datetime.now(tz=timezone.utc) + timedelta(seconds=expires_in)
+
+    log.info("Workspace token refresh via proxy succeeded.")
+    return TokenData(
+        access_token=access_token,
+        expires_at=expires_at,
+        scope="",  # scope not returned by refresh proxy; preserved from disk
+        refresh_token=None,  # caller must preserve the original refresh_token
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def save_token(
+    user_id: str,
+    token: TokenData,
+    token_dir: Path = _TOKEN_DIR,
+) -> None:
+    """Persist a user's Google Workspace OAuth token to local disk.
+
+    This is the sole write path. The local file is the canonical store.
+
+    Args:
+        user_id:   Unique identifier for the user (Telegram chat_id as str).
+        token:     TokenData to persist.
+        token_dir: Local token directory (injectable for testing).
+    """
+    _save_token_local(user_id, token, token_dir)
+
+
+def load_token(
+    user_id: str,
+    token_dir: Path = _TOKEN_DIR,
+) -> Optional[TokenData]:
+    """Load a user's Google Workspace OAuth token from local disk.
+
+    Args:
+        user_id:   Unique identifier for the user.
+        token_dir: Local token directory (injectable for testing).
+
+    Returns:
+        TokenData if the file exists and is parseable, else None.
+    """
+    return _load_token_local(user_id, token_dir)
+
+
+def get_valid_token(
+    user_id: str,
+    token_dir: Path = _TOKEN_DIR,
+) -> Optional[TokenData]:
+    """Return a valid Google Workspace access token for the user, refreshing if necessary.
+
+    Workflow:
+    1. Load token from local disk.
+    2. If no token -> return None (user must authenticate via consent link).
+    3. If token is still valid -> return it.
+    4. If token is expired -> call myownlobster refresh proxy.
+    5. Persist the refreshed token (preserving the original refresh_token).
+    6. If refresh fails -> log and return None.
+
+    Args:
+        user_id:   Unique identifier for the user (Telegram chat_id as str).
+        token_dir: Local token directory (injectable for testing).
+
+    Returns:
+        A valid TokenData, or None if no valid token is available.
+    """
+    token = _load_token_local(user_id, token_dir)
+    if token is None:
+        log.info("No local workspace token found for user_id=%r.", user_id)
+        return None
+
+    if is_token_valid(token):
+        return token
+
+    # Token is expired — attempt refresh via myownlobster proxy
+    if token.refresh_token is None:
+        log.warning(
+            "Workspace token for user_id=%r is expired and has no refresh_token; "
+            "user must re-authenticate.",
+            user_id,
+        )
+        return None
+
+    log.info("Workspace access token expired for user_id=%r — refreshing via proxy.", user_id)
+
+    refreshed_partial = _refresh_token_via_proxy(token.refresh_token)
+    if refreshed_partial is None:
+        log.error(
+            "Workspace token refresh failed for user_id=%r — user must re-authenticate.",
+            user_id,
+        )
+        return None
+
+    # Merge: preserve scope and refresh_token from the stored token
+    refreshed = TokenData(
+        access_token=refreshed_partial.access_token,
+        expires_at=refreshed_partial.expires_at,
+        scope=token.scope,           # preserve original scope
+        refresh_token=token.refresh_token,  # Google doesn't return new refresh_token here
+    )
+
+    _save_token_local(user_id, refreshed, token_dir)
+    return refreshed

--- a/src/mcp/inbox_server_http.py
+++ b/src/mcp/inbox_server_http.py
@@ -213,6 +213,7 @@ async def health_endpoint(scope, receive, send):
 _MESSAGES_DIR: Path = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages"))
 _GCAL_TOKEN_DIR: Path = _MESSAGES_DIR / "config" / "gcal-tokens"
 _GMAIL_TOKEN_DIR: Path = _MESSAGES_DIR / "config" / "gmail-tokens"
+_WORKSPACE_TOKEN_DIR: Path = _MESSAGES_DIR / "config" / "workspace-tokens"
 _TOKEN_FILE_MODE: int = stat.S_IRUSR | stat.S_IWUSR
 
 _INTERNAL_SECRET: str = os.environ.get("LOBSTER_INTERNAL_SECRET", "").strip()
@@ -599,6 +600,98 @@ async def enrichment_status_endpoint(scope, receive, send):
     await response(scope, receive, send)
 
 
+async def push_workspace_token_endpoint(scope, receive, send):
+    """POST /api/push-workspace-token — receive a Workspace token pushed by myownlobster.ai.
+
+    Expected JSON body::
+
+        {
+          "chat_id":       "<telegram chat_id as string>",
+          "access_token":  "<string>",
+          "refresh_token": "<string>",
+          "expires_at":    "<ISO 8601 UTC string>",
+          "scope":         "<space-separated scopes>"
+        }
+
+    Authentication: ``Authorization: Bearer <LOBSTER_INTERNAL_SECRET>``
+
+    Writes the token to ``~/messages/config/workspace-tokens/{chat_id}.json``
+    with mode 0o600.
+    """
+    request = Request(scope, receive)
+
+    if not _is_authorized_internal(request):
+        response = JSONResponse({"error": "Unauthorized"}, status_code=401)
+        await response(scope, receive, send)
+        return
+
+    try:
+        body = await request.json()
+    except Exception:
+        response = JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+        await response(scope, receive, send)
+        return
+
+    chat_id = body.get("chat_id", "").strip()
+    access_token = body.get("access_token", "").strip()
+    refresh_token = body.get("refresh_token")
+    expires_at_raw = body.get("expires_at", "").strip()
+    scope_str = body.get("scope", "")
+
+    if not chat_id or not access_token or not expires_at_raw:
+        response = JSONResponse(
+            {"error": "Missing required fields: chat_id, access_token, expires_at"},
+            status_code=400,
+        )
+        await response(scope, receive, send)
+        return
+
+    # Sanitise chat_id to prevent path traversal
+    safe_chat_id = "".join(c for c in chat_id if c.isalnum() or c in ("-", "_"))
+    if not safe_chat_id:
+        response = JSONResponse({"error": "Invalid chat_id"}, status_code=400)
+        await response(scope, receive, send)
+        return
+
+    try:
+        expires_at = datetime.fromisoformat(expires_at_raw)
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+    except ValueError:
+        response = JSONResponse(
+            {"error": "Invalid expires_at: must be ISO 8601"},
+            status_code=400,
+        )
+        await response(scope, receive, send)
+        return
+
+    token_data = {
+        "access_token": access_token,
+        "expires_at": expires_at.isoformat(),
+        "scope": scope_str,
+        "refresh_token": refresh_token,
+    }
+
+    try:
+        _WORKSPACE_TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+        token_path = _WORKSPACE_TOKEN_DIR / f"{safe_chat_id}.json"
+        tmp_path = token_path.with_suffix(".json.tmp")
+        payload = json.dumps(token_data, indent=2)
+        fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _TOKEN_FILE_MODE)
+        with os.fdopen(fd, "w") as f:
+            f.write(payload)
+        os.rename(str(tmp_path), str(token_path))
+        logger.info("Workspace token pushed and saved for chat_id=%r", safe_chat_id)
+    except Exception as exc:
+        logger.error("Failed to write workspace token for chat_id=%r: %s", safe_chat_id, exc)
+        response = JSONResponse({"error": "Failed to write token"}, status_code=500)
+        await response(scope, receive, send)
+        return
+
+    response = JSONResponse({"ok": True})
+    await response(scope, receive, send)
+
+
 async def mcp_endpoint(scope, receive, send):
     """Handle all requests: auth check then delegate to MCP."""
     request = Request(scope, receive)
@@ -626,6 +719,11 @@ async def mcp_endpoint(scope, receive, send):
 
     if path == "/enrichment_status":
         await enrichment_status_endpoint(scope, receive, send)
+        return
+
+    # Workspace token push — authenticated by LOBSTER_INTERNAL_SECRET
+    if path == "/api/push-workspace-token":
+        await push_workspace_token_endpoint(scope, receive, send)
         return
 
     # Only handle /mcp

--- a/tests/unit/test_integrations/test_workspace_consent.py
+++ b/tests/unit/test_integrations/test_workspace_consent.py
@@ -1,0 +1,85 @@
+"""
+Tests for Google Workspace support in generate_consent_link.
+
+Covers:
+- generate_consent_link("workspace") returns a URL
+- generate_consent_link("workspace") sends the correct scope in the JSON payload
+- "workspace" is in _VALID_SCOPES
+- "drive" and other non-workspace scopes are still rejected
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.google_auth.consent import _VALID_SCOPES, generate_consent_link
+
+_FAKE_INSTANCE_URL = "https://vps.example.com"
+_FAKE_SECRET = "test-internal-secret-abc123"
+_FAKE_WORKSPACE_URL = "https://myownlobster.ai/connect/workspace?token=test-uuid"
+
+
+def _mock_response(url: str) -> MagicMock:
+    resp = MagicMock()
+    resp.ok = True
+    resp.status_code = 201
+    resp.json.return_value = {"url": url}
+    resp.text = f'{{"url": "{url}"}}'
+    return resp
+
+
+def _env() -> dict:
+    return {
+        "LOBSTER_INSTANCE_URL": _FAKE_INSTANCE_URL,
+        "LOBSTER_INTERNAL_SECRET": _FAKE_SECRET,
+    }
+
+
+class TestWorkspaceScopeInValidScopes:
+    def test_workspace_is_in_valid_scopes(self):
+        assert "workspace" in _VALID_SCOPES
+
+    def test_calendar_still_in_valid_scopes(self):
+        assert "calendar" in _VALID_SCOPES
+
+    def test_gmail_still_in_valid_scopes(self):
+        assert "gmail" in _VALID_SCOPES
+
+    def test_drive_not_in_valid_scopes(self):
+        assert "drive" not in _VALID_SCOPES
+
+
+class TestGenerateConsentLinkWorkspace:
+    def test_workspace_scope_returns_url(self):
+        with patch.dict("os.environ", _env()), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_response(_FAKE_WORKSPACE_URL),
+        ) as mock_post:
+            result = generate_consent_link("workspace")
+
+        assert result == _FAKE_WORKSPACE_URL
+        mock_post.assert_called_once()
+
+    def test_workspace_scope_sends_correct_payload(self):
+        with patch.dict("os.environ", _env()), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_response(_FAKE_WORKSPACE_URL),
+        ) as mock_post:
+            generate_consent_link("workspace")
+
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs.kwargs.get("json") or (call_kwargs.args[1] if len(call_kwargs.args) > 1 else None)
+        if payload is None:
+            payload = call_kwargs.kwargs["json"]
+        assert payload["scope"] == "workspace"
+
+    def test_invalid_scope_still_rejected(self):
+        with patch.dict("os.environ", _env()):
+            with pytest.raises(ValueError, match="Invalid scope"):
+                generate_consent_link("sheets")

--- a/tests/unit/test_integrations/test_workspace_token_store.py
+++ b/tests/unit/test_integrations/test_workspace_token_store.py
@@ -1,0 +1,220 @@
+"""
+Tests for src/integrations/google_workspace/token_store.py.
+
+Covers:
+- save_token / load_token: roundtrip persistence with correct file permissions
+- load_token: returns None when file absent
+- load_token: returns None when file is corrupt JSON
+- get_valid_token: returns token when valid
+- get_valid_token: returns None when no token on disk
+- get_valid_token: refreshes expired token via proxy
+- get_valid_token: returns None when refresh fails
+- get_valid_token: returns None when refresh_token is missing
+- No token values appear in logs
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.google_calendar.oauth import TokenData
+from integrations.google_workspace import token_store
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _future_token(minutes: int = 60, refresh_token: str = "test-refresh") -> TokenData:
+    """Return a TokenData with an access token that expires in the future."""
+    return TokenData(
+        access_token="test-access-token",
+        expires_at=datetime.now(tz=timezone.utc) + timedelta(minutes=minutes),
+        scope="https://www.googleapis.com/auth/documents",
+        refresh_token=refresh_token,
+    )
+
+
+def _expired_token(refresh_token: str = "test-refresh") -> TokenData:
+    """Return a TokenData that is already expired."""
+    return TokenData(
+        access_token="expired-access-token",
+        expires_at=datetime.now(tz=timezone.utc) - timedelta(hours=1),
+        scope="https://www.googleapis.com/auth/documents",
+        refresh_token=refresh_token,
+    )
+
+
+# ---------------------------------------------------------------------------
+# save_token / load_token roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestSaveLoadRoundtrip:
+    def test_roundtrip_preserves_all_fields(self, tmp_path):
+        token = _future_token()
+        token_store.save_token("user123", token, token_dir=tmp_path)
+        loaded = token_store.load_token("user123", token_dir=tmp_path)
+
+        assert loaded is not None
+        assert loaded.access_token == token.access_token
+        assert loaded.scope == token.scope
+        assert loaded.refresh_token == token.refresh_token
+        # expires_at should be close (round-trip through ISO string)
+        delta = abs((loaded.expires_at - token.expires_at).total_seconds())
+        assert delta < 1.0
+
+    def test_token_file_has_mode_0o600(self, tmp_path):
+        token = _future_token()
+        token_store.save_token("user456", token, token_dir=tmp_path)
+        token_path = tmp_path / "user456.json"
+        file_stat = os.stat(token_path)
+        permissions = stat.S_IMODE(file_stat.st_mode)
+        assert permissions == 0o600
+
+    def test_token_file_is_valid_json(self, tmp_path):
+        token = _future_token()
+        token_store.save_token("user789", token, token_dir=tmp_path)
+        token_path = tmp_path / "user789.json"
+        data = json.loads(token_path.read_text())
+        assert "access_token" in data
+        assert "expires_at" in data
+
+    def test_save_creates_directory_if_needed(self, tmp_path):
+        nested_dir = tmp_path / "nested" / "deep" / "dir"
+        assert not nested_dir.exists()
+        token = _future_token()
+        token_store.save_token("user1", token, token_dir=nested_dir)
+        assert nested_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# load_token — edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestLoadToken:
+    def test_returns_none_when_file_absent(self, tmp_path):
+        result = token_store.load_token("nonexistent_user", token_dir=tmp_path)
+        assert result is None
+
+    def test_returns_none_for_corrupt_json(self, tmp_path):
+        (tmp_path / "corrupt.json").write_text("not valid json")
+        result = token_store.load_token("corrupt", token_dir=tmp_path)
+        assert result is None
+
+    def test_returns_none_for_missing_required_field(self, tmp_path):
+        (tmp_path / "incomplete.json").write_text('{"access_token": "tok"}')
+        result = token_store.load_token("incomplete", token_dir=tmp_path)
+        assert result is None
+
+    def test_sanitises_user_id(self, tmp_path):
+        """Path traversal characters are stripped from user_id."""
+        token = _future_token()
+        # Save with a safe id, verify by loading with the same raw id
+        token_store.save_token("safe123", token, token_dir=tmp_path)
+        loaded = token_store.load_token("safe123", token_dir=tmp_path)
+        assert loaded is not None
+
+    def test_raises_for_empty_user_id(self, tmp_path):
+        with pytest.raises(ValueError, match="empty filename"):
+            token_store.load_token("!!!", token_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# get_valid_token
+# ---------------------------------------------------------------------------
+
+
+class TestGetValidToken:
+    def test_returns_valid_token_without_refresh(self, tmp_path):
+        token = _future_token()
+        token_store.save_token("user1", token, token_dir=tmp_path)
+        result = token_store.get_valid_token("user1", token_dir=tmp_path)
+        assert result is not None
+        assert result.access_token == "test-access-token"
+
+    def test_returns_none_when_no_token_on_disk(self, tmp_path):
+        result = token_store.get_valid_token("no_such_user", token_dir=tmp_path)
+        assert result is None
+
+    def test_refreshes_expired_token(self, tmp_path):
+        expired = _expired_token(refresh_token="valid-refresh")
+        token_store.save_token("user_exp", expired, token_dir=tmp_path)
+
+        new_token_data = TokenData(
+            access_token="refreshed-access-token",
+            expires_at=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+            scope="",
+            refresh_token=None,
+        )
+
+        with patch.object(token_store, "_refresh_token_via_proxy", return_value=new_token_data):
+            result = token_store.get_valid_token("user_exp", token_dir=tmp_path)
+
+        assert result is not None
+        assert result.access_token == "refreshed-access-token"
+        assert result.refresh_token == "valid-refresh"  # preserved from disk
+
+    def test_returns_none_when_refresh_fails(self, tmp_path):
+        expired = _expired_token(refresh_token="valid-refresh")
+        token_store.save_token("user_fail", expired, token_dir=tmp_path)
+
+        with patch.object(token_store, "_refresh_token_via_proxy", return_value=None):
+            result = token_store.get_valid_token("user_fail", token_dir=tmp_path)
+
+        assert result is None
+
+    def test_returns_none_when_no_refresh_token(self, tmp_path):
+        expired = _expired_token(refresh_token=None)
+        token_store.save_token("user_no_refresh", expired, token_dir=tmp_path)
+        result = token_store.get_valid_token("user_no_refresh", token_dir=tmp_path)
+        assert result is None
+
+    def test_persists_refreshed_token(self, tmp_path):
+        """After a successful refresh, the new token is saved to disk."""
+        expired = _expired_token(refresh_token="valid-refresh")
+        token_store.save_token("user_persist", expired, token_dir=tmp_path)
+
+        new_token_data = TokenData(
+            access_token="newly-refreshed",
+            expires_at=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+            scope="",
+            refresh_token=None,
+        )
+
+        with patch.object(token_store, "_refresh_token_via_proxy", return_value=new_token_data):
+            token_store.get_valid_token("user_persist", token_dir=tmp_path)
+
+        # Load again without going through get_valid_token
+        persisted = token_store.load_token("user_persist", token_dir=tmp_path)
+        assert persisted is not None
+        assert persisted.access_token == "newly-refreshed"
+
+
+# ---------------------------------------------------------------------------
+# No token values in logs
+# ---------------------------------------------------------------------------
+
+
+class TestNoTokenValuesInLogs:
+    def test_access_token_not_logged(self, tmp_path, caplog):
+        import logging
+        token = _future_token()
+        with caplog.at_level(logging.DEBUG, logger="integrations.google_workspace.token_store"):
+            token_store.save_token("user_log", token, token_dir=tmp_path)
+            token_store.load_token("user_log", token_dir=tmp_path)
+            token_store.get_valid_token("user_log", token_dir=tmp_path)
+
+        for record in caplog.records:
+            assert "test-access-token" not in record.getMessage()

--- a/tests/unit/test_mcp_server/test_push_workspace_token_endpoint.py
+++ b/tests/unit/test_mcp_server/test_push_workspace_token_endpoint.py
@@ -1,0 +1,232 @@
+"""
+Tests for POST /api/push-workspace-token endpoint.
+
+Covers:
+- Happy path: valid authenticated request returns {"ok": true} and writes token file
+- Token file written to workspace-tokens/<chat_id>.json with mode 0o600
+- Atomic write: .tmp file is renamed to final path
+- Auth: missing Authorization header -> 401
+- Auth: wrong secret -> 401
+- Validation: missing chat_id -> 400
+- Validation: missing access_token -> 400
+- Validation: missing expires_at -> 400
+- Validation: invalid expires_at format -> 400
+- Path traversal: chat_id with "../" components is sanitised, not written outside token dir
+- Token values never appear in log output
+
+All file I/O uses a tmp_path fixture — no real disk writes outside the test sandbox.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from starlette.testclient import TestClient
+
+# inbox_server_http calls sys.exit(1) at import time when MCP_HTTP_TOKEN is
+# not set.  Pre-seed the env var before the first import so the module loads.
+os.environ.setdefault("MCP_HTTP_TOKEN", "test-mcp-token-placeholder")
+
+_MODULE = "src.mcp.inbox_server_http"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_SECRET = "test-workspace-secret-abc123"
+
+_VALID_BODY = {
+    "chat_id": "123456",
+    "access_token": "ya29.test-workspace-access-token",
+    "refresh_token": "1//test-workspace-refresh-token",
+    "expires_at": "2026-04-01T02:00:00Z",
+    "scope": "https://www.googleapis.com/auth/documents",
+}
+
+
+@pytest.fixture()
+def client_and_token_dir(tmp_path):
+    """Yield (TestClient, workspace_token_dir) with patched dirs and secret."""
+    workspace_token_dir = tmp_path / "config" / "workspace-tokens"
+
+    with (
+        patch(f"{_MODULE}._WORKSPACE_TOKEN_DIR", workspace_token_dir),
+        patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
+    ):
+        from src.mcp.inbox_server_http import app
+
+        client = TestClient(app, raise_server_exceptions=True)
+        yield client, workspace_token_dir
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_valid_request_returns_ok(client_and_token_dir):
+    client, _ = client_and_token_dir
+    resp = client.post(
+        "/api/push-workspace-token",
+        json=_VALID_BODY,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_token_file_written_to_correct_path(client_and_token_dir):
+    client, workspace_token_dir = client_and_token_dir
+    client.post(
+        "/api/push-workspace-token",
+        json=_VALID_BODY,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    token_path = workspace_token_dir / "123456.json"
+    assert token_path.exists()
+
+
+def test_token_file_has_mode_0o600(client_and_token_dir):
+    client, workspace_token_dir = client_and_token_dir
+    client.post(
+        "/api/push-workspace-token",
+        json=_VALID_BODY,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    token_path = workspace_token_dir / "123456.json"
+    permissions = stat.S_IMODE(os.stat(token_path).st_mode)
+    assert permissions == 0o600
+
+
+def test_token_file_contains_correct_data(client_and_token_dir):
+    client, workspace_token_dir = client_and_token_dir
+    client.post(
+        "/api/push-workspace-token",
+        json=_VALID_BODY,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    data = json.loads((workspace_token_dir / "123456.json").read_text())
+    assert data["access_token"] == _VALID_BODY["access_token"]
+    assert data["refresh_token"] == _VALID_BODY["refresh_token"]
+    assert "expires_at" in data
+    assert data["scope"] == _VALID_BODY["scope"]
+
+
+# ---------------------------------------------------------------------------
+# Auth failures
+# ---------------------------------------------------------------------------
+
+
+def test_missing_auth_header_returns_401(client_and_token_dir):
+    client, _ = client_and_token_dir
+    resp = client.post("/api/push-workspace-token", json=_VALID_BODY)
+    assert resp.status_code == 401
+
+
+def test_wrong_secret_returns_401(client_and_token_dir):
+    client, _ = client_and_token_dir
+    resp = client.post(
+        "/api/push-workspace-token",
+        json=_VALID_BODY,
+        headers={"Authorization": "Bearer wrong-secret"},
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Validation failures
+# ---------------------------------------------------------------------------
+
+
+def test_missing_chat_id_returns_400(client_and_token_dir):
+    client, _ = client_and_token_dir
+    body = {**_VALID_BODY}
+    del body["chat_id"]
+    resp = client.post(
+        "/api/push-workspace-token",
+        json=body,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    assert resp.status_code == 400
+
+
+def test_missing_access_token_returns_400(client_and_token_dir):
+    client, _ = client_and_token_dir
+    body = {**_VALID_BODY}
+    del body["access_token"]
+    resp = client.post(
+        "/api/push-workspace-token",
+        json=body,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    assert resp.status_code == 400
+
+
+def test_missing_expires_at_returns_400(client_and_token_dir):
+    client, _ = client_and_token_dir
+    body = {**_VALID_BODY}
+    del body["expires_at"]
+    resp = client.post(
+        "/api/push-workspace-token",
+        json=body,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    assert resp.status_code == 400
+
+
+def test_invalid_expires_at_format_returns_400(client_and_token_dir):
+    client, _ = client_and_token_dir
+    body = {**_VALID_BODY, "expires_at": "not-a-date"}
+    resp = client.post(
+        "/api/push-workspace-token",
+        json=body,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Path traversal protection
+# ---------------------------------------------------------------------------
+
+
+def test_path_traversal_chat_id_is_sanitised(client_and_token_dir):
+    client, workspace_token_dir = client_and_token_dir
+    body = {**_VALID_BODY, "chat_id": "../../../etc/passwd"}
+    resp = client.post(
+        "/api/push-workspace-token",
+        json=body,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    # The sanitised id should be "etcpasswd" (path separators stripped)
+    # and the file should NOT be written outside the token dir
+    assert not (Path("/etc") / "passwd").exists() or True  # can't write to /etc in tests
+    # If the request succeeded, verify the file is inside token_dir
+    if resp.status_code == 200:
+        written_files = list(workspace_token_dir.rglob("*.json"))
+        for f in written_files:
+            assert workspace_token_dir in f.parents or f.parent == workspace_token_dir
+
+
+# ---------------------------------------------------------------------------
+# No token values in logs
+# ---------------------------------------------------------------------------
+
+
+def test_access_token_not_logged(client_and_token_dir, caplog):
+    client, _ = client_and_token_dir
+    with caplog.at_level(logging.DEBUG):
+        client.post(
+            "/api/push-workspace-token",
+            json=_VALID_BODY,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+    for record in caplog.records:
+        assert "ya29.test-workspace-access-token" not in record.getMessage()


### PR DESCRIPTION
## Summary

Implements Slice 1 of the Google Workspace skill (#59): the full OAuth token pipeline so a Lobster instance can acquire, store, and refresh a Google Workspace token.

**Note:** This branch is based on `feature/bis256-gmail-skill` (Gmail skill + consent.py infrastructure). It should be merged after that branch merges to main.

New files:
- `src/integrations/google_workspace/__init__.py`
- `src/integrations/google_workspace/config.py` — WORKSPACE_SCOPES, is_enabled()
- `src/integrations/google_workspace/token_store.py` — save/load/refresh (mirrors gmail pattern)

Modified files:
- `src/integrations/google_auth/consent.py` — add "workspace" to _VALID_SCOPES
- `src/mcp/inbox_server_http.py` — add /api/push-workspace-token endpoint

35 passing tests covering: token roundtrip, 0o600 permissions, push endpoint auth/validation, no-secrets-in-logs.

**Depends on:** myownlobster PR `feat/workspace-mol-slice-1` (workspace scope in consent-link + new refresh endpoint)

## Test plan

- [ ] `uv run pytest tests/unit/test_integrations/test_workspace_consent.py tests/unit/test_integrations/test_workspace_token_store.py tests/unit/test_mcp_server/test_push_workspace_token_endpoint.py -v` — 35 tests pass

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)