### PR TITLE
fix(#1826): gate fallback rm -rf on confirmed-orphaned worktrees; add tests

### DIFF
--- a/scripts/prune-pr-worktrees.py
+++ b/scripts/prune-pr-worktrees.py
@@ -105,6 +105,21 @@ def dir_age_days(path: Path) -> float:
     return age.total_seconds() / 86400
 
 
+def is_worktree_registered(main_repo: Path, worktree_path: Path) -> bool:
+    """Return True if worktree_path still appears in `git worktree list --porcelain`."""
+    rc, out, _ = run(["git", "worktree", "list", "--porcelain"], cwd=main_repo)
+    if rc != 0:
+        # If the command fails we conservatively assume it IS registered to
+        # avoid accidentally deleting a live worktree.
+        return True
+    resolved = str(worktree_path.resolve())
+    for line in out.splitlines():
+        # Lines look like: "worktree /absolute/path"
+        if line.startswith("worktree ") and line[len("worktree "):].strip() == resolved:
+            return True
+    return False
+
+
 def remove_worktree(main_repo: Path, worktree_path: Path, dry_run: bool) -> bool:
     """Remove a git worktree and its directory."""
     if dry_run:
@@ -118,11 +133,17 @@ def remove_worktree(main_repo: Path, worktree_path: Path, dry_run: bool) -> bool
         log(f"  [REMOVED] {worktree_path}")
         return True
 
-    # git worktree remove failed. Only fall back to shutil.rmtree if the
-    # directory still exists (meaning git failed before touching it, e.g.
-    # because the worktree isn't registered). If git already partially removed
-    # it (unlikely with --force), we skip to avoid double-removal.
-    log(f"  [WARN] git worktree remove failed ({err or 'unknown'}) — trying direct removal")
+    # git worktree remove failed.  Before falling back to direct filesystem
+    # removal, confirm the worktree is no longer registered in git's list.
+    # If it is still registered the failure was transient (permissions, locks,
+    # etc.) and a direct rm -rf would leave git's metadata in an inconsistent
+    # state.  Only proceed when git has already forgotten the worktree —
+    # i.e. the directory is a pure filesystem orphan.
+    log(f"  [WARN] git worktree remove failed ({err or 'unknown'}) — checking worktree list")
+    if is_worktree_registered(main_repo, worktree_path):
+        log(f"  [ERROR] refusing rm -rf: {worktree_path} is still registered in git worktree list")
+        return False
+
     if worktree_path.exists():
         # Safety check: only delete paths that live under the expected projects
         # dir to prevent accidental data loss if path resolution goes wrong.

--- a/tests/unit/test_scheduled_tasks/test_prune_pr_worktrees.py
+++ b/tests/unit/test_scheduled_tasks/test_prune_pr_worktrees.py
@@ -1,0 +1,284 @@
+"""
+Tests for scripts/prune-pr-worktrees.py
+
+Covers:
+- TimeoutExpired in the scan loop does NOT abort the full run
+- Fallback rm -rf is gated on absence from `git worktree list --porcelain`
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the module under test.  The script lives in scripts/ which is not a
+# Python package, so we add it to sys.path manually.
+# ---------------------------------------------------------------------------
+SCRIPTS_DIR = Path(__file__).resolve().parents[3] / "scripts"
+
+
+@pytest.fixture(autouse=True)
+def _add_scripts_to_path(monkeypatch):
+    monkeypatch.syspath_prepend(str(SCRIPTS_DIR))
+
+
+import importlib
+
+@pytest.fixture()
+def prune():
+    """Return a freshly-imported prune_pr_worktrees module."""
+    # Use importlib so we can re-import cleanly per test.
+    import importlib
+    mod = importlib.import_module("prune-pr-worktrees".replace("-", "_"))
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Helper — importlib can't import a module whose name contains a hyphen via
+# normal attribute access, so we do it once at module level.
+# ---------------------------------------------------------------------------
+import importlib.util, types
+
+_spec = importlib.util.spec_from_file_location(
+    "prune_pr_worktrees",
+    SCRIPTS_DIR / "prune-pr-worktrees.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+run = _mod.run
+is_worktree_registered = _mod.is_worktree_registered
+remove_worktree = _mod.remove_worktree
+
+
+# ===========================================================================
+# Tests for TimeoutExpired handling in run()
+# ===========================================================================
+
+
+class TestRunTimeoutExpired:
+    """run() must catch TimeoutExpired and return (1, '', 'timeout')."""
+
+    def test_timeout_returns_error_tuple(self, tmp_path):
+        """When the subprocess hangs, run() returns (1, '', 'timeout')."""
+        # Patch Popen so that communicate() raises TimeoutExpired the first time
+        # (triggering the exception handler), then succeeds when called again
+        # after kill() to reap the process.
+        mock_proc = MagicMock()
+        mock_proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd=["git"], timeout=30),
+            ("", ""),  # second call after kill() to reap
+        ]
+        with patch("subprocess.Popen", return_value=mock_proc):
+            rc, stdout, stderr = run(["git", "branch"], timeout=30)
+        assert rc == 1
+        assert stdout == ""
+        assert stderr == "timeout"
+
+    def test_timeout_kills_process(self, tmp_path):
+        """When TimeoutExpired fires, the child process is killed and reaped."""
+        mock_proc = MagicMock()
+        # First communicate() raises; second (after kill) succeeds.
+        mock_proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd=["git"], timeout=30),
+            ("", ""),
+        ]
+        with patch("subprocess.Popen", return_value=mock_proc):
+            run(["git", "branch"], timeout=30)
+        mock_proc.kill.assert_called_once()
+        # communicate() called twice: once (raises), once after kill
+        assert mock_proc.communicate.call_count == 2
+
+    def test_timeout_does_not_propagate(self, tmp_path):
+        """TimeoutExpired must not escape run() — callers see a normal tuple."""
+        mock_proc = MagicMock()
+        mock_proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd=["gh"], timeout=30),
+            ("", ""),  # second call after kill() to reap
+        ]
+        with patch("subprocess.Popen", return_value=mock_proc):
+            result = run(["gh", "pr", "list"])
+        # If the exception had escaped, this line would not be reached.
+        assert isinstance(result, tuple) and len(result) == 3
+
+
+# ===========================================================================
+# Tests for is_worktree_registered()
+# ===========================================================================
+
+
+class TestIsWorktreeRegistered:
+    """is_worktree_registered() parses `git worktree list --porcelain` output."""
+
+    def _porcelain_output(self, paths: list[str]) -> str:
+        """Build fake --porcelain output for the given worktree paths."""
+        blocks = []
+        for p in paths:
+            blocks.append(f"worktree {p}\nHEAD abc123\nbranch refs/heads/main\n")
+        return "\n".join(blocks)
+
+    def test_returns_true_when_path_listed(self, tmp_path):
+        wt = tmp_path / "my-worktree"
+        wt.mkdir()
+        main_repo = tmp_path / "main"
+        porcelain = self._porcelain_output([str(wt.resolve())])
+        with patch.object(_mod, "run", return_value=(0, porcelain, "")):
+            assert is_worktree_registered(main_repo, wt) is True
+
+    def test_returns_false_when_path_absent(self, tmp_path):
+        wt = tmp_path / "my-worktree"
+        wt.mkdir()
+        main_repo = tmp_path / "main"
+        other = str(tmp_path / "other-worktree")
+        porcelain = self._porcelain_output([other])
+        with patch.object(_mod, "run", return_value=(0, porcelain, "")):
+            assert is_worktree_registered(main_repo, wt) is False
+
+    def test_returns_true_conservatively_when_git_fails(self, tmp_path):
+        """If git worktree list fails, assume registered (safe default)."""
+        wt = tmp_path / "my-worktree"
+        main_repo = tmp_path / "main"
+        with patch.object(_mod, "run", return_value=(1, "", "fatal: not a git repo")):
+            assert is_worktree_registered(main_repo, wt) is True
+
+
+# ===========================================================================
+# Tests for remove_worktree() fallback gating
+# ===========================================================================
+
+
+class TestRemoveWorktreeFallbackGating:
+    """Fallback rm -rf must only run when the worktree is absent from git list."""
+
+    def test_no_rmtree_when_still_registered(self, tmp_path):
+        """If git worktree remove fails AND the worktree is still registered,
+        shutil.rmtree must NOT be called."""
+        wt = tmp_path / "stale-wt"
+        wt.mkdir()
+        main_repo = tmp_path / "main"
+
+        # git worktree remove fails; git worktree list shows it as registered
+        def fake_run(cmd, cwd=None, timeout=30):
+            if "remove" in cmd:
+                return 1, "", "error: not a worktree"
+            if "list" in cmd and "--porcelain" in cmd:
+                return 0, f"worktree {wt.resolve()}\nHEAD abc\nbranch refs/heads/x\n", ""
+            return 0, "", ""
+
+        with patch.object(_mod, "run", side_effect=fake_run), \
+             patch("shutil.rmtree") as mock_rm:
+            result = remove_worktree(main_repo, wt, dry_run=False)
+
+        assert result is False, "Should return False — refused to rm -rf a registered worktree"
+        mock_rm.assert_not_called()
+
+    def test_rmtree_allowed_when_not_registered(self, tmp_path):
+        """If git worktree remove fails AND the worktree is absent from list,
+        shutil.rmtree IS allowed (path-safety permitting)."""
+        # Put the worktree under DEFAULT_PROJECTS_DIR so the path safety check passes
+        import importlib
+        projects_dir = _mod.DEFAULT_PROJECTS_DIR.resolve()
+        wt = projects_dir / "orphan-wt"
+        wt.mkdir(parents=True, exist_ok=True)
+        main_repo = tmp_path / "main"
+
+        # git worktree remove fails; git worktree list does NOT show this path
+        def fake_run(cmd, cwd=None, timeout=30):
+            if "remove" in cmd:
+                return 1, "", "error: not a worktree"
+            if "list" in cmd and "--porcelain" in cmd:
+                # List shows a different path — target is absent
+                return 0, "worktree /some/other/path\nHEAD abc\nbranch refs/heads/x\n", ""
+            # prune or other git commands
+            return 0, "", ""
+
+        with patch.object(_mod, "run", side_effect=fake_run), \
+             patch("shutil.rmtree") as mock_rm:
+            result = remove_worktree(main_repo, wt, dry_run=False)
+
+        assert result is True
+        mock_rm.assert_called_once_with(str(wt))
+
+        # cleanup
+        import shutil
+        if wt.exists():
+            shutil.rmtree(str(wt))
+
+    def test_git_worktree_remove_success_skips_fallback(self, tmp_path):
+        """When git worktree remove succeeds, shutil.rmtree is never called."""
+        wt = tmp_path / "clean-wt"
+        wt.mkdir()
+        main_repo = tmp_path / "main"
+
+        def fake_run(cmd, cwd=None, timeout=30):
+            if "remove" in cmd:
+                return 0, "", ""
+            return 0, "", ""
+
+        with patch.object(_mod, "run", side_effect=fake_run), \
+             patch("shutil.rmtree") as mock_rm:
+            result = remove_worktree(main_repo, wt, dry_run=False)
+
+        assert result is True
+        mock_rm.assert_not_called()
+
+
+# ===========================================================================
+# Integration-style test: scan loop survives a TimeoutExpired mid-scan
+# ===========================================================================
+
+
+class TestScanLoopSurvivesTimeout:
+    """The main scan loop must not abort when a sub-command times out."""
+
+    def test_scan_continues_after_timeout(self, tmp_path, capsys):
+        """If get_branch() (which calls run()) returns a timeout, the loop
+        continues and the summary line is still emitted."""
+        # Build two fake worktree dirs in a clean scan root
+        scan_root = tmp_path / "scan_root"
+        scan_root.mkdir()
+        for name in ("wt-a", "wt-b"):
+            d = scan_root / name
+            d.mkdir()
+            (d / ".git").write_text("gitdir: /fake/.git/worktrees/" + name)
+
+        # Patch the per-entry helpers so that wt-a times out on get_branch
+        # but wt-b succeeds (and is then skipped for having no PR).
+        visited = []
+
+        def fake_get_branch(path):
+            visited.append(path.name)
+            if path.name == "wt-a":
+                # Simulate a timeout: run() would have returned (1,'','timeout')
+                # which causes get_branch to return None
+                return None
+            return "my-feature-branch"
+
+        def fake_get_remote_url(path):
+            return "https://github.com/owner/repo.git"
+
+        def fake_get_pr_state(repo, branch):
+            return None  # no PR — skipped
+
+        def fake_dir_age_days(path):
+            return 10.0  # old enough
+
+        with patch.object(_mod, "get_branch", side_effect=fake_get_branch), \
+             patch.object(_mod, "get_remote_url", side_effect=fake_get_remote_url), \
+             patch.object(_mod, "get_pr_state", side_effect=fake_get_pr_state), \
+             patch.object(_mod, "dir_age_days", side_effect=fake_dir_age_days), \
+             patch.object(_mod, "is_worktree", return_value=True), \
+             patch.object(_mod, "LOG_FILE", tmp_path / "prune.log"):
+            sys.argv = ["prune-pr-worktrees", "--projects-dir", str(scan_root), "--age-days", "0"]
+            _mod.main()
+
+        out = capsys.readouterr().out
+        # Both directories were visited (get_branch called for each)
+        assert "wt-a" in visited, "wt-a should have been visited"
+        assert "wt-b" in visited, "wt-b should have been visited"
+        # Summary line must be present — confirms loop completed instead of aborting
+        assert "Summary:" in out


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Problem

Two robustness gaps in `scripts/prune-pr-worktrees.py` per issue #1826:

1. **TimeoutExpired handling** — already addressed in nit commits cc217ba9 and 862aaa68 (run() wraps Popen+communicate in try/except, kills and reaps the child, returns (1, '', 'timeout')). No new code needed for this part; tests now cover it explicitly.

2. **Unconditional fallback rm -rf** — when `git worktree remove` fails, the previous code fell back to `shutil.rmtree` unconditionally (subject only to a path-safety check). This is unsafe: if the failure was transient (permission error, lock) and the worktree is still registered in git's metadata, direct filesystem removal leaves git in an inconsistent state.

## Fix

Add `is_worktree_registered(main_repo, worktree_path)` which queries `git worktree list --porcelain` and checks whether the target path appears in the output. In `remove_worktree()`, after `git worktree remove` fails, call this function before attempting the `shutil.rmtree` fallback:

- If the worktree **is still registered**: log `[ERROR]` and return `False` — the failure was transient; do not touch the filesystem.
- If the worktree **is absent from the list** (confirmed orphan): proceed to `shutil.rmtree` as before.
- If `git worktree list` itself fails: conservatively assume registered (safe default).

## Tests added

`tests/unit/test_scheduled_tasks/test_prune_pr_worktrees.py` (10 tests, all passing):

- `run()` catches `TimeoutExpired`, kills+reaps child, returns `(1, '', 'timeout')`
- `run()` exception does not escape to the caller
- `is_worktree_registered()` parses `--porcelain` output correctly
- `is_worktree_registered()` returns `True` conservatively when git fails
- `remove_worktree()` refuses `shutil.rmtree` when worktree still registered
- `remove_worktree()` allows `shutil.rmtree` for confirmed-orphaned directories
- `remove_worktree()` does not call `shutil.rmtree` on clean removal success
- Scan loop continues past a timed-out directory and emits the summary line

## Scope

Changes isolated to `scripts/prune-pr-worktrees.py` and a new test file. No schema changes, no service restarts, no install changes.

Closes #1826