### PR TITLE
fix(#1777): handle dict format in build_inline_keyboard

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -1788,8 +1788,10 @@ def build_inline_keyboard(buttons: list) -> InlineKeyboardMarkup:
     """Build a Telegram InlineKeyboardMarkup from a nested list of button labels.
 
     Each inner list represents a row of buttons.  Each element in the row is
-    either a plain string label (callback_data == label) or a [label, data]
-    two-element list where data is the callback_data payload.
+    one of:
+    - a plain string label (callback_data == label)
+    - a [label, data] two-element list where data is the callback_data payload
+    - a {"text": label, "callback_data": data} dict (complex format)
 
     Pure function: no side effects.
     """
@@ -1797,7 +1799,10 @@ def build_inline_keyboard(buttons: list) -> InlineKeyboardMarkup:
     for row in buttons:
         keyboard_row = []
         for item in row:
-            if isinstance(item, (list, tuple)) and len(item) == 2:
+            if isinstance(item, dict):
+                label = str(item.get("text", ""))
+                data = str(item.get("callback_data", label))
+            elif isinstance(item, (list, tuple)) and len(item) == 2:
                 label, data = item
             else:
                 label = str(item)

--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -1800,7 +1800,11 @@ def build_inline_keyboard(buttons: list) -> InlineKeyboardMarkup:
         keyboard_row = []
         for item in row:
             if isinstance(item, dict):
-                label = str(item.get("text", ""))
+                if not item.get("text"):
+                    raise ValueError(
+                        f"Dict button spec is missing a non-empty 'text' key: {item!r}"
+                    )
+                label = str(item["text"])
                 data = str(item.get("callback_data", label))
             elif isinstance(item, (list, tuple)) and len(item) == 2:
                 label, data = item

--- a/tests/unit/test_bot/test_outbox_watcher.py
+++ b/tests/unit/test_bot/test_outbox_watcher.py
@@ -835,3 +835,93 @@ class TestPrepareSendItems:
             # <pre><code> and </code></pre> tags must be balanced
             assert html.count("<pre>") == html.count("</pre>") or True  # HTML tags may differ
             assert len(html) <= bot_module.TELEGRAM_HARD_LIMIT
+
+
+class TestBuildInlineKeyboard:
+    """Tests for build_inline_keyboard — the helper that converts button specs to InlineKeyboardMarkup.
+
+    Covers all three supported button element formats:
+    - Simple string (text == callback_data)
+    - [label, data] two-element list
+    - {"text": label, "callback_data": data} dict (the complex format from issue #1777)
+    """
+
+    @pytest.fixture
+    def bot_module(self):
+        return get_bot_module()
+
+    def test_simple_string_buttons(self, bot_module):
+        """Plain string buttons use the string as both text and callback_data."""
+        markup = bot_module.build_inline_keyboard([["Yes", "No"]])
+        row = markup.inline_keyboard[0]
+        assert len(row) == 2
+        assert row[0].text == "Yes"
+        assert row[0].callback_data == "Yes"
+        assert row[1].text == "No"
+        assert row[1].callback_data == "No"
+
+    def test_list_format_buttons(self, bot_module):
+        """Two-element list buttons use first element as text, second as callback_data."""
+        markup = bot_module.build_inline_keyboard([[["Label A", "data_a"], ["Label B", "data_b"]]])
+        row = markup.inline_keyboard[0]
+        assert len(row) == 2
+        assert row[0].text == "Label A"
+        assert row[0].callback_data == "data_a"
+        assert row[1].text == "Label B"
+        assert row[1].callback_data == "data_b"
+
+    def test_dict_format_buttons_text_and_callback_data(self, bot_module):
+        """Dict buttons extract 'text' as the label and 'callback_data' as the payload.
+
+        This is the regression test for issue #1777: the dict must NOT be rendered
+        as a string — only the 'text' field should appear as the button label.
+        """
+        markup = bot_module.build_inline_keyboard([[
+            {"text": "👍 got it", "callback_data": "card1b_next"},
+            {"text": "😴 sleep", "callback_data": "card1b_sleep"},
+        ]])
+        row = markup.inline_keyboard[0]
+        assert len(row) == 2
+        assert row[0].text == "👍 got it"
+        assert row[0].callback_data == "card1b_next"
+        assert row[1].text == "😴 sleep"
+        assert row[1].callback_data == "card1b_sleep"
+
+    def test_dict_format_button_label_is_not_raw_json(self, bot_module):
+        """Dict button labels must never include dict-like syntax such as '{' or 'callback_data'."""
+        markup = bot_module.build_inline_keyboard([[
+            {"text": "Click me", "callback_data": "action_x"},
+        ]])
+        label = markup.inline_keyboard[0][0].text
+        assert "{" not in label, f"Button label looks like raw JSON: {label!r}"
+        assert "callback_data" not in label, f"Button label contains dict key: {label!r}"
+        assert label == "Click me"
+
+    def test_dict_format_missing_callback_data_falls_back_to_text(self, bot_module):
+        """A dict button without 'callback_data' falls back to the text value."""
+        markup = bot_module.build_inline_keyboard([[{"text": "Only label"}]])
+        btn = markup.inline_keyboard[0][0]
+        assert btn.text == "Only label"
+        assert btn.callback_data == "Only label"
+
+    def test_multiple_rows(self, bot_module):
+        """Multiple rows are each represented as separate inner lists."""
+        markup = bot_module.build_inline_keyboard([
+            ["Row1 Btn1", "Row1 Btn2"],
+            ["Row2 Btn1"],
+        ])
+        assert len(markup.inline_keyboard) == 2
+        assert len(markup.inline_keyboard[0]) == 2
+        assert len(markup.inline_keyboard[1]) == 1
+
+    def test_mixed_formats_in_same_row(self, bot_module):
+        """A row may mix simple strings and dict buttons."""
+        markup = bot_module.build_inline_keyboard([[
+            "Simple",
+            {"text": "Complex", "callback_data": "payload"},
+        ]])
+        row = markup.inline_keyboard[0]
+        assert row[0].text == "Simple"
+        assert row[0].callback_data == "Simple"
+        assert row[1].text == "Complex"
+        assert row[1].callback_data == "payload"

--- a/tests/unit/test_bot/test_outbox_watcher.py
+++ b/tests/unit/test_bot/test_outbox_watcher.py
@@ -904,6 +904,26 @@ class TestBuildInlineKeyboard:
         assert btn.text == "Only label"
         assert btn.callback_data == "Only label"
 
+    def test_dict_format_missing_text_raises_value_error(self, bot_module):
+        """A dict button without a 'text' key raises ValueError immediately.
+
+        Previously, item.get('text', '') silently produced an empty label and the
+        failure only surfaced later inside the Telegram outbox handler.  The guard
+        must fire at construction time with a clear message so the caller sees the
+        bad spec as soon as build_inline_keyboard is called.
+        """
+        with pytest.raises(ValueError, match="missing a non-empty 'text' key"):
+            bot_module.build_inline_keyboard([[{"callback_data": "some_action"}]])
+
+    def test_dict_format_empty_text_raises_value_error(self, bot_module):
+        """A dict button with an empty-string 'text' also raises ValueError.
+
+        An empty label is just as unusable as a missing one — the guard covers
+        both cases so the outbox handler is never handed a button with no label.
+        """
+        with pytest.raises(ValueError, match="missing a non-empty 'text' key"):
+            bot_module.build_inline_keyboard([[{"text": "", "callback_data": "some_action"}]])
+
     def test_multiple_rows(self, bot_module):
         """Multiple rows are each represented as separate inner lists."""
         markup = bot_module.build_inline_keyboard([


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Summary

Fixes #1777: `send_reply` with the complex button format `[{"text": "Label", "callback_data": "value"}]` was rendering button labels as raw JSON strings instead of just the `text` field value.

**Root cause:** `build_inline_keyboard` in `src/bot/lobster_bot.py` handled `str`, `list`, and `tuple` button element types but had no `dict` branch. Dict items fell through to the `else` clause which called `str(item)`, serializing the entire dict as the button label.

**Fix:** Added a `dict` isinstance check before the existing list/tuple check. When a button element is a dict, `text` is extracted from `item["text"]` and `callback_data` from `item["callback_data"]` (falling back to the text value if `callback_data` is absent).

## Changes

- `src/bot/lobster_bot.py`: Added dict branch in `build_inline_keyboard`; updated docstring to document all three supported element formats.
- `tests/unit/test_bot/test_outbox_watcher.py`: Added `TestBuildInlineKeyboard` class with 7 tests covering the string, list, and dict formats, including a direct regression test for the `#1777` bug (label must not contain `{` or `callback_data`).

## Test plan

- [x] All 51 tests in `tests/unit/test_bot/test_outbox_watcher.py` pass
- [x] New `TestBuildInlineKeyboard` tests confirm dict buttons emit correct `text` and `callback_data` values
- [x] Regression test `test_dict_format_button_label_is_not_raw_json` explicitly asserts the label is `"Click me"` and contains no `{` or `callback_data` strings
- [x] No new failures introduced (pre-existing collection errors on other test modules are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)