### PR TITLE
fix(#1713): align wfm-active path — inbox_server writes epoch int to workspace/logs, health check reads it

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -100,6 +100,15 @@ HEARTBEAT_FILE="$WORKSPACE_DIR/logs/claude-heartbeat"   # legacy WFM-touch signa
 DISPATCHER_HEARTBEAT_FILE="${LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE:-$WORKSPACE_DIR/logs/dispatcher-heartbeat}"
 DISPATCHER_HEARTBEAT_STALE_SECONDS=1200   # 20 min — covers compaction (~5m) + catchup (~12m) + margin
 
+# WFM-active signal (issue #1713 / #949): inbox_server.py writes this file with
+# a Unix epoch timestamp when wait_for_messages begins blocking and refreshes it
+# every WAIT_HEARTBEAT_INTERVAL (60s). When this file is fresh, the dispatcher is
+# alive and waiting for messages — heartbeat staleness is expected, not a problem.
+# Threshold: 3x WAIT_HEARTBEAT_INTERVAL to absorb one missed refresh cycle.
+# File is deleted by the MCP server when WFM returns (message arrived or timeout).
+DISPATCHER_WFM_ACTIVE_FILE="${LOBSTER_WFM_ACTIVE_OVERRIDE:-$WORKSPACE_DIR/logs/dispatcher-wfm-active}"
+WFM_ACTIVE_STALE_SECONDS=180   # 3x WAIT_HEARTBEAT_INTERVAL (60s) — absorbs one missed tick
+
 OUTBOX_DIR="$MESSAGES_DIR/outbox"
 OUTBOX_STALE_THRESHOLD_SECONDS=900   # 15 min = RED
 OUTBOX_YELLOW_THRESHOLD_SECONDS=300  # 5 min = YELLOW
@@ -973,6 +982,26 @@ check_dispatcher_heartbeat() {
     age=$(( now - raw_ts ))
 
     if [[ $age -gt $DISPATCHER_HEARTBEAT_STALE_SECONDS ]]; then
+        # Heartbeat is stale — check the WFM-active signal before declaring RED.
+        # When the dispatcher is blocked in wait_for_messages, PostToolUse hooks
+        # do not fire so the heartbeat goes stale. inbox_server.py writes
+        # DISPATCHER_WFM_ACTIVE_FILE with a fresh epoch timestamp every 60s while
+        # WFM is blocking. A fresh WFM-active file means the dispatcher is alive
+        # and simply idle — not frozen or dead. (issue #1713 / #949)
+        local wfm_active_ts=""
+        if [[ -f "$DISPATCHER_WFM_ACTIVE_FILE" ]]; then
+            wfm_active_ts=$(cat "$DISPATCHER_WFM_ACTIVE_FILE" 2>/dev/null | tr -d '[:space:]')
+        fi
+        if [[ -n "$wfm_active_ts" ]] && [[ "$wfm_active_ts" =~ ^[0-9]+$ ]]; then
+            local wfm_age=$(( now - wfm_active_ts ))
+            if [[ $wfm_age -le $WFM_ACTIVE_STALE_SECONDS ]]; then
+                log_info "Dispatcher heartbeat stale (${age}s) but WFM-active is fresh (${wfm_age}s) — dispatcher alive in wait_for_messages, skipping RED"
+                return 0
+            else
+                log_error "RED: dispatcher heartbeat stale (${age}s) and WFM-active also stale (${wfm_age}s, threshold: ${WFM_ACTIVE_STALE_SECONDS}s) — dispatcher appears frozen"
+                return 2
+            fi
+        fi
         log_error "RED: dispatcher heartbeat stale — last tool use ${age}s ago (threshold: ${DISPATCHER_HEARTBEAT_STALE_SECONDS}s)"
         return 2
     fi

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -795,6 +795,30 @@ def normalize_message_type(msg: dict) -> dict:
 # Heartbeat file for health monitoring
 HEARTBEAT_FILE = _WORKSPACE / "logs" / "claude-heartbeat"
 
+# How often (in seconds) wait_for_messages touches heartbeats and refreshes
+# WFM-active during the blocking wait.  Exposed as a module-level constant so
+# tests can verify it matches the health-check's WFM_ACTIVE_STALE_SECONDS.
+WAIT_HEARTBEAT_INTERVAL = 60
+
+# WFM-active signal file (issue #1713 / #949): written with a Unix epoch
+# timestamp when wait_for_messages begins blocking, refreshed every
+# WAIT_HEARTBEAT_INTERVAL seconds, and deleted when WFM returns.
+#
+# The health check reads this file to distinguish "dispatcher alive, waiting
+# for messages" from "dispatcher frozen/dead" — suppressing the
+# heartbeat-stale RED that would otherwise fire after 20 minutes of quiet.
+#
+# Path: ~/lobster-workspace/logs/dispatcher-wfm-active
+# Content: single Unix epoch integer (e.g. "1713456789\n"), same format as
+#          dispatcher-heartbeat so health-check-v3.sh can parse it identically.
+# Override: LOBSTER_WFM_ACTIVE_OVERRIDE env var (used in tests).
+WFM_ACTIVE_FILE = Path(
+    os.environ.get(
+        "LOBSTER_WFM_ACTIVE_OVERRIDE",
+        str(_WORKSPACE / "logs" / "dispatcher-wfm-active"),
+    )
+)
+
 # Hibernation state file - tracks whether Lobster is active or hibernating
 LOBSTER_STATE_FILE = CONFIG_DIR / "lobster-state.json"
 
@@ -1434,6 +1458,28 @@ def touch_heartbeat():
         HEARTBEAT_FILE.touch()
     except Exception:
         pass  # Don't fail on heartbeat errors
+
+
+def _write_wfm_active_signal() -> None:
+    """Write the WFM-active heartbeat signal atomically (issue #1713 / #949).
+
+    Called at the start of the wait_for_messages blocking loop and refreshed
+    on every WAIT_HEARTBEAT_INTERVAL tick so the health check sees a fresh
+    signal throughout the entire WFM blocking period.
+
+    Content: single Unix epoch integer — same format as dispatcher-heartbeat —
+    so health-check-v3.sh can parse it with the same integer comparison logic.
+
+    Atomic write (tmp -> rename) prevents partial reads by the health check.
+    Silently swallowed on failure: health check degrades gracefully when absent.
+    """
+    try:
+        WFM_ACTIVE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = WFM_ACTIVE_FILE.with_name(f".wfm-active-{os.getpid()}.tmp")
+        tmp.write_text(str(int(time.time())) + "\n")
+        os.rename(str(tmp), str(WFM_ACTIVE_FILE))
+    except Exception:
+        pass  # Never block wait_for_messages on a heartbeat write failure
 
 
 # ---------------------------------------------------------------------------
@@ -4046,24 +4092,14 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
     # transient mode, calling wait_for_messages means Claude is up and running.
     _write_lobster_state(LOBSTER_STATE_FILE, "active")
 
-    # Write WFM active timestamp so the health check can distinguish a healthy
-    # idle-blocking dispatcher from a frozen one (PR #1646).
-    # The health check treats a fresh wfm-active signal as GREEN even when the
-    # heartbeat is stale, preventing false-positive kills during long idle periods.
+    # Write WFM-active signal so the health check can distinguish a healthy
+    # idle-blocking dispatcher from a frozen one (issue #1713 / #949).
+    # The health check treats a fresh WFM-active signal as GREEN even when
+    # dispatcher-heartbeat is stale — PostToolUse hooks don't fire during a
+    # blocking MCP call, so the heartbeat inevitably goes stale after 20 min.
     # We clear this file in the finally block so the signal only persists while
-    # WFM is actually running.
-    _wfm_active_file = CONFIG_DIR / "wfm-active.json"
-    try:
-        _wfm_start_ts = datetime.now(timezone.utc)
-        _wfm_active_payload = {
-            "started_at": _wfm_start_ts.isoformat(),
-            "pid": os.getpid(),
-        }
-        _wfm_tmp = _wfm_active_file.parent / f".wfm-active-{os.getpid()}.tmp"
-        _wfm_tmp.write_text(json.dumps(_wfm_active_payload))
-        _wfm_tmp.rename(_wfm_active_file)
-    except Exception as _wfm_exc:
-        log.warning(f"[wfm-active] Failed to write wfm-active.json: {_wfm_exc}")
+    # WFM is actually blocking.
+    _write_wfm_active_signal()
 
     # Recover stale processing and retryable failed messages
     _recover_stale_processing()
@@ -4117,8 +4153,10 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
             touch_heartbeat()
             inbox_results = await handle_check_inbox({"limit": 10})
             return _prepend_sessions_prefix(sessions_prefix, inbox_results)
-        # Wait with periodic heartbeats (every 60 seconds)
-        heartbeat_interval = 60
+        # Wait with periodic heartbeats (every WAIT_HEARTBEAT_INTERVAL seconds).
+        # Refresh WFM-active on every iteration so the health check sees a
+        # fresh signal even during long quiet periods (issue #1713 / #949).
+        heartbeat_interval = WAIT_HEARTBEAT_INTERVAL
         elapsed = 0
 
         while elapsed < timeout:
@@ -4132,8 +4170,9 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
             if arrived:
                 break
 
-            # Touch heartbeat to show we're still alive
+            # Touch heartbeat and refresh WFM-active to show we're still alive.
             touch_heartbeat()
+            _write_wfm_active_signal()
             elapsed += wait_time
 
         if message_arrived.is_set():
@@ -4178,13 +4217,13 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
     finally:
         observer.stop()
         observer.join(timeout=1)
-        # Clear WFM active file — health check reads this to detect healthy idle vs frozen.
+        # Clear WFM-active signal so the health check stops treating the
+        # dispatcher as "alive in WFM" once wait_for_messages returns.
         try:
-            _wfm_active_file = CONFIG_DIR / "wfm-active.json"
-            if _wfm_active_file.exists():
-                _wfm_active_file.unlink()
+            if WFM_ACTIVE_FILE.exists():
+                WFM_ACTIVE_FILE.unlink()
         except Exception as _wfm_clear_exc:
-            log.warning(f"[wfm-active] Failed to clear wfm-active.json: {_wfm_clear_exc}")
+            log.warning(f"[wfm-active] Failed to clear WFM-active signal: {_wfm_clear_exc}")
 
 
 def _is_report_command(text: str) -> bool:

--- a/tests/test-health-check-dispatcher-heartbeat.sh
+++ b/tests/test-health-check-dispatcher-heartbeat.sh
@@ -14,9 +14,10 @@
 #   7. Stale by 1 second past threshold → RED (boundary condition)
 #   8. Fresh by 1 second before threshold → GREEN (boundary condition)
 #
-# Key behavioral assertion: the check uses a SINGLE file with a SINGLE epoch
-# timestamp. No lobster-state.json reads, no WFM heartbeat file, no multi-signal
-# aggregation.
+# Key behavioral assertion: the check uses a single dispatcher-heartbeat file with
+# a single epoch timestamp. No lobster-state.json reads. The WFM-active file is
+# also consulted by check_dispatcher_heartbeat() but is bypassed safely here via
+# DISPATCHER_WFM_ACTIVE_FILE pointing to an absent file (defaulting to GREEN).
 #
 # Usage: bash tests/test-health-check-dispatcher-heartbeat.sh
 #===============================================================================
@@ -55,6 +56,10 @@ assert_exit() {
 # Source check_dispatcher_heartbeat() from the health check script once.
 LOG_FILE="$TEST_LOG_DIR/health-check.log"
 DISPATCHER_HEARTBEAT_STALE_SECONDS=1200
+# WFM-active variables (issue #1713): must match the values in health-check-v3.sh.
+# Default to an absent file so existing heartbeat tests are unaffected.
+DISPATCHER_WFM_ACTIVE_FILE="$TEST_LOG_DIR/dispatcher-wfm-active-ABSENT"
+WFM_ACTIVE_STALE_SECONDS=180
 
 log()       { echo "[$1] $2" >> "$LOG_FILE" 2>/dev/null; }
 log_info()  { log INFO "$1"; }

--- a/tests/test-health-check-wfm-active.sh
+++ b/tests/test-health-check-wfm-active.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+#===============================================================================
+# Test Suite: Health Check v3 - WFM-Active Signal (issue #1713 / #949)
+#
+# Tests for the WFM-active bypass in check_dispatcher_heartbeat():
+# When the dispatcher is blocked inside wait_for_messages, PostToolUse hooks
+# do not fire and the dispatcher-heartbeat file goes stale. A separate
+# dispatcher-wfm-active file (written and periodically refreshed by
+# inbox_server.py during the wait loop) lets the health check distinguish
+# "dispatcher idle in WFM" from "dispatcher frozen/dead".
+#
+# Tests:
+#   1. Stale heartbeat + absent WFM-active → RED (original behavior preserved)
+#   2. Stale heartbeat + fresh WFM-active → GREEN (WFM suppression works)
+#   3. Stale heartbeat + stale WFM-active → RED (both stale = frozen)
+#   4. Stale heartbeat + WFM-active 1s past threshold → RED (boundary)
+#   5. Stale heartbeat + WFM-active 1s before threshold → GREEN (boundary)
+#   6. Fresh heartbeat ignores WFM-active (heartbeat alone = GREEN)
+#   7. LOBSTER_WFM_ACTIVE_OVERRIDE env var is respected
+#   8. WFM-active file with non-integer content → RED (treat as absent)
+#
+# Usage: bash tests/test-health-check-wfm-active.sh
+#===============================================================================
+
+set -u
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts"
+HEALTH_SCRIPT="$SCRIPT_DIR/health-check-v3.sh"
+
+TEST_TMPDIR=$(mktemp -d /tmp/lobster-wfm-active-test-XXXXXX)
+TEST_LOG_DIR="$TEST_TMPDIR/logs"
+DISPATCHER_HEARTBEAT_FILE="$TEST_LOG_DIR/dispatcher-heartbeat"
+DISPATCHER_WFM_ACTIVE_FILE="$TEST_LOG_DIR/dispatcher-wfm-active"
+
+cleanup() { rm -rf "$TEST_TMPDIR"; }
+trap cleanup EXIT
+
+mkdir -p "$TEST_LOG_DIR"
+
+begin_test() { TOTAL=$((TOTAL + 1)); test_name="$1"; }
+pass()  { PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC} $test_name"; }
+fail()  { FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC} $test_name: $1"; }
+
+assert_exit() {
+    local actual="$1" expected="$2"
+    if [[ "$actual" -eq "$expected" ]]; then pass; else fail "expected exit $expected, got $actual"; fi
+}
+
+# Source check_dispatcher_heartbeat() from the health check script.
+LOG_FILE="$TEST_LOG_DIR/health-check.log"
+DISPATCHER_HEARTBEAT_STALE_SECONDS=1200
+WFM_ACTIVE_STALE_SECONDS=180
+
+log()       { echo "[$1] $2" >> "$LOG_FILE" 2>/dev/null; }
+log_info()  { log INFO "$1"; }
+log_warn()  { log WARN "$1"; }
+log_error() { log ERROR "$1"; }
+
+eval "$(sed -n '/^check_dispatcher_heartbeat()/,/^}/p' "$HEALTH_SCRIPT")" 2>/dev/null
+
+# Helper: write a stale heartbeat (20 minutes ago).
+write_stale_heartbeat() {
+    echo "$(( $(date +%s) - 1500 ))" > "$DISPATCHER_HEARTBEAT_FILE"
+}
+
+# Helper: write a fresh heartbeat (5 seconds ago).
+write_fresh_heartbeat() {
+    echo "$(( $(date +%s) - 5 ))" > "$DISPATCHER_HEARTBEAT_FILE"
+}
+
+echo "=== WFM-Active Signal Health Check Tests ==="
+echo ""
+
+# -------------------------------------------------------------------
+# Test 1: Stale heartbeat + absent WFM-active → RED
+# -------------------------------------------------------------------
+begin_test "Stale heartbeat + absent WFM-active → RED"
+write_stale_heartbeat
+rm -f "$DISPATCHER_WFM_ACTIVE_FILE"
+check_dispatcher_heartbeat && rc=$? || rc=$?
+assert_exit "$rc" 2
+
+# -------------------------------------------------------------------
+# Test 2: Stale heartbeat + fresh WFM-active → GREEN (WFM suppression)
+# -------------------------------------------------------------------
+begin_test "Stale heartbeat + fresh WFM-active → GREEN"
+write_stale_heartbeat
+echo "$(( $(date +%s) - 30 ))" > "$DISPATCHER_WFM_ACTIVE_FILE"
+check_dispatcher_heartbeat && rc=$? || rc=$?
+assert_exit "$rc" 0
+
+# -------------------------------------------------------------------
+# Test 3: Stale heartbeat + stale WFM-active → RED (both stale = frozen)
+# -------------------------------------------------------------------
+begin_test "Stale heartbeat + stale WFM-active (600s old) → RED"
+write_stale_heartbeat
+echo "$(( $(date +%s) - 600 ))" > "$DISPATCHER_WFM_ACTIVE_FILE"
+check_dispatcher_heartbeat && rc=$? || rc=$?
+assert_exit "$rc" 2
+
+# -------------------------------------------------------------------
+# Test 4: Stale heartbeat + WFM-active 1s past threshold → RED (boundary)
+# -------------------------------------------------------------------
+begin_test "Stale heartbeat + WFM-active ${WFM_ACTIVE_STALE_SECONDS}+1s old → RED"
+write_stale_heartbeat
+echo "$(( $(date +%s) - (WFM_ACTIVE_STALE_SECONDS + 1) ))" > "$DISPATCHER_WFM_ACTIVE_FILE"
+check_dispatcher_heartbeat && rc=$? || rc=$?
+assert_exit "$rc" 2
+
+# -------------------------------------------------------------------
+# Test 5: Stale heartbeat + WFM-active 1s before threshold → GREEN (boundary)
+# -------------------------------------------------------------------
+begin_test "Stale heartbeat + WFM-active ${WFM_ACTIVE_STALE_SECONDS}-1s old → GREEN"
+write_stale_heartbeat
+echo "$(( $(date +%s) - (WFM_ACTIVE_STALE_SECONDS - 1) ))" > "$DISPATCHER_WFM_ACTIVE_FILE"
+check_dispatcher_heartbeat && rc=$? || rc=$?
+assert_exit "$rc" 0
+
+# -------------------------------------------------------------------
+# Test 6: Fresh heartbeat → GREEN (WFM-active is irrelevant)
+# -------------------------------------------------------------------
+begin_test "Fresh heartbeat → GREEN regardless of WFM-active"
+write_fresh_heartbeat
+echo "$(( $(date +%s) - 600 ))" > "$DISPATCHER_WFM_ACTIVE_FILE"  # stale WFM-active
+check_dispatcher_heartbeat && rc=$? || rc=$?
+assert_exit "$rc" 0
+
+# -------------------------------------------------------------------
+# Test 7: LOBSTER_WFM_ACTIVE_OVERRIDE env var is respected
+# -------------------------------------------------------------------
+begin_test "LOBSTER_WFM_ACTIVE_OVERRIDE env var is respected"
+write_stale_heartbeat
+rm -f "$DISPATCHER_WFM_ACTIVE_FILE"
+OVERRIDE_FILE="$TEST_LOG_DIR/custom-wfm-active"
+echo "$(( $(date +%s) - 30 ))" > "$OVERRIDE_FILE"
+DISPATCHER_WFM_ACTIVE_FILE="$OVERRIDE_FILE"
+check_dispatcher_heartbeat && rc=$? || rc=$?
+DISPATCHER_WFM_ACTIVE_FILE="$TEST_LOG_DIR/dispatcher-wfm-active"
+assert_exit "$rc" 0
+
+# -------------------------------------------------------------------
+# Test 8: WFM-active file with non-integer content → treated as absent → RED
+# -------------------------------------------------------------------
+begin_test "WFM-active file non-integer content → treated as absent → RED"
+write_stale_heartbeat
+echo "not-a-number" > "$DISPATCHER_WFM_ACTIVE_FILE"
+check_dispatcher_heartbeat && rc=$? || rc=$?
+assert_exit "$rc" 2
+
+# -------------------------------------------------------------------
+# Summary
+# -------------------------------------------------------------------
+echo ""
+echo "Results: $PASS/$TOTAL passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/tests/unit/test_wfm_active_signal.py
+++ b/tests/unit/test_wfm_active_signal.py
@@ -1,0 +1,117 @@
+"""
+Tests for the WFM-active heartbeat signal (issue #1713 / #949).
+
+Verifies that:
+- _write_wfm_active_signal() writes a single Unix epoch integer
+- WFM_ACTIVE_FILE path is ~/lobster-workspace/logs/dispatcher-wfm-active
+- LOBSTER_WFM_ACTIVE_OVERRIDE env var overrides the path (test isolation)
+- WAIT_HEARTBEAT_INTERVAL is 60s (matches health-check's WFM_ACTIVE_STALE_SECONDS/3)
+- The written timestamp is within 2 seconds of now
+- Atomic write: a .tmp file is never left behind
+- The file is writable before the wait loop starts
+"""
+import importlib
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _load_inbox_server(tmp_wfm_file: Path):
+    """Import inbox_server with LOBSTER_WFM_ACTIVE_OVERRIDE set to a test path."""
+    env_patch = {
+        "LOBSTER_MESSAGES": str(tmp_wfm_file.parent.parent / "messages"),
+        "LOBSTER_WORKSPACE": str(tmp_wfm_file.parent.parent / "workspace"),
+        "LOBSTER_WFM_ACTIVE_OVERRIDE": str(tmp_wfm_file),
+    }
+    # Ensure messages dirs exist so module-level mkdir calls succeed
+    (tmp_wfm_file.parent.parent / "messages" / "inbox").mkdir(parents=True, exist_ok=True)
+    (tmp_wfm_file.parent.parent / "messages" / "config").mkdir(parents=True, exist_ok=True)
+    (tmp_wfm_file.parent.parent / "messages" / "processing").mkdir(parents=True, exist_ok=True)
+    (tmp_wfm_file.parent.parent / "workspace" / "logs").mkdir(parents=True, exist_ok=True)
+
+    with patch.dict(os.environ, env_patch):
+        # Force reimport with new env
+        if "inbox_server" in sys.modules:
+            del sys.modules["inbox_server"]
+        mcp_dir = str(Path(__file__).resolve().parent.parent.parent / "src" / "mcp")
+        if mcp_dir not in sys.path:
+            sys.path.insert(0, mcp_dir)
+        import inbox_server
+        importlib.reload(inbox_server)
+    return inbox_server
+
+
+def test_wfm_active_file_path_is_workspace_logs(tmp_path):
+    """WFM_ACTIVE_FILE default path is ~/lobster-workspace/logs/dispatcher-wfm-active."""
+    wfm_file = tmp_path / "logs" / "dispatcher-wfm-active"
+    server = _load_inbox_server(wfm_file)
+    # The override env var must point to the tmp path
+    assert str(server.WFM_ACTIVE_FILE) == str(wfm_file)
+
+
+def test_wait_heartbeat_interval_is_60():
+    """WAIT_HEARTBEAT_INTERVAL must be 60s to match health-check's 3x WFM_ACTIVE_STALE_SECONDS expectation."""
+    mcp_dir = str(Path(__file__).resolve().parent.parent.parent / "src" / "mcp")
+    if mcp_dir not in sys.path:
+        sys.path.insert(0, mcp_dir)
+    import inbox_server
+    assert inbox_server.WAIT_HEARTBEAT_INTERVAL == 60, (
+        "WAIT_HEARTBEAT_INTERVAL must be 60s — health-check WFM_ACTIVE_STALE_SECONDS=180 is 3x this value"
+    )
+
+
+def test_write_wfm_active_signal_creates_file(tmp_path):
+    """_write_wfm_active_signal() creates the WFM-active file with a Unix epoch integer."""
+    wfm_file = tmp_path / "logs" / "dispatcher-wfm-active"
+    server = _load_inbox_server(wfm_file)
+
+    assert not wfm_file.exists(), "File should not exist before signal is written"
+    before = int(time.time())
+    server._write_wfm_active_signal()
+    after = int(time.time())
+
+    assert wfm_file.exists(), "WFM-active file must exist after _write_wfm_active_signal()"
+    content = wfm_file.read_text().strip()
+    ts = int(content)
+    assert before <= ts <= after, (
+        f"Timestamp {ts} must be between {before} and {after}"
+    )
+
+
+def test_write_wfm_active_signal_no_tmp_leftover(tmp_path):
+    """_write_wfm_active_signal() must not leave a .tmp file behind (atomic write)."""
+    wfm_file = tmp_path / "logs" / "dispatcher-wfm-active"
+    server = _load_inbox_server(wfm_file)
+    server._write_wfm_active_signal()
+
+    tmp_files = list(tmp_path.glob("**/.wfm-active-*.tmp"))
+    assert tmp_files == [], f"Stale .tmp file(s) left behind: {tmp_files}"
+
+
+def test_write_wfm_active_signal_overwrites_on_refresh(tmp_path):
+    """Calling _write_wfm_active_signal() twice updates the timestamp."""
+    wfm_file = tmp_path / "logs" / "dispatcher-wfm-active"
+    server = _load_inbox_server(wfm_file)
+
+    server._write_wfm_active_signal()
+    first_ts = int(wfm_file.read_text().strip())
+
+    time.sleep(1.1)  # ensure clock advances
+    server._write_wfm_active_signal()
+    second_ts = int(wfm_file.read_text().strip())
+
+    assert second_ts >= first_ts, "Second write must produce timestamp >= first"
+
+
+def test_write_wfm_active_signal_silent_on_permission_error(tmp_path, monkeypatch):
+    """_write_wfm_active_signal() swallows exceptions silently — never raises."""
+    wfm_file = tmp_path / "logs" / "dispatcher-wfm-active"
+    server = _load_inbox_server(wfm_file)
+
+    # Patch os.rename to raise — simulates a permission error mid-write.
+    monkeypatch.setattr(os, "rename", lambda src, dst: (_ for _ in ()).throw(PermissionError("no write")))
+
+    # Must not raise
+    server._write_wfm_active_signal()


### PR DESCRIPTION
## Problem

When the dispatcher is idle in `wait_for_messages`, PostToolUse hooks don't fire, so `dispatcher-heartbeat` goes stale after 20 minutes. The health check then declares RED and restarts the dispatcher — even though it was alive and healthy. This caused two confirmed false-positive restarts today (18:48Z and 19:20Z).

The root cause is a path mismatch introduced when the fix was designed but never properly applied:

- `inbox_server.py` was writing a JSON payload to `~/messages/config/wfm-active.json`
- `health-check-v3.sh` had no code at all to read a WFM-active file — the suppression logic was never present in either `origin/main` or `local-dev`

## What changed

**`inbox_server.py`:**
- Added `WAIT_HEARTBEAT_INTERVAL = 60` (was an inline literal)
- Added `WFM_ACTIVE_FILE` constant pointing to `~/lobster-workspace/logs/dispatcher-wfm-active`, overridable via `LOBSTER_WFM_ACTIVE_OVERRIDE` for test isolation
- Added `_write_wfm_active_signal()`: atomic tmp→rename, single Unix epoch integer (same format as `dispatcher-heartbeat`), silent failure
- Calls `_write_wfm_active_signal()` before entering the wait loop and refreshes on every 60s tick
- Deletes `WFM_ACTIVE_FILE` in the `finally` block so the signal clears when WFM returns
- Removed the dead legacy write to `~/messages/config/wfm-active.json` (JSON payload, wrong directory, never read by anything)

**`health-check-v3.sh`:**
- Added `DISPATCHER_WFM_ACTIVE_FILE` constant and `WFM_ACTIVE_STALE_SECONDS=180` (3× WAIT_HEARTBEAT_INTERVAL, absorbs one missed tick)
- In `check_dispatcher_heartbeat()`: when heartbeat is stale, reads `DISPATCHER_WFM_ACTIVE_FILE` before declaring RED — fresh file → GREEN (dispatcher alive in WFM), absent or stale file → RED (dispatcher frozen or dead)

**Tests:**
- `tests/test-health-check-wfm-active.sh`: 8 new shell tests covering all WFM-active signal states
- `tests/unit/test_wfm_active_signal.py`: 6 Python unit tests covering `_write_wfm_active_signal()` behavior and `WFM_ACTIVE_FILE` path resolution
- `tests/test-health-check-dispatcher-heartbeat.sh`: updated to declare `DISPATCHER_WFM_ACTIVE_FILE` (pointing to absent file) and `WFM_ACTIVE_STALE_SECONDS` for `set -u` compatibility; existing 8 tests still pass

## Flow before/after

**Before:**

```
WFM blocking 20+ minutes
    → dispatcher-heartbeat stale (no PostToolUse events)
    → check_dispatcher_heartbeat() → RED
    → false-positive restart
```

**After:**

```
WFM blocking 20+ minutes
    → dispatcher-heartbeat stale
    → check_dispatcher_heartbeat(): heartbeat stale, check WFM-active
        → WFM-active file fresh (≤180s old) → GREEN (dispatcher alive)
        → WFM-active file absent/stale         → RED (dispatcher frozen)
```

## Functional patterns

Pure function: `_write_wfm_active_signal()` has no return value side-effects — pure I/O boundary with silent failure. Immutability: each write atomically replaces the previous file via tmp→rename, never partial-reads.

## Out of scope

No changes to heartbeat thresholds, restart logic, or other health checks. The existing `dispatcher-heartbeat` check is unchanged; WFM-active is consulted only when heartbeat is already stale.

## Tests run

- [x] `bash tests/test-health-check-wfm-active.sh` — 8/8 passed
- [x] `bash tests/test-health-check-dispatcher-heartbeat.sh` — 8/8 passed
- [x] `uv run pytest tests/unit/test_wfm_active_signal.py -v` — 6 passed, 0 failed
- [x] `uv run pytest tests/unit/ --ignore=tests/unit/test_mcp_server/test_ghost_session_fixes.py --ignore=tests/unit/test_mcp_server/test_lobstertalk_telegram_routing.py -q` — 2792 passed, 9 failed (pre-existing failures unrelated to this change, confirmed by running same tests on `origin/main`)

## Manual test

N/A — this change affects MCP server file I/O and the health check script. The user-visible outcome is absence of false-positive restart alerts; verification requires observing the system run through a quiet period (>20 minutes) without an incorrect restart. The unit and shell tests cover the behavioral contract. The fix cannot be safely end-to-end tested without waiting for a real quiet period.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits)
- [x] Integration/manual test run — N/A (no external service calls, file I/O only)
- [x] User-visible outcome: false-positive Telegram restart alerts will stop during idle periods
- [x] Side-effect audit: no volume changes, no shared state issues, bounded writes (single small file)
- [x] External service calls: none

Closes #1713

🤖🦞 Lobster (engineer): fix(#1713) wfm-active path alignment
