### PR TITLE
fix(systemd): backfill Environment=PATH= in existing Lobster service files (Migration 84)

### DIFF
--- a/scheduled-tasks/lobstertalk_unified.py
+++ b/scheduled-tasks/lobstertalk_unified.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env uv run python3
+#!/usr/bin/env -S uv run python3
 """
 LobsterTalk Unified Job — genericized production version.
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2891,6 +2891,32 @@ print(f'prune-pr-worktrees: {result.status}')
         warn "prune-pr-worktrees.py not found at $_m83_script or uv unavailable — skipping Migration 83"
     fi
 
+    # Migration 84: Backfill Environment=PATH= and Environment=HOME= in existing Lobster-managed
+    # system service files. PR #1838 fixed the code that generates new service files, but existing
+    # on-disk files were already missing these directives and fail with exit-127 when uv is not
+    # found on systemd's minimal PATH. This migration patches all Lobster service files in
+    # /etc/systemd/system/ that are missing Environment=PATH= and runs daemon-reload.
+    local _m84_patched=0
+    local _m84_env_path="Environment=PATH=${HOME}/.local/bin:/usr/local/bin:/usr/bin:/bin"
+    local _m84_env_home="Environment=HOME=${HOME}"
+    for _m84_svc in /etc/systemd/system/lobster-*.service; do
+        [ -f "$_m84_svc" ] || continue
+        if grep -q "Environment=PATH=" "$_m84_svc" 2>/dev/null; then
+            continue
+        fi
+        # Patch: insert PATH and HOME lines immediately before ExecStart=
+        if grep -q "^ExecStart=" "$_m84_svc" 2>/dev/null; then
+            sudo sed -i "s|^ExecStart=|${_m84_env_path}\n${_m84_env_home}\nExecStart=|" "$_m84_svc"
+            substep "Added PATH/HOME to $(basename "$_m84_svc")"
+            _m84_patched=$((_m84_patched + 1))
+        fi
+    done
+    if [ "$_m84_patched" -gt 0 ]; then
+        sudo systemctl daemon-reload 2>/dev/null || warn "daemon-reload failed — run manually"
+        success "Migration 84: patched $_m84_patched service file(s) with Environment=PATH= (daemon-reload done)"
+        migrated=$((migrated + _m84_patched))
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2917,6 +2917,45 @@ print(f'prune-pr-worktrees: {result.status}')
         migrated=$((migrated + _m84_patched))
     fi
 
+    # Migration 85: Fix lobster-lobstertalk-unified.service — two bugs left it silently broken
+    # even after Migration 84 added Environment=PATH=:
+    # 1. The shebang #!/usr/bin/env uv run python3 is missing the -S flag that env needs to
+    #    split multi-word interpreter strings. Without -S, env treats "uv run python3" as a
+    #    single binary name and exits 127.
+    # 2. The service file was missing EnvironmentFile directives, so BOT_TALK_URL and other
+    #    runtime secrets were never loaded, causing a RuntimeError on every execution.
+    # This migration patches the shebang in the script and adds EnvironmentFile lines to
+    # the service file, then runs daemon-reload.
+    local _m85_script="${LOBSTER_DIR}/scheduled-tasks/lobstertalk_unified.py"
+    local _m85_svc="/etc/systemd/system/lobster-lobstertalk-unified.service"
+    local _m85_patched=0
+
+    # Fix 1: shebang — replace #!/usr/bin/env uv run python3 with #!/usr/bin/env -S uv run python3
+    if [ -f "$_m85_script" ]; then
+        if head -1 "$_m85_script" | grep -q "^#!/usr/bin/env uv run python3$"; then
+            sed -i '1s|^#!/usr/bin/env uv run python3$|#!/usr/bin/env -S uv run python3|' "$_m85_script"
+            substep "Fixed shebang in lobstertalk_unified.py (added -S flag)"
+            _m85_patched=$((_m85_patched + 1))
+        fi
+    fi
+
+    # Fix 2: EnvironmentFile — add config file directives if missing
+    if [ -f "$_m85_svc" ]; then
+        if ! grep -q "^EnvironmentFile=" "$_m85_svc" 2>/dev/null; then
+            # Insert EnvironmentFile lines before ExecStart=
+            local _m85_env_files="EnvironmentFile=-${HOME}/lobster/config/config.env\nEnvironmentFile=${HOME}/lobster-config/config.env\nEnvironmentFile=-${HOME}/lobster-config/global.env"
+            sudo sed -i "s|^ExecStart=|${_m85_env_files}\nExecStart=|" "$_m85_svc"
+            substep "Added EnvironmentFile directives to lobster-lobstertalk-unified.service"
+            _m85_patched=$((_m85_patched + 1))
+        fi
+    fi
+
+    if [ "$_m85_patched" -gt 0 ]; then
+        sudo systemctl daemon-reload 2>/dev/null || warn "daemon-reload failed — run manually"
+        success "Migration 85: fixed lobstertalk-unified shebang and/or EnvironmentFile (daemon-reload done)"
+        migrated=$((_m85_patched + migrated))
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/services/lobster-mcp-local.service.template
+++ b/services/lobster-mcp-local.service.template
@@ -18,6 +18,8 @@ Environment=MCP_HTTP_PORT=8766
 EnvironmentFile=-{{INSTALL_DIR}}/config/config.env
 EnvironmentFile={{CONFIG_DIR}}/config.env
 EnvironmentFile=-{{CONFIG_DIR}}/global.env
+Environment=PATH={{HOME}}/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=HOME={{HOME}}
 ExecStart={{INSTALL_DIR}}/.venv/bin/python {{INSTALL_DIR}}/src/mcp/inbox_server.py --http --port 8766
 Restart=always
 RestartSec=5

--- a/services/lobster-mcp.service.template
+++ b/services/lobster-mcp.service.template
@@ -15,6 +15,8 @@ Environment=LOBSTER_USER_CONFIG={{USER_CONFIG_DIR}}
 EnvironmentFile=-{{INSTALL_DIR}}/config/config.env
 EnvironmentFile={{CONFIG_DIR}}/config.env
 EnvironmentFile=-{{CONFIG_DIR}}/global.env
+Environment=PATH={{HOME}}/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=HOME={{HOME}}
 ExecStart={{INSTALL_DIR}}/.venv/bin/python {{INSTALL_DIR}}/src/mcp/inbox_server_http.py
 Restart=always
 RestartSec=10


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What this fixes

PR #1838 fixed the code that GENERATES systemd service files — new jobs created after that deploy will have `Environment=PATH=` correctly. But existing service files on disk were already broken. This PR fixes three separate bugs that left `lobster-lobstertalk-unified` failing with exit-127 on every timer fire.

**Root cause analysis** (in order of how they were discovered):

1. **Missing `Environment=PATH=`** — all six lobster service files generated before #1838 were missing this directive. Systemd's default PATH omits `/home/lobster/.local/bin`, so `uv` was not found. Fixed by Migration 84.

2. **Broken shebang in `lobstertalk_unified.py`** — the script used `#!/usr/bin/env uv run python3` without the `-S` flag. `/usr/bin/env` treats the entire string `uv run python3` as a single binary name and fails to find it, exiting 127 even after PATH is fixed. Fixed by changing to `#!/usr/bin/env -S uv run python3`.

3. **Missing `EnvironmentFile` in the service unit** — after fixing the shebang, the script ran but immediately raised `RuntimeError: BOT_TALK_URL not set`. All other lobster service files load `lobster-config/config.env` via `EnvironmentFile=`, but `lobster-lobstertalk-unified.service` was missing those directives entirely. Fixed by Migration 85.

## What changed

**On-disk (applied before this PR was opened):**

Six service files patched for missing `Environment=PATH=` (Migration 84). Additionally, `lobster-lobstertalk-unified.service` had its shebang and EnvironmentFile fixed (Migration 85). All changes verified on disk — service now exits 0/SUCCESS.

**In this PR:**

1. **`scripts/upgrade.sh` — Migration 84**: Finds all `/etc/systemd/system/lobster-*.service` files missing `Environment=PATH=`, patches them in place, runs daemon-reload. Idempotent.

2. **`scripts/upgrade.sh` — Migration 85**: Two-part fix for `lobstertalk-unified` specifically:
   - Patches `lobstertalk_unified.py` shebang from `#!/usr/bin/env uv run python3` to `#!/usr/bin/env -S uv run python3`
   - Adds `EnvironmentFile` directives to `lobster-lobstertalk-unified.service` if missing, then runs daemon-reload
   - Both steps are guarded (idempotent — skips if already applied)

3. **`scheduled-tasks/lobstertalk_unified.py`**: Shebang fixed in source.

4. **`services/lobster-mcp-local.service.template`** and **`services/lobster-mcp.service.template`**: Added `Environment=PATH=` and `Environment=HOME=` for fresh installs.

## Before / after flow

```
Before:
  timer fires → systemd exec → /usr/bin/env "uv run python3" → exit 127

After shebang fix only:
  timer fires → /usr/bin/env -S uv run python3 script.py → RuntimeError: BOT_TALK_URL not set → exit 1

After both fixes (current state):
  timer fires → /usr/bin/env -S uv run python3 script.py → loads config.env → runs → exit 0
```

## Functional patterns

Migrations are structured as pure guard/patch loops — the idempotency guard (`grep -q`) is checked before any mutation. Side effects (sed, daemon-reload) only run when needed.

## Tests run

- [x] Migration 85 shebang fix verified idempotent: re-running with `-S` already present causes the `grep -q` guard to skip.
- [x] Migration 85 EnvironmentFile fix verified idempotent: already-patched file with `EnvironmentFile=` causes guard to skip.
- [x] `systemctl restart lobster-lobstertalk-unified.service` — exited 0/SUCCESS, no errors in journal.
- [x] `systemctl cat lobster-lobstertalk-unified` — shows `EnvironmentFile=` lines and `-S` shebang confirmed in script.
- [ ] Unit tests (`uv run pytest`) — shell migration logic is not covered by unit tests; existing suite unaffected.

## Manual test

Applied on disk before this commit. Verified:

```
systemctl status lobster-lobstertalk-unified.service
  → inactive (dead), last exit: status=0/SUCCESS
  → last log: "No new messages. hot_mode=False, consecutive_empty=1"

head -1 /home/lobster/lobster/scheduled-tasks/lobstertalk_unified.py
  → #!/usr/bin/env -S uv run python3

cat /etc/systemd/system/lobster-lobstertalk-unified.service
  → EnvironmentFile= lines present
```

User-visible outcome: `lobstertalk-unified` will no longer fail with exit-127 or RuntimeError on its next timer fire. Not directly observable by user (no Telegram output on startup), but the hourly LobsterTalk message sync will now function.

## Definition of Done

- [x] On-disk service files patched (6 files for PATH via Migration 84, lobstertalk-unified for EnvironmentFile via Migration 85)
- [x] Shebang fixed in source and on disk
- [x] Active service restarted and verified healthy (exit 0/SUCCESS)
- [x] Migrations 84 and 85 are idempotent (guard checks before patching)
- [x] Service templates fixed for fresh installs
- [x] Side-effect audit: sed only modifies files missing the directive; daemon-reload is always safe; no message floods

Closes #1840
Relates to #1838