### PR TITLE
chore: harden gmail+gcal skills — remove all instance config and PII

### DIFF
--- a/lobster-shop/gcal-links/behavior/system.md
+++ b/lobster-shop/gcal-links/behavior/system.md
@@ -11,11 +11,25 @@ import sys
 import os
 sys.path.insert(0, os.path.expanduser("~/lobster/src"))
 from integrations.google_calendar.token_store import load_token
-from mcp.user_model.owner import read_owner
 
-owner = read_owner()
-OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
-token = load_token(OWNER_USER_ID)
+# MULTI-USER: always prefer chat_id from the incoming message context.
+# Fall back to read_owner() only for single-user / legacy installs where
+# the message doesn't carry a chat_id (e.g. scheduled jobs).
+#
+# In the Lobster dispatcher the message looks like:
+#   message["chat_id"]  — Telegram chat_id of the user who sent the message
+#
+# Usage pattern (the subagent receives chat_id as a parameter):
+#   USER_ID = message_chat_id or _fallback_to_owner()
+def _fallback_to_owner() -> str:
+    from mcp.user_model.owner import read_owner
+    owner = read_owner()
+    return owner.get("owner", {}).get("telegram_chat_id", "")
+
+# Prefer caller's chat_id; fall back to owner for single-user installs.
+# `message_chat_id` must be passed in from the dispatcher context.
+USER_ID = str(message_chat_id) if message_chat_id else _fallback_to_owner()
+token = load_token(USER_ID)
 is_authenticated = token is not None
 ```
 
@@ -61,7 +75,19 @@ sys.path.insert(0, os.path.expanduser("~/lobster/src"))
 from integrations.google_calendar.client import get_upcoming_events
 from utils.calendar import gcal_add_link_md
 
-events = get_upcoming_events(user_id=OWNER_USER_ID, days=7)
+# MULTI-USER: use the chat_id from the message that triggered this subagent.
+# The dispatcher must pass it as a parameter when spawning the subagent.
+# Fall back to read_owner() only for single-user / legacy installs.
+def _get_user_id(message_chat_id=None) -> str:
+    if message_chat_id:
+        return str(message_chat_id)
+    from mcp.user_model.owner import read_owner
+    owner = read_owner()
+    return owner.get("owner", {}).get("telegram_chat_id", "")
+
+USER_ID = _get_user_id(message_chat_id)  # pass chat_id from dispatcher context
+
+events = get_upcoming_events(user_id=USER_ID, days=7)
 if not events:
     reply = "No upcoming events in the next 7 days."
 else:
@@ -85,24 +111,35 @@ from integrations.google_calendar.client import create_event
 from utils.calendar import gcal_add_link_md
 from datetime import datetime, timezone
 
+# MULTI-USER: use the chat_id from the message that triggered this subagent.
+def _get_user_id(message_chat_id=None) -> str:
+    if message_chat_id:
+        return str(message_chat_id)
+    from mcp.user_model.owner import read_owner
+    owner = read_owner()
+    return owner.get("owner", {}).get("telegram_chat_id", "")
+
+USER_ID = _get_user_id(message_chat_id)  # pass chat_id from dispatcher context
+
+# title, start, end are derived from the user's message (resolved by the dispatcher)
 event = create_event(
-    user_id=OWNER_USER_ID,
-    title="Meeting with Sarah",
-    start=datetime(2026, 3, 7, 14, 0, tzinfo=timezone.utc),
-    end=datetime(2026, 3, 7, 15, 0, tzinfo=timezone.utc),
+    user_id=USER_ID,
+    title=title,   # e.g. "Meeting with Sarah"
+    start=start,   # datetime resolved from user's message
+    end=end,       # datetime resolved from user's message (or start + 1h)
     description="",
     location="",
 )
 
 if event is not None:
     link = f"[View in Google Calendar]({event.url})" if event.url else gcal_add_link_md(
-        title="Meeting with Sarah",
-        start=datetime(2026, 3, 7, 14, 0, tzinfo=timezone.utc),
+        title=title,
+        start=start,
     )
-    reply = f"Done — added \"Meeting with Sarah\" to your calendar.\n{link}"
+    reply = f"Done — added \"{title}\" to your calendar.\n{link}"
 else:
     # API failed — fall back to deep link
-    link = gcal_add_link_md("Meeting with Sarah", datetime(2026, 3, 7, 14, 0, tzinfo=timezone.utc))
+    link = gcal_add_link_md(title, start)
     reply = f"Couldn't add via API — use this link instead:\n{link}"
 ```
 

--- a/lobster-shop/gcal-links/context/reference.md
+++ b/lobster-shop/gcal-links/context/reference.md
@@ -7,11 +7,18 @@ import sys
 import os
 sys.path.insert(0, os.path.expanduser("~/lobster/src"))
 from integrations.google_calendar.token_store import load_token
-from mcp.user_model.owner import read_owner
 
-owner = read_owner()
-OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
-token = load_token(OWNER_USER_ID)
+# MULTI-USER: prefer chat_id from the incoming message context.
+# Fall back to read_owner() only for single-user / legacy installs.
+def _get_user_id(message_chat_id=None) -> str:
+    if message_chat_id:
+        return str(message_chat_id)
+    from mcp.user_model.owner import read_owner
+    owner = read_owner()
+    return owner.get("owner", {}).get("telegram_chat_id", "")
+
+USER_ID = _get_user_id(message_chat_id)  # pass chat_id from dispatcher context
+token = load_token(USER_ID)
 is_authenticated = token is not None
 ```
 
@@ -44,7 +51,7 @@ link = gcal_add_link_md(title="Doctor appointment", start=start, end=end)
 ```python
 from integrations.google_calendar.client import get_upcoming_events
 
-events = get_upcoming_events(user_id=OWNER_USER_ID, days=7)
+events = get_upcoming_events(user_id=USER_ID, days=7)
 # Returns List[CalendarEvent] — empty list on auth failure or API error
 
 # CalendarEvent fields:
@@ -61,7 +68,7 @@ from integrations.google_calendar.client import create_event
 from datetime import datetime, timezone
 
 event = create_event(
-    user_id=OWNER_USER_ID,
+    user_id=USER_ID,
     title="Meeting with Sarah",
     start=datetime(2026, 3, 7, 14, 0, tzinfo=timezone.utc),
     end=datetime(2026, 3, 7, 15, 0, tzinfo=timezone.utc),   # optional
@@ -73,22 +80,34 @@ event = create_event(
 
 ---
 
-### Generate auth URL
+### Generate auth URL (consent flow)
 
 ```python
-import secrets
-from integrations.google_calendar.config import is_enabled
-from integrations.google_calendar.oauth import generate_auth_url
+from integrations.google_auth.consent import generate_consent_link
 
-if is_enabled():
-    state = secrets.token_urlsafe(32)
-    url = generate_auth_url(state=state)
-    # Send to user as: [Authorize Google Calendar](url)
+try:
+    url = generate_consent_link("calendar")
+    # Send to user as: [Connect Google Calendar](url)
+except Exception as exc:
+    # Log warning and send a user-friendly fallback message.
+    # Never surface exc details to the user.
+    pass
 ```
 
 ---
 
 ### User ID convention
 
-The owner's `user_id` is their Telegram chat_id as a string, read from `~/lobster-config/owner.toml`.
+For multi-user deployments, `user_id` is the **caller's Telegram `chat_id`**
+passed in from the message context — not the owner's ID.
+Fall back to `read_owner()` only for single-user / legacy installs where no
+`chat_id` is available in context.
+
 All token files live in `~/messages/config/gcal-tokens/{user_id}.json`.
+
+---
+
+### Scope isolation
+
+Calendar tokens (`gcal-tokens/`) and Gmail tokens (`gmail-tokens/`) are
+separate directories. Authenticating one never affects the other.

--- a/lobster-shop/gcal-links/onboarding.md
+++ b/lobster-shop/gcal-links/onboarding.md
@@ -1,0 +1,105 @@
+# Google Calendar Skill — Onboarding
+
+## What this skill does
+
+This skill has two modes:
+
+- **Unauthenticated:** Lobster generates a Google Calendar deep link for any
+  event with a date and time, so you can add it to your calendar in one tap.
+  No setup required.
+- **Authenticated:** Once connected, Lobster reads your upcoming events on demand
+  and can create events directly via the Google Calendar API.
+
+Say "what's on my calendar this week", "add a meeting tomorrow at 2pm", or
+"connect my Google Calendar" to get started.
+
+## Prerequisites
+
+- A Lobster instance with `LOBSTER_INSTANCE_URL` and `LOBSTER_INTERNAL_SECRET`
+  set in `~/lobster-config/config.env`
+- A myownlobster.ai account (handles OAuth consent — no GCP setup required
+  on your end)
+
+## One-time setup
+
+### Step 1: Connect your Google Calendar
+
+Send your Lobster assistant:
+
+```
+/calendar connect
+```
+
+or just say "connect my Google Calendar" or "authenticate Google Calendar".
+
+Lobster will reply with a one-time consent link:
+
+```
+To connect your Google Calendar, tap this link (expires in 30 minutes):
+[Connect Google Calendar](https://myownlobster.ai/connect/calendar?token=...)
+```
+
+Tap the link. You will be taken to Google's OAuth consent screen (hosted at
+myownlobster.ai, which holds the GCP credentials centrally). Grant the
+`calendar.readonly` and `calendar.events` permissions.
+
+### Step 2: Confirmation
+
+After granting access, myownlobster.ai exchanges the auth code for a token and
+pushes it to your Lobster instance. Your token is stored locally at
+`~/messages/config/gcal-tokens/{your_chat_id}.json` (mode 0o600 — owner
+read/write only). No credentials leave your VPS.
+
+Lobster will confirm when your calendar is connected.
+
+### Step 3: Use it
+
+```
+what's on my calendar this week?
+do I have anything tomorrow?
+add a dentist appointment for Friday at 10am
+schedule a call with Alex next Tuesday at 3pm
+```
+
+Tokens are refreshed automatically via the myownlobster.ai refresh proxy when
+they expire. You should not need to re-authenticate unless you revoke access
+from your Google account settings.
+
+## Environment variables required
+
+| Variable | Where | Purpose |
+|----------|-------|---------|
+| `LOBSTER_INSTANCE_URL` | `~/lobster-config/config.env` | Your VPS URL — myownlobster.ai pushes the token here after OAuth |
+| `LOBSTER_INTERNAL_SECRET` | `~/lobster-config/config.env` | Shared secret authenticating the token push and refresh calls |
+
+## Deep link mode (no auth required)
+
+Even without connecting your calendar, Lobster will always generate a Google
+Calendar deep link when you mention a concrete event with a date and time:
+
+> "Remind me about my dentist appointment on Friday at 10am"
+
+Lobster replies with:
+
+> [Add to Google Calendar](https://calendar.google.com/calendar/r/eventedit?...)
+
+Tap the link to open a pre-filled event in Google Calendar.
+
+## Scope
+
+This skill requests:
+- `calendar.readonly` — read upcoming events
+- `calendar.events` — create events on your behalf
+
+Lobster cannot delete or modify existing events unless you explicitly ask.
+
+Google Calendar and Gmail OAuth are independent — connecting one does not
+affect the other.
+
+## Revoking access
+
+Revoke in Google account settings:
+`https://myaccount.google.com/permissions`
+
+Alternatively, delete `~/messages/config/gcal-tokens/{your_chat_id}.json`
+on your VPS to immediately disconnect.

--- a/lobster-shop/google-workspace/behavior/system.md
+++ b/lobster-shop/google-workspace/behavior/system.md
@@ -11,11 +11,19 @@ import sys
 import os
 sys.path.insert(0, os.path.expanduser("~/lobster/src"))
 from integrations.google_workspace.token_store import load_token
-from mcp.user_model.owner import read_owner
 
-owner = read_owner()
-OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
-token = load_token(OWNER_USER_ID)
+# MULTI-USER: always prefer chat_id from the incoming message context.
+# Fall back to read_owner() only for single-user / legacy installs where
+# the message doesn't carry a chat_id (e.g. scheduled jobs).
+def _fallback_to_owner() -> str:
+    from mcp.user_model.owner import read_owner
+    owner = read_owner()
+    return owner.get("owner", {}).get("telegram_chat_id", "")
+
+# Prefer caller's chat_id; fall back to owner for single-user installs.
+# `message_chat_id` must be passed in from the dispatcher context.
+USER_ID = str(message_chat_id) if message_chat_id else _fallback_to_owner()
+token = load_token(USER_ID)
 is_authenticated = token is not None
 ```
 
@@ -72,13 +80,21 @@ import sys
 import os
 sys.path.insert(0, os.path.expanduser("~/lobster/src"))
 from integrations.google_workspace.docs_client import gdocs_read
-from mcp.user_model.owner import read_owner
 
-owner = read_owner()
-OWNER_USER_ID = owner.get("owner", {}).get("telegram_chat_id", "")
+# MULTI-USER: use the chat_id from the message that triggered this subagent.
+# The dispatcher must pass it as a parameter when spawning the subagent.
+# Fall back to read_owner() only for single-user / legacy installs.
+def _get_user_id(message_chat_id=None) -> str:
+    if message_chat_id:
+        return str(message_chat_id)
+    from mcp.user_model.owner import read_owner
+    owner = read_owner()
+    return owner.get("owner", {}).get("telegram_chat_id", "")
+
+USER_ID = _get_user_id(message_chat_id)  # pass chat_id from dispatcher context
 
 # doc_id_or_url comes from the user's message (doc ID or full docs.google.com URL)
-content = gdocs_read(user_id=OWNER_USER_ID, doc_id_or_url=doc_id_or_url)
+content = gdocs_read(user_id=USER_ID, doc_id_or_url=doc_id_or_url)
 if content is None:
     reply = "I couldn't read that document. Make sure Google Workspace is connected and you have access to the doc."
 else:

--- a/scheduled-tasks/tasks/lobstertalk-unified.md.template
+++ b/scheduled-tasks/tasks/lobstertalk-unified.md.template
@@ -132,7 +132,7 @@ For each INBOUND message (after filtering out self-messages):
      "id": "<timestamp_ms>_bot_talk_<uuid8>",
      "type": "text",
      "source": "bot-talk",
-     "chat_id": 8305714125,
+     "chat_id": {{TELEGRAM_CHAT_ID}},
      "user_name": "<sender>",
      "text": "<content>",
      "timestamp": "<ISO timestamp>",
@@ -141,7 +141,7 @@ For each INBOUND message (after filtering out self-messages):
      "to": "{{LOCAL_LOBSTER_IDENTITY}}"
    }
    ```
-   Note: `chat_id` is always the owner's `ADMIN_CHAT_ID` (integer `8305714125`) for
+   Note: `chat_id` is always the owner's `ADMIN_CHAT_ID` (set via `{{TELEGRAM_CHAT_ID}}`) for
    delivery routing. Sender identity is carried in the `from` field.
    Write atomically (`.tmp` then rename). This ensures the dispatcher processes it
    like any other inbox message.


### PR DESCRIPTION
## Summary

Gmail was cleaned up in PR #1659. This PR brings the GCal, Google Workspace, and a shared task template to the same standard — no hardcoded values, no instance-specific data, no PII.

**What was wrong:**

- `gcal-links` and `google-workspace` skill files used `read_owner()` to resolve the user ID — a single-owner pattern that silently routes all calendar/workspace API calls to the instance owner rather than the message sender. This breaks multi-user deployments.
- `lobstertalk-unified.md.template` had a hardcoded Telegram chat_id integer (`8305714125`) in the inbox routing JSON block — an instance-specific value that would deliver messages to the wrong user on any other install.

**What was not changed:**

- All `src/` source files (`client.py`, `token_store.py`, `oauth.py`, etc.) — these were already clean (env-var-driven, no hardcoded credentials or IDs).
- `gmail` skill — already hardened in #1659, no changes needed.
- `docs/google-calendar-setup.md` — this is operator-facing setup documentation, not instance config.

**Functional changes by file:**

| File | Change |
|------|--------|
| `gcal-links/behavior/system.md` | Replace `read_owner()` with `_get_user_id(message_chat_id)` multi-user pattern (mirrors gmail skill exactly) |
| `gcal-links/context/reference.md` | Same `USER_ID` pattern; replace legacy `generate_auth_url` snippet with `generate_consent_link` (the actual flow used in production); add scope isolation note |
| `gcal-links/onboarding.md` | New file — matches `gmail/onboarding.md` structure: required env vars, deep-link fallback, scope, revoke instructions |
| `google-workspace/behavior/system.md` | Replace `read_owner()` with multi-user pattern in both auth-check and `gdocs_read` subagent snippets |
| `lobstertalk-unified.md.template` | Replace hardcoded `8305714125` integer with `{{TELEGRAM_CHAT_ID}}` placeholder (consistent with other usages in that file) |

**Functional patterns used:** pure helper functions (`_get_user_id`, `_fallback_to_owner`) with explicit fallback chain; no mutation; all user resolution isolated to one named function per code block.

## Tests run

- [x] `uv run pytest tests/unit/test_integrations/test_gcal_skill_consent_behavior.py tests/unit/test_integrations/test_gmail_skill_consent_behavior.py tests/unit/test_integrations/test_google_calendar_client.py tests/unit/test_integrations/test_gmail_client.py -v` — 150 passed, 0 failed
- [x] Pre-push PII scanner — all clear, no PII or security issues detected
- [x] `uv run python -m py_compile` on all changed source integration files — clean

## Manual test

N/A — all changes are in skill markdown files (behavior instructions and code patterns for LLM consumption) and a task template. No runtime code was modified, no external services are called, no file I/O is affected. The changes are purely documentation that governs how the dispatcher generates subagent prompts.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (skill markdown only)
- [x] User-visible outcome verified — N/A (no user-visible output path changed)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: N/A (no source code changed)