### PR TITLE
Docker: use git clone for staging container instead of tarball updater

### DIFF
--- a/docker/staging/Dockerfile.staging
+++ b/docker/staging/Dockerfile.staging
@@ -4,6 +4,16 @@
 # Services are managed by systemd (lobster-router, lobster-claude, lobster-mcp-local),
 # and cron is managed by the cron daemon — no custom entrypoint workarounds.
 #
+# The repo is cloned from GitHub at build time (git clone), not copied from a
+# local tarball snapshot. This means the container always starts with current
+# code, and `execute_update` runs `git pull` (via update_manager.py) rather
+# than downloading a stale release tarball.
+#
+# REBUILD REQUIRED after merge: the existing lobster-staging image still uses
+# the old COPY-based approach. Run:
+#   sudo docker compose -f docker/staging/docker-compose.staging.yml build --no-cache
+#   sudo docker compose -f docker/staging/docker-compose.staging.yml up -d
+#
 # Usage:
 #   sudo docker compose -f docker/staging/docker-compose.staging.yml up -d
 #
@@ -101,8 +111,14 @@ WORKDIR /home/lobster
 RUN curl -fsSL https://astral.sh/uv/install.sh | sh
 ENV PATH="/home/lobster/.local/bin:${PATH}"
 
-# Copy repo (build context = repo root)
-COPY --chown=lobster:lobster . /home/lobster/lobster
+# Clone repo directly from GitHub — always current, git-managed.
+# This mirrors production installs and enables `git pull`-based updates
+# via execute_update (update_manager.py detects .git and uses the git path).
+# Build arg allows pinning a branch for testing (default: main).
+ARG LOBSTER_BRANCH=main
+RUN git clone --branch "${LOBSTER_BRANCH}" \
+    https://github.com/SiderealPress/lobster.git \
+    /home/lobster/lobster
 
 # Install Python dependencies
 WORKDIR /home/lobster/lobster

--- a/docs/DOCKER-STAGING.md
+++ b/docs/DOCKER-STAGING.md
@@ -26,7 +26,7 @@ Host machine
   ~/lobster-config/config.staging.env  <- env vars injected at compose up
 
 Container: lobster-staging (systemd as PID 1)
-  /home/lobster/lobster/              <- repo (baked into image at build time)
+  /home/lobster/lobster/              <- repo cloned from GitHub at build time (git clone)
   /home/lobster/messages/             <- Docker volume (lobster-staging-messages)
   /home/lobster/lobster-workspace/    <- Docker volume (lobster-staging-workspace)
   /home/lobster/lobster-config/       <- written by lobster-container-init.service
@@ -40,6 +40,21 @@ Systemd-managed services (start order):
 ```
 
 Credentials are **bind-mounted from the host** — they are never baked into the image.
+
+## Code freshness and updates
+
+The staging container clones the repo from GitHub (`git clone https://github.com/SiderealPress/lobster.git`) at Docker **build time**. The installed code is always current as of the image build — no stale tarball snapshots.
+
+**`execute_update` uses `git pull`**, not tarball download. `update_manager.py` detects the `.git` directory and calls `git pull origin main --ff-only`. This means updates are always safe and reproducible.
+
+To build a specific branch (e.g. for feature testing):
+
+```bash
+sudo docker compose -f docker/staging/docker-compose.staging.yml build \
+  --build-arg LOBSTER_BRANCH=feature/my-branch
+```
+
+The default branch is `main`.
 
 ---
 
@@ -120,6 +135,14 @@ All commands run from the repo root (`~/lobster/`).
 ```bash
 cd ~/lobster
 sudo docker compose -f docker/staging/docker-compose.staging.yml up -d --build
+```
+
+**After merging this PR** (switching from COPY to git clone): you must rebuild the image — the existing cached image still uses the old tarball-based approach. Run:
+
+```bash
+sudo docker compose -f docker/staging/docker-compose.staging.yml down
+sudo docker compose -f docker/staging/docker-compose.staging.yml build --no-cache
+sudo docker compose -f docker/staging/docker-compose.staging.yml up -d
 ```
 
 ### Subsequent runs (no Dockerfile changes)
@@ -256,3 +279,7 @@ sudo docker compose -f docker/staging/docker-compose.staging.yml up -d --build
 ### `claude: not found` inside the container
 
 The host claude binary is bind-mounted at `/home/lobster/.local/bin/claude`. Ensure `claude` is installed on the host at `~/.local/bin/claude`.
+
+### Container reverts to old/broken code after `execute_update`
+
+This was the root cause of [issue #1820](https://github.com/SiderealPress/lobster/issues/1820): the old tarball-based updater overwrote good code with a stale snapshot. After this PR, `execute_update` uses `git pull` and this cannot happen. If you are running an image built before this PR was merged, **rebuild the image** using the no-cache steps above.

--- a/src/mcp/update_manager.py
+++ b/src/mcp/update_manager.py
@@ -247,9 +247,20 @@ class UpdateManager:
             self._git("pull", "origin", "main", "--ff-only")
             new_sha = self._git("rev-parse", "HEAD").strip()
 
-            if os.path.exists(self.repo_path / "requirements.txt"):
+            # Sync dependencies using uv (preferred) or fall back to pip.
+            # uv sync keeps the lockfile-pinned environment consistent; pip
+            # install is a best-effort fallback for non-uv installs.
+            pyproject = self.repo_path / "pyproject.toml"
+            requirements = self.repo_path / "requirements.txt"
+            if pyproject.exists():
                 subprocess.run(
-                    ["pip", "install", "-r", "requirements.txt", "--quiet"],
+                    ["uv", "sync", "--frozen", "--no-install-project"],
+                    cwd=self.repo_path,
+                    capture_output=True,
+                )
+            elif requirements.exists():
+                subprocess.run(
+                    ["pip", "install", "-r", str(requirements), "--quiet"],
                     cwd=self.repo_path,
                     capture_output=True,
                 )


### PR DESCRIPTION
## Problem

The staging container's `execute_update` call was a ticking time bomb: it downloaded a stale release tarball and overwrote good MCP server files with an older version that was missing ~3,700 lines of code (HTTP transport, `pre-tool-heartbeat.py`, and 9 Python modules). This caused two manual recovery incidents. Any `execute_update` call would re-regress the container to the broken state.

The root cause was the install strategy: the Dockerfile used `COPY . /home/lobster/lobster` (a snapshot baked at build time), and the update path used `_execute_tarball_update` — which downloaded from GitHub Releases, not from HEAD. The tarball was stale.

## What changed

**`Dockerfile.staging`** — replaces the `COPY . /home/lobster/lobster` step with a `git clone`:

```dockerfile
ARG LOBSTER_BRANCH=main
RUN git clone --branch "${LOBSTER_BRANCH}" \
    https://github.com/SiderealPress/lobster.git \
    /home/lobster/lobster
```

Because `/home/lobster/lobster` now has a `.git` directory, `update_manager.py`'s `_is_git_install()` check returns `True` — and `execute_update` runs `git pull origin main --ff-only` instead of downloading a tarball. The regression path is eliminated structurally.

A `LOBSTER_BRANCH` build arg allows pinning a branch for feature testing; the default is `main`.

**`src/mcp/update_manager.py`** — in `_execute_git_update`, replaces the post-pull `pip install -r requirements.txt` with `uv sync --frozen --no-install-project` (falling back to pip only when `pyproject.toml` is absent). Keeps the lockfile-pinned environment consistent with the project's standard toolchain.

**`docs/DOCKER-STAGING.md`** — documents the git clone approach, the `LOBSTER_BRANCH` build arg, and the mandatory full rebuild step required after this PR merges (the existing cached image still uses COPY).

## Before / after

```
Before:
  docker build  →  COPY snapshot baked into image
  execute_update  →  _execute_tarball_update → downloads stale .tar.gz → overwrites files

After:
  docker build  →  git clone from main (always current)
  execute_update  →  _execute_git_update → git pull --ff-only → no overwrite risk
```

The strategy selection is already handled by `_is_git_install(repo_path)` — a pure function that checks for `.git`. No new branching logic was added.

## Rebuild required after merge

The existing `lobster-staging` image still uses the old COPY-based approach. After merging, run:

```bash
sudo docker compose -f docker/staging/docker-compose.staging.yml down
sudo docker compose -f docker/staging/docker-compose.staging.yml build --no-cache
sudo docker compose -f docker/staging/docker-compose.staging.yml up -d
```

## install.sh audit

This PR does not add new hooks, scripts, or services. No `install.sh` changes required.

## Tests run

- [x] `uv run pytest tests/unit/ -q -k "update_manager"` — 14 passed, 0 failed (all update_manager tests pass)
- [x] `uv run pytest tests/unit/ -q` — 2972 passed, 24 skipped; 2 pre-existing failures unrelated to this change (both also fail on origin/main: `test_dispatcher_agent_no_background_key_exits_2` and a timeout-plugin environment mismatch in worktree venv)
- [ ] Docker build verification — blocked: Docker build requires network access to clone GitHub repo, which is unavailable in this environment. The Dockerfile syntax is correct and mirrors the pattern used by `install.sh`'s own `git clone` steps.

## Manual test

N/A for this specific PR — the change is a build-time substitution (git clone for COPY). The functional behavior of `execute_update` is already covered by the unit tests in `test_update_manager.py`. A live Docker rebuild is required after merge (documented above) to verify end-to-end.

## Definition of Done

- [x] Unit tests pass — update_manager path confirmed via existing test suite
- [ ] Docker build test — cannot run in current environment (no Docker); rebuild documented for post-merge
- [x] User-visible outcome: not applicable — this change affects container internals, not Telegram output
- [x] Side-effect audit: no floods, no shared-state writes, no unintended volume; git clone is read-only from GitHub
- [x] External service: git clone hits GitHub (not mocked in tests, but no production Telegram interaction)

Closes #1820