### PR TITLE
fix(#1801,#1802,#1805): Compact-catchup filesystem validation, startup health checks, pipeline schema enforcement

### DIFF
--- a/.claude/agents/compact-catchup.md
+++ b/.claude/agents/compact-catchup.md
@@ -297,6 +297,22 @@ Omit the "Session context" section entirely if no session files were found.
 
 Keep each line to one sentence. The dispatcher is on mobile -- brevity matters.
 
+## Filesystem Verification
+
+After reconstructing state from the session notes, run a quick filesystem cross-check on any active projects or in-flight tasks mentioned:
+
+For each active project in the session note:
+1. Does the project directory exist? (`ls ~/lobster-workspace/projects/{name}/`)
+2. Does any required corpus/data path mentioned in the session note exist?
+3. Is any pipeline state file (pipeline-state.json) present, and do its flags match claimed state?
+
+If a check fails:
+- Note the discrepancy in the compact-catchup report
+- Include a "⚠️ State Mismatch" section in the catchup summary
+- Do NOT silently adopt the session note's claimed state for the failed check
+
+This prevents "garbage in, garbage out" across compaction boundaries.
+
 ## Rules
 
 - Do NOT call `send_reply` -- this is internal context recovery, not a user message.

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -97,6 +97,17 @@ Fill in:
 
 ---
 
+### Project Health Checks (if active pipeline projects)
+
+If handoff.md references an active pipeline project with a `spec_path` or `Project Invariants` section:
+- Read the project invariants from handoff.md
+- Run any health check scripts referenced there (e.g., `health-check.sh`)
+- Alert the user if any invariant fails (same urgency as the branch-check alert)
+
+This is especially important after compaction: the health check catches drift between claimed state and actual filesystem state before work resumes.
+
+If handoff.md uses a machine-readable format for project invariants (e.g., a YAML or JSON block under a `## Project Invariants` heading), read that block and evaluate each invariant as a filesystem or state check. Log any failures to the post-bootup status message.
+
 ## Main Loop
 
 ```

--- a/scripts/validate-pipeline-state.py
+++ b/scripts/validate-pipeline-state.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Validates a pipeline-state.json file against the required schema.
+Usage: uv run validate-pipeline-state.py <path-to-pipeline-state.json>
+Exits 0 if valid, 1 if invalid.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_FIELDS = {
+    'author': str,
+    'project': str,
+    'skill_valid': bool,
+    'current_round': int,
+    'writing_modes_used': list,
+}
+
+LOOP_GATE_FIELDS = {
+    'skill_valid': True,  # Must be True to enter The Loop
+}
+
+def validate(path: str) -> tuple[bool, list[str]]:
+    errors = []
+    try:
+        with open(path) as f:
+            state = json.load(f)
+    except Exception as e:
+        return False, [f"Cannot read file: {e}"]
+
+    for field, expected_type in REQUIRED_FIELDS.items():
+        if field not in state:
+            errors.append(f"Missing required field: {field}")
+        elif not isinstance(state[field], expected_type):
+            errors.append(f"Field '{field}' must be {expected_type.__name__}, got {type(state[field]).__name__}")
+
+    for field, required_value in LOOP_GATE_FIELDS.items():
+        if state.get(field) != required_value:
+            errors.append(f"LOOP GATE: '{field}' must be {required_value} before entering The Loop (got {state.get(field)})")
+
+    return len(errors) == 0, errors
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("Usage: validate-pipeline-state.py <path>")
+        sys.exit(1)
+
+    valid, errors = validate(sys.argv[1])
+    if valid:
+        print("✅ pipeline-state.json is valid")
+        sys.exit(0)
+    else:
+        print("❌ pipeline-state.json validation failed:")
+        for e in errors:
+            print(f"  - {e}")
+        sys.exit(1)


### PR DESCRIPTION
## What problem does this solve?

An RCA of a pipeline failure revealed three gaps in Lobster's context-recovery machinery that allow bad state to propagate silently:

1. **#1801**: Compact-catchup reconstructs dispatcher state from session notes, but never cross-checks whether that state matches what is actually on disk. If a session note encoded a wrong path or stale pipeline flag, every subsequent catchup inherited the error — indefinitely.

2. **#1802**: The dispatcher startup sequence validates the git branch but not project workspace health. A dispatcher that restarts with a drifted or missing project directory proceeds to work on that project without any early warning.

3. **#1805**: Pipeline state files (`pipeline-state.json`) have no schema enforcement. An artifact with `skill_valid: false` is indistinguishable from a valid one at load time, so agents can enter The Loop on invalid inputs.

## What changed

**`compact-catchup.md` — Filesystem Verification phase (closes #1801)**

Added a new `## Filesystem Verification` section between the Phase 4 commitment carry-forward and the Rules section. After reconstructing state from session notes, the agent now cross-checks each active project:
- Does the project directory exist on disk?
- Are any corpus/data paths mentioned in the session note present?
- Does any `pipeline-state.json` found on disk match the flags claimed in the session note?

Failures are surfaced as a `⚠️ State Mismatch` section in the catchup output rather than silently adopted. This is a behavioral instruction change — no code execution is added.

**`sys.dispatcher.bootup.md` — Project Health Checks at startup (closes #1802)**

Added a `### Project Health Checks (if active pipeline projects)` subsection to the Startup Behavior section. The dispatcher now has a documented gate: if handoff.md references an active pipeline project with invariants or a health-check script, evaluate those invariants at startup and alert on failures with the same urgency as the branch-check alert. Especially important post-compaction.

**`scripts/validate-pipeline-state.py` — Pipeline state schema enforcer (closes #1805)**

New standalone script. Validates a `pipeline-state.json` file against a defined schema:
- Required fields: `author` (str), `project` (str), `skill_valid` (bool), `current_round` (int), `writing_modes_used` (list)
- Loop gate: `skill_valid` must be `True` — exits 1 with a `LOOP GATE` error if not

Usage: `uv run validate-pipeline-state.py <path>`. Exit 0 = valid, exit 1 = invalid. Pure functions, no side effects.

## Before / after

```
Before (all three issues):
  Compact-catchup reads session note → adopts claimed state → perpetuates error
  Dispatcher starts → proceeds on invalid workspace → fails late
  Agent loads pipeline-state.json → no gate → enters Loop on invalid input

After:
  Compact-catchup reads session note → cross-checks disk → surfaces mismatch
  Dispatcher starts → checks project invariants → alerts early if drift detected
  validate-pipeline-state.py called before Loop entry → hard exit if skill_valid != True
```

## Functional patterns

The validator (`validate-pipeline-state.py`) uses pure functions with explicit error accumulation — `validate()` returns `(bool, list[str])` with no side effects. All branching is in code, not LLM judgment.

## Tests run
- [x] `python3 scripts/validate-pipeline-state.py` — usage message, correct exit
- [x] Valid state JSON → `✅ pipeline-state.json is valid`, exit 0
- [x] Missing `writing_modes_used` field → `❌ ... Missing required field`, exit 1
- [x] `skill_valid: false` → `❌ LOOP GATE: 'skill_valid' must be True`, exit 1

## Manual test
N/A — all three changes are documentation/instruction updates and a standalone script. No systemd, cron, external services, DB schema, or file I/O affecting runtime state. The script was exercised directly against test JSON fixtures above.

## Definition of Done
- [x] Unit tests pass (script validated against 3 fixture cases)
- [x] User-visible outcome: N/A — these are internal hardening changes
- [x] Side-effect audit: script is read-only; doc changes affect agent behavior on next compaction/startup
- [x] External service calls: none

Relates to #1801, #1802, #1805