### PR TITLE
fix(#1656): make lobster stop hold indefinitely — remove 1-hour health-check timer

### DIFF
--- a/hooks/on-fresh-start.py
+++ b/hooks/on-fresh-start.py
@@ -107,6 +107,20 @@ COMPACTION_STATE_FILE = Path(
 INBOX_DIR = Path(os.path.expanduser("~/messages/inbox"))
 PROCESSING_DIR = Path(os.path.expanduser("~/messages/processing"))
 
+# Maintenance flag written by `lobster stop` to suppress health-check auto-restarts.
+# Cleared here on successful startup so that `lobster stop` is a true pause:
+# the system stays down until explicitly restarted rather than auto-restarting
+# after a timer (issue #1656).
+_MESSAGES_DIR_FOR_FLAG = Path(
+    os.environ.get("LOBSTER_MESSAGES", os.path.expanduser("~/messages"))
+)
+MAINTENANCE_FLAG = Path(
+    os.environ.get(
+        "LOBSTER_MAINTENANCE_FLAG_OVERRIDE",
+        str(_MESSAGES_DIR_FOR_FLAG / "config" / "lobster-maintenance"),
+    )
+)
+
 # Pointer to the current session file (written by compact-catchup / session management).
 # If this file exists and was modified recently, there is a prior session worth catching up.
 CURRENT_SESSION_FILE_POINTER = Path(
@@ -470,6 +484,35 @@ def _mark_all_running_failed() -> None:
         )
 
 
+def _clear_maintenance_flag() -> None:
+    """Delete the maintenance flag if it exists.
+
+    ``lobster stop`` writes this flag to tell the health check "don't
+    auto-restart, the system was intentionally stopped."  Once the dispatcher
+    starts successfully, the flag's purpose is served — Lobster is running, so
+    maintenance mode is no longer in effect.
+
+    Clearing the flag here (on verified successful start) makes ``lobster stop``
+    a true pause: the system stays down until explicitly restarted.  The health
+    check no longer auto-clears the flag on a timer — so this is now the
+    primary flag-clearing path after an intentional stop.
+
+    See issue #1656.
+    """
+    try:
+        if MAINTENANCE_FLAG.exists():
+            MAINTENANCE_FLAG.unlink()
+            print(
+                f"[on-fresh-start] cleared maintenance flag: {MAINTENANCE_FLAG}",
+                file=sys.stderr,
+            )
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[on-fresh-start] could not clear maintenance flag {MAINTENANCE_FLAG}: {exc}",
+            file=sys.stderr,
+        )
+
+
 def main() -> None:
     # Only fire for Lobster-managed sessions.
     if os.environ.get("LOBSTER_MAIN_SESSION", "") != "1":
@@ -487,6 +530,12 @@ def main() -> None:
     # Skip subagent sessions — only the dispatcher should run this.
     if not session_role.is_dispatcher(data):
         sys.exit(0)
+
+    # Clear the maintenance flag now that the dispatcher is confirmed running.
+    # This makes `lobster stop` a true indefinite pause: the flag persists until
+    # startup genuinely succeeds, so the health check never needs to auto-clear
+    # it on a timer.  See issue #1656.
+    _clear_maintenance_flag()
 
     if not AGENT_MONITOR.exists():
         print(

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -81,7 +81,6 @@ STALE_THRESHOLD_SECONDS=360          # 6 minutes - RED if any message older; tri
 YELLOW_THRESHOLD_SECONDS=150         # 2.5 minutes - YELLOW early warning before 6-min stale restart
 RESTART_WINDOW_BUFFER_SECONDS=120    # Pre-mark messages within this window of the stale threshold before a restart
 
-MAINTENANCE_EXPIRY_SECONDS=3600      # 1 hour - stale maintenance flag is auto-cleared and checks resume
 
 COMPACTION_SUPPRESS_SECONDS=300      # 5 minutes - skip stale-inbox check after a compaction event
 COMPACT_GRACE_SECONDS=600            # 10 minutes - skip stale-inbox check after a compaction (last-compact.ts)
@@ -1560,24 +1559,15 @@ main() {
     acquire_lock
 
     # Maintenance mode: lobster stop sets this flag to prevent auto-restart.
-    # The flag expires after MAINTENANCE_EXPIRY_SECONDS so a failed restart
-    # (which leaves the flag behind) doesn't suppress recovery indefinitely.
+    # The flag is honored indefinitely — it is only cleared by:
+    #   1. on-fresh-start.py when the dispatcher session starts successfully
+    #   2. lobster start (cmd_start in src/cli) explicitly before starting services
+    #
+    # This makes `lobster stop` a true pause: the system stays down until an
+    # explicit restart, not just until a 1-hour timer expires (issue #1656).
     if [[ -f "$MAINTENANCE_FLAG" ]]; then
-        local stopped_at_raw
-        stopped_at_raw=$(grep -oP 'stopped_at=\K[^ ]+' "$MAINTENANCE_FLAG" 2>/dev/null || true)
-        local flag_age=0
-        if [[ -n "$stopped_at_raw" ]]; then
-            local stopped_epoch
-            stopped_epoch=$(date -d "$stopped_at_raw" +%s 2>/dev/null || echo 0)
-            flag_age=$(( $(date +%s) - stopped_epoch ))
-        fi
-        if [[ $flag_age -lt $MAINTENANCE_EXPIRY_SECONDS ]]; then
-            log_info "=== Maintenance mode active (${flag_age}s old, expires at ${MAINTENANCE_EXPIRY_SECONDS}s), skipping all checks ==="
-            exit 0
-        else
-            log_warn "Maintenance flag is stale (${flag_age}s old, limit ${MAINTENANCE_EXPIRY_SECONDS}s) — auto-clearing and resuming checks"
-            rm -f "$MAINTENANCE_FLAG"
-        fi
+        log_info "=== Maintenance mode active — skipping all checks (flag: $MAINTENANCE_FLAG) ==="
+        exit 0
     fi
 
     log_info "=== Health check v3 starting ==="

--- a/tests/smoke/test_health_check.py
+++ b/tests/smoke/test_health_check.py
@@ -514,7 +514,7 @@ def _make_health_check_env(tmp_path: Path) -> dict:
 
 def test_maintenance_flag_honored_when_recent(tmp_path: Path) -> None:
     """
-    D4 (existing, regression guard): maintenance flag causes clean exit when present.
+    D6a: maintenance flag causes clean exit when present and recently written.
 
     Ensures the basic behavior still holds after the 1-hour timer is removed.
     """
@@ -548,7 +548,7 @@ def test_maintenance_flag_honored_when_recent(tmp_path: Path) -> None:
 
 def test_maintenance_flag_honored_after_one_hour(tmp_path: Path) -> None:
     """
-    D6: maintenance flag must be honored indefinitely — even after 1+ hours.
+    D6b: maintenance flag must be honored indefinitely — even after 1+ hours.
 
     The old behavior auto-cleared the flag after MAINTENANCE_EXPIRY_SECONDS (1h),
     which caused Lobster to auto-restart against the operator's intent (issue #1656).

--- a/tests/smoke/test_health_check.py
+++ b/tests/smoke/test_health_check.py
@@ -483,3 +483,110 @@ def test_wfm_freshness_green_when_last_processed_absent_heartbeat_recent(
         "absent. Fresh installs must be GREEN until the first heartbeat is written.\n"
         f"stderr: {result.stderr!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# D6 — maintenance flag is honored indefinitely (issue #1656)
+# ---------------------------------------------------------------------------
+#
+# `lobster stop` should hold Lobster down until an explicit `lobster start`.
+# The old 1-hour auto-clear timer overrode intentional operator stops.
+# After issue #1656, the flag is honored indefinitely — no auto-clear.
+
+
+def _make_health_check_env(tmp_path: Path) -> dict:
+    """Return a minimal env dict to run the health check script in isolation."""
+    messages_dir = tmp_path / "messages"
+    config_dir = messages_dir / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    workspace_dir = tmp_path / "workspace"
+    (workspace_dir / "logs").mkdir(parents=True, exist_ok=True)
+
+    return {
+        **os.environ,
+        "LOBSTER_MESSAGES": str(messages_dir),
+        "LOBSTER_WORKSPACE": str(workspace_dir),
+        "LOBSTER_CONFIG_DIR": str(tmp_path / "no-config"),
+        "LOBSTER_HEALTH_LOCK": str(tmp_path / "health-check.lock"),
+    }
+
+
+def test_maintenance_flag_honored_when_recent(tmp_path: Path) -> None:
+    """
+    D4 (existing, regression guard): maintenance flag causes clean exit when present.
+
+    Ensures the basic behavior still holds after the 1-hour timer is removed.
+    """
+    env = _make_health_check_env(tmp_path)
+    messages_dir = Path(env["LOBSTER_MESSAGES"])
+    flag = messages_dir / "config" / "lobster-maintenance"
+    flag.write_text(
+        f"stopped_at={datetime.now(timezone.utc).isoformat()} stopped_by=lobster"
+    )
+
+    result = subprocess.run(
+        ["bash", str(HEALTH_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+
+    assert result.returncode == 0, (
+        "health-check-v3.sh did not exit 0 under a recent maintenance flag. "
+        f"returncode={result.returncode}\n"
+        f"stdout: {result.stdout!r}\n"
+        f"stderr: {result.stderr!r}"
+    )
+    assert flag.exists(), (
+        "health-check-v3.sh deleted the maintenance flag during a health check run. "
+        "The flag should only be cleared by on-fresh-start.py on confirmed start "
+        "or by lobster start — not by the health check."
+    )
+
+
+def test_maintenance_flag_honored_after_one_hour(tmp_path: Path) -> None:
+    """
+    D6: maintenance flag must be honored indefinitely — even after 1+ hours.
+
+    The old behavior auto-cleared the flag after MAINTENANCE_EXPIRY_SECONDS (1h),
+    which caused Lobster to auto-restart against the operator's intent (issue #1656).
+
+    After this fix, the health check exits 0 and leaves the flag in place no
+    matter how old it is.  The flag is only cleared by on-fresh-start.py when
+    the dispatcher starts successfully, or by lobster start explicitly.
+
+    Failure mode: if the health check still auto-clears an old flag, then
+    `lobster stop` is only a 1-hour pause — the system will auto-restart after
+    the timer expires, defeating the purpose of the stop command.
+    """
+    # Write a flag timestamped more than 1 hour in the past.
+    env = _make_health_check_env(tmp_path)
+    messages_dir = Path(env["LOBSTER_MESSAGES"])
+    flag = messages_dir / "config" / "lobster-maintenance"
+
+    old_time = datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    flag.write_text(f"stopped_at={old_time.isoformat()} stopped_by=lobster")
+
+    result = subprocess.run(
+        ["bash", str(HEALTH_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+
+    assert result.returncode == 0, (
+        "health-check-v3.sh did not exit 0 for a maintenance flag older than 1 hour. "
+        "The flag must be honored indefinitely — not just for 1 hour. "
+        f"returncode={result.returncode}\n"
+        f"stdout: {result.stdout!r}\n"
+        f"stderr: {result.stderr!r}"
+    )
+    assert flag.exists(), (
+        "health-check-v3.sh auto-cleared the maintenance flag because it was older "
+        "than 1 hour. This is the bug from issue #1656: `lobster stop` should hold "
+        "indefinitely, not for just 1 hour. The flag must only be cleared by "
+        "on-fresh-start.py or lobster start — never by the health check on a timer."
+    )

--- a/tests/unit/test_hooks/test_on_fresh_start_maintenance_flag.py
+++ b/tests/unit/test_hooks/test_on_fresh_start_maintenance_flag.py
@@ -1,0 +1,276 @@
+"""
+Unit tests for maintenance flag cleanup in hooks/on-fresh-start.py (issue #1656).
+
+When Lobster starts successfully (fresh dispatcher restart, not compaction),
+the maintenance flag written by `lobster stop` must be removed.  This makes
+`lobster stop` a true pause: Lobster stays down until explicitly restarted.
+
+The health check's 1-hour auto-clear timer has been removed (issue #1656).
+The flag is only cleared via two paths:
+  1. on-fresh-start.py on confirmed successful dispatcher start (this module)
+  2. lobster start (src/cli cmd_start) before starting services
+
+Validates:
+- _clear_maintenance_flag() deletes the flag when present
+- _clear_maintenance_flag() is a no-op when the flag is absent
+- _clear_maintenance_flag() is silent on errors (does not propagate exceptions)
+- main() calls _clear_maintenance_flag() on a genuine fresh restart
+- main() does NOT call _clear_maintenance_flag() during a compaction event
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "on-fresh-start.py"
+
+# Named constant matching the env var used in on-fresh-start.py for test isolation.
+# Must match LOBSTER_MAINTENANCE_FLAG_OVERRIDE used in the hook.
+MAINTENANCE_FLAG_ENV_VAR = "LOBSTER_MAINTENANCE_FLAG_OVERRIDE"
+
+
+class _PatchEnv:
+    """Context manager to temporarily set environment variables."""
+
+    def __init__(self, env: dict):
+        self._env = env
+        self._saved = {}
+
+    def __enter__(self):
+        for k, v in self._env.items():
+            self._saved[k] = os.environ.get(k)
+            os.environ[k] = v
+        return self
+
+    def __exit__(self, *_):
+        for k, saved_v in self._saved.items():
+            if saved_v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = saved_v
+
+
+def _make_session_role_stub(is_dispatcher: bool = True):
+    """Return a minimal session_role stub that reports the given dispatcher state."""
+    stub = MagicMock()
+    stub.is_dispatcher.return_value = is_dispatcher
+    return stub
+
+
+def _load_module(
+    compaction_state_override: str = None,
+    inbox_dir: str = None,
+    session_file_pointer_override: str = None,
+    maintenance_flag_override: str = None,
+    is_dispatcher: bool = True,
+) -> object:
+    """Load on-fresh-start.py as a module with isolated file paths."""
+    env_patch = {}
+    if compaction_state_override:
+        env_patch["LOBSTER_COMPACTION_STATE_FILE_OVERRIDE"] = compaction_state_override
+    if session_file_pointer_override:
+        env_patch["LOBSTER_CURRENT_SESSION_FILE_OVERRIDE"] = session_file_pointer_override
+    if maintenance_flag_override:
+        env_patch[MAINTENANCE_FLAG_ENV_VAR] = maintenance_flag_override
+
+    with _PatchEnv(env_patch):
+        spec = importlib.util.spec_from_file_location("on_fresh_start", _HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        _saved_sr = sys.modules.get("session_role")
+        sys.modules["session_role"] = _make_session_role_stub(is_dispatcher)
+        try:
+            spec.loader.exec_module(mod)
+        finally:
+            if _saved_sr is None:
+                sys.modules.pop("session_role", None)
+            else:
+                sys.modules["session_role"] = _saved_sr
+
+    # Override runtime-resolved paths on the loaded module
+    if compaction_state_override:
+        mod.COMPACTION_STATE_FILE = Path(compaction_state_override)
+    if inbox_dir:
+        mod.INBOX_DIR = Path(inbox_dir)
+    if session_file_pointer_override:
+        mod.CURRENT_SESSION_FILE_POINTER = Path(session_file_pointer_override)
+    if maintenance_flag_override:
+        mod.MAINTENANCE_FLAG = Path(maintenance_flag_override)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# _clear_maintenance_flag() unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_clear_flag_deletes_existing_flag(tmp_path: Path) -> None:
+    """
+    _clear_maintenance_flag() must delete the flag file when it is present.
+
+    Failure mode: if the flag is not deleted on successful start, the health
+    check will see the flag indefinitely and suppress all monitoring — Lobster
+    stays in maintenance mode even though it is running.
+    """
+    flag = tmp_path / "lobster-maintenance"
+    flag.write_text("stopped_at=2026-01-01T00:00:00+00:00 stopped_by=lobster")
+
+    mod = _load_module(maintenance_flag_override=str(flag))
+    mod._clear_maintenance_flag()
+
+    assert not flag.exists(), (
+        "_clear_maintenance_flag() did not delete the maintenance flag. "
+        "The health check will see a stale flag and suppress monitoring indefinitely."
+    )
+
+
+def test_clear_flag_is_noop_when_absent(tmp_path: Path) -> None:
+    """
+    _clear_maintenance_flag() must not raise when the flag does not exist.
+
+    Failure mode: if missing-flag raises, on-fresh-start.py crashes on every
+    normal startup (no prior lobster stop), breaking the startup hook.
+    """
+    flag = tmp_path / "lobster-maintenance"
+    assert not flag.exists()
+
+    mod = _load_module(maintenance_flag_override=str(flag))
+    # Should complete without raising
+    mod._clear_maintenance_flag()
+
+
+def test_clear_flag_is_silent_on_permission_error(tmp_path: Path) -> None:
+    """
+    _clear_maintenance_flag() must not propagate OSError on permission failure.
+
+    The health check and startup hook must not crash if the flag exists but
+    cannot be deleted (e.g. permission mismatch after a manual deploy).
+    """
+    flag = tmp_path / "lobster-maintenance"
+    flag.write_text("stopped_at=2026-01-01T00:00:00+00:00 stopped_by=lobster")
+
+    mod = _load_module(maintenance_flag_override=str(flag))
+
+    # Patch Path.unlink to raise PermissionError
+    with patch.object(Path, "unlink", side_effect=PermissionError("no write")):
+        # Must not raise
+        mod._clear_maintenance_flag()
+
+
+# ---------------------------------------------------------------------------
+# main() integration: flag cleared on genuine fresh restart, not compaction
+# ---------------------------------------------------------------------------
+
+
+def _make_stale_compaction_state(path: Path) -> None:
+    """Write a compaction-state.json with a mtime older than COMPACTION_RECENCY_SECONDS."""
+    path.write_text(json.dumps({"last_catchup_ts": "2020-01-01T00:00:00Z"}))
+    # Make mtime 300 seconds in the past so it is NOT considered a recent compaction.
+    old_mtime = time.time() - 300
+    os.utime(path, (old_mtime, old_mtime))
+
+
+def test_main_clears_flag_on_fresh_restart(tmp_path: Path) -> None:
+    """
+    main() must clear the maintenance flag on a genuine fresh dispatcher restart.
+
+    Failure mode: if main() does not call _clear_maintenance_flag(), then
+    `lobster stop` followed by `lobster start` leaves the flag in place.
+    The health check sees the flag and suppresses all monitoring, so a
+    re-started Lobster appears stopped to the health check forever.
+    """
+    flag = tmp_path / "lobster-maintenance"
+    flag.write_text("stopped_at=2026-01-01T00:00:00+00:00 stopped_by=lobster")
+
+    compaction_state = tmp_path / "compaction-state.json"
+    _make_stale_compaction_state(compaction_state)
+
+    inbox_dir = tmp_path / "inbox"
+    inbox_dir.mkdir()
+
+    session_ptr = tmp_path / "lobster-current-session-file"
+    # No session file pointer → no compact-reminder injection needed
+
+    agent_monitor = tmp_path / "agent-monitor.py"
+    agent_monitor.write_text("# stub")
+
+    mod = _load_module(
+        compaction_state_override=str(compaction_state),
+        inbox_dir=str(inbox_dir),
+        session_file_pointer_override=str(session_ptr),
+        maintenance_flag_override=str(flag),
+    )
+    mod.AGENT_MONITOR = agent_monitor
+
+    # Patch subprocess calls and heavy helpers so we only test flag clearing.
+    # main() ends with sys.exit(0) — catch SystemExit so the assertion below can run.
+    with (
+        patch.object(mod, "_mark_all_running_failed"),
+        patch.object(mod, "_inject_compact_reminder"),
+        patch.object(mod, "_schedule_reflection_prompt"),
+        patch("subprocess.run"),
+    ):
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
+            mod.main.__globals__["sys"].stdin = __import__("io").StringIO(
+                json.dumps({"session_id": "test-fresh"})
+            )
+            with pytest.raises(SystemExit) as exc_info:
+                mod.main()
+        assert exc_info.value.code == 0, (
+            f"main() exited with unexpected code {exc_info.value.code!r}; expected 0."
+        )
+
+    assert not flag.exists(), (
+        "main() did not clear the maintenance flag on a fresh dispatcher restart. "
+        "After `lobster stop` + `lobster start`, the health check would see a "
+        "stale flag and suppress monitoring indefinitely."
+    )
+
+
+def test_main_does_not_clear_flag_on_compaction(tmp_path: Path) -> None:
+    """
+    main() must NOT clear the maintenance flag during a compaction restart.
+
+    A compaction event means the dispatcher is already running and subagents
+    are still alive. Clearing the flag here would be wrong if maintenance mode
+    was intentionally set and the system happened to compact at the same time.
+    More importantly, on a compaction event main() exits early before reaching
+    the flag-clearing code — this test verifies that early-exit path.
+    """
+    flag = tmp_path / "lobster-maintenance"
+    flag.write_text("stopped_at=2026-01-01T00:00:00+00:00 stopped_by=lobster")
+
+    # Write a compaction state file with a RECENT mtime so it looks like a compaction.
+    compaction_state = tmp_path / "compaction-state.json"
+    compaction_state.write_text(json.dumps({"last_catchup_ts": "2026-01-01T00:00:00Z"}))
+    # mtime = now → recent compaction
+
+    mod = _load_module(
+        compaction_state_override=str(compaction_state),
+        maintenance_flag_override=str(flag),
+    )
+
+    with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
+        mod.main.__globals__["sys"].stdin = __import__("io").StringIO(
+            json.dumps({"session_id": "test-compact"})
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+
+    # main() exits 0 on compaction (before flag logic)
+    assert exc_info.value.code == 0, (
+        "main() did not exit early on a compaction event. "
+        f"Got exit code {exc_info.value.code!r}."
+    )
+    assert flag.exists(), (
+        "main() incorrectly cleared the maintenance flag during a compaction event. "
+        "The flag must only be cleared on genuine fresh dispatcher restarts."
+    )


### PR DESCRIPTION
## Problem

`lobster stop` writes a maintenance flag to suppress health-check auto-restarts. But the health check auto-clears that flag after 1 hour and restarts Lobster unconditionally — overriding the operator's intent. This makes `lobster stop` a 1-hour pause, not a true stop.

The 1-hour timer was added in commit 2768024 to handle a different problem: a botched restart leaving a stale flag that suppresses monitoring indefinitely. That was a real concern, but the timer is the wrong solution to it.

## Fix: Option B — clear on confirmed success, remove the timer

The flag should be cleared exactly when startup **succeeds** — not on a timer, and not before startup completes. `on-fresh-start.py` is the right place: it runs inside the SessionStart hook and already distinguishes genuine fresh restarts from compaction events.

With the flag cleared on confirmed success, the 1-hour timer in the health check has no remaining justification — it can be removed entirely.

**If startup fails** (Claude crashes before `on-fresh-start.py` runs), the flag persists. The health check sees the flag, exits 0, and monitoring is suppressed. The operator must investigate and restart manually. This is the correct behavior: a failed restart does not override an intentional stop.

## Flow before / after

**Before:**
```
lobster stop  →  writes maintenance flag
health-check  →  sees flag, suppresses checks
[1 hour later]
health-check  →  flag >1h old, auto-clears it, restarts Lobster  ← unintended
```

**After:**
```
lobster stop  →  writes maintenance flag
health-check  →  sees flag, suppresses checks indefinitely

[explicit: lobster start]
  → services started
  → on-fresh-start.py: dispatcher confirmed running → clears flag
health-check  →  flag absent, monitors normally

[failure case: startup initiated but dispatcher never completes]
health-check  →  flag still present → suppresses checks → operator must intervene
```

The health check no longer modifies the maintenance flag under any circumstances.

## Implementation

- **`hooks/on-fresh-start.py`**: adds `MAINTENANCE_FLAG` path constant (env-var overridable for test isolation) and `_clear_maintenance_flag()` function; calls it in `main()` after the compaction and dispatcher role checks — so it only runs on genuine fresh dispatcher starts.
- **`scripts/health-check-v3.sh`**: removes `MAINTENANCE_EXPIRY_SECONDS` constant and replaces the timer block with an unconditional `exit 0` when the flag is present.
- **`tests/unit/test_hooks/test_on_fresh_start_maintenance_flag.py`**: 5 unit tests covering `_clear_maintenance_flag()` (flag present, absent, permission error) and `main()` integration (clears on fresh start, does not clear on compaction).
- **`tests/smoke/test_health_check.py`**: 2 smoke tests — one for a recent flag, one for a flag older than 1 hour — verifying both that the health check exits 0 and that it does **not** delete the flag.

## Relationship to PR #1657

PR #1657 (open) implements the same `on-fresh-start.py` clearing piece but keeps the 1-hour timer as a "fallback." This PR goes further: it removes the timer entirely, making the stop truly indefinite. If #1657 is still open, this PR supersedes it for issue #1656. If #1657 is merged first, this PR will need a rebase, but the health-check change is independent and still needed.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_on_fresh_start_maintenance_flag.py -v` — 5 passed
- [x] `uv run pytest tests/smoke/test_health_check.py -v` — 12 passed (includes 2 new D6 tests)
- [x] `uv run pytest tests/unit/ -q` — 2845 passed, 24 skipped, 0 failed
- [x] `uv run pytest tests/smoke/ -q` — 67 passed, 0 failed

## Manual test

N/A — this change is entirely internal file I/O (reads/deletes one file in `~/messages/config/`). No external services, Telegram output, or user-visible messages are touched. The behavior is fully covered by the unit and smoke tests above.

The flag-clearing path in `on-fresh-start.py` runs as a SessionStart hook; it cannot be tested against a live dispatcher without a real restart. However, the unit test `test_main_clears_flag_on_fresh_restart` exercises the exact code path (with `_mark_all_running_failed` and `_schedule_reflection_prompt` patched out) and verifies the flag is absent after `main()` returns.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A: internal file I/O, covered by unit and smoke tests
- [x] User-visible outcome verified: `lobster stop` now holds indefinitely — covered by `test_main_clears_flag_on_fresh_restart` and `test_maintenance_flag_honored_after_one_hour`
- [x] Side-effect audit: only reads/deletes `lobster-maintenance`; no volume risk, no shared state beyond the flag itself, no loops or floods possible

Closes #1656