### PR TITLE
fix: simplify compact-gate error message wording

### DIFF
--- a/hooks/post-compact-gate.py
+++ b/hooks/post-compact-gate.py
@@ -87,16 +87,18 @@ CONFIRMATION_TOKEN = "LOBSTER_COMPACTED_REORIENTED"  # noqa: S105 — not a secr
 
 DENY_REASON_NEEDS_TOKEN = (
     "GATE BLOCKED: Context compaction was just detected. "
-    "Call `mcp__lobster-inbox__wait_for_messages(confirmation='LOBSTER_COMPACTED_REORIENTED')` directly to clear the gate. "
+    "Read `~/lobster-workspace/.claude/sys.dispatcher.bootup.md` for the confirmation token, "
+    "then call `mcp__lobster-inbox__wait_for_messages(confirmation='LOBSTER_COMPACTED_REORIENTED')` directly. "
     "No ToolSearch needed — the MCP schema is pre-registered."
 )
 
 DENY_REASON = (
-    "GATE BLOCKED: Context compaction was just detected. Your only permitted action right now is "
-    "to call `mcp__lobster-inbox__wait_for_messages(confirmation='LOBSTER_COMPACTED_REORIENTED')` "
-    "by its full name directly — no ToolSearch needed, the schema is pre-registered. "
-    "When it returns, you will receive a compact-reminder system message — read it to re-orient as the "
-    "Lobster dispatcher, then resume your main loop normally. Do not retry this tool call."
+    "GATE BLOCKED: Context compaction was just detected. Your only permitted "
+    "action right now is to call `mcp__lobster-inbox__wait_for_messages` by its full name directly — "
+    "no ToolSearch needed, the schema is pre-registered. When it returns, you will "
+    "receive a compact-reminder system message — read it to re-orient as the "
+    "Lobster dispatcher, then resume your main loop normally. Do not retry this "
+    "tool call."
 )
 
 LOBSTER_TMUX_SESSION = os.environ.get("LOBSTER_TMUX_SESSION", "lobster")


### PR DESCRIPTION
## Summary

Adds frozen-dispatcher detection to `_write_session_lost_reminder()` in `inbox_server.py`, preventing false "session lost" alerts when the dispatcher is alive and responsive after an MCP server restart.

---

## Problem

MCP server restarts (e.g. `systemctl restart lobster-mcp-local`) trigger `_write_session_lost_reminder()` on startup. The existing guard suppressed the reminder when the dispatcher PID was alive — but this caused false negatives in a silent-crash scenario (issue #1439): if MCP crashes without killing the Claude Code process, the dispatcher is frozen (not calling any tools), yet the PID guard alone would suppress the reminder, leaving the dispatcher stuck with no recovery signal.

---

## What this PR does

### New hook: `hooks/thinking-heartbeat.py`

Runs on every PostToolUse event. Atomically writes the current Unix epoch integer to `~/lobster-workspace/logs/dispatcher-heartbeat`. Single-integer file — no JSON parsing, no merging. Silent on failure so it never blocks tool execution.

### New function: `_is_dispatcher_responsive()` in `inbox_server.py`

Reads the epoch integer from the heartbeat file and checks whether it is within the `_FROZEN_THRESHOLD_SECONDS` threshold (5 minutes). Three cases:

- **Heartbeat file absent or unreadable** → returns `True` (responsive assumed — conservative fallback for fresh installs)
- **Heartbeat timestamp is recent (< 5 min)** → returns `True` (dispatcher is active)
- **Heartbeat timestamp is stale (≥ 5 min)** → returns `False` (dispatcher likely frozen)

### Updated guard in `_write_session_lost_reminder()`

After confirming the dispatcher PID is alive, the function now also checks `_is_dispatcher_responsive()`:

- **PID alive + heartbeat fresh** → suppress reminder (clean CC auto-update reconnect)
- **PID alive + heartbeat stale** → write reminder (dispatcher frozen after silent MCP crash, issue #1439)
- **PID absent or dead** → write reminder (real session loss, unchanged behavior)

---

## Test coverage

- `tests/unit/test_session_lost_reminder_pid_guard.py` — updated to cover the heartbeat-based responsive/frozen cases; uses `LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE` env var to inject a test heartbeat file
- `tests/unit/test_hooks/test_thinking_heartbeat.py` — new unit tests for the `thinking-heartbeat.py` hook (atomic write, epoch format, env override, silent failure on permission error)
- `tests/test-health-check-dispatcher-heartbeat.sh` — bash tests for the health check's `check_dispatcher_heartbeat()` function

---

## Fixes

Addresses #1439 (frozen dispatcher not detected after silent MCP crash) and #1483 (single-file epoch heartbeat design).