### PR TITLE
fix(#1797): change source="internal" to "system" in cron scripts to prevent quarantine

### DIFF
--- a/scripts/daily-update-check.sh
+++ b/scripts/daily-update-check.sh
@@ -31,7 +31,7 @@ if [ -d "$LOBSTER_DIR/.git" ]; then
         cat > "$INBOX/${TIMESTAMP}_update_available.json" << EOF
 {
   "id": "${TIMESTAMP}_update_available",
-  "source": "internal",
+  "source": "system",
   "chat_id": 0,
   "type": "update_notification",
   "text": "UPDATE AVAILABLE: Lobster is ${BEHIND} commits behind origin/main. Use check_updates for details.",
@@ -50,7 +50,7 @@ else
         cat > "$INBOX/${TIMESTAMP}_update_available.json" << EOF
 {
   "id": "${TIMESTAMP}_update_available",
-  "source": "internal",
+  "source": "system",
   "chat_id": 0,
   "type": "update_notification",
   "text": "UPDATE AVAILABLE: Lobster v${CURRENT_VERSION} -> v${LATEST_VERSION}. Use check_updates for details.",

--- a/scripts/nightly-consolidation.sh
+++ b/scripts/nightly-consolidation.sh
@@ -53,7 +53,7 @@ fi
 cat > "$INBOX/${TIMESTAMP}_consolidation.json" << EOF
 {
   "id": "${TIMESTAMP}_consolidation",
-  "source": "internal",
+  "source": "system",
   "chat_id": 0,
   "type": "consolidation",
   "text": "NIGHTLY CONSOLIDATION: Review today's events using memory_recent(hours=24) and update canonical memory files. Steps:\n1. Call memory_recent(hours=24) to get all events from the past day\n2. Synthesize key themes, decisions, and action items\n3. Update memory/canonical/daily-digest.md with the synthesis\n4. Update memory/canonical/priorities.md if priorities changed\n5. Update relevant project files in memory/canonical/projects/\n6. Update people files if new relationship info emerged\n7. Mark all reviewed events as consolidated using mark_consolidated\n8. Update memory/canonical/handoff.md with current state",

--- a/tests/unit/test_mcp_server/test_message_taxonomy.py
+++ b/tests/unit/test_mcp_server/test_message_taxonomy.py
@@ -13,6 +13,7 @@ tests/docker/Dockerfile.test.
 import asyncio
 import json
 import logging
+import re
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -239,3 +240,97 @@ class TestMarkProcessingTypeValidation:
             if "unknown message type" in r.message
         ]
         assert not type_warnings, f"Unexpected type warning for known type 'text': {type_warnings}"
+
+
+class TestScriptSourceValues:
+    """
+    Guardrail: every "source" value written by cron/system scripts must be in
+    INBOX_MESSAGE_SOURCES (issue #1797).
+
+    When PR #1736 added the quarantine guard it updated daily-health-check.sh
+    but missed nightly-consolidation.sh and daily-update-check.sh, which kept
+    writing source="internal". Those messages were silently quarantined for
+    3 nights before the bug was discovered. This class catches similar mismatches
+    at test time so the same class of error cannot be re-introduced.
+
+    Strategy: parse every *.sh file in scripts/ for JSON "source" values written
+    to the inbox (i.e. lines matching `"source": "<value>"`), then assert each
+    extracted value is in INBOX_MESSAGE_SOURCES.
+    """
+
+    # Regex: matches `"source": "some-value"` inside here-doc / inline JSON.
+    _SOURCE_RE = re.compile(r'"source"\s*:\s*"([^"]+)"')
+
+    @pytest.fixture(autouse=True)
+    def _load_sources(self):
+        from message_types import INBOX_MESSAGE_SOURCES
+        self._known_sources = INBOX_MESSAGE_SOURCES
+
+    def _extract_source_values(self, script_path: Path) -> list[tuple[int, str]]:
+        """Return list of (line_number, source_value) found in script_path."""
+        results = []
+        for lineno, line in enumerate(script_path.read_text().splitlines(), start=1):
+            for m in self._SOURCE_RE.finditer(line):
+                results.append((lineno, m.group(1)))
+        return results
+
+    def _get_scripts_dir(self) -> Path:
+        """Locate the repository scripts/ directory relative to this test file."""
+        # test_message_taxonomy.py → test_mcp_server/ → unit/ → tests/ → repo_root/
+        # parents[0]=test_mcp_server, [1]=unit, [2]=tests, [3]=repo_root
+        return Path(__file__).resolve().parents[3] / "scripts"
+
+    def test_nightly_consolidation_source_is_recognized(self):
+        """nightly-consolidation.sh must write a recognized source (regression: issue #1797)."""
+        scripts_dir = self._get_scripts_dir()
+        script = scripts_dir / "nightly-consolidation.sh"
+        assert script.exists(), f"Script not found: {script}"
+
+        found = self._extract_source_values(script)
+        assert found, f"No \"source\" values found in {script.name} — was the script refactored?"
+
+        bad = [(ln, v) for ln, v in found if v not in self._known_sources]
+        assert not bad, (
+            f"{script.name} writes unrecognized source value(s) — "
+            f"add to INBOX_MESSAGE_SOURCES or change to 'system':\n"
+            + "\n".join(f"  line {ln}: {v!r}" for ln, v in bad)
+        )
+
+    def test_daily_update_check_source_is_recognized(self):
+        """daily-update-check.sh must write a recognized source (regression: issue #1797)."""
+        scripts_dir = self._get_scripts_dir()
+        script = scripts_dir / "daily-update-check.sh"
+        assert script.exists(), f"Script not found: {script}"
+
+        found = self._extract_source_values(script)
+        assert found, f"No \"source\" values found in {script.name} — was the script refactored?"
+
+        bad = [(ln, v) for ln, v in found if v not in self._known_sources]
+        assert not bad, (
+            f"{script.name} writes unrecognized source value(s) — "
+            f"add to INBOX_MESSAGE_SOURCES or change to 'system':\n"
+            + "\n".join(f"  line {ln}: {v!r}" for ln, v in bad)
+        )
+
+    def test_all_scripts_write_recognized_sources(self):
+        """Every *.sh script in scripts/ that writes a JSON source field must use a known source.
+
+        This is the broad guardrail: adding a new script that writes
+        source="internal" (or any other unrecognized value) will fail here.
+        Existing scripts with no "source" field are ignored.
+        """
+        scripts_dir = self._get_scripts_dir()
+        assert scripts_dir.exists(), f"scripts/ directory not found at {scripts_dir}"
+
+        violations: list[str] = []
+        for script in sorted(scripts_dir.glob("*.sh")):
+            for lineno, value in self._extract_source_values(script):
+                if value not in self._known_sources:
+                    violations.append(f"{script.name}:{lineno}: {value!r}")
+
+        assert not violations, (
+            "The following scripts write source values not in INBOX_MESSAGE_SOURCES.\n"
+            "Either update INBOX_MESSAGE_SOURCES in message_types.py or change the\n"
+            "source to 'system' (the standard value for cron/system-generated messages):\n"
+            + "\n".join(f"  {v}" for v in violations)
+        )


### PR DESCRIPTION
🤖🦞 Lobster (engineer): Fix for issue #1797 — nightly consolidation and update-check messages were being silently quarantined to `failed/` because the scripts wrote `source="internal"`, which is not in `INBOX_MESSAGE_SOURCES`.

## Root Cause

PR #1736 added a quarantine guard for unrecognized message sources and updated `daily-health-check.sh` to use `source="system"`, but missed `nightly-consolidation.sh` and `daily-update-check.sh`, which both kept writing `source="internal"`. Since Apr 22, every nightly consolidation message has been quarantined, resulting in 3 missed consolidations (Apr 23–25) and degraded canonical memory. A timing collision with the health check also triggered a false-positive dispatcher restart at 2026-04-25 03:00 UTC.

## Changes

- **`scripts/nightly-consolidation.sh`**: Change `"source": "internal"` → `"source": "system"` (line 56)
- **`scripts/daily-update-check.sh`**: Change `"source": "internal"` → `"source": "system"` in both the git mode and tarball mode branches (lines 34 and 53)
- **`tests/unit/test_mcp_server/test_message_taxonomy.py`**: Add `TestScriptSourceValues` class with three tests:
  - Targeted regression tests for `nightly-consolidation.sh` and `daily-update-check.sh`
  - A broad guardrail (`test_all_scripts_write_recognized_sources`) that parses every `*.sh` in `scripts/` for JSON `"source"` fields and asserts each value is in `INBOX_MESSAGE_SOURCES` — so future script additions can't silently re-introduce this class of bug

## Test Plan

- [x] `uv run pytest tests/unit/test_mcp_server/test_message_taxonomy.py` — all 20 tests pass (17 pre-existing + 3 new)
- [x] `uv run pytest tests/unit/test_mcp_server/ --tb=no -q` — 843 passed, no new failures introduced
- [x] Verified pre-existing collection errors in full suite are pre-existing on `main` (not caused by this PR)

Closes #1797