### PR TITLE
fix(#1780,#1791): ssh-watcher self-echo filter + post-read stat + move to repo

### DIFF
--- a/scheduled-tasks/lobstertalk-ssh-watcher-job.py
+++ b/scheduled-tasks/lobstertalk-ssh-watcher-job.py
@@ -15,8 +15,6 @@ LOG_FILE = HOME / "lobster-workspace" / "logs" / "lobstertalk.jsonl"
 INBOX_DIR = HOME / "messages" / "inbox"
 SSH_KEY = HOME / ".ssh" / "lobsterbotsownkey"
 SSH_HOST = os.environ.get("BOT_TALK_SSH_HOST", "")
-if not SSH_HOST:
-    raise RuntimeError("BOT_TALK_SSH_HOST env var required (e.g. user@host.example.com)")
 REMOTE_FILE = os.environ.get("BOT_TALK_SSH_REMOTE_FILE", "~/bot-talk/messages.jsonl")
 OWNER_CHAT_ID = 8305714125
 JOB_NAME = "lobstertalk-ssh-watcher"
@@ -117,6 +115,10 @@ def write_task_output(output, status="success"):
 
 
 def main():
+    if not SSH_HOST:
+        write_task_output("BOT_TALK_SSH_HOST env var not set — cannot connect to bot-talk server", "failed")
+        return
+
     is_first_run = not STATE_FILE.exists()
     state = load_state()
     last_offset = state.get("last_offset", 0)

--- a/scheduled-tasks/lobstertalk-ssh-watcher-job.py
+++ b/scheduled-tasks/lobstertalk-ssh-watcher-job.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""LobsterTalk SSH Watcher Job — detects new messages written to shared server's messages.jsonl"""
+import json
+import os
+import uuid
+import time
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+RUN_ID = str(uuid.uuid4())[:8]
+HOME = Path.home()
+STATE_FILE = HOME / "lobster-workspace" / "data" / "lobstertalk-ssh-state.json"
+LOG_FILE = HOME / "lobster-workspace" / "logs" / "lobstertalk.jsonl"
+INBOX_DIR = HOME / "messages" / "inbox"
+SSH_KEY = HOME / ".ssh" / "lobsterbotsownkey"
+SSH_HOST = os.environ.get("BOT_TALK_SSH_HOST", "")
+if not SSH_HOST:
+    raise RuntimeError("BOT_TALK_SSH_HOST env var required (e.g. user@host.example.com)")
+REMOTE_FILE = os.environ.get("BOT_TALK_SSH_REMOTE_FILE", "~/bot-talk/messages.jsonl")
+OWNER_CHAT_ID = 8305714125
+JOB_NAME = "lobstertalk-ssh-watcher"
+
+# Self-echo filter: skip messages sent by this Lobster (re-delivered by relay).
+# Mirrors the BOT_TALK_SELF_USER filter on the HTTP path (issue #1345).
+MY_LOBSTER_NAME: str = (
+    os.environ.get("BOT_TALK_SELF_USER")
+    or os.environ.get("BOT_TALK_SENDER")
+    or os.environ.get("LOBSTER_NAME")
+    or "SaharLobster"
+)
+
+
+def load_state():
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text())
+        except Exception:
+            pass
+    return {"last_mtime": None, "last_size": 0, "last_offset": 0}
+
+
+def save_state(state):
+    tmp = STATE_FILE.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state, indent=2))
+    tmp.rename(STATE_FILE)
+
+
+def append_log(entry):
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if LOG_FILE.exists() and LOG_FILE.stat().st_size > 50 * 1024 * 1024:
+        LOG_FILE.rename(LOG_FILE.with_suffix(".jsonl.bak"))
+    with LOG_FILE.open("a") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def ssh_run(cmd, timeout=30):
+    """Run a command on the remote host via SSH."""
+    result = subprocess.run(
+        ["ssh", "-i", str(SSH_KEY), "-o", "StrictHostKeyChecking=no",
+         "-o", "ConnectTimeout=15", SSH_HOST, cmd],
+        capture_output=True, text=True, timeout=timeout
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def write_to_inbox(messages):
+    """Write new bot-talk messages to the Lobster inbox."""
+    INBOX_DIR.mkdir(parents=True, exist_ok=True)
+    routed = 0
+    skipped_self = 0
+    for msg in messages:
+        sender = msg.get("sender", msg.get("from", "unknown"))
+        content = msg.get("content", msg.get("text", ""))
+        ts = msg.get("timestamp", datetime.now(timezone.utc).isoformat())
+
+        # Self-echo filter: skip messages we sent (fix for issue #1791).
+        if sender == MY_LOBSTER_NAME:
+            skipped_self += 1
+            continue
+
+        msg_id = f"{int(time.time() * 1000)}_bot_talk_{str(uuid.uuid4())[:8]}"
+        inbox_msg = {
+            "id": msg_id,
+            "type": "text",
+            "source": "bot-talk",
+            "chat_id": OWNER_CHAT_ID,
+            "user_name": sender,
+            "text": content,
+            "timestamp": ts,
+            "direction": "INBOUND",
+            "from": sender,
+            "to": "SaharLobster",
+        }
+        tmp_path = INBOX_DIR / f"{msg_id}.tmp"
+        final_path = INBOX_DIR / f"{msg_id}.json"
+        tmp_path.write_text(json.dumps(inbox_msg))
+        tmp_path.rename(final_path)
+        append_log({"ts": ts, "direction": "INBOUND", "sender": sender, "content": content,
+                    "job_run": RUN_ID, "source": "ssh-watcher"})
+        routed += 1
+    if skipped_self:
+        append_log({"ts": datetime.now(timezone.utc).isoformat(), "direction": "INFO",
+                    "content": f"Skipped {skipped_self} self-echo message(s).",
+                    "job_run": RUN_ID, "source": "ssh-watcher"})
+    return routed
+
+
+def write_task_output(output, status="success"):
+    """Write job output via lobster MCP CLI shim."""
+    shim = HOME / "lobster" / "scheduled-tasks" / "write-task-output.sh"
+    if shim.exists():
+        subprocess.run([str(shim), JOB_NAME, output, status],
+                       capture_output=True, timeout=15)
+    else:
+        print(f"[{JOB_NAME}] {status}: {output}")
+
+
+def main():
+    is_first_run = not STATE_FILE.exists()
+    state = load_state()
+    last_offset = state.get("last_offset", 0)
+    last_mtime = state.get("last_mtime")
+    last_size = state.get("last_size", 0)
+    debug_mode = os.environ.get("LOBSTER_DEBUG", "").lower() == "true"
+
+    # Step 1: Get current file stat
+    rc, stat_out, stat_err = ssh_run(f"stat -c '%s %Y' {REMOTE_FILE} 2>/dev/null || echo 'MISSING'")
+    if rc != 0 or stat_out.strip() == "MISSING" or not stat_out.strip():
+        msg = f"SSH stat failed: rc={rc} err={stat_err.strip()[:200]}"
+        append_log({"ts": datetime.now(timezone.utc).isoformat(), "direction": "ERROR",
+                    "content": msg, "job_run": RUN_ID})
+        write_task_output(f"SSH failed: {stat_err.strip()[:200]}", "failed")
+        return
+
+    parts = stat_out.strip().split()
+    if len(parts) < 2:
+        write_task_output(f"Unexpected stat output: {stat_out.strip()[:100]}", "failed")
+        return
+
+    current_size = int(parts[0])
+    current_mtime = parts[1]
+
+    # First run: calibrate offset to end of file, don't route historical messages
+    if is_first_run:
+        state["last_mtime"] = current_mtime
+        state["last_size"] = current_size
+        state["last_offset"] = current_size
+        save_state(state)
+        write_task_output(f"First run: calibrated to current end of file ({current_size} bytes). Future runs will only see new messages.", "success")
+        return
+
+    # Step 2: Check if anything changed
+    if current_mtime == last_mtime and current_size == last_size:
+        # Silent — nothing changed
+        write_task_output("No change detected.", "success")
+        return
+
+    if current_size <= last_offset:
+        # File was truncated/rotated — reset offset
+        last_offset = 0
+        state["last_offset"] = 0
+
+    if current_size == last_offset:
+        # No new bytes despite mtime change
+        state["last_mtime"] = current_mtime
+        state["last_size"] = current_size
+        save_state(state)
+        write_task_output("File touched but no new bytes.", "success")
+        return
+
+    # Step 3: Read new bytes from offset
+    bytes_to_read = current_size - last_offset
+    rc, new_content, read_err = ssh_run(
+        f"tail -c +{last_offset + 1} {REMOTE_FILE} 2>/dev/null | head -c {bytes_to_read}"
+    )
+    if rc != 0:
+        write_task_output(f"SSH read failed: {read_err.strip()[:200]}", "failed")
+        return
+
+    # Step 4: Parse new JSONL lines
+    new_messages = []
+    actual_bytes_read = len(new_content.encode("utf-8"))
+    for line in new_content.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+            new_messages.append(msg)
+        except json.JSONDecodeError:
+            pass  # Skip malformed lines
+
+    if not new_messages:
+        # Update state even if no parseable messages
+        state["last_mtime"] = current_mtime
+        state["last_size"] = current_size
+        state["last_offset"] = last_offset + actual_bytes_read
+        save_state(state)
+        write_task_output("File changed but no parseable messages.", "success")
+        return
+
+    # Step 5: Route to inbox
+    routed = write_to_inbox(new_messages)
+
+    # Step 6: Re-stat after reading so last_size reflects actual post-read size
+    # (fixes issue #1780 Bug 1: race condition when messages arrive during read).
+    rc_post, stat_post_out, _ = ssh_run(f"stat -c '%s %Y' {REMOTE_FILE} 2>/dev/null")
+    if rc_post == 0 and stat_post_out.strip():
+        post_parts = stat_post_out.strip().split()
+        if len(post_parts) >= 2:
+            current_size = int(post_parts[0])
+            current_mtime = post_parts[1]
+
+    # Step 7: Update state
+    state["last_mtime"] = current_mtime
+    state["last_size"] = current_size
+    state["last_offset"] = last_offset + actual_bytes_read
+    save_state(state)
+
+    summary = f"Found {len(new_messages)} new message(s), routed {routed} to inbox."
+    append_log({"ts": datetime.now(timezone.utc).isoformat(), "direction": "INFO",
+                "content": summary, "job_run": RUN_ID})
+
+    if debug_mode:
+        # Send debug notification
+        for m in new_messages[:3]:
+            sender = m.get("sender", m.get("from", "unknown"))
+            content = m.get("content", m.get("text", ""))
+            print(f"[SSH-WATCHER DEBUG] {sender}: {content[:200]}")
+
+    write_task_output(summary, "success")
+
+
+if __name__ == "__main__":
+    main()

--- a/scheduled-tasks/tasks/README.md
+++ b/scheduled-tasks/tasks/README.md
@@ -46,6 +46,7 @@ time. Common placeholders:
 | `bot-talk-poller.md.template` | `bot-talk-poller` | Hourly baseline poller for bot-talk messages |
 | `bot-talk-poller-fast.md.template` | `bot-talk-poller-fast` | 2-minute fast poller (hot-mode only) |
 | `gmail-email-pipeline.md.template` | `gmail-email-pipeline` | Gmail polling with CRM enrichment |
+| `lobstertalk-ssh-watcher.md.template` | `lobstertalk-ssh-watcher` | SSH-based watcher for bot-talk messages.jsonl with self-echo filter |
 
 ## How to instantiate a template
 

--- a/scheduled-tasks/tasks/lobstertalk-ssh-watcher.md.template
+++ b/scheduled-tasks/tasks/lobstertalk-ssh-watcher.md.template
@@ -1,0 +1,42 @@
+# LobsterTalk SSH Watcher
+
+**Job**: lobstertalk-ssh-watcher
+**Schedule**: Every 6 hours (`0 */6 * * *`)
+
+## Purpose
+
+Detect new messages written directly to the shared server's `~/bot-talk/messages.jsonl` file
+via SSH, and route any new messages to the Lobster inbox as bot-talk messages.
+
+## Instructions
+
+Run the watcher script using uv:
+
+```bash
+uv run ~/lobster/scheduled-tasks/lobstertalk-ssh-watcher-job.py
+```
+
+The script handles everything:
+1. SSHes to `$BOT_TALK_SSH_HOST` (from config.env) using `~/.ssh/lobsterbotsownkey`
+2. Checks if `$BOT_TALK_SSH_REMOTE_FILE` (default: `~/bot-talk/messages.jsonl`) has changed since last run (via mtime + size)
+3. If unchanged: exits silently (no notification to you needed)
+4. If changed: reads new lines from the saved byte offset, parses JSONL, skips self-echoes (sender == `$BOT_TALK_SELF_USER`), routes each inbound message to `~/messages/inbox/`
+5. Updates state in `~/lobster-workspace/data/lobstertalk-ssh-state.json`
+
+## Your job
+
+1. Run the script with `uv run ~/lobster/scheduled-tasks/lobstertalk-ssh-watcher-job.py`
+2. Check the output (stdout/stderr)
+3. Call `write_task_output` with:
+   - `job_name`: "lobstertalk-ssh-watcher"
+   - `output`: the script's summary output (or error message if it failed)
+   - `status`: "success" if script exited 0, "failed" otherwise
+4. Call `write_result`:
+   - If new messages were routed (script output contains "routed"): `write_result(task_id=<task_id>, chat_id={{TELEGRAM_CHAT_ID}}, sent_reply_to_user=False)`
+   - Otherwise: `write_result(task_id=<task_id>, chat_id=0, sent_reply_to_user=False)`
+
+## Error handling
+
+- If the SSH connection fails: `write_task_output` with status="failed", then `write_result` with chat_id=0
+- If the script crashes: capture stderr, report it in `write_task_output` with status="failed"
+- Do NOT send a Telegram notification on SSH failures — log only


### PR DESCRIPTION
## Problem

Two bugs in lobstertalk-ssh-watcher-job.py causing incorrect message delivery:

**Issue #1791 (high severity):** No self-echo filter. The bot-talk relay returns a copy of every outbound POST to the sender's feed. On Apr 24 this caused 1,757 outbound messages to flood the inbox, burning ~53k tokens and creating a tight loop. The HTTP path had this filter (#1345) but the SSH watcher didn't.

**Issue #1780 Bug 1 (low severity):** last_size was saved as the pre-read file size, causing spurious "new content" detection when messages arrived during the read window.

## What changed

- Added scheduled-tasks/lobstertalk-ssh-watcher-job.py to the repo (previously untracked)
- Self-echo filter: MY_LOBSTER_NAME from BOT_TALK_SELF_USER/BOT_TALK_SENDER/LOBSTER_NAME env, skip sender==self in write_to_inbox
- Post-read stat: re-stat after routing to save accurate last_size
- SSH_HOST de-hardcoded: reads BOT_TALK_SSH_HOST env var (already in config.env)

## Test plan
- [ ] Self-echo messages skipped and logged
- [ ] Non-self messages still routed
- [ ] last_size after run matches fresh stat
- [ ] BOT_TALK_SSH_HOST reads from config.env

🤖 Generated with [Claude Code](https://claude.com/claude-code)