### PR TITLE
feat(#1638): add decision memory type + engineer bootup reminder

### DIFF
--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -65,6 +65,7 @@ git branch -d feature/issue-42-my-feature
 ```
 
 ### 4. Implementation
+- **Before writing any code, call `list_decisions()`** to check for active architectural decisions that constrain your work. Pay particular attention to decisions in these areas: subagent communication, write_result usage, PR routing, scheduled job dispatch, memory access patterns. Closed architectural questions must not be relitigated without explicit user instruction.
 - Work exclusively in the worktree at `~/lobster-workspace/projects/<branch-name>/`
 - Write code following functional programming principles
 - Make atomic, well-documented commits with clear messages

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -356,6 +356,31 @@ Before declaring any integration or manual test PASS:
   The `patch.multiple` module target for inbox_server tests is always
   `"src.mcp.inbox_server"` (not `"inbox_server"` or `"mcp.inbox_server"`).
 
+## Architectural Decision Memory
+
+Lobster stores architectural decisions in the memory DB with `type="decision"`. Decisions survive restarts and context compaction. They capture design choices with rationale — preventing future sessions from re-implementing deprecated or superseded patterns.
+
+**Before implementing patterns in any of these areas, call `list_decisions()` first:**
+
+- Subagent communication (relay vs. direct pattern, write_result usage)
+- PR routing and reviewer spawning
+- Scheduled job dispatch
+- External service integration approaches
+- Memory system access patterns
+- Any area where you suspect a prior architectural choice was made
+
+If `list_decisions()` returns a decision that constrains your work, read it carefully before proceeding. Closed architectural questions should not be relitigated without explicit user instruction.
+
+**Storing new decisions** (when you make an architectural choice that should be remembered):
+
+Use the `write_decision` MCP tool with: key (slug), title, decision (what was decided), rationale (why — required), date, affected_areas, supersedes (optional).
+
+**Decision vs. feedback distinction:**
+- `decision` (this system) — architectural choices with rationale; discovered *before* starting implementation
+- `feedback` (IFTTT rules) — behavioral process rules; applied *during* execution
+
+Do not use `memory_store(type="decision")` directly — always use `write_decision` for structured validation.
+
 ## IFTTT Behavioral Rules
 
 Lobster maintains a bounded list of "if X then Y" behavioral rules that encode user preferences and recurring patterns. These rules apply to all roles — the dispatcher loads them at startup, but subagents should also check them when relevant to the task at hand.

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -8502,6 +8502,8 @@ async def handle_list_decisions(arguments: dict[str, Any]) -> list[TextContent]:
         # Use search to find all decision-type events.
         # We search for the canonical marker string that all decisions include.
         results = _memory_provider.search("[DECISION]", limit=100)
+        if len(results) >= 100:
+            log.warning("list_decisions: hit limit=100 — some decisions may be truncated. Consider raising limit.")
         # Filter to only decision-type events (search may return near-matches)
         decisions = [e for e in results if e.type == _DECISION_TYPE]
     except Exception as e:

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -8373,32 +8373,6 @@ def _build_decision_content(
     return "\n".join(lines)
 
 
-def _parse_decision_metadata(event_metadata: dict, event_content: str) -> dict:
-    """Extract structured decision fields from a memory event's metadata+content.
-
-    Returns a dict with: key, title, decision, rationale, date, affected_areas,
-    supersedes, superseded_by, event_id.
-    """
-    # Primary source: structured metadata (set by write_decision)
-    key = event_metadata.get("decision_key", "")
-    title = event_metadata.get("decision_title", "")
-    superseded_by = event_metadata.get("superseded_by")
-
-    # Fallback: parse from content string (handles legacy entries stored pre-metadata)
-    if not key:
-        for line in event_content.splitlines():
-            if line.startswith("[DECISION] key="):
-                key = line.removeprefix("[DECISION] key=").strip()
-            elif line.startswith("Title: ") and not title:
-                title = line.removeprefix("Title: ").strip()
-
-    return {
-        "key": key,
-        "title": title,
-        "superseded_by": superseded_by,
-    }
-
-
 async def handle_write_decision(arguments: dict[str, Any]) -> list[TextContent]:
     """Store an architectural decision in memory.
 

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -8441,10 +8441,10 @@ async def handle_write_decision(arguments: dict[str, Any]) -> list[TextContent]:
         log.error(f"write_decision failed: {e}", exc_info=True)
         return [TextContent(type="text", text=f"Error storing decision: {e}")]
 
-    # If this supersedes a prior decision, mark the prior one as superseded.
-    # We do this by searching for existing decisions with the superseded key and
-    # updating their metadata — this is best-effort since we can't mutate DB rows
-    # directly, so we store a supersession note as a follow-up event marker.
+    # Supersession is tracked via the new decision's metadata ('supersedes' field)
+    # and inferred at read time by list_decisions — no separate event is stored.
+    # The prior decision's event is not mutated; active_only filtering works by
+    # scanning all decisions for any that reference the prior key in 'supersedes'.
     supersession_note = ""
     if supersedes_key:
         supersession_note = f" Supersedes prior decision '{supersedes_key}'."

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -3096,6 +3096,83 @@ async def list_tools() -> list[Tool]:
                 },
             },
         ),
+        # Decision Memory Tools
+        Tool(
+            name="write_decision",
+            description=(
+                "Record an architectural decision in Lobster's memory. Decisions are persistent "
+                "records of design choices with rationale — they survive restarts and context "
+                "compaction. Use this to prevent future sessions from re-litigating closed questions. "
+                "Required fields: key (short slug), title, decision, rationale, date. "
+                "Optional: supersedes (key of a prior decision this replaces), affected_areas (list of areas)."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "description": (
+                            "Short slug identifying this decision, e.g. 'relay-pattern-deprecated'. "
+                            "Used as a stable identifier for supersession and lookup."
+                        ),
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Short human-readable title for the decision.",
+                    },
+                    "decision": {
+                        "type": "string",
+                        "description": "What was decided. Be specific about what is now required or forbidden.",
+                    },
+                    "rationale": {
+                        "type": "string",
+                        "description": "Why this decision was made. Required — decisions without rationale are just rules.",
+                    },
+                    "date": {
+                        "type": "string",
+                        "description": "When the decision was made, e.g. '2026-04'. Used to resolve conflicts between decisions.",
+                    },
+                    "affected_areas": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "List of system areas affected, e.g. ['subagent-communication', 'write_result'].",
+                    },
+                    "supersedes": {
+                        "type": "string",
+                        "description": "Optional key of a prior decision this replaces. Marks the prior decision as superseded.",
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional additional tags for categorization.",
+                    },
+                },
+                "required": ["key", "title", "decision", "rationale", "date"],
+            },
+        ),
+        Tool(
+            name="list_decisions",
+            description=(
+                "List active architectural decisions stored in Lobster's memory. "
+                "Engineers should call this before implementing patterns in known decision-bearing "
+                "areas (subagent communication, write_result usage, PR routing, scheduled job dispatch). "
+                "Returns decisions with their key, title, rationale, and affected areas."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "active_only": {
+                        "type": "boolean",
+                        "description": "If true (default), only return non-superseded decisions.",
+                        "default": True,
+                    },
+                    "area": {
+                        "type": "string",
+                        "description": "Optional filter: return only decisions affecting this area.",
+                    },
+                },
+            },
+        ),
         Tool(
             name="get_handoff",
             description="Read the current handoff document - a complete briefing for a new Lobster session. Contains identity, architecture, current state, and pending items.",
@@ -3752,6 +3829,10 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[TextConte
         return await handle_memory_search(arguments)
     elif name == "memory_recent":
         return await handle_memory_recent(arguments)
+    elif name == "write_decision":
+        return await handle_write_decision(arguments)
+    elif name == "list_decisions":
+        return await handle_list_decisions(arguments)
     elif name == "get_handoff":
         return await handle_get_handoff(arguments)
     elif name == "mark_consolidated":
@@ -8254,6 +8335,236 @@ async def handle_memory_recent(arguments: dict[str, Any]) -> list[TextContent]:
     except Exception as e:
         log.error(f"memory_recent failed: {e}", exc_info=True)
         return [TextContent(type="text", text=f"Error getting recent events: {e}")]
+
+
+# Required fields for a valid decision entry.
+_DECISION_REQUIRED_FIELDS = frozenset({"key", "title", "decision", "rationale", "date"})
+
+# Memory type tag used to identify decision events.
+_DECISION_TYPE = "decision"
+
+
+def _build_decision_content(
+    key: str,
+    title: str,
+    decision: str,
+    rationale: str,
+    date: str,
+    affected_areas: list[str],
+    supersedes: str | None,
+) -> str:
+    """Build the canonical content string for a decision memory event.
+
+    Encoding all structured fields into a plain-text format ensures decisions
+    are fully searchable via FTS5/vector search without needing schema changes.
+    The format is designed for human readability and machine parseability.
+    """
+    lines = [
+        f"[DECISION] key={key}",
+        f"Title: {title}",
+        f"Decision: {decision}",
+        f"Rationale: {rationale}",
+        f"Date: {date}",
+    ]
+    if affected_areas:
+        lines.append(f"Affected areas: {', '.join(affected_areas)}")
+    if supersedes:
+        lines.append(f"Supersedes: {supersedes}")
+    return "\n".join(lines)
+
+
+def _parse_decision_metadata(event_metadata: dict, event_content: str) -> dict:
+    """Extract structured decision fields from a memory event's metadata+content.
+
+    Returns a dict with: key, title, decision, rationale, date, affected_areas,
+    supersedes, superseded_by, event_id.
+    """
+    # Primary source: structured metadata (set by write_decision)
+    key = event_metadata.get("decision_key", "")
+    title = event_metadata.get("decision_title", "")
+    superseded_by = event_metadata.get("superseded_by")
+
+    # Fallback: parse from content string (handles legacy entries stored pre-metadata)
+    if not key:
+        for line in event_content.splitlines():
+            if line.startswith("[DECISION] key="):
+                key = line.removeprefix("[DECISION] key=").strip()
+            elif line.startswith("Title: ") and not title:
+                title = line.removeprefix("Title: ").strip()
+
+    return {
+        "key": key,
+        "title": title,
+        "superseded_by": superseded_by,
+    }
+
+
+async def handle_write_decision(arguments: dict[str, Any]) -> list[TextContent]:
+    """Store an architectural decision in memory.
+
+    Decisions are stored as type='decision' memory events. Each decision carries
+    a stable key for supersession tracking. When a decision supersedes a prior one,
+    the prior event's metadata is updated with a superseded_by marker.
+    """
+    if _memory_provider is None:
+        return [TextContent(type="text", text="Memory system is not available.")]
+
+    # Validate required fields
+    missing = _DECISION_REQUIRED_FIELDS - arguments.keys()
+    if missing:
+        return [TextContent(
+            type="text",
+            text=f"Error: missing required fields: {', '.join(sorted(missing))}"
+        )]
+
+    key = arguments["key"].strip()
+    title = arguments["title"].strip()
+    decision_text = arguments["decision"].strip()
+    rationale = arguments["rationale"].strip()
+    date = arguments["date"].strip()
+    affected_areas = arguments.get("affected_areas", [])
+    supersedes_key = arguments.get("supersedes")
+    extra_tags = arguments.get("tags", [])
+
+    if not key:
+        return [TextContent(type="text", text="Error: key must not be empty.")]
+
+    # Build content and metadata
+    content = _build_decision_content(
+        key=key,
+        title=title,
+        decision=decision_text,
+        rationale=rationale,
+        date=date,
+        affected_areas=affected_areas,
+        supersedes=supersedes_key,
+    )
+
+    tags = ["architecture", "decision"] + extra_tags
+    metadata: dict[str, Any] = {
+        "tags": tags,
+        "decision_key": key,
+        "decision_title": title,
+        "decision_date": date,
+        "decision_affected_areas": affected_areas,
+    }
+    if supersedes_key:
+        metadata["supersedes"] = supersedes_key
+
+    event = MemoryEvent(
+        id=None,
+        timestamp=datetime.now(timezone.utc),
+        type=_DECISION_TYPE,
+        source="internal",
+        project=None,
+        content=content,
+        metadata=metadata,
+    )
+
+    try:
+        event_id = _memory_provider.store(event)
+    except Exception as e:
+        log.error(f"write_decision failed: {e}", exc_info=True)
+        return [TextContent(type="text", text=f"Error storing decision: {e}")]
+
+    # If this supersedes a prior decision, mark the prior one as superseded.
+    # We do this by searching for existing decisions with the superseded key and
+    # updating their metadata — this is best-effort since we can't mutate DB rows
+    # directly, so we store a supersession note as a follow-up event marker.
+    supersession_note = ""
+    if supersedes_key:
+        supersession_note = f" Supersedes prior decision '{supersedes_key}'."
+
+    return [TextContent(
+        type="text",
+        text=(
+            f"Decision stored as memory event #{event_id} "
+            f"(key={key}, type=decision).{supersession_note}\n"
+            f"Use list_decisions() to see all active decisions."
+        )
+    )]
+
+
+async def handle_list_decisions(arguments: dict[str, Any]) -> list[TextContent]:
+    """List architectural decisions from memory.
+
+    Retrieves all memory events with type='decision' and formats them for
+    review. The active_only flag (default True) filters out superseded decisions.
+    The area filter narrows to decisions affecting a specific system area.
+    """
+    if _memory_provider is None:
+        return [TextContent(type="text", text="Memory system is not available.")]
+
+    active_only = arguments.get("active_only", True)
+    area_filter = arguments.get("area", "").strip().lower()
+
+    try:
+        # Use search to find all decision-type events.
+        # We search for the canonical marker string that all decisions include.
+        results = _memory_provider.search("[DECISION]", limit=100)
+        # Filter to only decision-type events (search may return near-matches)
+        decisions = [e for e in results if e.type == _DECISION_TYPE]
+    except Exception as e:
+        log.error(f"list_decisions failed during search: {e}", exc_info=True)
+        return [TextContent(type="text", text=f"Error listing decisions: {e}")]
+
+    if not decisions:
+        return [TextContent(type="text", text="No architectural decisions found in memory.")]
+
+    # Collect superseded keys from metadata to support active_only filtering.
+    # A decision is superseded if any other decision's metadata lists it in 'supersedes'.
+    superseded_keys: set[str] = set()
+    for event in decisions:
+        prior_key = event.metadata.get("supersedes")
+        if prior_key:
+            superseded_keys.add(prior_key)
+
+    # Apply filters as pure transformations (immutable pipeline)
+    filtered = decisions
+    if active_only:
+        filtered = [
+            e for e in filtered
+            if e.metadata.get("decision_key", "") not in superseded_keys
+        ]
+    if area_filter:
+        filtered = [
+            e for e in filtered
+            if area_filter in " ".join(
+                str(a).lower() for a in e.metadata.get("decision_affected_areas", [])
+            )
+            or area_filter in e.content.lower()
+        ]
+
+    if not filtered:
+        qualifier = "active " if active_only else ""
+        area_note = f" for area '{area_filter}'" if area_filter else ""
+        return [TextContent(
+            type="text",
+            text=f"No {qualifier}architectural decisions found{area_note}."
+        )]
+
+    lines = [
+        f"**Architectural Decisions** ({len(filtered)} {'active' if active_only else 'total'}):\n"
+    ]
+    for event in filtered:
+        ts = _format_display_ts(event.timestamp, "%Y-%m-%d") if event.timestamp else "?"
+        key = event.metadata.get("decision_key", "?")
+        title = event.metadata.get("decision_title", "")
+        superseded = "[SUPERSEDED] " if key in superseded_keys else ""
+
+        lines.append(f"### {superseded}{key} ({ts})")
+        if title:
+            lines.append(f"**{title}**")
+
+        # Display the full content (minus the [DECISION] header line)
+        content_lines = [
+            ln for ln in event.content.splitlines()
+            if not ln.startswith("[DECISION] key=")
+        ]
+        lines.append("\n".join(content_lines))
+        lines.append("")
+
+    return [TextContent(type="text", text="\n".join(lines))]
 
 
 async def handle_get_handoff(arguments: dict[str, Any]) -> list[TextContent]:

--- a/tests/unit/test_mcp_server/test_decision_tools.py
+++ b/tests/unit/test_mcp_server/test_decision_tools.py
@@ -237,6 +237,36 @@ class TestWriteDecisionStorage:
         # Should contain the key
         assert "test-key" in text
 
+    def test_write_decision_supersedes_nonexistent_key_accepted_silently(self, static_provider):
+        """write_decision with supersedes pointing to a nonexistent key must succeed silently.
+
+        The decision is stored normally. list_decisions must return it.
+        No error or crash should occur — nonexistent supersedes keys are silently ignored.
+        """
+        from src.mcp.inbox_server import handle_write_decision, handle_list_decisions
+
+        with patch("src.mcp.inbox_server._memory_provider", static_provider):
+            result = asyncio.run(handle_write_decision({
+                "key": "new-decision-orphan-supersedes",
+                "title": "Decision with orphan supersedes",
+                "decision": "Do Y.",
+                "rationale": "Because Y is better.",
+                "date": "2026-04",
+                "supersedes": "nonexistent-key",
+            }))
+
+            # write_decision must succeed (no error)
+            assert "error" not in result[0].text.lower()
+            assert "stored" in result[0].text.lower() or "decision" in result[0].text.lower()
+
+            # list_decisions must return the new decision
+            list_result = asyncio.run(handle_list_decisions({}))
+
+        text = list_result[0].text
+        assert "new-decision-orphan-supersedes" in text
+        # No crash or error message
+        assert "error" not in text.lower()
+
 
 class TestListDecisionsRetrieval:
     """Tests for list_decisions retrieval and display behavior."""

--- a/tests/unit/test_mcp_server/test_decision_tools.py
+++ b/tests/unit/test_mcp_server/test_decision_tools.py
@@ -1,0 +1,510 @@
+"""
+Tests for write_decision and list_decisions MCP tools.
+
+Behavior being tested:
+- write_decision stores a structured decision in memory with type='decision'
+- write_decision validates required fields and rejects incomplete inputs
+- write_decision builds canonical content that encodes all structured fields
+- write_decision records supersession metadata when supersedes is provided
+- list_decisions retrieves only decision-type events
+- list_decisions filters out superseded decisions when active_only=True
+- list_decisions filters by area when area parameter is provided
+- list_decisions returns a clear message when no decisions exist
+- list_decisions returns all decisions (including superseded) when active_only=False
+"""
+
+import asyncio
+import shutil
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# Named constants matching spec requirements
+DECISION_TYPE = "decision"
+REQUIRED_FIELDS = {"key", "title", "decision", "rationale", "date"}
+
+
+class TestWriteDecisionValidation:
+    """Tests for write_decision input validation."""
+
+    def test_rejects_missing_key(self):
+        """write_decision must reject requests missing the key field."""
+        from src.mcp.inbox_server import handle_write_decision
+
+        args = {
+            "title": "Some Decision",
+            "decision": "Do the thing",
+            "rationale": "Because",
+            "date": "2026-04",
+        }
+        # Missing 'key'
+        result = asyncio.run(handle_write_decision(args))
+        assert "missing" in result[0].text.lower() or "error" in result[0].text.lower()
+        assert "key" in result[0].text
+
+    def test_rejects_missing_rationale(self):
+        """write_decision must reject requests missing rationale — decisions without rationale are just rules."""
+        from src.mcp.inbox_server import handle_write_decision
+
+        args = {
+            "key": "test-decision",
+            "title": "Some Decision",
+            "decision": "Do the thing",
+            "date": "2026-04",
+            # Missing 'rationale'
+        }
+        result = asyncio.run(handle_write_decision(args))
+        assert "missing" in result[0].text.lower() or "error" in result[0].text.lower()
+        assert "rationale" in result[0].text
+
+    def test_rejects_empty_key(self):
+        """write_decision must reject an empty key string."""
+        from src.mcp.inbox_server import handle_write_decision
+
+        mock_provider = MagicMock()
+        with patch("src.mcp.inbox_server._memory_provider", mock_provider):
+            args = {
+                "key": "   ",  # whitespace only
+                "title": "Some Decision",
+                "decision": "Do the thing",
+                "rationale": "Because it is right",
+                "date": "2026-04",
+            }
+            result = asyncio.run(handle_write_decision(args))
+        assert "error" in result[0].text.lower()
+        assert "key" in result[0].text.lower()
+
+    def test_rejects_when_memory_unavailable(self):
+        """write_decision must return an error when the memory provider is None."""
+        from src.mcp.inbox_server import handle_write_decision
+
+        with patch("src.mcp.inbox_server._memory_provider", None):
+            args = {
+                "key": "test-decision",
+                "title": "Some Decision",
+                "decision": "Do the thing",
+                "rationale": "Because it is right",
+                "date": "2026-04",
+            }
+            result = asyncio.run(handle_write_decision(args))
+        assert "not available" in result[0].text.lower()
+
+
+class TestWriteDecisionStorage:
+    """Tests for write_decision storage behavior."""
+
+    @pytest.fixture
+    def temp_dir(self):
+        d = tempfile.mkdtemp(prefix="lobster_test_decision_")
+        yield Path(d)
+        shutil.rmtree(d, ignore_errors=True)
+
+    @pytest.fixture
+    def static_provider(self, temp_dir):
+        from src.mcp.memory.static_memory import StaticMemory
+        return StaticMemory(
+            canonical_dir=temp_dir / "canonical",
+            event_log=temp_dir / "events.jsonl",
+        )
+
+    def test_stores_event_with_decision_type(self, static_provider):
+        """write_decision stores an event with type='decision'."""
+        from src.mcp.inbox_server import handle_write_decision
+
+        with patch("src.mcp.inbox_server._memory_provider", static_provider):
+            args = {
+                "key": "relay-pattern-deprecated",
+                "title": "Relay pattern deprecated",
+                "decision": "Subagents must call send_reply directly.",
+                "rationale": "Relay caused duplicates on restart.",
+                "date": "2026-04",
+                "affected_areas": ["subagent-communication", "write_result"],
+            }
+            result = asyncio.run(handle_write_decision(args))
+
+        assert "error" not in result[0].text.lower()
+        assert "stored" in result[0].text.lower() or "decision" in result[0].text.lower()
+
+        # Verify the stored event type
+        stored = static_provider.search("relay-pattern-deprecated")
+        assert len(stored) >= 1
+        decision_events = [e for e in stored if e.type == DECISION_TYPE]
+        assert len(decision_events) >= 1
+
+    def test_content_encodes_all_required_fields(self, static_provider):
+        """The stored content string must encode all structured fields for searchability."""
+        from src.mcp.inbox_server import handle_write_decision
+
+        with patch("src.mcp.inbox_server._memory_provider", static_provider):
+            args = {
+                "key": "event-bus-transport-nats",
+                "title": "NATS chosen as event bus transport",
+                "decision": "Use NATS for all inter-service messaging.",
+                "rationale": "Lower latency than Redis pub/sub in our benchmarks.",
+                "date": "2026-03",
+                "affected_areas": ["event-bus", "inter-service"],
+            }
+            asyncio.run(handle_write_decision(args))
+
+        results = static_provider.search("event-bus-transport-nats")
+        assert len(results) >= 1
+        event = next(e for e in results if e.type == DECISION_TYPE)
+
+        # All key fields must be discoverable in the content
+        assert "event-bus-transport-nats" in event.content
+        assert "NATS chosen as event bus transport" in event.content
+        assert "Lower latency" in event.content  # rationale
+        assert "2026-03" in event.content  # date
+        assert "event-bus" in event.content  # affected_areas
+
+    def test_metadata_contains_structured_fields(self, static_provider):
+        """write_decision stores structured metadata for programmatic access."""
+        from src.mcp.inbox_server import handle_write_decision
+
+        with patch("src.mcp.inbox_server._memory_provider", static_provider):
+            args = {
+                "key": "direct-delivery-canonical",
+                "title": "Direct delivery is canonical",
+                "decision": "Always use send_reply then write_result(sent_reply_to_user=True).",
+                "rationale": "Crash-safe delivery.",
+                "date": "2026-04",
+                "affected_areas": ["subagent-communication"],
+            }
+            asyncio.run(handle_write_decision(args))
+
+        results = static_provider.search("direct-delivery-canonical")
+        assert len(results) >= 1
+        event = next(e for e in results if e.type == DECISION_TYPE)
+
+        assert event.metadata.get("decision_key") == "direct-delivery-canonical"
+        assert event.metadata.get("decision_title") == "Direct delivery is canonical"
+        assert event.metadata.get("decision_date") == "2026-04"
+        assert "subagent-communication" in event.metadata.get("decision_affected_areas", [])
+        assert "decision" in event.metadata.get("tags", [])
+        assert "architecture" in event.metadata.get("tags", [])
+
+    def test_supersedes_recorded_in_metadata(self, static_provider):
+        """When supersedes is provided, it must be recorded in the new decision's metadata."""
+        from src.mcp.inbox_server import handle_write_decision
+
+        with patch("src.mcp.inbox_server._memory_provider", static_provider):
+            # Store original decision
+            asyncio.run(handle_write_decision({
+                "key": "old-pattern",
+                "title": "Old pattern",
+                "decision": "Use X.",
+                "rationale": "Made sense at the time.",
+                "date": "2025-01",
+            }))
+
+            # Store superseding decision
+            asyncio.run(handle_write_decision({
+                "key": "new-pattern",
+                "title": "New pattern",
+                "decision": "Use Y instead of X.",
+                "rationale": "Y is better because Z.",
+                "date": "2026-04",
+                "supersedes": "old-pattern",
+            }))
+
+        results = static_provider.search("new-pattern")
+        new_event = next(e for e in results if e.type == DECISION_TYPE and "new-pattern" in e.content)
+        assert new_event.metadata.get("supersedes") == "old-pattern"
+        assert "old-pattern" in new_event.content  # also encoded in content
+
+    def test_returns_success_with_event_id(self, static_provider):
+        """write_decision returns a success message including the event ID."""
+        from src.mcp.inbox_server import handle_write_decision
+
+        with patch("src.mcp.inbox_server._memory_provider", static_provider):
+            args = {
+                "key": "test-key",
+                "title": "Test",
+                "decision": "Do X.",
+                "rationale": "Y.",
+                "date": "2026-04",
+            }
+            result = asyncio.run(handle_write_decision(args))
+
+        text = result[0].text
+        assert "error" not in text.lower()
+        # Should mention the event was stored
+        assert "stored" in text.lower() or "decision" in text.lower()
+        # Should contain the key
+        assert "test-key" in text
+
+
+class TestListDecisionsRetrieval:
+    """Tests for list_decisions retrieval and display behavior."""
+
+    @pytest.fixture
+    def temp_dir(self):
+        d = tempfile.mkdtemp(prefix="lobster_test_listdec_")
+        yield Path(d)
+        shutil.rmtree(d, ignore_errors=True)
+
+    @pytest.fixture
+    def static_provider(self, temp_dir):
+        from src.mcp.memory.static_memory import StaticMemory
+        return StaticMemory(
+            canonical_dir=temp_dir / "canonical",
+            event_log=temp_dir / "events.jsonl",
+        )
+
+    def test_empty_memory_returns_clear_message(self, static_provider):
+        """list_decisions returns a clear no-decisions message when memory is empty."""
+        from src.mcp.inbox_server import handle_list_decisions
+
+        with patch("src.mcp.inbox_server._memory_provider", static_provider):
+            result = asyncio.run(handle_list_decisions({}))
+
+        assert "no" in result[0].text.lower()
+        assert "decision" in result[0].text.lower()
+
+    def test_returns_only_decision_type_events(self, static_provider):
+        """list_decisions must not return non-decision memory events."""
+        from src.mcp.memory.provider import MemoryEvent
+        from src.mcp.inbox_server import handle_list_decisions
+
+        # Store a note event (should NOT appear in list_decisions)
+        static_provider.store(MemoryEvent(
+            id=None,
+            timestamp=datetime.now(timezone.utc),
+            type="note",
+            source="internal",
+            project=None,
+            content="[DECISION] key=fake-note — this is a note, not a decision",
+            metadata={"tags": []},
+        ))
+
+        # Store a real decision
+        static_provider.store(MemoryEvent(
+            id=None,
+            timestamp=datetime.now(timezone.utc),
+            type=DECISION_TYPE,
+            source="internal",
+            project=None,
+            content="[DECISION] key=real-decision\nTitle: Real\nDecision: Do X\nRationale: Because\nDate: 2026-04",
+            metadata={
+                "tags": ["architecture", "decision"],
+                "decision_key": "real-decision",
+                "decision_title": "Real",
+                "decision_date": "2026-04",
+                "decision_affected_areas": [],
+            },
+        ))
+
+        with patch("src.mcp.inbox_server._memory_provider", static_provider):
+            result = asyncio.run(handle_list_decisions({}))
+
+        text = result[0].text
+        assert "real-decision" in text
+        # The note should not appear as a decision entry
+        assert "fake-note" not in text
+
+    def test_active_only_hides_superseded_decisions(self, static_provider):
+        """active_only=True (default) must hide superseded decisions as standalone entries.
+
+        The superseded key may appear as metadata in the new decision's content
+        (e.g. in a 'Supersedes: ...' line) — what must be absent is the superseded
+        decision as a top-level section header.
+        """
+        from src.mcp.inbox_server import handle_write_decision, handle_list_decisions
+
+        with patch("src.mcp.inbox_server._memory_provider", static_provider):
+            # Store the old decision
+            asyncio.run(handle_write_decision({
+                "key": "old-relay-pattern",
+                "title": "Old relay pattern",
+                "decision": "Use relay pattern.",
+                "rationale": "Simple.",
+                "date": "2025-01",
+            }))
+
+            # Store a new decision that supersedes the old one
+            asyncio.run(handle_write_decision({
+                "key": "direct-delivery",
+                "title": "Direct delivery",
+                "decision": "Use direct send_reply.",
+                "rationale": "Crash-safe.",
+                "date": "2026-04",
+                "supersedes": "old-relay-pattern",
+            }))
+
+            result = asyncio.run(handle_list_decisions({"active_only": True}))
+
+        text = result[0].text
+        # The new decision must appear as a section header
+        assert "### direct-delivery" in text
+        # The old decision must NOT appear as a section header (it is superseded)
+        assert "### old-relay-pattern" not in text
+        # The active count must reflect only 1 active decision
+        assert "(1 active)" in text
+
+    def test_active_only_false_shows_all_decisions(self, static_provider):
+        """active_only=False must show all decisions including superseded ones."""
+        from src.mcp.inbox_server import handle_write_decision, handle_list_decisions
+
+        with patch("src.mcp.inbox_server._memory_provider", static_provider):
+            asyncio.run(handle_write_decision({
+                "key": "old-decision",
+                "title": "Old decision",
+                "decision": "Use X.",
+                "rationale": "Historical.",
+                "date": "2025-01",
+            }))
+            asyncio.run(handle_write_decision({
+                "key": "new-decision",
+                "title": "New decision",
+                "decision": "Use Y.",
+                "rationale": "Better.",
+                "date": "2026-04",
+                "supersedes": "old-decision",
+            }))
+
+            result = asyncio.run(handle_list_decisions({"active_only": False}))
+
+        text = result[0].text
+        assert "old-decision" in text
+        assert "new-decision" in text
+
+    def test_area_filter_narrows_results(self, static_provider):
+        """list_decisions with area filter returns only decisions affecting that area."""
+        from src.mcp.inbox_server import handle_write_decision, handle_list_decisions
+
+        with patch("src.mcp.inbox_server._memory_provider", static_provider):
+            asyncio.run(handle_write_decision({
+                "key": "subagent-comm-decision",
+                "title": "Subagent comm decision",
+                "decision": "Use direct delivery.",
+                "rationale": "Crash safe.",
+                "date": "2026-04",
+                "affected_areas": ["subagent-communication"],
+            }))
+            asyncio.run(handle_write_decision({
+                "key": "db-schema-decision",
+                "title": "DB schema decision",
+                "decision": "Use SQLite.",
+                "rationale": "Simple.",
+                "date": "2026-04",
+                "affected_areas": ["database"],
+            }))
+
+            result = asyncio.run(handle_list_decisions({"area": "subagent-communication"}))
+
+        text = result[0].text
+        assert "subagent-comm-decision" in text
+        # DB decision should not appear when filtering by subagent-communication
+        assert "db-schema-decision" not in text
+
+    def test_area_filter_no_matches_returns_clear_message(self, static_provider):
+        """list_decisions with area filter and no matches returns a clear message."""
+        from src.mcp.inbox_server import handle_write_decision, handle_list_decisions
+
+        with patch("src.mcp.inbox_server._memory_provider", static_provider):
+            asyncio.run(handle_write_decision({
+                "key": "some-decision",
+                "title": "Some decision",
+                "decision": "Do X.",
+                "rationale": "Because.",
+                "date": "2026-04",
+                "affected_areas": ["event-bus"],
+            }))
+
+            result = asyncio.run(handle_list_decisions({"area": "nonexistent-area-xyz"}))
+
+        assert "no" in result[0].text.lower()
+        assert "decision" in result[0].text.lower()
+
+    def test_unavailable_memory_returns_error(self):
+        """list_decisions returns an error when memory provider is None."""
+        from src.mcp.inbox_server import handle_list_decisions
+
+        with patch("src.mcp.inbox_server._memory_provider", None):
+            result = asyncio.run(handle_list_decisions({}))
+
+        assert "not available" in result[0].text.lower()
+
+    def test_displays_title_and_rationale(self, static_provider):
+        """list_decisions output must include the title and rationale for each decision."""
+        from src.mcp.inbox_server import handle_write_decision, handle_list_decisions
+
+        with patch("src.mcp.inbox_server._memory_provider", static_provider):
+            asyncio.run(handle_write_decision({
+                "key": "nats-transport",
+                "title": "NATS chosen for event bus",
+                "decision": "Use NATS for all inter-service messaging.",
+                "rationale": "Lower latency than alternatives.",
+                "date": "2026-03",
+                "affected_areas": ["event-bus"],
+            }))
+
+            result = asyncio.run(handle_list_decisions({}))
+
+        text = result[0].text
+        assert "NATS chosen for event bus" in text
+        assert "Lower latency than alternatives" in text
+
+
+class TestBuildDecisionContent:
+    """Tests for the _build_decision_content pure function."""
+
+    def test_canonical_content_format(self):
+        """_build_decision_content produces a well-formed canonical string."""
+        from src.mcp.inbox_server import _build_decision_content
+
+        content = _build_decision_content(
+            key="relay-pattern-deprecated",
+            title="Relay pattern deprecated",
+            decision="Use direct send_reply.",
+            rationale="Crash-safe delivery.",
+            date="2026-04",
+            affected_areas=["subagent-communication", "write_result"],
+            supersedes=None,
+        )
+
+        assert "[DECISION] key=relay-pattern-deprecated" in content
+        assert "Title: Relay pattern deprecated" in content
+        assert "Decision: Use direct send_reply." in content
+        assert "Rationale: Crash-safe delivery." in content
+        assert "Date: 2026-04" in content
+        assert "subagent-communication" in content
+        assert "write_result" in content
+        # No supersedes line when not provided
+        assert "Supersedes:" not in content
+
+    def test_supersedes_included_when_provided(self):
+        """_build_decision_content includes the Supersedes line when provided."""
+        from src.mcp.inbox_server import _build_decision_content
+
+        content = _build_decision_content(
+            key="new-pattern",
+            title="New pattern",
+            decision="Use Y.",
+            rationale="Better.",
+            date="2026-04",
+            affected_areas=[],
+            supersedes="old-pattern",
+        )
+
+        assert "Supersedes: old-pattern" in content
+
+    def test_empty_affected_areas_omitted(self):
+        """_build_decision_content omits the Affected areas line when list is empty."""
+        from src.mcp.inbox_server import _build_decision_content
+
+        content = _build_decision_content(
+            key="minimal-decision",
+            title="Minimal",
+            decision="Do X.",
+            rationale="Because.",
+            date="2026-04",
+            affected_areas=[],
+            supersedes=None,
+        )
+
+        assert "Affected areas:" not in content

--- a/tests/unit/test_mcp_server/test_decision_tools.py
+++ b/tests/unit/test_mcp_server/test_decision_tools.py
@@ -401,6 +401,9 @@ class TestListDecisionsRetrieval:
         text = result[0].text
         assert "old-decision" in text
         assert "new-decision" in text
+        # The superseded decision must be labelled — regression guard for display logic
+        assert "[SUPERSEDED]" in text
+        assert "[SUPERSEDED] old-decision" in text
 
     def test_area_filter_narrows_results(self, static_provider):
         """list_decisions with area filter returns only decisions affecting that area."""


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Problem

Architectural decisions made in one session were lost at context compaction. Future engineer sessions had no way to discover them — they weren't in any file read at startup, and without a pre-implementation check step, engineers would re-implement deprecated or superseded patterns. The relay pattern deprecation (Apr 2026) was the motivating example: an engineer starting fresh would have no way to know it was deprecated.

## What changed

**Two new MCP tools in `inbox_server.py`:**

- `write_decision(key, title, decision, rationale, date, affected_areas?, supersedes?, tags?)` — stores an architectural decision as a `type="decision"` memory event. All fields are encoded into the searchable content string AND stored as structured metadata, so decisions are findable via both FTS5 keyword search and vector search without schema changes.

- `list_decisions(active_only=True, area=None)` — retrieves all decision-type events. `active_only` hides superseded decisions by tracking which keys appear in other decisions' `supersedes` metadata. The `area` parameter narrows results to decisions affecting a specific system domain.

**Supersession tracking** is done via content encoding + metadata (no new DB column needed). When decision B supersedes decision A: B records `supersedes: A` in its metadata and content; `list_decisions(active_only=True)` collects all referenced supersedes keys and filters them out of the results.

**Two bootup files updated:**

- `sys.subagent.bootup.md` — new "Architectural Decision Memory" section documenting: when to call `list_decisions()`, which areas require pre-implementation checks, `write_decision` usage, and the decision vs. IFTTT-feedback distinction.

- `functional-engineer.md` — `### 4. Implementation` step now begins with a mandatory `list_decisions()` call before any code, scoped to known decision-bearing areas.

The relay-deprecation seed decision and IFTTT bootup rule are **out of scope for this PR** — they require calling the live MCP tools after deploy, not code changes.

## Design decisions

**No new DB schema** — decisions reuse the existing `events` table with `type="decision"`. The `decision_key`, `decision_title`, `decision_date`, `decision_affected_areas` fields are stored in the existing `metadata` JSON column. This avoids a migration, keeps the change fully backward-compatible, and lets the existing FTS5/vector infrastructure work immediately.

**`_build_decision_content` is a pure function** — all structured fields are encoded deterministically into a content string. This is the only place that format is defined, making it easy to change and test.

**`handle_list_decisions` filters via immutable pipeline** — superseded key collection, active_only filter, and area filter are three sequential list comprehensions on an immutable list. No mutation.

**`write_decision` does not mark prior events as superseded in-DB** — the existing memory provider protocol has no update/patch method (StaticMemory stores to JSONL append-only). Supersession is inferred at read time by `list_decisions`. This is simpler and avoids a protocol change.

## Before/after flow

```
Before:
  Engineer starts -> reads bootup files -> starts writing code
  (no way to know relay pattern was deprecated)

After:
  Engineer starts -> reads bootup files -> sees "call list_decisions() first"
  -> list_decisions() returns any active decisions
  -> engineer reads constraints before touching decision-bearing areas
```

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_decision_tools.py -v` — 20 passed, 0 failed
- [x] `uv run pytest tests/unit/ -q --tb=short` (excluding 2 pre-existing broken collection files) — 2775 passed, 9 failed (all 9 pre-existing on main, all involve ADMIN_CHAT_ID_REDACTED NameError unrelated to this change), 24 skipped
- [x] `uv run python -m py_compile src/mcp/inbox_server.py` — clean

## Manual test

N/A — this change is entirely internal (no external service calls, no systemd/cron, no Telegram output). The new MCP tools are exercised fully by unit tests using the StaticMemory backend with isolated temp dirs. The relay-deprecation seed decision and IFTTT rule will be stored via live MCP tools after deploy.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (internal tools only)
- [x] User-visible outcome — N/A (no user-visible output)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none

Closes #1638