### PR TITLE
fix: register 'gmail' as a recognized inbox source

### DIFF
--- a/src/mcp/message_types.py
+++ b/src/mcp/message_types.py
@@ -74,6 +74,7 @@ INBOX_MESSAGE_SOURCES: frozenset[str] = frozenset({
     "bisque",
     "system",
     "bot-talk",  # cross-Lobster bot-to-bot messages (issue #1350)
+    "gmail",     # email poller injects messages with source="gmail"
 })
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_server/test_message_taxonomy.py
+++ b/tests/unit/test_mcp_server/test_message_taxonomy.py
@@ -93,7 +93,7 @@ class TestTaxonomyConstants:
     def test_required_sources_present(self):
         """All known message sources must be in INBOX_MESSAGE_SOURCES."""
         from message_types import INBOX_MESSAGE_SOURCES
-        required = {"telegram", "slack", "sms", "signal", "whatsapp", "bisque", "system"}
+        required = {"telegram", "slack", "sms", "signal", "whatsapp", "bisque", "system", "gmail"}
         missing = required - INBOX_MESSAGE_SOURCES
         assert not missing, f"Required sources missing: {missing}"
 


### PR DESCRIPTION
## Problem

The Gmail email poller correctly injects messages into \`~/messages/inbox/\` with \`source=\"gmail\"\`. But every one of those messages was being immediately quarantined to \`~/messages/failed/\` by the dispatcher's source-validation guard, with the error:

> Unrecognized inbox source 'gmail' — not in INBOX_MESSAGE_SOURCES.

Root cause: \`\"gmail\"\` was simply never added to \`INBOX_MESSAGE_SOURCES\` in \`message_types.py\` when the Gmail poller was introduced.

## Change

Two-line fix:

- **\`src/mcp/message_types.py\`** — adds \`\"gmail\"\` to \`INBOX_MESSAGE_SOURCES\` (the frozenset that the quarantine guard checks)
- **\`tests/unit/test_mcp_server/test_message_taxonomy.py\`** — adds \`\"gmail\"\` to the \`required\` set in \`test_required_sources_present\` so the registry stays in sync with the poller going forward

No routing logic changes. Gmail messages are processed as regular inbox messages, routed the same way as any other recognized source.

## Immediate effect

After this merges, the 20+ stuck emails in \`~/messages/failed/\` (gmail-* prefix) will be re-queued to inbox and processed normally. Two emails Drew is expecting — Ryan Conlon/Dropbox and Ricky Olson/DocuSign — are among those.

## Functional patterns

Pure data change to an immutable constant (frozenset). No side effects, no control flow changes.

## Tests run

- [x] \`uv run pytest tests/unit/test_mcp_server/test_message_taxonomy.py tests/unit/test_mcp_server/test_unrecognized_source_quarantine.py -v\` — 25 passed, 0 failed

## Manual test

N/A — this change is entirely internal (no systemd units, no external service calls, no file I/O beyond the constant declaration). Correctness is verified by the quarantine tests passing with "gmail" now included in recognized sources.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (pure constant change, covered by unit tests)
- [x] User-visible outcome — re-queueing stuck emails handled post-merge as a separate step
- [x] Side-effect audit: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none in this change