### PR TITLE
feat(workspace): Slice 5 — Google Sheets read (#63)

### DIFF
--- a/lobster-shop/gmail/behavior/system.md
+++ b/lobster-shop/gmail/behavior/system.md
@@ -1,0 +1,173 @@
+## Gmail — Dual-Mode Behavior
+
+This skill operates in two modes depending on whether the user has connected their Gmail account.
+
+### How to detect which mode to use
+
+Run this check (takes < 1 second, no network call):
+
+```python
+import sys
+import os
+sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+from integrations.gmail.token_store import load_token
+from mcp.user_model.owner import read_owner
+
+owner = read_owner()
+OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
+token = load_token(OWNER_USER_ID)
+is_authenticated = token is not None
+```
+
+---
+
+### Mode A: Unauthenticated (no token on disk)
+
+Call `generate_consent_link("gmail")` to send the user a one-time consent URL.
+If `generate_consent_link` raises, degrade gracefully with a user-friendly message.
+
+```python
+import sys
+import os
+sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+from integrations.google_auth.consent import generate_consent_link
+import logging
+
+log = logging.getLogger(__name__)
+
+try:
+    url = generate_consent_link("gmail")
+    reply = (
+        "To connect your Gmail, tap this link (expires in 30 minutes):\n"
+        f"[Connect Gmail]({url})\n\n"
+        "After connecting, I'll be able to read and search your emails."
+    )
+except Exception as exc:
+    log.warning("generate_consent_link('gmail') failed: %s", exc)
+    reply = (
+        "I couldn't generate a Gmail connection link right now. "
+        "Please try again in a few minutes, or check that LOBSTER_INSTANCE_URL "
+        "and LOBSTER_INTERNAL_SECRET are set in config.env."
+    )
+    # Do NOT surface exc, env var names, or token values to the user.
+```
+
+---
+
+### Mode B: Authenticated (token exists)
+
+Read Gmail via the API. Always delegate to a background subagent — network calls
+take longer than 7 seconds total.
+
+```
+send_reply(chat_id, "Checking your inbox...")
+Task(prompt="...", subagent_type="general-purpose", run_in_background=true)
+```
+
+#### Reading recent emails ("check my email", "what emails do I have", "any new messages")
+
+Subagent code pattern:
+
+```python
+import sys
+import os
+sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+from integrations.gmail.client import get_recent_emails
+from mcp.user_model.owner import read_owner
+
+owner = read_owner()
+OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
+
+emails = get_recent_emails(user_id=OWNER_USER_ID, max_results=5)
+if not emails:
+    reply = "No recent emails in your inbox, or Gmail is not connected."
+else:
+    lines = []
+    for e in emails:
+        date_str = e.date.strftime("%a %b %-d, %-I:%M %p UTC")
+        subject = e.subject or "(no subject)"
+        lines.append(f"- {date_str} | {e.sender}: {subject}")
+    reply = f"Your {len(emails)} most recent emails:\n" + "\n".join(lines)
+```
+
+#### Searching emails ("find emails from X", "search for Y in my email")
+
+```python
+import sys
+import os
+sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+from integrations.gmail.client import search_emails
+from mcp.user_model.owner import read_owner
+
+owner = read_owner()
+OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
+
+# query is the Gmail search string derived from user's message
+emails = search_emails(user_id=OWNER_USER_ID, query=query, max_results=5)
+if not emails:
+    reply = f"No emails found matching \"{query}\"."
+else:
+    lines = []
+    for e in emails:
+        date_str = e.date.strftime("%a %b %-d")
+        subject = e.subject or "(no subject)"
+        lines.append(f"- {date_str} | {e.sender}: {subject}")
+    reply = f"Found {len(emails)} email(s) for \"{query}\":\n" + "\n".join(lines)
+```
+
+---
+
+### Auth trigger ("connect my Gmail", "authenticate Gmail", "link Gmail account")
+
+Respond immediately on the main thread — no subagent needed:
+
+```python
+import sys
+import os
+sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+from integrations.google_auth.consent import generate_consent_link
+import logging
+
+log = logging.getLogger(__name__)
+
+try:
+    url = generate_consent_link("gmail")
+    reply = (
+        "To connect your Gmail, tap this link (expires in 30 minutes):\n"
+        f"[Connect Gmail]({url})\n\n"
+        "After connecting, I'll be able to read and search your emails."
+    )
+except Exception as exc:
+    log.warning("generate_consent_link('gmail') failed — degrading gracefully: %s", exc)
+    reply = (
+        "I couldn't generate a Gmail connection link right now. "
+        "Please try again in a few minutes."
+    )
+```
+
+---
+
+### Natural language patterns to recognize
+
+| Pattern | Intent |
+|---------|--------|
+| "check my email" / "any new emails" / "what's in my inbox" | Read recent emails |
+| "find emails from [person]" / "search for [subject] in my email" | Search emails |
+| "connect my Gmail" / "link Gmail" / "authenticate Gmail" | Auth flow |
+
+---
+
+### Graceful degradation
+
+If `get_recent_emails` or `search_emails` returns an empty list (auth failure,
+network error, empty inbox), tell the user nothing was found or Gmail is not
+connected.  Never surface token values, error codes, or credentials in messages.
+
+---
+
+### Scope isolation
+
+Gmail and Calendar OAuth flows are completely independent:
+- Gmail tokens live in `~/messages/config/gmail-tokens/`
+- Calendar tokens live in `~/messages/config/gcal-tokens/`
+- Connecting Gmail never touches the Calendar token, and vice versa.

--- a/lobster-shop/gmail/context/reference.md
+++ b/lobster-shop/gmail/context/reference.md
@@ -1,0 +1,79 @@
+## Gmail Skill — Quick Reference
+
+### Check authentication status (pure, no network)
+
+```python
+import sys
+import os
+sys.path.insert(0, os.path.expanduser("~/lobster/src"))
+from integrations.gmail.token_store import load_token
+from mcp.user_model.owner import read_owner
+
+owner = read_owner()
+OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
+token = load_token(OWNER_USER_ID)
+is_authenticated = token is not None
+```
+
+---
+
+### Generate consent URL (unauthenticated)
+
+**Module:** `src/integrations/google_auth/consent.py`
+
+```python
+from integrations.google_auth.consent import generate_consent_link
+
+try:
+    url = generate_consent_link("gmail")
+    # Send to user as: [Connect Gmail](url)
+except Exception as exc:
+    # Log warning and send a user-friendly fallback message.
+    # Never surface exc details to the user.
+    pass
+```
+
+---
+
+### Read recent emails (authenticated)
+
+**Module:** `src/integrations/gmail/client.py`
+
+```python
+from integrations.gmail.client import get_recent_emails
+
+emails = get_recent_emails(user_id=OWNER_USER_ID, max_results=10)
+# Returns List[EmailMessage] — empty list on auth failure or API error
+
+# EmailMessage fields:
+#   id: str, thread_id: str, subject: str, sender: str,
+#   date: datetime (UTC), snippet: str, labels: tuple[str, ...]
+```
+
+---
+
+### Search emails (authenticated)
+
+```python
+from integrations.gmail.client import search_emails
+
+emails = search_emails(user_id=OWNER_USER_ID, query="from:boss@example.com is:unread")
+# Returns List[EmailMessage] — empty list on auth failure or no results
+```
+
+Gmail search operators work as-is (from:, subject:, is:unread, after:, label:, etc.).
+
+---
+
+### User ID convention
+
+The owner's `user_id` is their Telegram chat_id as a string, read from
+`~/lobster-config/owner.toml`.
+All Gmail token files live in `~/messages/config/gmail-tokens/{user_id}.json`.
+
+---
+
+### Scope isolation
+
+Gmail tokens (`gmail-tokens/`) and Calendar tokens (`gcal-tokens/`) are
+separate directories.  Authenticating one never affects the other.

--- a/lobster-shop/gmail/skill.toml
+++ b/lobster-shop/gmail/skill.toml
@@ -1,0 +1,39 @@
+[skill]
+name = "gmail"
+version = "1.0.0"
+description = "Gmail integration: read recent emails and search inbox via API when authenticated, or prompt with a one-time consent URL when unauthenticated"
+author = "Lobster"
+category = "behavioral"
+
+[activation]
+mode = "triggered"
+triggers = ["/gmail", "/email", "/inbox"]
+context_patterns = [
+    "when user asks to check their email",
+    "when user asks about emails, messages, or inbox",
+    "when user wants to search their email",
+    "when user asks if they have new email",
+    "when user wants to connect or authenticate Gmail",
+    "when user mentions reading or finding an email",
+]
+
+[layering]
+priority = 40
+merge_strategy = "append"
+
+[provides]
+mcp_tools = []
+bot_commands = ["/gmail", "/email", "/inbox"]
+
+[compatibility]
+enhances = []
+conflicts = []
+
+[dependencies]
+pip = []
+npm = []
+system = []
+api_keys = []
+
+[dependencies.runtime]
+python = ">=3.11"

--- a/src/integrations/gmail/__init__.py
+++ b/src/integrations/gmail/__init__.py
@@ -1,0 +1,1 @@
+"""Gmail integration package."""

--- a/src/integrations/gmail/client.py
+++ b/src/integrations/gmail/client.py
@@ -1,0 +1,408 @@
+"""
+Gmail API client.
+
+Provides a clean, typed Python layer over the Gmail REST API so Lobster can
+list recent emails and search a user's inbox on their behalf.
+
+All HTTP calls go through ``_call_gmail_api``, the single point of contact
+with the network.  Auth failures and HTTP errors are caught and converted to
+domain exceptions; callers that want graceful degradation can use the
+high-level helpers (``get_recent_emails``, ``search_emails``) which return
+empty lists on auth failure rather than propagating exceptions.
+
+Design principles (consistent with the Google Calendar client):
+- Immutable value objects (frozen dataclasses)
+- Pure helpers isolated from I/O
+- Side effects (network calls, token refresh) kept at the boundaries
+- No credentials or token values ever appear in logs or exception messages
+- Timezone-aware datetimes throughout (UTC)
+
+Gmail REST API docs:
+    https://developers.google.com/gmail/api/reference/rest/v1/users.messages
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import requests
+
+from integrations.gmail.token_store import get_valid_token
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Gmail REST API constants
+# ---------------------------------------------------------------------------
+
+_GMAIL_API_BASE: str = "https://gmail.googleapis.com/gmail/v1"
+_USER_ID: str = "me"  # Gmail API uses "me" for the authenticated user
+
+# Timeout for HTTP requests to the Gmail API (seconds).
+_HTTP_TIMEOUT: int = 15
+
+# Maximum number of message IDs to fetch in a single list call.
+_DEFAULT_MAX_RESULTS: int = 10
+
+
+# ---------------------------------------------------------------------------
+# Domain types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EmailMessage:
+    """Immutable representation of a single Gmail message.
+
+    Attributes:
+        id:        Gmail-assigned message identifier.
+        thread_id: Thread this message belongs to.
+        subject:   Message subject line (empty string if absent).
+        sender:    Sender's name/address from the ``From`` header.
+        date:      Message date as a timezone-aware UTC datetime.
+        snippet:   Short plain-text preview of the message body.
+        labels:    Tuple of Gmail label IDs applied to this message
+                   (e.g. ``("INBOX", "UNREAD")``).
+    """
+
+    id: str
+    thread_id: str
+    subject: str
+    sender: str
+    date: datetime
+    snippet: str
+    labels: tuple[str, ...] = field(default_factory=tuple)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class GmailAPIError(RuntimeError):
+    """Raised when the Gmail API returns a non-2xx response.
+
+    The message includes the HTTP status code and a short description but
+    never the raw response body (which might contain user data) and never
+    any credential or token values.
+    """
+
+    def __init__(self, status_code: int, summary: str = "") -> None:
+        self.status_code = status_code
+        super().__init__(
+            f"Gmail API error {status_code}"
+            + (f": {summary}" if summary else "")
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_header(headers: list[dict], name: str) -> str:
+    """Extract the value of a named header from a Gmail message part headers list.
+
+    Pure function — no I/O.
+
+    Args:
+        headers: List of ``{"name": ..., "value": ...}`` dicts from the Gmail API.
+        name:    Case-insensitive header name to find.
+
+    Returns:
+        Header value string, or empty string if the header is absent.
+    """
+    name_lower = name.lower()
+    for h in headers:
+        if h.get("name", "").lower() == name_lower:
+            return h.get("value", "")
+    return ""
+
+
+def _parse_date_header(raw: str) -> datetime:
+    """Parse a Gmail ``Date`` header into a timezone-aware UTC datetime.
+
+    Gmail returns RFC 2822 date strings such as
+    ``"Wed, 1 Apr 2026 14:30:00 +0000"``.  Falls back to the current UTC
+    time if parsing fails so callers always receive a valid datetime.
+
+    Pure function — only processes the input string.
+
+    Args:
+        raw: Raw date string from the Gmail API message headers.
+
+    Returns:
+        A timezone-aware datetime in UTC.
+    """
+    from email.utils import parsedate_to_datetime
+
+    if not raw:
+        return datetime.now(tz=timezone.utc)
+    try:
+        dt = parsedate_to_datetime(raw)
+        return dt.astimezone(timezone.utc)
+    except Exception:
+        return datetime.now(tz=timezone.utc)
+
+
+def _parse_message(raw: dict) -> EmailMessage:
+    """Convert a raw Gmail message dict (full format) into an EmailMessage.
+
+    Handles missing optional fields by returning sensible defaults.
+
+    Pure function — no I/O.
+
+    Args:
+        raw: A single message object from the Gmail API (format=``"full"``).
+
+    Returns:
+        A frozen EmailMessage instance.
+    """
+    payload: dict = raw.get("payload", {})
+    headers: list[dict] = payload.get("headers", [])
+
+    subject = _parse_header(headers, "Subject")
+    sender = _parse_header(headers, "From")
+    date_str = _parse_header(headers, "Date")
+    date = _parse_date_header(date_str)
+
+    labels_raw: list[str] = raw.get("labelIds", [])
+
+    return EmailMessage(
+        id=raw.get("id", ""),
+        thread_id=raw.get("threadId", ""),
+        subject=subject,
+        sender=sender,
+        date=date,
+        snippet=raw.get("snippet", ""),
+        labels=tuple(labels_raw),
+    )
+
+
+def _auth_header(access_token: str) -> dict[str, str]:
+    """Return an Authorization header dict for a bearer token.
+
+    Pure function — constructs the header without any side effects.
+
+    Args:
+        access_token: A valid Google OAuth access token.
+
+    Returns:
+        Dict with a single ``Authorization`` key.
+    """
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+# ---------------------------------------------------------------------------
+# HTTP helper (side-effecting boundary)
+# ---------------------------------------------------------------------------
+
+
+def _call_gmail_api(
+    method: str,
+    url: str,
+    token: str,
+    **kwargs: Any,
+) -> Any:
+    """Make an authenticated HTTP call to the Gmail API.
+
+    This is the single point of network contact for all Gmail API calls.
+    All other helpers in this module call through here.
+
+    Args:
+        method: HTTP method string, e.g. ``"GET"``.
+        url:    Full API endpoint URL.
+        token:  Valid OAuth access token (used in Authorization header).
+        **kwargs: Additional keyword arguments forwarded to ``requests.request``
+                  (e.g. ``params``, ``json``).
+
+    Returns:
+        Parsed JSON response body (dict or list).
+
+    Raises:
+        GmailAPIError: If the response status code is not 2xx.
+        requests.exceptions.RequestException: On network-level failures.
+    """
+    headers = {**_auth_header(token), "Accept": "application/json"}
+    kwargs.setdefault("timeout", _HTTP_TIMEOUT)
+
+    log.debug("Gmail API %s %s", method, url)
+
+    response = requests.request(method, url, headers=headers, **kwargs)
+
+    if not response.ok:
+        try:
+            err_body: dict = response.json()
+            summary = err_body.get("error", {}).get("message", "")
+        except Exception:
+            summary = ""
+        log.warning(
+            "Gmail API returned %d for %s %s",
+            response.status_code, method, url,
+        )
+        raise GmailAPIError(status_code=response.status_code, summary=summary)
+
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_recent_emails(
+    user_id: str,
+    max_results: int = _DEFAULT_MAX_RESULTS,
+    token_dir=None,
+) -> list[EmailMessage]:
+    """Fetch recent emails from the user's Gmail inbox.
+
+    Queries the INBOX label, ordered by most recent first.  Returns an
+    empty list if the user has no valid token or if any API/network error
+    occurs.
+
+    Args:
+        user_id:     Lobster user identifier (e.g. Telegram chat_id as str).
+        max_results: Maximum number of messages to return.  Defaults to 10.
+        token_dir:   Optional Path for token directory (injectable for testing).
+
+    Returns:
+        List of EmailMessage objects ordered by most recent first.
+        Empty list on any failure.
+    """
+    kwargs = {}
+    if token_dir is not None:
+        kwargs["token_dir"] = token_dir
+    token = get_valid_token(user_id, **kwargs)
+    if token is None:
+        log.info(
+            "get_recent_emails: no valid Gmail token for user_id=%r — returning []",
+            user_id,
+        )
+        return []
+
+    list_url = f"{_GMAIL_API_BASE}/users/{_USER_ID}/messages"
+    params = {
+        "labelIds": "INBOX",
+        "maxResults": max_results,
+    }
+
+    try:
+        list_data = _call_gmail_api("GET", list_url, token.access_token, params=params)
+    except (GmailAPIError, requests.exceptions.RequestException) as exc:
+        log.warning(
+            "get_recent_emails: list call failed for user_id=%r: %s",
+            user_id, type(exc).__name__,
+        )
+        return []
+
+    message_refs: list[dict] = list_data.get("messages", [])
+    if not message_refs:
+        log.info("get_recent_emails: inbox empty for user_id=%r", user_id)
+        return []
+
+    messages: list[EmailMessage] = []
+    for ref in message_refs:
+        msg_id = ref.get("id", "")
+        if not msg_id:
+            continue
+        msg_url = f"{_GMAIL_API_BASE}/users/{_USER_ID}/messages/{msg_id}"
+        try:
+            raw_msg = _call_gmail_api(
+                "GET", msg_url, token.access_token,
+                params={"format": "full"},
+            )
+            messages.append(_parse_message(raw_msg))
+        except (GmailAPIError, requests.exceptions.RequestException) as exc:
+            log.warning(
+                "get_recent_emails: fetch failed for message_id=%r user_id=%r: %s",
+                msg_id, user_id, type(exc).__name__,
+            )
+
+    log.info(
+        "get_recent_emails: fetched %d messages for user_id=%r",
+        len(messages), user_id,
+    )
+    return messages
+
+
+def search_emails(
+    user_id: str,
+    query: str,
+    max_results: int = _DEFAULT_MAX_RESULTS,
+    token_dir=None,
+) -> list[EmailMessage]:
+    """Search Gmail using the Gmail search query syntax.
+
+    Supports all Gmail search operators (from:, subject:, is:unread, etc.).
+    Returns an empty list if the user has no valid token or on any error.
+
+    Args:
+        user_id:     Lobster user identifier.
+        query:       Gmail search query string (e.g. ``"from:boss@example.com"``).
+        max_results: Maximum number of messages to return.  Defaults to 10.
+        token_dir:   Optional Path for token directory (injectable for testing).
+
+    Returns:
+        List of EmailMessage objects matching the query.  Empty list on failure.
+    """
+    kwargs = {}
+    if token_dir is not None:
+        kwargs["token_dir"] = token_dir
+    token = get_valid_token(user_id, **kwargs)
+    if token is None:
+        log.info(
+            "search_emails: no valid Gmail token for user_id=%r — returning []",
+            user_id,
+        )
+        return []
+
+    list_url = f"{_GMAIL_API_BASE}/users/{_USER_ID}/messages"
+    params = {
+        "q": query,
+        "maxResults": max_results,
+    }
+
+    try:
+        list_data = _call_gmail_api("GET", list_url, token.access_token, params=params)
+    except (GmailAPIError, requests.exceptions.RequestException) as exc:
+        log.warning(
+            "search_emails: list call failed for user_id=%r query=%r: %s",
+            user_id, query, type(exc).__name__,
+        )
+        return []
+
+    message_refs: list[dict] = list_data.get("messages", [])
+    if not message_refs:
+        log.info(
+            "search_emails: no results for user_id=%r query=%r",
+            user_id, query,
+        )
+        return []
+
+    messages: list[EmailMessage] = []
+    for ref in message_refs:
+        msg_id = ref.get("id", "")
+        if not msg_id:
+            continue
+        msg_url = f"{_GMAIL_API_BASE}/users/{_USER_ID}/messages/{msg_id}"
+        try:
+            raw_msg = _call_gmail_api(
+                "GET", msg_url, token.access_token,
+                params={"format": "full"},
+            )
+            messages.append(_parse_message(raw_msg))
+        except (GmailAPIError, requests.exceptions.RequestException) as exc:
+            log.warning(
+                "search_emails: fetch failed for message_id=%r user_id=%r: %s",
+                msg_id, user_id, type(exc).__name__,
+            )
+
+    log.info(
+        "search_emails: fetched %d messages for user_id=%r query=%r",
+        len(messages), user_id, query,
+    )
+    return messages

--- a/src/integrations/gmail/token_store.py
+++ b/src/integrations/gmail/token_store.py
@@ -1,0 +1,407 @@
+"""
+Per-user Gmail OAuth token persistence — local-disk edition.
+
+Tokens are stored as JSON files at:
+    ~/messages/config/gmail-tokens/{user_id}.json
+
+This module is the Gmail counterpart of
+``integrations.google_calendar.token_store``.  The two share the same
+on-disk schema and the same refresh-proxy pattern; the only differences
+are the token directory path and the refresh endpoint name.
+
+Refresh flow
+------------
+When an access token is expired, this module calls the myownlobster.ai
+``/api/internal/refresh-gmail-token`` endpoint (functionally identical to
+``/api/internal/refresh-calendar-token`` — both proxy a Google OAuth
+refresh call — but kept separate for clarity and independent routing).
+
+The refresh proxy URL is read from
+``~/messages/config/gmail-config.json``::
+
+    {
+      "myownlobster_api_base": "https://myownlobster.ai"
+    }
+
+If that key is absent, ``https://myownlobster.ai`` is used as a default.
+
+Token schema on disk::
+
+    {
+        "access_token":  "<string>",
+        "expires_at":    "<ISO 8601 UTC>",
+        "scope":         "<space-separated scopes>",
+        "refresh_token": "<string or null>"
+    }
+
+Design principles
+-----------------
+- Side effects (file I/O, HTTP) are isolated to dedicated private functions.
+- ``is_token_valid`` is a pure function (delegates to
+  ``google_calendar.oauth.is_token_valid``).
+- ``get_valid_token`` composes load -> check -> maybe refresh -> persist.
+- No token values are written to logs.
+- Token file isolation: gmail-tokens/ and gcal-tokens/ are separate
+  directories; OAuth for one scope never touches the other.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+from integrations.google_calendar.oauth import (
+    OAuthError,
+    TokenData,
+    is_token_valid,
+)
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Storage locations
+# ---------------------------------------------------------------------------
+
+_HOME: Path = Path.home()
+_MESSAGES_DIR: Path = Path(os.environ.get("LOBSTER_MESSAGES", str(_HOME / "messages")))
+_TOKEN_DIR: Path = _MESSAGES_DIR / "config" / "gmail-tokens"
+_GMAIL_CONFIG_PATH: Path = _MESSAGES_DIR / "config" / "gmail-config.json"
+
+# File permissions: owner read+write only (octal 0o600)
+_TOKEN_FILE_MODE: int = stat.S_IRUSR | stat.S_IWUSR
+
+# HTTP timeout for refresh proxy calls (seconds)
+_HTTP_TIMEOUT: int = 10
+
+# Default refresh proxy base URL (GCP secrets live here)
+_DEFAULT_API_BASE: str = "https://myownlobster.ai"
+_REFRESH_ENDPOINT: str = "/api/internal/refresh-gmail-token"
+
+
+# ---------------------------------------------------------------------------
+# Gmail config loader
+# ---------------------------------------------------------------------------
+
+
+def _load_gmail_config() -> dict:
+    """Return the parsed gmail-config.json, or an empty dict if absent.
+
+    Pure-ish function: reads one file; returns a stable default on error.
+    """
+    if not _GMAIL_CONFIG_PATH.exists():
+        return {}
+    try:
+        return json.loads(_GMAIL_CONFIG_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning("Failed to parse gmail-config.json: %s", exc)
+        return {}
+
+
+def _myownlobster_api_base() -> str:
+    """Return the myownlobster API base URL from config, or the default."""
+    config = _load_gmail_config()
+    return config.get("myownlobster_api_base", _DEFAULT_API_BASE).rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Auth header helper
+# ---------------------------------------------------------------------------
+
+
+def _internal_auth_header() -> dict[str, str]:
+    """Return the Authorization header for internal API calls.
+
+    Reads LOBSTER_INTERNAL_SECRET from the environment.
+
+    Raises:
+        RuntimeError: If LOBSTER_INTERNAL_SECRET is not set.
+    """
+    secret = os.environ.get("LOBSTER_INTERNAL_SECRET", "").strip()
+    if not secret:
+        raise RuntimeError(
+            "LOBSTER_INTERNAL_SECRET is not set. "
+            "Add it to config.env to enable token refresh via myownlobster."
+        )
+    return {"Authorization": f"Bearer {secret}"}
+
+
+# ---------------------------------------------------------------------------
+# Serialisation helpers (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def _token_to_dict(token: TokenData) -> dict:
+    """Convert a TokenData to a JSON-serialisable dict."""
+    return {
+        "access_token": token.access_token,
+        "expires_at": token.expires_at.isoformat(),
+        "scope": token.scope,
+        "refresh_token": token.refresh_token,
+    }
+
+
+def _dict_to_token(data: dict) -> TokenData:
+    """Reconstruct a TokenData from a deserialised JSON dict."""
+    expires_at = datetime.fromisoformat(data["expires_at"])
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return TokenData(
+        access_token=data["access_token"],
+        expires_at=expires_at,
+        scope=data.get("scope", ""),
+        refresh_token=data.get("refresh_token"),
+    )
+
+
+def _token_path(user_id: str, token_dir: Path = _TOKEN_DIR) -> Path:
+    """Return the absolute path to a user's Gmail token file.
+
+    Pure function: no filesystem access.
+
+    Args:
+        user_id:   Telegram chat_id as a string.
+        token_dir: Directory holding per-user token files.
+
+    Returns:
+        Absolute Path to ``{token_dir}/{safe_user_id}.json``.
+
+    Raises:
+        ValueError: If the sanitised user_id would produce an empty filename.
+    """
+    safe_id = "".join(c for c in user_id if c.isalnum() or c in ("-", "_"))
+    if not safe_id:
+        raise ValueError(
+            f"user_id {user_id!r} produces an empty filename after sanitisation"
+        )
+    return token_dir / f"{safe_id}.json"
+
+
+# ---------------------------------------------------------------------------
+# Local file I/O (side-effecting)
+# ---------------------------------------------------------------------------
+
+
+def _save_token_local(
+    user_id: str,
+    token: TokenData,
+    token_dir: Path = _TOKEN_DIR,
+) -> None:
+    """Persist a user's Gmail OAuth token to a local JSON file (mode 0o600).
+
+    Uses an atomic write (write to .tmp, then rename) to avoid corruption
+    if the process is interrupted mid-write.
+
+    Args:
+        user_id:   Unique identifier for the user.
+        token:     TokenData to persist.
+        token_dir: Directory for token files.
+    """
+    token_dir.mkdir(parents=True, exist_ok=True)
+    path = _token_path(user_id, token_dir)
+    payload = json.dumps(_token_to_dict(token), indent=2)
+    tmp_path = path.with_suffix(".json.tmp")
+    try:
+        fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _TOKEN_FILE_MODE)
+        with os.fdopen(fd, "w") as f:
+            f.write(payload)
+        os.rename(str(tmp_path), str(path))
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+    log.info("Gmail token saved locally for user_id=%r at %s", user_id, path)
+
+
+def _load_token_local(
+    user_id: str,
+    token_dir: Path = _TOKEN_DIR,
+) -> Optional[TokenData]:
+    """Load a user's Gmail token from the local JSON file.
+
+    Args:
+        user_id:   Unique identifier for the user.
+        token_dir: Directory for token files.
+
+    Returns:
+        TokenData if the file exists and is valid JSON, else None.
+    """
+    path = _token_path(user_id, token_dir)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return _dict_to_token(data)
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        log.warning("Failed to parse local Gmail token for user_id=%r: %s", user_id, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Refresh proxy (calls myownlobster.ai — side-effecting)
+# ---------------------------------------------------------------------------
+
+
+def _refresh_token_via_proxy(refresh_token: str) -> Optional[TokenData]:
+    """Obtain a new Gmail access token by calling the myownlobster refresh proxy.
+
+    myownlobster.ai holds the GCP client_id + client_secret and proxies the
+    refresh call to Google, returning only the new access_token and expires_in.
+
+    Args:
+        refresh_token: The long-lived refresh token.
+
+    Returns:
+        A new TokenData (refresh_token preserved from caller), or None on error.
+    """
+    api_base = _myownlobster_api_base()
+    url = f"{api_base}{_REFRESH_ENDPOINT}"
+
+    try:
+        headers = _internal_auth_header()
+    except RuntimeError as exc:
+        log.error("Gmail token refresh proxy: %s", exc)
+        return None
+
+    try:
+        resp = requests.post(
+            url,
+            json={"refresh_token": refresh_token},
+            headers=headers,
+            timeout=_HTTP_TIMEOUT,
+        )
+    except requests.exceptions.RequestException as exc:
+        log.warning("Gmail token refresh proxy unreachable: %s", exc)
+        return None
+
+    if not resp.ok:
+        log.warning(
+            "Gmail token refresh proxy returned %d: %s",
+            resp.status_code,
+            resp.text[:200],
+        )
+        return None
+
+    try:
+        data = resp.json()
+        access_token = data["access_token"]
+        expires_in = int(data["expires_in"])
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        log.warning("Gmail token refresh proxy returned unexpected payload: %s", exc)
+        return None
+
+    expires_at = datetime.now(tz=timezone.utc) + timedelta(seconds=expires_in)
+
+    log.info("Gmail token refresh via proxy succeeded.")
+    return TokenData(
+        access_token=access_token,
+        expires_at=expires_at,
+        scope="",  # scope not returned by refresh proxy; preserved from disk
+        refresh_token=None,  # caller must preserve the original refresh_token
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def save_token(
+    user_id: str,
+    token: TokenData,
+    token_dir: Path = _TOKEN_DIR,
+) -> None:
+    """Persist a user's Gmail OAuth token to local disk.
+
+    This is the sole write path. The local file is the canonical store.
+
+    Args:
+        user_id:   Unique identifier for the user (Telegram chat_id as str).
+        token:     TokenData to persist.
+        token_dir: Local token directory (injectable for testing).
+    """
+    _save_token_local(user_id, token, token_dir)
+
+
+def load_token(
+    user_id: str,
+    token_dir: Path = _TOKEN_DIR,
+) -> Optional[TokenData]:
+    """Load a user's Gmail OAuth token from local disk.
+
+    Args:
+        user_id:   Unique identifier for the user.
+        token_dir: Local token directory (injectable for testing).
+
+    Returns:
+        TokenData if the file exists and is parseable, else None.
+    """
+    return _load_token_local(user_id, token_dir)
+
+
+def get_valid_token(
+    user_id: str,
+    token_dir: Path = _TOKEN_DIR,
+) -> Optional[TokenData]:
+    """Return a valid Gmail access token for the user, refreshing if necessary.
+
+    Workflow:
+    1. Load token from local disk.
+    2. If no token -> return None (user must authenticate via consent link).
+    3. If token is still valid -> return it.
+    4. If token is expired -> call myownlobster refresh proxy.
+    5. Persist the refreshed token (preserving the original refresh_token).
+    6. If refresh fails -> log and return None.
+
+    Args:
+        user_id:   Unique identifier for the user (Telegram chat_id as str).
+        token_dir: Local token directory (injectable for testing).
+
+    Returns:
+        A valid TokenData, or None if no valid token is available.
+    """
+    token = _load_token_local(user_id, token_dir)
+    if token is None:
+        log.info("No local Gmail token found for user_id=%r.", user_id)
+        return None
+
+    if is_token_valid(token):
+        return token
+
+    # Token is expired — attempt refresh via myownlobster proxy
+    if token.refresh_token is None:
+        log.warning(
+            "Gmail token for user_id=%r is expired and has no refresh_token; "
+            "user must re-authenticate.",
+            user_id,
+        )
+        return None
+
+    log.info("Gmail access token expired for user_id=%r — refreshing via proxy.", user_id)
+
+    refreshed_partial = _refresh_token_via_proxy(token.refresh_token)
+    if refreshed_partial is None:
+        log.error(
+            "Gmail token refresh failed for user_id=%r — user must re-authenticate.",
+            user_id,
+        )
+        return None
+
+    # Merge: preserve scope and refresh_token from the stored token
+    refreshed = TokenData(
+        access_token=refreshed_partial.access_token,
+        expires_at=refreshed_partial.expires_at,
+        scope=token.scope,           # preserve original scope
+        refresh_token=token.refresh_token,  # Google doesn't return new refresh_token here
+    )
+
+    _save_token_local(user_id, refreshed, token_dir)
+    return refreshed

--- a/src/integrations/google_auth/consent.py
+++ b/src/integrations/google_auth/consent.py
@@ -11,7 +11,8 @@ The VPS never holds GCP client credentials.  Instead it calls
 The caller (skill handler, MCP tool, etc.) sends that URL to the user;
 the user clicks it, grants consent in their browser, and myownlobster.ai
 pushes the resulting tokens back to the VPS via
-``/api/push-calendar-token`` or ``/api/push-gmail-token``.
+``/api/push-calendar-token``, ``/api/push-gmail-token``, or
+``/api/push-workspace-token``.
 
 Design principles
 -----------------
@@ -51,7 +52,7 @@ log = logging.getLogger(__name__)
 _CONSENT_ENDPOINT: str = "https://myownlobster.ai/api/generate-consent-link"
 _HTTP_TIMEOUT: int = 10
 
-_VALID_SCOPES: frozenset[str] = frozenset({"calendar", "gmail"})
+_VALID_SCOPES: frozenset[str] = frozenset({"calendar", "gmail", "workspace"})
 
 
 # ---------------------------------------------------------------------------

--- a/src/integrations/google_workspace/__init__.py
+++ b/src/integrations/google_workspace/__init__.py
@@ -1,0 +1,17 @@
+"""
+Google Workspace integration package — Docs, Drive, Sheets, Gmail, Calendar.
+
+Provides OAuth token management and API clients for Google Workspace services.
+All tokens are stored locally at ~/messages/config/workspace-tokens/{user_id}.json
+using the same stateless code pass-through OAuth pattern as the gmail and
+google_calendar integrations.
+
+Quick usage::
+
+    from integrations.google_workspace.token_store import get_valid_token
+
+    token = get_valid_token(user_id)
+    if token is None:
+        # User needs to authorize — call generate_consent_link("workspace")
+        ...
+"""

--- a/src/integrations/google_workspace/config.py
+++ b/src/integrations/google_workspace/config.py
@@ -1,0 +1,92 @@
+"""
+Google Workspace OAuth scope configuration.
+
+Defines the full scope bundle requested when a user authorizes Google Workspace
+access. The workspace scope covers Docs, Drive, Sheets, Gmail, and Calendar
+in a single consent grant, so a single token is sufficient for all operations.
+
+The ``is_enabled()`` function provides a cheap pre-flight check that degrades
+gracefully when LOBSTER_INSTANCE_URL or LOBSTER_INTERNAL_SECRET are absent.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# OAuth scopes
+# ---------------------------------------------------------------------------
+
+#: All scopes requested in the workspace consent grant.
+WORKSPACE_SCOPES: tuple[str, ...] = (
+    # Google Docs: full read/write
+    "https://www.googleapis.com/auth/documents",
+    # Google Drive: full access + app-created files
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/drive.file",
+    # Google Sheets: full read/write
+    "https://www.googleapis.com/auth/spreadsheets",
+    # Gmail: read + send + archive (included for unified-token support)
+    "https://www.googleapis.com/auth/gmail.modify",
+    # Calendar: full read/write (included for unified-token support)
+    "https://www.googleapis.com/auth/calendar",
+)
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_HOME: Path = Path.home()
+_MESSAGES_DIR: Path = Path(os.environ.get("LOBSTER_MESSAGES", str(_HOME / "messages")))
+WORKSPACE_TOKEN_DIR: Path = _MESSAGES_DIR / "config" / "workspace-tokens"
+
+
+# ---------------------------------------------------------------------------
+# is_enabled — cheap pre-flight check
+# ---------------------------------------------------------------------------
+
+
+def is_enabled() -> bool:
+    """Return True if Google Workspace can be activated for a user.
+
+    A workspace token does not need to exist yet — this checks whether the
+    OAuth flow is possible (i.e. the required environment variables are set
+    so generate_consent_link("workspace") can succeed).
+
+    Returns True if either:
+    - A workspace token already exists for any user, OR
+    - Both LOBSTER_INSTANCE_URL and LOBSTER_INTERNAL_SECRET are set in the
+      environment (meaning the consent flow is possible).
+
+    Degrades gracefully: always returns False rather than raising.
+    """
+    instance_url = os.environ.get("LOBSTER_INSTANCE_URL", "").strip()
+    internal_secret = os.environ.get("LOBSTER_INTERNAL_SECRET", "").strip()
+
+    if instance_url and internal_secret:
+        return True
+
+    # Also enabled if a token directory already exists with at least one token
+    if WORKSPACE_TOKEN_DIR.exists():
+        try:
+            if any(WORKSPACE_TOKEN_DIR.glob("*.json")):
+                return True
+        except OSError:
+            pass
+
+    missing = []
+    if not instance_url:
+        missing.append("LOBSTER_INSTANCE_URL")
+    if not internal_secret:
+        missing.append("LOBSTER_INTERNAL_SECRET")
+
+    log.warning(
+        "Google Workspace integration unavailable — missing environment variables: %s. "
+        "Set these in config.env to enable workspace features.",
+        ", ".join(missing),
+    )
+    return False

--- a/src/integrations/google_workspace/drive_client.py
+++ b/src/integrations/google_workspace/drive_client.py
@@ -1,0 +1,239 @@
+"""
+Google Drive API client — list and search operations.
+
+Provides ``gdrive_list`` and ``gdrive_search`` to enumerate files in a Drive
+folder or search by Drive query syntax.
+
+Design principles (consistent with gmail, calendar, docs clients):
+- Immutable value objects (frozen dataclasses)
+- Pure helpers isolated from I/O
+- Side effects (network calls, token refresh) at the boundaries
+- No credentials or token values ever appear in logs
+- Returns empty list (not None, not raises) on auth failure or API error
+
+Google Drive REST API v3 docs:
+    https://developers.google.com/drive/api/reference/rest/v3
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+import requests
+
+from integrations.google_workspace.token_store import get_valid_token
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# API constants
+# ---------------------------------------------------------------------------
+
+_DRIVE_API_BASE: str = "https://www.googleapis.com/drive/v3"
+_HTTP_TIMEOUT: int = 15
+
+# Fields requested from the Drive API for each file.
+_FILE_FIELDS: str = "id,name,mimeType,modifiedTime,webViewLink"
+
+# MIME type displayed for Google Docs, Sheets, Folders etc.
+_MIME_FOLDER: str = "application/vnd.google-apps.folder"
+
+
+# ---------------------------------------------------------------------------
+# Domain types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DriveFile:
+    """Immutable representation of a Google Drive file or folder.
+
+    Attributes:
+        id:            Drive file ID.
+        name:          File or folder name.
+        mime_type:     Google MIME type string (e.g. ``application/vnd.google-apps.document``).
+        modified_time: Last modification time (UTC, timezone-aware).
+        url:           HTTPS URL to open the file in a browser.
+    """
+
+    id: str
+    name: str
+    mime_type: str
+    modified_time: datetime
+    url: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def _parse_drive_file(item: dict) -> Optional[DriveFile]:
+    """Parse a single Drive API file item into a DriveFile.
+
+    Returns None if any required field is missing or malformed.
+    """
+    file_id = item.get("id", "").strip()
+    name = item.get("name", "").strip()
+    mime_type = item.get("mimeType", "").strip()
+    url = item.get("webViewLink", "").strip()
+    modified_time_str = item.get("modifiedTime", "")
+
+    if not file_id or not name:
+        return None
+
+    try:
+        modified_time = datetime.fromisoformat(modified_time_str.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        modified_time = datetime.now(tz=timezone.utc)
+
+    return DriveFile(
+        id=file_id,
+        name=name,
+        mime_type=mime_type,
+        modified_time=modified_time,
+        url=url,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def _call_drive_api(
+    path: str,
+    access_token: str,
+    params: Optional[dict] = None,
+) -> Optional[dict]:
+    """Make an authenticated GET call to the Google Drive API.
+
+    Args:
+        path:         URL path after the API base (e.g. ``"/files"``).
+        access_token: Bearer token for Google API auth.
+        params:       Optional query parameters.
+
+    Returns:
+        Parsed JSON response dict, or None on any error.
+    """
+    url = f"{_DRIVE_API_BASE}{path}"
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    try:
+        resp = requests.get(url, headers=headers, params=params or {}, timeout=_HTTP_TIMEOUT)
+    except requests.exceptions.RequestException as exc:
+        log.warning("Drive API network error (GET %s): %s", path, exc)
+        return None
+
+    if resp.status_code == 401:
+        log.warning("Drive API: 401 Unauthorized — token may be expired (path=%s)", path)
+        return None
+
+    if not resp.ok:
+        log.warning("Drive API returned %d for GET %s", resp.status_code, path)
+        return None
+
+    try:
+        return resp.json()
+    except ValueError as exc:
+        log.warning("Drive API returned non-JSON for GET %s: %s", path, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def gdrive_list(
+    user_id: str,
+    folder_id: str = "root",
+    max_results: int = 20,
+) -> list[DriveFile]:
+    """List files in a Google Drive folder.
+
+    Args:
+        user_id:     Telegram chat_id used to look up the workspace token.
+        folder_id:   Drive folder ID to list. Defaults to ``"root"`` (My Drive).
+        max_results: Maximum number of files to return (1–100).
+
+    Returns:
+        List of DriveFile objects, sorted by the Drive API default order
+        (most recently modified first). Returns ``[]`` on any error.
+    """
+    token = get_valid_token(user_id)
+    if token is None:
+        log.info("gdrive_list: no valid workspace token for user_id=%r", user_id)
+        return []
+
+    params = {
+        "q": f"'{folder_id}' in parents and trashed=false",
+        "pageSize": min(max(1, max_results), 100),
+        "fields": f"files({_FILE_FIELDS})",
+        "orderBy": "modifiedTime desc",
+    }
+
+    data = _call_drive_api("/files", token.access_token, params=params)
+    if data is None:
+        return []
+
+    files = []
+    for item in data.get("files", []):
+        parsed = _parse_drive_file(item)
+        if parsed is not None:
+            files.append(parsed)
+
+    return files
+
+
+def gdrive_search(
+    user_id: str,
+    query: str,
+    max_results: int = 10,
+) -> list[DriveFile]:
+    """Search Google Drive using Drive query syntax.
+
+    The ``query`` parameter follows the Drive API query syntax. Examples:
+    - ``"name contains 'budget'"``
+    - ``"mimeType='application/vnd.google-apps.document'"``
+    - ``"name contains 'report' and mimeType='application/vnd.google-apps.spreadsheet'"``
+
+    See: https://developers.google.com/drive/api/guides/search-files
+
+    Args:
+        user_id:     Telegram chat_id used to look up the workspace token.
+        query:       Drive API query string.
+        max_results: Maximum number of files to return (1–100).
+
+    Returns:
+        List of DriveFile objects. Returns ``[]`` on any error or no results.
+    """
+    token = get_valid_token(user_id)
+    if token is None:
+        log.info("gdrive_search: no valid workspace token for user_id=%r", user_id)
+        return []
+
+    # Always exclude trashed files
+    full_query = f"({query}) and trashed=false"
+
+    params = {
+        "q": full_query,
+        "pageSize": min(max(1, max_results), 100),
+        "fields": f"files({_FILE_FIELDS})",
+        "orderBy": "modifiedTime desc",
+    }
+
+    data = _call_drive_api("/files", token.access_token, params=params)
+    if data is None:
+        return []
+
+    files = []
+    for item in data.get("files", []):
+        parsed = _parse_drive_file(item)
+        if parsed is not None:
+            files.append(parsed)
+
+    return files

--- a/src/integrations/google_workspace/sheets_client.py
+++ b/src/integrations/google_workspace/sheets_client.py
@@ -1,0 +1,261 @@
+"""
+Google Sheets API client — read operations (Slice 5) and write operations (Slice 6).
+
+Provides:
+  - ``gsheets_read``  — fetch a cell range as a 2D list of strings (Slice 5)
+  - ``gsheets_write`` — write values to a cell range (Slice 6)
+  - ``gsheets_create`` — create a new spreadsheet (Slice 6)
+
+Design principles (consistent with other workspace clients):
+- Immutable value objects (frozen dataclasses)
+- Pure helpers isolated from I/O
+- Side effects (network calls, token refresh) at the boundaries
+- No credentials or token values ever appear in logs
+- Returns empty list / False / None on auth failure or API error
+
+Google Sheets REST API v4 docs:
+    https://developers.google.com/sheets/api/reference/rest
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Optional
+
+import requests
+
+from integrations.google_workspace.token_store import get_valid_token
+from integrations.google_workspace.drive_client import DriveFile
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# API constants
+# ---------------------------------------------------------------------------
+
+_SHEETS_API_BASE: str = "https://sheets.googleapis.com/v4/spreadsheets"
+_DRIVE_API_BASE: str = "https://www.googleapis.com/drive/v3"
+_HTTP_TIMEOUT: int = 15
+
+_MIME_SHEET: str = "application/vnd.google-apps.spreadsheet"
+
+
+# ---------------------------------------------------------------------------
+# Helpers (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def _sheet_id_from_url(sheet_id_or_url: str) -> str:
+    """Extract the spreadsheet ID from a full Google Sheets URL, or return as-is.
+
+    Accepts:
+    - A raw spreadsheet ID
+    - A full URL: ``https://docs.google.com/spreadsheets/d/<ID>/edit``
+
+    Returns the spreadsheet ID string.
+    """
+    match = re.search(r"/spreadsheets/d/([a-zA-Z0-9_-]+)", sheet_id_or_url)
+    if match:
+        return match.group(1)
+    return sheet_id_or_url.strip()
+
+
+def _normalise_row(row: list) -> list[str]:
+    """Convert all values in a row to strings."""
+    return [str(v) if v is not None else "" for v in row]
+
+
+# ---------------------------------------------------------------------------
+# Internal I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def _call_sheets_api(
+    path: str,
+    access_token: str,
+    method: str = "GET",
+    params: Optional[dict] = None,
+    json_body: Optional[dict] = None,
+) -> Optional[dict]:
+    """Make an authenticated call to the Google Sheets API.
+
+    Args:
+        path:         URL path after the Sheets API base.
+        access_token: Bearer token for Google API auth.
+        method:       ``"GET"``, ``"POST"``, or ``"PUT"``.
+        params:       Optional query parameters.
+        json_body:    Optional JSON body for write requests.
+
+    Returns:
+        Parsed JSON response dict, or None on any error.
+    """
+    url = f"{_SHEETS_API_BASE}{path}"
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    try:
+        if method == "GET":
+            resp = requests.get(url, headers=headers, params=params or {}, timeout=_HTTP_TIMEOUT)
+        elif method == "PUT":
+            resp = requests.put(
+                url, headers=headers, params=params or {}, json=json_body, timeout=_HTTP_TIMEOUT
+            )
+        else:
+            resp = requests.post(url, headers=headers, json=json_body, timeout=_HTTP_TIMEOUT)
+    except requests.exceptions.RequestException as exc:
+        log.warning("Sheets API network error (%s %s): %s", method, path, exc)
+        return None
+
+    if resp.status_code == 401:
+        log.warning("Sheets API: 401 Unauthorized — token may be expired (path=%s)", path)
+        return None
+
+    if not resp.ok:
+        log.warning("Sheets API returned %d for %s %s", resp.status_code, method, path)
+        return None
+
+    try:
+        return resp.json()
+    except ValueError as exc:
+        log.warning("Sheets API returned non-JSON for %s %s: %s", method, path, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public API — Slice 5 (read)
+# ---------------------------------------------------------------------------
+
+
+def gsheets_read(
+    user_id: str,
+    sheet_id_or_url: str,
+    range_a1: str,
+) -> list[list[str]]:
+    """Read a range of cells from a Google Sheet.
+
+    Args:
+        user_id:         Telegram chat_id used to look up the workspace token.
+        sheet_id_or_url: Spreadsheet ID or full Google Sheets URL.
+        range_a1:        A1 notation range (e.g. ``"A1:C10"``, ``"Sheet1!A1:B5"``).
+
+    Returns:
+        A 2D list of string values. Empty cells are represented as empty strings.
+        Returns ``[]`` on any error (no token, sheet not found, API error).
+    """
+    token = get_valid_token(user_id)
+    if token is None:
+        log.info("gsheets_read: no valid workspace token for user_id=%r", user_id)
+        return []
+
+    sheet_id = _sheet_id_from_url(sheet_id_or_url)
+
+    data = _call_sheets_api(
+        f"/{sheet_id}/values/{range_a1}",
+        token.access_token,
+        method="GET",
+    )
+    if data is None:
+        return []
+
+    raw_rows = data.get("values", [])
+    return [_normalise_row(row) for row in raw_rows]
+
+
+# ---------------------------------------------------------------------------
+# Public API — Slice 6 (write)
+# ---------------------------------------------------------------------------
+
+
+def gsheets_write(
+    user_id: str,
+    sheet_id_or_url: str,
+    range_a1: str,
+    values: list[list],
+) -> bool:
+    """Write values to a range in a Google Sheet.
+
+    Uses the ``values.update`` endpoint with ``valueInputOption=USER_ENTERED``
+    so formulas and dates are interpreted correctly.
+
+    Args:
+        user_id:         Telegram chat_id used to look up the workspace token.
+        sheet_id_or_url: Spreadsheet ID or full Google Sheets URL.
+        range_a1:        A1 notation range for the top-left anchor.
+        values:          2D list of values to write.
+
+    Returns:
+        True on success, False on any error.
+    """
+    token = get_valid_token(user_id)
+    if token is None:
+        log.info("gsheets_write: no valid workspace token for user_id=%r", user_id)
+        return False
+
+    sheet_id = _sheet_id_from_url(sheet_id_or_url)
+
+    body = {
+        "range": range_a1,
+        "majorDimension": "ROWS",
+        "values": values,
+    }
+
+    data = _call_sheets_api(
+        f"/{sheet_id}/values/{range_a1}",
+        token.access_token,
+        method="PUT",
+        params={"valueInputOption": "USER_ENTERED"},
+        json_body=body,
+    )
+
+    return data is not None
+
+
+def gsheets_create(
+    user_id: str,
+    title: str,
+) -> Optional[DriveFile]:
+    """Create a new Google Spreadsheet.
+
+    Args:
+        user_id: Telegram chat_id used to look up the workspace token.
+        title:   Title for the new spreadsheet.
+
+    Returns:
+        A DriveFile with the spreadsheet's ID and URL, or None on failure.
+    """
+    from datetime import timezone
+
+    token = get_valid_token(user_id)
+    if token is None:
+        log.info("gsheets_create: no valid workspace token for user_id=%r", user_id)
+        return None
+
+    body = {
+        "properties": {"title": title},
+    }
+
+    data = _call_sheets_api(
+        "",
+        token.access_token,
+        method="POST",
+        json_body=body,
+    )
+    if data is None:
+        return None
+
+    sheet_id = data.get("spreadsheetId", "")
+    url = data.get("spreadsheetUrl", "")
+    sheet_title = data.get("properties", {}).get("title", title)
+
+    if not sheet_id:
+        log.warning("gsheets_create: API response missing spreadsheetId")
+        return None
+
+    from datetime import datetime, timezone as tz_module
+    return DriveFile(
+        id=sheet_id,
+        name=sheet_title,
+        mime_type=_MIME_SHEET,
+        modified_time=datetime.now(tz=tz_module.utc),
+        url=url,
+    )

--- a/src/integrations/google_workspace/token_store.py
+++ b/src/integrations/google_workspace/token_store.py
@@ -1,0 +1,407 @@
+"""
+Per-user Google Workspace OAuth token persistence — local-disk edition.
+
+Tokens are stored as JSON files at:
+    ~/messages/config/workspace-tokens/{user_id}.json
+
+This module is the Google Workspace counterpart of
+``integrations.gmail.token_store`` and ``integrations.google_calendar.token_store``.
+The three share the same on-disk schema and the same refresh-proxy pattern;
+the only differences are the token directory path and the refresh endpoint name.
+
+Refresh flow
+------------
+When an access token is expired, this module calls the myownlobster.ai
+``/api/internal/refresh-workspace-token`` endpoint (functionally identical to
+``/api/internal/refresh-gmail-token`` — both proxy a Google OAuth refresh call
+using the server-side GCP credentials).
+
+The refresh proxy URL is read from
+``~/messages/config/workspace-config.json``::
+
+    {
+      "myownlobster_api_base": "https://myownlobster.ai"
+    }
+
+If that key is absent, ``https://myownlobster.ai`` is used as a default.
+
+Token schema on disk::
+
+    {
+        "access_token":  "<string>",
+        "expires_at":    "<ISO 8601 UTC>",
+        "scope":         "<space-separated scopes>",
+        "refresh_token": "<string or null>"
+    }
+
+Design principles
+-----------------
+- Side effects (file I/O, HTTP) are isolated to dedicated private functions.
+- ``is_token_valid`` is a pure function (delegates to
+  ``google_calendar.oauth.is_token_valid``).
+- ``get_valid_token`` composes load -> check -> maybe refresh -> persist.
+- No token values are written to logs.
+- Token file isolation: workspace-tokens/ is separate from gmail-tokens/ and
+  gcal-tokens/; OAuth for one scope never touches the other.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+from integrations.google_calendar.oauth import (
+    OAuthError,
+    TokenData,
+    is_token_valid,
+)
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Storage locations
+# ---------------------------------------------------------------------------
+
+_HOME: Path = Path.home()
+_MESSAGES_DIR: Path = Path(os.environ.get("LOBSTER_MESSAGES", str(_HOME / "messages")))
+_TOKEN_DIR: Path = _MESSAGES_DIR / "config" / "workspace-tokens"
+_WORKSPACE_CONFIG_PATH: Path = _MESSAGES_DIR / "config" / "workspace-config.json"
+
+# File permissions: owner read+write only (octal 0o600)
+_TOKEN_FILE_MODE: int = stat.S_IRUSR | stat.S_IWUSR
+
+# HTTP timeout for refresh proxy calls (seconds)
+_HTTP_TIMEOUT: int = 10
+
+# Default refresh proxy base URL (GCP secrets live here)
+_DEFAULT_API_BASE: str = "https://myownlobster.ai"
+_REFRESH_ENDPOINT: str = "/api/internal/refresh-workspace-token"
+
+
+# ---------------------------------------------------------------------------
+# Workspace config loader
+# ---------------------------------------------------------------------------
+
+
+def _load_workspace_config() -> dict:
+    """Return the parsed workspace-config.json, or an empty dict if absent.
+
+    Pure-ish function: reads one file; returns a stable default on error.
+    """
+    if not _WORKSPACE_CONFIG_PATH.exists():
+        return {}
+    try:
+        return json.loads(_WORKSPACE_CONFIG_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning("Failed to parse workspace-config.json: %s", exc)
+        return {}
+
+
+def _myownlobster_api_base() -> str:
+    """Return the myownlobster API base URL from config, or the default."""
+    config = _load_workspace_config()
+    return config.get("myownlobster_api_base", _DEFAULT_API_BASE).rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Auth header helper
+# ---------------------------------------------------------------------------
+
+
+def _internal_auth_header() -> dict[str, str]:
+    """Return the Authorization header for internal API calls.
+
+    Reads LOBSTER_INTERNAL_SECRET from the environment.
+
+    Raises:
+        RuntimeError: If LOBSTER_INTERNAL_SECRET is not set.
+    """
+    secret = os.environ.get("LOBSTER_INTERNAL_SECRET", "").strip()
+    if not secret:
+        raise RuntimeError(
+            "LOBSTER_INTERNAL_SECRET is not set. "
+            "Add it to config.env to enable token refresh via myownlobster."
+        )
+    return {"Authorization": f"Bearer {secret}"}
+
+
+# ---------------------------------------------------------------------------
+# Serialisation helpers (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def _token_to_dict(token: TokenData) -> dict:
+    """Convert a TokenData to a JSON-serialisable dict."""
+    return {
+        "access_token": token.access_token,
+        "expires_at": token.expires_at.isoformat(),
+        "scope": token.scope,
+        "refresh_token": token.refresh_token,
+    }
+
+
+def _dict_to_token(data: dict) -> TokenData:
+    """Reconstruct a TokenData from a deserialised JSON dict."""
+    expires_at = datetime.fromisoformat(data["expires_at"])
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return TokenData(
+        access_token=data["access_token"],
+        expires_at=expires_at,
+        scope=data.get("scope", ""),
+        refresh_token=data.get("refresh_token"),
+    )
+
+
+def _token_path(user_id: str, token_dir: Path = _TOKEN_DIR) -> Path:
+    """Return the absolute path to a user's workspace token file.
+
+    Pure function: no filesystem access.
+
+    Args:
+        user_id:   Telegram chat_id as a string.
+        token_dir: Directory holding per-user token files.
+
+    Returns:
+        Absolute Path to ``{token_dir}/{safe_user_id}.json``.
+
+    Raises:
+        ValueError: If the sanitised user_id would produce an empty filename.
+    """
+    safe_id = "".join(c for c in user_id if c.isalnum() or c in ("-", "_"))
+    if not safe_id:
+        raise ValueError(
+            f"user_id {user_id!r} produces an empty filename after sanitisation"
+        )
+    return token_dir / f"{safe_id}.json"
+
+
+# ---------------------------------------------------------------------------
+# Local file I/O (side-effecting)
+# ---------------------------------------------------------------------------
+
+
+def _save_token_local(
+    user_id: str,
+    token: TokenData,
+    token_dir: Path = _TOKEN_DIR,
+) -> None:
+    """Persist a user's workspace OAuth token to a local JSON file (mode 0o600).
+
+    Uses an atomic write (write to .tmp, then rename) to avoid corruption
+    if the process is interrupted mid-write.
+
+    Args:
+        user_id:   Unique identifier for the user.
+        token:     TokenData to persist.
+        token_dir: Directory for token files.
+    """
+    token_dir.mkdir(parents=True, exist_ok=True)
+    path = _token_path(user_id, token_dir)
+    payload = json.dumps(_token_to_dict(token), indent=2)
+    tmp_path = path.with_suffix(".json.tmp")
+    try:
+        fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _TOKEN_FILE_MODE)
+        with os.fdopen(fd, "w") as f:
+            f.write(payload)
+        os.rename(str(tmp_path), str(path))
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+    log.info("Workspace token saved locally for user_id=%r at %s", user_id, path)
+
+
+def _load_token_local(
+    user_id: str,
+    token_dir: Path = _TOKEN_DIR,
+) -> Optional[TokenData]:
+    """Load a user's workspace token from the local JSON file.
+
+    Args:
+        user_id:   Unique identifier for the user.
+        token_dir: Directory for token files.
+
+    Returns:
+        TokenData if the file exists and is valid JSON, else None.
+    """
+    path = _token_path(user_id, token_dir)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return _dict_to_token(data)
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        log.warning("Failed to parse local workspace token for user_id=%r: %s", user_id, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Refresh proxy (calls myownlobster.ai — side-effecting)
+# ---------------------------------------------------------------------------
+
+
+def _refresh_token_via_proxy(refresh_token: str) -> Optional[TokenData]:
+    """Obtain a new workspace access token by calling the myownlobster refresh proxy.
+
+    myownlobster.ai holds the GCP client_id + client_secret and proxies the
+    refresh call to Google, returning only the new access_token and expires_in.
+
+    Args:
+        refresh_token: The long-lived refresh token.
+
+    Returns:
+        A new TokenData (refresh_token preserved from caller), or None on error.
+    """
+    api_base = _myownlobster_api_base()
+    url = f"{api_base}{_REFRESH_ENDPOINT}"
+
+    try:
+        headers = _internal_auth_header()
+    except RuntimeError as exc:
+        log.error("Workspace token refresh proxy: %s", exc)
+        return None
+
+    try:
+        resp = requests.post(
+            url,
+            json={"refresh_token": refresh_token},
+            headers=headers,
+            timeout=_HTTP_TIMEOUT,
+        )
+    except requests.exceptions.RequestException as exc:
+        log.warning("Workspace token refresh proxy unreachable: %s", exc)
+        return None
+
+    if not resp.ok:
+        log.warning(
+            "Workspace token refresh proxy returned %d: %s",
+            resp.status_code,
+            resp.text[:200],
+        )
+        return None
+
+    try:
+        data = resp.json()
+        access_token = data["access_token"]
+        expires_in = int(data["expires_in"])
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        log.warning("Workspace token refresh proxy returned unexpected payload: %s", exc)
+        return None
+
+    expires_at = datetime.now(tz=timezone.utc) + timedelta(seconds=expires_in)
+
+    log.info("Workspace token refresh via proxy succeeded.")
+    return TokenData(
+        access_token=access_token,
+        expires_at=expires_at,
+        scope="",  # scope not returned by refresh proxy; preserved from disk
+        refresh_token=None,  # caller must preserve the original refresh_token
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def save_token(
+    user_id: str,
+    token: TokenData,
+    token_dir: Path = _TOKEN_DIR,
+) -> None:
+    """Persist a user's Google Workspace OAuth token to local disk.
+
+    This is the sole write path. The local file is the canonical store.
+
+    Args:
+        user_id:   Unique identifier for the user (Telegram chat_id as str).
+        token:     TokenData to persist.
+        token_dir: Local token directory (injectable for testing).
+    """
+    _save_token_local(user_id, token, token_dir)
+
+
+def load_token(
+    user_id: str,
+    token_dir: Path = _TOKEN_DIR,
+) -> Optional[TokenData]:
+    """Load a user's Google Workspace OAuth token from local disk.
+
+    Args:
+        user_id:   Unique identifier for the user.
+        token_dir: Local token directory (injectable for testing).
+
+    Returns:
+        TokenData if the file exists and is parseable, else None.
+    """
+    return _load_token_local(user_id, token_dir)
+
+
+def get_valid_token(
+    user_id: str,
+    token_dir: Path = _TOKEN_DIR,
+) -> Optional[TokenData]:
+    """Return a valid Google Workspace access token for the user, refreshing if necessary.
+
+    Workflow:
+    1. Load token from local disk.
+    2. If no token -> return None (user must authenticate via consent link).
+    3. If token is still valid -> return it.
+    4. If token is expired -> call myownlobster refresh proxy.
+    5. Persist the refreshed token (preserving the original refresh_token).
+    6. If refresh fails -> log and return None.
+
+    Args:
+        user_id:   Unique identifier for the user (Telegram chat_id as str).
+        token_dir: Local token directory (injectable for testing).
+
+    Returns:
+        A valid TokenData, or None if no valid token is available.
+    """
+    token = _load_token_local(user_id, token_dir)
+    if token is None:
+        log.info("No local workspace token found for user_id=%r.", user_id)
+        return None
+
+    if is_token_valid(token):
+        return token
+
+    # Token is expired — attempt refresh via myownlobster proxy
+    if token.refresh_token is None:
+        log.warning(
+            "Workspace token for user_id=%r is expired and has no refresh_token; "
+            "user must re-authenticate.",
+            user_id,
+        )
+        return None
+
+    log.info("Workspace access token expired for user_id=%r — refreshing via proxy.", user_id)
+
+    refreshed_partial = _refresh_token_via_proxy(token.refresh_token)
+    if refreshed_partial is None:
+        log.error(
+            "Workspace token refresh failed for user_id=%r — user must re-authenticate.",
+            user_id,
+        )
+        return None
+
+    # Merge: preserve scope and refresh_token from the stored token
+    refreshed = TokenData(
+        access_token=refreshed_partial.access_token,
+        expires_at=refreshed_partial.expires_at,
+        scope=token.scope,           # preserve original scope
+        refresh_token=token.refresh_token,  # Google doesn't return new refresh_token here
+    )
+
+    _save_token_local(user_id, refreshed, token_dir)
+    return refreshed

--- a/src/mcp/inbox_server_http.py
+++ b/src/mcp/inbox_server_http.py
@@ -208,6 +208,7 @@ async def health_endpoint(scope, receive, send):
 _MESSAGES_DIR: Path = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages"))
 _GCAL_TOKEN_DIR: Path = _MESSAGES_DIR / "config" / "gcal-tokens"
 _GMAIL_TOKEN_DIR: Path = _MESSAGES_DIR / "config" / "gmail-tokens"
+_WORKSPACE_TOKEN_DIR: Path = _MESSAGES_DIR / "config" / "workspace-tokens"
 _TOKEN_FILE_MODE: int = stat.S_IRUSR | stat.S_IWUSR
 
 _INTERNAL_SECRET: str = os.environ.get("LOBSTER_INTERNAL_SECRET", "").strip()
@@ -408,6 +409,98 @@ async def push_gmail_token_endpoint(scope, receive, send):
     await response(scope, receive, send)
 
 
+async def push_workspace_token_endpoint(scope, receive, send):
+    """POST /api/push-workspace-token — receive a Workspace token pushed by myownlobster.ai.
+
+    Expected JSON body::
+
+        {
+          "chat_id":       "<telegram chat_id as string>",
+          "access_token":  "<string>",
+          "refresh_token": "<string>",
+          "expires_at":    "<ISO 8601 UTC string>",
+          "scope":         "<space-separated scopes>"
+        }
+
+    Authentication: ``Authorization: Bearer <LOBSTER_INTERNAL_SECRET>``
+
+    Writes the token to ``~/messages/config/workspace-tokens/{chat_id}.json``
+    with mode 0o600.
+    """
+    request = Request(scope, receive)
+
+    if not _is_authorized_internal(request):
+        response = JSONResponse({"error": "Unauthorized"}, status_code=401)
+        await response(scope, receive, send)
+        return
+
+    try:
+        body = await request.json()
+    except Exception:
+        response = JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+        await response(scope, receive, send)
+        return
+
+    chat_id = body.get("chat_id", "").strip()
+    access_token = body.get("access_token", "").strip()
+    refresh_token = body.get("refresh_token")
+    expires_at_raw = body.get("expires_at", "").strip()
+    scope_str = body.get("scope", "")
+
+    if not chat_id or not access_token or not expires_at_raw:
+        response = JSONResponse(
+            {"error": "Missing required fields: chat_id, access_token, expires_at"},
+            status_code=400,
+        )
+        await response(scope, receive, send)
+        return
+
+    # Sanitise chat_id to prevent path traversal
+    safe_chat_id = "".join(c for c in chat_id if c.isalnum() or c in ("-", "_"))
+    if not safe_chat_id:
+        response = JSONResponse({"error": "Invalid chat_id"}, status_code=400)
+        await response(scope, receive, send)
+        return
+
+    try:
+        expires_at = datetime.fromisoformat(expires_at_raw)
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+    except ValueError:
+        response = JSONResponse(
+            {"error": "Invalid expires_at: must be ISO 8601"},
+            status_code=400,
+        )
+        await response(scope, receive, send)
+        return
+
+    token_data = {
+        "access_token": access_token,
+        "expires_at": expires_at.isoformat(),
+        "scope": scope_str,
+        "refresh_token": refresh_token,
+    }
+
+    try:
+        _WORKSPACE_TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+        token_path = _WORKSPACE_TOKEN_DIR / f"{safe_chat_id}.json"
+        tmp_path = token_path.with_suffix(".json.tmp")
+        payload = json.dumps(token_data, indent=2)
+        fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _TOKEN_FILE_MODE)
+        with os.fdopen(fd, "w") as f:
+            f.write(payload)
+        os.rename(str(tmp_path), str(token_path))
+        logger.info("Workspace token pushed and saved for chat_id=%r", safe_chat_id)
+    except Exception as exc:
+        logger.error("Failed to write workspace token for chat_id=%r: %s", safe_chat_id, exc)
+        response = JSONResponse({"error": "Failed to write token"}, status_code=500)
+        await response(scope, receive, send)
+        return
+
+    response = JSONResponse({"ok": True})
+    await response(scope, receive, send)
+
+
 async def mcp_endpoint(scope, receive, send):
     """Handle all requests: auth check then delegate to MCP."""
     request = Request(scope, receive)
@@ -426,6 +519,11 @@ async def mcp_endpoint(scope, receive, send):
     # Gmail token push — authenticated by LOBSTER_INTERNAL_SECRET
     if path == "/api/push-gmail-token":
         await push_gmail_token_endpoint(scope, receive, send)
+        return
+
+    # Workspace token push — authenticated by LOBSTER_INTERNAL_SECRET
+    if path == "/api/push-workspace-token":
+        await push_workspace_token_endpoint(scope, receive, send)
         return
 
     # Only handle /mcp

--- a/tests/unit/test_integrations/test_gmail_client.py
+++ b/tests/unit/test_integrations/test_gmail_client.py
@@ -1,0 +1,372 @@
+"""
+Unit tests for src/integrations/gmail/client.py (BIS-256).
+
+All HTTP and token I/O is mocked.  Tests verify the public API contract:
+- get_recent_emails returns EmailMessage list on success, [] on failure
+- search_emails returns EmailMessage list on success, [] on failure
+- Pure helpers (_parse_header, _parse_date_header, _parse_message) are tested
+  independently to verify correctness without network calls.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.gmail import client as gc
+from integrations.gmail.client import (
+    EmailMessage,
+    GmailAPIError,
+    _auth_header,
+    _parse_date_header,
+    _parse_header,
+    _parse_message,
+    get_recent_emails,
+    search_emails,
+)
+from integrations.google_calendar.oauth import TokenData
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FUTURE = datetime.now(tz=timezone.utc) + timedelta(hours=2)
+
+_VALID_TOKEN = TokenData(
+    access_token="test-access-token",
+    expires_at=_FUTURE,
+    scope="https://mail.google.com/",
+    refresh_token="refresh-tok",
+)
+
+_SAMPLE_HEADERS = [
+    {"name": "Subject", "value": "Hello World"},
+    {"name": "From", "value": "Alice <alice@example.com>"},
+    {"name": "Date", "value": "Wed, 1 Apr 2026 14:30:00 +0000"},
+]
+
+_SAMPLE_RAW_MESSAGE = {
+    "id": "msg1",
+    "threadId": "thread1",
+    "snippet": "Hello there, this is a snippet",
+    "labelIds": ["INBOX", "UNREAD"],
+    "payload": {
+        "headers": _SAMPLE_HEADERS,
+    },
+}
+
+_SAMPLE_LIST_RESPONSE = {
+    "messages": [{"id": "msg1"}, {"id": "msg2"}],
+}
+
+
+# ---------------------------------------------------------------------------
+# _parse_header — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestParseHeader:
+    def test_finds_subject(self):
+        val = _parse_header(_SAMPLE_HEADERS, "Subject")
+        assert val == "Hello World"
+
+    def test_case_insensitive(self):
+        val = _parse_header(_SAMPLE_HEADERS, "subject")
+        assert val == "Hello World"
+
+    def test_returns_empty_when_absent(self):
+        val = _parse_header(_SAMPLE_HEADERS, "X-Missing")
+        assert val == ""
+
+    def test_empty_headers_list(self):
+        val = _parse_header([], "Subject")
+        assert val == ""
+
+
+# ---------------------------------------------------------------------------
+# _parse_date_header — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestParseDateHeader:
+    def test_parses_rfc2822_date(self):
+        dt = _parse_date_header("Wed, 1 Apr 2026 14:30:00 +0000")
+        assert dt.year == 2026
+        assert dt.month == 4
+        assert dt.day == 1
+        assert dt.tzinfo is not None
+
+    def test_returns_utc_datetime_on_empty(self):
+        dt = _parse_date_header("")
+        assert dt.tzinfo is not None
+
+    def test_returns_utc_datetime_on_garbage(self):
+        dt = _parse_date_header("not a date at all")
+        assert dt.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# _parse_message — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestParseMessage:
+    def test_parses_subject(self):
+        msg = _parse_message(_SAMPLE_RAW_MESSAGE)
+        assert msg.subject == "Hello World"
+
+    def test_parses_sender(self):
+        msg = _parse_message(_SAMPLE_RAW_MESSAGE)
+        assert "alice@example.com" in msg.sender
+
+    def test_parses_snippet(self):
+        msg = _parse_message(_SAMPLE_RAW_MESSAGE)
+        assert msg.snippet == "Hello there, this is a snippet"
+
+    def test_parses_labels(self):
+        msg = _parse_message(_SAMPLE_RAW_MESSAGE)
+        assert "INBOX" in msg.labels
+        assert "UNREAD" in msg.labels
+
+    def test_parses_id_and_thread_id(self):
+        msg = _parse_message(_SAMPLE_RAW_MESSAGE)
+        assert msg.id == "msg1"
+        assert msg.thread_id == "thread1"
+
+    def test_missing_optional_fields_default_to_empty(self):
+        msg = _parse_message({"id": "x", "threadId": "t"})
+        assert msg.subject == ""
+        assert msg.sender == ""
+        assert msg.snippet == ""
+        assert msg.labels == ()
+
+    def test_is_frozen_dataclass(self):
+        msg = _parse_message(_SAMPLE_RAW_MESSAGE)
+        with pytest.raises((AttributeError, TypeError)):
+            msg.subject = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# _auth_header — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestAuthHeader:
+    def test_returns_bearer_header(self):
+        h = _auth_header("my-token")
+        assert h == {"Authorization": "Bearer my-token"}
+
+
+# ---------------------------------------------------------------------------
+# GmailAPIError
+# ---------------------------------------------------------------------------
+
+
+class TestGmailAPIError:
+    def test_contains_status_code(self):
+        err = GmailAPIError(403, "Forbidden")
+        assert "403" in str(err)
+        assert "Forbidden" in str(err)
+
+    def test_no_summary_still_valid(self):
+        err = GmailAPIError(500)
+        assert "500" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# get_recent_emails
+# ---------------------------------------------------------------------------
+
+
+def _mock_get_token_valid(user_id, token_dir=None):
+    return _VALID_TOKEN
+
+
+def _mock_get_token_none(user_id, token_dir=None):
+    return None
+
+
+class TestGetRecentEmails:
+    def test_returns_empty_when_no_token(self, tmp_path):
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_none,
+        ):
+            result = get_recent_emails("999", token_dir=tmp_path)
+        assert result == []
+
+    def test_returns_messages_on_success(self, tmp_path):
+        def mock_api_call(method, url, token, **kwargs):
+            if "messages" in url and "/" not in url.split("messages")[-1].lstrip("/"):
+                # List call
+                return _SAMPLE_LIST_RESPONSE
+            else:
+                # Individual message fetch
+                msg_id = url.rstrip("/").split("/")[-1]
+                raw = dict(_SAMPLE_RAW_MESSAGE)
+                raw["id"] = msg_id
+                return raw
+
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            side_effect=mock_api_call,
+        ):
+            result = get_recent_emails("123", token_dir=tmp_path)
+
+        assert len(result) == 2
+        assert all(isinstance(m, EmailMessage) for m in result)
+
+    def test_returns_empty_on_api_error(self, tmp_path):
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            side_effect=GmailAPIError(403, "Forbidden"),
+        ):
+            result = get_recent_emails("123", token_dir=tmp_path)
+        assert result == []
+
+    def test_returns_empty_on_network_error(self, tmp_path):
+        import requests as req_lib
+
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            side_effect=req_lib.exceptions.ConnectionError("refused"),
+        ):
+            result = get_recent_emails("123", token_dir=tmp_path)
+        assert result == []
+
+    def test_returns_empty_when_inbox_is_empty(self, tmp_path):
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            return_value={"messages": []},
+        ):
+            result = get_recent_emails("123", token_dir=tmp_path)
+        assert result == []
+
+    def test_skips_failed_individual_message(self, tmp_path):
+        """If one message fetch fails, others should still be returned."""
+        call_count = [0]
+
+        def selective_fail(method, url, token, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # List call succeeds
+                return {"messages": [{"id": "good"}, {"id": "bad"}]}
+            elif "good" in url:
+                return dict(_SAMPLE_RAW_MESSAGE, id="good")
+            else:
+                raise GmailAPIError(500, "Server error")
+
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            side_effect=selective_fail,
+        ):
+            result = get_recent_emails("123", token_dir=tmp_path)
+
+        # Should get 1 successful message even though 1 failed
+        assert len(result) == 1
+        assert result[0].id == "good"
+
+    def test_respects_max_results_param(self, tmp_path):
+        """max_results must be forwarded to the list API call."""
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            return_value={"messages": []},
+        ) as mock_call:
+            get_recent_emails("123", max_results=3, token_dir=tmp_path)
+
+        params = mock_call.call_args.kwargs.get("params", {})
+        assert params.get("maxResults") == 3
+
+
+# ---------------------------------------------------------------------------
+# search_emails
+# ---------------------------------------------------------------------------
+
+
+class TestSearchEmails:
+    def test_returns_empty_when_no_token(self, tmp_path):
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_none,
+        ):
+            result = search_emails("999", "from:boss@example.com", token_dir=tmp_path)
+        assert result == []
+
+    def test_returns_messages_on_success(self, tmp_path):
+        def mock_api_call(method, url, token, **kwargs):
+            if "messages" in url and kwargs.get("params", {}).get("q"):
+                return {"messages": [{"id": "m1"}]}
+            else:
+                return dict(_SAMPLE_RAW_MESSAGE, id="m1")
+
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            side_effect=mock_api_call,
+        ):
+            result = search_emails("123", "from:alice@example.com", token_dir=tmp_path)
+
+        assert len(result) == 1
+        assert isinstance(result[0], EmailMessage)
+
+    def test_forwards_query_param(self, tmp_path):
+        """The search query must be passed as the 'q' parameter."""
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            return_value={"messages": []},
+        ) as mock_call:
+            search_emails("123", "subject:invoice", token_dir=tmp_path)
+
+        params = mock_call.call_args.kwargs.get("params", {})
+        assert params.get("q") == "subject:invoice"
+
+    def test_returns_empty_when_no_results(self, tmp_path):
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            return_value={"messages": []},
+        ):
+            result = search_emails("123", "from:nobody@x.com", token_dir=tmp_path)
+        assert result == []
+
+    def test_returns_empty_on_api_error(self, tmp_path):
+        with patch(
+            "integrations.gmail.client.get_valid_token",
+            side_effect=_mock_get_token_valid,
+        ), patch(
+            "integrations.gmail.client._call_gmail_api",
+            side_effect=GmailAPIError(401, "Unauthorized"),
+        ):
+            result = search_emails("123", "anything", token_dir=tmp_path)
+        assert result == []

--- a/tests/unit/test_integrations/test_gmail_skill_consent_behavior.py
+++ b/tests/unit/test_integrations/test_gmail_skill_consent_behavior.py
@@ -1,0 +1,341 @@
+"""
+Tests for the gmail skill's consent-link auth trigger behavior (BIS-256).
+
+These tests verify the Python logic pattern prescribed in
+``lobster-shop/gmail/behavior/system.md`` for the "connect my Gmail" intent.
+The pattern is:
+
+1. Call ``generate_consent_link("gmail")``; on success, send the user the
+   myownlobster.ai consent URL.
+2. On any exception (RuntimeError from missing env vars, network failure, etc.),
+   fall back gracefully with a user-friendly message — never surface the error
+   to the user.
+3. The scope passed to generate_consent_link must be "gmail", not "calendar".
+
+The tests import the real ``generate_consent_link`` function with HTTP and
+env-var I/O mocked out, verifying real integration points without live services.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pathlib import Path
+
+# Make src importable without installing the package
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.google_auth.consent import generate_consent_link
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_FAKE_INSTANCE_URL = "https://vps.example.com"
+_FAKE_SECRET = "test-internal-secret-abc123"
+_FAKE_CONSENT_URL = "https://myownlobster.ai/connect/gmail?token=abc123"
+_ENV = {
+    "LOBSTER_INSTANCE_URL": _FAKE_INSTANCE_URL,
+    "LOBSTER_INTERNAL_SECRET": _FAKE_SECRET,
+}
+
+
+def _mock_consent_response(url: str = _FAKE_CONSENT_URL) -> MagicMock:
+    resp = MagicMock()
+    resp.ok = True
+    resp.status_code = 200
+    resp.json.return_value = {"url": url}
+    resp.text = f'{{"url": "{url}"}}'
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Helper: the exact auth-trigger logic from behavior/system.md
+# (extracted as a pure function so we can test it without a full dispatcher)
+# ---------------------------------------------------------------------------
+
+
+def _handle_connect_gmail() -> tuple[str, list[str]]:
+    """
+    Replicate the auth-trigger code block from behavior/system.md as a
+    plain function.
+
+    Returns:
+        (reply_text, warning_messages) — warning_messages is empty on success.
+    """
+    import logging
+
+    warnings: list[str] = []
+    log = logging.getLogger(__name__)
+
+    try:
+        url = generate_consent_link("gmail")
+        reply = (
+            "To connect your Gmail, tap this link (expires in 30 minutes):\n"
+            f"[Connect Gmail]({url})\n\n"
+            "After connecting, I'll be able to read and search your emails."
+        )
+    except Exception as exc:
+        msg = f"generate_consent_link('gmail') failed — degrading gracefully: {exc}"
+        log.warning(msg)
+        warnings.append(msg)
+        reply = (
+            "I couldn't generate a Gmail connection link right now. "
+            "Please try again in a few minutes."
+        )
+
+    return reply, warnings
+
+
+# ---------------------------------------------------------------------------
+# Happy path: generate_consent_link succeeds
+# ---------------------------------------------------------------------------
+
+
+class TestAuthTriggerHappyPath:
+    def test_reply_contains_myownlobster_url(self):
+        """When generate_consent_link succeeds, the reply contains the consent URL."""
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_consent_response(),
+        ):
+            reply, warnings = _handle_connect_gmail()
+
+        assert _FAKE_CONSENT_URL in reply
+        assert warnings == []
+
+    def test_reply_contains_connect_gmail_link_text(self):
+        """Reply uses the expected link label for mobile readability."""
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_consent_response(),
+        ):
+            reply, _ = _handle_connect_gmail()
+
+        assert "Connect Gmail" in reply
+
+    def test_reply_mentions_expiry(self):
+        """Reply tells the user the link expires so they know to act promptly."""
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_consent_response(),
+        ):
+            reply, _ = _handle_connect_gmail()
+
+        assert "30 minutes" in reply
+
+    def test_reply_does_not_mention_fallback_language(self):
+        """On success, the reply should not mention fallback language."""
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_consent_response(),
+        ):
+            reply, _ = _handle_connect_gmail()
+
+        assert "couldn't generate" not in reply.lower()
+
+    def test_consent_url_contains_gmail_scope(self):
+        """The returned URL must point to the gmail consent path."""
+        url = "https://myownlobster.ai/connect/gmail?token=xyz"
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_consent_response(url=url),
+        ):
+            reply, _ = _handle_connect_gmail()
+
+        assert "myownlobster.ai/connect/gmail" in reply
+        assert "token=" in reply
+
+
+# ---------------------------------------------------------------------------
+# Fallback: generate_consent_link raises RuntimeError (missing env vars)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthTriggerFallbackMissingEnv:
+    def test_fallback_when_instance_url_missing(self):
+        """Missing LOBSTER_INSTANCE_URL → graceful fallback, no user-facing error."""
+        env = {"LOBSTER_INTERNAL_SECRET": _FAKE_SECRET}
+        with patch.dict("os.environ", env, clear=True):
+            reply, warnings = _handle_connect_gmail()
+
+        assert "couldn't generate" in reply.lower()
+        assert len(warnings) == 1
+
+    def test_fallback_when_secret_missing(self):
+        """Missing LOBSTER_INTERNAL_SECRET → graceful fallback."""
+        env = {"LOBSTER_INSTANCE_URL": _FAKE_INSTANCE_URL}
+        with patch.dict("os.environ", env, clear=True):
+            reply, warnings = _handle_connect_gmail()
+
+        assert "couldn't generate" in reply.lower()
+        assert len(warnings) == 1
+
+    def test_fallback_when_both_env_vars_missing(self):
+        """Both env vars missing → graceful fallback."""
+        with patch.dict("os.environ", {}, clear=True):
+            reply, warnings = _handle_connect_gmail()
+
+        assert "couldn't generate" in reply.lower()
+        assert len(warnings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Fallback: generate_consent_link raises due to network error
+# ---------------------------------------------------------------------------
+
+
+class TestAuthTriggerFallbackNetworkError:
+    def test_fallback_on_connection_error(self):
+        """Network failure → graceful fallback, no error surfaced to user."""
+        import requests as req_lib
+
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            side_effect=req_lib.exceptions.ConnectionError("connection refused"),
+        ):
+            reply, warnings = _handle_connect_gmail()
+
+        assert "couldn't generate" in reply.lower()
+        assert len(warnings) == 1
+
+    def test_fallback_on_timeout(self):
+        """Timeout → graceful fallback."""
+        import requests as req_lib
+
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            side_effect=req_lib.exceptions.Timeout("timed out"),
+        ):
+            reply, warnings = _handle_connect_gmail()
+
+        assert "couldn't generate" in reply.lower()
+
+    def test_fallback_on_http_500(self):
+        """Server error from myownlobster.ai → graceful fallback."""
+        error_resp = MagicMock()
+        error_resp.ok = False
+        error_resp.status_code = 500
+        error_resp.text = "Internal Server Error"
+
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=error_resp,
+        ):
+            reply, warnings = _handle_connect_gmail()
+
+        assert "couldn't generate" in reply.lower()
+
+
+# ---------------------------------------------------------------------------
+# Fallback reply must not expose internal error details
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackReplyIsUserFriendly:
+    def test_env_var_names_not_surfaced(self):
+        """Fallback reply must not contain env var names."""
+        with patch.dict("os.environ", {}, clear=True):
+            reply, _ = _handle_connect_gmail()
+
+        assert "LOBSTER_INSTANCE_URL" not in reply
+        assert "LOBSTER_INTERNAL_SECRET" not in reply
+        assert "RuntimeError" not in reply
+        assert "Missing required" not in reply
+
+    def test_network_error_details_not_surfaced(self):
+        """Network error details must not leak into the reply text."""
+        import requests as req_lib
+
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            side_effect=req_lib.exceptions.ConnectionError("connection refused"),
+        ):
+            reply, _ = _handle_connect_gmail()
+
+        assert "connection refused" not in reply
+        assert "ConnectionError" not in reply
+
+
+# ---------------------------------------------------------------------------
+# Scope isolation: gmail skill uses "gmail" scope, not "calendar"
+# ---------------------------------------------------------------------------
+
+
+class TestConsentLinkScope:
+    def test_requests_gmail_scope(self):
+        """The auth trigger must call generate_consent_link with scope='gmail'."""
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_consent_response(),
+        ) as mock_post:
+            _handle_connect_gmail()
+
+        call_json = mock_post.call_args.kwargs["json"]
+        assert call_json["scope"] == "gmail"
+
+    def test_calendar_scope_not_used(self):
+        """The Gmail auth trigger must not request calendar scope."""
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_consent_response(),
+        ) as mock_post:
+            _handle_connect_gmail()
+
+        call_json = mock_post.call_args.kwargs["json"]
+        assert call_json["scope"] != "calendar"
+
+
+# ---------------------------------------------------------------------------
+# Warning logged on fallback (without leaking secrets)
+# ---------------------------------------------------------------------------
+
+
+class TestWarningLogging:
+    def test_warning_logged_on_fallback(self, caplog):
+        """A warning must be logged when generate_consent_link fails."""
+        with caplog.at_level(logging.WARNING):
+            with patch.dict("os.environ", {}, clear=True):
+                _handle_connect_gmail()
+
+        warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warning_messages) >= 1
+
+    def test_secret_not_in_warning_log(self, caplog):
+        """The internal secret must not appear in any log record."""
+        import requests as req_lib
+
+        with caplog.at_level(logging.DEBUG):
+            with patch.dict("os.environ", _ENV), patch(
+                "integrations.google_auth.consent.requests.post",
+                side_effect=req_lib.exceptions.ConnectionError("conn fail"),
+            ):
+                _handle_connect_gmail()
+
+        for record in caplog.records:
+            assert _FAKE_SECRET not in record.getMessage()
+
+
+# ---------------------------------------------------------------------------
+# Calendar skill consent behavior is unaffected by gmail skill
+# ---------------------------------------------------------------------------
+
+
+class TestCalendarSkillUnaffected:
+    """Verify that the gmail and calendar consent paths are independent."""
+
+    def test_gmail_consent_link_uses_gmail_path(self):
+        """Gmail consent link should point to /connect/gmail."""
+        url = "https://myownlobster.ai/connect/gmail?token=abc"
+        with patch.dict("os.environ", _ENV), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_consent_response(url=url),
+        ):
+            reply, _ = _handle_connect_gmail()
+
+        assert "/connect/gmail" in reply
+        assert "/connect/calendar" not in reply

--- a/tests/unit/test_integrations/test_gmail_token_store.py
+++ b/tests/unit/test_integrations/test_gmail_token_store.py
@@ -1,0 +1,337 @@
+"""
+Unit tests for src/integrations/gmail/token_store.py (BIS-256).
+
+These tests mirror the structure of test_google_calendar_token_store.py,
+adapted for the Gmail token store.  All file I/O and HTTP are mocked.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make src importable without installing the package
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.google_calendar.oauth import TokenData
+from integrations.gmail import token_store as ts
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+_FUTURE = datetime.now(tz=timezone.utc) + timedelta(hours=2)
+_EXPIRED = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+
+_VALID_TOKEN = TokenData(
+    access_token="valid-access-token",
+    expires_at=_FUTURE,
+    scope="https://mail.google.com/",
+    refresh_token="refresh-token-abc",
+)
+
+_EXPIRED_TOKEN = TokenData(
+    access_token="expired-access-token",
+    expires_at=_EXPIRED,
+    scope="https://mail.google.com/",
+    refresh_token="refresh-token-xyz",
+)
+
+
+# ---------------------------------------------------------------------------
+# _token_path — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestTokenPath:
+    def test_basic_user_id(self, tmp_path):
+        path = ts._token_path("12345", tmp_path)
+        assert path == tmp_path / "12345.json"
+
+    def test_sanitises_special_chars(self, tmp_path):
+        path = ts._token_path("../evil", tmp_path)
+        assert "/" not in path.name
+        assert ".." not in path.name
+
+    def test_empty_after_sanitise_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            ts._token_path("!@#$%", tmp_path)
+
+    def test_hyphen_and_underscore_preserved(self, tmp_path):
+        path = ts._token_path("user-123_abc", tmp_path)
+        assert path.name == "user-123_abc.json"
+
+
+# ---------------------------------------------------------------------------
+# _token_to_dict / _dict_to_token — pure serialisation round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSerialisation:
+    def test_round_trip_preserves_all_fields(self):
+        d = ts._token_to_dict(_VALID_TOKEN)
+        restored = ts._dict_to_token(d)
+        assert restored.access_token == _VALID_TOKEN.access_token
+        assert restored.refresh_token == _VALID_TOKEN.refresh_token
+        assert restored.scope == _VALID_TOKEN.scope
+        # expires_at round-trips through isoformat
+        assert restored.expires_at == _VALID_TOKEN.expires_at
+
+    def test_round_trip_with_null_refresh_token(self):
+        token = TokenData(
+            access_token="tok",
+            expires_at=_FUTURE,
+            scope="",
+            refresh_token=None,
+        )
+        d = ts._token_to_dict(token)
+        restored = ts._dict_to_token(d)
+        assert restored.refresh_token is None
+
+    def test_naive_datetime_gets_utc_tzinfo(self):
+        data = {
+            "access_token": "tok",
+            "expires_at": "2026-01-01T12:00:00",  # no tzinfo
+            "scope": "",
+            "refresh_token": None,
+        }
+        token = ts._dict_to_token(data)
+        assert token.expires_at.tzinfo == timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# _save_token_local / _load_token_local — file I/O
+# ---------------------------------------------------------------------------
+
+
+class TestSaveLoadLocal:
+    def test_save_creates_file(self, tmp_path):
+        ts._save_token_local("99", _VALID_TOKEN, tmp_path)
+        assert (tmp_path / "99.json").exists()
+
+    def test_save_sets_mode_0600(self, tmp_path):
+        ts._save_token_local("99", _VALID_TOKEN, tmp_path)
+        mode = (tmp_path / "99.json").stat().st_mode
+        assert mode & 0o777 == stat.S_IRUSR | stat.S_IWUSR
+
+    def test_load_returns_none_when_file_absent(self, tmp_path):
+        result = ts._load_token_local("nonexistent", tmp_path)
+        assert result is None
+
+    def test_load_returns_token_after_save(self, tmp_path):
+        ts._save_token_local("42", _VALID_TOKEN, tmp_path)
+        loaded = ts._load_token_local("42", tmp_path)
+        assert loaded is not None
+        assert loaded.access_token == _VALID_TOKEN.access_token
+
+    def test_load_returns_none_on_corrupted_json(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text("not json", encoding="utf-8")
+        # Rename to match user_id "bad"
+        result = ts._load_token_local("bad", tmp_path)
+        assert result is None
+
+    def test_save_creates_parent_dirs(self, tmp_path):
+        deep = tmp_path / "a" / "b" / "c"
+        ts._save_token_local("x", _VALID_TOKEN, deep)
+        assert (deep / "x.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# _refresh_token_via_proxy — HTTP side-effecting boundary
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshTokenViaProxy:
+    def _mock_success_response(self) -> MagicMock:
+        resp = MagicMock()
+        resp.ok = True
+        resp.status_code = 200
+        resp.json.return_value = {
+            "access_token": "new-access-token",
+            "expires_in": 3600,
+        }
+        return resp
+
+    def test_returns_new_token_on_success(self):
+        with patch.dict(
+            "os.environ",
+            {"LOBSTER_INTERNAL_SECRET": "secret"},
+        ), patch(
+            "integrations.gmail.token_store.requests.post",
+            return_value=self._mock_success_response(),
+        ):
+            result = ts._refresh_token_via_proxy("refresh-tok")
+
+        assert result is not None
+        assert result.access_token == "new-access-token"
+        assert result.expires_at > datetime.now(tz=timezone.utc)
+
+    def test_returns_none_when_secret_missing(self):
+        with patch.dict("os.environ", {}, clear=True):
+            result = ts._refresh_token_via_proxy("refresh-tok")
+        assert result is None
+
+    def test_returns_none_on_network_error(self):
+        import requests as req_lib
+
+        with patch.dict("os.environ", {"LOBSTER_INTERNAL_SECRET": "secret"}), patch(
+            "integrations.gmail.token_store.requests.post",
+            side_effect=req_lib.exceptions.ConnectionError("refused"),
+        ):
+            result = ts._refresh_token_via_proxy("refresh-tok")
+        assert result is None
+
+    def test_returns_none_on_non_ok_response(self):
+        bad = MagicMock()
+        bad.ok = False
+        bad.status_code = 500
+        bad.text = "Internal Server Error"
+        with patch.dict("os.environ", {"LOBSTER_INTERNAL_SECRET": "secret"}), patch(
+            "integrations.gmail.token_store.requests.post",
+            return_value=bad,
+        ):
+            result = ts._refresh_token_via_proxy("refresh-tok")
+        assert result is None
+
+    def test_returns_none_on_bad_json(self):
+        resp = MagicMock()
+        resp.ok = True
+        resp.json.return_value = {"unexpected": "keys"}
+        with patch.dict("os.environ", {"LOBSTER_INTERNAL_SECRET": "secret"}), patch(
+            "integrations.gmail.token_store.requests.post",
+            return_value=resp,
+        ):
+            result = ts._refresh_token_via_proxy("refresh-tok")
+        assert result is None
+
+    def test_uses_gmail_refresh_endpoint(self):
+        """Refresh must call the gmail-specific endpoint, not the calendar one."""
+        with patch.dict("os.environ", {"LOBSTER_INTERNAL_SECRET": "secret"}), patch(
+            "integrations.gmail.token_store.requests.post",
+            return_value=self._mock_success_response(),
+        ) as mock_post:
+            ts._refresh_token_via_proxy("refresh-tok")
+
+        called_url = mock_post.call_args.args[0]
+        assert "gmail" in called_url
+        assert "calendar" not in called_url
+
+
+# ---------------------------------------------------------------------------
+# get_valid_token — composition of load + check + refresh
+# ---------------------------------------------------------------------------
+
+
+class TestGetValidToken:
+    def test_returns_none_when_no_token(self, tmp_path):
+        result = ts.get_valid_token("unknown", token_dir=tmp_path)
+        assert result is None
+
+    def test_returns_valid_token_directly(self, tmp_path):
+        ts._save_token_local("u1", _VALID_TOKEN, tmp_path)
+        result = ts.get_valid_token("u1", token_dir=tmp_path)
+        assert result is not None
+        assert result.access_token == _VALID_TOKEN.access_token
+
+    def test_refreshes_expired_token(self, tmp_path):
+        ts._save_token_local("u2", _EXPIRED_TOKEN, tmp_path)
+
+        refreshed_partial = TokenData(
+            access_token="refreshed-access",
+            expires_at=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+            scope="",
+            refresh_token=None,
+        )
+
+        with patch.dict("os.environ", {"LOBSTER_INTERNAL_SECRET": "secret"}), patch(
+            "integrations.gmail.token_store._refresh_token_via_proxy",
+            return_value=refreshed_partial,
+        ):
+            result = ts.get_valid_token("u2", token_dir=tmp_path)
+
+        assert result is not None
+        assert result.access_token == "refreshed-access"
+        # refresh_token preserved from original
+        assert result.refresh_token == _EXPIRED_TOKEN.refresh_token
+
+    def test_returns_none_when_expired_no_refresh_token(self, tmp_path):
+        expired_no_rt = TokenData(
+            access_token="expired",
+            expires_at=_EXPIRED,
+            scope="",
+            refresh_token=None,
+        )
+        ts._save_token_local("u3", expired_no_rt, tmp_path)
+        result = ts.get_valid_token("u3", token_dir=tmp_path)
+        assert result is None
+
+    def test_returns_none_when_refresh_fails(self, tmp_path):
+        ts._save_token_local("u4", _EXPIRED_TOKEN, tmp_path)
+        with patch.dict("os.environ", {"LOBSTER_INTERNAL_SECRET": "secret"}), patch(
+            "integrations.gmail.token_store._refresh_token_via_proxy",
+            return_value=None,
+        ):
+            result = ts.get_valid_token("u4", token_dir=tmp_path)
+        assert result is None
+
+    def test_saves_refreshed_token_to_disk(self, tmp_path):
+        ts._save_token_local("u5", _EXPIRED_TOKEN, tmp_path)
+
+        refreshed_partial = TokenData(
+            access_token="refreshed-persist",
+            expires_at=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+            scope="",
+            refresh_token=None,
+        )
+
+        with patch.dict("os.environ", {"LOBSTER_INTERNAL_SECRET": "secret"}), patch(
+            "integrations.gmail.token_store._refresh_token_via_proxy",
+            return_value=refreshed_partial,
+        ):
+            ts.get_valid_token("u5", token_dir=tmp_path)
+
+        # Read back from disk to confirm persistence
+        persisted = ts._load_token_local("u5", tmp_path)
+        assert persisted is not None
+        assert persisted.access_token == "refreshed-persist"
+
+
+# ---------------------------------------------------------------------------
+# Token isolation: gmail-tokens != gcal-tokens
+# ---------------------------------------------------------------------------
+
+
+class TestTokenIsolation:
+    def test_gmail_token_dir_is_separate_from_gcal(self):
+        """The default token directory must be gmail-tokens, not gcal-tokens."""
+        assert "gmail" in str(ts._TOKEN_DIR)
+        assert "gcal" not in str(ts._TOKEN_DIR)
+
+    def test_saving_gmail_token_does_not_touch_gcal_dir(self, tmp_path):
+        gmail_dir = tmp_path / "gmail-tokens"
+        gcal_dir = tmp_path / "gcal-tokens"
+        gcal_dir.mkdir()
+
+        ts._save_token_local("99", _VALID_TOKEN, gmail_dir)
+
+        # gcal directory should still be empty
+        assert list(gcal_dir.iterdir()) == []
+
+    def test_loading_from_gmail_dir_does_not_read_gcal_dir(self, tmp_path):
+        gmail_dir = tmp_path / "gmail-tokens"
+        gcal_dir = tmp_path / "gcal-tokens"
+        gcal_dir.mkdir()
+
+        # Put a token in gcal dir only
+        ts._save_token_local("99", _VALID_TOKEN, gcal_dir)
+
+        # Loading from gmail dir must return None (not the gcal token)
+        result = ts._load_token_local("99", gmail_dir)
+        assert result is None

--- a/tests/unit/test_integrations/test_sheets_client_read.py
+++ b/tests/unit/test_integrations/test_sheets_client_read.py
@@ -1,0 +1,244 @@
+"""
+Tests for gsheets_read in src/integrations/google_workspace/sheets_client.py (Slice 5).
+
+Covers:
+- gsheets_read: returns 2D list on success
+- gsheets_read: returns [] when no valid token
+- gsheets_read: returns [] on API error
+- gsheets_read: returns [] on network error
+- gsheets_read: empty cells become empty strings
+- gsheets_read: accepts full Sheets URL
+- _sheet_id_from_url: extracts ID from full URL
+- _sheet_id_from_url: returns raw string if not a URL
+- _normalise_row: converts non-string values to strings
+- No token values appear in logs
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.google_calendar.oauth import TokenData
+from integrations.google_workspace.sheets_client import (
+    _normalise_row,
+    _sheet_id_from_url,
+    gsheets_read,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_ACCESS_TOKEN = "ya29.fake-sheets-token"
+_FAKE_SHEET_ID = "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms"
+_FAKE_SHEET_URL = f"https://docs.google.com/spreadsheets/d/{_FAKE_SHEET_ID}/edit"
+
+
+def _valid_token() -> TokenData:
+    return TokenData(
+        access_token=_FAKE_ACCESS_TOKEN,
+        expires_at=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+        scope="https://www.googleapis.com/auth/spreadsheets",
+        refresh_token="test-refresh",
+    )
+
+
+def _sheets_response(values: list) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.ok = True
+    resp.json.return_value = {"values": values, "range": "A1:C3"}
+    return resp
+
+
+def _error_response(status_code: int = 500) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.ok = False
+    resp.json.return_value = {}
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _sheet_id_from_url — pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestSheetIdFromUrl:
+    def test_extracts_id_from_full_edit_url(self):
+        result = _sheet_id_from_url(_FAKE_SHEET_URL)
+        assert result == _FAKE_SHEET_ID
+
+    def test_extracts_id_from_view_url(self):
+        url = f"https://docs.google.com/spreadsheets/d/{_FAKE_SHEET_ID}/view"
+        result = _sheet_id_from_url(url)
+        assert result == _FAKE_SHEET_ID
+
+    def test_returns_raw_id_when_no_url_match(self):
+        result = _sheet_id_from_url(_FAKE_SHEET_ID)
+        assert result == _FAKE_SHEET_ID
+
+    def test_strips_whitespace_from_raw_id(self):
+        result = _sheet_id_from_url(f"  {_FAKE_SHEET_ID}  ")
+        assert result == _FAKE_SHEET_ID
+
+
+# ---------------------------------------------------------------------------
+# _normalise_row — pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormaliseRow:
+    def test_strings_pass_through(self):
+        result = _normalise_row(["a", "b", "c"])
+        assert result == ["a", "b", "c"]
+
+    def test_numbers_become_strings(self):
+        result = _normalise_row([1, 2.5, 3])
+        assert result == ["1", "2.5", "3"]
+
+    def test_none_becomes_empty_string(self):
+        result = _normalise_row([None, "x", None])
+        assert result == ["", "x", ""]
+
+    def test_empty_row_returns_empty_list(self):
+        result = _normalise_row([])
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# gsheets_read — integration tests (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestGsheetsRead:
+    def test_returns_2d_list_on_success(self):
+        values = [["col1", "col2", "col3"], ["a", "b", "c"], ["d", "e", "f"]]
+        http_resp = _sheets_response(values)
+
+        with patch(
+            "integrations.google_workspace.sheets_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.sheets_client.requests.get",
+            return_value=http_resp,
+        ):
+            result = gsheets_read("user123", _FAKE_SHEET_ID, "A1:C3")
+
+        assert result == [["col1", "col2", "col3"], ["a", "b", "c"], ["d", "e", "f"]]
+
+    def test_returns_empty_list_when_no_token(self):
+        with patch(
+            "integrations.google_workspace.sheets_client.get_valid_token",
+            return_value=None,
+        ):
+            result = gsheets_read("user123", _FAKE_SHEET_ID, "A1:C3")
+
+        assert result == []
+
+    def test_returns_empty_list_on_api_error(self):
+        with patch(
+            "integrations.google_workspace.sheets_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.sheets_client.requests.get",
+            return_value=_error_response(403),
+        ):
+            result = gsheets_read("user123", _FAKE_SHEET_ID, "A1:C3")
+
+        assert result == []
+
+    def test_returns_empty_list_on_network_error(self):
+        import requests as req_lib
+        with patch(
+            "integrations.google_workspace.sheets_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.sheets_client.requests.get",
+            side_effect=req_lib.exceptions.ConnectionError("connection refused"),
+        ):
+            result = gsheets_read("user123", _FAKE_SHEET_ID, "A1:C3")
+
+        assert result == []
+
+    def test_returns_empty_list_when_no_data_in_range(self):
+        # API returns empty values when range has no data
+        http_resp = MagicMock()
+        http_resp.status_code = 200
+        http_resp.ok = True
+        http_resp.json.return_value = {}  # no "values" key when range is empty
+
+        with patch(
+            "integrations.google_workspace.sheets_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.sheets_client.requests.get",
+            return_value=http_resp,
+        ):
+            result = gsheets_read("user123", _FAKE_SHEET_ID, "Z1:Z10")
+
+        assert result == []
+
+    def test_accepts_full_url(self):
+        values = [["x"]]
+        http_resp = _sheets_response(values)
+
+        with patch(
+            "integrations.google_workspace.sheets_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.sheets_client.requests.get",
+            return_value=http_resp,
+        ) as mock_get:
+            gsheets_read("user123", _FAKE_SHEET_URL, "A1:A1")
+
+        # Verify the called URL contains the extracted sheet ID
+        called_url = mock_get.call_args[0][0]
+        assert _FAKE_SHEET_ID in called_url
+        assert "spreadsheets/d" not in called_url  # full URL not used as path
+
+    def test_all_cells_are_strings(self):
+        # API may return numbers as native JSON types
+        values = [[1, 2.5, None, "text"]]
+        http_resp = _sheets_response(values)
+
+        with patch(
+            "integrations.google_workspace.sheets_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.sheets_client.requests.get",
+            return_value=http_resp,
+        ):
+            result = gsheets_read("user123", _FAKE_SHEET_ID, "A1:D1")
+
+        assert result == [["1", "2.5", "", "text"]]
+
+
+# ---------------------------------------------------------------------------
+# No token values in logs
+# ---------------------------------------------------------------------------
+
+
+def test_access_token_not_logged(caplog):
+    import logging
+    http_resp = _sheets_response([["data"]])
+
+    with caplog.at_level(logging.DEBUG, logger="integrations.google_workspace.sheets_client"):
+        with patch(
+            "integrations.google_workspace.sheets_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.sheets_client.requests.get",
+            return_value=http_resp,
+        ):
+            gsheets_read("user123", _FAKE_SHEET_ID, "A1:B2")
+
+    for record in caplog.records:
+        assert _FAKE_ACCESS_TOKEN not in record.getMessage()

--- a/tests/unit/test_integrations/test_workspace_consent.py
+++ b/tests/unit/test_integrations/test_workspace_consent.py
@@ -1,0 +1,85 @@
+"""
+Tests for Google Workspace support in generate_consent_link.
+
+Covers:
+- generate_consent_link("workspace") returns a URL
+- generate_consent_link("workspace") sends the correct scope in the JSON payload
+- "workspace" is in _VALID_SCOPES
+- "drive" and other non-workspace scopes are still rejected
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.google_auth.consent import _VALID_SCOPES, generate_consent_link
+
+_FAKE_INSTANCE_URL = "https://vps.example.com"
+_FAKE_SECRET = "test-internal-secret-abc123"
+_FAKE_WORKSPACE_URL = "https://myownlobster.ai/connect/workspace?token=test-uuid"
+
+
+def _mock_response(url: str) -> MagicMock:
+    resp = MagicMock()
+    resp.ok = True
+    resp.status_code = 201
+    resp.json.return_value = {"url": url}
+    resp.text = f'{{"url": "{url}"}}'
+    return resp
+
+
+def _env() -> dict:
+    return {
+        "LOBSTER_INSTANCE_URL": _FAKE_INSTANCE_URL,
+        "LOBSTER_INTERNAL_SECRET": _FAKE_SECRET,
+    }
+
+
+class TestWorkspaceScopeInValidScopes:
+    def test_workspace_is_in_valid_scopes(self):
+        assert "workspace" in _VALID_SCOPES
+
+    def test_calendar_still_in_valid_scopes(self):
+        assert "calendar" in _VALID_SCOPES
+
+    def test_gmail_still_in_valid_scopes(self):
+        assert "gmail" in _VALID_SCOPES
+
+    def test_drive_not_in_valid_scopes(self):
+        assert "drive" not in _VALID_SCOPES
+
+
+class TestGenerateConsentLinkWorkspace:
+    def test_workspace_scope_returns_url(self):
+        with patch.dict("os.environ", _env()), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_response(_FAKE_WORKSPACE_URL),
+        ) as mock_post:
+            result = generate_consent_link("workspace")
+
+        assert result == _FAKE_WORKSPACE_URL
+        mock_post.assert_called_once()
+
+    def test_workspace_scope_sends_correct_payload(self):
+        with patch.dict("os.environ", _env()), patch(
+            "integrations.google_auth.consent.requests.post",
+            return_value=_mock_response(_FAKE_WORKSPACE_URL),
+        ) as mock_post:
+            generate_consent_link("workspace")
+
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs.kwargs.get("json") or (call_kwargs.args[1] if len(call_kwargs.args) > 1 else None)
+        if payload is None:
+            payload = call_kwargs.kwargs["json"]
+        assert payload["scope"] == "workspace"
+
+    def test_invalid_scope_still_rejected(self):
+        with patch.dict("os.environ", _env()):
+            with pytest.raises(ValueError, match="Invalid scope"):
+                generate_consent_link("sheets")

--- a/tests/unit/test_integrations/test_workspace_token_store.py
+++ b/tests/unit/test_integrations/test_workspace_token_store.py
@@ -1,0 +1,220 @@
+"""
+Tests for src/integrations/google_workspace/token_store.py.
+
+Covers:
+- save_token / load_token: roundtrip persistence with correct file permissions
+- load_token: returns None when file absent
+- load_token: returns None when file is corrupt JSON
+- get_valid_token: returns token when valid
+- get_valid_token: returns None when no token on disk
+- get_valid_token: refreshes expired token via proxy
+- get_valid_token: returns None when refresh fails
+- get_valid_token: returns None when refresh_token is missing
+- No token values appear in logs
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.google_calendar.oauth import TokenData
+from integrations.google_workspace import token_store
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _future_token(minutes: int = 60, refresh_token: str = "test-refresh") -> TokenData:
+    """Return a TokenData with an access token that expires in the future."""
+    return TokenData(
+        access_token="test-access-token",
+        expires_at=datetime.now(tz=timezone.utc) + timedelta(minutes=minutes),
+        scope="https://www.googleapis.com/auth/documents",
+        refresh_token=refresh_token,
+    )
+
+
+def _expired_token(refresh_token: str = "test-refresh") -> TokenData:
+    """Return a TokenData that is already expired."""
+    return TokenData(
+        access_token="expired-access-token",
+        expires_at=datetime.now(tz=timezone.utc) - timedelta(hours=1),
+        scope="https://www.googleapis.com/auth/documents",
+        refresh_token=refresh_token,
+    )
+
+
+# ---------------------------------------------------------------------------
+# save_token / load_token roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestSaveLoadRoundtrip:
+    def test_roundtrip_preserves_all_fields(self, tmp_path):
+        token = _future_token()
+        token_store.save_token("user123", token, token_dir=tmp_path)
+        loaded = token_store.load_token("user123", token_dir=tmp_path)
+
+        assert loaded is not None
+        assert loaded.access_token == token.access_token
+        assert loaded.scope == token.scope
+        assert loaded.refresh_token == token.refresh_token
+        # expires_at should be close (round-trip through ISO string)
+        delta = abs((loaded.expires_at - token.expires_at).total_seconds())
+        assert delta < 1.0
+
+    def test_token_file_has_mode_0o600(self, tmp_path):
+        token = _future_token()
+        token_store.save_token("user456", token, token_dir=tmp_path)
+        token_path = tmp_path / "user456.json"
+        file_stat = os.stat(token_path)
+        permissions = stat.S_IMODE(file_stat.st_mode)
+        assert permissions == 0o600
+
+    def test_token_file_is_valid_json(self, tmp_path):
+        token = _future_token()
+        token_store.save_token("user789", token, token_dir=tmp_path)
+        token_path = tmp_path / "user789.json"
+        data = json.loads(token_path.read_text())
+        assert "access_token" in data
+        assert "expires_at" in data
+
+    def test_save_creates_directory_if_needed(self, tmp_path):
+        nested_dir = tmp_path / "nested" / "deep" / "dir"
+        assert not nested_dir.exists()
+        token = _future_token()
+        token_store.save_token("user1", token, token_dir=nested_dir)
+        assert nested_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# load_token — edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestLoadToken:
+    def test_returns_none_when_file_absent(self, tmp_path):
+        result = token_store.load_token("nonexistent_user", token_dir=tmp_path)
+        assert result is None
+
+    def test_returns_none_for_corrupt_json(self, tmp_path):
+        (tmp_path / "corrupt.json").write_text("not valid json")
+        result = token_store.load_token("corrupt", token_dir=tmp_path)
+        assert result is None
+
+    def test_returns_none_for_missing_required_field(self, tmp_path):
+        (tmp_path / "incomplete.json").write_text('{"access_token": "tok"}')
+        result = token_store.load_token("incomplete", token_dir=tmp_path)
+        assert result is None
+
+    def test_sanitises_user_id(self, tmp_path):
+        """Path traversal characters are stripped from user_id."""
+        token = _future_token()
+        # Save with a safe id, verify by loading with the same raw id
+        token_store.save_token("safe123", token, token_dir=tmp_path)
+        loaded = token_store.load_token("safe123", token_dir=tmp_path)
+        assert loaded is not None
+
+    def test_raises_for_empty_user_id(self, tmp_path):
+        with pytest.raises(ValueError, match="empty filename"):
+            token_store.load_token("!!!", token_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# get_valid_token
+# ---------------------------------------------------------------------------
+
+
+class TestGetValidToken:
+    def test_returns_valid_token_without_refresh(self, tmp_path):
+        token = _future_token()
+        token_store.save_token("user1", token, token_dir=tmp_path)
+        result = token_store.get_valid_token("user1", token_dir=tmp_path)
+        assert result is not None
+        assert result.access_token == "test-access-token"
+
+    def test_returns_none_when_no_token_on_disk(self, tmp_path):
+        result = token_store.get_valid_token("no_such_user", token_dir=tmp_path)
+        assert result is None
+
+    def test_refreshes_expired_token(self, tmp_path):
+        expired = _expired_token(refresh_token="valid-refresh")
+        token_store.save_token("user_exp", expired, token_dir=tmp_path)
+
+        new_token_data = TokenData(
+            access_token="refreshed-access-token",
+            expires_at=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+            scope="",
+            refresh_token=None,
+        )
+
+        with patch.object(token_store, "_refresh_token_via_proxy", return_value=new_token_data):
+            result = token_store.get_valid_token("user_exp", token_dir=tmp_path)
+
+        assert result is not None
+        assert result.access_token == "refreshed-access-token"
+        assert result.refresh_token == "valid-refresh"  # preserved from disk
+
+    def test_returns_none_when_refresh_fails(self, tmp_path):
+        expired = _expired_token(refresh_token="valid-refresh")
+        token_store.save_token("user_fail", expired, token_dir=tmp_path)
+
+        with patch.object(token_store, "_refresh_token_via_proxy", return_value=None):
+            result = token_store.get_valid_token("user_fail", token_dir=tmp_path)
+
+        assert result is None
+
+    def test_returns_none_when_no_refresh_token(self, tmp_path):
+        expired = _expired_token(refresh_token=None)
+        token_store.save_token("user_no_refresh", expired, token_dir=tmp_path)
+        result = token_store.get_valid_token("user_no_refresh", token_dir=tmp_path)
+        assert result is None
+
+    def test_persists_refreshed_token(self, tmp_path):
+        """After a successful refresh, the new token is saved to disk."""
+        expired = _expired_token(refresh_token="valid-refresh")
+        token_store.save_token("user_persist", expired, token_dir=tmp_path)
+
+        new_token_data = TokenData(
+            access_token="newly-refreshed",
+            expires_at=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+            scope="",
+            refresh_token=None,
+        )
+
+        with patch.object(token_store, "_refresh_token_via_proxy", return_value=new_token_data):
+            token_store.get_valid_token("user_persist", token_dir=tmp_path)
+
+        # Load again without going through get_valid_token
+        persisted = token_store.load_token("user_persist", token_dir=tmp_path)
+        assert persisted is not None
+        assert persisted.access_token == "newly-refreshed"
+
+
+# ---------------------------------------------------------------------------
+# No token values in logs
+# ---------------------------------------------------------------------------
+
+
+class TestNoTokenValuesInLogs:
+    def test_access_token_not_logged(self, tmp_path, caplog):
+        import logging
+        token = _future_token()
+        with caplog.at_level(logging.DEBUG, logger="integrations.google_workspace.token_store"):
+            token_store.save_token("user_log", token, token_dir=tmp_path)
+            token_store.load_token("user_log", token_dir=tmp_path)
+            token_store.get_valid_token("user_log", token_dir=tmp_path)
+
+        for record in caplog.records:
+            assert "test-access-token" not in record.getMessage()

--- a/tests/unit/test_mcp_server/test_push_workspace_token_endpoint.py
+++ b/tests/unit/test_mcp_server/test_push_workspace_token_endpoint.py
@@ -1,0 +1,232 @@
+"""
+Tests for POST /api/push-workspace-token endpoint.
+
+Covers:
+- Happy path: valid authenticated request returns {"ok": true} and writes token file
+- Token file written to workspace-tokens/<chat_id>.json with mode 0o600
+- Atomic write: .tmp file is renamed to final path
+- Auth: missing Authorization header -> 401
+- Auth: wrong secret -> 401
+- Validation: missing chat_id -> 400
+- Validation: missing access_token -> 400
+- Validation: missing expires_at -> 400
+- Validation: invalid expires_at format -> 400
+- Path traversal: chat_id with "../" components is sanitised, not written outside token dir
+- Token values never appear in log output
+
+All file I/O uses a tmp_path fixture — no real disk writes outside the test sandbox.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from starlette.testclient import TestClient
+
+# inbox_server_http calls sys.exit(1) at import time when MCP_HTTP_TOKEN is
+# not set.  Pre-seed the env var before the first import so the module loads.
+os.environ.setdefault("MCP_HTTP_TOKEN", "test-mcp-token-placeholder")
+
+_MODULE = "src.mcp.inbox_server_http"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_SECRET = "test-workspace-secret-abc123"
+
+_VALID_BODY = {
+    "chat_id": "123456",
+    "access_token": "ya29.test-workspace-access-token",
+    "refresh_token": "1//test-workspace-refresh-token",
+    "expires_at": "2026-04-01T02:00:00Z",
+    "scope": "https://www.googleapis.com/auth/documents",
+}
+
+
+@pytest.fixture()
+def client_and_token_dir(tmp_path):
+    """Yield (TestClient, workspace_token_dir) with patched dirs and secret."""
+    workspace_token_dir = tmp_path / "config" / "workspace-tokens"
+
+    with (
+        patch(f"{_MODULE}._WORKSPACE_TOKEN_DIR", workspace_token_dir),
+        patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
+    ):
+        from src.mcp.inbox_server_http import app
+
+        client = TestClient(app, raise_server_exceptions=True)
+        yield client, workspace_token_dir
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_valid_request_returns_ok(client_and_token_dir):
+    client, _ = client_and_token_dir
+    resp = client.post(
+        "/api/push-workspace-token",
+        json=_VALID_BODY,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_token_file_written_to_correct_path(client_and_token_dir):
+    client, workspace_token_dir = client_and_token_dir
+    client.post(
+        "/api/push-workspace-token",
+        json=_VALID_BODY,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    token_path = workspace_token_dir / "123456.json"
+    assert token_path.exists()
+
+
+def test_token_file_has_mode_0o600(client_and_token_dir):
+    client, workspace_token_dir = client_and_token_dir
+    client.post(
+        "/api/push-workspace-token",
+        json=_VALID_BODY,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    token_path = workspace_token_dir / "123456.json"
+    permissions = stat.S_IMODE(os.stat(token_path).st_mode)
+    assert permissions == 0o600
+
+
+def test_token_file_contains_correct_data(client_and_token_dir):
+    client, workspace_token_dir = client_and_token_dir
+    client.post(
+        "/api/push-workspace-token",
+        json=_VALID_BODY,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    data = json.loads((workspace_token_dir / "123456.json").read_text())
+    assert data["access_token"] == _VALID_BODY["access_token"]
+    assert data["refresh_token"] == _VALID_BODY["refresh_token"]
+    assert "expires_at" in data
+    assert data["scope"] == _VALID_BODY["scope"]
+
+
+# ---------------------------------------------------------------------------
+# Auth failures
+# ---------------------------------------------------------------------------
+
+
+def test_missing_auth_header_returns_401(client_and_token_dir):
+    client, _ = client_and_token_dir
+    resp = client.post("/api/push-workspace-token", json=_VALID_BODY)
+    assert resp.status_code == 401
+
+
+def test_wrong_secret_returns_401(client_and_token_dir):
+    client, _ = client_and_token_dir
+    resp = client.post(
+        "/api/push-workspace-token",
+        json=_VALID_BODY,
+        headers={"Authorization": "Bearer wrong-secret"},
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Validation failures
+# ---------------------------------------------------------------------------
+
+
+def test_missing_chat_id_returns_400(client_and_token_dir):
+    client, _ = client_and_token_dir
+    body = {**_VALID_BODY}
+    del body["chat_id"]
+    resp = client.post(
+        "/api/push-workspace-token",
+        json=body,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    assert resp.status_code == 400
+
+
+def test_missing_access_token_returns_400(client_and_token_dir):
+    client, _ = client_and_token_dir
+    body = {**_VALID_BODY}
+    del body["access_token"]
+    resp = client.post(
+        "/api/push-workspace-token",
+        json=body,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    assert resp.status_code == 400
+
+
+def test_missing_expires_at_returns_400(client_and_token_dir):
+    client, _ = client_and_token_dir
+    body = {**_VALID_BODY}
+    del body["expires_at"]
+    resp = client.post(
+        "/api/push-workspace-token",
+        json=body,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    assert resp.status_code == 400
+
+
+def test_invalid_expires_at_format_returns_400(client_and_token_dir):
+    client, _ = client_and_token_dir
+    body = {**_VALID_BODY, "expires_at": "not-a-date"}
+    resp = client.post(
+        "/api/push-workspace-token",
+        json=body,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Path traversal protection
+# ---------------------------------------------------------------------------
+
+
+def test_path_traversal_chat_id_is_sanitised(client_and_token_dir):
+    client, workspace_token_dir = client_and_token_dir
+    body = {**_VALID_BODY, "chat_id": "../../../etc/passwd"}
+    resp = client.post(
+        "/api/push-workspace-token",
+        json=body,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    # The sanitised id should be "etcpasswd" (path separators stripped)
+    # and the file should NOT be written outside the token dir
+    assert not (Path("/etc") / "passwd").exists() or True  # can't write to /etc in tests
+    # If the request succeeded, verify the file is inside token_dir
+    if resp.status_code == 200:
+        written_files = list(workspace_token_dir.rglob("*.json"))
+        for f in written_files:
+            assert workspace_token_dir in f.parents or f.parent == workspace_token_dir
+
+
+# ---------------------------------------------------------------------------
+# No token values in logs
+# ---------------------------------------------------------------------------
+
+
+def test_access_token_not_logged(client_and_token_dir, caplog):
+    client, _ = client_and_token_dir
+    with caplog.at_level(logging.DEBUG):
+        client.post(
+            "/api/push-workspace-token",
+            json=_VALID_BODY,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+    for record in caplog.records:
+        assert "ya29.test-workspace-access-token" not in record.getMessage()


### PR DESCRIPTION
## Summary

- Implements `gsheets_read(user_id, sheet_id_or_url, range_a1) -> list[list[str]]` against the Sheets API v4
- Adds `_sheet_id_from_url` (URL/ID parsing), `_normalise_row` (type coercion to str, None → ""), and `_call_sheets_api` (GET/PUT/POST authenticated layer)
- Also includes `gsheets_write` and `gsheets_create` implementations (Slice 6 scope) in the same file; Slice 6 will add write-specific tests
- 16 passing unit tests for read path, covering success, empty range, URL acceptance, type normalisation, network errors, and no-token-in-logs

## Test plan

- [ ] `uv run pytest tests/unit/test_integrations/test_sheets_client_read.py -v` — 16 tests pass
- [ ] Depends on Slice 1 (PR #1639) being merged first
- [ ] Also depends on drive_client.py (Slice 4, PR #1641) — copied into this worktree as import dependency

**Slice chain**: #59 (Slice 1) → this PR (Slice 5) → #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)