### PR TITLE
fix(#1763): pass env vars to container init service

### DIFF
--- a/docker/staging/lobster-container-init.service
+++ b/docker/staging/lobster-container-init.service
@@ -11,6 +11,14 @@ User=lobster
 Group=lobster
 Environment=HOME=/home/lobster
 Environment=PATH=/home/lobster/.local/bin:/usr/local/bin:/usr/bin:/bin
+# Pass env vars injected by docker-compose env_file into this systemd unit.
+# Without these directives systemd spawns the service in a clean environment,
+# so lobster-container-init.sh sees no values and writes a blank config.env.
+PassEnvironment=TELEGRAM_BOT_TOKEN
+PassEnvironment=TELEGRAM_ALLOWED_USERS
+PassEnvironment=LOBSTER_ADMIN_CHAT_ID
+PassEnvironment=LOBSTER_ENV
+PassEnvironment=LOBSTER_DEBUG
 ExecStart=/home/lobster/lobster-container-init.sh
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
## Problem

On a cold `docker compose up`, `lobster-container-init.service` fires via systemd and writes `config.env` from its environment. But systemd spawns services in a clean environment — Docker's `env_file` values (injected into the container's PID 1 environment) are not automatically inherited by child units. Without `PassEnvironment` directives, `lobster-container-init.sh` sees no values for `TELEGRAM_BOT_TOKEN` and the other vars, writes a blank `config.env`, and the router starts with an empty token — crash-looping on every cold boot.

## What changed

Added `PassEnvironment=` directives to the `[Service]` section of `docker/staging/lobster-container-init.service` for all five environment variables the init script reads:

- `TELEGRAM_BOT_TOKEN`
- `TELEGRAM_ALLOWED_USERS`
- `LOBSTER_ADMIN_CHAT_ID`
- `LOBSTER_ENV`
- `LOBSTER_DEBUG`

This is the complete set — confirmed by reading `lobster-container-init.sh` lines 57–64 where these five vars are the only ones referenced in the `config.env` heredoc.

The fix is in the source file (`docker/staging/lobster-container-init.service`), which is `COPY`'d directly into `/etc/systemd/system/` by `Dockerfile.staging` line 256. No template layer or `install.sh` to update.

## Boot flow (before / after)

```
Before:
  docker compose up
    └── PID 1 env: TELEGRAM_BOT_TOKEN=xxx, ...
          └── systemd starts lobster-container-init.service
                └── clean env: TELEGRAM_BOT_TOKEN=(unset)
                      └── config.env written with blank values
                            └── lobster-router starts, crashes (empty token)

After:
  docker compose up
    └── PID 1 env: TELEGRAM_BOT_TOKEN=xxx, ...
          └── systemd starts lobster-container-init.service
                └── PassEnvironment copies vars from PID 1 env
                      └── config.env written with correct values
                            └── lobster-router starts OK
```

## Tests run

- [x] Diff reviewed manually — only `PassEnvironment` lines added, no other changes
- [ ] Cold `docker compose up` integration test — blocked: Docker/staging environment not available in this subagent context. Requires a container restart to verify. **Needs manual verification before merge.**

## Manual test

Required before merge:

1. Rebuild the staging image (`docker compose build`)
2. Start from clean state (`docker compose down -v && docker compose up`)
3. Confirm `lobster-container-init.service` exits with status 0 (`systemctl status lobster-container-init`)
4. Confirm `config.env` contains non-blank `TELEGRAM_BOT_TOKEN` value
5. Confirm `lobster-router.service` starts without crash-looping

The manual workaround (writing config.env directly) will no longer be needed once this fix is deployed.

## Definition of Done

- [x] Unit tests pass with proper mocking — N/A, pure config change
- [ ] Integration/manual test run — blocked, see above
- [ ] User-visible outcome verified — after cold restart, router stays up and bot responds in Telegram
- [x] Side-effect audit complete: no floods, no unscoped writes
- [x] External service calls: none introduced by this change

Closes #1763