### PR TITLE
fix(#1662): add alwaysLoad metadata + bootup ToolSearch pre-load for core MCP tools

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -30,6 +30,15 @@ When you first start (or after reading this file), follow these steps:
 0. Call `session_start(agent_type="dispatcher", agent_id="lobster-dispatcher", description="Lobster dispatcher main loop", chat_id=<ADMIN_CHAT_ID>)` to register this session as the dispatcher. This clears any stale `_dispatcher_session_id` from a previous dispatcher instance and ensures all guarded MCP tools (`send_reply`, `check_inbox`, etc.) work immediately. Without this, a new dispatcher session may be blocked by a stale session ID from the previous instance.
    - Get ADMIN_CHAT_ID from `lobster.conf` (`grep ADMIN_CHAT_ID ~/lobster-config/lobster.conf` or equivalent), or use the `chat_id` from `context-handoff.json` if available.
    - This is the FIRST action before any guarded tools — must fire before step 2d.
+
+0b. **ToolSearch pre-load** — ALL MCP tools are deferred by default in Claude Code. Without schema pre-loading, the CC client's Zod validator stringifies numeric/boolean args, causing `InputValidationError: '10' is not of type 'integer'`. Call ToolSearch immediately after step 0:
+
+    ```
+    ToolSearch(query="select:session_start,send_reply,get_conversation_history,list_rules,check_inbox,wait_for_messages,mark_processing,mark_processed")
+    ```
+
+    This loads the JSON schemas for the 8 core startup tools before any of them are called. These tools are used unconditionally on every startup — schema pre-loading must happen before step 1.
+
 1. Call `session_start(agent_type='dispatcher', claude_session_id=hook_input["session_id"])` — pass the Claude session UUID injected by the SessionStart hook. This writes the UUID to `$LOBSTER_WORKSPACE/data/dispatcher-claude-session-id`, enabling `inject-bootup-context.py` to identify your session as the dispatcher and inject this file on future restarts. Without this call, the primary detection path is never populated and you will receive the subagent bootup file instead of this one.
 1a. Read `~/lobster-user-config/memory/canonical/handoff.md` — user context, active projects, key people, git rules, available integrations.
 1b. **Restore conversational context** — restarts are invisible to users, who expect you to remember the conversation. Do both of these unconditionally:

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -1659,6 +1659,7 @@ async def list_tools() -> list[Tool]:
                     },
                 },
             },
+            _meta={"anthropic/alwaysLoad": True},
         ),
         Tool(
             name="check_inbox",
@@ -1686,6 +1687,7 @@ async def list_tools() -> list[Tool]:
                     },
                 },
             },
+            _meta={"anthropic/alwaysLoad": True},
         ),
         Tool(
             name="send_reply",
@@ -1754,6 +1756,7 @@ async def list_tools() -> list[Tool]:
                 },
                 "required": ["chat_id", "text"],
             },
+            _meta={"anthropic/alwaysLoad": True},
         ),
         Tool(
             name="send_whatsapp_reply",
@@ -1809,6 +1812,7 @@ async def list_tools() -> list[Tool]:
                 },
                 "required": ["message_id"],
             },
+            _meta={"anthropic/alwaysLoad": True},
         ),
         Tool(
             name="mark_processing",
@@ -1823,6 +1827,7 @@ async def list_tools() -> list[Tool]:
                 },
                 "required": ["message_id"],
             },
+            _meta={"anthropic/alwaysLoad": True},
         ),
         Tool(
             name="mark_failed",
@@ -1976,6 +1981,7 @@ async def list_tools() -> list[Tool]:
                     },
                 },
             },
+            _meta={"anthropic/alwaysLoad": True},
         ),
         # Telegram Message Lookup Tool
         Tool(
@@ -2113,6 +2119,7 @@ async def list_tools() -> list[Tool]:
                     },
                 },
             },
+            _meta={"anthropic/alwaysLoad": True},
         ),
         Tool(
             name="add_rule",
@@ -2741,6 +2748,7 @@ async def list_tools() -> list[Tool]:
                 },
                 "required": ["agent_id", "description", "chat_id"],
             },
+            _meta={"anthropic/alwaysLoad": True},
         ),
         Tool(
             name="session_end",


### PR DESCRIPTION
## Problem

During dispatcher startup, calls to `get_conversation_history`, `list_rules`, and `send_reply` intermittently fail with:

```
InputValidationError: '10' is not of type 'integer'
InputValidationError: 'true' is not of type 'boolean'
```

Root cause: ALL MCP tools are deferred by default in Claude Code (`isMcp === true`). When a deferred tool's schema hasn't been loaded via ToolSearch, the CC client has no JSON Schema locally and its Zod validator coerces all args to strings before passing them to the MCP server. The server's type validator then rejects them.

The 8 core startup tools — `session_start`, `send_reply`, `get_conversation_history`, `list_rules`, `check_inbox`, `wait_for_messages`, `mark_processing`, `mark_processed` — are called unconditionally on every dispatcher restart, before any ToolSearch has been invoked, making them reliably vulnerable.

## Fix

Two complementary defenses, both required for full coverage:

**Part A — Dispatcher bootup pre-load (behavioral, `sys.dispatcher.bootup.md`):**

Adds Step 0b: a ToolSearch call immediately after `session_start`, before any other startup tool is used:

```
ToolSearch(query="select:session_start,send_reply,get_conversation_history,list_rules,check_inbox,wait_for_messages,mark_processing,mark_processed")
```

This ensures schemas are loaded in the correct order on every restart, covering new dispatcher sessions that don't have a cached schema.

**Part B — Server-side opt-out (`inbox_server.py`):**

Adds `_meta={"anthropic/alwaysLoad": True}` to the `Tool()` constructor for each of the 8 critical tools. Per the CC binary's `isDeferredTool` logic:

```javascript
if (q.alwaysLoad === true) return false;  // opt-out via _meta["anthropic/alwaysLoad"]
```

This opts each tool out of deferred loading entirely — the CC client always sends full schemas to the API regardless of ToolSearch state. This is a server-side guarantee that doesn't depend on the dispatcher following the correct startup sequence.

Both fixes are applied: Part B is the hard guarantee, Part A ensures the schemas are available early for any code paths that call ToolSearch-dependent validation before the first tool use.

Only the 8 listed tools receive `alwaysLoad`. Adding it to all tools would bloat the API context window for every session.

## Implementation

Pure data change — no logic, no control flow altered. Uses the `_meta` extension field on `mcp.types.Tool`, which accepts `dict[str, Any] | None`.

## Tests run

- [x] `uv run python -c "import ast; ast.parse(open('src/mcp/inbox_server.py').read()); print('Syntax OK')"` — Syntax OK
- [x] `uv run pytest tests/unit/test_mcp_server/ -q` (excluding 3 pre-existing collection errors due to `ADMIN_CHAT_ID_REDACTED` in test files not authored in this PR) — 708 passed, 0 failed
- [x] Pre-existing failures on main confirmed identical to pre-existing failures in this branch — no regressions introduced

## Manual test

N/A — this change does not touch external services, file I/O, or database schema. The fix takes effect when the MCP server next starts (or when the dispatcher next restarts). The `_meta` field is a standard MCP protocol extension; the CC client reads it at tool registration time.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (pure MCP metadata + bootup text change)
- [x] User-visible outcome: dispatcher startup type validation errors eliminated — not directly observable in this PR, verified by the root cause analysis in issue #1662
- [x] Side-effect audit: no floods, no unscoped writes, no unintended volume — this is a read-only metadata addition
- [x] External service calls: none

Closes #1662