### PR TITLE
fix(wfm): move WFM-active heartbeat to daemon thread, independent of asyncio event loop

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -4212,12 +4212,13 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
     # survive a crash.  The stop_event lets the finally block terminate the
     # thread cleanly on normal exit.
     _hb_stop = threading.Event()
-    threading.Thread(
+    _hb_thread = threading.Thread(
         target=_wfm_heartbeat_thread_fn,
         args=(_hb_stop, WAIT_HEARTBEAT_INTERVAL),
         daemon=True,
         name="wfm-heartbeat",
-    ).start()
+    )
+    _hb_thread.start()
 
     try:
         # Now that the observer is running, check for messages that already
@@ -4292,7 +4293,10 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
         # Stop the heartbeat daemon thread before writing the tombstone.
         # Setting the event wakes the thread's stop_event.wait() immediately
         # so it exits without waiting for the next interval tick.
+        # join() ensures the thread has fully exited before we write the tombstone,
+        # so no stale heartbeat can overwrite the tombstone after _clear_wfm_active_signal().
         _hb_stop.set()
+        _hb_thread.join(timeout=1)
         observer.stop()
         observer.join(timeout=1)
         # Write tombstone to WFM_ACTIVE_FILE instead of deleting it (issue #1730).

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -1482,6 +1482,25 @@ def _write_wfm_active_signal() -> None:
         pass  # Never block wait_for_messages on a heartbeat write failure
 
 
+def _wfm_heartbeat_thread_fn(stop_event: threading.Event, interval: int) -> None:
+    """Daemon thread that refreshes the WFM-active heartbeat on wall-clock time.
+
+    Runs independently of the asyncio event loop so that heartbeat writes
+    continue even when the loop is stalled (e.g. during Claude API streaming).
+    Fires every `interval` seconds until stop_event is set.
+
+    Exceptions are swallowed so the thread never crashes the process.
+    daemon=True on the spawning site guarantees this thread dies with the
+    process — no fake heartbeats survive a crash or unexpected exit.
+    """
+    while not stop_event.wait(timeout=interval):
+        try:
+            touch_heartbeat()
+            _write_wfm_active_signal()
+        except Exception:
+            pass  # Never crash the heartbeat thread
+
+
 # Tombstone value written to WFM_ACTIVE_FILE when WFM exits (Fix 2, issue #1730).
 # Using a non-integer string means:
 #   - The file is NEVER absent between the health check's -f gate and its cat read
@@ -4185,6 +4204,21 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
     observer.schedule(InboxHandler(), str(INBOX_DIR), recursive=False)
     observer.start()
 
+    # Start a daemon thread to refresh the WFM-active heartbeat on wall-clock
+    # time, independent of the asyncio event loop (issue #1823).  The event
+    # loop can stall for minutes during Claude API streaming; the daemon thread
+    # keeps writing so the health check never sees a false-stale signal.
+    # daemon=True means the thread dies with the process — no heartbeats
+    # survive a crash.  The stop_event lets the finally block terminate the
+    # thread cleanly on normal exit.
+    _hb_stop = threading.Event()
+    threading.Thread(
+        target=_wfm_heartbeat_thread_fn,
+        args=(_hb_stop, WAIT_HEARTBEAT_INTERVAL),
+        daemon=True,
+        name="wfm-heartbeat",
+    ).start()
+
     try:
         # Now that the observer is running, check for messages that already
         # existed before we started watching.  Any message that arrives from
@@ -4196,9 +4230,9 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
             touch_heartbeat()
             inbox_results = await handle_check_inbox({"limit": 10})
             return _prepend_sessions_prefix(sessions_prefix, inbox_results)
-        # Wait with periodic heartbeats (every WAIT_HEARTBEAT_INTERVAL seconds).
-        # Refresh WFM-active on every iteration so the health check sees a
-        # fresh signal even during long quiet periods (issue #1713 / #949).
+        # Wait loop: block until a message arrives or timeout expires.
+        # Heartbeat and WFM-active refresh are handled by the daemon thread
+        # started above — they no longer depend on this event-loop coroutine.
         heartbeat_interval = WAIT_HEARTBEAT_INTERVAL
         elapsed = 0
 
@@ -4213,9 +4247,6 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
             if arrived:
                 break
 
-            # Touch heartbeat and refresh WFM-active to show we're still alive.
-            touch_heartbeat()
-            _write_wfm_active_signal()
             elapsed += wait_time
 
         if message_arrived.is_set():
@@ -4258,6 +4289,10 @@ async def handle_wait_for_messages(args: dict) -> list[TextContent]:
                 timeout_text = sessions_prefix + "\n\n" + timeout_text
             return [TextContent(type="text", text=timeout_text)]
     finally:
+        # Stop the heartbeat daemon thread before writing the tombstone.
+        # Setting the event wakes the thread's stop_event.wait() immediately
+        # so it exits without waiting for the next interval tick.
+        _hb_stop.set()
         observer.stop()
         observer.join(timeout=1)
         # Write tombstone to WFM_ACTIVE_FILE instead of deleting it (issue #1730).

--- a/tests/unit/test_wfm_active_signal.py
+++ b/tests/unit/test_wfm_active_signal.py
@@ -19,6 +19,7 @@ TOCTOU fix (issue #1730):
 import importlib
 import os
 import sys
+import threading
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -204,3 +205,98 @@ def test_clear_wfm_active_signal_silent_on_write_error(tmp_path, monkeypatch):
         server._clear_wfm_active_signal()
     finally:
         wfm_file.parent.chmod(0o755)
+
+
+# ---------------------------------------------------------------------------
+# _wfm_heartbeat_thread_fn tests (issue #1823)
+# ---------------------------------------------------------------------------
+
+def test_wfm_heartbeat_thread_fn_fires_at_least_once(tmp_path):
+    """_wfm_heartbeat_thread_fn fires touch_heartbeat and _write_wfm_active_signal
+    at least once within a short interval."""
+    wfm_file = tmp_path / "logs" / "dispatcher-wfm-active"
+    server = _load_inbox_server(wfm_file)
+
+    calls = []
+    original_touch = server.touch_heartbeat
+    original_write = server._write_wfm_active_signal
+
+    def spy_touch():
+        calls.append("touch")
+        original_touch()
+
+    def spy_write():
+        calls.append("write")
+        original_write()
+
+    stop_event = threading.Event()
+    with patch.object(server, "touch_heartbeat", spy_touch), \
+         patch.object(server, "_write_wfm_active_signal", spy_write):
+        t = threading.Thread(
+            target=server._wfm_heartbeat_thread_fn,
+            args=(stop_event, 0.05),
+            daemon=True,
+        )
+        t.start()
+        # Wait long enough for at least one tick (interval=0.05s, wait 0.3s)
+        time.sleep(0.3)
+        stop_event.set()
+        t.join(timeout=2)
+
+    assert "touch" in calls, "_wfm_heartbeat_thread_fn must call touch_heartbeat at least once"
+    assert "write" in calls, "_wfm_heartbeat_thread_fn must call _write_wfm_active_signal at least once"
+
+
+def test_wfm_heartbeat_thread_fn_stops_after_stop_event(tmp_path):
+    """_wfm_heartbeat_thread_fn stops (thread exits) after stop_event.set()."""
+    wfm_file = tmp_path / "logs" / "dispatcher-wfm-active"
+    server = _load_inbox_server(wfm_file)
+
+    stop_event = threading.Event()
+    t = threading.Thread(
+        target=server._wfm_heartbeat_thread_fn,
+        args=(stop_event, 0.05),
+        daemon=True,
+    )
+    t.start()
+    # Let it start, then signal stop
+    time.sleep(0.1)
+    stop_event.set()
+    t.join(timeout=1)
+
+    assert not t.is_alive(), (
+        "Thread must not be alive after stop_event.set() and join(timeout=1)"
+    )
+
+
+def test_wfm_heartbeat_thread_fn_swallows_exceptions(tmp_path):
+    """_wfm_heartbeat_thread_fn swallows exceptions from touch_heartbeat — never raises."""
+    wfm_file = tmp_path / "logs" / "dispatcher-wfm-active"
+    server = _load_inbox_server(wfm_file)
+
+    def raising_touch():
+        raise RuntimeError("simulated heartbeat failure")
+
+    # stop_event already set: the thread loop will never fire even one tick,
+    # but we want to confirm a stop_event that is NOT set still works fine
+    # when exceptions occur.  Use a very short interval so the exception path
+    # is exercised, then set the stop_event.
+    stop_event = threading.Event()
+    with patch.object(server, "touch_heartbeat", raising_touch):
+        t = threading.Thread(
+            target=server._wfm_heartbeat_thread_fn,
+            args=(stop_event, 0.05),
+            daemon=True,
+        )
+        t.start()
+        # Give it time to fire (and raise) at least once
+        time.sleep(0.3)
+        stop_event.set()
+        t.join(timeout=1)
+
+    # If the thread is dead without us killing it via stop_event first,
+    # it means an unhandled exception propagated — which is a test failure.
+    # After stop_event.set() + join, it should be cleanly stopped (not crashed).
+    assert not t.is_alive(), (
+        "Thread crashed due to an unswallowed exception from touch_heartbeat"
+    )

--- a/tests/unit/test_wfm_active_signal.py
+++ b/tests/unit/test_wfm_active_signal.py
@@ -291,12 +291,17 @@ def test_wfm_heartbeat_thread_fn_swallows_exceptions(tmp_path):
         t.start()
         # Give it time to fire (and raise) at least once
         time.sleep(0.3)
+        # Verify the thread survived the repeated exceptions — if it is NOT alive
+        # here, the exception propagated and crashed the thread before stop_event
+        # was set, which is the failure mode we are testing against.
+        assert t.is_alive(), (
+            "Thread died due to an unswallowed exception from touch_heartbeat "
+            "(crashed before stop_event was set)"
+        )
         stop_event.set()
         t.join(timeout=1)
 
-    # If the thread is dead without us killing it via stop_event first,
-    # it means an unhandled exception propagated — which is a test failure.
-    # After stop_event.set() + join, it should be cleanly stopped (not crashed).
+    # After stop_event.set() + join, the thread should be cleanly stopped.
     assert not t.is_alive(), (
-        "Thread crashed due to an unswallowed exception from touch_heartbeat"
+        "Thread should have exited cleanly after stop_event.set() and join()"
     )


### PR DESCRIPTION
## Problem

On 2026-04-26, the MCP server's asyncio event loop stalled for ~4 minutes during Claude API streaming. The WFM-active heartbeat — previously written via `run_in_executor` inside the asyncio coroutine — could not fire because the event loop had no opportunity to yield. After 258 seconds without a fresh heartbeat, the health check triggered a false restart.

The stall ended the moment a new inbox file arrived (183ms recovery), confirming the event loop was not dead — it was starved inside an anyio task group awaitable with no timeout.

## Fix

Moves heartbeat writes out of the asyncio event loop entirely. A dedicated daemon thread (`wfm-heartbeat`) calls `touch_heartbeat()` and `_write_wfm_active_signal()` on wall-clock time every `WAIT_HEARTBEAT_INTERVAL` (60s), using `threading.Event.wait(timeout=...)` as its sleep primitive. This is completely independent of asyncio stalls.

Key properties:
- `daemon=True`: the thread dies with the process. A crash produces no fake heartbeats.
- `stop_event.set()` in the `finally` block: the thread wakes immediately on normal WFM exit, so it doesn't keep ticking after the tombstone is written.
- The existing `finally` block writes the tombstone after `_hb_stop.set()`, preserving the TOCTOU fix from issue #1730.
- The while loop in `handle_wait_for_messages` no longer calls `touch_heartbeat()` or `_write_wfm_active_signal()` — the thread owns those.

## Flow

**Before:**
```
asyncio event loop
  └─ WFM coroutine (run_in_executor wait)
       └─ on each 60s tick: touch_heartbeat() + _write_wfm_active_signal()
            <- BLOCKED when event loop is stalled by Claude API streaming
```

**After:**
```
asyncio event loop            daemon thread (wfm-heartbeat)
  └─ WFM coroutine              └─ every 60s wall-clock:
       └─ run_in_executor wait       touch_heartbeat()
            (no heartbeat calls)     _write_wfm_active_signal()
                                     <- unaffected by event loop state
```

## Functional patterns

Pure function (`_wfm_heartbeat_thread_fn`): takes explicit inputs (`stop_event`, `interval`), no shared mutable state beyond the files it writes. Side effects isolated at the boundary (the thread entry point).

## Scope

Only `src/mcp/inbox_server.py` is changed. No health-check script changes needed — same file path, same integer timestamp format.

## Tests run

- [x] `uv run pytest tests/unit/test_wfm_active_signal.py -v` — 11 passed, 0 failed
- [x] `uv run pytest tests/unit/ -v` — 2997 passed, 24 skipped, 0 failed
- [x] `uv run python -m py_compile src/mcp/inbox_server.py` — syntax clean

## Manual test

N/A — this change is internal to the MCP server's blocking loop. The heartbeat file path and content format are unchanged; what changes is which thread writes it. The existing WFM-active signal tests (`test_wfm_active_signal.py`) cover the write/clear/tombstone behavior.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (internal scheduling change, no external service)
- [x] User-visible outcome — N/A (this is infrastructure; user sees no change in behavior, only absence of false restarts)
- [x] Side-effect audit: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none introduced

Closes #1823