### PR TITLE
feat(#1786): add PreToolUse heartbeat hook

### DIFF
--- a/hooks/pre-tool-heartbeat.py
+++ b/hooks/pre-tool-heartbeat.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook: dispatcher pre-tool heartbeat.
+
+Writes the current Unix epoch timestamp to a dedicated heartbeat file on every
+PreToolUse event. This complements thinking-heartbeat.py (PostToolUse) and narrows
+the detection window for inference-gap cases (issue #1695).
+
+Purpose
+-------
+thinking-heartbeat.py fires after each tool call completes. For long-running tools
+(e.g., wait_for_messages with a multi-hour timeout), the post-tool signal goes stale
+even though the dispatcher is alive and about to execute a tool. The pre-tool
+heartbeat fires *before* the tool runs, so:
+
+  - A stale pre-tool heartbeat + fresh post-tool heartbeat => tool is running (OK)
+  - A stale pre-tool heartbeat + stale post-tool heartbeat => dispatcher frozen (BAD)
+  - A fresh pre-tool heartbeat + stale post-tool heartbeat => tool is running (OK)
+
+In practice, the health check can use the pre-tool heartbeat as a lower bound on
+dispatcher liveness: if neither signal has been updated in N seconds, the dispatcher
+is frozen.
+
+For the inference-gap case (#1695, #1786): lowering the PostToolUse heartbeat
+threshold (currently 1200s) risks false positives during legitimate long tool calls.
+The pre-tool heartbeat lets us reduce that threshold safely — it confirms the
+dispatcher called the tool even if post-tool hasn't fired yet.
+
+Design
+------
+- Fires on every PreToolUse (matcher: "")
+- Atomic write: write to .tmp, then os.rename() to avoid partial reads
+- Single integer timestamp — no JSON parsing, no locking, no network
+- Silent on failure: health check degrades gracefully when file absent
+- < 1ms on warm OS (rename is a kernel atomic op on same-filesystem paths)
+
+File location: ~/lobster-workspace/logs/dispatcher-pre-tool-heartbeat
+Content: single Unix epoch integer (e.g. "1713456789\\n")
+
+See issue #1786 (thinking-freeze mitigations) and #1695 (inference-gap detection).
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+
+WORKSPACE_DIR = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+HEARTBEAT_FILE = Path(
+    os.environ.get(
+        "LOBSTER_PRE_TOOL_HEARTBEAT_OVERRIDE",
+        WORKSPACE_DIR / "logs" / "dispatcher-pre-tool-heartbeat",
+    )
+)
+
+
+def write_heartbeat(heartbeat_file: Path) -> None:
+    """Write current Unix epoch to heartbeat_file atomically."""
+    heartbeat_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp = heartbeat_file.with_suffix(".tmp")
+    tmp.write_text(str(int(time.time())) + "\n")
+    os.rename(str(tmp), str(heartbeat_file))
+
+
+def main() -> None:
+    try:
+        write_heartbeat(HEARTBEAT_FILE)
+    except Exception:
+        # Never block tool execution.
+        pass
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/install.sh
+++ b/install.sh
@@ -1696,6 +1696,29 @@ else
     info "Skipping thinking-heartbeat hook (settings.json not yet created)"
 fi
 
+# Set up Claude Code PreToolUse hook to write a pre-tool heartbeat timestamp (issue #1786).
+# Complements thinking-heartbeat.py (PostToolUse) and narrows the inference-gap detection
+# window (#1695), allowing the PostToolUse threshold to be lowered without false positives.
+chmod +x "$INSTALL_DIR/hooks/pre-tool-heartbeat.py" || true
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.PreToolUse[]? | select(.hooks[]?.command | contains("pre-tool-heartbeat"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+            "matcher": "",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 '"$INSTALL_DIR"'/hooks/pre-tool-heartbeat.py",
+                "timeout": 5
+            }]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "pre-tool-heartbeat hook installed"
+    else
+        info "pre-tool-heartbeat hook already configured in Claude Code settings"
+    fi
+else
+    info "Skipping pre-tool-heartbeat hook (settings.json not yet created)"
+fi
+
 # Set up Claude Code PreToolUse hook to block tool use after compaction without context reload.
 # Uses a shell wrapper so Python is only spawned when the sentinel file exists (~1% of calls).
 # On the 99%+ of calls where the sentinel is absent, `test ! -f ...` exits in ~1ms with no

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2778,6 +2778,44 @@ CREATE TABLE IF NOT EXISTS dispatcher_lock (
         fi
     done
 
+    # Migration 81: Install PreToolUse heartbeat hook (issue #1786).
+    # pre-tool-heartbeat.py writes a timestamp before each tool call, complementing
+    # thinking-heartbeat.py (PostToolUse). Together they allow the health check to
+    # distinguish "tool is running (long)" from "dispatcher is frozen" without
+    # false positives, enabling the PostToolUse threshold to be lowered safely.
+    if [ -f "$CLAUDE_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
+        local _m81_hook_path="$LOBSTER_DIR/hooks/pre-tool-heartbeat.py"
+        if [ -f "$_m81_hook_path" ]; then
+            chmod +x "$_m81_hook_path" 2>/dev/null || true
+            local _m81_present
+            _m81_present=$(jq -r '
+                [.hooks.PreToolUse[]?.hooks[]?.command // empty]
+                | map(select(contains("pre-tool-heartbeat")))
+                | length
+            ' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+            if [ "${_m81_present:-0}" = "0" ] || [ "${_m81_present:-0}" = "" ]; then
+                TMP_SETTINGS=$(mktemp)
+                jq --arg cmd "python3 $LOBSTER_DIR/hooks/pre-tool-heartbeat.py" \
+                   '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+                    "matcher": "",
+                    "hooks": [{
+                        "type": "command",
+                        "command": $cmd,
+                        "timeout": 5
+                    }]
+                }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+                substep "Registered pre-tool-heartbeat hook in Claude Code settings"
+                migrated=$((migrated + 1))
+            else
+                substep "pre-tool-heartbeat hook already present — skipping Migration 81"
+            fi
+        else
+            warn "pre-tool-heartbeat.py not found at $_m81_hook_path — skipping Migration 81"
+        fi
+    else
+        warn "Claude settings not found at $CLAUDE_SETTINGS or jq missing — skipping Migration 81"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/tests/unit/test_hooks/test_pre_tool_heartbeat.py
+++ b/tests/unit/test_hooks/test_pre_tool_heartbeat.py
@@ -1,0 +1,218 @@
+"""
+Unit tests for hooks/pre-tool-heartbeat.py
+
+Tests cover the PreToolUse heartbeat hook (issue #1786):
+- write_heartbeat() writes a Unix epoch integer to the heartbeat file
+- Atomic write: uses .tmp then rename, no .tmp left behind
+- Creates parent directory if absent
+- Overwrites existing content on each call
+- Timestamp is within a small window of time.time()
+- main() exits 0 on success
+- main() exits 0 even when write fails (silent failure — never block tool use)
+- LOBSTER_PRE_TOOL_HEARTBEAT_OVERRIDE env var is respected
+- Written to a DIFFERENT file than the PostToolUse heartbeat
+
+The hook is intentionally symmetric with thinking-heartbeat.py (PostToolUse)
+but writes to dispatcher-pre-tool-heartbeat instead of dispatcher-heartbeat.
+"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+import time
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+HOOK_PATH = _HOOKS_DIR / "pre-tool-heartbeat.py"
+
+# How close (in seconds) the written timestamp must be to now.
+TIMESTAMP_TOLERANCE_SECONDS = 5
+
+
+# ---------------------------------------------------------------------------
+# Module loader
+# ---------------------------------------------------------------------------
+
+def _load_module(monkeypatch, heartbeat_file: Path):
+    """Load pre-tool-heartbeat as a fresh module with heartbeat file override."""
+    monkeypatch.setenv("LOBSTER_PRE_TOOL_HEARTBEAT_OVERRIDE", str(heartbeat_file))
+    spec = importlib.util.spec_from_file_location("pre_tool_heartbeat", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_raw():
+    """Load module without any env override (uses default paths internally)."""
+    spec = importlib.util.spec_from_file_location("pre_tool_heartbeat_raw", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests
+# ---------------------------------------------------------------------------
+
+class TestWriteHeartbeat:
+    def test_writes_integer_epoch_to_file(self, tmp_path):
+        mod = _load_raw()
+        hb = tmp_path / "dispatcher-pre-tool-heartbeat"
+        before = int(time.time())
+        mod.write_heartbeat(hb)
+        after = int(time.time())
+        assert hb.exists()
+        content = hb.read_text().strip()
+        ts = int(content)
+        assert before <= ts <= after + 1  # allow 1s rounding
+
+    def test_content_is_pure_integer_no_json(self, tmp_path):
+        mod = _load_raw()
+        hb = tmp_path / "dispatcher-pre-tool-heartbeat"
+        mod.write_heartbeat(hb)
+        content = hb.read_text().strip()
+        # Must be parseable as int, not JSON
+        ts = int(content)
+        assert ts > 0
+
+    def test_no_tmp_file_left_behind(self, tmp_path):
+        mod = _load_raw()
+        hb = tmp_path / "dispatcher-pre-tool-heartbeat"
+        mod.write_heartbeat(hb)
+        tmp = hb.with_suffix(".tmp")
+        assert not tmp.exists()
+
+    def test_creates_parent_directory(self, tmp_path):
+        mod = _load_raw()
+        nested = tmp_path / "nested" / "deep" / "dispatcher-pre-tool-heartbeat"
+        mod.write_heartbeat(nested)
+        assert nested.exists()
+
+    def test_overwrites_previous_content(self, tmp_path):
+        mod = _load_raw()
+        hb = tmp_path / "dispatcher-pre-tool-heartbeat"
+        hb.write_text("99999\n")
+        time.sleep(0.01)
+        mod.write_heartbeat(hb)
+        content = hb.read_text().strip()
+        ts = int(content)
+        # New timestamp should be recent (not the old 99999)
+        assert ts > 1000000000  # sanity: real epoch, not legacy value
+
+    def test_timestamp_within_tolerance_of_now(self, tmp_path):
+        mod = _load_raw()
+        hb = tmp_path / "dispatcher-pre-tool-heartbeat"
+        before = time.time()
+        mod.write_heartbeat(hb)
+        after = time.time()
+        ts = int(hb.read_text().strip())
+        assert before - TIMESTAMP_TOLERANCE_SECONDS <= ts <= after + TIMESTAMP_TOLERANCE_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Separation from PostToolUse heartbeat file
+# ---------------------------------------------------------------------------
+
+class TestHeartbeatFileSeparation:
+    """Pre-tool heartbeat must use a different filename than the PostToolUse heartbeat."""
+
+    def test_default_filename_is_not_dispatcher_heartbeat(self):
+        """Default file must be dispatcher-pre-tool-heartbeat, not dispatcher-heartbeat."""
+        mod = _load_raw()
+        assert "pre-tool" in str(mod.HEARTBEAT_FILE), (
+            f"Expected 'pre-tool' in heartbeat path, got: {mod.HEARTBEAT_FILE}"
+        )
+
+    def test_default_filename_differs_from_post_tool_heartbeat(self):
+        """Pre-tool and post-tool heartbeat files must be different paths."""
+        pre_spec = importlib.util.spec_from_file_location("pre_hb", HOOK_PATH)
+        pre_mod = importlib.util.module_from_spec(pre_spec)
+        pre_spec.loader.exec_module(pre_mod)
+
+        post_path = _HOOKS_DIR / "thinking-heartbeat.py"
+        post_spec = importlib.util.spec_from_file_location("post_hb", post_path)
+        post_mod = importlib.util.module_from_spec(post_spec)
+        post_spec.loader.exec_module(post_mod)
+
+        assert pre_mod.HEARTBEAT_FILE != post_mod.HEARTBEAT_FILE, (
+            "Pre-tool and post-tool heartbeat hooks must write to different files"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Hook main() integration tests
+# ---------------------------------------------------------------------------
+
+def _run_hook(monkeypatch, heartbeat_file: Path) -> tuple[int, str, str]:
+    """Execute the hook's main() capturing exit code and stdio."""
+    monkeypatch.setenv("LOBSTER_PRE_TOOL_HEARTBEAT_OVERRIDE", str(heartbeat_file))
+
+    spec = importlib.util.spec_from_file_location("pre_tool_heartbeat", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+
+    stdout_cap = StringIO()
+    stderr_cap = StringIO()
+
+    exit_code = None
+    with (
+        patch("sys.stdout", stdout_cap),
+        patch("sys.stderr", stderr_cap),
+    ):
+        try:
+            spec.loader.exec_module(mod)
+            mod.main()
+        except SystemExit as e:
+            exit_code = e.code
+
+    return exit_code, stdout_cap.getvalue(), stderr_cap.getvalue()
+
+
+class TestHookMain:
+    def test_exits_zero_on_success(self, monkeypatch, tmp_path):
+        hb = tmp_path / "dispatcher-pre-tool-heartbeat"
+        code, _, _ = _run_hook(monkeypatch, hb)
+        assert code == 0
+
+    def test_writes_heartbeat_on_success(self, monkeypatch, tmp_path):
+        hb = tmp_path / "dispatcher-pre-tool-heartbeat"
+        _run_hook(monkeypatch, hb)
+        assert hb.exists()
+        ts = int(hb.read_text().strip())
+        assert ts > 0
+
+    def test_exits_zero_even_when_write_fails(self, monkeypatch, tmp_path):
+        """Hook must never block tool execution even if write fails."""
+        readonly_dir = tmp_path / "readonly_dir"
+        readonly_dir.mkdir()
+        readonly_dir.chmod(0o444)  # read-only directory
+        hb = readonly_dir / "dispatcher-pre-tool-heartbeat"
+
+        try:
+            code, _, _ = _run_hook(monkeypatch, hb)
+            assert code == 0
+        finally:
+            readonly_dir.chmod(0o755)  # restore for cleanup
+
+    def test_env_override_respected(self, monkeypatch, tmp_path):
+        """LOBSTER_PRE_TOOL_HEARTBEAT_OVERRIDE must be used when set."""
+        custom = tmp_path / "custom-pre-tool-heartbeat"
+        code, _, _ = _run_hook(monkeypatch, custom)
+        assert code == 0
+        assert custom.exists()
+
+    def test_no_stdout_output(self, monkeypatch, tmp_path):
+        """Hook must produce no stdout output."""
+        hb = tmp_path / "dispatcher-pre-tool-heartbeat"
+        _, stdout, _ = _run_hook(monkeypatch, hb)
+        assert stdout == ""
+
+    def test_no_stderr_output(self, monkeypatch, tmp_path):
+        """Hook must produce no stderr output."""
+        hb = tmp_path / "dispatcher-pre-tool-heartbeat"
+        _, _, stderr = _run_hook(monkeypatch, hb)
+        assert stderr == ""


### PR DESCRIPTION
## Summary

- Adds `hooks/pre-tool-heartbeat.py`: a PreToolUse hook that writes a Unix epoch timestamp to `~/lobster-workspace/logs/dispatcher-pre-tool-heartbeat` before every tool call
- Registers the hook in `install.sh` (new installs) and `scripts/upgrade.sh` Migration 81 (existing installs)
- Adds 14 unit tests in `tests/unit/test_hooks/test_pre_tool_heartbeat.py` (all pass)

## Context

Issue #1786 tracks dispatcher thinking-freeze mitigations. The PostToolUse heartbeat (`thinking-heartbeat.py`) correctly detects complete freezes. However, the 1200s detection threshold is high because lowering it risks false positives when legitimate long-running tools (e.g., `wait_for_messages`) are executing — the post-tool signal goes stale while the tool runs.

The pre-tool heartbeat fires **before** each tool call, so the health check can now distinguish:
- Fresh pre-tool + stale post-tool => tool is currently running (no freeze)
- Stale pre-tool + stale post-tool => dispatcher is genuinely frozen (restart)

This paves the way to lower the PostToolUse threshold from 1200s to ~600s, halving MTTR without increasing false positives.

Note: as the issue correctly states, this hook does NOT prevent thinking freezes (a frozen dispatcher never calls tools, so the hook never fires). Its purpose is to narrow the inference-gap detection window for issue #1695 and enable a safer threshold reduction.

## Test plan

- [ ] All 14 unit tests pass: `python3 -m pytest tests/unit/test_hooks/test_pre_tool_heartbeat.py -v`
- [ ] `hooks/pre-tool-heartbeat.py` is executable
- [ ] After running `install.sh` or `upgrade.sh`, `~/.claude/settings.json` contains a PreToolUse entry for `pre-tool-heartbeat.py` with matcher `""`
- [ ] After a tool call fires, `~/lobster-workspace/logs/dispatcher-pre-tool-heartbeat` exists and contains a recent epoch integer
- [ ] Hook exits 0 even when the target directory is not writable

🤖 Generated with [Claude Code](https://claude.com/claude-code)