### PR TITLE
fix(health-check): move lock file from /tmp to lobster-owned path

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -115,7 +115,7 @@ OUTBOX_YELLOW_THRESHOLD_SECONDS=300  # 5 min = YELLOW
 OUTBOX_HISTORICAL_CUTOFF=3600        # Skip files > 1 hour (dead-letter candidates)
 
 LOG_FILE="$WORKSPACE_DIR/logs/health-check.log"
-LOCK_FILE="${LOBSTER_HEALTH_LOCK:-/tmp/lobster-health-check-v3.lock}"
+LOCK_FILE="${LOBSTER_HEALTH_LOCK:-$WORKSPACE_DIR/logs/health-check-v3.lock}"
 
 MAX_RESTART_ATTEMPTS=3
 RESTART_COOLDOWN_SECONDS=600         # 10 min window for counting attempts
@@ -161,6 +161,7 @@ LOBSTER_ENV="${LOBSTER_ENV:-production}"
 mkdir -p "$(dirname "$LOG_FILE")"
 mkdir -p "$(dirname "$RESTART_STATE_FILE")"
 mkdir -p "$ALERT_DEDUP_DIR"
+mkdir -p "$(dirname "$LOCK_FILE")"
 
 # Dry-run gate: skip all real actions when LOBSTER_HEALTH_CHECK_DRY_RUN=1.
 # Used by tests to exercise parsing/reading logic without executing systemctl,


### PR DESCRIPTION
## Why this exists

On Apr 28 2026, a root process recreated `/tmp/lobster-health-check-v3.lock` with `root:root` ownership at 13:32 UTC. The health-check script runs as the `lobster` user and needs write access to the lock file for `flock`. Because `/tmp` is world-writable, any root process can silently overwrite or recreate files there with root ownership. The result: `flock` failed silently on every 4-minute cron invocation for **8.5 hours** (13:32–22:09 UTC), disabling health monitoring entirely with no visible error or alert.

A temporary fix (`sudo chown lobster:lobster /tmp/...`) was applied, but the vulnerability persists on the next root write to `/tmp`.

## What changed

One path constant and one directory guard:

1. `LOCK_FILE` default changed from `/tmp/lobster-health-check-v3.lock` to `$WORKSPACE_DIR/logs/health-check-v3.lock`. This directory is owned by the `lobster` user — no root process will touch it incidentally.

2. Added `mkdir -p "$(dirname "$LOCK_FILE")"` alongside the existing log-directory setup, so the directory is guaranteed to exist before `acquire_lock` runs. This also handles the `$LOBSTER_HEALTH_LOCK` env override path (used in tests and custom deploys) correctly.

The `$LOBSTER_HEALTH_LOCK` env override is preserved. Existing tests that set this override continue to work — the D4 smoke test confirms this (all 10 pass).

## What is not changed

No logic changes. No new alert paths. No changes to the locking mechanism itself (`flock -n 200`). The lock file behavior is identical — only the path moves from a world-writable directory to a lobster-owned one.

## Functional patterns used

Pure declarative configuration: the change is entirely in the constant definition and the idempotent `mkdir -p` guard. No conditional logic added.

## Tests run

- [x] `uv run pytest tests/smoke/test_health_check.py -v` — 10 passed, 0 failed (includes D1 syntax check and D4 maintenance-flag test that exercises the full script with a custom lock path)
- [x] `bash -n scripts/health-check-v3.sh` — clean (also covered by D1 above)

## Manual test

N/A — this is a path-only constant change. The lock file mechanism is unchanged; only the directory is different. The target directory (`$WORKSPACE_DIR/logs/`) is created by the existing `mkdir -p "$(dirname "$LOG_FILE")"` line and always exists before `acquire_lock` is called. No production system behavior is affected until the old `/tmp` lock file ages out naturally.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, path-only constant change, no external services involved
- [x] User-visible outcome verified — not applicable (internal lock file, no user-facing output)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume — `mkdir -p` is idempotent; no new files written beyond the lock file itself
- [x] External service calls: none

Closes #1832