### PR TITLE
fix(compact-catchup): eliminate false-positive unanswered messages

### DIFF
--- a/.claude/agents/compact-catchup.md
+++ b/.claude/agents/compact-catchup.md
@@ -57,6 +57,14 @@ You are the **compact_catchup** subagent. Your job is to:
    - `subagent_result` messages (these are recently-returned subagent results -- collect their `task_id` values; these represent work that completed and may need dispatcher follow-up)
    - Notable system events: `update_notification`, `consolidation`
    - Exclude: `self_check`, `compact-reminder`, `compact_catchup`, `subagent_notification`, test messages
+
+   **Critical: `_directory` field determines message status.**
+   Every message returned by `check_inbox(since_ts=...)` carries a `_directory` field:
+   - `_directory == "processed"` -- the message was already handled and moved to `processed/`. It must **never** be classified as an open or unanswered thread. It may appear in the summary as context ("user asked X, we replied"), but not as outstanding work.
+   - `_directory == "inbox"` -- the message is still in the inbox and may be genuinely unhandled. Treat these as potentially open threads.
+
+   This distinction eliminates false-positive "unanswered thread" reports: a message in `processed/` was replied to and marked done; the reply may not appear in the `check_inbox` scan (replies go to `sent/`, not `processed/` or `inbox/`), but the presence of the message in `processed/` is conclusive evidence it was handled.
+
 5. **Call `get_active_sessions()` now** to retrieve all currently running agent sessions. Filter to `status: "running"` sessions, excluding dispatcher sessions. These are in-flight subagents that were active at compaction time and may still be running. If `get_active_sessions()` errors, note the failure and continue. Also read `~/lobster-workspace/data/inflight-work.jsonl` if it exists — find all `task_id` values that have at least one entry with `"status": "running"` but no entry with `"status": "done"` and `started_at` more than 30 minutes before now; these are potentially lost subagents not yet recovered by the sessions DB. (30 min is intentionally conservative — trades some false positives for earlier detection of genuinely lost work.)
 6. Read session notes in tiers (see "Session notes reading" below).
 7. **Verify live GitHub state for any PRs marked "awaiting sign-off" in session notes.**
@@ -120,7 +128,7 @@ You are the **compact_catchup** subagent. Your job is to:
 11. Build the session file content using the data from phases 1 and 2:
 
     - **Summary** (1-3 sentences, decision-log format): Synthesize from the catchup window. Write in narrative style: what we started working on, what we discovered or decided, what is still in progress. Example: "We started working on X; we realized Y and pivoted to Z; A and B are still in progress." Avoid changelog style (do not list "merged PR #N, commented on issue #M").
-    - **Open Threads**: Carry forward any threads found in the existing session file that are still pending. Add new threads for in-flight requests visible in the catchup window.
+    - **Open Threads**: Carry forward any threads found in the existing session file that are still pending. Add new threads for in-flight requests visible in the catchup window. Only messages with `_directory == "inbox"` may qualify as new open threads -- messages with `_directory == "processed"` are already handled and must never be added to the open-threads list (even if no corresponding reply is visible in the scan).
     - **Open Tasks**: List tasks from the catchup window that are not yet resolved. Include task IDs.
     - **Open Subagents**: List every agent from `get_active_sessions()` that is still in `running` state. Format: `task_id`, brief description (from the agent name or recent subagent_result), how long running (from the `started_at` field). Exclude dispatcher sessions.
     - **Notable Events**: Restarts, compactions, failed subagents, user decisions, errors -- pulled from the catchup window.

--- a/src/db/reader.py
+++ b/src/db/reader.py
@@ -180,13 +180,14 @@ def get_conversation_history(
     sender_type: str | None = None,
     limit: int = 20,
     offset: int = 0,
+    since_ts: str | None = None,
 ) -> list[Row]:
     """
     Fetch conversation history from the messages table.
 
     Applies optional filters for chat_id, source, full-text search,
-    direction (received/sent/all), and sender_type.  Results are ordered
-    newest-first.
+    direction (received/sent/all), sender_type, and since_ts.  Results are
+    ordered newest-first.
 
     Args:
         conn:        Open sqlite3.Connection.
@@ -201,6 +202,11 @@ def get_conversation_history(
                      None / omitted — all messages (current default behaviour)
         limit:       Maximum number of rows to return.
         offset:      Rows to skip for pagination.
+        since_ts:    ISO 8601 UTC timestamp string (e.g. '2026-01-01T12:00:00Z').
+                     When provided, only messages with timestamp >= since_ts are
+                     returned.  This prevents high-volume sessions from pushing
+                     earlier replies off the page when a fixed LIMIT is applied.
+                     Accepts the same formats as check_inbox since_ts.
 
     Returns:
         List of plain dicts with all message columns plus '_direction'.
@@ -232,6 +238,19 @@ def get_conversation_history(
     if source:
         conditions.append("LOWER(source) = LOWER(?)")
         params.append(source)
+
+    # since_ts filter — exclude messages older than the given UTC timestamp.
+    # Stored timestamps are ISO 8601 strings; SQLite lexicographic comparison
+    # works correctly for ISO 8601 when both sides use the same format.
+    # We normalise the caller's since_ts to the bare datetime prefix so that
+    # "2026-01-01T12:00:00Z" compares correctly against stored values like
+    # "2026-01-01T12:00:00.000000" or "2026-01-01T12:00:00+00:00".
+    if since_ts:
+        # Strip trailing Z or +00:00 offset so we compare just the datetime part,
+        # which is always stored as a naive ISO string in messages.db.
+        _since_normalised = since_ts.strip().rstrip("Z").split("+")[0]
+        conditions.append("timestamp >= ?")
+        params.append(_since_normalised)
 
     where_clause = ("WHERE " + " AND ".join(conditions)) if conditions else ""
 
@@ -298,6 +317,7 @@ def count_conversation_history(
     search: str | None = None,
     direction: str = "all",
     sender_type: str | None = None,
+    since_ts: str | None = None,
 ) -> int:
     """
     Return the total number of messages matching the given filters (for pagination).
@@ -306,6 +326,7 @@ def count_conversation_history(
     the row count, avoiding the overhead of fetching full rows.
 
     sender_type: see get_conversation_history for semantics.
+    since_ts: see get_conversation_history for semantics.
     """
     conditions: list[str] = []
     params: list[Any] = []
@@ -327,6 +348,12 @@ def count_conversation_history(
     if source:
         conditions.append("LOWER(source) = LOWER(?)")
         params.append(source)
+
+    # since_ts filter — mirror the same normalisation used in get_conversation_history.
+    if since_ts:
+        _since_normalised = since_ts.strip().rstrip("Z").split("+")[0]
+        conditions.append("timestamp >= ?")
+        params.append(_since_normalised)
 
     if search:
         use_fts = _table_exists(conn, "messages_fts")

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -2065,6 +2065,16 @@ async def list_tools() -> list[Tool]:
                         ),
                         "enum": ["user", "lobster", "conversation"],
                     },
+                    "since_ts": {
+                        "type": "string",
+                        "description": (
+                            "ISO 8601 UTC timestamp (e.g. '2026-01-01T12:00:00Z'). "
+                            "When provided, only messages with a timestamp >= since_ts are returned. "
+                            "Useful for catch-up agents that need to verify replies without being subject to "
+                            "the fixed LIMIT truncation: pass the window start to retrieve all messages "
+                            "(both directions) within the window regardless of volume."
+                        ),
+                    },
                 },
             },
             _meta={"anthropic/alwaysLoad": True},
@@ -5672,13 +5682,18 @@ def _apply_filters_and_paginate(
     limit: int,
     offset: int,
     sender_type: str | None = None,
+    since_ts: str | None = None,
 ) -> tuple[list[dict], int]:
-    """Apply chat_id / source / search / sender_type filters, sort by timestamp, then paginate.
-
+    """Apply chat_id / source / search / sender_type / since_ts filters, sort by timestamp, then paginate.
 
     Returns (paginated_slice, total_count_before_pagination).
     All filtering and sorting is performed in-memory. This is the legacy
     fallback path used when messages.db is unavailable.
+
+    since_ts: ISO 8601 UTC timestamp string. When provided, messages with a
+    timestamp strictly before this value are excluded. Uses the same
+    timezone-aware parsing as _parse_ts so Z-suffixed and offset-suffixed
+    values compare correctly against stored naive ISO strings.
     """
     def _parse_ts(msg: dict) -> 'datetime':
         ts = msg.get("timestamp", "")
@@ -5690,6 +5705,16 @@ def _apply_filters_and_paginate(
             return datetime.min.replace(tzinfo=timezone.utc)
 
     filtered = messages
+
+    # since_ts filter — applied first to minimise work for subsequent filters.
+    if since_ts:
+        try:
+            since_dt = datetime.fromisoformat(since_ts.strip().replace("Z", "+00:00"))
+            if since_dt.tzinfo is None:
+                since_dt = since_dt.replace(tzinfo=timezone.utc)
+            filtered = [m for m in filtered if _parse_ts(m) >= since_dt]
+        except (ValueError, TypeError):
+            pass  # malformed since_ts — skip filter rather than crash
 
     if sender_type:
         filtered = _apply_sender_type_filter(filtered, sender_type)
@@ -5779,6 +5804,7 @@ async def handle_get_conversation_history(args: dict) -> list[TextContent]:
     direction = args.get("direction", "all").lower()
     source_filter = args.get("source", "").lower().strip()
     sender_type = args.get("sender_type") or None  # None when omitted or empty string
+    since_ts = args.get("since_ts") or None  # ISO 8601 UTC timestamp lower bound
 
     paginated: list[dict] = []
     total_count: int = 0
@@ -5800,6 +5826,7 @@ async def handle_get_conversation_history(args: dict) -> list[TextContent]:
                     sender_type=sender_type,
                     limit=limit,
                     offset=offset,
+                    since_ts=since_ts,
                 )
                 total_count = _db_count_conversation_history(
                     conn,
@@ -5808,6 +5835,7 @@ async def handle_get_conversation_history(args: dict) -> list[TextContent]:
                     search=search_text or None,
                     direction=direction,
                     sender_type=sender_type,
+                    since_ts=since_ts,
                 )
                 used_db = True
                 log.debug(
@@ -5839,6 +5867,7 @@ async def handle_get_conversation_history(args: dict) -> list[TextContent]:
             limit=limit,
             offset=offset,
             sender_type=sender_type,
+            since_ts=since_ts,
         )
 
     # ------------------------------------------------------------------

--- a/tests/unit/test_mcp_server/test_conversation_history_since_ts.py
+++ b/tests/unit/test_mcp_server/test_conversation_history_since_ts.py
@@ -1,0 +1,388 @@
+"""
+Tests for since_ts parameter in get_conversation_history (issue #1825).
+
+Verifies that:
+- get_conversation_history accepts a since_ts parameter
+- Messages older than since_ts are excluded from DB query results
+- Messages at or after since_ts are included
+- count_conversation_history also respects since_ts
+- handle_get_conversation_history propagates since_ts to the DB reader
+- _apply_filters_and_paginate respects since_ts in the filesystem fallback path
+
+The since_ts parameter closes the secondary failure path where high-volume
+sessions can push replies off the page when get_conversation_history is called
+without a time bound (fixed limit=20 default).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure src/ and src/db/ and src/mcp/ are importable.
+_SRC_DIR = Path(__file__).parent.parent.parent.parent / "src"
+_MCP_DIR = _SRC_DIR / "mcp"
+_DB_DIR = _SRC_DIR / "db"
+for _d in (_SRC_DIR, _MCP_DIR, _DB_DIR):
+    if str(_d) not in sys.path:
+        sys.path.insert(0, str(_d))
+
+# Pre-load inbox_server so patch.multiple resolves it.
+import src.mcp.inbox_server  # noqa: F401
+from src.mcp.inbox_server import (
+    handle_get_conversation_history,
+    _apply_filters_and_paginate,
+)
+from src.db.reader import get_conversation_history, count_conversation_history
+
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+_BASE_TS = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+_BEFORE_TS = _BASE_TS - timedelta(hours=2)   # 10:00 — old reply
+_WINDOW_START = _BASE_TS                      # 12:00 — since_ts cutoff
+_AFTER_TS = _BASE_TS + timedelta(hours=1)    # 13:00 — new message
+
+_WINDOW_START_ISO = "2026-01-01T12:00:00Z"
+_BEFORE_TS_ISO = "2026-01-01T10:00:00.000000"
+_AFTER_TS_ISO = "2026-01-01T13:00:00.000000"
+
+
+# ---------------------------------------------------------------------------
+# In-memory DB helpers
+# ---------------------------------------------------------------------------
+
+def _make_in_memory_db() -> sqlite3.Connection:
+    """Create an in-memory SQLite DB with the messages schema."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("""
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY,
+            direction TEXT DEFAULT 'in',
+            source TEXT,
+            type TEXT,
+            chat_id TEXT,
+            user_id TEXT,
+            username TEXT,
+            user_name TEXT,
+            text TEXT,
+            reply_to TEXT,
+            reply_to_message_id TEXT,
+            image_file TEXT,
+            image_width TEXT,
+            image_height TEXT,
+            audio_file TEXT,
+            audio_duration TEXT,
+            audio_mime_type TEXT,
+            transcription TEXT,
+            transcribed_at TEXT,
+            transcription_model TEXT,
+            file_path TEXT,
+            file_name TEXT,
+            mime_type TEXT,
+            file_size TEXT,
+            telegram_message_id TEXT,
+            callback_data TEXT,
+            callback_query_id TEXT,
+            original_message_id TEXT,
+            original_message_text TEXT,
+            media_group_id TEXT,
+            timestamp TEXT,
+            extra TEXT
+        )
+    """)
+    return conn
+
+
+def _insert_msg(
+    conn: sqlite3.Connection,
+    msg_id: str,
+    ts_iso: str,
+    direction: str = "in",
+    text: str = "hello",
+    chat_id: str = "111",
+    source: str = "telegram",
+) -> None:
+    conn.execute(
+        "INSERT INTO messages (id, direction, source, chat_id, text, timestamp, type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (msg_id, direction, source, chat_id, text, ts_iso, "text"),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_conversation_history with since_ts (DB layer)
+# ---------------------------------------------------------------------------
+
+
+class TestGetConversationHistoryWithSinceTs:
+    """Tests for since_ts filtering in the DB reader layer."""
+
+    def test_since_ts_excludes_messages_before_window(self):
+        """Messages with timestamp before since_ts are not returned."""
+        conn = _make_in_memory_db()
+        _insert_msg(conn, "old-reply", _BEFORE_TS_ISO)
+        _insert_msg(conn, "new-msg", _AFTER_TS_ISO)
+
+        rows = get_conversation_history(conn, since_ts=_WINDOW_START_ISO)
+        ids = {r["id"] for r in rows}
+
+        assert "new-msg" in ids
+        assert "old-reply" not in ids
+
+    def test_since_ts_includes_messages_at_boundary(self):
+        """A message exactly at since_ts is included (>= boundary)."""
+        conn = _make_in_memory_db()
+        _insert_msg(conn, "boundary-msg", "2026-01-01T12:00:00.000000")
+
+        rows = get_conversation_history(conn, since_ts=_WINDOW_START_ISO)
+        ids = {r["id"] for r in rows}
+
+        assert "boundary-msg" in ids
+
+    def test_since_ts_returns_all_within_window(self):
+        """Multiple messages within the window are all returned."""
+        conn = _make_in_memory_db()
+        _insert_msg(conn, "m1", _AFTER_TS_ISO)
+        _insert_msg(conn, "m2", _AFTER_TS_ISO)
+        _insert_msg(conn, "old", _BEFORE_TS_ISO)
+
+        rows = get_conversation_history(conn, since_ts=_WINDOW_START_ISO)
+        ids = {r["id"] for r in rows}
+
+        assert "m1" in ids
+        assert "m2" in ids
+        assert "old" not in ids
+
+    def test_since_ts_compatible_with_direction_filter(self):
+        """since_ts and direction='sent' can be combined."""
+        conn = _make_in_memory_db()
+        _insert_msg(conn, "old-in", _BEFORE_TS_ISO, direction="in")
+        _insert_msg(conn, "new-in", _AFTER_TS_ISO, direction="in")
+        _insert_msg(conn, "new-out", _AFTER_TS_ISO, direction="out")
+
+        rows = get_conversation_history(conn, since_ts=_WINDOW_START_ISO, direction="sent")
+        ids = {r["id"] for r in rows}
+
+        assert "new-out" in ids
+        assert "new-in" not in ids
+        assert "old-in" not in ids
+
+    def test_since_ts_compatible_with_chat_id_filter(self):
+        """since_ts and chat_id can be combined."""
+        conn = _make_in_memory_db()
+        _insert_msg(conn, "right-chat", _AFTER_TS_ISO, chat_id="111")
+        _insert_msg(conn, "wrong-chat", _AFTER_TS_ISO, chat_id="222")
+        _insert_msg(conn, "old-right", _BEFORE_TS_ISO, chat_id="111")
+
+        rows = get_conversation_history(conn, since_ts=_WINDOW_START_ISO, chat_id="111")
+        ids = {r["id"] for r in rows}
+
+        assert "right-chat" in ids
+        assert "wrong-chat" not in ids
+        assert "old-right" not in ids
+
+    def test_without_since_ts_returns_latest_n_regardless_of_age(self):
+        """Without since_ts, old messages are still returned (existing behavior preserved)."""
+        conn = _make_in_memory_db()
+        _insert_msg(conn, "very-old", _BEFORE_TS_ISO)
+
+        rows = get_conversation_history(conn)  # no since_ts
+        ids = {r["id"] for r in rows}
+
+        assert "very-old" in ids
+
+
+# ---------------------------------------------------------------------------
+# Tests: count_conversation_history with since_ts (DB layer)
+# ---------------------------------------------------------------------------
+
+
+class TestCountConversationHistoryWithSinceTs:
+    """Tests for since_ts filtering in count_conversation_history."""
+
+    def test_count_excludes_messages_before_window(self):
+        """count_conversation_history with since_ts counts only in-window messages."""
+        conn = _make_in_memory_db()
+        _insert_msg(conn, "old", _BEFORE_TS_ISO)
+        _insert_msg(conn, "new1", _AFTER_TS_ISO)
+        _insert_msg(conn, "new2", _AFTER_TS_ISO)
+
+        count = count_conversation_history(conn, since_ts=_WINDOW_START_ISO)
+        assert count == 2
+
+    def test_count_without_since_ts_counts_all(self):
+        """Without since_ts, count_conversation_history counts all messages."""
+        conn = _make_in_memory_db()
+        _insert_msg(conn, "old", _BEFORE_TS_ISO)
+        _insert_msg(conn, "new", _AFTER_TS_ISO)
+
+        count = count_conversation_history(conn)
+        assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: _apply_filters_and_paginate with since_ts (filesystem fallback)
+# ---------------------------------------------------------------------------
+
+
+def _make_fs_msg(
+    msg_id: str,
+    ts: str,
+    direction: str = "received",
+    chat_id: str = "111",
+) -> dict:
+    return {
+        "id": msg_id,
+        "_direction": direction,
+        "source": "telegram",
+        "chat_id": chat_id,
+        "timestamp": ts,
+        "text": f"text for {msg_id}",
+    }
+
+
+class TestApplyFiltersWithSinceTs:
+    """Tests for since_ts in the filesystem-fallback filter helper."""
+
+    def test_since_ts_filters_old_messages_in_filesystem_path(self):
+        """Messages older than since_ts are excluded by _apply_filters_and_paginate."""
+        msgs = [
+            _make_fs_msg("old-reply", _BEFORE_TS_ISO, direction="sent"),
+            _make_fs_msg("new-user", _AFTER_TS_ISO, direction="received"),
+        ]
+        result, total = _apply_filters_and_paginate(
+            msgs,
+            chat_id_filter=None,
+            source_filter="",
+            search_text="",
+            limit=10,
+            offset=0,
+            since_ts=_WINDOW_START_ISO,
+        )
+        ids = {m["id"] for m in result}
+        assert "new-user" in ids
+        assert "old-reply" not in ids
+        assert total == 1
+
+    def test_since_ts_boundary_included_in_filesystem_path(self):
+        """Message at exact since_ts boundary is included."""
+        msgs = [_make_fs_msg("exact", "2026-01-01T12:00:00.000000")]
+        result, total = _apply_filters_and_paginate(
+            msgs,
+            chat_id_filter=None,
+            source_filter="",
+            search_text="",
+            limit=10,
+            offset=0,
+            since_ts=_WINDOW_START_ISO,
+        )
+        assert total == 1
+        assert result[0]["id"] == "exact"
+
+    def test_without_since_ts_no_time_filtering(self):
+        """Without since_ts, _apply_filters_and_paginate returns all messages."""
+        msgs = [
+            _make_fs_msg("old", _BEFORE_TS_ISO),
+            _make_fs_msg("new", _AFTER_TS_ISO),
+        ]
+        result, total = _apply_filters_and_paginate(
+            msgs,
+            chat_id_filter=None,
+            source_filter="",
+            search_text="",
+            limit=10,
+            offset=0,
+        )
+        assert total == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: handle_get_conversation_history propagates since_ts
+# ---------------------------------------------------------------------------
+
+
+class TestHandleGetConversationHistoryWithSinceTs:
+    """Tests that handle_get_conversation_history propagates since_ts correctly."""
+
+    def test_since_ts_propagated_to_db_reader(self):
+        """since_ts arg is forwarded to _db_get_conversation_history."""
+        mock_get = MagicMock(return_value=[])
+        mock_count = MagicMock(return_value=0)
+        mock_conn = MagicMock()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            _db_get_conversation_history=mock_get,
+            _db_count_conversation_history=mock_count,
+            _open_messages_db_conn=MagicMock(return_value=mock_conn),
+            PROCESSED_DIR=Path("/tmp"),
+            SENT_DIR=Path("/tmp"),
+        ):
+            asyncio.run(handle_get_conversation_history({"since_ts": _WINDOW_START_ISO}))
+
+        _, kwargs = mock_get.call_args
+        assert kwargs.get("since_ts") == _WINDOW_START_ISO
+
+    def test_since_ts_propagated_to_count_reader(self):
+        """since_ts arg is forwarded to _db_count_conversation_history."""
+        mock_get = MagicMock(return_value=[{"id": "m1", "_direction": "received",
+                                            "text": "hi", "timestamp": _AFTER_TS_ISO,
+                                            "source": "telegram", "chat_id": "111",
+                                            "user_name": "u", "username": "u"}])
+        mock_count = MagicMock(return_value=1)
+        mock_conn = MagicMock()
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            _db_get_conversation_history=mock_get,
+            _db_count_conversation_history=mock_count,
+            _open_messages_db_conn=MagicMock(return_value=mock_conn),
+        ):
+            asyncio.run(handle_get_conversation_history({"since_ts": _WINDOW_START_ISO}))
+
+        _, kwargs = mock_count.call_args
+        assert kwargs.get("since_ts") == _WINDOW_START_ISO
+
+    def test_since_ts_in_filesystem_fallback(self, tmp_path: Path):
+        """since_ts filters filesystem messages when DB is unavailable."""
+        processed = tmp_path / "processed"
+        processed.mkdir()
+        sent = tmp_path / "sent"
+        sent.mkdir()
+
+        old_msg = {"id": "old-reply", "text": "old message text", "timestamp": _BEFORE_TS_ISO,
+                   "source": "telegram", "chat_id": "111"}
+        new_msg = {"id": "new-msg", "text": "new message text", "timestamp": _AFTER_TS_ISO,
+                   "source": "telegram", "chat_id": "111"}
+        (processed / "old-reply.json").write_text(json.dumps(old_msg))
+        (processed / "new-msg.json").write_text(json.dumps(new_msg))
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            _db_get_conversation_history=None,
+            _db_count_conversation_history=None,
+            PROCESSED_DIR=processed,
+            SENT_DIR=sent,
+        ):
+            result = asyncio.run(handle_get_conversation_history(
+                {"since_ts": _WINDOW_START_ISO}
+            ))
+
+        text = result[0].text
+        # The formatted output includes message text content; assert on unique text strings.
+        assert "new message text" in text
+        # Only 1 of 2 messages passes the since_ts filter — "old message text" is excluded.
+        assert "old message text" not in text
+        assert "showing 1-1 of 1" in text


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

Fixes #1825

## What this solves

After a compaction, compact-catchup scans recent message history via `check_inbox(since_ts=...)`. The Apr 27 incident showed that messages already replied to and moved to `processed/` were being flagged as open/unanswered threads. The false positives arose because:

1. **Primary cause**: The catchup agent had no explicit instruction to treat `_directory == "processed"` messages as handled. The `_directory` field was already present on every message, but the agent wasn't told to use it — so the LLM sometimes classified `processed/` messages as open threads when no reply was visible in the scan.

2. **Secondary cause**: `get_conversation_history` had no `since_ts` parameter. It returned the latest N messages ordered by `timestamp DESC LIMIT ?`. In a high-volume session, replies sent just before the window start could fall off the page, making it appear that no reply had been sent.

## Changes

**Option C — prompt fix** (`.claude/agents/compact-catchup.md`):

The filter step (step 4) now explicitly documents the `_directory` field semantics:
- `_directory == "processed"` → already handled; must never be added to open-threads
- `_directory == "inbox"` → still in queue; potentially open

The session-file population step (step 11) reinforces this: only inbox messages may qualify as new open threads.

**Option B — code fix** (`src/db/reader.py`, `src/mcp/inbox_server.py`):

`get_conversation_history` (both DB reader and MCP tool) now accepts `since_ts: str | None`. When provided:
- DB path: adds `WHERE timestamp >= ?` using ISO 8601 lexicographic comparison (correct for SQLite's string-stored timestamps after normalising the `Z`/`+00:00` suffix)
- Filesystem fallback (`_apply_filters_and_paginate`): timezone-aware `datetime` comparison, malformed `since_ts` is silently skipped rather than crashing
- MCP tool schema: `since_ts` exposed to callers with a description that names the catch-up use case

The `count_conversation_history` function also gains `since_ts` for consistent pagination counts.

## Functional patterns

- Pure functions throughout: `_apply_filters_and_paginate` is extended without mutation; `since_ts` filter is a composable predicate applied before other filters
- Explicit parameter injection: `since_ts` flows from handler args → DB call → count call, no shared state
- Safe degradation: malformed `since_ts` in the filesystem path is caught and ignored, preserving existing behaviour

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_conversation_history_since_ts.py --tb=short -q` — 14 passed, 0 failed (new tests, written before implementation)
- [x] `uv run pytest tests/unit/ --tb=no -q` — 3011 passed, 24 skipped, 0 failed

## Manual test

N/A — this change is entirely internal to the compact-catchup agent and the DB reader layer. No external service calls, no file system side effects beyond what is already tested in unit tests. The `_directory` field used in the prompt fix is already populated by `inbox_server.py` (line 4685) and does not require any schema migration.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (internal change only)
- [x] User-visible outcome: no false-positive Telegram notifications to the user — not applicable to verify in isolation, but the prompt fix prevents the LLM from generating them and the code fix provides the data needed to verify replies
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none