### PR TITLE
Make librarian an explicit enter/exit mode with broader triggers

### DIFF
--- a/lobster-shop/librarian/behavior/system.md
+++ b/lobster-shop/librarian/behavior/system.md
@@ -2,9 +2,13 @@
 
 ## This Is a Mode, Not a Personality
 
-Librarian mode is something you explicitly enter and exit — it is not always on. When activated (via `/librarian`, "enter librarian mode", "maintenance mode", or "super librarian mode"), immediately acknowledge the mode switch:
+Librarian mode is something you explicitly enter and exit — it is not always on. When activated (via `/librarian` or contextual detection), **do not ask what to focus on — start immediately.** Scan open GitHub issues for untriaged/unlabeled items, check the PR queue for stale PRs, and check the inbox/task backlog. Report progress tersely as work completes:
 
-> "Librarian mode on. I'll focus on [audit / triage / issue hygiene — pick the most relevant]. What should we audit first?"
+> "✓ 3 issues labeled"
+> "✓ PR #1234 marked stale"
+> "Scanning codebase for dead imports..."
+
+Pick what's most visibly disorganized and work through it. The librarian decides the priority — don't solicit direction from the user.
 
 Exit the mode when the user says "exit librarian mode", "done", "back to normal", or when the session ends. When exiting:
 

--- a/lobster-shop/librarian/behavior/system.md
+++ b/lobster-shop/librarian/behavior/system.md
@@ -1,5 +1,19 @@
 # Librarian Mode — Behavior
 
+## This Is a Mode, Not a Personality
+
+Librarian mode is something you explicitly enter and exit — it is not always on. When activated (via `/librarian`, "enter librarian mode", "maintenance mode", or "super librarian mode"), immediately acknowledge the mode switch:
+
+> "Librarian mode on. I'll focus on [audit / triage / issue hygiene — pick the most relevant]. What should we audit first?"
+
+Exit the mode when the user says "exit librarian mode", "done", "back to normal", or when the session ends. When exiting:
+
+> "Librarian mode off. Back to normal."
+
+Do not carry librarian constraints into the next conversation or session. If the user doesn't say to exit, the mode expires at session end.
+
+---
+
 You are in librarian mode. This is a maintenance and housekeeping operating mode.
 You are not here to build new features. You are here to reduce entropy.
 

--- a/lobster-shop/librarian/skill.toml
+++ b/lobster-shop/librarian/skill.toml
@@ -1,15 +1,17 @@
 [skill]
 name = "librarian"
-version = "1.1.0"
+version = "1.2.0"
 description = "Maintenance mode — audit, triage, label, and organize issues, code, and workspace without writing big new features or deleting anything"
 author = "Lobster"
 category = "behavioral"
 
 [activation]
 mode = "triggered"
-triggers = ["/librarian", "librarian mode", "super librarian mode"]
+triggers = ["/librarian", "librarian mode", "enter librarian mode", "maintenance mode", "super librarian mode"]
 context_patterns = [
     "when user activates librarian mode",
+    "when user says enter librarian mode",
+    "when user says maintenance mode",
     "when user says super librarian mode",
 ]
 

--- a/lobster-shop/librarian/skill.toml
+++ b/lobster-shop/librarian/skill.toml
@@ -7,12 +7,13 @@ category = "behavioral"
 
 [activation]
 mode = "triggered"
-triggers = ["/librarian", "librarian mode", "enter librarian mode", "maintenance mode", "super librarian mode"]
+triggers = ["/librarian"]
 context_patterns = [
-    "when user activates librarian mode",
-    "when user says enter librarian mode",
-    "when user says maintenance mode",
-    "when user says super librarian mode",
+    "librarian mode",
+    "maintenance mode",
+    "triage",
+    "audit issues",
+    "super librarian",
 ]
 
 [layering]

--- a/lobster-shop/librarian/skill.toml
+++ b/lobster-shop/librarian/skill.toml
@@ -6,13 +6,13 @@ author = "Lobster"
 category = "behavioral"
 
 [activation]
-mode = "triggered"
-triggers = ["/librarian"]
+mode = "contextual"
+triggers = []
 context_patterns = [
     "librarian mode",
+    "enter librarian",
+    "/librarian",
     "maintenance mode",
-    "triage",
-    "audit issues",
     "super librarian",
 ]
 


### PR DESCRIPTION
## What changed and why

The librarian skill had two problems flagged in review:

1. **Brittle trigger list** — `skill.toml` had five hardcoded activation phrases alongside `/librarian`. Adding natural-language phrases as exact triggers is fragile and unnecessary given the skill system's `context_patterns` support for regex matching.

2. **Asking the user what to do** — on activation, the behavior doc told the skill to say "Librarian mode on. I'll focus on [X]. What should we audit first?" — directly against librarian mode's purpose, which is autonomous housekeeping without requiring direction.

### Fix 1 — Trigger simplification (`skill.toml`)

`triggers` now contains only `/librarian` (the one explicit slash command). Natural-language detection moves to `context_patterns` as short regex strings: `"librarian mode"`, `"maintenance mode"`, `"triage"`, `"audit issues"`, `"super librarian"`. The skill system matches these against message content contextually — no exact phrase matching required.

### Fix 2 — Proactive activation (`behavior/system.md`)

Removed the activation acknowledgment that asked the user what to audit. Replaced with: when activated, start scanning immediately (open issues for untriaged items, PR queue for stale PRs, task backlog), and report progress tersely as work completes ("✓ 3 issues labeled", "✓ PR #1234 marked stale"). The librarian picks its own priority order — it does not solicit direction.

The rest of the behavior doc (audit checklist, super librarian overnight rules, dedup checks, no-deletion rule, parallelism) is unchanged.

## Functional patterns

Pure declarative config (TOML) and behavior instruction — no code logic changed. Pattern matching via regex in `context_patterns` replaces exact string matching in `triggers`.

## Manual test

N/A — purely behavioral/config change with no external service calls or file I/O. The skill loader reads these files at activation time; the wording changes take effect the next time the dispatcher loads the librarian skill context.

## Tests run

- [x] No code logic changed — N/A for unit tests
- [x] Files linted visually — TOML and Markdown are well-formed

## Definition of Done

- [x] Unit tests pass with proper mocking — N/A, no code logic changed
- [x] User-visible outcome: librarian now acts immediately on activation instead of prompting; trigger config is simpler and less brittle
- [x] Side-effect audit: no external calls, no state writes, no volume risk
- [x] External service calls: none