### PR TITLE
fix(dispatcher-bootup): update ADMIN_CHAT_ID lookup path from lobster.conf to config.env

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -28,7 +28,7 @@ When you first start (or after reading this file), follow these steps:
 > **Note on stale agent sessions:** The `on-fresh-start.py` SessionStart hook runs automatically before your first turn and calls `agent-monitor.py --mark-failed` to clear any sessions left in "running" state. You do not need to do this manually.
 
 0. Call `session_start(agent_type="dispatcher", agent_id="lobster-dispatcher", description="Lobster dispatcher main loop", chat_id=<ADMIN_CHAT_ID>)` to register this session as the dispatcher. This clears any stale `_dispatcher_session_id` from a previous dispatcher instance and ensures all guarded MCP tools (`send_reply`, `check_inbox`, etc.) work immediately. Without this, a new dispatcher session may be blocked by a stale session ID from the previous instance.
-   - Get ADMIN_CHAT_ID from `lobster.conf` (`grep ADMIN_CHAT_ID ~/lobster-config/lobster.conf` or equivalent), or use the `chat_id` from `context-handoff.json` if available.
+   - Get ADMIN_CHAT_ID from `config.env` (`grep ADMIN_CHAT_ID ~/lobster-config/config.env` or equivalent), or use the `chat_id` from `context-handoff.json` if available.
    - This is the FIRST action before any guarded tools — must fire before step 2d.
 
 0b. **ToolSearch pre-load** — ALL MCP tools are deferred by default in Claude Code. Without schema pre-loading, the CC client's Zod validator stringifies numeric/boolean args, causing `InputValidationError: '10' is not of type 'integer'`. Call ToolSearch immediately after step 0:
@@ -283,7 +283,7 @@ After a context compaction you lose situational awareness of the last ~30 minute
 - Do NOT send_reply — this is internal context, except:
   - If `LOBSTER_DEBUG=true`: send a brief status to ADMIN_CHAT_ID:
     `"🔄 Back online. Context recovered from [window_start] to [now]. [N messages] processed, [M subagents] were running."`
-    (Fill in N and M from `msg["text"]`. ADMIN_CHAT_ID from `lobster.conf` or the compact-reminder context.)
+    (Fill in N and M from `msg["text"]`. ADMIN_CHAT_ID from `config.env` or the compact-reminder context.)
     **Before composing this message, convert `[window_start]` and `[now]` from UTC ISO timestamps to ET (e.g. "5:29 AM ET"). Rule: EDT (UTC-4) mid-March through early November, EST (UTC-5) otherwise. Never send raw UTC ISO strings to the user.**
 - `mark_processed`
 


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

The dispatcher bootup instructions told the dispatcher to run `grep ADMIN_CHAT_ID ~/lobster-config/lobster.conf` to find its admin chat ID at startup. That file does not exist. The real file is `~/lobster-config/config.env`, which contains `LOBSTER_ADMIN_CHAT_ID`. The gap was partially masked by the `LOBSTER_ADMIN_CHAT_ID` environment variable (set from `config.env` at boot), but the canonical grep command pointed to a non-existent path, which would mislead any dispatcher instance that tried to follow it literally.

Two references updated in `.claude/sys.dispatcher.bootup.md`:
- Step 0 startup instruction (canonical grep command and file reference)
- Compact-reminder handler note about where to find ADMIN_CHAT_ID

No behavioral code changed — this is a documentation-only fix to a system prompt.

## Tests run
- [x] `uv run pytest tests/ --ignore=tests/test_messages_db.py --ignore=tests/test_vps_integration.py --ignore=tests/test_whatsapp_bridge_adapter.py --tb=no -q` — 3489 passed, 27 skipped (the 3 ignored files have pre-existing collection errors unrelated to this change)
- [x] `uv run pytest tests/unit/ --tb=no -q` — 2997 passed, 24 skipped

## Manual test
N/A — this change is entirely internal to a documentation/instructions file. No external service calls, no file I/O affecting runtime state, no systemd/cron changes. The corrected grep command can be manually verified: `grep ADMIN_CHAT_ID ~/lobster-config/config.env` returns `LOBSTER_ADMIN_CHAT_ID=<value>`.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [ ] Integration/manual test run — not applicable (documentation-only change)
- [x] User-visible outcome verified — not applicable (internal dispatcher instructions only)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none in this change

Closes #1781