### PR TITLE
fix(health-check): lower heartbeat threshold to 600s, add compaction-grace suppression, fix STALE_THRESHOLD to 360s

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -26,16 +26,17 @@
 #   and trigger a false-positive restart. To prevent this, on-compact.py writes
 #   a compacted_at timestamp to lobster-state.json, and the stale-inbox check
 #   is skipped for COMPACTION_SUPPRESS_SECONDS after that timestamp.
-#   NOTE: Dispatcher liveness check (check_dispatcher_heartbeat) is NOT
-#   suppressed during compaction — the 20-minute threshold covers it naturally.
+#   NOTE: Dispatcher liveness check (check_dispatcher_heartbeat) IS suppressed
+#   during the post-compaction grace period (is_compact_grace_period) to prevent
+#   false restarts during the up-to-12-minute catchup run that follows compaction.
 #
 # Dispatcher liveness (replaces WFM freshness + catchup suppression):
 #   hooks/thinking-heartbeat.py writes a Unix epoch timestamp to
 #   ~/lobster-workspace/logs/dispatcher-heartbeat on every PostToolUse event.
 #   check_dispatcher_heartbeat() reads this single file and checks its age.
-#   The 1200s threshold covers compaction, catchup, and boot without any
-#   suppression logic. The dispatcher no longer needs to call
-#   record-catchup-state.sh to suppress false alarms. See issue #1483.
+#   The 600s threshold (10 min) reduces MTTR for thinking-freeze from 20 min to
+#   10 min. The post-compaction grace period suppression covers catchup runs that
+#   can last up to 12 min. See issue #1483, #1786.
 #
 # Boot grace period:
 #   After any restart (health-check-initiated or manual), the new Claude session
@@ -75,7 +76,7 @@ INBOX_DIR="$MESSAGES_DIR/inbox"
 MAINTENANCE_FLAG="$MESSAGES_DIR/config/lobster-maintenance"
 LOBSTER_STATE_FILE="${LOBSTER_STATE_FILE_OVERRIDE:-$MESSAGES_DIR/config/lobster-state.json}"
 DISPATCHER_PID_FILE="$MESSAGES_DIR/config/dispatcher.pid"
-STALE_THRESHOLD_SECONDS=240          # 4 minutes - RED if any message older (watchdog handles soft recovery at 90s)
+STALE_THRESHOLD_SECONDS=360          # 6 minutes - RED if any message older (watchdog handles soft recovery at 90s)
 YELLOW_THRESHOLD_SECONDS=150         # 2.5 minutes - YELLOW warning
 RESTART_WINDOW_BUFFER_SECONDS=120    # Pre-mark messages within this window of the stale threshold before a restart
 
@@ -98,7 +99,7 @@ HEARTBEAT_FILE="$WORKSPACE_DIR/logs/claude-heartbeat"   # legacy WFM-touch signa
 # Single file, single integer (Unix epoch seconds). No JSON parsing required.
 # Threshold is generous enough to cover compaction + catchup without suppression.
 DISPATCHER_HEARTBEAT_FILE="${LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE:-$WORKSPACE_DIR/logs/dispatcher-heartbeat}"
-DISPATCHER_HEARTBEAT_STALE_SECONDS=1200   # 20 min — covers compaction (~5m) + catchup (~12m) + margin
+DISPATCHER_HEARTBEAT_STALE_SECONDS=600    # 10 min — covers compaction (~5m) + catchup margin; grace period handles the rest
 
 # WFM-active signal (issue #1713 / #949): inbox_server.py writes this file with
 # a Unix epoch timestamp when wait_for_messages begins blocking and refreshes it
@@ -946,7 +947,7 @@ check_outbox_drain() {
     fi
 }
 
-# Check 6: Dispatcher heartbeat sentinel (issue #1483 simplification)
+# Check 6: Dispatcher heartbeat sentinel (issue #1483 simplification, #1786 tuning)
 #
 # The dispatcher is considered alive if hooks/thinking-heartbeat.py has written
 # to DISPATCHER_HEARTBEAT_FILE within the last DISPATCHER_HEARTBEAT_STALE_SECONDS.
@@ -954,12 +955,10 @@ check_outbox_drain() {
 #
 # This single-file check replaces the previous multi-signal approach
 # (claude-heartbeat file + last_processed_at + last_thinking_at in
-# lobster-state.json). The 20-minute threshold naturally covers:
-#   - Context compaction pause (1-3 minutes with no tool calls)
-#   - Startup catchup subagent (up to 10-12 minutes)
-#   - Boot grace period (60-90 seconds)
-#
-# No suppression logic needed — the threshold does the work.
+# lobster-state.json). Threshold is 600s (10 min) — reduced from 1200s to lower
+# MTTR for thinking-freeze. The post-compaction grace suppression in main() covers
+# catchup runs that can exceed 10 min. Boot grace period (90s) is well within
+# the 600s threshold.
 #
 # Gracefully skips the check if the heartbeat file does not exist (fresh install
 # or first run before the hook has fired).
@@ -1845,17 +1844,20 @@ main() {
         level="YELLOW"
     fi
 
-    # --- Dispatcher heartbeat check (issue #1483 simplification) ---
+    # --- Dispatcher heartbeat check (issue #1483 simplification, #1786 tuning) ---
     # Single-file liveness check: hooks/thinking-heartbeat.py writes a Unix
     # epoch timestamp to DISPATCHER_HEARTBEAT_FILE on every PostToolUse event.
-    # The 20-minute threshold covers compaction + catchup without suppression.
+    # Threshold is 600s (10 min) — reduces MTTR for thinking-freeze from 20 min
+    # to 10 min.
     #
-    # Only suppressed during:
+    # Suppressed during:
     #   - Hibernation (dispatcher process is not running)
     #   - Transient lifecycle states (starting/restarting/waking/backoff/stopped —
     #     the wrapper hasn't even launched Claude yet)
-    # Boot grace and catchup suppression are no longer needed: the threshold
-    # absorbs them. The dispatcher no longer needs to call record-catchup-state.sh.
+    #   - Post-compaction grace period (is_compact_grace_period): catchup runs
+    #     after compaction can last up to 12 min, exceeding the 10-min threshold.
+    #     Grace period is COMPACT_GRACE_SECONDS (15 min) from last-compact.ts.
+    # Boot grace is not needed: 600s is still well above the 90s boot window.
 
     if is_hibernating; then
         log_info "Dispatcher heartbeat suppressed (hibernating)"
@@ -1863,6 +1865,8 @@ main() {
             "$lobster_mode" == "waking"    || "$lobster_mode" == "backoff"    || \
             "$lobster_mode" == "stopped" ]]; then
         log_info "Dispatcher heartbeat suppressed (transient lifecycle state: $lobster_mode)"
+    elif is_compact_grace_period; then
+        log_info "Dispatcher heartbeat suppressed (post-compaction grace period — catchup may still be running)"
     else
         check_dispatcher_heartbeat
         local hb_rc=$?

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -47,7 +47,7 @@
 #   (after each health-check-initiated restart). Resource checks (memory, disk,
 #   auth, outbox) still run during the grace period.
 #   NOTE: Dispatcher heartbeat check is NOT suppressed during boot grace — the
-#   20-minute threshold absorbs the 90s boot window naturally.
+#   10-minute threshold absorbs the 90s boot window naturally.
 #
 # Escalation ladder:
 #   GREEN  - All checks pass (or in expected transient state)
@@ -530,14 +530,14 @@ is_compact_grace_period() {
     now=$(date +%s)
     local age=$((now - compact_ts))
     if [[ $age -le $COMPACT_GRACE_SECONDS ]]; then
-        log_info "Post-compaction grace period: compaction ${age}s ago (threshold: ${COMPACT_GRACE_SECONDS}s) — stale-inbox check suppressed"
+        log_info "Post-compaction grace period: compaction ${age}s ago (threshold: ${COMPACT_GRACE_SECONDS}s) — heartbeat and stale-inbox checks suppressed"
         return 0
     fi
     return 1
 }
 
 # is_catchup_active() removed (issue #1483).
-# The dispatcher heartbeat threshold (DISPATCHER_HEARTBEAT_STALE_SECONDS = 1200s)
+# The dispatcher heartbeat threshold (DISPATCHER_HEARTBEAT_STALE_SECONDS = 600s)
 # covers catchup duration naturally. No per-catchup suppression needed.
 # The dispatcher no longer needs to call record-catchup-state.sh.
 

--- a/tests/smoke/test_health_check.py
+++ b/tests/smoke/test_health_check.py
@@ -30,6 +30,12 @@ D4. The maintenance flag (written by `lobster stop`) must cause an immediate
     clean exit with no checks run and no restart attempted.  If this flag is
     ignored, manual maintenance windows trigger spurious health-check restarts
     that fight the operator.
+
+D6. The post-compaction grace period must suppress the dispatcher heartbeat check.
+    Lowering DISPATCHER_HEARTBEAT_STALE_SECONDS to 600s (issue #1786) means
+    a catchup run lasting longer than 10 min would trigger a false restart.
+    is_compact_grace_period() must return true (exit 0) when last-compact.ts is
+    within COMPACT_GRACE_SECONDS, and false otherwise.
 """
 
 from __future__ import annotations
@@ -356,7 +362,7 @@ def test_maintenance_flag_causes_clean_exit(tmp_path: Path) -> None:
 # against DISPATCHER_HEARTBEAT_STALE_SECONDS.
 
 # How long before a dispatcher is considered stale (must match script constant).
-DISPATCHER_HEARTBEAT_STALE_SECONDS = 1200
+DISPATCHER_HEARTBEAT_STALE_SECONDS = 600
 
 
 def _check_dispatcher_heartbeat_script(
@@ -481,5 +487,126 @@ def test_wfm_freshness_green_when_last_processed_absent_heartbeat_recent(
     assert result.returncode == 0, (
         "check_dispatcher_heartbeat() returned RED when the heartbeat file is "
         "absent. Fresh installs must be GREEN until the first heartbeat is written.\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# D6 — compact grace period (issue #1786)
+# ---------------------------------------------------------------------------
+#
+# With DISPATCHER_HEARTBEAT_STALE_SECONDS lowered to 600s, catchup runs that
+# last up to 12 min would trip the heartbeat check. is_compact_grace_period()
+# gates the check for COMPACT_GRACE_SECONDS (15 min) after last-compact.ts.
+
+# Must match COMPACT_GRACE_SECONDS in health-check-v3.sh (900).
+COMPACT_GRACE_SECONDS = 900
+
+
+def _is_compact_grace_period_script(ts_file: Path, tmp_path: Path) -> str:
+    """
+    Build a self-contained bash script fragment that:
+    - Sets WORKSPACE_DIR so is_compact_grace_period() can find last-compact.ts
+    - Injects stub log functions
+    - Calls is_compact_grace_period()
+    - Exits with the function's return code (0=grace active, 1=grace expired)
+    """
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "health-check.log"
+
+    fn_body = _extract_function("is_compact_grace_period")
+
+    # ts_file is ~/lobster-workspace/data/last-compact.ts; point WORKSPACE_DIR
+    # at tmp_path so the function resolves "$WORKSPACE_DIR/data/last-compact.ts".
+    workspace_dir = ts_file.parent.parent
+
+    return f"""
+#!/bin/bash
+WORKSPACE_DIR="{workspace_dir}"
+COMPACT_GRACE_SECONDS={COMPACT_GRACE_SECONDS}
+LOG_FILE="{log_file}"
+mkdir -p "$(dirname "$LOG_FILE")"
+log()      {{ echo "[$(date -Iseconds)] [$1] $2" >> "$LOG_FILE"; }}
+log_info() {{ log "INFO" "$1"; }}
+
+{fn_body}
+
+is_compact_grace_period
+exit $?
+"""
+
+
+def test_compact_grace_period_active_when_recent(tmp_path: Path) -> None:
+    """
+    D6a: is_compact_grace_period() must return true (exit 0) when last-compact.ts
+    was written within the last COMPACT_GRACE_SECONDS.
+
+    Failure mode: if this returns false for a recent compaction, the heartbeat
+    check fires immediately after compaction and restarts the dispatcher during
+    the catchup run — disrupting state and losing context.
+    """
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    ts_file = data_dir / "last-compact.ts"
+    ts_file.write_text(str(int(time.time()) - 60))  # 60s ago — well within grace
+
+    fragment = _is_compact_grace_period_script(ts_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode == 0, (
+        "is_compact_grace_period() returned false for a 60s-old compaction, "
+        f"but COMPACT_GRACE_SECONDS is {COMPACT_GRACE_SECONDS}. "
+        "The heartbeat check must be suppressed during the grace window.\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_compact_grace_period_expired_when_stale(tmp_path: Path) -> None:
+    """
+    D6b: is_compact_grace_period() must return false (non-zero) when last-compact.ts
+    is older than COMPACT_GRACE_SECONDS.
+
+    Failure mode: if this returns true for a stale timestamp, the heartbeat check
+    is suppressed indefinitely after any past compaction — a genuine thinking-freeze
+    would never trigger a restart.
+    """
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    ts_file = data_dir / "last-compact.ts"
+    stale_ts = int(time.time()) - (COMPACT_GRACE_SECONDS + 120)
+    ts_file.write_text(str(stale_ts))
+
+    fragment = _is_compact_grace_period_script(ts_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode != 0, (
+        f"is_compact_grace_period() returned true for a compaction that is "
+        f"{COMPACT_GRACE_SECONDS + 120}s old. The grace window is only "
+        f"{COMPACT_GRACE_SECONDS}s — stale timestamps must not suppress monitoring.\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_compact_grace_period_inactive_when_no_ts_file(tmp_path: Path) -> None:
+    """
+    D6c: is_compact_grace_period() must return false (non-zero) when last-compact.ts
+    does not exist.
+
+    Failure mode: if this returns true when the file is absent, the heartbeat check
+    is suppressed on systems that have never had a compaction — monitoring is broken
+    from first install.
+    """
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    ts_file = data_dir / "last-compact.ts"
+    # Do NOT create the file.
+
+    fragment = _is_compact_grace_period_script(ts_file, tmp_path)
+    result = _run_bash_fragment(fragment)
+
+    assert result.returncode != 0, (
+        "is_compact_grace_period() returned true when last-compact.ts does not exist. "
+        "The grace period must only activate after a real compaction event.\n"
         f"stderr: {result.stderr!r}"
     )


### PR DESCRIPTION
## What this fixes

Thinking-freeze incidents (#1786) went undetected for up to 20 minutes because `DISPATCHER_HEARTBEAT_STALE_SECONDS=1200`. The dispatcher stops making tool calls entirely — the heartbeat goes stale — but nothing fires until the 20-minute mark. This PR cuts MTTR to 10 minutes.

The challenge: simply lowering the threshold from 1200s to 600s would cause false restarts during post-compaction catchup runs, which can last up to 12 minutes. The fix requires adding a suppression gate alongside the threshold change.

## Three changes

**1. Lower `DISPATCHER_HEARTBEAT_STALE_SECONDS` from 1200 to 600 (line 101)**

Halves MTTR for thinking-freeze. The compaction-grace gate (change 2) makes this safe.

**2. Add `is_compact_grace_period()` gate for the heartbeat check in `main()` (lines ~1862–1869)**

Post-compaction catchup runs (reading bootup files, processing backlog) can last up to 12 minutes — exceeding the new 600s threshold. The existing `COMPACT_GRACE_SECONDS=900` window already suppresses the inbox-drain check; this PR extends the same gate to the heartbeat check. The heartbeat check was previously ungated because the 1200s threshold "absorbed" catchup naturally. That approach stops working at 600s.

`is_compact_grace_period()` reads `$WORKSPACE_DIR/data/last-compact.ts` (written by `on-compact.py`). The grace window is 15 minutes. The heartbeat check resumes immediately after the grace expires, so a thinking-freeze that starts mid-catchup will be caught at most 15 minutes + 10 minutes = 25 minutes after compaction.

**3. Fix `STALE_THRESHOLD_SECONDS` from 240 to 360 (line 78)**

PR #1634 intended to set this to 360s (6 minutes) but the deployed value was 240s (4 minutes). This corrects that unrelated bug in the same pass.

## Before / after flow

```
Before:
  compaction fires → is_compact_grace_period suppresses inbox drain
                   → heartbeat check runs unconditionally at 1200s threshold
                   → thinking-freeze detected at ~20 min

After:
  compaction fires → is_compact_grace_period suppresses inbox drain
                   → is_compact_grace_period suppresses heartbeat check (15-min window)
  grace expires   → heartbeat check runs at 600s threshold
                   → thinking-freeze detected at ~10 min (outside grace window)
                   → or at most 25 min if freeze starts during catchup
```

## No hook changes needed

`PreToolUse` hook does not fire during thinking-freeze (zero tool calls). The heartbeat file goes stale because there are no PostToolUse events. No hook changes are required.

## Tests run

- [x] `uv run pytest tests/smoke/test_health_check.py -v` — 13 passed (10 existing + 3 new D6 tests for `is_compact_grace_period`), 0 failed
- [x] `bash -n scripts/health-check-v3.sh` — clean syntax check (also verified by D1 test above)

## Manual test

N/A — change is to threshold constants and suppression logic. No external services, no file I/O, no DB schema. The only observable effect is the health check firing sooner on a genuinely frozen dispatcher. Smoke tests verify both the grace period function behavior and the heartbeat threshold via extracted bash fragments.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (pure logic change, no external services)
- [x] User-visible outcome: thinking-freeze MTTR halved (10 min vs 20 min) — not directly testable without a live freeze, but the threshold constant and suppression gate are both verified by tests
- [x] Side-effect audit: no floods, no unscoped writes — change is read-only constants + one new `elif` branch
- [x] External service calls: none

Closes #1786