### PR TITLE
fix(#1768): add fresh-dispatcher-start fallback in on-fresh-start.py

### DIFF
--- a/hooks/on-fresh-start.py
+++ b/hooks/on-fresh-start.py
@@ -104,6 +104,20 @@ COMPACTION_STATE_FILE = Path(
     )
 )
 
+# Primary dispatcher state file — written by the MCP server when the dispatcher
+# calls session_start(agent_type='dispatcher', claude_session_id=...).
+# The MCP server CLEARS this file on every startup, so it is absent during the
+# window between MCP restart and the dispatcher's first session_start() call.
+# On compaction, on-compact.py writes this file proactively so the new session
+# is identified before session_start() is called.
+# Override path for tests.
+_MCP_CLAUDE_SESSION_FILE = Path(
+    os.environ.get(
+        "LOBSTER_MCP_CLAUDE_SESSION_FILE_OVERRIDE",
+        os.path.expanduser("~/lobster-workspace/data/dispatcher-claude-session-id"),
+    )
+)
+
 INBOX_DIR = Path(os.path.expanduser("~/messages/inbox"))
 PROCESSING_DIR = Path(os.path.expanduser("~/messages/processing"))
 
@@ -470,6 +484,61 @@ def _mark_all_running_failed() -> None:
         )
 
 
+def _is_fresh_dispatcher_start(hook_input: dict) -> bool:
+    """Return True if this SessionStart looks like a fresh (post-restart) dispatcher boot.
+
+    This is a fallback check for the case where session_role.is_dispatcher()
+    returns False despite the session being the real dispatcher.  That failure
+    mode occurs when write-dispatcher-session-id.py misidentifies the new
+    dispatcher as a subagent (issue #1768): it does so when the previous
+    dispatcher's JSONL file has a recent mtime, causing _stored_session_is_alive()
+    to return True and suppressing the session-ID file update.  The tertiary
+    file then contains the old session UUID, which does not match the new session
+    UUID, so is_dispatcher() returns False.
+
+    ## Why absent primary file + LOBSTER_MAIN_SESSION=1 implies fresh dispatcher start
+
+    The primary state file (dispatcher-claude-session-id) lifecycle:
+
+    - MCP server startup: file is **deleted** (_clear_dispatcher_state_file)
+    - After dispatcher calls session_start(..., claude_session_id=uuid): file is written
+    - Compaction: on-compact.py proactively writes the file with the new UUID
+      so the new session is identifiable before session_start() is called
+
+    Consequence:
+
+    - At a fresh restart (new process, MCP server restarted): the file is absent
+      from MCP startup until the dispatcher calls session_start().
+    - At a subagent SessionStart: the file is present (the dispatcher already
+      called session_start() before spawning any subagents via Task()).
+    - At a compaction SessionStart: the file is present (on-compact.py wrote it).
+
+    Therefore: absent primary file at a non-compaction SessionStart, combined
+    with LOBSTER_MAIN_SESSION=1, is a reliable signal that this is the dispatcher
+    booting for the first time in this session — not a subagent.
+
+    This check intentionally runs ONLY when is_dispatcher() has already returned
+    False.  When is_dispatcher() returns True (the common case), this function is
+    never called.
+    """
+    # LOBSTER_MAIN_SESSION=1 is required — must be a Lobster-managed session.
+    if os.environ.get("LOBSTER_MAIN_SESSION", "") != "1":
+        return False
+
+    # Not a compaction event (callers should already gate on this, but double-check).
+    if _is_compact_event(hook_input):
+        return False
+
+    # Primary file absent ↔ MCP server has started but session_start() has not
+    # yet been called by the dispatcher.  This is the pre-session_start window
+    # that exists only on genuine fresh restarts.
+    try:
+        return not _MCP_CLAUDE_SESSION_FILE.exists()
+    except OSError:
+        # If we cannot stat the file, do not assume dispatcher — return False.
+        return False
+
+
 def main() -> None:
     # Only fire for Lobster-managed sessions.
     if os.environ.get("LOBSTER_MAIN_SESSION", "") != "1":
@@ -485,7 +554,24 @@ def main() -> None:
         sys.exit(0)
 
     # Skip subagent sessions — only the dispatcher should run this.
-    if not session_role.is_dispatcher(data):
+    #
+    # is_dispatcher() uses two state files to detect the dispatcher:
+    # 1. Primary: dispatcher-claude-session-id (written by MCP server on session_start)
+    # 2. Tertiary: messages/config/dispatcher-session-id (written by write-dispatcher-session-id.py)
+    #
+    # On a fresh restart, write-dispatcher-session-id.py may misclassify the new
+    # dispatcher as a subagent when the previous session's JSONL file has a recent
+    # mtime — causing it to skip the session-ID file update.  The tertiary file
+    # then contains the old UUID, producing a mismatch → is_dispatcher() returns False.
+    #
+    # Fallback (issue #1768): if is_dispatcher() returns False but the primary
+    # state file is absent AND we are in a LOBSTER_MAIN_SESSION=1 environment,
+    # treat this as a fresh dispatcher start.  The primary file is cleared by the
+    # MCP server on startup and is absent until the dispatcher calls session_start();
+    # at that point, subagents have not yet been spawned, so absent primary file
+    # + non-compaction event + LOBSTER_MAIN_SESSION=1 reliably identifies the
+    # dispatcher.
+    if not session_role.is_dispatcher(data) and not _is_fresh_dispatcher_start(data):
         sys.exit(0)
 
     if not AGENT_MONITOR.exists():

--- a/tests/unit/test_hooks/test_fresh_dispatcher_start_fallback.py
+++ b/tests/unit/test_hooks/test_fresh_dispatcher_start_fallback.py
@@ -1,0 +1,381 @@
+"""
+Unit tests for the fresh-dispatcher-start fallback in hooks/on-fresh-start.py.
+
+Issue #1768: when write-dispatcher-session-id.py misidentifies a newly restarted
+dispatcher as a subagent (because the old JSONL file has a recent mtime), the
+tertiary state file retains the previous session UUID.  is_dispatcher() then
+returns False for the new dispatcher session, and on-fresh-start.py exits
+before calling _mark_all_running_failed() — leaving stale "running" sessions
+in agent_sessions.db.
+
+The fix adds _is_fresh_dispatcher_start() as a fallback: when is_dispatcher()
+would return False, we check whether the primary state file
+(dispatcher-claude-session-id) is absent.  If so, the MCP server has not yet
+received a session_start() call, which means the dispatcher has not started its
+main loop yet — i.e., this IS the dispatcher's fresh start, not a subagent.
+
+Subagents cannot fire this fallback because by the time any subagent starts
+(Task() spawning), the dispatcher has already called session_start(), which
+writes the primary file.  Compaction events are also excluded: on-compact.py
+writes the primary file proactively for the new post-compact session UUID.
+
+Tests cover:
+- _is_fresh_dispatcher_start() returns True when primary file absent + no compaction
+- _is_fresh_dispatcher_start() returns False when primary file is present
+- _is_fresh_dispatcher_start() returns False during compaction events
+- _is_fresh_dispatcher_start() returns False when LOBSTER_MAIN_SESSION != 1
+- _is_fresh_dispatcher_start() returns False on OSError reading the path
+- Integration: main() proceeds when is_dispatcher() returns False but primary file absent
+- Integration: main() exits when is_dispatcher() returns False and primary file present
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "on-fresh-start.py"
+
+
+class _PatchEnv:
+    """Context manager to temporarily set / restore environment variables."""
+
+    def __init__(self, env: dict):
+        self._env = env
+        self._saved: dict = {}
+
+    def __enter__(self):
+        for k, v in self._env.items():
+            self._saved[k] = os.environ.get(k)
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        return self
+
+    def __exit__(self, *_):
+        for k, saved_v in self._saved.items():
+            if saved_v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = saved_v
+
+
+def _load_module(
+    compaction_state_override: str | None = None,
+    mcp_claude_session_file_override: str | None = None,
+    session_file_pointer_override: str | None = None,
+    is_dispatcher_return: bool = True,
+) -> object:
+    """Load on-fresh-start.py in an isolated namespace, overriding key paths.
+
+    Uses a unique module name per call to avoid polluting the sys.modules cache
+    between test invocations.  The session_role stub is installed and removed
+    within this function so it does not bleed into other test modules.
+    """
+    import types
+    import uuid
+
+    env_patch: dict = {}
+    if compaction_state_override:
+        env_patch["LOBSTER_COMPACTION_STATE_FILE_OVERRIDE"] = compaction_state_override
+    if mcp_claude_session_file_override:
+        env_patch["LOBSTER_MCP_CLAUDE_SESSION_FILE_OVERRIDE"] = mcp_claude_session_file_override
+    if session_file_pointer_override:
+        env_patch["LOBSTER_CURRENT_SESSION_FILE_OVERRIDE"] = session_file_pointer_override
+
+    # Build the stub before installing it.
+    stub = types.ModuleType("session_role")
+    stub.is_dispatcher = lambda data: is_dispatcher_return  # type: ignore[attr-defined]
+
+    # Use a unique module name so repeated calls don't share cached state.
+    unique_name = f"on_fresh_start_fallback_test_{uuid.uuid4().hex}"
+
+    # Save and restore the real session_role to avoid test pollution.
+    real_session_role = sys.modules.get("session_role")
+    try:
+        sys.modules["session_role"] = stub
+        with _PatchEnv(env_patch):
+            spec = importlib.util.spec_from_file_location(unique_name, _HOOK_PATH)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+    finally:
+        if real_session_role is None:
+            sys.modules.pop("session_role", None)
+        else:
+            sys.modules["session_role"] = real_session_role
+
+    # Override module-level path constants for isolation.
+    if compaction_state_override:
+        mod.COMPACTION_STATE_FILE = Path(compaction_state_override)
+    if mcp_claude_session_file_override:
+        mod._MCP_CLAUDE_SESSION_FILE = Path(mcp_claude_session_file_override)
+    if session_file_pointer_override:
+        mod.CURRENT_SESSION_FILE_POINTER = Path(session_file_pointer_override)
+
+    # Attach the stub to the module for test introspection, and point the
+    # module's session_role reference at the stub (not the real module).
+    mod.session_role = stub
+    return mod
+
+
+def _make_session_role_stub(is_dispatcher: bool = True) -> object:
+    """Return a minimal session_role stub (kept for backwards compatibility)."""
+    import types
+
+    stub = types.ModuleType("session_role")
+    stub.is_dispatcher = lambda data: is_dispatcher  # type: ignore[attr-defined]
+    return stub
+
+
+def _make_non_compaction_input() -> dict:
+    """Return a SessionStart payload that is NOT a compaction event.
+
+    _is_compact_event() inspects compaction-state.json mtime, NOT the payload.
+    An empty dict is sufficient because the function only reads the file.
+    """
+    return {"session_id": "new-session-uuid-1234"}
+
+
+# ---------------------------------------------------------------------------
+# Tests for _is_fresh_dispatcher_start()
+# ---------------------------------------------------------------------------
+
+
+class TestIsFreshDispatcherStart:
+    """Unit tests for _is_fresh_dispatcher_start()."""
+
+    def test_returns_true_when_primary_file_absent_and_no_compaction(
+        self, tmp_path, monkeypatch
+    ):
+        """Primary file absent + non-compaction → fresh dispatcher start."""
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+        absent_primary = str(tmp_path / "nonexistent-dispatcher-claude-session-id")
+        # Compaction state file absent → _is_compact_event returns False.
+        absent_compaction = str(tmp_path / "nonexistent-compaction-state.json")
+
+        mod = _load_module(
+            mcp_claude_session_file_override=absent_primary,
+            compaction_state_override=absent_compaction,
+        )
+        result = mod._is_fresh_dispatcher_start(_make_non_compaction_input())
+        assert result is True
+
+    def test_returns_false_when_primary_file_present(self, tmp_path, monkeypatch):
+        """Primary file exists → dispatcher already called session_start, not a fresh boot."""
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+        primary_file = tmp_path / "dispatcher-claude-session-id"
+        primary_file.write_text("old-session-uuid-abcd")
+        absent_compaction = str(tmp_path / "nonexistent-compaction-state.json")
+
+        mod = _load_module(
+            mcp_claude_session_file_override=str(primary_file),
+            compaction_state_override=absent_compaction,
+        )
+        result = mod._is_fresh_dispatcher_start(_make_non_compaction_input())
+        assert result is False
+
+    def test_returns_false_when_main_session_not_set(self, tmp_path, monkeypatch):
+        """LOBSTER_MAIN_SESSION != 1 → not a Lobster-managed session, return False."""
+        monkeypatch.delenv("LOBSTER_MAIN_SESSION", raising=False)
+        absent_primary = str(tmp_path / "nonexistent-dispatcher-claude-session-id")
+        absent_compaction = str(tmp_path / "nonexistent-compaction-state.json")
+
+        mod = _load_module(
+            mcp_claude_session_file_override=absent_primary,
+            compaction_state_override=absent_compaction,
+        )
+        result = mod._is_fresh_dispatcher_start(_make_non_compaction_input())
+        assert result is False
+
+    def test_returns_false_when_main_session_is_zero(self, tmp_path, monkeypatch):
+        """LOBSTER_MAIN_SESSION=0 → return False."""
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "0")
+        absent_primary = str(tmp_path / "nonexistent-dispatcher-claude-session-id")
+        absent_compaction = str(tmp_path / "nonexistent-compaction-state.json")
+
+        mod = _load_module(
+            mcp_claude_session_file_override=absent_primary,
+            compaction_state_override=absent_compaction,
+        )
+        result = mod._is_fresh_dispatcher_start(_make_non_compaction_input())
+        assert result is False
+
+    def test_returns_false_during_compaction_event(self, tmp_path, monkeypatch):
+        """Compaction event → subagents are still alive, must not mark them failed."""
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+        absent_primary = str(tmp_path / "nonexistent-dispatcher-claude-session-id")
+
+        # Write a fresh compaction-state.json (mtime = now) → _is_compact_event returns True.
+        compaction_state = tmp_path / "compaction-state.json"
+        compaction_state.write_text(
+            json.dumps({"last_compaction_ts": "2026-04-23T07:00:00Z"})
+        )
+
+        mod = _load_module(
+            mcp_claude_session_file_override=absent_primary,
+            compaction_state_override=str(compaction_state),
+        )
+        result = mod._is_fresh_dispatcher_start(_make_non_compaction_input())
+        assert result is False
+
+    def test_returns_false_on_oserror_stat(self, tmp_path, monkeypatch):
+        """OSError when stat-ing the primary file → return False (safe default)."""
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+        absent_compaction = str(tmp_path / "nonexistent-compaction-state.json")
+
+        mod = _load_module(
+            compaction_state_override=absent_compaction,
+        )
+
+        # Patch _MCP_CLAUDE_SESSION_FILE.exists() to raise OSError.
+        mock_path = MagicMock(spec=Path)
+        mock_path.exists.side_effect = OSError("permission denied")
+        mod._MCP_CLAUDE_SESSION_FILE = mock_path
+
+        result = mod._is_fresh_dispatcher_start(_make_non_compaction_input())
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: main() gating — is_dispatcher() False + _is_fresh_dispatcher_start()
+# ---------------------------------------------------------------------------
+
+
+class TestMainGatingFallback:
+    """Integration tests: main() proceeds / exits based on the combined dispatcher check."""
+
+    def _make_compaction_state(self, tmp_path: Path, age_seconds: float = 3600) -> Path:
+        """Write a compaction-state.json whose mtime is `age_seconds` in the past."""
+        p = tmp_path / "compaction-state.json"
+        p.write_text(json.dumps({"last_compaction_ts": "2026-01-01T00:00:00Z"}))
+        mtime = time.time() - age_seconds
+        os.utime(str(p), (mtime, mtime))
+        return p
+
+    def test_proceeds_when_is_dispatcher_false_but_primary_file_absent(
+        self, tmp_path, monkeypatch
+    ):
+        """Issue #1768 fix: mark-failed runs even when is_dispatcher() returns False.
+
+        Simulates the exact failure mode: write-dispatcher-session-id.py skips
+        writing the tertiary file, so is_dispatcher() returns False.  But the
+        primary file is absent (MCP server cleared it on restart), so
+        _is_fresh_dispatcher_start() returns True and the hook proceeds.
+        """
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+
+        # Primary file absent → fresh start fallback active.
+        absent_primary = str(tmp_path / "nonexistent-dispatcher-claude-session-id")
+        # Compaction state file old (> 60s) → not a compaction event.
+        old_compaction = self._make_compaction_state(tmp_path, age_seconds=3600)
+
+        mod = _load_module(
+            is_dispatcher_return=False,  # Simulate is_dispatcher() → False
+            mcp_claude_session_file_override=absent_primary,
+            compaction_state_override=str(old_compaction),
+        )
+
+        # Stub agent monitor path so the hook doesn't bail early.
+        mock_agent_monitor = tmp_path / "agent-monitor.py"
+        mock_agent_monitor.write_text("# stub")
+        mod.AGENT_MONITOR = mock_agent_monitor
+
+        # Capture _mark_all_running_failed calls.
+        mark_failed_called: list[bool] = []
+        mod._mark_all_running_failed = lambda: mark_failed_called.append(True)
+
+        # Avoid _inject_compact_reminder side effects.
+        mod._is_catchup_stale = lambda: False
+        mod._has_recent_session_file = lambda: False
+        mod._schedule_reflection_prompt = lambda trigger: None
+
+        hook_input = json.dumps({"session_id": "new-session-uuid-1234"})
+
+        with patch("sys.stdin", __import__("io").StringIO(hook_input)):
+            with pytest.raises(SystemExit) as exc_info:
+                mod.main()
+
+        assert exc_info.value.code == 0
+        assert len(mark_failed_called) == 1, (
+            "_mark_all_running_failed must be called — the hook should not exit early "
+            "just because is_dispatcher() returned False"
+        )
+
+    def test_exits_when_is_dispatcher_false_and_primary_file_present(
+        self, tmp_path, monkeypatch
+    ):
+        """When primary file is present, _is_fresh_dispatcher_start returns False.
+
+        This is the subagent case: the dispatcher has already called session_start
+        (writing the primary file), so a non-matching session must be a subagent.
+        The hook must exit without calling _mark_all_running_failed.
+        """
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+
+        # Primary file present → dispatcher already started.
+        primary_file = tmp_path / "dispatcher-claude-session-id"
+        primary_file.write_text("old-session-uuid-abcd")
+        old_compaction = self._make_compaction_state(tmp_path, age_seconds=3600)
+
+        mod = _load_module(
+            is_dispatcher_return=False,  # is_dispatcher() returns False
+            mcp_claude_session_file_override=str(primary_file),
+            compaction_state_override=str(old_compaction),
+        )
+
+        mark_failed_called: list[bool] = []
+        mod._mark_all_running_failed = lambda: mark_failed_called.append(True)
+
+        hook_input = json.dumps({"session_id": "subagent-session-uuid-9999"})
+
+        with patch("sys.stdin", __import__("io").StringIO(hook_input)):
+            with pytest.raises(SystemExit) as exc_info:
+                mod.main()
+
+        # Exits 0 (early exit on the subagent guard).
+        assert exc_info.value.code == 0
+        assert len(mark_failed_called) == 0, (
+            "_mark_all_running_failed must NOT be called for a subagent session"
+        )
+
+    def test_proceeds_normally_when_is_dispatcher_true(self, tmp_path, monkeypatch):
+        """Happy path: is_dispatcher() returns True → hook proceeds regardless of primary file."""
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+
+        # Primary file absent (but is_dispatcher() already returns True — doesn't matter).
+        absent_primary = str(tmp_path / "nonexistent-primary")
+        old_compaction = self._make_compaction_state(tmp_path, age_seconds=3600)
+
+        mod = _load_module(
+            is_dispatcher_return=True,
+            mcp_claude_session_file_override=absent_primary,
+            compaction_state_override=str(old_compaction),
+        )
+
+        mock_agent_monitor = tmp_path / "agent-monitor.py"
+        mock_agent_monitor.write_text("# stub")
+        mod.AGENT_MONITOR = mock_agent_monitor
+
+        mark_failed_called: list[bool] = []
+        mod._mark_all_running_failed = lambda: mark_failed_called.append(True)
+        mod._is_catchup_stale = lambda: False
+        mod._has_recent_session_file = lambda: False
+        mod._schedule_reflection_prompt = lambda trigger: None
+
+        hook_input = json.dumps({"session_id": "dispatcher-session-uuid"})
+
+        with patch("sys.stdin", __import__("io").StringIO(hook_input)):
+            with pytest.raises(SystemExit) as exc_info:
+                mod.main()
+
+        assert exc_info.value.code == 0
+        assert len(mark_failed_called) == 1


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## Summary

Fixes issue #1768: stale agent sessions not cleared on dispatcher restart.

**Root cause (per issue investigation):** When the dispatcher is killed and immediately restarted, `write-dispatcher-session-id.py` sees the previous session's JSONL file has a recent mtime and concludes the old dispatcher is still alive — skipping the session-ID marker file update. The tertiary marker file retains the old UUID, causing `is_dispatcher()` to return False for the new dispatcher session. `on-fresh-start.py` exits early at the subagent guard and never calls `_mark_all_running_failed()`, leaving stale `running` sessions in `agent_sessions.db`.

## Fix

Adds `_is_fresh_dispatcher_start()` as a fallback in `on-fresh-start.py`. When `is_dispatcher()` returns False, we check whether the primary state file (`dispatcher-claude-session-id`) is absent:

- The MCP server **clears** this file on every startup
- It is re-written only when the dispatcher calls `session_start()`  
- Subagents cannot trigger this path because they start only after the dispatcher has called `session_start()` (which writes the primary file)
- Compaction events are excluded: `on-compact.py` writes the primary file proactively for the new post-compact session UUID

So: absent primary file + non-compaction event + `LOBSTER_MAIN_SESSION=1` reliably identifies the pre-`session_start` dispatcher window.

The fix is purely additive — when `is_dispatcher()` already returns True (the common case), `_is_fresh_dispatcher_start()` is never called.

## Changes

- `hooks/on-fresh-start.py`: Add `_MCP_CLAUDE_SESSION_FILE` constant (with test override env var) and `_is_fresh_dispatcher_start()` fallback; update `main()` dispatcher guard to use both checks
- `tests/unit/test_hooks/test_fresh_dispatcher_start_fallback.py`: 9 new unit tests covering the fallback logic and main() gating integration, including a regression test for the exact issue #1768 failure scenario

## Test plan

- [ ] All 9 new unit tests pass (`test_fresh_dispatcher_start_fallback.py`)
- [ ] No regressions: 3424 existing tests still pass
- [ ] Regression scenario covered: `is_dispatcher()=False` + primary file absent → `_mark_all_running_failed()` is called
- [ ] Subagent scenario covered: `is_dispatcher()=False` + primary file present → hook exits without calling `_mark_all_running_failed()`
- [ ] Compaction scenario covered: compaction event → fallback returns False, hook exits correctly