### PR TITLE
Encode issue→scope→TDD→review as default dev workflow

### DIFF
--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -27,10 +27,10 @@ Match the process overhead to the complexity of the change:
 | Size | When | What to do |
 |------|------|------------|
 | **Tiny** | 1-line fix, obvious cause, no decision needed | PR directly. Issue optional. |
-| **Medium** | Non-trivial but reasonably well-understood | Issue with: problem + lightweight approach exploration inline (list options considered, pick one with brief rationale). No scoping sub-issue needed. |
-| **Large** | Multiple viable approaches, non-obvious tradeoffs | Issue (problem only) + scoping sub-issue. Scoping captures: candidate approaches with suspected pros/cons, open design questions, captured intuitions ("we suspect X might work because..."). Don't wait for certainty — capture the thinking. |
+| **Medium** | Non-trivial but reasonably well-understood | Scoping required. Inline in the issue body is sufficient — list options considered, pick one with brief rationale. A dedicated sub-issue is also fine if the problem warrants it. Can go as deep as Large. Use judgment. |
+| **Large** | Complex enough that deeper scoping is the expected norm | Issue (problem only) + dedicated scoping sub-issue. Scoping captures: candidate approaches with suspected pros/cons, open design questions, captured intuitions ("we suspect X might work because..."). Don't wait for certainty — capture the thinking. |
 
-The difference between Medium and Large is the **depth and formality of scoping**, not whether scoping happens. Medium does it inline in the issue body; Large gets its own sub-issue. Scoping is not optional for Medium — it's just less formal.
+**Tiers set the floor, not a ceiling.** Medium requires scoping — inline is sufficient, but a sub-issue is also fine. Medium can be as thorough as Large; it just doesn't have to be. Large makes a dedicated sub-issue the expected default because the problem is complex enough to warrant it.
 
 After scoping (for Large): pick one approach, confirm with the user if the choice is non-obvious, then write tests first and implement.
 

--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -20,6 +20,19 @@ You strongly prefer functional style in your implementations:
 - Isolate side effects at the boundaries of your system
 - Use pattern matching and algebraic data types where the language supports them
 
+## Development Workflow: Issue → Scope → TDD → Review
+
+Before writing any code, follow this sequence:
+
+1. **Issue describes the problem only.** Never propose a solution in the issue body. State what is broken or missing, not how to fix it.
+2. **File a scoping sub-issue.** Explore candidate approaches, ask design questions (who owns state? how does expiry work? what does a test look like?), surface trade-offs.
+3. **Pick an approach.** After scoping, choose one. Confirm with the user if the choice is non-obvious.
+4. **Write tests first (TDD).** Tests must be derived from the spec/issue, not from the code you are about to write.
+5. **Implement.** Write code to pass the tests.
+6. **Code review.** Use a reviewer subagent before presenting to the user. Engineers must not review their own work.
+
+The anti-pattern to avoid: jumping from "problem observed" directly to "here is the implementation" in the issue body.
+
 ## Workflow Protocol
 
 When assigned to work on a GitHub issue, you follow this structured workflow. **Critical: Update project status at each phase transition.**

--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -27,8 +27,10 @@ Match the process overhead to the complexity of the change:
 | Size | When | What to do |
 |------|------|------------|
 | **Tiny** | 1-line fix, obvious cause, no decision needed | PR directly. Issue optional. |
-| **Medium** | Approach is clear but worth documenting | Issue with: problem + "we'll use approach X because [brief reason]". No scoping sub-issue needed. |
+| **Medium** | Non-trivial but reasonably well-understood | Issue with: problem + lightweight approach exploration inline (list options considered, pick one with brief rationale). No scoping sub-issue needed. |
 | **Large** | Multiple viable approaches, non-obvious tradeoffs | Issue (problem only) + scoping sub-issue. Scoping captures: candidate approaches with suspected pros/cons, open design questions, captured intuitions ("we suspect X might work because..."). Don't wait for certainty — capture the thinking. |
+
+The difference between Medium and Large is the **depth and formality of scoping**, not whether scoping happens. Medium does it inline in the issue body; Large gets its own sub-issue. Scoping is not optional for Medium — it's just less formal.
 
 After scoping (for Large): pick one approach, confirm with the user if the choice is non-obvious, then write tests first and implement.
 

--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -20,18 +20,19 @@ You strongly prefer functional style in your implementations:
 - Isolate side effects at the boundaries of your system
 - Use pattern matching and algebraic data types where the language supports them
 
-## Development Workflow: Issue → Scope → TDD → Review
+## Development Workflow: Issue → (Scope?) → TDD → Review
 
-Before writing any code, follow this sequence:
+Match the process overhead to the complexity of the change:
 
-1. **Issue describes the problem only.** Never propose a solution in the issue body. State what is broken or missing, not how to fix it.
-2. **File a scoping sub-issue.** Explore candidate approaches, ask design questions (who owns state? how does expiry work? what does a test look like?), surface trade-offs.
-3. **Pick an approach.** After scoping, choose one. Confirm with the user if the choice is non-obvious.
-4. **Write tests first (TDD).** Tests must be derived from the spec/issue, not from the code you are about to write.
-5. **Implement.** Write code to pass the tests.
-6. **Code review.** Use a reviewer subagent before presenting to the user. Engineers must not review their own work.
+| Size | When | What to do |
+|------|------|------------|
+| **Tiny** | 1-line fix, obvious cause, no decision needed | PR directly. Issue optional. |
+| **Medium** | Approach is clear but worth documenting | Issue with: problem + "we'll use approach X because [brief reason]". No scoping sub-issue needed. |
+| **Large** | Multiple viable approaches, non-obvious tradeoffs | Issue (problem only) + scoping sub-issue. Scoping captures: candidate approaches with suspected pros/cons, open design questions, captured intuitions ("we suspect X might work because..."). Don't wait for certainty — capture the thinking. |
 
-The anti-pattern to avoid: jumping from "problem observed" directly to "here is the implementation" in the issue body.
+After scoping (for Large): pick one approach, confirm with the user if the choice is non-obvious, then write tests first and implement.
+
+**The anti-pattern:** jumping from "problem observed" directly to implementation without capturing *why* that approach was chosen. The issue is not "having ideas in the issue body" — it's skipping the thinking entirely.
 
 ## Workflow Protocol
 

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -292,7 +292,11 @@ Before declaring any integration or manual test PASS:
 
 ## Tooling conventions
 
-- **When filing GitHub issues:** Describe the problem only — what is broken or missing. Do not propose a solution in the issue body. File a scoping sub-issue to explore candidate approaches before committing to any implementation.
+- **When filing GitHub issues:** Match process to complexity:
+  - *Tiny* (obvious fix, no decision needed): PR directly, issue optional.
+  - *Medium* (approach is clear): Issue with problem + brief rationale for the approach. No separate scoping sub-issue.
+  - *Large* (multiple approaches, non-obvious tradeoffs): Issue (problem only) + scoping sub-issue. Scoping should capture candidate approaches with suspected pros/cons, open design questions, and intuitions ("we suspect X might work because..."). Don't wait for certainty — capture the thinking.
+  - **Anti-pattern:** jumping to implementation without capturing *why* that approach was chosen. The problem is skipping the thinking, not having ideas in the issue body.
 
 - **GitHub operations:** Use `gh` CLI (via Bash tool) for all GitHub operations — posting PR reviews, merging PRs, creating issues, etc. Do NOT use `mcp__github__*` MCP tools in agent code.
   - Post a PR review: `gh pr review <number> --comment --body "..." --repo <owner/repo>`

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -292,6 +292,8 @@ Before declaring any integration or manual test PASS:
 
 ## Tooling conventions
 
+- **When filing GitHub issues:** Describe the problem only — what is broken or missing. Do not propose a solution in the issue body. File a scoping sub-issue to explore candidate approaches before committing to any implementation.
+
 - **GitHub operations:** Use `gh` CLI (via Bash tool) for all GitHub operations — posting PR reviews, merging PRs, creating issues, etc. Do NOT use `mcp__github__*` MCP tools in agent code.
   - Post a PR review: `gh pr review <number> --comment --body "..." --repo <owner/repo>`
   - Merge a PR: `gh pr merge <number> --squash --repo <owner/repo>`

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -294,8 +294,9 @@ Before declaring any integration or manual test PASS:
 
 - **When filing GitHub issues:** Match process to complexity:
   - *Tiny* (obvious fix, no decision needed): PR directly, issue optional.
-  - *Medium* (approach is clear): Issue with problem + brief rationale for the approach. No separate scoping sub-issue.
+  - *Medium* (non-trivial but reasonably well-understood): Issue with problem + lightweight approach exploration inline — list options considered, pick one with brief rationale. No separate scoping sub-issue. Scoping is not optional for Medium; it's just less formal than Large.
   - *Large* (multiple approaches, non-obvious tradeoffs): Issue (problem only) + scoping sub-issue. Scoping should capture candidate approaches with suspected pros/cons, open design questions, and intuitions ("we suspect X might work because..."). Don't wait for certainty — capture the thinking.
+  - **Key distinction:** Medium and Large differ in the depth and formality of scoping, not whether scoping happens. Medium does it inline; Large gets its own sub-issue.
   - **Anti-pattern:** jumping to implementation without capturing *why* that approach was chosen. The problem is skipping the thinking, not having ideas in the issue body.
 
 - **GitHub operations:** Use `gh` CLI (via Bash tool) for all GitHub operations — posting PR reviews, merging PRs, creating issues, etc. Do NOT use `mcp__github__*` MCP tools in agent code.

--- a/.claude/sys.subagent.bootup.md
+++ b/.claude/sys.subagent.bootup.md
@@ -294,9 +294,9 @@ Before declaring any integration or manual test PASS:
 
 - **When filing GitHub issues:** Match process to complexity:
   - *Tiny* (obvious fix, no decision needed): PR directly, issue optional.
-  - *Medium* (non-trivial but reasonably well-understood): Issue with problem + lightweight approach exploration inline — list options considered, pick one with brief rationale. No separate scoping sub-issue. Scoping is not optional for Medium; it's just less formal than Large.
-  - *Large* (multiple approaches, non-obvious tradeoffs): Issue (problem only) + scoping sub-issue. Scoping should capture candidate approaches with suspected pros/cons, open design questions, and intuitions ("we suspect X might work because..."). Don't wait for certainty — capture the thinking.
-  - **Key distinction:** Medium and Large differ in the depth and formality of scoping, not whether scoping happens. Medium does it inline; Large gets its own sub-issue.
+  - *Medium* (non-trivial but reasonably well-understood): Scoping required. Inline in the issue body is sufficient — list options considered, pick one with brief rationale. A dedicated sub-issue is also fine if the problem warrants it. Can go as deep as Large. Use judgment.
+  - *Large* (complex enough that deeper scoping is the expected norm): Issue (problem only) + dedicated scoping sub-issue. Scoping should capture candidate approaches with suspected pros/cons, open design questions, and intuitions ("we suspect X might work because..."). Don't wait for certainty — capture the thinking.
+  - **Key distinction:** Tiers set the *floor*, not a *ceiling*. Medium can be as thorough as Large; it just doesn't have to be. Large makes a dedicated sub-issue the expected default because the problem is complex enough to warrant it.
   - **Anti-pattern:** jumping to implementation without capturing *why* that approach was chosen. The problem is skipping the thinking, not having ideas in the issue body.
 
 - **GitHub operations:** Use `gh` CLI (via Bash tool) for all GitHub operations — posting PR reviews, merging PRs, creating issues, etc. Do NOT use `mcp__github__*` MCP tools in agent code.


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

The development workflow (problem-only issue → scoping sub-issue → pick approach → TDD → implement → code review) has been encoded as default behavior in two agent definition files, so it is enforced structurally rather than remembered situationally.

## What changed

**`functional-engineer.md`:** Added a "Development Workflow: Issue → Scope → TDD → Review" section immediately before the existing Workflow Protocol. The section gives the 6-step sequence as a numbered list and explicitly names the anti-pattern to avoid: jumping from problem statement to implementation in the issue body.

**`sys.subagent.bootup.md`:** Added a "When filing GitHub issues" rule at the top of the Tooling Conventions section. Rule: describe the problem only; do not propose a solution; file a scoping sub-issue to explore approaches first.

`lobster-shop/working-on-lobster/behavior/system.md` was not edited — the file does not exist.

## Why these two files

`functional-engineer.md` is the agent definition loaded whenever Lobster works on a GitHub issue end-to-end. Adding the workflow here means every engineer invocation sees it at session start, before any planning begins.

`sys.subagent.bootup.md` is pre-injected into all subagent sessions. The "when filing issues" rule there covers any subagent that might touch a GitHub issue, not just the dedicated engineer agent.

## Functional patterns
Pure data (no state mutation): both changes are additive text blocks inserted at natural section boundaries. No logic changes.

## Tests run
- [x] Verified both edits with `grep` — content matches expected insertion, no duplication
- [ ] No unit tests applicable — this is a documentation/behavior-file change only

## Manual test
N/A — this change is entirely internal (agent behavior files, no external service calls, no runtime state affected).

## Definition of Done
- [x] Unit tests pass with proper mocking — N/A (behavior files only)
- [x] Integration/manual test — N/A (see above)
- [x] User-visible outcome — N/A (internal behavior encoding)
- [x] Side-effect audit — no runtime effects; files are read-only at dispatch time
- [x] External service calls — none