### PR TITLE
fix(#1791): add SSH watcher to repo with self-echo filter

### DIFF
--- a/scheduled-tasks/lobstertalk-ssh-watcher-job.py
+++ b/scheduled-tasks/lobstertalk-ssh-watcher-job.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""LobsterTalk SSH Watcher Job — detects new messages written to shared server's messages.jsonl"""
+import json
+import os
+import uuid
+import time
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+RUN_ID = str(uuid.uuid4())[:8]
+HOME = Path.home()
+STATE_FILE = HOME / "lobster-workspace" / "data" / "lobstertalk-ssh-state.json"
+LOG_FILE = HOME / "lobster-workspace" / "logs" / "lobstertalk.jsonl"
+INBOX_DIR = HOME / "messages" / "inbox"
+SSH_KEY = HOME / ".ssh" / "lobsterbotsownkey"
+SSH_HOST = os.environ.get("BOT_TALK_SSH_HOST", "")
+REMOTE_FILE = os.environ.get("BOT_TALK_SSH_REMOTE_FILE", "~/bot-talk/messages.jsonl")
+OWNER_CHAT_ID = 8305714125
+JOB_NAME = "lobstertalk-ssh-watcher"
+
+# Self-echo filter: skip messages sent by this Lobster (re-delivered by relay).
+# Mirrors the BOT_TALK_SELF_USER filter on the HTTP path (issue #1345).
+MY_LOBSTER_NAME: str = (
+    os.environ.get("BOT_TALK_SELF_USER")
+    or os.environ.get("BOT_TALK_SENDER")
+    or os.environ.get("LOBSTER_NAME")
+    or "SaharLobster"
+)
+
+
+def load_state():
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text())
+        except Exception:
+            pass
+    return {"last_mtime": None, "last_size": 0, "last_offset": 0}
+
+
+def save_state(state):
+    tmp = STATE_FILE.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state, indent=2))
+    tmp.rename(STATE_FILE)
+
+
+def append_log(entry):
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if LOG_FILE.exists() and LOG_FILE.stat().st_size > 50 * 1024 * 1024:
+        LOG_FILE.rename(LOG_FILE.with_suffix(".jsonl.bak"))
+    with LOG_FILE.open("a") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def ssh_run(cmd, timeout=30):
+    """Run a command on the remote host via SSH."""
+    result = subprocess.run(
+        ["ssh", "-i", str(SSH_KEY), "-o", "StrictHostKeyChecking=no",
+         "-o", "ConnectTimeout=15", SSH_HOST, cmd],
+        capture_output=True, text=True, timeout=timeout
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def write_to_inbox(messages):
+    """Write new bot-talk messages to the Lobster inbox."""
+    INBOX_DIR.mkdir(parents=True, exist_ok=True)
+    routed = 0
+    skipped_self = 0
+    for msg in messages:
+        sender = msg.get("sender", msg.get("from", "unknown"))
+        content = msg.get("content", msg.get("text", ""))
+        ts = msg.get("timestamp", datetime.now(timezone.utc).isoformat())
+
+        # Self-echo filter: skip messages we sent (fix for issue #1791).
+        if sender == MY_LOBSTER_NAME:
+            skipped_self += 1
+            continue
+
+        msg_id = f"{int(time.time() * 1000)}_bot_talk_{str(uuid.uuid4())[:8]}"
+        inbox_msg = {
+            "id": msg_id,
+            "type": "text",
+            "source": "bot-talk",
+            "chat_id": OWNER_CHAT_ID,
+            "user_name": sender,
+            "text": content,
+            "timestamp": ts,
+            "direction": "INBOUND",
+            "from": sender,
+            "to": "SaharLobster",
+        }
+        tmp_path = INBOX_DIR / f"{msg_id}.tmp"
+        final_path = INBOX_DIR / f"{msg_id}.json"
+        tmp_path.write_text(json.dumps(inbox_msg))
+        tmp_path.rename(final_path)
+        append_log({"ts": ts, "direction": "INBOUND", "sender": sender, "content": content,
+                    "job_run": RUN_ID, "source": "ssh-watcher"})
+        routed += 1
+    if skipped_self:
+        append_log({"ts": datetime.now(timezone.utc).isoformat(), "direction": "INFO",
+                    "content": f"Skipped {skipped_self} self-echo message(s).",
+                    "job_run": RUN_ID, "source": "ssh-watcher"})
+    return routed
+
+
+def write_task_output(output, status="success"):
+    """Write job output via lobster MCP CLI shim."""
+    shim = HOME / "lobster" / "scheduled-tasks" / "write-task-output.sh"
+    if shim.exists():
+        subprocess.run([str(shim), JOB_NAME, output, status],
+                       capture_output=True, timeout=15)
+    else:
+        print(f"[{JOB_NAME}] {status}: {output}")
+
+
+def main():
+    if not SSH_HOST:
+        write_task_output("BOT_TALK_SSH_HOST env var not set — cannot connect to bot-talk server", "failed")
+        return
+
+    is_first_run = not STATE_FILE.exists()
+    state = load_state()
+    last_offset = state.get("last_offset", 0)
+    last_mtime = state.get("last_mtime")
+    last_size = state.get("last_size", 0)
+    debug_mode = os.environ.get("LOBSTER_DEBUG", "").lower() == "true"
+
+    # Step 1: Get current file stat
+    rc, stat_out, stat_err = ssh_run(f"stat -c '%s %Y' {REMOTE_FILE} 2>/dev/null || echo 'MISSING'")
+    if rc != 0 or stat_out.strip() == "MISSING" or not stat_out.strip():
+        msg = f"SSH stat failed: rc={rc} err={stat_err.strip()[:200]}"
+        append_log({"ts": datetime.now(timezone.utc).isoformat(), "direction": "ERROR",
+                    "content": msg, "job_run": RUN_ID})
+        write_task_output(f"SSH failed: {stat_err.strip()[:200]}", "failed")
+        return
+
+    parts = stat_out.strip().split()
+    if len(parts) < 2:
+        write_task_output(f"Unexpected stat output: {stat_out.strip()[:100]}", "failed")
+        return
+
+    current_size = int(parts[0])
+    current_mtime = parts[1]
+
+    # First run: calibrate offset to end of file, don't route historical messages
+    if is_first_run:
+        state["last_mtime"] = current_mtime
+        state["last_size"] = current_size
+        state["last_offset"] = current_size
+        save_state(state)
+        write_task_output(f"First run: calibrated to current end of file ({current_size} bytes). Future runs will only see new messages.", "success")
+        return
+
+    # Step 2: Check if anything changed
+    if current_mtime == last_mtime and current_size == last_size:
+        # Silent — nothing changed
+        write_task_output("No change detected.", "success")
+        return
+
+    if current_size <= last_offset:
+        # File was truncated/rotated — reset offset
+        last_offset = 0
+        state["last_offset"] = 0
+
+    if current_size == last_offset:
+        # No new bytes despite mtime change
+        state["last_mtime"] = current_mtime
+        state["last_size"] = current_size
+        save_state(state)
+        write_task_output("File touched but no new bytes.", "success")
+        return
+
+    # Step 3: Read new bytes from offset
+    bytes_to_read = current_size - last_offset
+    rc, new_content, read_err = ssh_run(
+        f"tail -c +{last_offset + 1} {REMOTE_FILE} 2>/dev/null | head -c {bytes_to_read}"
+    )
+    if rc != 0:
+        write_task_output(f"SSH read failed: {read_err.strip()[:200]}", "failed")
+        return
+
+    # Step 4: Parse new JSONL lines
+    new_messages = []
+    actual_bytes_read = len(new_content.encode("utf-8"))
+    for line in new_content.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+            new_messages.append(msg)
+        except json.JSONDecodeError:
+            pass  # Skip malformed lines
+
+    if not new_messages:
+        # Update state even if no parseable messages
+        state["last_mtime"] = current_mtime
+        state["last_size"] = current_size
+        state["last_offset"] = last_offset + actual_bytes_read
+        save_state(state)
+        write_task_output("File changed but no parseable messages.", "success")
+        return
+
+    # Step 5: Route to inbox
+    routed = write_to_inbox(new_messages)
+
+    # Step 6: Re-stat after reading so last_size reflects actual post-read size
+    # (fixes issue #1780 Bug 1: race condition when messages arrive during read).
+    rc_post, stat_post_out, _ = ssh_run(f"stat -c '%s %Y' {REMOTE_FILE} 2>/dev/null")
+    if rc_post == 0 and stat_post_out.strip():
+        post_parts = stat_post_out.strip().split()
+        if len(post_parts) >= 2:
+            current_size = int(post_parts[0])
+            current_mtime = post_parts[1]
+
+    # Step 7: Update state
+    state["last_mtime"] = current_mtime
+    state["last_size"] = current_size
+    state["last_offset"] = last_offset + actual_bytes_read
+    save_state(state)
+
+    summary = f"Found {len(new_messages)} new message(s), routed {routed} to inbox."
+    append_log({"ts": datetime.now(timezone.utc).isoformat(), "direction": "INFO",
+                "content": summary, "job_run": RUN_ID})
+
+    if debug_mode:
+        # Send debug notification
+        for m in new_messages[:3]:
+            sender = m.get("sender", m.get("from", "unknown"))
+            content = m.get("content", m.get("text", ""))
+            print(f"[SSH-WATCHER DEBUG] {sender}: {content[:200]}")
+
+    write_task_output(summary, "success")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_scheduled_tasks/test_ssh_watcher_self_echo.py
+++ b/tests/unit/test_scheduled_tasks/test_ssh_watcher_self_echo.py
@@ -1,0 +1,326 @@
+"""Unit tests for the SSH watcher self-echo filter (issue #1791).
+
+The SSH watcher now skips inbox writes for messages where sender == MY_LOBSTER_NAME.
+These are outbound messages re-delivered by the bot-talk relay — not inbound messages
+from other Lobster instances.
+
+Without the filter, every outbound POST by this Lobster is echoed back to the sender's
+own message feed, which the SSH watcher picks up and routes to the inbox — causing a
+tight dispatch loop (confirmed: 1757 messages flooded the inbox on Apr 24 2026).
+
+The filter mirrors the BOT_TALK_SELF_USER check applied on the HTTP path in issue #1345.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+import time
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the SSH watcher module by path (it has no package structure).
+# We patch subprocess and os.environ so no real SSH calls are made.
+# ---------------------------------------------------------------------------
+
+WATCHER_PATH = (
+    Path(__file__).parent.parent.parent.parent
+    / "scheduled-tasks"
+    / "lobstertalk-ssh-watcher-job.py"
+)
+
+# Module name for importlib
+_MODULE_NAME = "lobstertalk_ssh_watcher"
+
+
+def _load_watcher_module(env_overrides: dict[str, str] | None = None):
+    """Import the watcher module with env var overrides in effect.
+
+    Because the module computes MY_LOBSTER_NAME at import time from env vars,
+    we must reload it within the patched env to pick up different values.
+    """
+    env = {
+        "BOT_TALK_SSH_HOST": "testhost",
+        **(env_overrides or {}),
+    }
+    with patch.dict(os.environ, env, clear=False):
+        spec = importlib.util.spec_from_file_location(_MODULE_NAME, WATCHER_PATH)
+        assert spec is not None, f"Could not find module at {WATCHER_PATH}"
+        mod = importlib.util.module_from_spec(spec)
+        # Fresh load — don't reuse cached version
+        if _MODULE_NAME in sys.modules:
+            del sys.modules[_MODULE_NAME]
+        spec.loader.exec_module(mod)
+        return mod
+
+
+# ---------------------------------------------------------------------------
+# Pure helper: extract the write_to_inbox logic as a testable function.
+# These tests drive the core invariant: self-echoes never reach the inbox.
+# ---------------------------------------------------------------------------
+
+def _make_msg(sender: str, content: str = "hello") -> dict[str, Any]:
+    """Build a minimal bot-talk message dict."""
+    return {
+        "sender": sender,
+        "content": content,
+        "timestamp": "2026-04-24T18:00:00Z",
+    }
+
+
+class TestSelfEchoFilterBehavior:
+    """Self-echo messages must never be written to the inbox."""
+
+    LOCAL_IDENTITY = "SaharLobster"
+
+    def test_self_echo_is_not_written_to_inbox(self, tmp_path):
+        """A message where sender == MY_LOBSTER_NAME must not appear in the inbox."""
+        mod = _load_watcher_module({"BOT_TALK_SELF_USER": self.LOCAL_IDENTITY})
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+
+        with patch.object(mod, "INBOX_DIR", inbox), \
+             patch.object(mod, "LOG_FILE", tmp_path / "lobstertalk.jsonl"), \
+             patch.object(mod, "MY_LOBSTER_NAME", self.LOCAL_IDENTITY):
+            routed = mod.write_to_inbox([_make_msg(self.LOCAL_IDENTITY, "my own echo")])
+
+        assert routed == 0, "Self-echo must not be routed to inbox"
+        inbox_files = list(inbox.glob("*.json"))
+        assert inbox_files == [], "No inbox files must be created for self-echo"
+
+    def test_other_sender_is_written_to_inbox(self, tmp_path):
+        """A message from another Lobster must be routed to inbox."""
+        mod = _load_watcher_module({"BOT_TALK_SELF_USER": self.LOCAL_IDENTITY})
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+
+        with patch.object(mod, "INBOX_DIR", inbox), \
+             patch.object(mod, "LOG_FILE", tmp_path / "lobstertalk.jsonl"), \
+             patch.object(mod, "MY_LOBSTER_NAME", self.LOCAL_IDENTITY):
+            routed = mod.write_to_inbox([_make_msg("AlbertLobster", "hello from albert")])
+
+        assert routed == 1, "Message from another sender must be routed"
+        inbox_files = list(inbox.glob("*.json"))
+        assert len(inbox_files) == 1
+
+    def test_mixed_batch_routes_only_non_self(self, tmp_path):
+        """In a batch of mixed messages, only non-self messages are routed."""
+        mod = _load_watcher_module({"BOT_TALK_SELF_USER": self.LOCAL_IDENTITY})
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+
+        messages = [
+            _make_msg(self.LOCAL_IDENTITY, "[OUTBOUND] PR review sent"),
+            _make_msg("AlbertLobster", "got your review, thanks"),
+            _make_msg(self.LOCAL_IDENTITY, "[OUTBOUND] health update"),
+            _make_msg("CarolLobster", "checking in"),
+        ]
+
+        with patch.object(mod, "INBOX_DIR", inbox), \
+             patch.object(mod, "LOG_FILE", tmp_path / "lobstertalk.jsonl"), \
+             patch.object(mod, "MY_LOBSTER_NAME", self.LOCAL_IDENTITY):
+            routed = mod.write_to_inbox(messages)
+
+        assert routed == 2, "Only AlbertLobster and CarolLobster messages should be routed"
+        inbox_files = list(inbox.glob("*.json"))
+        assert len(inbox_files) == 2
+        senders = {json.loads(f.read_text())["from"] for f in inbox_files}
+        assert senders == {"AlbertLobster", "CarolLobster"}
+
+    def test_all_self_echoes_produces_zero_inbox_writes(self, tmp_path):
+        """If every message in the batch is a self-echo, no inbox files are created."""
+        mod = _load_watcher_module({"BOT_TALK_SELF_USER": self.LOCAL_IDENTITY})
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+
+        messages = [
+            _make_msg(self.LOCAL_IDENTITY, "echo 1"),
+            _make_msg(self.LOCAL_IDENTITY, "echo 2"),
+            _make_msg(self.LOCAL_IDENTITY, "echo 3"),
+        ]
+
+        with patch.object(mod, "INBOX_DIR", inbox), \
+             patch.object(mod, "LOG_FILE", tmp_path / "lobstertalk.jsonl"), \
+             patch.object(mod, "MY_LOBSTER_NAME", self.LOCAL_IDENTITY):
+            routed = mod.write_to_inbox(messages)
+
+        assert routed == 0
+        assert list(inbox.glob("*.json")) == []
+
+    def test_empty_message_list_routes_nothing(self, tmp_path):
+        """Empty input produces no inbox writes and no errors."""
+        mod = _load_watcher_module({"BOT_TALK_SELF_USER": self.LOCAL_IDENTITY})
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+
+        with patch.object(mod, "INBOX_DIR", inbox), \
+             patch.object(mod, "LOG_FILE", tmp_path / "lobstertalk.jsonl"), \
+             patch.object(mod, "MY_LOBSTER_NAME", self.LOCAL_IDENTITY):
+            routed = mod.write_to_inbox([])
+
+        assert routed == 0
+
+
+class TestSelfEchoSkipLogging:
+    """Skipped self-echo messages must be logged so we can audit the filter."""
+
+    LOCAL_IDENTITY = "SaharLobster"
+
+    def test_skipped_echoes_logged_to_jsonl(self, tmp_path):
+        """When self-echoes are skipped, a log entry noting the count is written."""
+        mod = _load_watcher_module({"BOT_TALK_SELF_USER": self.LOCAL_IDENTITY})
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        log_file = tmp_path / "lobstertalk.jsonl"
+
+        messages = [
+            _make_msg(self.LOCAL_IDENTITY, "echo 1"),
+            _make_msg(self.LOCAL_IDENTITY, "echo 2"),
+        ]
+
+        with patch.object(mod, "INBOX_DIR", inbox), \
+             patch.object(mod, "LOG_FILE", log_file), \
+             patch.object(mod, "MY_LOBSTER_NAME", self.LOCAL_IDENTITY):
+            mod.write_to_inbox(messages)
+
+        assert log_file.exists(), "Log file must be created when echoes are skipped"
+        lines = [l.strip() for l in log_file.read_text().splitlines() if l.strip()]
+        assert len(lines) >= 1
+        last_entry = json.loads(lines[-1])
+        assert "Skipped" in last_entry.get("content", ""), (
+            "Log entry must mention skipped count"
+        )
+        assert "2" in last_entry["content"], "Log must mention the count (2 echoes)"
+
+    def test_no_log_entry_when_no_echoes(self, tmp_path):
+        """When no self-echoes are found, no extra log entry for skips is written."""
+        mod = _load_watcher_module({"BOT_TALK_SELF_USER": self.LOCAL_IDENTITY})
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        log_file = tmp_path / "lobstertalk.jsonl"
+
+        with patch.object(mod, "INBOX_DIR", inbox), \
+             patch.object(mod, "LOG_FILE", log_file), \
+             patch.object(mod, "MY_LOBSTER_NAME", self.LOCAL_IDENTITY):
+            mod.write_to_inbox([_make_msg("AlbertLobster", "hi")])
+
+        # If log file exists, no "Skipped" entry should be present
+        if log_file.exists():
+            for line in log_file.read_text().splitlines():
+                if line.strip():
+                    entry = json.loads(line)
+                    assert "Skipped" not in entry.get("content", ""), (
+                        "No skip log entry when there are no self-echoes"
+                    )
+
+
+class TestSenderFieldFallback:
+    """write_to_inbox handles messages that use 'from' instead of 'sender'."""
+
+    LOCAL_IDENTITY = "SaharLobster"
+
+    def test_from_field_used_when_sender_absent(self, tmp_path):
+        """If 'sender' key is missing, 'from' is used to identify self-echoes."""
+        mod = _load_watcher_module({"BOT_TALK_SELF_USER": self.LOCAL_IDENTITY})
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+
+        # Use 'from' field instead of 'sender'
+        msg = {"from": self.LOCAL_IDENTITY, "content": "echo via from field",
+               "timestamp": "2026-04-24T18:00:00Z"}
+
+        with patch.object(mod, "INBOX_DIR", inbox), \
+             patch.object(mod, "LOG_FILE", tmp_path / "lobstertalk.jsonl"), \
+             patch.object(mod, "MY_LOBSTER_NAME", self.LOCAL_IDENTITY):
+            routed = mod.write_to_inbox([msg])
+
+        assert routed == 0, "Self-echo via 'from' field must also be filtered"
+
+    def test_other_sender_via_from_field_passes_through(self, tmp_path):
+        """'from' field with a different sender should be routed normally."""
+        mod = _load_watcher_module({"BOT_TALK_SELF_USER": self.LOCAL_IDENTITY})
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+
+        msg = {"from": "AlbertLobster", "content": "hi via from field",
+               "timestamp": "2026-04-24T18:00:00Z"}
+
+        with patch.object(mod, "INBOX_DIR", inbox), \
+             patch.object(mod, "LOG_FILE", tmp_path / "lobstertalk.jsonl"), \
+             patch.object(mod, "MY_LOBSTER_NAME", self.LOCAL_IDENTITY):
+            routed = mod.write_to_inbox([msg])
+
+        assert routed == 1
+
+
+class TestMyLobsterNameEnvFallback:
+    """MY_LOBSTER_NAME reads from env vars in priority order."""
+
+    def test_bot_talk_self_user_takes_precedence(self):
+        """BOT_TALK_SELF_USER overrides other env vars when set."""
+        mod = _load_watcher_module({
+            "BOT_TALK_SELF_USER": "PrimaryLobster",
+            "BOT_TALK_SENDER": "FallbackLobster",
+            "LOBSTER_NAME": "TertiaryLobster",
+        })
+        assert mod.MY_LOBSTER_NAME == "PrimaryLobster"
+
+    def test_bot_talk_sender_is_second_fallback(self):
+        """BOT_TALK_SENDER is used when BOT_TALK_SELF_USER is not set."""
+        env = {
+            "BOT_TALK_SENDER": "SecondaryLobster",
+            "LOBSTER_NAME": "TertiaryLobster",
+        }
+        # Ensure BOT_TALK_SELF_USER is absent
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("BOT_TALK_SELF_USER", None)
+            mod = _load_watcher_module(env)
+        assert mod.MY_LOBSTER_NAME == "SecondaryLobster"
+
+    def test_lobster_name_is_third_fallback(self):
+        """LOBSTER_NAME is used when both BOT_TALK_SELF_USER and BOT_TALK_SENDER are absent."""
+        env = {"LOBSTER_NAME": "TertiaryLobster"}
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("BOT_TALK_SELF_USER", None)
+            os.environ.pop("BOT_TALK_SENDER", None)
+            mod = _load_watcher_module(env)
+        assert mod.MY_LOBSTER_NAME == "TertiaryLobster"
+
+    def test_saharlobster_is_default_when_no_env_set(self):
+        """Falls back to 'SaharLobster' when no env vars are set."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("BOT_TALK_SELF_USER", None)
+            os.environ.pop("BOT_TALK_SENDER", None)
+            os.environ.pop("LOBSTER_NAME", None)
+            mod = _load_watcher_module({})
+        assert mod.MY_LOBSTER_NAME == "SaharLobster"
+
+
+class TestInboxMessageContent:
+    """Routed messages contain the correct fields."""
+
+    LOCAL_IDENTITY = "SaharLobster"
+
+    def test_routed_message_has_correct_fields(self, tmp_path):
+        """Inbox messages from other senders have correct direction and source fields."""
+        mod = _load_watcher_module({"BOT_TALK_SELF_USER": self.LOCAL_IDENTITY})
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+
+        with patch.object(mod, "INBOX_DIR", inbox), \
+             patch.object(mod, "LOG_FILE", tmp_path / "lobstertalk.jsonl"), \
+             patch.object(mod, "MY_LOBSTER_NAME", self.LOCAL_IDENTITY):
+            routed = mod.write_to_inbox([_make_msg("AlbertLobster", "hello")])
+
+        assert routed == 1
+        inbox_files = list(inbox.glob("*.json"))
+        assert len(inbox_files) == 1
+        msg = json.loads(inbox_files[0].read_text())
+        assert msg["direction"] == "INBOUND"
+        assert msg["source"] == "bot-talk"
+        assert msg["from"] == "AlbertLobster"
+        assert msg["text"] == "hello"


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Problem

The SSH watcher was not tracked in git and lacked a self-echo filter. The bot-talk relay echoes every outbound POST back to the sender's own message feed. Without filtering, the SSH watcher treated each echo as an inbound message and wrote it to the dispatcher inbox — causing a tight dispatch loop.

Confirmed at scale: Apr 24 2026 ~18:00Z, 1757 messages flooded the inbox, all confirmed self-echoes (PR reviews, polling answers, health updates, test messages). Every message had `sender == "SaharLobster"`.

## What changed

**`scheduled-tasks/lobstertalk-ssh-watcher-job.py`** — new file, now tracked in git.

The key addition is a sender check in `write_to_inbox()`:

```python
if sender == MY_LOBSTER_NAME:
    skipped_self += 1
    continue
```

`MY_LOBSTER_NAME` reads from `BOT_TALK_SELF_USER` → `BOT_TALK_SENDER` → `LOBSTER_NAME`, falling back to `"SaharLobster"`. This mirrors the `BOT_TALK_SELF_USER` check applied to the HTTP path in issue #1345.

Skipped echoes are counted and logged as an `INFO` entry so the filter's activity is auditable.

**Functional patterns used:** pure constant lookup for identity resolution (env var chain), early `continue` to avoid nesting, atomic file writes (tmp + rename).

## What is not changed

The `lobstertalk_unified.py` (HTTP path) is untouched — it already has the equivalent filter from #1345. State management, offset tracking, and hot-mode logic in the SSH watcher are unchanged.

## Before / After

```
Before:
  bot-talk relay → SSH watcher → inbox write (for ALL messages including self-echoes)
  → dispatcher processes self-echo → sends reply → relay echoes reply → repeat (loop)

After:
  bot-talk relay → SSH watcher → [sender == MY_LOBSTER_NAME? skip + log] → inbox write (non-self only)
  → dispatcher sees only genuine inbound messages from other Lobster instances
```

## Tests run

- [x] `uv run pytest tests/unit/test_scheduled_tasks/test_ssh_watcher_self_echo.py -v` — 14 passed, 0 failed
- [x] `uv run pytest tests/unit/ -v` — 3011 passed, 24 skipped, 9 warnings, 0 failed

## Manual test

N/A — this change is entirely internal filesystem I/O (inbox writes), with no external service calls or Telegram output. The fix is verified by unit tests that mock `INBOX_DIR` and `LOG_FILE` and assert that self-echo messages produce zero inbox files.

The SSH watcher requires `BOT_TALK_SSH_HOST` to connect; no live SSH connection was made in testing (and the unit tests do not exercise the SSH path — they exercise `write_to_inbox()` directly).

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (internal only, no external services in the filter path)
- [x] User-visible outcome: self-echoes no longer appear in inbox (verified by unit tests asserting zero inbox writes)
- [x] Side-effect audit complete: filter only skips writes, no floods, no unscoped writes
- [x] External service calls: not applicable to the filter logic

Closes #1791