### PR TITLE
fix(#1848): change docker worker-entrypoint source value to allowlisted 'system'

### DIFF
--- a/docker/worker-entrypoint.sh
+++ b/docker/worker-entrypoint.sh
@@ -82,7 +82,7 @@ json_output=$(printf '%s' "$output" | jq -Rs .)
 cat > "$tmp_file" <<ENDJSON
 {
   "id": "${msg_id}",
-  "source": "worker",
+  "source": "system",
   "chat_id": ${WORKER_CHAT_ID},
   "user_id": 0,
   "username": "docker-worker",

--- a/tests/unit/test_mcp_server/test_message_taxonomy.py
+++ b/tests/unit/test_mcp_server/test_message_taxonomy.py
@@ -13,6 +13,7 @@ tests/docker/Dockerfile.test.
 import asyncio
 import json
 import logging
+import re
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -239,3 +240,145 @@ class TestMarkProcessingTypeValidation:
             if "unknown message type" in r.message
         ]
         assert not type_warnings, f"Unexpected type warning for known type 'text': {type_warnings}"
+
+
+class TestScriptSourceValues:
+    """
+    Guardrail: every "source" value written by cron/system scripts must be in
+    INBOX_MESSAGE_SOURCES (issue #1797).
+
+    When PR #1736 added the quarantine guard it updated daily-health-check.sh
+    but missed nightly-consolidation.sh and daily-update-check.sh, which kept
+    writing source="internal". Those messages were silently quarantined for
+    3 nights before the bug was discovered. This class catches similar mismatches
+    at test time so the same class of error cannot be re-introduced.
+
+    Strategy: parse every *.sh file in scripts/ for JSON "source" values written
+    to the inbox (i.e. lines matching `"source": "<value>"`), then assert each
+    extracted value is in INBOX_MESSAGE_SOURCES.
+    """
+
+    # Regex: matches `"source": "some-value"` inside here-doc / inline JSON.
+    _SOURCE_RE = re.compile(r'"source"\s*:\s*"([^"]+)"')
+
+    @pytest.fixture(autouse=True)
+    def _load_sources(self):
+        from message_types import INBOX_MESSAGE_SOURCES
+        self._known_sources = INBOX_MESSAGE_SOURCES
+
+    def _extract_source_values(self, script_path: Path) -> list[tuple[int, str]]:
+        """Return list of (line_number, source_value) found in script_path."""
+        results = []
+        for lineno, line in enumerate(script_path.read_text().splitlines(), start=1):
+            for m in self._SOURCE_RE.finditer(line):
+                results.append((lineno, m.group(1)))
+        return results
+
+    def _get_scripts_dir(self) -> Path:
+        """Locate the repository scripts/ directory relative to this test file."""
+        # test_message_taxonomy.py → test_mcp_server/ → unit/ → tests/ → repo_root/
+        # parents[0]=test_mcp_server, [1]=unit, [2]=tests, [3]=repo_root
+        return Path(__file__).resolve().parents[3] / "scripts"
+
+    def _get_docker_dir(self) -> Path:
+        """Locate the repository docker/ directory relative to this test file."""
+        return Path(__file__).resolve().parents[3] / "docker"
+
+    def test_nightly_consolidation_source_is_recognized(self):
+        """nightly-consolidation.sh must write a recognized source (regression: issue #1797)."""
+        scripts_dir = self._get_scripts_dir()
+        script = scripts_dir / "nightly-consolidation.sh"
+        assert script.exists(), f"Script not found: {script}"
+
+        found = self._extract_source_values(script)
+        assert found, f"No \"source\" values found in {script.name} — was the script refactored?"
+
+        bad = [(ln, v) for ln, v in found if v not in self._known_sources]
+        assert not bad, (
+            f"{script.name} writes unrecognized source value(s) — "
+            f"add to INBOX_MESSAGE_SOURCES or change to 'system':\n"
+            + "\n".join(f"  line {ln}: {v!r}" for ln, v in bad)
+        )
+
+    def test_daily_update_check_source_is_recognized(self):
+        """daily-update-check.sh must write a recognized source (regression: issue #1797)."""
+        scripts_dir = self._get_scripts_dir()
+        script = scripts_dir / "daily-update-check.sh"
+        assert script.exists(), f"Script not found: {script}"
+
+        found = self._extract_source_values(script)
+        assert found, f"No \"source\" values found in {script.name} — was the script refactored?"
+
+        bad = [(ln, v) for ln, v in found if v not in self._known_sources]
+        assert not bad, (
+            f"{script.name} writes unrecognized source value(s) — "
+            f"add to INBOX_MESSAGE_SOURCES or change to 'system':\n"
+            + "\n".join(f"  line {ln}: {v!r}" for ln, v in bad)
+        )
+
+    def test_all_scripts_write_recognized_sources(self):
+        """Every *.sh script in scripts/ that writes a JSON source field must use a known source.
+
+        This is the broad guardrail: adding a new script that writes
+        source="internal" (or any other unrecognized value) will fail here.
+        Existing scripts with no "source" field are ignored.
+        """
+        scripts_dir = self._get_scripts_dir()
+        assert scripts_dir.exists(), f"scripts/ directory not found at {scripts_dir}"
+
+        violations: list[str] = []
+        for script in sorted(scripts_dir.glob("*.sh")):
+            for lineno, value in self._extract_source_values(script):
+                if value not in self._known_sources:
+                    violations.append(f"{script.name}:{lineno}: {value!r}")
+
+        assert not violations, (
+            "The following scripts write source values not in INBOX_MESSAGE_SOURCES.\n"
+            "Either update INBOX_MESSAGE_SOURCES in message_types.py or change the\n"
+            "source to 'system' (the standard value for cron/system-generated messages):\n"
+            + "\n".join(f"  {v}" for v in violations)
+        )
+
+    def test_worker_entrypoint_source_is_recognized(self):
+        """worker-entrypoint.sh must write a recognized source (regression: issue #1848).
+
+        PR #1845 added the scripts/ guardrail but missed docker/worker-entrypoint.sh,
+        which was writing source="worker" — not in INBOX_MESSAGE_SOURCES.
+        """
+        docker_dir = self._get_docker_dir()
+        script = docker_dir / "worker-entrypoint.sh"
+        assert script.exists(), f"Script not found: {script}"
+
+        found = self._extract_source_values(script)
+        assert found, (
+            f"No \"source\" values found in {script.name} — was the script refactored?"
+        )
+
+        bad = [(ln, v) for ln, v in found if v not in self._known_sources]
+        assert not bad, (
+            f"{script.name} writes unrecognized source value(s) — "
+            f"add to INBOX_MESSAGE_SOURCES or change to 'system':\n"
+            + "\n".join(f"  line {ln}: {v!r}" for ln, v in bad)
+        )
+
+    def test_all_docker_scripts_write_recognized_sources(self):
+        """Every *.sh script in docker/ that writes a JSON source field must use a known source.
+
+        Broad guardrail for the docker/ directory, mirroring test_all_scripts_write_recognized_sources
+        for scripts/. Ensures future docker entrypoints don't silently reintroduce this class of bug.
+        """
+        docker_dir = self._get_docker_dir()
+        assert docker_dir.exists(), f"docker/ directory not found at {docker_dir}"
+
+        violations: list[str] = []
+        for script in sorted(docker_dir.glob("*.sh")):
+            for lineno, value in self._extract_source_values(script):
+                if value not in self._known_sources:
+                    violations.append(f"{script.name}:{lineno}: {value!r}")
+
+        assert not violations, (
+            "The following docker scripts write source values not in INBOX_MESSAGE_SOURCES.\n"
+            "Either update INBOX_MESSAGE_SOURCES in message_types.py or change the\n"
+            "source to 'system' (the standard value for system-generated messages):\n"
+            + "\n".join(f"  {v}" for v in violations)
+        )

--- a/tests/unit/test_mcp_server/test_message_taxonomy.py
+++ b/tests/unit/test_mcp_server/test_message_taxonomy.py
@@ -242,18 +242,20 @@ class TestMarkProcessingTypeValidation:
         assert not type_warnings, f"Unexpected type warning for known type 'text': {type_warnings}"
 
 
-class TestScriptSourceValues:
+class TestDockerScriptSourceValues:
     """
-    Guardrail: every "source" value written by cron/system scripts must be in
-    INBOX_MESSAGE_SOURCES (issue #1797).
+    Guardrail: every "source" value written by docker/*.sh scripts must be in
+    INBOX_MESSAGE_SOURCES (issue #1848).
 
-    When PR #1736 added the quarantine guard it updated daily-health-check.sh
-    but missed nightly-consolidation.sh and daily-update-check.sh, which kept
-    writing source="internal". Those messages were silently quarantined for
-    3 nights before the bug was discovered. This class catches similar mismatches
-    at test time so the same class of error cannot be re-introduced.
+    docker/worker-entrypoint.sh was writing source="worker" — not in the
+    allowlist. Since PR #1736 added the quarantine guard (Apr 22 2026), every
+    Docker worker message has been silently quarantined and never reached the
+    dispatcher.
 
-    Strategy: parse every *.sh file in scripts/ for JSON "source" values written
+    The parallel guardrail for scripts/*.sh is in PR #1845 (TestScriptSourceValues).
+    This class covers docker/*.sh, which PR #1845 missed.
+
+    Strategy: parse every *.sh file in docker/ for JSON "source" values written
     to the inbox (i.e. lines matching `"source": "<value>"`), then assert each
     extracted value is in INBOX_MESSAGE_SOURCES.
     """
@@ -274,76 +276,19 @@ class TestScriptSourceValues:
                 results.append((lineno, m.group(1)))
         return results
 
-    def _get_scripts_dir(self) -> Path:
-        """Locate the repository scripts/ directory relative to this test file."""
-        # test_message_taxonomy.py → test_mcp_server/ → unit/ → tests/ → repo_root/
-        # parents[0]=test_mcp_server, [1]=unit, [2]=tests, [3]=repo_root
-        return Path(__file__).resolve().parents[3] / "scripts"
-
     def _get_docker_dir(self) -> Path:
         """Locate the repository docker/ directory relative to this test file."""
+        # test_message_taxonomy.py → test_mcp_server/ → unit/ → tests/ → repo_root/
+        # parents[0]=test_mcp_server, [1]=unit, [2]=tests, [3]=repo_root
         return Path(__file__).resolve().parents[3] / "docker"
-
-    def test_nightly_consolidation_source_is_recognized(self):
-        """nightly-consolidation.sh must write a recognized source (regression: issue #1797)."""
-        scripts_dir = self._get_scripts_dir()
-        script = scripts_dir / "nightly-consolidation.sh"
-        assert script.exists(), f"Script not found: {script}"
-
-        found = self._extract_source_values(script)
-        assert found, f"No \"source\" values found in {script.name} — was the script refactored?"
-
-        bad = [(ln, v) for ln, v in found if v not in self._known_sources]
-        assert not bad, (
-            f"{script.name} writes unrecognized source value(s) — "
-            f"add to INBOX_MESSAGE_SOURCES or change to 'system':\n"
-            + "\n".join(f"  line {ln}: {v!r}" for ln, v in bad)
-        )
-
-    def test_daily_update_check_source_is_recognized(self):
-        """daily-update-check.sh must write a recognized source (regression: issue #1797)."""
-        scripts_dir = self._get_scripts_dir()
-        script = scripts_dir / "daily-update-check.sh"
-        assert script.exists(), f"Script not found: {script}"
-
-        found = self._extract_source_values(script)
-        assert found, f"No \"source\" values found in {script.name} — was the script refactored?"
-
-        bad = [(ln, v) for ln, v in found if v not in self._known_sources]
-        assert not bad, (
-            f"{script.name} writes unrecognized source value(s) — "
-            f"add to INBOX_MESSAGE_SOURCES or change to 'system':\n"
-            + "\n".join(f"  line {ln}: {v!r}" for ln, v in bad)
-        )
-
-    def test_all_scripts_write_recognized_sources(self):
-        """Every *.sh script in scripts/ that writes a JSON source field must use a known source.
-
-        This is the broad guardrail: adding a new script that writes
-        source="internal" (or any other unrecognized value) will fail here.
-        Existing scripts with no "source" field are ignored.
-        """
-        scripts_dir = self._get_scripts_dir()
-        assert scripts_dir.exists(), f"scripts/ directory not found at {scripts_dir}"
-
-        violations: list[str] = []
-        for script in sorted(scripts_dir.glob("*.sh")):
-            for lineno, value in self._extract_source_values(script):
-                if value not in self._known_sources:
-                    violations.append(f"{script.name}:{lineno}: {value!r}")
-
-        assert not violations, (
-            "The following scripts write source values not in INBOX_MESSAGE_SOURCES.\n"
-            "Either update INBOX_MESSAGE_SOURCES in message_types.py or change the\n"
-            "source to 'system' (the standard value for cron/system-generated messages):\n"
-            + "\n".join(f"  {v}" for v in violations)
-        )
 
     def test_worker_entrypoint_source_is_recognized(self):
         """worker-entrypoint.sh must write a recognized source (regression: issue #1848).
 
-        PR #1845 added the scripts/ guardrail but missed docker/worker-entrypoint.sh,
-        which was writing source="worker" — not in INBOX_MESSAGE_SOURCES.
+        PR #1845 added guardrail tests for scripts/*.sh but missed
+        docker/worker-entrypoint.sh, which was writing source="worker" —
+        not in INBOX_MESSAGE_SOURCES. This targeted test catches a re-introduction
+        of that exact bug.
         """
         docker_dir = self._get_docker_dir()
         script = docker_dir / "worker-entrypoint.sh"
@@ -364,8 +309,9 @@ class TestScriptSourceValues:
     def test_all_docker_scripts_write_recognized_sources(self):
         """Every *.sh script in docker/ that writes a JSON source field must use a known source.
 
-        Broad guardrail for the docker/ directory, mirroring test_all_scripts_write_recognized_sources
-        for scripts/. Ensures future docker entrypoints don't silently reintroduce this class of bug.
+        Broad guardrail for the docker/ directory: adding a new docker entrypoint
+        that writes an unrecognized source= value will fail here before quarantine
+        silently drops its messages in production.
         """
         docker_dir = self._get_docker_dir()
         assert docker_dir.exists(), f"docker/ directory not found at {docker_dir}"


### PR DESCRIPTION
## What this fixes

Since PR #1736 added a quarantine guard for unrecognized inbox sources (Apr 22), every message produced by the Docker worker has been silently dropped into `failed/` and never reached the dispatcher. The root cause: `docker/worker-entrypoint.sh` was writing `"source": "worker"`, which is not in `INBOX_MESSAGE_SOURCES`.

This is a direct sibling of issue #1797 (fixed in PR #1845 for `scripts/*.sh`). Both are instances of the same class of bug: a script writing an inbox message with a source value that wasn't in the allowlist when the quarantine guard was introduced.

## Change

**`docker/worker-entrypoint.sh`**: `"source": "worker"` → `"source": "system"`

`"system"` is the correct semantic value — the Docker worker is a system-initiated process, not a user-facing messaging platform. The actual reply routing uses `worker_metadata.reply_source` and `worker_metadata.reply_chat_id`, not the top-level `source` field, so this change is safe and purely additive.

**`tests/unit/test_mcp_server/test_message_taxonomy.py`**: New `TestDockerScriptSourceValues` class adds:
- `test_worker_entrypoint_source_is_recognized` — targeted regression test for `docker/worker-entrypoint.sh`
- `test_all_docker_scripts_write_recognized_sources` — broad guardrail scanning all `docker/*.sh` for JSON source fields

The `scripts/*.sh` guardrail (for the parallel issue) is in PR #1845 (`TestScriptSourceValues`). This PR covers `docker/*.sh` only, which #1845 missed.

## Functional patterns

Pure, composable test helpers: `_extract_source_values` is a pure function (path → list of tuples) used by both guardrail tests. The regex constant and source set are injected via a fixture, keeping the test data-driven rather than hard-coded.

## Flow: before → after

```
Before:
  Docker worker completes → writes inbox message with source="worker"
  → check_inbox quarantine guard fires (source not in INBOX_MESSAGE_SOURCES)
  → message moved to failed/ with _permanently_failed=True
  → dispatcher never sees the result

After:
  Docker worker completes → writes inbox message with source="system"
  → check_inbox accepts the message (source recognized)
  → dispatcher receives the result normally
```

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_message_taxonomy.py -v` — 19 passed (17 pre-existing + 2 new), 0 failed
- [x] `uv run pytest tests/unit/test_mcp_server/test_unrecognized_source_quarantine.py -v` — 8 passed
- [x] `uv run pytest tests/ --ignore=tests/test_messages_db.py --ignore=tests/test_vps_integration.py --ignore=tests/test_whatsapp_bridge_adapter.py --ignore=tests/unit/test_ifttt_rules.py --ignore=tests/unit/test_mcp_server/test_message_tools.py --tb=no -q` — 3406 passed, 27 skipped
  - Collection errors present but are pre-existing on main (not caused by this PR — verified by comparing error count on main)

## Manual test

N/A — the change is purely to a value written in an inbox message JSON payload. No systemd, no cron, no live API calls. The quarantine guard is covered by unit tests. The fix is a single string value swap with a clear behavioral invariant verified by tests.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (no external services, no systemd, no DB schema)
- [x] User-visible outcome verified — N/A: this restores internal message routing; Docker worker is not currently in active production use for user-visible features
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: N/A

Closes #1848