### PR TITLE
fix(#1689): route reviewer subagents to review agent type

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -453,7 +453,7 @@ Background subagents call `write_result(task_id, chat_id, text, ...)`, which dro
                mark_processed(message_id)
            else:
                Task(
-                   subagent_type="lobster-generalist",
+                   subagent_type="review",
                    run_in_background=True,
                    prompt=(
                        f"---\ntask_id: {reviewer_task_id}\nchat_id: {msg['chat_id']}\n"
@@ -767,7 +767,7 @@ If `reacted_to_text` is empty: use `get_conversation_history` to get context.
                pr_repo   = f"{pr_parts[-4]}/{pr_parts[-3]}"
                reviewer_task_id = f"review-delete-confirmed-{task_id_slug}"
                Task(
-                   subagent_type="lobster-generalist",
+                   subagent_type="review",
                    run_in_background=True,
                    prompt=(
                        f"---\ntask_id: {reviewer_task_id}\nchat_id: {chat_id}\nsource: {source}\n---\n\n"

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -323,8 +323,11 @@ Before declaring any integration or manual test PASS:
 
 - **Code reviews — always post to the PR:** When conducting a code review of a GitHub PR, you MUST post the review directly to the PR using `gh pr review`, then also send the summary back via `write_result`.
   1. Post to the PR: `gh pr review <PR_NUMBER> --repo <owner/repo> --comment --body "REVIEW TEXT"`
-  2. Then call `write_result` with a concise summary for the user (scene → problem → fix → impact, 3–6 lines, include PR link).
-  - If no PR exists yet (local changes only), skip step 1 and report findings entirely via `write_result`.
+  2. **Before calling write_result for any code review:**
+     - [ ] Confirmed `gh pr review N --repo owner/repo --comment --body "..."` was run
+     - If not run yet: run it now, then call write_result
+  3. Then call `write_result` with a concise summary for the user (scene → problem → fix → impact, 3–6 lines, include PR link).
+  - If no PR exists yet (local changes only), skip steps 1–2 and report findings entirely via `write_result`.
 
 - **GitHub attribution:** All PR descriptions, review comments, and issue comments written by Lobster must include an attribution prefix. The `gh` CLI is authenticated as the owner's account — without this prefix, GitHub content appears to come from the owner personally.
   - PR body (when opening a PR): first line is `🤖🦞 Lobster (engineer):` followed by a blank line


### PR DESCRIPTION
Reviewer subagents were spawned with \`subagent_type="lobster-generalist"\`, which meant the \`review.md\` agent definition never loaded. Without that definition, reviewers had no system instruction to post \`gh pr review\` comments and consistently skipped the step.

## What changed

**\`sys.dispatcher.bootup.md\` — two spawn sites changed:**
- Line 456: main engineer→reviewer routing path (\`# --- ENGINEER → REVIEWER routing ---\`)
- Line 770: delete-confirmed callback path (\`delete-confirm-yes-\` handler)

Both changed \`subagent_type="lobster-generalist"\` to \`subagent_type="review"\`. No other \`lobster-generalist\` calls are touched (relay subagents at lines 495/512 and job dispatch at line 815 are unchanged).

**\`sys.subagent.bootup.md\` — hard pre-flight checklist added:**

The Code reviews section previously said "you MUST post using gh pr review" but gave no enforcement point. Added a mandatory checklist gate between step 1 (post the review) and the write_result call:

```
2. **Before calling write_result for any code review:**
   - [ ] Confirmed gh pr review N --repo owner/repo --comment --body "..." was run
   - If not run yet: run it now, then call write_result
```

## What is out of scope

The reviewer prompt text passed inline in the dispatcher is not changed. The REVIEWER PROCESS and POST instructions already say the right thing. The fix is routing, not prompting.

## Before / after flow

```
Before:
  engineer write_result (PR URL in text)
    dispatcher spawns lobster-generalist
      generic context, no review.md
      may skip gh pr review
      calls write_result

After:
  engineer write_result (PR URL in text)
    dispatcher spawns review
      review.md loads, full reviewer context active
      hard checklist: must run gh pr review before write_result
      calls write_result
```

Both reviewer spawn paths (main path + delete-confirmed callback) follow the After flow.

## Tests run
- [x] grep verification: exactly two lobster-generalist → review changes; relay and job-dispatch uses unchanged
- [x] git diff reviewed: 4 lines changed in dispatcher, 7-line net in subagent bootup; no unintended changes
- [ ] Live reviewer flow — requires a real PR and running dispatcher; no automated test exists for dispatcher routing logic. Change is a one-word string substitution in a text instruction file.

**Blocked items needing attention before merge:** none

## Manual test
N/A — text-only change to instruction files (no systemd, cron, external services, file I/O, or DB schema).

## Definition of Done
- [x] Unit tests — N/A (instruction files only, no code changed)
- [x] Integration/manual test — N/A (static text change)
- [x] User-visible outcome — not applicable directly; observable via gh pr review comments appearing on future PRs
- [x] Side-effect audit — no floods, no shared state writes, no volume concerns
- [x] External service calls — none

Closes #1689