### PR TITLE
fix: encapsulate Gmail skill — remove PII, add onboarding, register in shop

### DIFF
--- a/lobster-shop/INDEX.md
+++ b/lobster-shop/INDEX.md
@@ -17,6 +17,7 @@ Browse available skills for your Lobster assistant. Install any skill with one c
 | [Hibernation](./hibernation/) | Dispatcher hibernation — idle timeout behavior, state file semantics, and how to break the hibernation loop cleanly | Behavioral | Available |
 | [Obsidian KM](./obsidian-km/) | Sync and access your Obsidian vault via Telegram — create, read, search, and manage notes from anywhere | Tool | In Dev |
 | [Buy Things](./buy-things/) | Purchase items via Telegram — search products, confirm with you, and complete checkout using Camofox browser automation | Tool | Available |
+| [Gmail](./gmail/) | Read and search your Gmail inbox via chat — authenticate once with Google OAuth, then check email, find messages, and get summaries on demand | Integration | Available |
 
 ## Templates
 
@@ -32,7 +33,6 @@ Browse available skills for your Lobster assistant. Install any skill with one c
 | Notion | Search your notes, create pages, manage databases from chat | Coming Soon |
 | Spotify | Control your music — play, pause, skip, queue songs by asking | Coming Soon |
 | Home Automation | Control lights, thermostats, and devices via HomeKit or Home Assistant | Coming Soon |
-| Email Triage | Summarize your inbox, flag important emails, draft replies | Coming Soon |
 | Expense Tracking | Log expenses, categorize spending, get summaries on demand | Coming Soon |
 
 ---

--- a/lobster-shop/gmail/onboarding.md
+++ b/lobster-shop/gmail/onboarding.md
@@ -1,0 +1,82 @@
+# Gmail Skill — Onboarding
+
+## What this skill does
+
+Once connected, Lobster can read and search your Gmail inbox on demand. Say
+"check my email", "any new messages?", or "find emails from [person]" and
+Lobster will fetch results directly from the Gmail API using your OAuth token.
+
+## Prerequisites
+
+- A Lobster instance running with `LOBSTER_INSTANCE_URL` and
+  `LOBSTER_INTERNAL_SECRET` set in `~/lobster-config/config.env`
+- A myownlobster.ai account (handles OAuth consent — no GCP setup required
+  on your end)
+
+## One-time setup
+
+### Step 1: Connect your Gmail account
+
+Send your Lobster assistant:
+
+```
+/gmail connect
+```
+
+or just say "connect my Gmail" or "authenticate Gmail".
+
+Lobster will reply with a one-time consent link:
+
+```
+To connect your Gmail, tap this link (expires in 30 minutes):
+[Connect Gmail](https://myownlobster.ai/connect/gmail?token=...)
+```
+
+Tap the link. You will be taken to Google's OAuth consent screen (hosted at
+myownlobster.ai, which holds the GCP credentials centrally). Grant the
+`gmail.readonly` permission.
+
+### Step 2: Confirmation
+
+After granting access, myownlobster.ai exchanges the auth code for a token and
+pushes it to your Lobster instance via `POST /api/push-gmail-token`. Your token
+is stored locally at `~/messages/config/gmail-tokens/{your_chat_id}.json`
+(mode 0o600 — owner read/write only). No credentials leave your VPS.
+
+Lobster will confirm when your Gmail is connected.
+
+### Step 3: Use it
+
+```
+check my email
+any new emails?
+find emails from Sarah
+search for "invoice" in my email
+```
+
+Tokens are refreshed automatically via the myownlobster.ai refresh proxy when
+they expire. You should not need to re-authenticate unless you revoke access
+from your Google account settings.
+
+## Environment variables required
+
+| Variable | Where | Purpose |
+|----------|-------|---------|
+| `LOBSTER_INSTANCE_URL` | `~/lobster-config/config.env` | Your VPS URL — myownlobster.ai pushes the token here after OAuth |
+| `LOBSTER_INTERNAL_SECRET` | `~/lobster-config/config.env` | Shared secret authenticating the token push and refresh calls |
+
+## Scope
+
+This skill requests `gmail.readonly` only. Lobster cannot send, delete, or
+modify emails on your behalf.
+
+Gmail and Google Calendar OAuth are independent — connecting one does not
+affect the other.
+
+## Revoking access
+
+Revoke in Google account settings:
+`https://myaccount.google.com/permissions`
+
+Alternatively, delete `~/messages/config/gmail-tokens/{your_chat_id}.json`
+on your VPS to immediately disconnect.

--- a/scheduled-tasks/tasks/gmail-email-pipeline.md.template
+++ b/scheduled-tasks/tasks/gmail-email-pipeline.md.template
@@ -303,7 +303,7 @@ def debug_step(text: str) -> None:
     msg = {
         "id": str(uuid.uuid4()),
         "source": "gmail-pipeline",
-        "chat_id": 8305714125,
+        "chat_id": {{TELEGRAM_CHAT_ID}},
         "type": "text",
         "subtype": "pipeline_step",
         "text": text,


### PR DESCRIPTION
## What problem does this solve?

The Gmail skill had one instance of AWP-specific PII baked into the codebase: a hardcoded Telegram `chat_id` in the `debug_step` helper inside `scheduled-tasks/tasks/gmail-email-pipeline.md.template`. Every other `chat_id` reference in that same template correctly uses `{{TELEGRAM_CHAT_ID}}` — this one was missed.

Additionally, the Gmail skill existed in `lobster-shop/gmail/` but was not registered in `lobster-shop/INDEX.md`, making it invisible to new users browsing available skills. There was also no user-facing onboarding document explaining how to connect Gmail (prerequisites, consent flow, token storage, revocation).

## What changed

**1. PII removed** (`scheduled-tasks/tasks/gmail-email-pipeline.md.template`):  
`"chat_id": 8305714125` replaced with `"chat_id": {{TELEGRAM_CHAT_ID}}` — now consistent with the rest of the template.

**2. Onboarding document added** (`lobster-shop/gmail/onboarding.md`):  
New file covering: what the skill does, prerequisites (`LOBSTER_INSTANCE_URL`, `LOBSTER_INTERNAL_SECRET`), step-by-step OAuth consent flow via myownlobster.ai, the token push/storage mechanism, required env vars table, scope (gmail.readonly only), and revocation steps. No GCP setup required by end users — myownlobster.ai holds credentials centrally.

**3. Shop index updated** (`lobster-shop/INDEX.md`):  
Gmail registered as "Available" in the skill table. The "Email Triage" Coming Soon placeholder removed (Gmail covers that use case).

## What was not changed

The skill code itself — `lobster-shop/gmail/skill.toml`, `behavior/system.md`, `context/reference.md`, and `src/integrations/gmail/` — was already clean and generic. No user-specific names, email addresses, org names, or tokens in any of those files. The multi-user pattern (`chat_id` from message context, fallback to `read_owner()` for legacy installs) is correctly implemented. No changes needed there.

The gcal-links skill behavior still uses the older single-user `read_owner()` pattern; that's a separate issue.

## Functional patterns

Pure functions (`_parse_message`, `_parse_header`, `_token_path`, `_token_to_dict`, `_dict_to_token`) are isolated from all I/O. Side effects (network calls, file writes) are pushed to dedicated boundary functions (`_call_gmail_api`, `_save_token_local`, `_refresh_token_via_proxy`). All public APIs return empty-list / None on failure rather than propagating exceptions.

## Tests run

- [x] `uv run pytest tests/unit/test_integrations/test_gmail_skill_consent_behavior.py tests/unit/test_integrations/test_gmail_token_store.py tests/unit/test_integrations/test_gmail_client.py tests/unit/test_mcp_server/test_push_gmail_token_endpoint.py -v` — 91 passed, 0 failed
- [x] Pre-push PII scanner — passed clean

## Manual test

N/A — this PR changes only documentation files and a template placeholder. No runtime behavior is altered. No external services are touched. No Telegram messages are sent by this change.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A, documentation-only change
- [x] User-visible outcome: onboarding doc is readable, shop index shows Gmail as Available
- [x] Side-effect audit: no runtime code changed, no floods or state writes possible
- [x] External service calls: none in this PR

Closes #1364 (partial — skill is now properly encapsulated; GCP scope approval and E2E test remain as noted in the issue)