### PR TITLE
fix: add cron to staging Docker for health check and scheduled job testing

### DIFF
--- a/docker/staging/Dockerfile.staging
+++ b/docker/staging/Dockerfile.staging
@@ -15,10 +15,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     procps \
     python3 \
     iproute2 \
+    cron \
+    sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # Create the lobster user (uid 1000 matches host)
 RUN useradd -u 1000 -m -s /bin/bash lobster
+
+# Allow lobster to start/stop cron without a password (staging only)
+RUN echo "lobster ALL=(ALL) NOPASSWD: /usr/sbin/service cron start, /usr/sbin/service cron stop, /usr/sbin/service cron status, /usr/sbin/cron" \
+    > /etc/sudoers.d/lobster-cron && chmod 0440 /etc/sudoers.d/lobster-cron
 
 USER lobster
 WORKDIR /home/lobster

--- a/docker/staging/entrypoint-staging.sh
+++ b/docker/staging/entrypoint-staging.sh
@@ -105,6 +105,55 @@ PYEOF
 fi
 
 #-------------------------------------------------------------------------------
+# Start cron daemon and install system crontab entries
+#
+# Cron is required for health checks, nightly consolidation, log exports,
+# ghost detector, OOM monitor, and cleanup jobs — the same jobs that run
+# in production via install.sh. Without cron these jobs are silently skipped,
+# making staging an incomplete test environment.
+#
+# Entries mirror install.sh exactly (schedule and script paths are identical).
+# cron-manage.sh is used for idempotent, marker-based installation.
+#-------------------------------------------------------------------------------
+echo "[staging] Starting cron daemon..."
+sudo service cron start || true
+echo "[staging] Cron daemon started."
+
+echo "[staging] Installing crontab entries..."
+CRON_MANAGE="$LOBSTER_DIR/scripts/cron-manage.sh"
+
+# Health check (every 4 minutes)
+"$CRON_MANAGE" add "# LOBSTER-HEALTH" \
+    "*/4 * * * * $LOBSTER_DIR/scripts/health-check-v3.sh # LOBSTER-HEALTH"
+
+# Daily dependency health check (06:00 daily)
+"$CRON_MANAGE" add "# LOBSTER-DAILY-HEALTH" \
+    "0 6 * * * $LOBSTER_DIR/scripts/daily-health-check.sh # LOBSTER-DAILY-HEALTH"
+
+# Nightly consolidation (03:00 daily)
+"$CRON_MANAGE" add "# LOBSTER-NIGHTLY-CONSOLIDATION" \
+    "0 3 * * * $LOBSTER_DIR/scripts/nightly-consolidation.sh # LOBSTER-NIGHTLY-CONSOLIDATION"
+
+# Daily log export (03:00 UTC)
+"$CRON_MANAGE" add "# LOBSTER-LOG-EXPORT" \
+    "0 3 * * * cd $LOBSTER_DIR && uv run scheduled-tasks/export-logs.py # LOBSTER-LOG-EXPORT"
+
+# Ghost detector (every 5 minutes)
+"$CRON_MANAGE" add "# LOBSTER-GHOST-DETECTOR" \
+    "*/5 * * * * cd $HOME && uv run $LOBSTER_DIR/scripts/agent-monitor.py --alert --mark-failed >> $LOG_DIR/agent-monitor.log 2>&1 # LOBSTER-GHOST-DETECTOR"
+
+# OOM monitor (every 10 minutes)
+"$CRON_MANAGE" add "# LOBSTER-OOM-CHECK" \
+    "*/10 * * * * cd $HOME && uv run $LOBSTER_DIR/scripts/oom-monitor.py --since-minutes 10 >> $LOG_DIR/oom-monitor.log 2>&1 # LOBSTER-OOM-CHECK"
+
+# Worktree + audio cleanup (04:00 daily)
+"$CRON_MANAGE" add "# LOBSTER-CLEANUP" \
+    "0 4 * * * $LOBSTER_DIR/scripts/cleanup-worktrees-audio.sh >> $LOG_DIR/cleanup.log 2>&1 # LOBSTER-CLEANUP"
+
+echo "[staging] Crontab entries installed:"
+crontab -l 2>/dev/null | grep "LOBSTER" || true
+
+#-------------------------------------------------------------------------------
 # Start the lobster-router (Telegram bot)
 #-------------------------------------------------------------------------------
 echo "[staging] Starting lobster-router..."

--- a/docs/DOCKER-STAGING.md
+++ b/docs/DOCKER-STAGING.md
@@ -1,0 +1,246 @@
+# Docker Staging Runbook
+
+The staging Docker environment spins up a full live Lobster instance connected to a real Telegram bot for manual end-to-end testing. Unlike the [Docker testing environment](DOCKER-TESTING.md) (which uses a mock Telegram server), staging talks to the real Telegram API via a dedicated test bot: **@Lobstertown_test_bot**.
+
+## When to use it
+
+Use staging when:
+- Manually testing a feature end-to-end before merging
+- Verifying Telegram bot behavior (formatting, button interactions, threading)
+- Checking dispatcher startup, MCP server launch, and routing in a realistic environment
+- Reproducing a bug that only appears under live conditions
+- Testing cron-dependent behavior (health checks, nightly consolidation, scheduled jobs)
+
+Do not use staging for:
+- Automated regression testing (use Docker Testing / `docker-compose.test.yml` instead)
+- Production deployment (staging uses a test bot token, not the production token)
+
+---
+
+## Architecture
+
+```
+Host machine
+  ~/.claude/              <- bind-mounted read-write into container
+  ~/.local/bin/claude     <- bind-mounted read-only (reuses host binary)
+  ~/lobster-config/config.staging.env  <- env vars injected at compose up
+
+Container: lobster-staging
+  /home/lobster/lobster/              <- repo (baked into image at build time)
+  /home/lobster/messages/             <- Docker volume (lobster-staging-messages)
+  /home/lobster/lobster-workspace/    <- Docker volume (lobster-staging-workspace)
+  /home/lobster/lobster-config/       <- written by entrypoint from env vars
+
+Inside container:
+  crond                               <- cron daemon (started by entrypoint)
+  tmux session "lobster" (socket: /tmp/tmux-*/lobster)
+    +-- dispatcher (Claude Code + MCP server)
+  lobster_bot.py            <- Telegram router process (background)
+```
+
+Credentials are **bind-mounted from the host** — they are never baked into the image.
+
+---
+
+## Cron in the staging container
+
+The staging container runs a full cron daemon, mirroring production behavior. The entrypoint installs the same crontab entries that `install.sh` sets up on a production host:
+
+| Job | Schedule | Marker |
+|-----|----------|--------|
+| Health check (v3) | every 4 minutes | `LOBSTER-HEALTH` |
+| Daily dependency health check | 06:00 daily | `LOBSTER-DAILY-HEALTH` |
+| Nightly consolidation | 03:00 daily | `LOBSTER-NIGHTLY-CONSOLIDATION` |
+| Log export | 03:00 daily | `LOBSTER-LOG-EXPORT` |
+| Ghost detector | every 5 minutes | `LOBSTER-GHOST-DETECTOR` |
+| OOM monitor | every 10 minutes | `LOBSTER-OOM-CHECK` |
+| Worktree + audio cleanup | 04:00 daily | `LOBSTER-CLEANUP` |
+
+**Verifying cron is running inside the container:**
+
+```bash
+sudo docker exec lobster-staging service cron status
+sudo docker exec lobster-staging crontab -l
+```
+
+**Tailing cron-driven log output:**
+
+```bash
+# Health check log (written by health-check-v3.sh)
+sudo docker exec lobster-staging tail -f /home/lobster/lobster-workspace/logs/health-check.log
+
+# Ghost detector log
+sudo docker exec lobster-staging tail -f /home/lobster/lobster-workspace/logs/agent-monitor.log
+```
+
+---
+
+## Prerequisites
+
+1. **Docker and docker compose** installed on the host.
+
+2. **lobster-config checked out** with the staging env file present:
+
+   ```
+   ~/lobster-config/config.staging.env
+   ```
+
+   The file must contain at minimum:
+
+   ```env
+   TELEGRAM_BOT_TOKEN=<test bot token>
+   TELEGRAM_ALLOWED_USERS=<your Telegram user ID>
+   LOBSTER_ADMIN_CHAT_ID=<your Telegram user ID>
+   LOBSTER_ENV=production
+   LOBSTER_DEBUG=false
+   ```
+
+   > **Critical:** `LOBSTER_ENV` must be `production`. See [LOBSTER_ENV gotcha](#lobster_env-gotcha) below.
+
+3. **Host Claude credentials** must be present at `~/.claude/` — the container bind-mounts this directory and reads credentials from it.
+
+4. **Host claude binary** must be installed at `~/.local/bin/claude` — this binary is also bind-mounted into the container.
+
+---
+
+## Building and starting
+
+All commands run from the repo root (`~/lobster/`).
+
+### First run (or after Dockerfile changes)
+
+```bash
+cd ~/lobster
+sudo docker compose -f docker/staging/docker-compose.staging.yml up -d --build
+```
+
+### Subsequent runs (no Dockerfile changes)
+
+```bash
+sudo docker compose -f docker/staging/docker-compose.staging.yml up -d
+```
+
+---
+
+## LOBSTER_ENV gotcha
+
+**`LOBSTER_ENV` must be set to `production`, not `staging`.**
+
+This is counter-intuitive. The env var does not mean "which environment am I running in" — it controls which dispatcher mode is active. Setting `LOBSTER_ENV=staging` causes the dispatcher to exit immediately without starting the message loop.
+
+---
+
+## Credential pattern
+
+Credentials are **never copied into the Docker image**. The host's `~/.claude/` directory is bind-mounted into the container at the same path:
+
+```yaml
+volumes:
+  - /home/lobster/.claude:/home/lobster/.claude
+```
+
+---
+
+## Cold start time
+
+The first time the container starts (or after a workspace volume wipe), the dispatcher takes approximately **10 minutes** to become responsive. During this time it is reading bootup context files, initializing the MCP server, and completing the dispatcher loop startup sequence.
+
+---
+
+## Verifying it is working
+
+### 1. Check the container is running
+
+```bash
+sudo docker ps
+```
+
+Look for `lobster-staging` with status `Up`.
+
+### 2. Attach to the dispatcher tmux session
+
+```bash
+sudo docker exec -it lobster-staging tmux -L lobster attach -t lobster
+```
+
+### 3. Check cron is running
+
+```bash
+sudo docker exec lobster-staging service cron status
+sudo docker exec lobster-staging crontab -l
+```
+
+### 4. Tail the MCP server log
+
+```bash
+sudo docker exec lobster-staging tail -f /home/lobster/lobster-workspace/logs/mcp-server.log
+```
+
+---
+
+## Tailing logs
+
+| What | Command |
+|------|---------|
+| Router (Telegram bot) | `sudo docker exec lobster-staging tail -f /home/lobster/lobster-workspace/logs/router.log` |
+| Claude session | `sudo docker exec lobster-staging tail -f /home/lobster/lobster-workspace/logs/claude.log` |
+| MCP server | `sudo docker exec lobster-staging tail -f /home/lobster/lobster-workspace/logs/mcp-server.log` |
+| Health check | `sudo docker exec lobster-staging tail -f /home/lobster/lobster-workspace/logs/health-check.log` |
+| Ghost detector | `sudo docker exec lobster-staging tail -f /home/lobster/lobster-workspace/logs/agent-monitor.log` |
+
+---
+
+## Stopping and cleanup
+
+### Stop the container (preserves volumes)
+
+```bash
+sudo docker compose -f docker/staging/docker-compose.staging.yml down
+```
+
+### Stop and wipe volumes (fresh start)
+
+```bash
+sudo docker compose -f docker/staging/docker-compose.staging.yml down -v
+```
+
+### Remove the built image (forces full rebuild)
+
+```bash
+sudo docker compose -f docker/staging/docker-compose.staging.yml down --rmi local
+```
+
+---
+
+## Common issues
+
+### Dispatcher never starts / no tmux session
+
+**Symptom:** Container is running but `tmux -L lobster ls` inside shows no sessions.
+
+**Check:** `sudo docker logs lobster-staging` — look for `ERROR` lines.
+
+### Messages to the test bot go unanswered
+
+**Check 1 — LOBSTER_ENV:** Verify `config.staging.env` has `LOBSTER_ENV=production`.
+
+**Check 2 — Cold start:** Wait up to 10 minutes for the dispatcher to finish its bootup sequence.
+
+**Check 3 — Router log:** `sudo docker exec lobster-staging tail -30 /home/lobster/lobster-workspace/logs/router.log`
+
+### Cron jobs not running
+
+**Check 1 — Daemon:** `sudo docker exec lobster-staging service cron status`
+
+**Check 2 — Crontab:** `sudo docker exec lobster-staging crontab -l` — verify LOBSTER entries are present.
+
+**Note:** If the container was built before this fix was added, rebuild the image:
+
+```bash
+sudo docker compose -f docker/staging/docker-compose.staging.yml down --rmi local
+sudo docker compose -f docker/staging/docker-compose.staging.yml up -d --build
+```
+
+### `claude: not found` inside the container
+
+The host claude binary is bind-mounted at `/home/lobster/.local/bin/claude`. Ensure `claude` is installed on the host at `~/.local/bin/claude`.


### PR DESCRIPTION
## Problem

The staging container lacked a cron daemon, so health checks, nightly consolidation, log exports, ghost detector, OOM monitor, and cleanup jobs never ran during staging soaks. This was discovered in session 20260421-003: the WFM health check fix in #1714 could not be verified in staging because `crond` was never started — the health check never fired during a 1-hour soak.

Staging was structurally unable to test any cron-dependent behavior, which is the entire class of scheduled infrastructure that runs in production.

Closes #1719.

## What changed

**`Dockerfile.staging`**: adds `cron` and `sudo` to the apt package list, and adds a scoped sudoers rule (`/etc/sudoers.d/lobster-cron`) that allows the `lobster` user to run `service cron start/stop/status` without a password. This is a staging-only container with a test bot token; the scope is intentionally narrow.

**`entrypoint-staging.sh`**: before starting the router, the entrypoint now:
1. Starts the cron daemon via `sudo service cron start`
2. Installs all seven crontab entries that `install.sh` registers in production, using `cron-manage.sh` for idempotent, marker-based installation

The entries installed are identical in schedule and path to what `install.sh` sets up:

| Job | Schedule | Marker |
|-----|----------|--------|
| Health check (v3) | every 4 min | `LOBSTER-HEALTH` |
| Daily dependency health | 06:00 | `LOBSTER-DAILY-HEALTH` |
| Nightly consolidation | 03:00 | `LOBSTER-NIGHTLY-CONSOLIDATION` |
| Log export | 03:00 | `LOBSTER-LOG-EXPORT` |
| Ghost detector | every 5 min | `LOBSTER-GHOST-DETECTOR` |
| OOM monitor | every 10 min | `LOBSTER-OOM-CHECK` |
| Worktree + audio cleanup | 04:00 | `LOBSTER-CLEANUP` |

**`docs/DOCKER-STAGING.md`**: new file. Runbook for the staging environment, including cron architecture, job schedule table, and verification commands (`service cron status`, `crontab -l`).

## Flow (before / after)

```
Before:
  entrypoint-staging.sh
    -> install.sh --container-setup
    -> [no cron daemon started]
    -> [no crontab entries installed]
    -> start lobster_bot.py
    -> start claude in tmux
  Result: health-check-v3.sh never fires

After:
  entrypoint-staging.sh
    -> install.sh --container-setup
    -> sudo service cron start          [NEW]
    -> cron-manage.sh add x7 entries    [NEW]
    -> start lobster_bot.py
    -> start claude in tmux
  Result: crond running, health check fires every 4 min
```

## What is not changed

- Production install path (`install.sh`) is unchanged
- The `--container-setup` mode in `install.sh` is unchanged — cron setup is not added there because `--container-setup` runs as the `lobster` user without sudo, and cron startup requires root
- The compose file is unchanged
- No behavior changes to any other container

## Tests run

- [x] `git diff origin/main` reviewed — changes are self-contained to staging docker files and the new doc
- [ ] Docker build + container smoke test — not run: Docker daemon is not available in this subagent environment. Needs manual verification before merge: `sudo docker compose -f docker/staging/docker-compose.staging.yml up -d --build`, then `sudo docker exec lobster-staging service cron status` and `sudo docker exec lobster-staging crontab -l`

**Blocked items needing attention before merge:** Docker build + smoke test must be run manually on a host with Docker.

## Manual test

N/A for automated runs (Docker not available in this environment).

For the reviewer: before merging, please run:
```bash
cd ~/lobster
sudo docker compose -f docker/staging/docker-compose.staging.yml up -d --build
sudo docker exec lobster-staging service cron status
sudo docker exec lobster-staging crontab -l
```

Expected: `cron is running`, and `crontab -l` shows 7 `# LOBSTER-*` entries.

## Definition of Done

- [x] Changes are scoped to staging Docker only — no production path affected
- [x] Crontab entries mirror install.sh exactly (same schedules, same script paths)
- [x] `cron-manage.sh` used for idempotent installation (safe to call multiple times)
- [ ] Docker build + smoke test — blocked pending manual run (see above)
- [ ] User-visible outcome (health check fires in staging) — blocked pending Docker test