### PR TITLE
feat(write_result): add reply_text field to split internal summary from user reply

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -2447,7 +2447,8 @@ async def list_tools() -> list[Tool]:
                             "sent_reply_to_user is False, the dispatcher sends this to the user "
                             "instead of text. Use this to keep text as a terse internal summary "
                             "while sending a richer or differently-phrased message to the user. "
-                            "Omit if text is already the right user-facing message."
+                            "Omit if text is already the right user-facing message. "
+                            "Do not include raw file paths — use relative paths or descriptions instead."
                         ),
                     },
                     "source": {
@@ -7248,8 +7249,8 @@ async def handle_write_result(args: dict) -> list[TextContent]:
         message["warning"] = "User already received the subagent's reply. Don't summarize it. If you respond, add new value only — a question, a correction, missing context."
     # reply_text: user-facing reply separate from the internal dispatcher summary (text).
     # Only stored when there is an active user relay path: sent_reply_to_user=False and
-    # chat_id != 0 (chat_id 0 is dispatcher-internal; no user reply is ever sent).
-    if reply_text and not sent_reply_to_user and chat_id != 0:
+    # chat_id not in (0, "0") (chat_id 0 is dispatcher-internal; no user reply is ever sent).
+    if reply_text and not sent_reply_to_user and chat_id not in (0, "0"):
         message["reply_text"] = reply_text
     if artifacts:
         message["artifacts"] = artifacts

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -2432,13 +2432,22 @@ async def list_tools() -> list[Tool]:
                     "text": {
                         "type": "string",
                         "description": (
-                            "The result text to deliver to the user. "
-                            "Keep this to a concise summary (ideally under ~4KB / ~500 words). "
+                            "Dispatcher-internal summary of this result. "
+                            "Kept short (ideally under ~500 words) so the dispatcher's context does not grow. "
+                            "Not shown to the user when reply_text is provided. "
                             "For large outputs — reports, diffs, full analysis — write the content "
                             "to ~/lobster-workspace/reports/<task_id>.md and pass the path in "
-                            "`artifacts` instead. The dispatcher reads artifact files and inlines "
-                            "their content in the reply. Never put raw file paths in text — they "
-                            "are server-side references that are useless to mobile users."
+                            "`artifacts` instead."
+                        ),
+                    },
+                    "reply_text": {
+                        "type": "string",
+                        "description": (
+                            "Optional user-facing reply text. When provided and "
+                            "sent_reply_to_user is False, the dispatcher sends this to the user "
+                            "instead of text. Use this to keep text as a terse internal summary "
+                            "while sending a richer or differently-phrased message to the user. "
+                            "Omit if text is already the right user-facing message."
                         ),
                     },
                     "source": {
@@ -7162,6 +7171,7 @@ async def handle_write_result(args: dict) -> list[TextContent]:
     task_id = args.get("task_id", "").strip()
     chat_id = args.get("chat_id")
     text = args.get("text", "").strip()
+    reply_text = (args.get("reply_text") or "").strip() or None
     source = args.get("source", "telegram").strip() or "telegram"
     status = args.get("status", "success")
     artifacts = args.get("artifacts") or []
@@ -7236,6 +7246,11 @@ async def handle_write_result(args: dict) -> list[TextContent]:
     }
     if msg_type == "subagent_notification":
         message["warning"] = "User already received the subagent's reply. Don't summarize it. If you respond, add new value only — a question, a correction, missing context."
+    # reply_text: user-facing reply separate from the internal dispatcher summary (text).
+    # Only stored when there is an active user relay path: sent_reply_to_user=False and
+    # chat_id != 0 (chat_id 0 is dispatcher-internal; no user reply is ever sent).
+    if reply_text and not sent_reply_to_user and chat_id != 0:
+        message["reply_text"] = reply_text
     if artifacts:
         message["artifacts"] = artifacts
     if thread_ts:

--- a/tests/unit/test_mcp_server/test_write_result_reply_text.py
+++ b/tests/unit/test_mcp_server/test_write_result_reply_text.py
@@ -1,0 +1,229 @@
+"""
+Tests for write_result reply_text field (Closes #1621 clean rewrite).
+
+reply_text lets subagents decouple the dispatcher-internal summary from what
+the user actually sees. When reply_text is provided and the subagent has NOT
+already sent a reply (sent_reply_to_user=False) and chat_id != 0, the
+dispatcher receives reply_text in the inbox message so it can send that to the
+user instead of text.
+
+text always remains as the internal dispatcher summary.
+
+Behaviors tested:
+- reply_text is stored in the inbox message when provided and non-empty
+- reply_text is absent from the inbox message when not provided
+- empty / whitespace-only reply_text is treated as absent
+- text is always stored regardless of reply_text
+- reply_text is NOT stored when sent_reply_to_user=True (user already got a reply)
+- reply_text is NOT stored when chat_id == 0 (dispatcher-internal tasks)
+- backward compatibility: callers that omit reply_text see identical behavior
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup: ensure src/mcp and src/agents are importable
+# ---------------------------------------------------------------------------
+
+_ROOT = Path(__file__).parents[4]
+for _p in [str(_ROOT / "src" / "mcp"), str(_ROOT / "src" / "agents"),
+           str(_ROOT / "src"), str(_ROOT / "src" / "utils")]:
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import src.mcp.inbox_server  # noqa: F401 — pre-load so patch.multiple resolves it
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_dirs(tmp_path: Path):
+    """Return (inbox, outbox, sent, sent_replies, task_replied) under tmp_path."""
+    inbox = tmp_path / "inbox"
+    outbox = tmp_path / "outbox"
+    sent = tmp_path / "sent"
+    sent_replies = tmp_path / "sent-replies"
+    task_replied = tmp_path / "task-replied"
+    for d in (inbox, outbox, sent, sent_replies, task_replied):
+        d.mkdir(parents=True, exist_ok=True)
+    return inbox, outbox, sent, sent_replies, task_replied
+
+
+def _mock_session_store() -> MagicMock:
+    store = MagicMock()
+    store.session_end.return_value = None
+    store.set_notified.return_value = None
+    return store
+
+
+def _run_write_result(tmp_path: Path, args: dict) -> dict:
+    """Run handle_write_result and return the inbox message written."""
+    inbox, outbox, sent, sent_replies, task_replied = _make_dirs(tmp_path)
+    mock_store = _mock_session_store()
+
+    with patch.multiple(
+        "src.mcp.inbox_server",
+        INBOX_DIR=inbox,
+        OUTBOX_DIR=outbox,
+        SENT_DIR=sent,
+        SENT_REPLIES_DIR=sent_replies,
+        TASK_REPLIED_DIR=task_replied,
+        _session_store=mock_store,
+        _db_persist_agent_event=None,
+    ):
+        from src.mcp.inbox_server import handle_write_result
+        asyncio.run(handle_write_result(args))
+
+    inbox_files = list(inbox.glob("*.json"))
+    assert len(inbox_files) == 1, f"Expected 1 inbox file, got {len(inbox_files)}"
+    return json.loads(inbox_files[0].read_text())
+
+
+# ---------------------------------------------------------------------------
+# Tests: reply_text stored when provided
+# ---------------------------------------------------------------------------
+
+class TestReplyTextStoredInInboxMessage:
+    """reply_text is stored in the inbox message when provided and non-empty."""
+
+    def test_reply_text_stored_in_message(self, tmp_path):
+        """reply_text field appears in inbox message when provided."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "my-task",
+            "chat_id": 12345,
+            "text": "Terse dispatcher summary.",
+            "reply_text": "PR #42 is open and ready for review.",
+        })
+        assert msg.get("reply_text") == "PR #42 is open and ready for review."
+
+    def test_text_always_stored_when_reply_text_provided(self, tmp_path):
+        """text field is always present even when reply_text is also provided."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "my-task",
+            "chat_id": 12345,
+            "text": "Internal dispatcher summary.",
+            "reply_text": "Short user-facing reply.",
+        })
+        assert msg.get("text") == "Internal dispatcher summary."
+
+    def test_reply_text_preserved_verbatim(self, tmp_path):
+        """reply_text is stored exactly as provided — no normalization."""
+        user_reply = "Done! Here is the summary:\n- item one\n- item two"
+        msg = _run_write_result(tmp_path, {
+            "task_id": "task-abc",
+            "chat_id": 99,
+            "text": "Summary.",
+            "reply_text": user_reply,
+        })
+        assert msg["reply_text"] == user_reply
+
+
+# ---------------------------------------------------------------------------
+# Tests: reply_text absent when not provided or falsy
+# ---------------------------------------------------------------------------
+
+class TestReplyTextAbsentWhenNotProvided:
+    """reply_text must not appear in inbox message when absent or falsy."""
+
+    def test_reply_text_absent_when_not_provided(self, tmp_path):
+        """No reply_text key in inbox message when caller omits it."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "no-reply-text-task",
+            "chat_id": 12345,
+            "text": "Direct user-facing text.",
+        })
+        assert "reply_text" not in msg
+
+    def test_reply_text_absent_when_empty_string(self, tmp_path):
+        """Empty string reply_text is treated as absent — not stored in message."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "empty-reply-text-task",
+            "chat_id": 12345,
+            "text": "Summary.",
+            "reply_text": "",
+        })
+        assert "reply_text" not in msg
+
+    def test_reply_text_absent_when_whitespace_only(self, tmp_path):
+        """Whitespace-only reply_text is treated as absent — not stored."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "ws-reply-text-task",
+            "chat_id": 12345,
+            "text": "Summary.",
+            "reply_text": "   ",
+        })
+        assert "reply_text" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Tests: reply_text suppressed when irrelevant
+# ---------------------------------------------------------------------------
+
+class TestReplyTextSuppressedWhenIrrelevant:
+    """reply_text must not be stored when the user already has a reply or
+    when the message is dispatcher-internal (chat_id == 0)."""
+
+    def test_reply_text_not_stored_when_sent_reply_to_user_true(self, tmp_path):
+        """When sent_reply_to_user=True, user already got a reply.
+        reply_text in the inbox message would be confusing — omit it."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "already-replied-task",
+            "chat_id": 12345,
+            "text": "Dispatcher summary.",
+            "reply_text": "This was already sent directly.",
+            "sent_reply_to_user": True,
+        })
+        assert "reply_text" not in msg
+
+    def test_reply_text_not_stored_when_chat_id_is_zero(self, tmp_path):
+        """chat_id == 0 is a dispatcher-internal task.
+        No user relay happens, so reply_text is meaningless — omit it."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "dispatcher-internal-task",
+            "chat_id": 0,
+            "text": "Internal summary.",
+            "reply_text": "This would never be sent to anyone.",
+        })
+        assert "reply_text" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Tests: backward compatibility — existing callers unaffected
+# ---------------------------------------------------------------------------
+
+class TestBackwardCompatibility:
+    """Callers that do not pass reply_text see unchanged behavior."""
+
+    def test_existing_fields_unchanged_without_reply_text(self, tmp_path):
+        """Core fields (text, task_id, chat_id, status, source) are unchanged."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "compat-task",
+            "chat_id": 42,
+            "text": "My result.",
+            "source": "telegram",
+            "status": "success",
+        })
+        assert msg["task_id"] == "compat-task"
+        assert msg["chat_id"] == 42
+        assert msg["text"] == "My result."
+        assert msg["source"] == "telegram"
+        assert msg["status"] == "success"
+        assert "reply_text" not in msg
+
+    def test_sent_reply_to_user_false_by_default(self, tmp_path):
+        """sent_reply_to_user defaults to False when not provided."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "default-sent",
+            "chat_id": 1,
+            "text": "Text.",
+        })
+        assert msg["sent_reply_to_user"] is False

--- a/tests/unit/test_mcp_server/test_write_result_reply_text.py
+++ b/tests/unit/test_mcp_server/test_write_result_reply_text.py
@@ -195,6 +195,17 @@ class TestReplyTextSuppressedWhenIrrelevant:
         })
         assert "reply_text" not in msg
 
+    def test_reply_text_not_stored_when_chat_id_is_string_zero(self, tmp_path):
+        """chat_id == '0' (string sentinel) is also dispatcher-internal.
+        The guard must handle both int 0 and string '0' to prevent accidental relay."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "dispatcher-internal-string-task",
+            "chat_id": "0",
+            "text": "Internal summary.",
+            "reply_text": "This would never be sent to anyone.",
+        })
+        assert "reply_text" not in msg
+
 
 # ---------------------------------------------------------------------------
 # Tests: backward compatibility — existing callers unaffected


### PR DESCRIPTION
## What this solves

`write_result` currently has one `text` field that serves two audiences: the dispatcher (for situational awareness) and the user (the relay). Subagents that want a verbose internal audit trail have no way to keep it out of the user-facing reply, and vice versa.

Closes #1621 (clean reimplementation — relay-pattern dependencies removed).

## What changed

Adds an optional `reply_text` string parameter to `write_result`.

- When `reply_text` is provided and `sent_reply_to_user` is False: the inbox message carries `reply_text` so the dispatcher sends it to the user instead of `text`.
- `text` remains as the dispatcher-internal summary — read for orientation, never shown to the user when `reply_text` is present.
- `reply_text` is suppressed (not written to the inbox message) when `sent_reply_to_user=True` (user already got a reply) or `chat_id==0` (dispatcher-internal tasks with no relay path).
- Callers that omit `reply_text` see identical behavior — fully backward-compatible.

**Before:**
```
write_result(text="PR #42 open. Branch: feat/..., commit: abc123, CI: passing, 3 reviewers assigned, ...")
→ dispatcher context grows · user sees wall of detail
```

**After:**
```
write_result(
    text="PR #42 open.",
    reply_text="PR #42 is open and ready for review.",
)
```

## Flow

```
subagent → write_result(text=<summary>, reply_text=<user reply>)
                │
                ▼
         inbox message written:
           { text: <summary>, reply_text: <user reply>, ... }
                │
                ▼
         dispatcher reads subagent_result:
           reads text for orientation (short)
           sends reply_text to user (or text if reply_text absent)
```

No dispatcher routing states change. `reply_text` is an additive field in the inbox JSON.

## Functional patterns

- `reply_text` extraction: `(args.get("reply_text") or "").strip() or None` — single falsy-check guard
- Storage: `if reply_text and not sent_reply_to_user and chat_id != 0` — pure conditional, no shared state mutation

## What is NOT in scope

Updating existing subagents to use `reply_text` — that is a follow-on.

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_write_result_reply_text.py -v` — 10 passed, 0 failed
- [x] `uv run pytest tests/unit/ -q` (excluding 2 collection-broken pre-existing test files) — 2766 passed, 8 failed (8 pre-existing failures confirmed identical on main before this PR), 24 skipped
- [x] Python syntax check on `inbox_server.py` — clean

## Manual test

N/A — purely additive to the inbox message schema. No Telegram API or external service is called by this handler.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (no external service calls, no Telegram output from this handler)
- [x] User-visible outcome — dispatcher reads `reply_text` and routes to user; the data contract is verified by unit tests
- [x] Side-effect audit: no floods, no unscoped writes; additive optional field only
- [x] External service calls: none