### PR TITLE
fix(systemd-jobs): inject PATH and HOME into generated service units (#1784)

### DIFF
--- a/src/mcp/systemd_jobs.py
+++ b/src/mcp/systemd_jobs.py
@@ -31,6 +31,20 @@ SYSTEMD_DIR = Path("/etc/systemd/system")
 UNIT_PREFIX = "lobster-"
 LOBSTER_MARKER = "# LOBSTER-MANAGED"
 LOBSTER_USER = "lobster"
+LOBSTER_HOME = f"/home/{LOBSTER_USER}"
+
+# PATH injected into every generated service unit so that tools installed in
+# the user's local bin (e.g. uv at ~/.local/bin/uv) are found by the kernel
+# when it resolves the script shebang (#!/usr/bin/env -S uv run python3).
+# Systemd's default service PATH omits ~/.local/bin entirely.
+SERVICE_PATH = f"{LOBSTER_HOME}/.local/bin:/usr/local/bin:/usr/bin:/bin"
+
+# Optional env files loaded into every generated service unit.
+# The leading "-" means "ignore if missing" (systemd syntax).
+SERVICE_ENV_FILES = [
+    f"-{LOBSTER_HOME}/lobster-config/config.env",
+    f"-{LOBSTER_HOME}/lobster-config/global.env",
+]
 
 # Maximum name length (prefix + name must fit comfortably in a unit filename)
 MAX_NAME_LEN = 50
@@ -322,6 +336,7 @@ WantedBy=timers.target
 
 def _service_unit(name: str, command: str, description: str) -> str:
     desc = description or f"Lobster job: {name}"
+    env_file_lines = "\n".join(f"EnvironmentFile={f}" for f in SERVICE_ENV_FILES)
     return f"""[Unit]
 Description={desc}
 {LOBSTER_MARKER}
@@ -329,6 +344,9 @@ Description={desc}
 [Service]
 Type=oneshot
 User={LOBSTER_USER}
+Environment=PATH={SERVICE_PATH}
+Environment=HOME={LOBSTER_HOME}
+{env_file_lines}
 ExecStart={command}
 """
 

--- a/tests/unit/test_systemd_jobs.py
+++ b/tests/unit/test_systemd_jobs.py
@@ -149,6 +149,47 @@ class TestServiceUnit:
         content = sj._service_unit("myjob", "/bin/echo", "")
         assert f"User={sj.LOBSTER_USER}" in content
 
+    # --- Issue #1784: PATH= must be set so uv shebang scripts can be found ---
+
+    def test_service_unit_includes_path_env(self):
+        """Generated service file must set PATH so uv is found by the kernel."""
+        content = sj._service_unit("myjob", "/bin/echo", "")
+        assert f"Environment=PATH={sj.SERVICE_PATH}" in content
+
+    def test_service_path_includes_local_bin(self):
+        """SERVICE_PATH must include the lobster user's ~/.local/bin where uv lives."""
+        assert f"{sj.LOBSTER_HOME}/.local/bin" in sj.SERVICE_PATH
+
+    def test_service_unit_includes_home_env(self):
+        """Generated service file must set HOME so Python tools find their config."""
+        content = sj._service_unit("myjob", "/bin/echo", "")
+        assert f"Environment=HOME={sj.LOBSTER_HOME}" in content
+
+    def test_service_unit_includes_env_files(self):
+        """Generated service file must include EnvironmentFile entries for lobster config."""
+        content = sj._service_unit("myjob", "/bin/echo", "")
+        for env_file in sj.SERVICE_ENV_FILES:
+            assert f"EnvironmentFile={env_file}" in content, (
+                f"Expected 'EnvironmentFile={env_file}' in service unit content"
+            )
+
+    def test_env_files_are_optional(self):
+        """All EnvironmentFile entries must be optional (prefixed with '-') so jobs
+        work on installs that don't have the config files."""
+        for env_file in sj.SERVICE_ENV_FILES:
+            assert env_file.startswith("-"), (
+                f"EnvironmentFile entry must start with '-' to be optional: {env_file!r}"
+            )
+
+    def test_path_env_appears_before_exec_start(self):
+        """Environment= lines must precede ExecStart= in the [Service] section."""
+        content = sj._service_unit("myjob", "/bin/echo", "")
+        path_pos = content.index("Environment=PATH=")
+        exec_pos = content.index("ExecStart=")
+        assert path_pos < exec_pos, (
+            "Environment=PATH= must appear before ExecStart= in the service unit"
+        )
+
 
 class TestUnitPaths:
     def test_timer_path(self):


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What this fixes

Every scheduled job registered via `create_scheduled_job` silently failed at runtime because the generated systemd service file had no `Environment=PATH=` directive. Systemd's default service PATH omits `/home/lobster/.local/bin`, where `uv` is installed. So any script with the canonical Lobster shebang (`#!/usr/bin/env -S uv run python3`) would exit immediately with status 127 — "uv: No such file or directory" — on every timer fire.

The failure was invisible: `list_scheduled_jobs` reported `active`, `systemctl status ... .timer` reported `active (waiting)`, and the fired-state file was empty. Only `journalctl -u <service>` exposed the exit 127 error. This caused ~180 consecutive silent failures over 20 hours in the interview-prep nudge case.

## What changed

`_service_unit()` in `src/mcp/systemd_jobs.py` now emits:

```ini
[Service]
Type=oneshot
User=lobster
Environment=PATH=/home/lobster/.local/bin:/usr/local/bin:/usr/bin:/bin
Environment=HOME=/home/lobster
EnvironmentFile=-/home/lobster/lobster-config/config.env
EnvironmentFile=-/home/lobster/lobster-config/global.env
ExecStart={command}
```

This matches the pattern already used by `lobster-lobstertalk-unified.service` (which works). The `EnvironmentFile` entries use the `-` prefix (systemd "ignore if missing") so jobs succeed on installs that don't have those files.

Three new named constants were added:
- `SERVICE_PATH` — the PATH to inject (avoids magic literals)
- `LOBSTER_HOME` — `/home/lobster`, derived from `LOBSTER_USER`
- `SERVICE_ENV_FILES` — the list of optional env files to load

No changes to timer units, `update_job`, `delete_job`, or `list_jobs`. Existing jobs that were manually patched (the two interview-prep jobs) need no changes since their service files were already rewritten to this pattern.

## Functional patterns

Pure function (`_service_unit` has no side effects — it's a string transformer). Named constants eliminate the magic literals the issue called out as a maintenance hazard.

## Tests run

- [x] `uv run pytest tests/unit/test_systemd_jobs.py -v` — 99 passed, 0 failed (6 new tests added for the PATH fix)
- [x] `uv run pytest tests/unit/ -q` — 3003 passed, 24 skipped, 0 failures

## Manual test

The fix only changes the string template emitted by a pure function. Integration with the real systemd stack (confirming that a newly-created job's service file now has the correct `Environment=` lines and that `uv` resolves successfully) requires a restart of the MCP server and a new `create_scheduled_job` call, which is outside the scope of this PR's automated tests. The manual mitigation described in the issue (rewriting the two affected service files and running `systemctl daemon-reload`) confirms the fix pattern is correct.

N/A for Telegram/UI output — this change is entirely internal to unit file generation.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Manual test N/A — pure function change, no systemd calls in this diff
- [x] User-visible outcome: new jobs will no longer silently fail at runtime
- [x] Side-effect audit: no floods, no unscoped writes — only the generated string content changes
- [x] External service calls: none in this diff

Closes #1784