### PR TITLE
docs: DOCKER-STAGING.md runbook

### DIFF
--- a/docs/DOCKER-STAGING.md
+++ b/docs/DOCKER-STAGING.md
@@ -1,0 +1,253 @@
+# Docker Staging Runbook
+
+The staging Docker environment spins up a full live Lobster instance connected to a real Telegram bot for manual end-to-end testing. Unlike the [Docker testing environment](DOCKER-TESTING.md) (which uses a mock Telegram server), staging talks to the real Telegram API via a dedicated test bot: **@Lobstertown_test_bot**.
+
+## When to use it
+
+Use staging when:
+- Manually testing a feature end-to-end before merging
+- Verifying Telegram bot behavior (formatting, button interactions, threading)
+- Checking dispatcher startup, MCP server launch, and routing in a realistic environment
+- Reproducing a bug that only appears under live conditions
+
+Do not use staging for:
+- Automated regression testing (use Docker Testing / `docker-compose.test.yml` instead)
+- Production deployment (staging uses a test bot token, not the production token)
+
+---
+
+## Architecture
+
+```
+Host machine
+  ~/.claude/              ← bind-mounted read-write into container
+  ~/.local/bin/claude     ← bind-mounted read-only (reuses host binary)
+  ~/lobster-config/config.staging.env  ← env vars injected at compose up
+
+Container: lobster-staging
+  /home/lobster/lobster/              ← repo (baked into image at build time)
+  /home/lobster/messages/             ← Docker volume (lobster-staging-messages)
+  /home/lobster/lobster-workspace/    ← Docker volume (lobster-staging-workspace)
+  /home/lobster/lobster-config/       ← written by entrypoint from env vars
+
+Inside container:
+  tmux session "lobster" (socket: /tmp/tmux-*/lobster)
+    └── dispatcher (Claude Code + MCP server)
+  lobster_bot.py            ← Telegram router process (background)
+```
+
+Credentials are **bind-mounted from the host** — they are never baked into the image. This is intentional; see [Credential pattern](#credential-pattern) below.
+
+---
+
+## Prerequisites
+
+1. **Docker and docker compose** installed on the host.
+
+2. **lobster-config checked out** with the staging env file present:
+
+   ```
+   ~/lobster-config/config.staging.env
+   ```
+
+   The file must contain at minimum:
+
+   ```env
+   TELEGRAM_BOT_TOKEN=<test bot token>
+   TELEGRAM_ALLOWED_USERS=<your Telegram user ID>
+   LOBSTER_ADMIN_CHAT_ID=<your Telegram user ID>
+   LOBSTER_ENV=production
+   LOBSTER_DEBUG=false
+   ```
+
+   > **Critical:** `LOBSTER_ENV` must be `production`. See [LOBSTER_ENV gotcha](#lobster_env-gotcha) below.
+
+3. **Host Claude credentials** must be present at `~/.claude/` — the container bind-mounts this directory and reads credentials from it.
+
+4. **Host claude binary** must be installed at `~/.local/bin/claude` — this binary is also bind-mounted into the container.
+
+---
+
+## Building and starting
+
+All commands run from the repo root (`~/lobster/`).
+
+### First run (or after Dockerfile changes)
+
+Build the image and start the container in the background:
+
+```bash
+cd ~/lobster
+sudo docker compose -f docker/staging/docker-compose.staging.yml up -d --build
+```
+
+### Subsequent runs (no Dockerfile changes)
+
+Skip the build step:
+
+```bash
+sudo docker compose -f docker/staging/docker-compose.staging.yml up -d
+```
+
+---
+
+## LOBSTER_ENV gotcha
+
+**`LOBSTER_ENV` must be set to `production`, not `staging`.**
+
+This is counter-intuitive. The env var does not mean "which environment am I running in" — it controls which dispatcher mode is active. Setting `LOBSTER_ENV=staging` causes the dispatcher to exit immediately without starting the message loop. The dispatcher only runs in `production` mode.
+
+The staging Docker container is a *staging instance of the production dispatcher* — it uses the test bot token but must run the production dispatcher loop.
+
+Symptom if misconfigured: the container starts, the router connects to Telegram, but no Claude session appears in tmux, and messages to the test bot go unanswered.
+
+Fix: ensure `config.staging.env` contains `LOBSTER_ENV=production`.
+
+---
+
+## Credential pattern
+
+Credentials are **never copied into the Docker image**. Instead, the host's `~/.claude/` directory is bind-mounted into the container at the same path:
+
+```yaml
+volumes:
+  - /home/lobster/.claude:/home/lobster/.claude
+```
+
+This means:
+- The container reads Claude auth tokens, `settings.json`, and MCP config from the host.
+- The entrypoint script updates `settings.json` inside the container to point MCP commands at the correct in-container paths — this is why `~/.claude/` cannot be read-only.
+- Rotating credentials on the host immediately affects the container on next restart.
+- Never add `COPY ~/.claude` or similar to `Dockerfile.staging`.
+
+---
+
+## Cold start time
+
+The first time the container starts (or after a workspace volume wipe), the dispatcher takes approximately **10 minutes** to become responsive. During this time it is:
+
+1. Reading bootup context files
+2. Initializing the MCP server
+3. Completing the dispatcher loop startup sequence
+
+The container and router are running during this window — you can tail logs immediately. Just wait before sending test messages.
+
+---
+
+## Verifying it is working
+
+### 1. Check the container is running
+
+```bash
+sudo docker ps
+```
+
+Look for `lobster-staging` with status `Up`.
+
+### 2. Attach to the dispatcher tmux session
+
+```bash
+sudo docker exec -it lobster-staging tmux -L lobster attach -t lobster
+```
+
+You should see the Claude Code dispatcher session. Press `Ctrl-b d` to detach without stopping it.
+
+### 3. Check MCP server startup in docker logs
+
+```bash
+sudo docker logs lobster-staging
+```
+
+Look for lines like `[staging] Router started` and `[staging] Claude session started in tmux`.
+
+### 4. Tail the MCP server log
+
+```bash
+sudo docker exec lobster-staging tail -f /home/lobster/lobster-workspace/logs/mcp-server.log
+```
+
+### 5. Capture the current tmux pane (non-interactive)
+
+```bash
+sudo docker exec lobster-staging tmux -L lobster capture-pane -pt lobster
+```
+
+---
+
+## Tailing logs
+
+| What | Command |
+|------|---------|
+| Router (Telegram bot) | `sudo docker exec lobster-staging tail -f /home/lobster/lobster-workspace/logs/router.log` |
+| Claude session | `sudo docker exec lobster-staging tail -f /home/lobster/lobster-workspace/logs/claude.log` |
+| MCP server | `sudo docker exec lobster-staging tail -f /home/lobster/lobster-workspace/logs/mcp-server.log` |
+| Both router + claude (compose) | `sudo docker compose -f docker/staging/docker-compose.staging.yml logs -f` |
+
+---
+
+## Stopping and cleanup
+
+### Stop the container (preserves volumes)
+
+```bash
+sudo docker compose -f docker/staging/docker-compose.staging.yml down
+```
+
+The `lobster-staging-messages` and `lobster-staging-workspace` volumes persist. This is intentional — it preserves dispatcher state across restarts.
+
+### Stop and wipe volumes (fresh start)
+
+```bash
+sudo docker compose -f docker/staging/docker-compose.staging.yml down -v
+```
+
+Use this when you want a completely clean slate (e.g., testing a fresh install flow or recovering from a corrupted workspace).
+
+### Remove the built image (forces full rebuild)
+
+```bash
+sudo docker compose -f docker/staging/docker-compose.staging.yml down --rmi local
+```
+
+---
+
+## Common issues
+
+### Dispatcher never starts / no tmux session
+
+**Symptom:** `sudo docker ps` shows the container running, but `tmux -L lobster ls` inside the container shows no sessions.
+
+**Most likely cause:** The `entrypoint-staging.sh` crashed early, or the router process failed health check and the entrypoint exited.
+
+**Check:** `sudo docker logs lobster-staging` — look for `ERROR` lines near the top.
+
+### Messages to the test bot go unanswered
+
+**Check 1 — LOBSTER_ENV:** Verify `config.staging.env` has `LOBSTER_ENV=production`. If it was set to `staging`, the dispatcher exited without starting the loop.
+
+**Check 2 — Cold start:** If the container just started, wait up to 10 minutes for the dispatcher to finish its bootup sequence.
+
+**Check 3 — Router log:** `sudo docker exec lobster-staging tail -30 /home/lobster/lobster-workspace/logs/router.log` — confirm the bot connected to Telegram without error.
+
+### Stale workspace volume causing startup errors
+
+The `lobster-staging-workspace` volume persists between container runs. Occasionally stale state (e.g., an in-progress message left in `messages/processing/`) can cause the dispatcher to behave unexpectedly on restart.
+
+**Fix:** Wipe and restart with fresh volumes:
+
+```bash
+sudo docker compose -f docker/staging/docker-compose.staging.yml down -v
+sudo docker compose -f docker/staging/docker-compose.staging.yml up -d --build
+```
+
+### `claude: not found` inside the container
+
+The host claude binary is bind-mounted at `/home/lobster/.local/bin/claude`. If the host binary is not present or the mount fails, the tmux session will fail immediately.
+
+**Fix:** Ensure `claude` is installed on the host at `~/.local/bin/claude` before starting the container.
+
+### settings.json permission error
+
+The entrypoint script updates `~/.claude/settings.json` to rewrite MCP server paths for the container environment. If the host's `~/.claude/` is owned by root or has restrictive permissions, this write will fail.
+
+**Fix:** Ensure `~/.claude/` and `~/.claude/settings.json` are owned by the `lobster` user (uid 1000) on the host.

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -100,6 +100,15 @@ HEARTBEAT_FILE="$WORKSPACE_DIR/logs/claude-heartbeat"   # legacy WFM-touch signa
 DISPATCHER_HEARTBEAT_FILE="${LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE:-$WORKSPACE_DIR/logs/dispatcher-heartbeat}"
 DISPATCHER_HEARTBEAT_STALE_SECONDS=1200   # 20 min — covers compaction (~5m) + catchup (~12m) + margin
 
+# WFM-active signal (issue #1713 / #949): inbox_server.py writes this file with
+# a Unix epoch timestamp when wait_for_messages begins blocking and refreshes it
+# every WAIT_HEARTBEAT_INTERVAL (60s). When this file is fresh, the dispatcher is
+# alive and waiting for messages — heartbeat staleness is expected, not a problem.
+# Threshold: 3x WAIT_HEARTBEAT_INTERVAL to absorb one missed refresh cycle.
+# File is deleted by the MCP server when WFM returns (message arrived or timeout).
+DISPATCHER_WFM_ACTIVE_FILE="${LOBSTER_WFM_ACTIVE_OVERRIDE:-$WORKSPACE_DIR/logs/dispatcher-wfm-active}"
+WFM_ACTIVE_STALE_SECONDS=180   # 3x WAIT_HEARTBEAT_INTERVAL (60s) — absorbs one missed tick
+
 OUTBOX_DIR="$MESSAGES_DIR/outbox"
 OUTBOX_STALE_THRESHOLD_SECONDS=900   # 15 min = RED
 OUTBOX_YELLOW_THRESHOLD_SECONDS=300  # 5 min = YELLOW
@@ -973,6 +982,26 @@ check_dispatcher_heartbeat() {
     age=$(( now - raw_ts ))
 
     if [[ $age -gt $DISPATCHER_HEARTBEAT_STALE_SECONDS ]]; then
+        # Heartbeat is stale — check the WFM-active signal before declaring RED.
+        # When the dispatcher is blocked in wait_for_messages, PostToolUse hooks
+        # do not fire so the heartbeat goes stale. inbox_server.py writes
+        # DISPATCHER_WFM_ACTIVE_FILE with a fresh epoch timestamp every 60s while
+        # WFM is blocking. A fresh WFM-active file means the dispatcher is alive
+        # and simply idle — not frozen or dead. (issue #1713 / #949)
+        local wfm_active_ts=""
+        if [[ -f "$DISPATCHER_WFM_ACTIVE_FILE" ]]; then
+            wfm_active_ts=$(cat "$DISPATCHER_WFM_ACTIVE_FILE" 2>/dev/null | tr -d '[:space:]')
+        fi
+        if [[ -n "$wfm_active_ts" ]] && [[ "$wfm_active_ts" =~ ^[0-9]+$ ]]; then
+            local wfm_age=$(( now - wfm_active_ts ))
+            if [[ $wfm_age -le $WFM_ACTIVE_STALE_SECONDS ]]; then
+                log_info "Dispatcher heartbeat stale (${age}s) but WFM-active is fresh (${wfm_age}s) — dispatcher alive in wait_for_messages, skipping RED"
+                return 0
+            else
+                log_error "RED: dispatcher heartbeat stale (${age}s) and WFM-active also stale (${wfm_age}s, threshold: ${WFM_ACTIVE_STALE_SECONDS}s) — dispatcher appears frozen"
+                return 2
+            fi
+        fi
         log_error "RED: dispatcher heartbeat stale — last tool use ${age}s ago (threshold: ${DISPATCHER_HEARTBEAT_STALE_SECONDS}s)"
         return 2
     fi

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -795,6 +795,30 @@ def normalize_message_type(msg: dict) -> dict:
 # Heartbeat file for health monitoring
 HEARTBEAT_FILE = _WORKSPACE / "logs" / "claude-heartbeat"
 
+# How often (in seconds) wait_for_messages touches heartbeats and refreshes
+# WFM-active during the blocking wait.  Exposed as a module-level constant so
+# tests can verify it matches the health-check's WFM_ACTIVE_STALE_SECONDS.
+WAIT_HEARTBEAT_INTERVAL = 60
+
+# WFM-active signal file (issue #1713 / #949): written with a Unix epoch
+# timestamp when wait_for_messages begins blocking, refreshed every
+# WAIT_HEARTBEAT_INTERVAL seconds, and deleted when WFM returns.
+#
+# The health check reads this file to distinguish "dispatcher alive, waiting
+# for messages" from "dispatcher frozen/dead" — suppressing the
+# heartbeat-stale RED that would otherwise fire after 20 minutes of quiet.
+#
+# Path: ~/lobster-workspace/logs/dispatcher-wfm-active
+# Content: single Unix epoch integer (e.g. "1713456789\n"), same format as
+#          dispatcher-heartbeat so health-check-v3.sh can parse it identically.
+# Override: LOBSTER_WFM_ACTIVE_OVERRIDE env var (used in tests).
+WFM_ACTIVE_FILE = Path(
+    os.environ.get(
+        "LOBSTER_WFM_ACTIVE_OVERRIDE",
+        str(_WORKSPACE / "logs" / "dispatcher-wfm-active"),
+    )
+)
+
 # Hibernation state file - tracks whether Lobster is active or hibernating
 LOBSTER_STATE_FILE = CONFIG_DIR / "lobster-state.json"
 
@@ -1434,6 +1458,28 @@ def touch_heartbeat():
         HEARTBEAT_FILE.touch()
     except Exception:
         pass  # Don't fail on heartbeat errors
+
+
+def _write_wfm_active_signal() -> None:
+    """Write the WFM-active heartbeat signal atomically (issue #1713 / #949).
+
+    Called at the start of the wait_for_messages blocking loop and refreshed
+    on every WAIT_HEARTBEAT_INTERVAL tick so the health check sees a fresh
+    signal throughout the entire WFM blocking period.
+
+    Content: single Unix epoch integer — same format as dispatcher-heartbeat —
+    so health-check-v3.sh can parse it with the same integer comparison logic.
+
+    Atomic write (tmp -> rename) prevents partial reads by the health check.
+    Silently swallowed on failure: health check degrades gracefully when absent.
+    """
+    try:
+        WFM_ACTIVE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = WFM_ACTIVE_FILE.with_name(f".wfm-active-{os.getpid()}.tmp")
+        tmp.write_text(str(int(time.time())) + "\n")
+        os.rename(str(tmp), str(WFM_ACTIVE_FILE))
+    except Exception:
+        pass  # Never block wait_for_messages on a heartbeat write failure
 
 
 # ---------------------------------------------------------------------------
@@ -4046,24 +4092,14 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
     # transient mode, calling wait_for_messages means Claude is up and running.
     _write_lobster_state(LOBSTER_STATE_FILE, "active")
 
-    # Write WFM active timestamp so the health check can distinguish a healthy
-    # idle-blocking dispatcher from a frozen one (PR #1646).
-    # The health check treats a fresh wfm-active signal as GREEN even when the
-    # heartbeat is stale, preventing false-positive kills during long idle periods.
+    # Write WFM-active signal so the health check can distinguish a healthy
+    # idle-blocking dispatcher from a frozen one (issue #1713 / #949).
+    # The health check treats a fresh WFM-active signal as GREEN even when
+    # dispatcher-heartbeat is stale — PostToolUse hooks don't fire during a
+    # blocking MCP call, so the heartbeat inevitably goes stale after 20 min.
     # We clear this file in the finally block so the signal only persists while
-    # WFM is actually running.
-    _wfm_active_file = CONFIG_DIR / "wfm-active.json"
-    try:
-        _wfm_start_ts = datetime.now(timezone.utc)
-        _wfm_active_payload = {
-            "started_at": _wfm_start_ts.isoformat(),
-            "pid": os.getpid(),
-        }
-        _wfm_tmp = _wfm_active_file.parent / f".wfm-active-{os.getpid()}.tmp"
-        _wfm_tmp.write_text(json.dumps(_wfm_active_payload))
-        _wfm_tmp.rename(_wfm_active_file)
-    except Exception as _wfm_exc:
-        log.warning(f"[wfm-active] Failed to write wfm-active.json: {_wfm_exc}")
+    # WFM is actually blocking.
+    _write_wfm_active_signal()
 
     # Recover stale processing and retryable failed messages
     _recover_stale_processing()
@@ -4117,8 +4153,10 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
             touch_heartbeat()
             inbox_results = await handle_check_inbox({"limit": 10})
             return _prepend_sessions_prefix(sessions_prefix, inbox_results)
-        # Wait with periodic heartbeats (every 60 seconds)
-        heartbeat_interval = 60
+        # Wait with periodic heartbeats (every WAIT_HEARTBEAT_INTERVAL seconds).
+        # Refresh WFM-active on every iteration so the health check sees a
+        # fresh signal even during long quiet periods (issue #1713 / #949).
+        heartbeat_interval = WAIT_HEARTBEAT_INTERVAL
         elapsed = 0
 
         while elapsed < timeout:
@@ -4132,8 +4170,9 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
             if arrived:
                 break
 
-            # Touch heartbeat to show we're still alive
+            # Touch heartbeat and refresh WFM-active to show we're still alive.
             touch_heartbeat()
+            _write_wfm_active_signal()
             elapsed += wait_time
 
         if message_arrived.is_set():
@@ -4178,13 +4217,13 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
     finally:
         observer.stop()
         observer.join(timeout=1)
-        # Clear WFM active file — health check reads this to detect healthy idle vs frozen.
+        # Clear WFM-active signal so the health check stops treating the
+        # dispatcher as "alive in WFM" once wait_for_messages returns.
         try:
-            _wfm_active_file = CONFIG_DIR / "wfm-active.json"
-            if _wfm_active_file.exists():
-                _wfm_active_file.unlink()
+            if WFM_ACTIVE_FILE.exists():
+                WFM_ACTIVE_FILE.unlink()
         except Exception as _wfm_clear_exc:
-            log.warning(f"[wfm-active] Failed to clear wfm-active.json: {_wfm_clear_exc}")
+            log.warning(f"[wfm-active] Failed to clear WFM-active signal: {_wfm_clear_exc}")
 
 
 def _is_report_command(text: str) -> bool:

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -2439,13 +2439,22 @@ async def list_tools() -> list[Tool]:
                     "text": {
                         "type": "string",
                         "description": (
-                            "The result text to deliver to the user. "
-                            "Keep this to a concise summary (ideally under ~4KB / ~500 words). "
+                            "Dispatcher-internal summary of this result. "
+                            "Kept short (ideally under ~500 words) so the dispatcher's context does not grow. "
+                            "Not shown to the user when reply_text is provided. "
                             "For large outputs — reports, diffs, full analysis — write the content "
                             "to ~/lobster-workspace/reports/<task_id>.md and pass the path in "
-                            "`artifacts` instead. The dispatcher reads artifact files and inlines "
-                            "their content in the reply. Never put raw file paths in text — they "
-                            "are server-side references that are useless to mobile users."
+                            "`artifacts` instead."
+                        ),
+                    },
+                    "reply_text": {
+                        "type": "string",
+                        "description": (
+                            "Optional user-facing reply text. When provided and "
+                            "sent_reply_to_user is False, the dispatcher sends this to the user "
+                            "instead of text. Use this to keep text as a terse internal summary "
+                            "while sending a richer or differently-phrased message to the user. "
+                            "Omit if text is already the right user-facing message."
                         ),
                     },
                     "source": {
@@ -7170,6 +7179,7 @@ async def handle_write_result(args: dict) -> list[TextContent]:
     task_id = args.get("task_id", "").strip()
     chat_id = args.get("chat_id")
     text = args.get("text", "").strip()
+    reply_text = (args.get("reply_text") or "").strip() or None
     source = args.get("source", "telegram").strip() or "telegram"
     status = args.get("status", "success")
     artifacts = args.get("artifacts") or []
@@ -7244,6 +7254,11 @@ async def handle_write_result(args: dict) -> list[TextContent]:
     }
     if msg_type == "subagent_notification":
         message["warning"] = "User already received the subagent's reply. Don't summarize it. If you respond, add new value only — a question, a correction, missing context."
+    # reply_text: user-facing reply separate from the internal dispatcher summary (text).
+    # Only stored when there is an active user relay path: sent_reply_to_user=False and
+    # chat_id != 0 (chat_id 0 is dispatcher-internal; no user reply is ever sent).
+    if reply_text and not sent_reply_to_user and chat_id != 0:
+        message["reply_text"] = reply_text
     if artifacts:
         message["artifacts"] = artifacts
     if thread_ts:

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -2454,7 +2454,8 @@ async def list_tools() -> list[Tool]:
                             "sent_reply_to_user is False, the dispatcher sends this to the user "
                             "instead of text. Use this to keep text as a terse internal summary "
                             "while sending a richer or differently-phrased message to the user. "
-                            "Omit if text is already the right user-facing message."
+                            "Omit if text is already the right user-facing message. "
+                            "Do not include raw file paths — use relative paths or descriptions instead."
                         ),
                     },
                     "source": {
@@ -7256,8 +7257,8 @@ async def handle_write_result(args: dict) -> list[TextContent]:
         message["warning"] = "User already received the subagent's reply. Don't summarize it. If you respond, add new value only — a question, a correction, missing context."
     # reply_text: user-facing reply separate from the internal dispatcher summary (text).
     # Only stored when there is an active user relay path: sent_reply_to_user=False and
-    # chat_id != 0 (chat_id 0 is dispatcher-internal; no user reply is ever sent).
-    if reply_text and not sent_reply_to_user and chat_id != 0:
+    # chat_id not in (0, "0") (chat_id 0 is dispatcher-internal; no user reply is ever sent).
+    if reply_text and not sent_reply_to_user and chat_id not in (0, "0"):
         message["reply_text"] = reply_text
     if artifacts:
         message["artifacts"] = artifacts

--- a/tests/test-health-check-dispatcher-heartbeat.sh
+++ b/tests/test-health-check-dispatcher-heartbeat.sh
@@ -14,9 +14,10 @@
 #   7. Stale by 1 second past threshold → RED (boundary condition)
 #   8. Fresh by 1 second before threshold → GREEN (boundary condition)
 #
-# Key behavioral assertion: the check uses a SINGLE file with a SINGLE epoch
-# timestamp. No lobster-state.json reads, no WFM heartbeat file, no multi-signal
-# aggregation.
+# Key behavioral assertion: the check uses a single dispatcher-heartbeat file with
+# a single epoch timestamp. No lobster-state.json reads. The WFM-active file is
+# also consulted by check_dispatcher_heartbeat() but is bypassed safely here via
+# DISPATCHER_WFM_ACTIVE_FILE pointing to an absent file (defaulting to GREEN).
 #
 # Usage: bash tests/test-health-check-dispatcher-heartbeat.sh
 #===============================================================================
@@ -55,6 +56,10 @@ assert_exit() {
 # Source check_dispatcher_heartbeat() from the health check script once.
 LOG_FILE="$TEST_LOG_DIR/health-check.log"
 DISPATCHER_HEARTBEAT_STALE_SECONDS=1200
+# WFM-active variables (issue #1713): must match the values in health-check-v3.sh.
+# Default to an absent file so existing heartbeat tests are unaffected.
+DISPATCHER_WFM_ACTIVE_FILE="$TEST_LOG_DIR/dispatcher-wfm-active-ABSENT"
+WFM_ACTIVE_STALE_SECONDS=180
 
 log()       { echo "[$1] $2" >> "$LOG_FILE" 2>/dev/null; }
 log_info()  { log INFO "$1"; }

--- a/tests/test-health-check-wfm-active.sh
+++ b/tests/test-health-check-wfm-active.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+#===============================================================================
+# Test Suite: Health Check v3 - WFM-Active Signal (issue #1713 / #949)
+#
+# Tests for the WFM-active bypass in check_dispatcher_heartbeat():
+# When the dispatcher is blocked inside wait_for_messages, PostToolUse hooks
+# do not fire and the dispatcher-heartbeat file goes stale. A separate
+# dispatcher-wfm-active file (written and periodically refreshed by
+# inbox_server.py during the wait loop) lets the health check distinguish
+# "dispatcher idle in WFM" from "dispatcher frozen/dead".
+#
+# Tests:
+#   1. Stale heartbeat + absent WFM-active → RED (original behavior preserved)
+#   2. Stale heartbeat + fresh WFM-active → GREEN (WFM suppression works)
+#   3. Stale heartbeat + stale WFM-active → RED (both stale = frozen)
+#   4. Stale heartbeat + WFM-active 1s past threshold → RED (boundary)
+#   5. Stale heartbeat + WFM-active 1s before threshold → GREEN (boundary)
+#   6. Fresh heartbeat ignores WFM-active (heartbeat alone = GREEN)
+#   7. LOBSTER_WFM_ACTIVE_OVERRIDE env var is respected
+#   8. WFM-active file with non-integer content → RED (treat as absent)
+#
+# Usage: bash tests/test-health-check-wfm-active.sh
+#===============================================================================
+
+set -u
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts"
+HEALTH_SCRIPT="$SCRIPT_DIR/health-check-v3.sh"
+
+TEST_TMPDIR=$(mktemp -d /tmp/lobster-wfm-active-test-XXXXXX)
+TEST_LOG_DIR="$TEST_TMPDIR/logs"
+DISPATCHER_HEARTBEAT_FILE="$TEST_LOG_DIR/dispatcher-heartbeat"
+DISPATCHER_WFM_ACTIVE_FILE="$TEST_LOG_DIR/dispatcher-wfm-active"
+
+cleanup() { rm -rf "$TEST_TMPDIR"; }
+trap cleanup EXIT
+
+mkdir -p "$TEST_LOG_DIR"
+
+begin_test() { TOTAL=$((TOTAL + 1)); test_name="$1"; }
+pass()  { PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC} $test_name"; }
+fail()  { FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC} $test_name: $1"; }
+
+assert_exit() {
+    local actual="$1" expected="$2"
+    if [[ "$actual" -eq "$expected" ]]; then pass; else fail "expected exit $expected, got $actual"; fi
+}
+
+# Source check_dispatcher_heartbeat() from the health check script.
+LOG_FILE="$TEST_LOG_DIR/health-check.log"
+DISPATCHER_HEARTBEAT_STALE_SECONDS=1200
+WFM_ACTIVE_STALE_SECONDS=180
+
+log()       { echo "[$1] $2" >> "$LOG_FILE" 2>/dev/null; }
+log_info()  { log INFO "$1"; }
+log_warn()  { log WARN "$1"; }
+log_error() { log ERROR "$1"; }
+
+eval "$(sed -n '/^check_dispatcher_heartbeat()/,/^}/p' "$HEALTH_SCRIPT")" 2>/dev/null
+
+# Helper: write a stale heartbeat (20 minutes ago).
+write_stale_heartbeat() {
+    echo "$(( $(date +%s) - 1500 ))" > "$DISPATCHER_HEARTBEAT_FILE"
+}
+
+# Helper: write a fresh heartbeat (5 seconds ago).
+write_fresh_heartbeat() {
+    echo "$(( $(date +%s) - 5 ))" > "$DISPATCHER_HEARTBEAT_FILE"
+}
+
+echo "=== WFM-Active Signal Health Check Tests ==="
+echo ""
+
+# -------------------------------------------------------------------
+# Test 1: Stale heartbeat + absent WFM-active → RED
+# -------------------------------------------------------------------
+begin_test "Stale heartbeat + absent WFM-active → RED"
+write_stale_heartbeat
+rm -f "$DISPATCHER_WFM_ACTIVE_FILE"
+check_dispatcher_heartbeat && rc=$? || rc=$?
+assert_exit "$rc" 2
+
+# -------------------------------------------------------------------
+# Test 2: Stale heartbeat + fresh WFM-active → GREEN (WFM suppression)
+# -------------------------------------------------------------------
+begin_test "Stale heartbeat + fresh WFM-active → GREEN"
+write_stale_heartbeat
+echo "$(( $(date +%s) - 30 ))" > "$DISPATCHER_WFM_ACTIVE_FILE"
+check_dispatcher_heartbeat && rc=$? || rc=$?
+assert_exit "$rc" 0
+
+# -------------------------------------------------------------------
+# Test 3: Stale heartbeat + stale WFM-active → RED (both stale = frozen)
+# -------------------------------------------------------------------
+begin_test "Stale heartbeat + stale WFM-active (600s old) → RED"
+write_stale_heartbeat
+echo "$(( $(date +%s) - 600 ))" > "$DISPATCHER_WFM_ACTIVE_FILE"
+check_dispatcher_heartbeat && rc=$? || rc=$?
+assert_exit "$rc" 2
+
+# -------------------------------------------------------------------
+# Test 4: Stale heartbeat + WFM-active 1s past threshold → RED (boundary)
+# -------------------------------------------------------------------
+begin_test "Stale heartbeat + WFM-active ${WFM_ACTIVE_STALE_SECONDS}+1s old → RED"
+write_stale_heartbeat
+echo "$(( $(date +%s) - (WFM_ACTIVE_STALE_SECONDS + 1) ))" > "$DISPATCHER_WFM_ACTIVE_FILE"
+check_dispatcher_heartbeat && rc=$? || rc=$?
+assert_exit "$rc" 2
+
+# -------------------------------------------------------------------
+# Test 5: Stale heartbeat + WFM-active 1s before threshold → GREEN (boundary)
+# -------------------------------------------------------------------
+begin_test "Stale heartbeat + WFM-active ${WFM_ACTIVE_STALE_SECONDS}-1s old → GREEN"
+write_stale_heartbeat
+echo "$(( $(date +%s) - (WFM_ACTIVE_STALE_SECONDS - 1) ))" > "$DISPATCHER_WFM_ACTIVE_FILE"
+check_dispatcher_heartbeat && rc=$? || rc=$?
+assert_exit "$rc" 0
+
+# -------------------------------------------------------------------
+# Test 6: Fresh heartbeat → GREEN (WFM-active is irrelevant)
+# -------------------------------------------------------------------
+begin_test "Fresh heartbeat → GREEN regardless of WFM-active"
+write_fresh_heartbeat
+echo "$(( $(date +%s) - 600 ))" > "$DISPATCHER_WFM_ACTIVE_FILE"  # stale WFM-active
+check_dispatcher_heartbeat && rc=$? || rc=$?
+assert_exit "$rc" 0
+
+# -------------------------------------------------------------------
+# Test 7: LOBSTER_WFM_ACTIVE_OVERRIDE env var is respected
+# -------------------------------------------------------------------
+begin_test "LOBSTER_WFM_ACTIVE_OVERRIDE env var is respected"
+write_stale_heartbeat
+rm -f "$DISPATCHER_WFM_ACTIVE_FILE"
+OVERRIDE_FILE="$TEST_LOG_DIR/custom-wfm-active"
+echo "$(( $(date +%s) - 30 ))" > "$OVERRIDE_FILE"
+DISPATCHER_WFM_ACTIVE_FILE="$OVERRIDE_FILE"
+check_dispatcher_heartbeat && rc=$? || rc=$?
+DISPATCHER_WFM_ACTIVE_FILE="$TEST_LOG_DIR/dispatcher-wfm-active"
+assert_exit "$rc" 0
+
+# -------------------------------------------------------------------
+# Test 8: WFM-active file with non-integer content → treated as absent → RED
+# -------------------------------------------------------------------
+begin_test "WFM-active file non-integer content → treated as absent → RED"
+write_stale_heartbeat
+echo "not-a-number" > "$DISPATCHER_WFM_ACTIVE_FILE"
+check_dispatcher_heartbeat && rc=$? || rc=$?
+assert_exit "$rc" 2
+
+# -------------------------------------------------------------------
+# Summary
+# -------------------------------------------------------------------
+echo ""
+echo "Results: $PASS/$TOTAL passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/tests/unit/test_mcp_server/test_write_result_reply_text.py
+++ b/tests/unit/test_mcp_server/test_write_result_reply_text.py
@@ -1,0 +1,229 @@
+"""
+Tests for write_result reply_text field (Closes #1621 clean rewrite).
+
+reply_text lets subagents decouple the dispatcher-internal summary from what
+the user actually sees. When reply_text is provided and the subagent has NOT
+already sent a reply (sent_reply_to_user=False) and chat_id != 0, the
+dispatcher receives reply_text in the inbox message so it can send that to the
+user instead of text.
+
+text always remains as the internal dispatcher summary.
+
+Behaviors tested:
+- reply_text is stored in the inbox message when provided and non-empty
+- reply_text is absent from the inbox message when not provided
+- empty / whitespace-only reply_text is treated as absent
+- text is always stored regardless of reply_text
+- reply_text is NOT stored when sent_reply_to_user=True (user already got a reply)
+- reply_text is NOT stored when chat_id == 0 (dispatcher-internal tasks)
+- backward compatibility: callers that omit reply_text see identical behavior
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup: ensure src/mcp and src/agents are importable
+# ---------------------------------------------------------------------------
+
+_ROOT = Path(__file__).parents[4]
+for _p in [str(_ROOT / "src" / "mcp"), str(_ROOT / "src" / "agents"),
+           str(_ROOT / "src"), str(_ROOT / "src" / "utils")]:
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import src.mcp.inbox_server  # noqa: F401 — pre-load so patch.multiple resolves it
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_dirs(tmp_path: Path):
+    """Return (inbox, outbox, sent, sent_replies, task_replied) under tmp_path."""
+    inbox = tmp_path / "inbox"
+    outbox = tmp_path / "outbox"
+    sent = tmp_path / "sent"
+    sent_replies = tmp_path / "sent-replies"
+    task_replied = tmp_path / "task-replied"
+    for d in (inbox, outbox, sent, sent_replies, task_replied):
+        d.mkdir(parents=True, exist_ok=True)
+    return inbox, outbox, sent, sent_replies, task_replied
+
+
+def _mock_session_store() -> MagicMock:
+    store = MagicMock()
+    store.session_end.return_value = None
+    store.set_notified.return_value = None
+    return store
+
+
+def _run_write_result(tmp_path: Path, args: dict) -> dict:
+    """Run handle_write_result and return the inbox message written."""
+    inbox, outbox, sent, sent_replies, task_replied = _make_dirs(tmp_path)
+    mock_store = _mock_session_store()
+
+    with patch.multiple(
+        "src.mcp.inbox_server",
+        INBOX_DIR=inbox,
+        OUTBOX_DIR=outbox,
+        SENT_DIR=sent,
+        SENT_REPLIES_DIR=sent_replies,
+        TASK_REPLIED_DIR=task_replied,
+        _session_store=mock_store,
+        _db_persist_agent_event=None,
+    ):
+        from src.mcp.inbox_server import handle_write_result
+        asyncio.run(handle_write_result(args))
+
+    inbox_files = list(inbox.glob("*.json"))
+    assert len(inbox_files) == 1, f"Expected 1 inbox file, got {len(inbox_files)}"
+    return json.loads(inbox_files[0].read_text())
+
+
+# ---------------------------------------------------------------------------
+# Tests: reply_text stored when provided
+# ---------------------------------------------------------------------------
+
+class TestReplyTextStoredInInboxMessage:
+    """reply_text is stored in the inbox message when provided and non-empty."""
+
+    def test_reply_text_stored_in_message(self, tmp_path):
+        """reply_text field appears in inbox message when provided."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "my-task",
+            "chat_id": 12345,
+            "text": "Terse dispatcher summary.",
+            "reply_text": "PR #42 is open and ready for review.",
+        })
+        assert msg.get("reply_text") == "PR #42 is open and ready for review."
+
+    def test_text_always_stored_when_reply_text_provided(self, tmp_path):
+        """text field is always present even when reply_text is also provided."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "my-task",
+            "chat_id": 12345,
+            "text": "Internal dispatcher summary.",
+            "reply_text": "Short user-facing reply.",
+        })
+        assert msg.get("text") == "Internal dispatcher summary."
+
+    def test_reply_text_preserved_verbatim(self, tmp_path):
+        """reply_text is stored exactly as provided — no normalization."""
+        user_reply = "Done! Here is the summary:\n- item one\n- item two"
+        msg = _run_write_result(tmp_path, {
+            "task_id": "task-abc",
+            "chat_id": 99,
+            "text": "Summary.",
+            "reply_text": user_reply,
+        })
+        assert msg["reply_text"] == user_reply
+
+
+# ---------------------------------------------------------------------------
+# Tests: reply_text absent when not provided or falsy
+# ---------------------------------------------------------------------------
+
+class TestReplyTextAbsentWhenNotProvided:
+    """reply_text must not appear in inbox message when absent or falsy."""
+
+    def test_reply_text_absent_when_not_provided(self, tmp_path):
+        """No reply_text key in inbox message when caller omits it."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "no-reply-text-task",
+            "chat_id": 12345,
+            "text": "Direct user-facing text.",
+        })
+        assert "reply_text" not in msg
+
+    def test_reply_text_absent_when_empty_string(self, tmp_path):
+        """Empty string reply_text is treated as absent — not stored in message."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "empty-reply-text-task",
+            "chat_id": 12345,
+            "text": "Summary.",
+            "reply_text": "",
+        })
+        assert "reply_text" not in msg
+
+    def test_reply_text_absent_when_whitespace_only(self, tmp_path):
+        """Whitespace-only reply_text is treated as absent — not stored."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "ws-reply-text-task",
+            "chat_id": 12345,
+            "text": "Summary.",
+            "reply_text": "   ",
+        })
+        assert "reply_text" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Tests: reply_text suppressed when irrelevant
+# ---------------------------------------------------------------------------
+
+class TestReplyTextSuppressedWhenIrrelevant:
+    """reply_text must not be stored when the user already has a reply or
+    when the message is dispatcher-internal (chat_id == 0)."""
+
+    def test_reply_text_not_stored_when_sent_reply_to_user_true(self, tmp_path):
+        """When sent_reply_to_user=True, user already got a reply.
+        reply_text in the inbox message would be confusing — omit it."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "already-replied-task",
+            "chat_id": 12345,
+            "text": "Dispatcher summary.",
+            "reply_text": "This was already sent directly.",
+            "sent_reply_to_user": True,
+        })
+        assert "reply_text" not in msg
+
+    def test_reply_text_not_stored_when_chat_id_is_zero(self, tmp_path):
+        """chat_id == 0 is a dispatcher-internal task.
+        No user relay happens, so reply_text is meaningless — omit it."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "dispatcher-internal-task",
+            "chat_id": 0,
+            "text": "Internal summary.",
+            "reply_text": "This would never be sent to anyone.",
+        })
+        assert "reply_text" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Tests: backward compatibility — existing callers unaffected
+# ---------------------------------------------------------------------------
+
+class TestBackwardCompatibility:
+    """Callers that do not pass reply_text see unchanged behavior."""
+
+    def test_existing_fields_unchanged_without_reply_text(self, tmp_path):
+        """Core fields (text, task_id, chat_id, status, source) are unchanged."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "compat-task",
+            "chat_id": 42,
+            "text": "My result.",
+            "source": "telegram",
+            "status": "success",
+        })
+        assert msg["task_id"] == "compat-task"
+        assert msg["chat_id"] == 42
+        assert msg["text"] == "My result."
+        assert msg["source"] == "telegram"
+        assert msg["status"] == "success"
+        assert "reply_text" not in msg
+
+    def test_sent_reply_to_user_false_by_default(self, tmp_path):
+        """sent_reply_to_user defaults to False when not provided."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "default-sent",
+            "chat_id": 1,
+            "text": "Text.",
+        })
+        assert msg["sent_reply_to_user"] is False

--- a/tests/unit/test_mcp_server/test_write_result_reply_text.py
+++ b/tests/unit/test_mcp_server/test_write_result_reply_text.py
@@ -195,6 +195,17 @@ class TestReplyTextSuppressedWhenIrrelevant:
         })
         assert "reply_text" not in msg
 
+    def test_reply_text_not_stored_when_chat_id_is_string_zero(self, tmp_path):
+        """chat_id == '0' (string sentinel) is also dispatcher-internal.
+        The guard must handle both int 0 and string '0' to prevent accidental relay."""
+        msg = _run_write_result(tmp_path, {
+            "task_id": "dispatcher-internal-string-task",
+            "chat_id": "0",
+            "text": "Internal summary.",
+            "reply_text": "This would never be sent to anyone.",
+        })
+        assert "reply_text" not in msg
+
 
 # ---------------------------------------------------------------------------
 # Tests: backward compatibility — existing callers unaffected

--- a/tests/unit/test_wfm_active_signal.py
+++ b/tests/unit/test_wfm_active_signal.py
@@ -1,0 +1,117 @@
+"""
+Tests for the WFM-active heartbeat signal (issue #1713 / #949).
+
+Verifies that:
+- _write_wfm_active_signal() writes a single Unix epoch integer
+- WFM_ACTIVE_FILE path is ~/lobster-workspace/logs/dispatcher-wfm-active
+- LOBSTER_WFM_ACTIVE_OVERRIDE env var overrides the path (test isolation)
+- WAIT_HEARTBEAT_INTERVAL is 60s (matches health-check's WFM_ACTIVE_STALE_SECONDS/3)
+- The written timestamp is within 2 seconds of now
+- Atomic write: a .tmp file is never left behind
+- The file is writable before the wait loop starts
+"""
+import importlib
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _load_inbox_server(tmp_wfm_file: Path):
+    """Import inbox_server with LOBSTER_WFM_ACTIVE_OVERRIDE set to a test path."""
+    env_patch = {
+        "LOBSTER_MESSAGES": str(tmp_wfm_file.parent.parent / "messages"),
+        "LOBSTER_WORKSPACE": str(tmp_wfm_file.parent.parent / "workspace"),
+        "LOBSTER_WFM_ACTIVE_OVERRIDE": str(tmp_wfm_file),
+    }
+    # Ensure messages dirs exist so module-level mkdir calls succeed
+    (tmp_wfm_file.parent.parent / "messages" / "inbox").mkdir(parents=True, exist_ok=True)
+    (tmp_wfm_file.parent.parent / "messages" / "config").mkdir(parents=True, exist_ok=True)
+    (tmp_wfm_file.parent.parent / "messages" / "processing").mkdir(parents=True, exist_ok=True)
+    (tmp_wfm_file.parent.parent / "workspace" / "logs").mkdir(parents=True, exist_ok=True)
+
+    with patch.dict(os.environ, env_patch):
+        # Force reimport with new env
+        if "inbox_server" in sys.modules:
+            del sys.modules["inbox_server"]
+        mcp_dir = str(Path(__file__).resolve().parent.parent.parent / "src" / "mcp")
+        if mcp_dir not in sys.path:
+            sys.path.insert(0, mcp_dir)
+        import inbox_server
+        importlib.reload(inbox_server)
+    return inbox_server
+
+
+def test_wfm_active_file_path_is_workspace_logs(tmp_path):
+    """WFM_ACTIVE_FILE default path is ~/lobster-workspace/logs/dispatcher-wfm-active."""
+    wfm_file = tmp_path / "logs" / "dispatcher-wfm-active"
+    server = _load_inbox_server(wfm_file)
+    # The override env var must point to the tmp path
+    assert str(server.WFM_ACTIVE_FILE) == str(wfm_file)
+
+
+def test_wait_heartbeat_interval_is_60():
+    """WAIT_HEARTBEAT_INTERVAL must be 60s to match health-check's 3x WFM_ACTIVE_STALE_SECONDS expectation."""
+    mcp_dir = str(Path(__file__).resolve().parent.parent.parent / "src" / "mcp")
+    if mcp_dir not in sys.path:
+        sys.path.insert(0, mcp_dir)
+    import inbox_server
+    assert inbox_server.WAIT_HEARTBEAT_INTERVAL == 60, (
+        "WAIT_HEARTBEAT_INTERVAL must be 60s — health-check WFM_ACTIVE_STALE_SECONDS=180 is 3x this value"
+    )
+
+
+def test_write_wfm_active_signal_creates_file(tmp_path):
+    """_write_wfm_active_signal() creates the WFM-active file with a Unix epoch integer."""
+    wfm_file = tmp_path / "logs" / "dispatcher-wfm-active"
+    server = _load_inbox_server(wfm_file)
+
+    assert not wfm_file.exists(), "File should not exist before signal is written"
+    before = int(time.time())
+    server._write_wfm_active_signal()
+    after = int(time.time())
+
+    assert wfm_file.exists(), "WFM-active file must exist after _write_wfm_active_signal()"
+    content = wfm_file.read_text().strip()
+    ts = int(content)
+    assert before <= ts <= after, (
+        f"Timestamp {ts} must be between {before} and {after}"
+    )
+
+
+def test_write_wfm_active_signal_no_tmp_leftover(tmp_path):
+    """_write_wfm_active_signal() must not leave a .tmp file behind (atomic write)."""
+    wfm_file = tmp_path / "logs" / "dispatcher-wfm-active"
+    server = _load_inbox_server(wfm_file)
+    server._write_wfm_active_signal()
+
+    tmp_files = list(tmp_path.glob("**/.wfm-active-*.tmp"))
+    assert tmp_files == [], f"Stale .tmp file(s) left behind: {tmp_files}"
+
+
+def test_write_wfm_active_signal_overwrites_on_refresh(tmp_path):
+    """Calling _write_wfm_active_signal() twice updates the timestamp."""
+    wfm_file = tmp_path / "logs" / "dispatcher-wfm-active"
+    server = _load_inbox_server(wfm_file)
+
+    server._write_wfm_active_signal()
+    first_ts = int(wfm_file.read_text().strip())
+
+    time.sleep(1.1)  # ensure clock advances
+    server._write_wfm_active_signal()
+    second_ts = int(wfm_file.read_text().strip())
+
+    assert second_ts >= first_ts, "Second write must produce timestamp >= first"
+
+
+def test_write_wfm_active_signal_silent_on_permission_error(tmp_path, monkeypatch):
+    """_write_wfm_active_signal() swallows exceptions silently — never raises."""
+    wfm_file = tmp_path / "logs" / "dispatcher-wfm-active"
+    server = _load_inbox_server(wfm_file)
+
+    # Patch os.rename to raise — simulates a permission error mid-write.
+    monkeypatch.setattr(os, "rename", lambda src, dst: (_ for _ in ()).throw(PermissionError("no write")))
+
+    # Must not raise
+    server._write_wfm_active_signal()


### PR DESCRIPTION
## Summary

- Add `docs/DOCKER-STAGING.md` runbook for spinning up the full staging Docker instance with @Lobstertown_test_bot
- Documents the `LOBSTER_ENV=production` gotcha (counter-intuitive: must be `production`, not `staging`, or the dispatcher exits immediately)
- Covers credential bind-mount pattern, cold-start timing (~10 min), verification steps, log tailing commands, cleanup, and common issues section

## Test plan

- [ ] Confirm `LOBSTER_ENV` gotcha section accurately describes the symptom and fix
- [ ] Verify all `docker exec` / `docker compose` commands match the actual compose file service/container names
- [ ] Check that the credential bind-mount description matches `docker-compose.staging.yml` volumes block

🤖 Generated with [Claude Code](https://claude.com/claude-code)