### PR TITLE
fix: agent-monitor.py path resolution fails when run as root

### DIFF
--- a/scripts/agent-monitor.py
+++ b/scripts/agent-monitor.py
@@ -54,15 +54,22 @@ Classification = Literal[
     "HEALTHY",
 ]
 
-DB_PATH = Path.home() / "messages" / "config" / "agent_sessions.db"
+# Resolve the lobster home directory from LOBSTER_HOME env var (set in install.sh
+# and cron entries), falling back to /home/lobster.  Deliberately NOT using
+# Path.home() or os.path.expanduser("~") because those resolve to /root when the
+# script is invoked as root (e.g. via a stale root crontab entry), causing the DB
+# lookup to fail silently.
+LOBSTER_HOME = Path(os.environ.get("LOBSTER_HOME", "/home/lobster"))
+
+DB_PATH = LOBSTER_HOME / "messages" / "config" / "agent_sessions.db"
 
 # Glob pattern for Claude Code session task directories.
 # The middle component is a session UUID that changes per Claude Code invocation.
-# The path component is derived dynamically from the actual home directory so the
-# script works on any install regardless of the username (e.g. /home/lobster vs
+# The path component is derived dynamically from LOBSTER_HOME so the script
+# works on any install regardless of the username (e.g. /home/lobster vs
 # /home/admin).  Claude Code maps workspace paths to /tmp by replacing '/' with '-'.
 def _default_agent_output_glob() -> str:
-    home = os.path.expanduser("~")
+    home = str(LOBSTER_HOME)
     # /home/lobster -> -home-lobster-
     path_slug = home.strip("/").replace("/", "-")
     return f"/tmp/claude-1000/-{path_slug}-lobster-workspace/*/tasks/"
@@ -624,7 +631,7 @@ def _resolve_owner_chat_id() -> str:
         if first:
             return first
 
-    config_env = Path.home() / "lobster-config" / "config.env"
+    config_env = LOBSTER_HOME / "lobster-config" / "config.env"
     if config_env.exists():
         try:
             for line in config_env.read_text().splitlines():
@@ -723,7 +730,7 @@ def build_mark_failed_inbox_message(agent: ClassifiedAgent) -> dict:
 
 def drop_inbox_message(payload: dict) -> None:
     """Write a JSON message file to ~/messages/inbox/ for dispatcher pickup."""
-    inbox_dir = Path.home() / "messages" / "inbox"
+    inbox_dir = LOBSTER_HOME / "messages" / "inbox"
     inbox_dir.mkdir(parents=True, exist_ok=True)
     dest = inbox_dir / f"{payload['id']}.json"
     dest.write_text(json.dumps(payload, indent=2))

--- a/tests/unit/test_ghost_detector_filesystem.py
+++ b/tests/unit/test_ghost_detector_filesystem.py
@@ -653,3 +653,38 @@ class TestLiveDispatcherGuard:
         out = capsys.readouterr().out
         assert "Skipping" in out
         assert "dispatcher" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# LOBSTER_HOME path resolution
+# ---------------------------------------------------------------------------
+
+
+class TestLobsterHomePaths:
+    """Verify that all paths derived from LOBSTER_HOME are consistent.
+
+    The module resolves LOBSTER_HOME once at import time, so we test the
+    resulting constant values rather than re-loading the module.  The key
+    invariant is that every path must be rooted at LOBSTER_HOME — never at
+    /root or any other user's home directory.
+    """
+
+    def test_db_path_rooted_at_lobster_home(self) -> None:
+        """DB_PATH must be a child of LOBSTER_HOME, not Path.home()."""
+        assert str(gd.DB_PATH).startswith(str(gd.LOBSTER_HOME))
+
+    def test_db_path_correct_relative_structure(self) -> None:
+        """DB_PATH must follow the canonical messages/config/agent_sessions.db layout."""
+        expected_suffix = Path("messages") / "config" / "agent_sessions.db"
+        assert gd.DB_PATH == gd.LOBSTER_HOME / expected_suffix
+
+    def test_lobster_home_never_resolves_to_root(self) -> None:
+        """LOBSTER_HOME must not be /root — that indicates Path.home() was used as root."""
+        assert str(gd.LOBSTER_HOME) != "/root"
+
+    def test_agent_output_glob_contains_lobster_home_slug(self) -> None:
+        """The agent output glob must encode the LOBSTER_HOME path, not /root."""
+        home_slug = str(gd.LOBSTER_HOME).strip("/").replace("/", "-")
+        assert home_slug in gd.AGENT_OUTPUT_GLOB, (
+            f"Expected slug '{home_slug}' in AGENT_OUTPUT_GLOB={gd.AGENT_OUTPUT_GLOB!r}"
+        )


### PR DESCRIPTION
## Problem

When `agent-monitor.py` runs as root (via a duplicate root crontab entry), `Path.home()` resolves to `/root` rather than `/home/lobster`. The script then looks for `/root/messages/config/agent_sessions.db`, which does not exist, causing silent ghost detection failure. The same bug affects the `drop_inbox_message()` function, which would write alerts to `/root/messages/inbox/` instead of the actual inbox.

The root crontab entry (`LOBSTER-GHOST-DETECTOR`) was a duplicate — the canonical entry already lives in the lobster user's crontab and runs correctly there.

## Fix

Introduce a `LOBSTER_HOME` module constant derived from `os.environ.get("LOBSTER_HOME", "/home/lobster")`, consistent with how `install.sh` and `update-lobster.sh` already parameterise the install path. All four `Path.home()` / `os.path.expanduser("~")` usages are replaced with `LOBSTER_HOME`.

The duplicate root crontab entry (`LOBSTER-GHOST-DETECTOR`) was removed; only the lobster-user crontab entry remains.

## Functional patterns used

Pure constant derivation at module load time — `LOBSTER_HOME` is computed once from the environment and then referenced everywhere, making the resolution logic easy to test and override.

## What is not changed

The lobster-user crontab entry is untouched. The `_default_agent_output_glob()` function logic is unchanged — only the home-directory input to it was fixed. No other scripts were modified.

## Tests run
- [x] `uv run pytest tests/unit/test_ghost_detector_filesystem.py -v` — 48 passed, 0 failed (includes 4 new `TestLobsterHomePaths` regression tests)
- [x] `uv run pytest tests/unit/ --ignore=tests/unit/test_bisque --ignore=tests/unit/test_mcp_server/test_ghost_session_fixes.py --ignore=tests/unit/test_mcp_server/test_lobstertalk_telegram_routing.py -q` — 2680 passed, 3 pre-existing failures (all in `test_message_tools.py`, present on main before this change)

## Manual test
The crontab change was verified with `sudo crontab -l` — the `LOBSTER-GHOST-DETECTOR` entry no longer appears in the root crontab. The lobster user's crontab entry for the ghost detector is untouched and continues to run correctly under the lobster user where `LOBSTER_HOME` is not needed (no root conflict). N/A for user-visible Telegram output — this is a monitoring script that only sends alerts when ghosts are detected.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — crontab verified via `sudo crontab -l`
- [x] User-visible outcome: N/A — internal monitoring fix; no change to alert message content or routing
- [x] Side-effect audit: removing a duplicate crontab entry has no side effects; the canonical entry remains
- [x] External service calls: none in this change

Closes #1758