### PR TITLE
fix(#1733): add reply-context grounding rule to dispatcher bootup

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -119,6 +119,8 @@ Never pass `hibernate_on_timeout=True` — feature removed in issue #1442; cause
 
 **Stop hook error rule:** If the `require-wait-for-messages.py` stop hook fires and injects an error (e.g. "WFM not called"), the ONLY correct response is: call `wait_for_messages()` immediately. Do NOT treat the injected error message as a user prompt. Do NOT respond to it inline. The hook's intent is to force WFM — honor it by calling WFM and nothing else.
 
+**Reply-context grounding:** When processing a Telegram message that includes a `↩️ Replying to (msg_id=...)` block, always use that block's quoted content as the primary referent for pronouns and topic references before interpreting the message. Short replies like "Is this still happening?", "Did you finish?", "What does that mean?" must be grounded in what they're replying to — not in recently-active topics from working context. Read the reply-to block first, then interpret the message.
+
 ---
 
 ## The 7-Second Rule


### PR DESCRIPTION
## What problem this solves

The dispatcher has a documented anchor-bias bug (issue #1733): when Sahar sends a Telegram reply, it interprets her short message against the most recently active topic in working context instead of reading the explicit `↩️ Replying to` block first. This has caused at least four confirmed misreads:

- Apr 22, 2026: "Is this still happening?" (about a research status) → answered about dispatcher restarts
- Mar 26, 2026: Reply about PR #968 → answered about pyproject.toml
- Apr 21, 2026: Health check question → misread the test condition
- Apr 19, 2026: "I meant for now, in Linear" → misread the referent entirely

Each incident required Sahar to explicitly correct the dispatcher and explain what she was replying to — despite the `wait_for_messages` output containing an unambiguous `↩️ Replying to (msg_id=XXXXX):` block with the full quoted text.

## What changed

Added a single `**Reply-context grounding:**` behavioral rule in the Main Loop section of `sys.dispatcher.bootup.md`, placed between the stop-hook error rule and the 7-second rule — the point in the file where the dispatcher is instructed on how to handle incoming messages before routing.

The rule makes explicit what should already be the expected behavior: read the reply-to block first, ground pronouns and topic references in that content, then interpret the message. Applies specifically to short replies that are ambiguous without the reply context ("Is this still happening?", "Did you finish?", "What does that mean?").

## What was not changed

- No code changes — this is a behavioral instruction file only
- No changes to `inbox_server.py`, `wait_for_messages` output format, or message routing
- No changes to any other bootup or agent files

## Functional patterns

This is a pure behavioral constraint added to a declarative instruction document. No functional programming patterns apply — it's a rule specification, not code.

## Tests run
- [x] Verified the file diff is a clean 2-line insertion with no surrounding context disturbed
- [x] Confirmed the rule is in the correct location (Main Loop section, alongside other behavioral rules)
- [ ] Live behavioral test — not applicable in automated testing. This is a bootup instruction change; effect is observed at runtime when the dispatcher reads the file on next compaction or restart. No unit test framework exists for dispatcher behavioral rules.

## Manual test
N/A — this change is entirely internal to a behavioral instruction file. The rule instructs the dispatcher how to interpret incoming messages; verifying it works requires observing dispatcher behavior on a real reply-to message in a live session. The change is safe to deploy and soak: worst case the rule is ignored; it cannot cause regressions.

## Definition of Done
- [x] Unit tests pass with proper mocking — N/A (no executable code changed)
- [x] User-visible outcome: not directly verifiable pre-merge; soak period will surface whether misreads recur
- [x] Side-effect audit: no side effects — read-only instruction document addition
- [x] External service calls: none

Closes #1733