### PR TITLE
feat(workspace): Slice 2 — read a Google Doc (#60)

### DIFF
--- a/lobster-shop/google-workspace/behavior/system.md
+++ b/lobster-shop/google-workspace/behavior/system.md
@@ -1,0 +1,151 @@
+## Google Workspace — Dual-Mode Behavior
+
+This skill operates in two modes depending on whether the user has connected their Google Workspace account.
+
+### How to detect which mode to use
+
+Run this check (takes < 1 second, no network call):
+
+```python
+import sys
+import os
+sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+from integrations.google_workspace.token_store import load_token
+from mcp.user_model.owner import read_owner
+
+owner = read_owner()
+OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
+token = load_token(OWNER_USER_ID)
+is_authenticated = token is not None
+```
+
+---
+
+### Mode A: Unauthenticated (no token on disk)
+
+Call `generate_consent_link("workspace")` to send the user a one-time consent URL.
+If `generate_consent_link` raises, degrade gracefully with a user-friendly message.
+
+```python
+import sys
+import os
+sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+from integrations.google_auth.consent import generate_consent_link
+import logging
+
+log = logging.getLogger(__name__)
+
+try:
+    url = generate_consent_link("workspace")
+    reply = (
+        "To connect Google Workspace (Docs, Drive, Sheets), tap this link "
+        "(expires in 30 minutes):\n"
+        f"[Connect Google Workspace]({url})\n\n"
+        "After connecting, I'll be able to read, create, and edit your Google Docs, "
+        "list Drive files, and read/write Sheets."
+    )
+except Exception as exc:
+    log.warning("generate_consent_link('workspace') failed: %s", exc)
+    reply = (
+        "I couldn't generate a Google Workspace connection link right now. "
+        "Please try again in a few minutes, or check that LOBSTER_INSTANCE_URL "
+        "and LOBSTER_INTERNAL_SECRET are set in config.env."
+    )
+    # Do NOT surface exc, env var names, or token values to the user.
+```
+
+---
+
+### Mode B: Authenticated — Read a Google Doc
+
+Always delegate to a background subagent — network calls take longer than 7 seconds total.
+
+```
+send_reply(chat_id, "Reading your doc...")
+Task(prompt="...", subagent_type="general-purpose", run_in_background=true)
+```
+
+Subagent code pattern:
+
+```python
+import sys
+import os
+sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+from integrations.google_workspace.docs_client import gdocs_read
+from mcp.user_model.owner import read_owner
+
+owner = read_owner()
+OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
+
+# doc_id_or_url comes from the user's message (doc ID or full docs.google.com URL)
+content = gdocs_read(user_id=OWNER_USER_ID, doc_id_or_url=doc_id_or_url)
+if content is None:
+    reply = "I couldn't read that document. Make sure Google Workspace is connected and you have access to the doc."
+else:
+    # Truncate very long docs for Telegram display
+    if len(content) > 3000:
+        reply = content[:3000] + "\n\n[...doc continues — ask me to search for specific sections]"
+    else:
+        reply = content
+```
+
+---
+
+### Auth trigger ("/workspace connect", "connect my Google", "link Google Workspace")
+
+Respond immediately on the main thread — no subagent needed:
+
+```python
+import sys
+import os
+sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+from integrations.google_auth.consent import generate_consent_link
+import logging
+
+log = logging.getLogger(__name__)
+
+try:
+    url = generate_consent_link("workspace")
+    reply = (
+        "Tap this link to connect Google Workspace (expires in 30 minutes):\n"
+        f"[Connect Google Workspace]({url})\n\n"
+        "This grants access to Google Docs, Drive, and Sheets. "
+        "After connecting, try /gdocs, /gdrive, or /gsheets."
+    )
+except Exception as exc:
+    log.warning("generate_consent_link('workspace') failed — degrading gracefully: %s", exc)
+    reply = (
+        "I couldn't generate a Google Workspace connection link right now. "
+        "Please try again in a few minutes."
+    )
+```
+
+---
+
+### Natural language patterns to recognize
+
+| Pattern | Intent |
+|---------|--------|
+| "read my doc [URL or title]" / "show me [doc]" / "what's in [doc]" | Read Doc → `gdocs_read` |
+| "create a doc called X" / "make a new document" | Create Doc → `gdocs_create` (Slice 3) |
+| "write [content] to my doc" / "add this to my document" | Edit Doc → `gdocs_edit` (Slice 3) |
+| "list my Drive files" / "what's in my Drive" | List Drive → `gdrive_list` (Slice 4) |
+| "find docs about X" / "search Drive for X" | Search Drive → `gdrive_search` (Slice 4) |
+| "read cells A1:C10 of [sheet]" / "show me my spreadsheet" | Read Sheet → `gsheets_read` (Slice 5) |
+| "update [sheet] with [data]" / "write to my spreadsheet" | Write Sheet → `gsheets_write` (Slice 6) |
+| "connect Google" / "/workspace connect" / "link my Google account" | Auth flow |
+
+---
+
+### Graceful degradation
+
+If any client function returns None (auth failure, network error, doc not found), tell the
+user the operation failed and suggest reconnecting. Never surface token values, error codes,
+or credentials in messages.
+
+---
+
+### Token location
+
+Workspace tokens live at `~/messages/config/workspace-tokens/{user_id}.json`.
+A single token covers Docs, Drive, Sheets, Gmail, and Calendar.

--- a/lobster-shop/google-workspace/context/reference.md
+++ b/lobster-shop/google-workspace/context/reference.md
@@ -1,0 +1,64 @@
+# Google Workspace — Quick Reference
+
+## Auth check
+
+```python
+from integrations.google_workspace.token_store import load_token
+token = load_token(user_id)
+is_authenticated = token is not None
+```
+
+## Token location
+
+`~/messages/config/workspace-tokens/{user_id}.json` (0o600)
+
+## Function signatures
+
+### Docs (Slice 2 — read; Slice 3 — write)
+
+```python
+from integrations.google_workspace.docs_client import gdocs_read, gdocs_create, gdocs_edit
+from integrations.google_workspace.docs_client import DocFile
+
+# Read — returns plain text or None
+content: str | None = gdocs_read(user_id: str, doc_id_or_url: str)
+
+# Create — returns DocFile or None
+doc: DocFile | None = gdocs_create(user_id: str, title: str, content: str = "")
+# DocFile.id, DocFile.title, DocFile.url
+
+# Edit — returns bool
+ok: bool = gdocs_edit(user_id: str, doc_id: str, instructions: str)
+```
+
+### Drive (Slice 4)
+
+```python
+from integrations.google_workspace.drive_client import gdrive_list, gdrive_search
+from integrations.google_workspace.drive_client import DriveFile
+
+files: list[DriveFile] = gdrive_list(user_id: str, folder_id: str = "root", max_results: int = 20)
+files: list[DriveFile] = gdrive_search(user_id: str, query: str, max_results: int = 10)
+# DriveFile.id, DriveFile.name, DriveFile.mime_type, DriveFile.modified_time, DriveFile.url
+```
+
+### Sheets (Slices 5 + 6)
+
+```python
+from integrations.google_workspace.sheets_client import gsheets_read, gsheets_write, gsheets_create
+
+rows: list[list[str]] = gsheets_read(user_id: str, sheet_id: str, range_a1: str)
+ok: bool = gsheets_write(user_id: str, sheet_id: str, range_a1: str, values: list[list])
+sheet: DriveFile | None = gsheets_create(user_id: str, title: str)
+```
+
+## Consent flow (unauthenticated)
+
+```python
+from integrations.google_auth.consent import generate_consent_link
+url = generate_consent_link("workspace")  # one-time URL, 30-min TTL
+```
+
+## Scope bundle
+
+The workspace consent grants: Docs, Drive, Drive.file, Sheets, Gmail, Calendar.

--- a/lobster-shop/google-workspace/skill.toml
+++ b/lobster-shop/google-workspace/skill.toml
@@ -1,0 +1,40 @@
+[skill]
+name = "google-workspace"
+version = "1.0.0"
+description = "Google Workspace integration: Docs, Drive, and Sheets — full read/write via API when authenticated, or one-tap consent link when not"
+author = "Lobster"
+category = "integration"
+
+[activation]
+mode = "triggered"
+triggers = ["/gdocs", "/gdrive", "/gsheets", "/workspace", "/doc", "/sheet"]
+context_patterns = [
+    "when user asks to create, read, edit, or search a Google Doc",
+    "when user mentions a Google Doc, Drive file, or Sheet by name or URL",
+    "when user wants to write something to a document",
+    "when user asks to list files in Google Drive",
+    "when user wants to connect Google Workspace",
+    "when user asks to create a spreadsheet or read spreadsheet data",
+    "when user mentions docs.google.com or drive.google.com or sheets.google.com",
+]
+
+[layering]
+priority = 40
+merge_strategy = "append"
+
+[provides]
+mcp_tools = []
+bot_commands = ["/gdocs", "/gdrive", "/gsheets", "/workspace", "/doc", "/sheet"]
+
+[compatibility]
+enhances = ["gmail", "gcal-links"]
+conflicts = []
+
+[dependencies]
+pip = ["google-api-python-client", "google-auth", "google-auth-httplib2"]
+npm = []
+system = []
+api_keys = []
+
+[dependencies.runtime]
+python = ">=3.11"

--- a/src/integrations/google_workspace/docs_client.py
+++ b/src/integrations/google_workspace/docs_client.py
@@ -1,0 +1,200 @@
+"""
+Google Docs API client — read operations.
+
+Provides ``gdocs_read`` to fetch the full plain-text content of a Google Doc
+by its document ID.  Write operations (create/edit) are in this same module
+but are covered by Slice 3.
+
+Design principles (consistent with gmail and calendar clients):
+- Immutable value objects (frozen dataclasses)
+- Pure helpers isolated from I/O
+- Side effects (network calls, token refresh) at the boundaries
+- No credentials or token values ever appear in logs
+- Returns None (not raises) on auth failure or API error for graceful degradation
+
+Google Docs REST API docs:
+    https://developers.google.com/docs/api/reference/rest
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+import requests
+
+from integrations.google_workspace.token_store import get_valid_token
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# API constants
+# ---------------------------------------------------------------------------
+
+_DOCS_API_BASE: str = "https://docs.googleapis.com/v1/documents"
+_HTTP_TIMEOUT: int = 15
+
+
+# ---------------------------------------------------------------------------
+# Domain types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DocFile:
+    """Immutable representation of a Google Doc.
+
+    Attributes:
+        id:    The document's unique ID (from the Google Docs URL).
+        title: The document title as set in Google Docs.
+        url:   Full HTTPS URL to open the document in a browser.
+    """
+
+    id: str
+    title: str
+    url: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def _doc_id_from_url(doc_id_or_url: str) -> str:
+    """Extract the document ID from a full Google Docs URL, or return as-is.
+
+    Accepts:
+    - A raw document ID: ``1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms``
+    - A full URL: ``https://docs.google.com/document/d/<ID>/edit``
+    - A URL without the path suffix
+
+    Returns the document ID string.
+    """
+    match = re.search(r"/document/d/([a-zA-Z0-9_-]+)", doc_id_or_url)
+    if match:
+        return match.group(1)
+    return doc_id_or_url.strip()
+
+
+def _extract_text_from_doc(doc_json: dict) -> str:
+    """Extract plain text from a Google Docs API response.
+
+    Traverses the structural elements (paragraphs, table cells, etc.) and
+    concatenates their text content. Preserves paragraph breaks.
+
+    Args:
+        doc_json: Parsed JSON response from the Docs API ``GET /documents/{id}`` endpoint.
+
+    Returns:
+        Plain-text string with newlines between structural elements.
+    """
+    parts: list[str] = []
+
+    def _extract_paragraph_text(paragraph: dict) -> str:
+        text_parts = []
+        for element in paragraph.get("elements", []):
+            text_run = element.get("textRun", {})
+            content = text_run.get("content", "")
+            if content:
+                text_parts.append(content)
+        return "".join(text_parts)
+
+    for body_element in doc_json.get("body", {}).get("content", []):
+        if "paragraph" in body_element:
+            text = _extract_paragraph_text(body_element["paragraph"])
+            if text:
+                parts.append(text)
+        elif "table" in body_element:
+            for row in body_element["table"].get("tableRows", []):
+                for cell in row.get("tableCells", []):
+                    for cell_element in cell.get("content", []):
+                        if "paragraph" in cell_element:
+                            text = _extract_paragraph_text(cell_element["paragraph"])
+                            if text:
+                                parts.append(text)
+
+    return "".join(parts).strip()
+
+
+# ---------------------------------------------------------------------------
+# Internal I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def _call_docs_api(
+    path: str,
+    access_token: str,
+    method: str = "GET",
+    json_body: Optional[dict] = None,
+) -> Optional[dict]:
+    """Make an authenticated call to the Google Docs API.
+
+    Args:
+        path:         URL path after the API base (e.g. ``"/1abc123"``).
+        access_token: Bearer token for Google API auth.
+        method:       HTTP method (``"GET"`` or ``"POST"``).
+        json_body:    Optional JSON body for POST/PATCH requests.
+
+    Returns:
+        Parsed JSON response dict, or None on any error (auth, network, API).
+    """
+    url = f"{_DOCS_API_BASE}{path}"
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    try:
+        if method == "GET":
+            resp = requests.get(url, headers=headers, timeout=_HTTP_TIMEOUT)
+        else:
+            resp = requests.post(url, headers=headers, json=json_body, timeout=_HTTP_TIMEOUT)
+    except requests.exceptions.RequestException as exc:
+        log.warning("Docs API network error (%s %s): %s", method, path, exc)
+        return None
+
+    if resp.status_code == 401:
+        log.warning("Docs API: 401 Unauthorized — token may be expired (path=%s)", path)
+        return None
+
+    if not resp.ok:
+        log.warning("Docs API returned %d for %s %s", resp.status_code, method, path)
+        return None
+
+    try:
+        return resp.json()
+    except ValueError as exc:
+        log.warning("Docs API returned non-JSON for %s %s: %s", method, path, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public API — read operations (Slice 2)
+# ---------------------------------------------------------------------------
+
+
+def gdocs_read(user_id: str, doc_id_or_url: str) -> Optional[str]:
+    """Read the plain-text content of a Google Doc.
+
+    Fetches the full document structure from the Google Docs API and extracts
+    plain text from all paragraphs and table cells.
+
+    Args:
+        user_id:       Telegram chat_id used to look up the workspace token.
+        doc_id_or_url: Google Docs document ID or full document URL.
+
+    Returns:
+        Plain-text string with the document content, or None if the document
+        cannot be accessed (no token, doc not found, API error).
+    """
+    token = get_valid_token(user_id)
+    if token is None:
+        log.info("gdocs_read: no valid workspace token for user_id=%r", user_id)
+        return None
+
+    doc_id = _doc_id_from_url(doc_id_or_url)
+
+    data = _call_docs_api(f"/{doc_id}", token.access_token)
+    if data is None:
+        return None
+
+    return _extract_text_from_doc(data)

--- a/tests/unit/test_integrations/test_docs_client_read.py
+++ b/tests/unit/test_integrations/test_docs_client_read.py
@@ -1,0 +1,284 @@
+"""
+Tests for gdocs_read in src/integrations/google_workspace/docs_client.py (Slice 2).
+
+Covers:
+- gdocs_read: returns plain text from a valid API response
+- gdocs_read: returns None when no valid token
+- gdocs_read: returns None on 401 (expired/revoked token)
+- gdocs_read: returns None on 404 (doc not found)
+- gdocs_read: returns None on network error
+- _doc_id_from_url: extracts ID from full URL
+- _doc_id_from_url: returns raw string if not a URL
+- _extract_text_from_doc: extracts text from paragraphs
+- _extract_text_from_doc: handles empty document
+- _extract_text_from_doc: handles table cells
+- No token values appear in logs
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.google_workspace.docs_client import (
+    _doc_id_from_url,
+    _extract_text_from_doc,
+    gdocs_read,
+)
+from integrations.google_calendar.oauth import TokenData
+from datetime import datetime, timedelta, timezone
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_ACCESS_TOKEN = "ya29.fake-workspace-token"
+_FAKE_DOC_ID = "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms"
+_FAKE_DOC_URL = f"https://docs.google.com/document/d/{_FAKE_DOC_ID}/edit"
+
+
+def _valid_token() -> TokenData:
+    return TokenData(
+        access_token=_FAKE_ACCESS_TOKEN,
+        expires_at=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+        scope="https://www.googleapis.com/auth/documents",
+        refresh_token="test-refresh",
+    )
+
+
+def _mock_doc_response(text: str = "Hello, World!") -> dict:
+    """Build a minimal Docs API response body."""
+    return {
+        "documentId": _FAKE_DOC_ID,
+        "title": "Test Document",
+        "body": {
+            "content": [
+                {
+                    "paragraph": {
+                        "elements": [
+                            {"textRun": {"content": text}}
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+
+
+def _http_response(status_code: int = 200, json_data: dict = None) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.ok = status_code < 400
+    resp.json.return_value = json_data or {}
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _doc_id_from_url — pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestDocIdFromUrl:
+    def test_extracts_id_from_full_edit_url(self):
+        result = _doc_id_from_url(_FAKE_DOC_URL)
+        assert result == _FAKE_DOC_ID
+
+    def test_extracts_id_from_view_url(self):
+        url = f"https://docs.google.com/document/d/{_FAKE_DOC_ID}/view"
+        result = _doc_id_from_url(url)
+        assert result == _FAKE_DOC_ID
+
+    def test_returns_raw_id_when_no_url_match(self):
+        result = _doc_id_from_url(_FAKE_DOC_ID)
+        assert result == _FAKE_DOC_ID
+
+    def test_strips_whitespace_from_raw_id(self):
+        result = _doc_id_from_url(f"  {_FAKE_DOC_ID}  ")
+        assert result == _FAKE_DOC_ID
+
+
+# ---------------------------------------------------------------------------
+# _extract_text_from_doc — pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTextFromDoc:
+    def test_extracts_paragraph_text(self):
+        doc = _mock_doc_response("Hello, World!\n")
+        result = _extract_text_from_doc(doc)
+        assert "Hello, World!" in result
+
+    def test_handles_empty_document(self):
+        doc = {"body": {"content": []}}
+        result = _extract_text_from_doc(doc)
+        assert result == ""
+
+    def test_handles_missing_body(self):
+        result = _extract_text_from_doc({})
+        assert result == ""
+
+    def test_concatenates_multiple_paragraphs(self):
+        doc = {
+            "body": {
+                "content": [
+                    {"paragraph": {"elements": [{"textRun": {"content": "Line 1\n"}}]}},
+                    {"paragraph": {"elements": [{"textRun": {"content": "Line 2\n"}}]}},
+                ]
+            }
+        }
+        result = _extract_text_from_doc(doc)
+        assert "Line 1" in result
+        assert "Line 2" in result
+
+    def test_handles_table_cells(self):
+        doc = {
+            "body": {
+                "content": [
+                    {
+                        "table": {
+                            "tableRows": [
+                                {
+                                    "tableCells": [
+                                        {
+                                            "content": [
+                                                {
+                                                    "paragraph": {
+                                                        "elements": [
+                                                            {"textRun": {"content": "Cell text"}}
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+        result = _extract_text_from_doc(doc)
+        assert "Cell text" in result
+
+    def test_skips_empty_text_runs(self):
+        doc = {
+            "body": {
+                "content": [
+                    {"paragraph": {"elements": [{"textRun": {"content": ""}}]}}
+                ]
+            }
+        }
+        result = _extract_text_from_doc(doc)
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# gdocs_read — integration tests (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestGdocsRead:
+    def test_returns_text_on_success(self):
+        doc_json = _mock_doc_response("Document content here.\n")
+        http_resp = _http_response(200, doc_json)
+
+        with patch(
+            "integrations.google_workspace.docs_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.docs_client.requests.get",
+            return_value=http_resp,
+        ):
+            result = gdocs_read("user123", _FAKE_DOC_ID)
+
+        assert result is not None
+        assert "Document content here." in result
+
+    def test_returns_none_when_no_token(self):
+        with patch(
+            "integrations.google_workspace.docs_client.get_valid_token",
+            return_value=None,
+        ):
+            result = gdocs_read("user123", _FAKE_DOC_ID)
+
+        assert result is None
+
+    def test_returns_none_on_401(self):
+        with patch(
+            "integrations.google_workspace.docs_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.docs_client.requests.get",
+            return_value=_http_response(401),
+        ):
+            result = gdocs_read("user123", _FAKE_DOC_ID)
+
+        assert result is None
+
+    def test_returns_none_on_404(self):
+        with patch(
+            "integrations.google_workspace.docs_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.docs_client.requests.get",
+            return_value=_http_response(404),
+        ):
+            result = gdocs_read("user123", "nonexistent-doc-id")
+
+        assert result is None
+
+    def test_returns_none_on_network_error(self):
+        import requests as req_lib
+        with patch(
+            "integrations.google_workspace.docs_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.docs_client.requests.get",
+            side_effect=req_lib.exceptions.ConnectionError("connection refused"),
+        ):
+            result = gdocs_read("user123", _FAKE_DOC_ID)
+
+        assert result is None
+
+    def test_accepts_full_url(self):
+        doc_json = _mock_doc_response("URL-based read.\n")
+        http_resp = _http_response(200, doc_json)
+
+        with patch(
+            "integrations.google_workspace.docs_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.docs_client.requests.get",
+            return_value=http_resp,
+        ) as mock_get:
+            gdocs_read("user123", _FAKE_DOC_URL)
+
+        # Verify the call used the extracted doc ID, not the full URL
+        called_url = mock_get.call_args[0][0]
+        assert _FAKE_DOC_ID in called_url
+        assert "docs.google.com" not in called_url  # full URL not passed to API
+
+    def test_access_token_not_in_logs(self, caplog):
+        import logging
+        doc_json = _mock_doc_response("Test\n")
+        http_resp = _http_response(200, doc_json)
+
+        with caplog.at_level(logging.DEBUG, logger="integrations.google_workspace.docs_client"):
+            with patch(
+                "integrations.google_workspace.docs_client.get_valid_token",
+                return_value=_valid_token(),
+            ), patch(
+                "integrations.google_workspace.docs_client.requests.get",
+                return_value=http_resp,
+            ):
+                gdocs_read("user123", _FAKE_DOC_ID)
+
+        for record in caplog.records:
+            assert _FAKE_ACCESS_TOKEN not in record.getMessage()


### PR DESCRIPTION
## Summary

- Implements `gdocs_read(user_id, doc_id_or_url) -> Optional[str]` that fetches and extracts plain text from a Google Doc
- Adds `_doc_id_from_url` (URL/ID parsing) and `_extract_text_from_doc` (body traversal including tables)
- Adds Google Workspace skill files: `skill.toml`, `behavior/system.md`, `context/reference.md` with dual-mode pattern (unauthenticated → consent link, authenticated → subagent)
- 17 passing unit tests covering success, error codes, network errors, URL acceptance, and no-token-in-logs

## Test plan

- [ ] `uv run pytest tests/unit/test_integrations/test_docs_client_read.py -v` — 17 tests pass
- [ ] Depends on Slice 1 (PR #1639) being merged first

**Slice chain**: #59 (Slice 1) → this PR (Slice 2) → #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)