### PR TITLE
fix: remove all hardcoded PII from public repo

### DIFF
--- a/lobster-shop/multiplayer-telegram-bot/tests/test_integration.py
+++ b/lobster-shop/multiplayer-telegram-bot/tests/test_integration.py
@@ -558,8 +558,8 @@ class TestFullEndToEndFlow:
 # Simulate the group that is already configured on the live system.
 LIVE_GROUP_ID = -5033634362
 LIVE_GROUP_ID_STR = str(LIVE_GROUP_ID)
-LIVE_USER_ID_ADMIN = 6645894734   # Primary admin user
-LIVE_USER_ID_MEMBER = 5717728951  # Secondary group member
+LIVE_USER_ID_ADMIN = 1111111111   # Primary admin user (placeholder — real ID in config)
+LIVE_USER_ID_MEMBER = 2222222222  # Secondary group member (placeholder — real ID in config)
 LIVE_GROUP_NAME = "Group"
 
 

--- a/scheduled-tasks/deprecated/gmail-watch-renewal.py
+++ b/scheduled-tasks/deprecated/gmail-watch-renewal.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -43,7 +44,8 @@ from integrations.gmail.token_store import get_valid_token  # noqa: E402
 GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1"
 PUBSUB_TOPIC = "projects/myownlobster/topics/gmail-investor-notifications"
 LABEL_IDS = ["INBOX"]
-LOBSTER_USER_ID = "6645894734"
+# Read from environment — never hardcode in source. Validated at runtime in main().
+LOBSTER_USER_ID: str = os.environ.get("LOBSTER_ADMIN_CHAT_ID") or os.environ.get("ADMIN_CHAT_ID") or ""
 CONFIG_PATH = Path.home() / "lobster-config" / "config.env"
 STATE_PATH = Path.home() / "lobster-workspace" / "data" / "gmail-watch-state.json"
 MCP_URL = "http://localhost:9100"
@@ -87,6 +89,11 @@ def call_gmail_watch(access_token: str) -> dict:
 
 
 def main() -> None:
+    if not LOBSTER_USER_ID:
+        msg = "LOBSTER_ADMIN_CHAT_ID env var is not set (set in ~/lobster-config/config.env)"
+        log.error(msg)
+        _write_task_output(msg, "failed")
+        sys.exit(1)
     try:
         token = get_valid_token(LOBSTER_USER_ID)
         if not token or not token.access_token:

--- a/scheduled-tasks/gmail-poll.py
+++ b/scheduled-tasks/gmail-poll.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import base64
 import json
 import logging
+import os
 import re
 import sys
 import time
@@ -56,7 +57,9 @@ SKIP_LABEL_IDS = frozenset({
 })
 
 # User ID for the Gmail token store (Telegram chat_id = user identifier).
-GMAIL_USER_ID = "6645894734"
+# Read from environment — never hardcode in source.
+# Validated at runtime in acquire_access_token(), not at import, so tests can load the module.
+GMAIL_USER_ID: str = os.environ.get("LOBSTER_ADMIN_CHAT_ID") or os.environ.get("ADMIN_CHAT_ID") or ""
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -304,8 +307,14 @@ def acquire_access_token() -> str:
     """Return a valid Gmail access token, refreshing via the token store if needed.
 
     Raises:
-        SystemExit(1): If no valid token is available.
+        SystemExit(1): If no valid token is available or LOBSTER_ADMIN_CHAT_ID is unset.
     """
+    if not GMAIL_USER_ID:
+        log.error(
+            "LOBSTER_ADMIN_CHAT_ID env var is not set. "
+            "Set it in ~/lobster-config/config.env."
+        )
+        sys.exit(1)
     token = get_valid_token(GMAIL_USER_ID)
     if token is None or not token.access_token:
         log.error(

--- a/scheduled-tasks/tasks/granola-sync.md
+++ b/scheduled-tasks/tasks/granola-sync.md
@@ -64,7 +64,7 @@ After running:
    - `output`: The JSON output from the script (or error message)
    - `status`: `"success"` or `"failed"`
 
-2. If `notes_written > 0`, send a Telegram notification to the admin (chat_id: 6645894734):
+2. If `notes_written > 0`, send a Telegram notification to the admin (chat_id from `LOBSTER_ADMIN_CHAT_ID` env var):
    - Message: `Granola sync: {notes_written} new notes added to vault. [{timestamp}]`
    - Keep it brief — only send if there are actually new notes.
 

--- a/src/channels/outbox.py
+++ b/src/channels/outbox.py
@@ -51,7 +51,7 @@ class OutboxFileHandler(_FSEHandler):
 
     **Writer mode** (original BIS-159 interface):
         handler = OutboxFileHandler(outbox_dir=Path("/home/lobster/messages/outbox"))
-        handler.write({"id": "12345_telegram", "chat_id": 6645894734, "text": "Hi"})
+        handler.write({"id": "12345_telegram", "chat_id": 1234567890, "text": "Hi"})
 
     **Watchdog mode** (BIS-166 router interface):
         Subclasses watchdog.FileSystemEventHandler so it can be passed directly

--- a/tests/test_messages_db.py
+++ b/tests/test_messages_db.py
@@ -175,7 +175,7 @@ class TestBuildMessageRow:
         return {
             "id": "1769219731361_22",
             "source": "telegram",
-            "chat_id": 6645894734,
+            "chat_id": 1234567890,
             "text": "Hello",
             "timestamp": "2026-01-24T01:55:31.361389",
         }
@@ -191,9 +191,9 @@ class TestBuildMessageRow:
 
     def test_chat_id_coerced_to_str(self):
         record = self._minimal()
-        record["chat_id"] = 6645894734  # int in JSON
+        record["chat_id"] = 1234567890  # int in JSON
         row = build_message_row(record, "in")
-        assert row["chat_id"] == "6645894734"
+        assert row["chat_id"] == "1234567890"
 
     def test_overflow_fields_go_to_extra(self):
         record = self._minimal()
@@ -227,14 +227,14 @@ class TestBuildBisqueEventRow:
         record = {
             "id": "bisque_123",
             "source": "bisque",
-            "chat_id": "drew@lobster.ai",
+            "chat_id": "user@example.com",
             "type": "text",
             "text": "Hello from bisque",
             "timestamp": "2026-03-19T09:33:49.129780+00:00",
         }
         row = build_bisque_event_row(record)
         assert row["id"] == "bisque_123"
-        assert row["chat_id"] == "drew@lobster.ai"
+        assert row["chat_id"] == "user@example.com"
         assert row["type"] == "text"
         assert row["text"] == "Hello from bisque"
 
@@ -265,7 +265,7 @@ class TestBuildAgentEventRow:
             "id": "1773682753027_reconciler_abc",
             "type": "subagent_result",
             "source": "telegram",
-            "chat_id": "6645894734",
+            "chat_id": "1234567890",
             "task_id": "abc123",
             "status": "success",
             "text": "Done",
@@ -359,7 +359,7 @@ class TestMigrateDirectory:
             {
                 "id": "msg001",
                 "source": "telegram",
-                "chat_id": "6645894734",
+                "chat_id": "1234567890",
                 "text": "hi there",
                 "timestamp": "2026-01-01T00:00:00",
             },
@@ -382,7 +382,7 @@ class TestMigrateDirectory:
                 "id": "agent001",
                 "type": "subagent_result",
                 "source": "telegram",
-                "chat_id": "6645894734",
+                "chat_id": "1234567890",
                 "task_id": "t001",
                 "status": "success",
                 "text": "Task done",
@@ -404,7 +404,7 @@ class TestMigrateDirectory:
             {
                 "id": "bisque001",
                 "source": "bisque",
-                "chat_id": "drew@lobster.ai",
+                "chat_id": "user@example.com",
                 "type": "text",
                 "text": "Bisque message",
                 "timestamp": "2026-01-01T00:00:02",
@@ -418,7 +418,7 @@ class TestMigrateDirectory:
             "SELECT * FROM bisque_events WHERE id = 'bisque001'"
         ).fetchone()
         assert row is not None
-        assert row["chat_id"] == "drew@lobster.ai"
+        assert row["chat_id"] == "user@example.com"
 
     def test_idempotent_migration(self, tmp_dir):
         write_json(
@@ -427,7 +427,7 @@ class TestMigrateDirectory:
             {
                 "id": "dup001",
                 "source": "telegram",
-                "chat_id": "6645894734",
+                "chat_id": "1234567890",
                 "text": "duplicate",
                 "timestamp": "2026-01-01T00:00:00",
             },
@@ -465,7 +465,7 @@ class TestMigrateDirectory:
             {
                 "id": "sent001",
                 "source": "telegram",
-                "chat_id": "6645894734",
+                "chat_id": "1234567890",
                 "text": "reply text",
                 "timestamp": "2026-01-01T00:00:00",
             },

--- a/tests/unit/test_db_message_store.py
+++ b/tests/unit/test_db_message_store.py
@@ -362,7 +362,7 @@ class TestDBRoundTrip:
             "id": "ae-test-1",
             "type": "subagent_result",
             "source": "telegram",
-            "chat_id": 6645894734,
+            "chat_id": 1234567890,
             "task_id": "task-abc",
             "text": "Done!",
             "status": "success",

--- a/tests/unit/test_scheduled_tasks/test_gmail_poll.py
+++ b/tests/unit/test_scheduled_tasks/test_gmail_poll.py
@@ -210,7 +210,7 @@ class TestExtractBody:
 # should_skip_message
 # ---------------------------------------------------------------------------
 
-ACCOUNT_EMAIL = "sebastian@alternativewealthpartners.com"
+ACCOUNT_EMAIL = "owner@example.com"
 
 # SKIP_LABEL_IDS is a frozenset defined in the module.
 PROMO_LABEL = next(iter(SKIP_LABEL_IDS))  # any one skip label
@@ -259,7 +259,7 @@ class TestBuildInboxMessage:
         subject: Optional[str] = "Investment Inquiry",
         from_name: Optional[str] = "Bob Investor",
         from_email: str = "bob@investor.com",
-        to_header: Optional[str] = "sebastian@alternativewealthpartners.com",
+        to_header: Optional[str] = "owner@example.com",
         body_text: str = "Hi, I am interested in investing.",
         received_at: str = "2024-01-01T00:00:00+00:00",
         account_email: str = ACCOUNT_EMAIL,


### PR DESCRIPTION
## Problem

PR #1809 (merged Apr 25) brought gmail-poll.py under version control. That file, along with its tests and several pre-existing files, contained hardcoded PII that must not appear in a public open-source repository:

- Telegram chat ID 6645894734 (owner's real ID) — in gmail-poll.py, deprecated/gmail-watch-renewal.py, test fixtures in test_messages_db.py, test_db_message_store.py, and a docstring example in outbox.py
- Telegram user IDs 6645894734 and 5717728951 — in lobster-shop/multiplayer-telegram-bot/tests/test_integration.py, labeled as "Primary admin user" and "Secondary group member"
- Email address (personal AWP domain) — in tests/unit/test_scheduled_tasks/test_gmail_poll.py as ACCOUNT_EMAIL constant and to_header default

## What changed

**Runtime scripts** — two scripts now read user ID from the environment rather than embedding it:

- scheduled-tasks/gmail-poll.py: GMAIL_USER_ID reads LOBSTER_ADMIN_CHAT_ID env var (fallback: ADMIN_CHAT_ID). Validation is in acquire_access_token() rather than at import time, so the module can be loaded in tests without the env var set.
- scheduled-tasks/deprecated/gmail-watch-renewal.py: same pattern, validation in main().

**Task definition** — scheduled-tasks/tasks/granola-sync.md: replaces the literal chat_id value with a reference to the LOBSTER_ADMIN_CHAT_ID env var.

**Test fixtures** — replaced with clearly fictional placeholder values:
- Real Telegram chat ID replaced with 1234567890 everywhere it appeared as a test fixture
- Personal email (AWP domain) replaced with owner@example.com
- drew@lobster.ai replaced with user@example.com
- Real LIVE_USER_ID_ADMIN and LIVE_USER_ID_MEMBER values replaced with 1111111111 / 2222222222 with updated comments

**Docstring** — src/channels/outbox.py: example in class docstring uses 1234567890 instead of the real chat ID.

No behavioral logic is changed. The env var pattern matches what lobstertalk_unified.py already uses.

## Functional patterns

Pure configuration injection: the user ID is read from the environment at module load and validated at the point of use (the side-effecting acquire_access_token() function), keeping pure helper functions free of I/O.

## History note

The PII still exists in git history at commit d420e26 and earlier commits. This PR removes it from HEAD. Full expunge requires git filter-repo + force push to main — that rewrites public history and will break forks/clones. Drew should decide whether to proceed.

## Tests run

- [x] uv run pytest tests/unit/test_scheduled_tasks/ -v — 37 passed, 0 failed
- [x] uv run pytest tests/test_messages_db.py tests/unit/test_db_message_store.py -v — 83 passed, 0 failed
- [x] uv run pytest tests/unit/ --ignore=tests/unit/test_mcp_server/ -q — 2100 passed, 24 skipped, 2 pre-existing vector memory failures (confirmed failing on main before this change)
- [x] Pre-push PII scanner — All clear, no PII or security issues detected

Pre-existing failures (not caused by this PR):
- tests/unit/test_mcp_server/ — ADMIN_CHAT_ID_REDACTED used as Python identifier instead of string literal in two files
- tests/unit/test_memory.py::TestVectorMemory — vector similarity threshold failures

## Manual test

N/A — internal change only. No external services, no systemd units, no file I/O behavior changed. Runtime behavior of the scripts is identical — env var was already set in production via config.env.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A, internal change
- [x] User-visible outcome — N/A
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none introduced