### PR TITLE
feat(workspace): Slice 4 — Google Drive listing and search (#62)

### DIFF
--- a/src/integrations/google_workspace/drive_client.py
+++ b/src/integrations/google_workspace/drive_client.py
@@ -1,0 +1,239 @@
+"""
+Google Drive API client — list and search operations.
+
+Provides ``gdrive_list`` and ``gdrive_search`` to enumerate files in a Drive
+folder or search by Drive query syntax.
+
+Design principles (consistent with gmail, calendar, docs clients):
+- Immutable value objects (frozen dataclasses)
+- Pure helpers isolated from I/O
+- Side effects (network calls, token refresh) at the boundaries
+- No credentials or token values ever appear in logs
+- Returns empty list (not None, not raises) on auth failure or API error
+
+Google Drive REST API v3 docs:
+    https://developers.google.com/drive/api/reference/rest/v3
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+import requests
+
+from integrations.google_workspace.token_store import get_valid_token
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# API constants
+# ---------------------------------------------------------------------------
+
+_DRIVE_API_BASE: str = "https://www.googleapis.com/drive/v3"
+_HTTP_TIMEOUT: int = 15
+
+# Fields requested from the Drive API for each file.
+_FILE_FIELDS: str = "id,name,mimeType,modifiedTime,webViewLink"
+
+# MIME type displayed for Google Docs, Sheets, Folders etc.
+_MIME_FOLDER: str = "application/vnd.google-apps.folder"
+
+
+# ---------------------------------------------------------------------------
+# Domain types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DriveFile:
+    """Immutable representation of a Google Drive file or folder.
+
+    Attributes:
+        id:            Drive file ID.
+        name:          File or folder name.
+        mime_type:     Google MIME type string (e.g. ``application/vnd.google-apps.document``).
+        modified_time: Last modification time (UTC, timezone-aware).
+        url:           HTTPS URL to open the file in a browser.
+    """
+
+    id: str
+    name: str
+    mime_type: str
+    modified_time: datetime
+    url: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def _parse_drive_file(item: dict) -> Optional[DriveFile]:
+    """Parse a single Drive API file item into a DriveFile.
+
+    Returns None if any required field is missing or malformed.
+    """
+    file_id = item.get("id", "").strip()
+    name = item.get("name", "").strip()
+    mime_type = item.get("mimeType", "").strip()
+    url = item.get("webViewLink", "").strip()
+    modified_time_str = item.get("modifiedTime", "")
+
+    if not file_id or not name:
+        return None
+
+    try:
+        modified_time = datetime.fromisoformat(modified_time_str.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        modified_time = datetime.now(tz=timezone.utc)
+
+    return DriveFile(
+        id=file_id,
+        name=name,
+        mime_type=mime_type,
+        modified_time=modified_time,
+        url=url,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def _call_drive_api(
+    path: str,
+    access_token: str,
+    params: Optional[dict] = None,
+) -> Optional[dict]:
+    """Make an authenticated GET call to the Google Drive API.
+
+    Args:
+        path:         URL path after the API base (e.g. ``"/files"``).
+        access_token: Bearer token for Google API auth.
+        params:       Optional query parameters.
+
+    Returns:
+        Parsed JSON response dict, or None on any error.
+    """
+    url = f"{_DRIVE_API_BASE}{path}"
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    try:
+        resp = requests.get(url, headers=headers, params=params or {}, timeout=_HTTP_TIMEOUT)
+    except requests.exceptions.RequestException as exc:
+        log.warning("Drive API network error (GET %s): %s", path, exc)
+        return None
+
+    if resp.status_code == 401:
+        log.warning("Drive API: 401 Unauthorized — token may be expired (path=%s)", path)
+        return None
+
+    if not resp.ok:
+        log.warning("Drive API returned %d for GET %s", resp.status_code, path)
+        return None
+
+    try:
+        return resp.json()
+    except ValueError as exc:
+        log.warning("Drive API returned non-JSON for GET %s: %s", path, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def gdrive_list(
+    user_id: str,
+    folder_id: str = "root",
+    max_results: int = 20,
+) -> list[DriveFile]:
+    """List files in a Google Drive folder.
+
+    Args:
+        user_id:     Telegram chat_id used to look up the workspace token.
+        folder_id:   Drive folder ID to list. Defaults to ``"root"`` (My Drive).
+        max_results: Maximum number of files to return (1–100).
+
+    Returns:
+        List of DriveFile objects, sorted by the Drive API default order
+        (most recently modified first). Returns ``[]`` on any error.
+    """
+    token = get_valid_token(user_id)
+    if token is None:
+        log.info("gdrive_list: no valid workspace token for user_id=%r", user_id)
+        return []
+
+    params = {
+        "q": f"'{folder_id}' in parents and trashed=false",
+        "pageSize": min(max(1, max_results), 100),
+        "fields": f"files({_FILE_FIELDS})",
+        "orderBy": "modifiedTime desc",
+    }
+
+    data = _call_drive_api("/files", token.access_token, params=params)
+    if data is None:
+        return []
+
+    files = []
+    for item in data.get("files", []):
+        parsed = _parse_drive_file(item)
+        if parsed is not None:
+            files.append(parsed)
+
+    return files
+
+
+def gdrive_search(
+    user_id: str,
+    query: str,
+    max_results: int = 10,
+) -> list[DriveFile]:
+    """Search Google Drive using Drive query syntax.
+
+    The ``query`` parameter follows the Drive API query syntax. Examples:
+    - ``"name contains 'budget'"``
+    - ``"mimeType='application/vnd.google-apps.document'"``
+    - ``"name contains 'report' and mimeType='application/vnd.google-apps.spreadsheet'"``
+
+    See: https://developers.google.com/drive/api/guides/search-files
+
+    Args:
+        user_id:     Telegram chat_id used to look up the workspace token.
+        query:       Drive API query string.
+        max_results: Maximum number of files to return (1–100).
+
+    Returns:
+        List of DriveFile objects. Returns ``[]`` on any error or no results.
+    """
+    token = get_valid_token(user_id)
+    if token is None:
+        log.info("gdrive_search: no valid workspace token for user_id=%r", user_id)
+        return []
+
+    # Always exclude trashed files
+    full_query = f"({query}) and trashed=false"
+
+    params = {
+        "q": full_query,
+        "pageSize": min(max(1, max_results), 100),
+        "fields": f"files({_FILE_FIELDS})",
+        "orderBy": "modifiedTime desc",
+    }
+
+    data = _call_drive_api("/files", token.access_token, params=params)
+    if data is None:
+        return []
+
+    files = []
+    for item in data.get("files", []):
+        parsed = _parse_drive_file(item)
+        if parsed is not None:
+            files.append(parsed)
+
+    return files

--- a/tests/unit/test_integrations/test_drive_client.py
+++ b/tests/unit/test_integrations/test_drive_client.py
@@ -1,0 +1,285 @@
+"""
+Tests for src/integrations/google_workspace/drive_client.py (Slice 4).
+
+Covers:
+- gdrive_list: returns DriveFile list on success
+- gdrive_list: returns [] when no valid token
+- gdrive_list: returns [] on API error
+- gdrive_list: returns [] on network error
+- gdrive_search: returns matching files
+- gdrive_search: returns [] when no results
+- gdrive_search: appends trashed=false to query
+- _parse_drive_file: parses a valid item correctly
+- _parse_drive_file: returns None for missing id or name
+- No token values appear in logs
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.google_calendar.oauth import TokenData
+from integrations.google_workspace.drive_client import (
+    DriveFile,
+    _parse_drive_file,
+    gdrive_list,
+    gdrive_search,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_ACCESS_TOKEN = "ya29.fake-drive-token"
+
+
+def _valid_token() -> TokenData:
+    return TokenData(
+        access_token=_FAKE_ACCESS_TOKEN,
+        expires_at=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+        scope="https://www.googleapis.com/auth/drive",
+        refresh_token="test-refresh",
+    )
+
+
+def _drive_item(
+    file_id: str = "abc123",
+    name: str = "Test Doc",
+    mime_type: str = "application/vnd.google-apps.document",
+    url: str = "https://docs.google.com/document/d/abc123/edit",
+    modified_time: str = "2026-04-18T10:00:00Z",
+) -> dict:
+    return {
+        "id": file_id,
+        "name": name,
+        "mimeType": mime_type,
+        "webViewLink": url,
+        "modifiedTime": modified_time,
+    }
+
+
+def _http_response(items: list, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.ok = status_code < 400
+    resp.json.return_value = {"files": items}
+    return resp
+
+
+def _error_response(status_code: int = 500) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.ok = False
+    resp.json.return_value = {"error": {"code": status_code}}
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _parse_drive_file — pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseDriveFile:
+    def test_parses_valid_item(self):
+        item = _drive_item()
+        result = _parse_drive_file(item)
+        assert result is not None
+        assert result.id == "abc123"
+        assert result.name == "Test Doc"
+        assert result.mime_type == "application/vnd.google-apps.document"
+        assert result.url == "https://docs.google.com/document/d/abc123/edit"
+        assert isinstance(result.modified_time, datetime)
+        assert result.modified_time.tzinfo is not None
+
+    def test_returns_none_for_missing_id(self):
+        item = _drive_item(file_id="")
+        result = _parse_drive_file(item)
+        assert result is None
+
+    def test_returns_none_for_missing_name(self):
+        item = _drive_item(name="")
+        result = _parse_drive_file(item)
+        assert result is None
+
+    def test_handles_missing_modified_time(self):
+        item = _drive_item()
+        del item["modifiedTime"]
+        result = _parse_drive_file(item)
+        assert result is not None
+        assert result.modified_time.tzinfo is not None  # falls back to now()
+
+
+# ---------------------------------------------------------------------------
+# gdrive_list
+# ---------------------------------------------------------------------------
+
+
+class TestGdriveList:
+    def test_returns_list_on_success(self):
+        items = [_drive_item("id1", "Doc 1"), _drive_item("id2", "Doc 2")]
+        http_resp = _http_response(items)
+
+        with patch(
+            "integrations.google_workspace.drive_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.drive_client.requests.get",
+            return_value=http_resp,
+        ):
+            result = gdrive_list("user123")
+
+        assert len(result) == 2
+        assert all(isinstance(f, DriveFile) for f in result)
+        assert result[0].id == "id1"
+        assert result[1].id == "id2"
+
+    def test_returns_empty_list_when_no_token(self):
+        with patch(
+            "integrations.google_workspace.drive_client.get_valid_token",
+            return_value=None,
+        ):
+            result = gdrive_list("user123")
+
+        assert result == []
+
+    def test_returns_empty_list_on_api_error(self):
+        with patch(
+            "integrations.google_workspace.drive_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.drive_client.requests.get",
+            return_value=_error_response(500),
+        ):
+            result = gdrive_list("user123")
+
+        assert result == []
+
+    def test_returns_empty_list_on_network_error(self):
+        import requests as req_lib
+        with patch(
+            "integrations.google_workspace.drive_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.drive_client.requests.get",
+            side_effect=req_lib.exceptions.ConnectionError("connection refused"),
+        ):
+            result = gdrive_list("user123")
+
+        assert result == []
+
+    def test_returns_empty_list_on_empty_results(self):
+        http_resp = _http_response([])
+        with patch(
+            "integrations.google_workspace.drive_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.drive_client.requests.get",
+            return_value=http_resp,
+        ):
+            result = gdrive_list("user123")
+
+        assert result == []
+
+    def test_uses_folder_id_in_query(self):
+        http_resp = _http_response([])
+        with patch(
+            "integrations.google_workspace.drive_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.drive_client.requests.get",
+            return_value=http_resp,
+        ) as mock_get:
+            gdrive_list("user123", folder_id="specific-folder-id")
+
+        params = mock_get.call_args.kwargs.get("params") or mock_get.call_args[1].get("params", {})
+        assert "specific-folder-id" in params.get("q", "")
+
+
+# ---------------------------------------------------------------------------
+# gdrive_search
+# ---------------------------------------------------------------------------
+
+
+class TestGdriveSearch:
+    def test_returns_matching_files(self):
+        items = [_drive_item("search1", "Search Result")]
+        http_resp = _http_response(items)
+
+        with patch(
+            "integrations.google_workspace.drive_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.drive_client.requests.get",
+            return_value=http_resp,
+        ):
+            result = gdrive_search("user123", "name contains 'Search'")
+
+        assert len(result) == 1
+        assert result[0].name == "Search Result"
+
+    def test_returns_empty_list_when_no_results(self):
+        http_resp = _http_response([])
+        with patch(
+            "integrations.google_workspace.drive_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.drive_client.requests.get",
+            return_value=http_resp,
+        ):
+            result = gdrive_search("user123", "name contains 'nonexistent'")
+
+        assert result == []
+
+    def test_appends_trashed_false_to_query(self):
+        http_resp = _http_response([])
+        with patch(
+            "integrations.google_workspace.drive_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.drive_client.requests.get",
+            return_value=http_resp,
+        ) as mock_get:
+            gdrive_search("user123", "name contains 'test'")
+
+        params = mock_get.call_args.kwargs.get("params") or mock_get.call_args[1].get("params", {})
+        assert "trashed=false" in params.get("q", "")
+
+    def test_returns_empty_list_when_no_token(self):
+        with patch(
+            "integrations.google_workspace.drive_client.get_valid_token",
+            return_value=None,
+        ):
+            result = gdrive_search("user123", "name contains 'test'")
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# No token values in logs
+# ---------------------------------------------------------------------------
+
+
+def test_access_token_not_logged(caplog):
+    import logging
+    http_resp = _http_response([_drive_item()])
+
+    with caplog.at_level(logging.DEBUG, logger="integrations.google_workspace.drive_client"):
+        with patch(
+            "integrations.google_workspace.drive_client.get_valid_token",
+            return_value=_valid_token(),
+        ), patch(
+            "integrations.google_workspace.drive_client.requests.get",
+            return_value=http_resp,
+        ):
+            gdrive_list("user123")
+            gdrive_search("user123", "name contains 'test'")
+
+    for record in caplog.records:
+        assert _FAKE_ACCESS_TOKEN not in record.getMessage()


### PR DESCRIPTION
## Summary

- Implements `gdrive_list(user_id, folder_id, max_results) -> list[DriveFile]` — list files in a Drive folder
- Implements `gdrive_search(user_id, query, max_results) -> list[DriveFile]` — Drive query syntax search
- DriveFile dataclass: id, name, mime_type, modified_time, url
- Unit tests covering success, auth failure, empty results, malformed responses

## Note
Replaces closed PR #1641 (original was stacked against feat/workspace-slice-1 which was merged and deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)