### PR TITLE
fix(#1772): increase COMPACT_GRACE_SECONDS from 600s to 900s to prevent false health-check restarts

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -82,7 +82,7 @@ RESTART_WINDOW_BUFFER_SECONDS=120    # Pre-mark messages within this window of t
 MAINTENANCE_EXPIRY_SECONDS=3600      # 1 hour - stale maintenance flag is auto-cleared and checks resume
 
 COMPACTION_SUPPRESS_SECONDS=300      # 5 minutes - skip stale-inbox check after a compaction event
-COMPACT_GRACE_SECONDS=600            # 10 minutes - skip stale-inbox check after a compaction (last-compact.ts)
+COMPACT_GRACE_SECONDS=900            # 15 minutes - skip stale-inbox check after a compaction (last-compact.ts)
 # CATCHUP_SUPPRESS_SECONDS removed (issue #1483): dispatcher heartbeat threshold covers catchup naturally
 RESTART_COOLDOWN_SUPPRESS_SECONDS=240 # 4 minutes - suppress stale-inbox RED after a recent restart
 
@@ -511,9 +511,9 @@ except Exception:
 # Check if a context compaction occurred within the last COMPACT_GRACE_SECONDS.
 # Returns 0 (true) if inbox staleness checks should be suppressed, 1 otherwise.
 # Reads the Unix timestamp from last-compact.ts (written by hooks/on-compact.py).
-# This provides a 10-minute grace period for post-compaction re-orientation,
+# This provides a 15-minute grace period for post-compaction re-orientation,
 # extending the existing COMPACTION_SUPPRESS_SECONDS (5 min) window by an additional
-# 5 minutes to cover cases where re-orientation takes longer than expected.
+# 10 minutes to cover cases where re-orientation takes longer than expected.
 is_compact_grace_period() {
     local ts_file="$WORKSPACE_DIR/data/last-compact.ts"
     if [[ ! -f "$ts_file" ]]; then
@@ -1599,7 +1599,7 @@ main() {
     # Claude Code pauses tool calls during context compaction for 1-3+ minutes.
     # If on-compact.py recorded a compacted_at within the last
     # COMPACTION_SUPPRESS_SECONDS, skip all stale-inbox checks this run.
-    # Additionally, check last-compact.ts for a 10-minute grace period that
+    # Additionally, check last-compact.ts for a 15-minute grace period that
     # covers the post-compaction re-orientation window (reading bootup files,
     # processing inbox backlog, waiting for compact-catchup to complete).
     local compaction_recent=false


### PR DESCRIPTION
## Problem

After context compaction, post-compaction re-orientation (reading bootup files, spawning compact-catchup, processing inbox) takes ~13 minutes. The current 10-minute grace window expires before re-orientation completes, causing health-check to see a stale inbox and fire a false restart.

This has caused two confirmed false restarts (2026-04-16 and 2026-04-23T13:16Z).

## Fix

Increase `COMPACT_GRACE_SECONDS` from 600 to 900 (10 min → 15 min). This gives enough headroom for re-orientation to complete before stale-inbox checks resume.

Three comment strings in `health-check-v3.sh` were updated to match the new value: the inline constant comment (line 85), the `is_compact_grace_period()` function docblock (line 514), and the inline comment in `main()` (line 1602).

Note: `COMPACTION_SUPPRESS_SECONDS=300` (5 min, line 84) is a separate mechanism using the on-compact signal and does not need changing.

## Tests run
- [x] Manual diff review — 4 lines changed: 1 value change + 3 comment updates, all internally consistent
- [ ] Live health-check run — N/A for this one-line config change; the value is used directly in an integer comparison with no code path affected

## Manual test
N/A — this change is entirely internal to a bash constant. No external service calls, no file I/O changes, no schema changes. The constant is compared against elapsed seconds in `is_compact_grace_period()` — no observable side effects to test outside of a real compaction event.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests) — N/A, bash constant
- [x] User-visible outcome verified OR not applicable — not applicable, this suppresses false user-visible restarts rather than producing new output
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume — config constant only
- [x] External service calls: N/A

Fixes #1772