### PR TITLE
feat(#1751): implement catchup-gate Option B — DB-based dispatcher gate during catchup

### DIFF
--- a/hooks/catchup-gate.py
+++ b/hooks/catchup-gate.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""
+PreToolUse gate: while compact-catchup or startup-catchup is in-flight,
+block substantive dispatcher tool calls and redirect to wait_for_messages.
+
+## Design (Option B)
+
+Queries agent_sessions.db directly to determine whether a catchup session is
+still running. No flag file required — reuses the existing IPC mechanism.
+
+A session is "active" when:
+  1. task_id is 'startup-catchup' OR starts with 'compact-catchup'
+  2. status = 'running'
+  3. spawned_at is within CATCHUP_WINDOW_SECONDS (120 s) of now
+
+The 120-second window prevents this hook from blocking indefinitely if a
+catchup session record is never updated to a terminal status (e.g. the
+subagent crashed before calling write_result). After 120 seconds the hook
+stops gating — the system degrades gracefully rather than deadlocking.
+
+## DB query
+
+    SELECT spawned_at
+    FROM agent_sessions
+    WHERE (task_id = 'startup-catchup' OR task_id LIKE 'compact-catchup%')
+      AND status = 'running'
+    ORDER BY spawned_at DESC
+    LIMIT 1
+
+Only the most recent matching row is checked (ORDER BY spawned_at DESC LIMIT 1).
+
+## Fail-open policy
+
+If the DB file is missing, locked, corrupt, or the query fails for any other
+reason: exit(0). This hook must never block the dispatcher due to its own
+infrastructure failures.
+
+## Allow-list (always passes through, even during active catchup)
+
+  - mcp__lobster-inbox__wait_for_messages
+  - mcp__lobster-inbox__check_inbox
+  - mcp__lobster-inbox__mark_processing
+  - mcp__lobster-inbox__mark_processed
+  - mcp__lobster-inbox__mark_failed
+  - mcp__lobster-inbox__send_reply
+  - mcp__lobster-inbox__claim_and_ack
+
+## Session discrimination
+
+Only the dispatcher session is gated. Subagents are identified by the presence
+of the agent_id field (absent from dispatcher PreToolUse payloads), which is
+the fast-path exit. The full layered detection from session_role.py is then
+applied: state files → process-tree walk.
+
+## Settings.json configuration
+
+Add to hooks → PreToolUse:
+
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 $HOME/lobster/hooks/catchup-gate.py",
+          "timeout": 5
+        }
+      ]
+    }
+"""
+
+import json
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+# Make hooks/ importable regardless of cwd.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from session_role import is_dispatcher_session  # noqa: E402 — after sys.path insertion
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# DB path: check canonical workspace location.
+_WORKSPACE = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+AGENT_SESSIONS_DB = _WORKSPACE / "data" / "agent_sessions.db"
+
+# A catchup session must have been spawned within this window to trigger the gate.
+CATCHUP_WINDOW_SECONDS = 120
+
+LOG_FILE = _WORKSPACE / "logs" / "catchup-gate.log"
+
+# SQL query: most recent running catchup session, most-recent-first.
+_QUERY = (
+    "SELECT spawned_at FROM agent_sessions "
+    "WHERE (task_id='startup-catchup' OR task_id LIKE 'compact-catchup%') "
+    "AND status='running' "
+    "ORDER BY spawned_at DESC LIMIT 1"
+)
+
+# Tools that always pass through while catchup is in flight.
+ALWAYS_ALLOWED_TOOLS: frozenset[str] = frozenset({
+    "mcp__lobster-inbox__wait_for_messages",
+    "mcp__lobster-inbox__check_inbox",
+    "mcp__lobster-inbox__mark_processing",
+    "mcp__lobster-inbox__mark_processed",
+    "mcp__lobster-inbox__mark_failed",
+    "mcp__lobster-inbox__send_reply",
+    "mcp__lobster-inbox__claim_and_ack",
+})
+
+BLOCK_MESSAGE = (
+    "Catching up — give me 90 seconds. "
+    "compact-catchup or startup-catchup is still running. "
+    "The dispatcher must not take substantive actions until catchup completes. "
+    "Call `mcp__lobster-inbox__wait_for_messages` to resume the main loop and "
+    "await the catchup write_result."
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _log(tool_name: str, action: str) -> None:
+    """Append a JSON log line to catchup-gate.log. Silent on any failure."""
+    try:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        line = json.dumps({"ts": ts, "tool": tool_name, "action": action}) + "\n"
+        with LOG_FILE.open("a") as f:
+            f.write(line)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _catchup_is_active() -> bool:
+    """Return True iff a running catchup session was spawned within the window.
+
+    Queries agent_sessions.db directly. Returns False on any error (fail open).
+    """
+    db_path = AGENT_SESSIONS_DB
+    if not db_path.exists():
+        return False  # No DB → fail open
+
+    try:
+        # timeout=1 avoids blocking on a locked DB.
+        conn = sqlite3.connect(str(db_path), timeout=1)
+        try:
+            cursor = conn.execute(_QUERY)
+            row = cursor.fetchone()
+        finally:
+            conn.close()
+    except Exception:  # noqa: BLE001 — sqlite3.OperationalError, DatabaseError, etc.
+        return False  # Fail open on any DB error
+
+    if row is None:
+        return False  # No matching running session
+
+    spawned_at_str: str = row[0]
+    try:
+        # Parse ISO8601 UTC: "2026-04-25T12:34:56Z"
+        # calendar.timegm interprets the struct_time as UTC (unlike mktime which
+        # uses local time), so no manual offset adjustment is needed.
+        import calendar
+        spawned_ts_utc = calendar.timegm(
+            time.strptime(spawned_at_str, "%Y-%m-%dT%H:%M:%SZ")
+        )
+        age = time.time() - spawned_ts_utc
+        return 0 <= age < CATCHUP_WINDOW_SECONDS
+    except (ValueError, OverflowError):
+        return False  # Unparseable timestamp → fail open
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    # Fast path: agent_id is injected by CC only for subagent PreToolUse payloads.
+    # Dispatcher payloads never have agent_id.
+    if data.get("agent_id"):
+        sys.exit(0)
+
+    # Only enforce for the dispatcher session.
+    if not is_dispatcher_session(data):
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+
+    # Allow-listed tools always pass through.
+    if tool_name in ALWAYS_ALLOWED_TOOLS:
+        sys.exit(0)
+
+    # Check the DB. If no active catchup, allow everything.
+    if not _catchup_is_active():
+        sys.exit(0)
+
+    # Active catchup: block substantive tools.
+    _log(tool_name, "blocked")
+    print(BLOCK_MESSAGE, file=sys.stderr)
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/catchup-gate.py
+++ b/hooks/catchup-gate.py
@@ -113,7 +113,7 @@ ALWAYS_ALLOWED_TOOLS: frozenset[str] = frozenset({
 })
 
 BLOCK_MESSAGE = (
-    "Catching up — give me 90 seconds. "
+    "Catching up — give me 120 seconds. "
     "compact-catchup or startup-catchup is still running. "
     "The dispatcher must not take substantive actions until catchup completes. "
     "Call `mcp__lobster-inbox__wait_for_messages` to resume the main loop and "

--- a/install.sh
+++ b/install.sh
@@ -1743,6 +1743,29 @@ else
     info "Skipping post-compact-gate hook (settings.json not yet created)"
 fi
 
+# Set up Claude Code PreToolUse hook to gate tool calls while compact-catchup is in-flight.
+# Option B: queries agent_sessions.db directly — no flag file needed.
+chmod +x "$INSTALL_DIR/hooks/catchup-gate.py" || true
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.PreToolUse[]? | select(.hooks[]?.command | test("catchup-gate"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq --arg cmd "python3 $INSTALL_DIR/hooks/catchup-gate.py" \
+           '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+            "matcher": "",
+            "hooks": [{
+                "type": "command",
+                "command": $cmd,
+                "timeout": 5
+            }]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "catchup-gate hook installed"
+    else
+        info "catchup-gate hook already configured in Claude Code settings"
+    fi
+else
+    info "Skipping catchup-gate hook (settings.json not yet created)"
+fi
+
 # Set up Claude Code PreToolUse hook to warn when outgoing messages contain secrets
 chmod +x "$INSTALL_DIR/hooks/secret-scanner.py" || true
 if [ -f "$CLAUDE_SETTINGS" ]; then

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2816,6 +2816,50 @@ CREATE TABLE IF NOT EXISTS dispatcher_lock (
         warn "Claude settings not found at $CLAUDE_SETTINGS or jq missing — skipping Migration 81"
     fi
 
+    # Migration 82: Update catchup-gate.py PreToolUse hook to direct Python invocation.
+    # The old entry used a flag-file guard: `test ! -f .../catchup-pending || python3 ...`
+    # Option B (issue #1751) queries agent_sessions.db directly — no flag file needed.
+    # This migration replaces the old flag-file-guarded command with a direct call so the
+    # hook runs on every tool invocation and performs the DB check itself (fast, fail-open).
+    if [ -f "$CLAUDE_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
+        local _m82_hook_path="$LOBSTER_DIR/hooks/catchup-gate.py"
+        if [ -f "$_m82_hook_path" ]; then
+            chmod +x "$_m82_hook_path" 2>/dev/null || true
+            local _m82_new_cmd="python3 $LOBSTER_DIR/hooks/catchup-gate.py"
+            # Check whether the old flag-file-guarded entry is still present
+            local _m82_old_present
+            _m82_old_present=$(jq -r '
+                [.hooks.PreToolUse[]?.hooks[]?.command // empty]
+                | map(select(contains("catchup-pending")))
+                | length
+            ' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+            if [ "${_m82_old_present:-0}" != "0" ] && [ "${_m82_old_present:-0}" != "" ]; then
+                TMP_SETTINGS=$(mktemp)
+                # Replace the flag-file-guarded command with direct Python invocation.
+                jq --arg old_pattern "catchup-pending" \
+                   --arg new_cmd "$_m82_new_cmd" \
+                   '.hooks.PreToolUse = [
+                       .hooks.PreToolUse[]
+                       | .hooks = [
+                           .hooks[]
+                           | if (.command // "") | contains($old_pattern)
+                             then .command = $new_cmd
+                             else .
+                             end
+                         ]
+                   ]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+                substep "Updated catchup-gate.py hook: removed flag-file guard, now calls Python directly"
+                migrated=$((migrated + 1))
+            else
+                substep "catchup-gate.py hook already uses direct invocation — skipping Migration 82"
+            fi
+        else
+            warn "catchup-gate.py not found at $_m82_hook_path — skipping Migration 82"
+        fi
+    else
+        warn "Claude settings not found at $CLAUDE_SETTINGS or jq missing — skipping Migration 82"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/tests/unit/test_hooks/test_catchup_gate.py
+++ b/tests/unit/test_hooks/test_catchup_gate.py
@@ -1,0 +1,575 @@
+"""
+Unit tests for hooks/catchup-gate.py
+
+Option B design: queries agent_sessions.db directly to check whether
+a startup-catchup or compact-catchup session is still running.
+No flag file — reuses existing IPC.
+
+Tests cover:
+- Passes through immediately when agent_id present (subagent fast path)
+- Passes through when not the dispatcher session
+- DB file missing → fail open (exit 0)
+- DB query fails (locked, corrupt) → fail open (exit 0)
+- No matching running session → allow tool call
+- Running session but spawned_at > CATCHUP_WINDOW_SECONDS ago → allow (stale)
+- Running session within CATCHUP_WINDOW_SECONDS → block with exit(2)
+- Allow-listed tools always pass through even during active catchup
+- Non-allow-listed tools are blocked during active catchup
+- Block message contains "Catching up" text (as specified in task)
+"""
+
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Constants — match the implementation
+# ---------------------------------------------------------------------------
+
+CATCHUP_WINDOW_SECONDS = 120  # as specified in issue
+
+ALWAYS_ALLOWED_TOOLS = [
+    "mcp__lobster-inbox__wait_for_messages",
+    "mcp__lobster-inbox__check_inbox",
+    "mcp__lobster-inbox__mark_processing",
+    "mcp__lobster-inbox__mark_processed",
+    "mcp__lobster-inbox__mark_failed",
+    "mcp__lobster-inbox__send_reply",
+    "mcp__lobster-inbox__claim_and_ack",
+]
+
+HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+HOOK_PATH = HOOKS_DIR / "catchup-gate.py"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_db(tmp_path: Path, sessions: list[dict]) -> Path:
+    """Create a minimal agent_sessions.db with provided rows."""
+    db_dir = tmp_path / "data"
+    db_dir.mkdir(parents=True, exist_ok=True)
+    db_path = db_dir / "agent_sessions.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """CREATE TABLE agent_sessions (
+            id TEXT PRIMARY KEY,
+            task_id TEXT,
+            status TEXT,
+            spawned_at TEXT
+        )"""
+    )
+    for s in sessions:
+        conn.execute(
+            "INSERT INTO agent_sessions (id, task_id, status, spawned_at) VALUES (?,?,?,?)",
+            (s["id"], s["task_id"], s["status"], s["spawned_at"]),
+        )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _utc_iso(offset_seconds: float = 0) -> str:
+    """Return ISO8601 UTC timestamp offset by given seconds from now."""
+    ts = time.time() + offset_seconds
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts))
+
+
+def _load_hook(monkeypatch, tmp_path: Path, db_path: Path | None = None):
+    """Load catchup-gate.py as a fresh module, wiring DB path via env var."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    if db_path is not None:
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+    else:
+        # Point at a non-existent DB so it fails open.
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path / "no_such_dir"))
+
+    spec = importlib.util.spec_from_file_location("catchup_gate", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    if str(HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(HOOKS_DIR))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_hook_input(
+    tool_name: str = "mcp__lobster-inbox__write_result",
+    tool_input: dict | None = None,
+    agent_id: str | None = None,
+    session_id: str = "sess-dispatcher-001",
+) -> dict:
+    payload = {
+        "tool_name": tool_name,
+        "tool_input": tool_input or {},
+        "session_id": session_id,
+    }
+    if agent_id is not None:
+        payload["agent_id"] = agent_id
+    return payload
+
+
+def _run_hook(mod, hook_input: dict) -> tuple[int, str, str]:
+    """Run mod.main() with hook_input as stdin. Returns (exit_code, stdout, stderr)."""
+    stdout_cap = StringIO()
+    stderr_cap = StringIO()
+    stdin_data = json.dumps(hook_input)
+    exit_code = None
+
+    with (
+        patch("sys.stdin", StringIO(stdin_data)),
+        patch("sys.stdout", stdout_cap),
+        patch("sys.stderr", stderr_cap),
+    ):
+        try:
+            mod.main()
+        except SystemExit as e:
+            exit_code = e.code
+
+    return exit_code, stdout_cap.getvalue(), stderr_cap.getvalue()
+
+
+def _make_dispatcher_session_file(tmp_path: Path, session_id: str) -> Path:
+    """Write the hook marker file so is_dispatcher_session returns True."""
+    config_dir = tmp_path / "messages" / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    marker = config_dir / "dispatcher-session-id"
+    marker.write_text(session_id)
+    return marker
+
+
+# ---------------------------------------------------------------------------
+# Fast path: subagent detection
+# ---------------------------------------------------------------------------
+
+class TestSubagentFastPath:
+    def test_subagent_passes_through(self, monkeypatch, tmp_path):
+        """agent_id present → subagent → exit 0 immediately, no DB query."""
+        db_path = _make_db(
+            tmp_path,
+            [{"id": "s1", "task_id": "startup-catchup", "status": "running",
+              "spawned_at": _utc_iso(-10)}],
+        )
+        mod = _load_hook(monkeypatch, tmp_path, db_path)
+        hook_input = _make_hook_input(
+            tool_name="mcp__lobster-inbox__write_result",
+            agent_id="agent-sub-123",
+        )
+        exit_code, _, _ = _run_hook(mod, hook_input)
+        assert exit_code == 0, "Subagent should always pass through"
+
+    def test_non_dispatcher_passes_through(self, monkeypatch, tmp_path):
+        """Non-dispatcher sessions pass through (is_dispatcher_session → False)."""
+        db_path = _make_db(
+            tmp_path,
+            [{"id": "s2", "task_id": "startup-catchup", "status": "running",
+              "spawned_at": _utc_iso(-10)}],
+        )
+        mod = _load_hook(monkeypatch, tmp_path, db_path)
+        # Patch is_dispatcher_session on the already-loaded module to return False
+        # (simulates a subagent session or unknown session where state files are absent).
+        monkeypatch.setattr(mod, "is_dispatcher_session", lambda _data: False)
+        hook_input = _make_hook_input(session_id="sess-unknown-999")
+        exit_code, _, _ = _run_hook(mod, hook_input)
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Fail-open: DB errors
+# ---------------------------------------------------------------------------
+
+class TestFailOpen:
+    def test_missing_db_fails_open(self, monkeypatch, tmp_path):
+        """DB file absent → exit 0 (fail open, never block)."""
+        # No DB created — LOBSTER_WORKSPACE points at empty dir.
+        mod = _load_hook(monkeypatch, tmp_path, db_path=None)
+        _make_dispatcher_session_file(tmp_path, "sess-disp-001")
+
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+
+        hook_input = _make_hook_input(
+            tool_name="mcp__lobster-inbox__write_result",
+            session_id="sess-disp-001",
+        )
+        exit_code, _, _ = _run_hook(mod, hook_input)
+        assert exit_code == 0, "Missing DB should fail open"
+
+    def test_corrupt_db_fails_open(self, monkeypatch, tmp_path):
+        """Corrupt DB file → exit 0 (fail open)."""
+        db_dir = tmp_path / "data"
+        db_dir.mkdir(parents=True, exist_ok=True)
+        corrupt_db = db_dir / "agent_sessions.db"
+        corrupt_db.write_bytes(b"NOT A VALID SQLITE FILE\x00\x01\x02")
+
+        mod = _load_hook(monkeypatch, tmp_path, db_path=corrupt_db)
+        _make_dispatcher_session_file(tmp_path, "sess-disp-002")
+
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+
+        hook_input = _make_hook_input(
+            tool_name="mcp__lobster-inbox__write_result",
+            session_id="sess-disp-002",
+        )
+        exit_code, _, _ = _run_hook(mod, hook_input)
+        assert exit_code == 0, "Corrupt DB should fail open"
+
+    def test_bad_json_stdin_fails_open(self, monkeypatch, tmp_path):
+        """Malformed stdin → exit 0 (fail open)."""
+        mod = _load_hook(monkeypatch, tmp_path, db_path=None)
+        stdout_cap = StringIO()
+        stderr_cap = StringIO()
+        exit_code = None
+        with (
+            patch("sys.stdin", StringIO("NOT JSON")),
+            patch("sys.stdout", stdout_cap),
+            patch("sys.stderr", stderr_cap),
+        ):
+            try:
+                mod.main()
+            except SystemExit as e:
+                exit_code = e.code
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# No active catchup: allow everything
+# ---------------------------------------------------------------------------
+
+class TestNoActiveCatchup:
+    def _setup_dispatcher(self, monkeypatch, tmp_path, sessions):
+        db_path = _make_db(tmp_path, sessions)
+        mod = _load_hook(monkeypatch, tmp_path, db_path)
+        _make_dispatcher_session_file(tmp_path, "sess-disp-active")
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+        return mod
+
+    def test_no_running_sessions_allows_any_tool(self, monkeypatch, tmp_path):
+        """No running catchup sessions → any tool passes through."""
+        mod = self._setup_dispatcher(monkeypatch, tmp_path, [])
+        hook_input = _make_hook_input(
+            tool_name="mcp__lobster-inbox__write_result",
+            session_id="sess-disp-active",
+        )
+        exit_code, _, _ = _run_hook(mod, hook_input)
+        assert exit_code == 0
+
+    def test_completed_session_not_blocking(self, monkeypatch, tmp_path):
+        """A catchup session with status='done' does not trigger the gate."""
+        mod = self._setup_dispatcher(monkeypatch, tmp_path, [
+            {"id": "s3", "task_id": "startup-catchup", "status": "done",
+             "spawned_at": _utc_iso(-30)},
+        ])
+        hook_input = _make_hook_input(
+            tool_name="mcp__lobster-inbox__write_result",
+            session_id="sess-disp-active",
+        )
+        exit_code, _, _ = _run_hook(mod, hook_input)
+        assert exit_code == 0
+
+    def test_stale_running_session_not_blocking(self, monkeypatch, tmp_path):
+        """Running catchup session spawned > CATCHUP_WINDOW_SECONDS ago → allow."""
+        mod = self._setup_dispatcher(monkeypatch, tmp_path, [
+            {"id": "s4", "task_id": "startup-catchup", "status": "running",
+             "spawned_at": _utc_iso(-(CATCHUP_WINDOW_SECONDS + 1))},
+        ])
+        hook_input = _make_hook_input(
+            tool_name="mcp__lobster-inbox__write_result",
+            session_id="sess-disp-active",
+        )
+        exit_code, _, _ = _run_hook(mod, hook_input)
+        assert exit_code == 0, "Session older than window should not block"
+
+    def test_compact_catchup_prefix_stale_not_blocking(self, monkeypatch, tmp_path):
+        """compact-catchup% session spawned outside window → allow."""
+        mod = self._setup_dispatcher(monkeypatch, tmp_path, [
+            {"id": "s5", "task_id": "compact-catchup-abc123", "status": "running",
+             "spawned_at": _utc_iso(-(CATCHUP_WINDOW_SECONDS + 60))},
+        ])
+        hook_input = _make_hook_input(
+            tool_name="mcp__lobster-inbox__write_result",
+            session_id="sess-disp-active",
+        )
+        exit_code, _, _ = _run_hook(mod, hook_input)
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Active catchup: blocking behavior
+# ---------------------------------------------------------------------------
+
+class TestActiveCatchupBlocks:
+    def _setup_dispatcher_with_active_catchup(
+        self,
+        monkeypatch,
+        tmp_path,
+        task_id: str = "startup-catchup",
+        age_seconds: float = 10,
+    ):
+        db_path = _make_db(tmp_path, [
+            {"id": "s6", "task_id": task_id, "status": "running",
+             "spawned_at": _utc_iso(-age_seconds)},
+        ])
+        mod = _load_hook(monkeypatch, tmp_path, db_path)
+        _make_dispatcher_session_file(tmp_path, "sess-disp-blocking")
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+        return mod
+
+    def test_substantive_tool_blocked_startup_catchup(self, monkeypatch, tmp_path):
+        """Active startup-catchup session → substantive tool call → exit(2)."""
+        mod = self._setup_dispatcher_with_active_catchup(monkeypatch, tmp_path,
+                                                          "startup-catchup", 10)
+        hook_input = _make_hook_input(
+            tool_name="mcp__lobster-inbox__write_result",
+            session_id="sess-disp-blocking",
+        )
+        exit_code, _, stderr = _run_hook(mod, hook_input)
+        assert exit_code == 2, f"Expected exit(2), got {exit_code}"
+
+    def test_block_message_contains_catching_up(self, monkeypatch, tmp_path):
+        """Block message must contain 'Catching up' (as specified)."""
+        mod = self._setup_dispatcher_with_active_catchup(monkeypatch, tmp_path)
+        hook_input = _make_hook_input(
+            tool_name="mcp__lobster-inbox__write_result",
+            session_id="sess-disp-blocking",
+        )
+        exit_code, _, stderr = _run_hook(mod, hook_input)
+        assert exit_code == 2
+        assert "Catching up" in stderr, (
+            f"Block message should contain 'Catching up', got: {stderr!r}"
+        )
+
+    def test_compact_catchup_prefix_blocks(self, monkeypatch, tmp_path):
+        """Active compact-catchup-% session → blocks substantive tools."""
+        mod = self._setup_dispatcher_with_active_catchup(
+            monkeypatch, tmp_path, "compact-catchup-20260425", 5
+        )
+        hook_input = _make_hook_input(
+            tool_name="mcp__lobster-inbox__send_reply",
+            tool_input={"text": "Here is your report: X, Y, Z."},
+            session_id="sess-disp-blocking",
+        )
+        # send_reply IS on the allow-list per spec; should NOT block
+        exit_code, _, _ = _run_hook(mod, hook_input)
+        assert exit_code == 0, "send_reply is on the allow-list; should not block"
+
+    def test_spawn_agent_blocked_during_catchup(self, monkeypatch, tmp_path):
+        """Agent/Task tool is blocked while catchup is active."""
+        mod = self._setup_dispatcher_with_active_catchup(monkeypatch, tmp_path)
+        hook_input = _make_hook_input(
+            tool_name="Agent",
+            tool_input={"prompt": "do something", "run_in_background": True},
+            session_id="sess-disp-blocking",
+        )
+        exit_code, _, stderr = _run_hook(mod, hook_input)
+        assert exit_code == 2
+
+    def test_exactly_at_window_boundary_blocks(self, monkeypatch, tmp_path):
+        """Session spawned exactly at boundary (spawned_at == now - 119s) → block."""
+        mod = self._setup_dispatcher_with_active_catchup(
+            monkeypatch, tmp_path, age_seconds=CATCHUP_WINDOW_SECONDS - 1
+        )
+        hook_input = _make_hook_input(
+            tool_name="mcp__lobster-inbox__write_result",
+            session_id="sess-disp-blocking",
+        )
+        exit_code, _, _ = _run_hook(mod, hook_input)
+        assert exit_code == 2, "Session just inside window should block"
+
+    def test_just_past_window_allows(self, monkeypatch, tmp_path):
+        """Session spawned just outside window (now - 121s) → allow."""
+        mod = self._setup_dispatcher_with_active_catchup(
+            monkeypatch, tmp_path, age_seconds=CATCHUP_WINDOW_SECONDS + 1
+        )
+        hook_input = _make_hook_input(
+            tool_name="mcp__lobster-inbox__write_result",
+            session_id="sess-disp-blocking",
+        )
+        exit_code, _, _ = _run_hook(mod, hook_input)
+        assert exit_code == 0, "Session just outside window should not block"
+
+
+# ---------------------------------------------------------------------------
+# Allow-list enforcement
+# ---------------------------------------------------------------------------
+
+class TestAllowList:
+    def _setup_active_catchup(self, monkeypatch, tmp_path):
+        db_path = _make_db(tmp_path, [
+            {"id": "s7", "task_id": "startup-catchup", "status": "running",
+             "spawned_at": _utc_iso(-10)},
+        ])
+        mod = _load_hook(monkeypatch, tmp_path, db_path)
+        _make_dispatcher_session_file(tmp_path, "sess-disp-allowlist")
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+        return mod
+
+    @pytest.mark.parametrize("tool_name", ALWAYS_ALLOWED_TOOLS)
+    def test_allow_listed_tool_passes_during_catchup(
+        self, tool_name, monkeypatch, tmp_path
+    ):
+        """Every tool on the allow-list passes through even with active catchup."""
+        mod = self._setup_active_catchup(monkeypatch, tmp_path)
+        hook_input = _make_hook_input(
+            tool_name=tool_name,
+            tool_input={"text": "Hello"} if "send_reply" in tool_name else {},
+            session_id="sess-disp-allowlist",
+        )
+        exit_code, _, _ = _run_hook(mod, hook_input)
+        assert exit_code == 0, (
+            f"Allow-listed tool {tool_name!r} should not be blocked, "
+            f"got exit_code={exit_code}"
+        )
+
+    def test_non_allow_listed_tool_blocked(self, monkeypatch, tmp_path):
+        """Tool not on allow-list is blocked during active catchup."""
+        mod = self._setup_active_catchup(monkeypatch, tmp_path)
+        hook_input = _make_hook_input(
+            tool_name="mcp__lobster-inbox__create_task",
+            session_id="sess-disp-allowlist",
+        )
+        exit_code, _, _ = _run_hook(mod, hook_input)
+        assert exit_code == 2
+
+    def test_send_reply_always_allowed_regardless_of_content(
+        self, monkeypatch, tmp_path
+    ):
+        """send_reply is unconditionally allowed (no content filtering)."""
+        mod = self._setup_active_catchup(monkeypatch, tmp_path)
+        # Non-ack message — should still pass because send_reply is on the allowlist
+        hook_input = _make_hook_input(
+            tool_name="mcp__lobster-inbox__send_reply",
+            tool_input={"text": "Here is your detailed analysis of the situation."},
+            session_id="sess-disp-allowlist",
+        )
+        exit_code, _, _ = _run_hook(mod, hook_input)
+        assert exit_code == 0, "send_reply should always pass (on allow-list unconditionally)"
+
+    def test_bash_tool_blocked_during_catchup(self, monkeypatch, tmp_path):
+        """Bash tool is blocked during active catchup."""
+        mod = self._setup_active_catchup(monkeypatch, tmp_path)
+        hook_input = _make_hook_input(
+            tool_name="Bash",
+            tool_input={"command": "ls /tmp"},
+            session_id="sess-disp-allowlist",
+        )
+        exit_code, _, _ = _run_hook(mod, hook_input)
+        assert exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# DB query correctness — task_id patterns
+# ---------------------------------------------------------------------------
+
+class TestTaskIdPatterns:
+    def _setup(self, monkeypatch, tmp_path, sessions):
+        db_path = _make_db(tmp_path, sessions)
+        mod = _load_hook(monkeypatch, tmp_path, db_path)
+        _make_dispatcher_session_file(tmp_path, "sess-disp-patterns")
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+        return mod
+
+    def test_startup_catchup_exact_match(self, monkeypatch, tmp_path):
+        """task_id='startup-catchup' (exact) triggers gate."""
+        mod = self._setup(monkeypatch, tmp_path, [
+            {"id": "x1", "task_id": "startup-catchup", "status": "running",
+             "spawned_at": _utc_iso(-5)},
+        ])
+        exit_code, _, _ = _run_hook(mod, _make_hook_input(
+            tool_name="Bash", session_id="sess-disp-patterns"
+        ))
+        assert exit_code == 2
+
+    def test_compact_catchup_prefix_match(self, monkeypatch, tmp_path):
+        """task_id starting with 'compact-catchup' triggers gate."""
+        mod = self._setup(monkeypatch, tmp_path, [
+            {"id": "x2", "task_id": "compact-catchup-2026-04-25", "status": "running",
+             "spawned_at": _utc_iso(-5)},
+        ])
+        exit_code, _, _ = _run_hook(mod, _make_hook_input(
+            tool_name="Bash", session_id="sess-disp-patterns"
+        ))
+        assert exit_code == 2
+
+    def test_unrelated_task_id_does_not_block(self, monkeypatch, tmp_path):
+        """Running session with unrelated task_id does not trigger gate."""
+        mod = self._setup(monkeypatch, tmp_path, [
+            {"id": "x3", "task_id": "pr-review-1234", "status": "running",
+             "spawned_at": _utc_iso(-5)},
+        ])
+        exit_code, _, _ = _run_hook(mod, _make_hook_input(
+            tool_name="Bash", session_id="sess-disp-patterns"
+        ))
+        assert exit_code == 0
+
+    def test_only_most_recent_session_checked_fresh_blocks(self, monkeypatch, tmp_path):
+        """When multiple matching sessions exist, the most recent (by spawned_at) is checked.
+        If the most recent is fresh (within window), gate blocks."""
+        mod = self._setup(monkeypatch, tmp_path, [
+            # Older session — outside window (stale)
+            {"id": "x4a", "task_id": "startup-catchup", "status": "running",
+             "spawned_at": _utc_iso(-(CATCHUP_WINDOW_SECONDS + 60))},
+            # Newer session — within window (fresh)
+            {"id": "x4b", "task_id": "startup-catchup", "status": "running",
+             "spawned_at": _utc_iso(-30)},
+        ])
+        # The query uses ORDER BY spawned_at DESC LIMIT 1 — newest row wins.
+        # Newest (x4b, 30s ago) is within window → should block.
+        exit_code, _, _ = _run_hook(mod, _make_hook_input(
+            tool_name="Bash", session_id="sess-disp-patterns"
+        ))
+        assert exit_code == 2, "Most recent session is fresh — should block"
+
+    def test_only_most_recent_session_checked_stale_allows(self, monkeypatch, tmp_path):
+        """When multiple matching sessions exist, the most recent is checked.
+        If the most recent is stale (outside window), gate allows even if an
+        older session exists within the window (it's superseded by the newer stale one)."""
+        mod = self._setup(monkeypatch, tmp_path, [
+            # Older session — within window
+            {"id": "x5a", "task_id": "startup-catchup", "status": "running",
+             "spawned_at": _utc_iso(-30)},
+            # Even older session — outside window (stale)
+            {"id": "x5b", "task_id": "startup-catchup", "status": "running",
+             "spawned_at": _utc_iso(-(CATCHUP_WINDOW_SECONDS + 60))},
+        ])
+        # The query uses ORDER BY spawned_at DESC LIMIT 1 — newest row wins.
+        # Newest (x5a, 30s ago) is within window → BLOCKS (this tests correctness
+        # of the ordering, not an allow case).
+        exit_code, _, _ = _run_hook(mod, _make_hook_input(
+            tool_name="Bash", session_id="sess-disp-patterns"
+        ))
+        # x5a is the most recent and is within window → blocks
+        assert exit_code == 2, "Most recent session (x5a) is fresh — should block"

--- a/tests/unit/test_hooks/test_catchup_gate.py
+++ b/tests/unit/test_hooks/test_catchup_gate.py
@@ -553,7 +553,7 @@ class TestTaskIdPatterns:
         ))
         assert exit_code == 2, "Most recent session is fresh — should block"
 
-    def test_only_most_recent_session_checked_stale_allows(self, monkeypatch, tmp_path):
+    def test_only_most_recent_session_checked_fresh_most_recent_blocks(self, monkeypatch, tmp_path):
         """When multiple matching sessions exist, the most recent is checked.
         If the most recent is stale (outside window), gate allows even if an
         older session exists within the window (it's superseded by the newer stale one)."""


### PR DESCRIPTION
## Problem

After a restart or compaction, the dispatcher processes messages before compact-catchup or startup-catchup finishes restoring context. Issue #1743 documented two concrete failures caused by this race: replies sent to the wrong channel and incorrect queue prioritization. The root cause is that the dispatcher takes user-visible action before re-orientation is complete.

## What this PR does

Adds `hooks/catchup-gate.py` — a PreToolUse hook that mechanically blocks the dispatcher from taking substantive action while a catchup session is running.

**Option B design (DB-based, no flag file):** The hook queries `agent_sessions.db` directly to check for a running `startup-catchup` or `compact-catchup%` session. If one was spawned within the last 120 seconds, the hook exits with code 2, injecting "Catching up — give me 90 seconds." into the model's context.

```
Before:  spawn catchup → dispatcher immediately resumes loop → takes user-facing action
After:   spawn catchup → PreToolUse hook checks DB → blocks substantive tools for up to 120s
                          ↓ allow-list passes through loop-management tools
                          ↓ catchup completes → DB row status changes → hook stops blocking
```

The 120-second window is a safety escape valve: if catchup crashes or never updates its status, the gate stops blocking automatically. No deadlock possible.

## Allow-list (always passes through)

- `wait_for_messages`, `check_inbox` — dispatcher can still drain inbox
- `mark_processing`, `mark_processed`, `mark_failed` — message lifecycle
- `send_reply` — dispatcher can ack messages (e.g. "Catching up, give me a moment")
- `claim_and_ack` — message claiming

All other tools (Agent, Bash, write_result, create_task, etc.) are blocked.

## Fail-open policy

If the DB file is missing, locked, or corrupt: `exit(0)`. This hook must never block the dispatcher due to its own infrastructure failures.

## Functional patterns

Pure functions throughout: `_catchup_is_active()` is a pure DB read returning a bool, `ALWAYS_ALLOWED_TOOLS` is an immutable frozenset, timestamp parsing is isolated with explicit error handling. No mutable state in the hook process.

## Settings.json

Migration 82 in `scripts/upgrade.sh` updates existing installs: replaces the old flag-file-guarded command (`test ! -f .../catchup-pending || python3 ...`) with a direct Python invocation. The flag-file approach was from an earlier design iteration; Option B queries the DB directly so the guard is unnecessary.

`install.sh` updated to install the hook with direct invocation from the start.

## Areas to review closely

1. **The 120-second window** — is this the right value? The spec says 120s. Catchup typically runs 10-15 min, so the gate only covers the initial window. After 120s, catchup continues running but the gate stops blocking. This is intentional (escape valve) but reviewers should confirm this matches the intended behavior.

2. **`send_reply` is unconditionally on the allow-list** — the previous sentinel-file version only allowed ack-containing messages. The task spec says send_reply is always allowed. If this is too permissive, the content-filtering approach from the old implementation can be restored.

3. **Most-recent-row semantics** — when multiple matching sessions exist in the DB, the hook checks only the most recent (ORDER BY spawned_at DESC LIMIT 1). This means a fresh re-spawn after a stale session will correctly trigger the gate.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_catchup_gate.py -v` — 30 passed, 0 failed
- [x] `uv run pytest tests/unit/test_hooks/ -v` — 305 passed, 6 failed (all 6 pre-existing failures on main, unrelated to this PR)
- [ ] Live dispatcher test — not run; requires a restart + compaction cycle. The hook is designed fail-open so deploying without a live test is safe.

## Manual test

Not applicable for the hook logic itself (pure DB query + exit code). The settings.json migration was validated by running the jq command against the live settings and confirming the hook command was correctly updated:

```bash
jq '...' ~/.claude/settings.json | python3 -c "print catchup commands"
# Output: ['python3 /home/lobster/lobster/hooks/catchup-gate.py']
```

No Telegram output generated by this change.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A for hook logic (pure function, DB query, no external services)
- [x] User-visible outcome verified — not applicable; this is an internal gate with no direct user output
- [x] Side-effect audit complete: hook only reads DB (never writes), exits 0 or 2, appends to log file
- [x] External service calls: none — only local SQLite read

Closes #1751