### PR TITLE
fix(#1823): upgrade MCP SDK to 1.27.0 + add session_idle_timeout=1800

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Always-on AI assistant with Telegram/Slack integration"
 requires-python = ">=3.11"
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.27.0",
     "httpx>=0.27.0",
     "watchdog>=4.0.0",
     "psutil>=5.9.0",

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -803,9 +803,10 @@ WAIT_HEARTBEAT_INTERVAL = 60
 # Idle timeout for the stateful StreamableHTTP session manager (issue #1823).
 # Sessions idle longer than this many seconds are reaped via anyio.CancelScope,
 # preventing task group accumulation that caused 4-minute event loop stalls.
-# The SDK recommends 1800s (30 min) — long enough to survive normal SSE polling
-# gaps without false reaps.  Requires MCP SDK >= 1.27.0.
-SESSION_IDLE_TIMEOUT_SECONDS = 1800
+# Must be >= wait_for_messages timeout (72000s / 20h) so the MCP session is
+# never reaped while the dispatcher is idle in WFM — 1800s caused crash loops
+# overnight when the dispatcher sat idle between messages (issue #1873).
+SESSION_IDLE_TIMEOUT_SECONDS = 72000
 
 # WFM-active signal file (issue #1713 / #949): written with a Unix epoch
 # timestamp when wait_for_messages begins blocking, refreshed every

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -800,6 +800,13 @@ HEARTBEAT_FILE = _WORKSPACE / "logs" / "claude-heartbeat"
 # tests can verify it matches the health-check's WFM_ACTIVE_STALE_SECONDS.
 WAIT_HEARTBEAT_INTERVAL = 60
 
+# Idle timeout for the stateful StreamableHTTP session manager (issue #1823).
+# Sessions idle longer than this many seconds are reaped via anyio.CancelScope,
+# preventing task group accumulation that caused 4-minute event loop stalls.
+# The SDK recommends 1800s (30 min) — long enough to survive normal SSE polling
+# gaps without false reaps.  Requires MCP SDK >= 1.27.0.
+SESSION_IDLE_TIMEOUT_SECONDS = 1800
+
 # WFM-active signal file (issue #1713 / #949): written with a Unix epoch
 # timestamp when wait_for_messages begins blocking, refreshed every
 # WAIT_HEARTBEAT_INTERVAL seconds, and deleted when WFM returns.
@@ -9977,7 +9984,11 @@ async def main():
             except (ValueError, IndexError):
                 pass
 
-        session_manager = StreamableHTTPSessionManager(app=server, stateless=False)
+        session_manager = StreamableHTTPSessionManager(
+            app=server,
+            stateless=False,
+            session_idle_timeout=SESSION_IDLE_TIMEOUT_SECONDS,
+        )
 
         # Publish the session_manager reference so tool handlers (and /dispatcher-session)
         # can inspect live session state without importing from main().

--- a/tests/unit/test_mcp_server/test_http_session_idle_timeout.py
+++ b/tests/unit/test_mcp_server/test_http_session_idle_timeout.py
@@ -1,5 +1,5 @@
 """
-Tests for HTTP session idle timeout configuration (issue #1823).
+Tests for HTTP session idle timeout configuration (issue #1823, fix #1873).
 
 The MCP server's stateful HTTP transport must be constructed with
 session_idle_timeout=SESSION_IDLE_TIMEOUT_SECONDS to prevent anyio task
@@ -7,7 +7,11 @@ group accumulation in the StreamableHTTPSessionManager — the root cause of
 the 4-minute asyncio stall observed on 2026-04-26.
 
 The constant SESSION_IDLE_TIMEOUT_SECONDS must be defined at module level so
-health checks and tests can reference it without hardcoding the literal 1800.
+health checks and tests can reference it without hardcoding the literal.
+
+The value must be >= the wait_for_messages timeout (72000s / 20h) to prevent
+the MCP session from being reaped while the dispatcher is idle in WFM.
+Setting this to 1800s caused dispatcher crash loops overnight (issue #1873).
 """
 
 import asyncio
@@ -16,20 +20,22 @@ import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
-# Expected values — must match the spec in issue #1823 and the SDK recommendation.
-EXPECTED_SESSION_IDLE_TIMEOUT_SECONDS = 1800  # 30 minutes per SDK docs
+# Expected values — must be >= WFM timeout (72000s) so sessions survive
+# dispatcher idle waits.  1800s was too short and caused crash loops (#1873).
+EXPECTED_SESSION_IDLE_TIMEOUT_SECONDS = 72000  # 20 hours, matching WFM default
 
 
 class TestSessionIdleTimeoutConstant:
     """SESSION_IDLE_TIMEOUT_SECONDS must be exported from inbox_server."""
 
     def test_constant_is_defined_and_correct(self):
-        """MODULE must export SESSION_IDLE_TIMEOUT_SECONDS = 1800."""
+        """MODULE must export SESSION_IDLE_TIMEOUT_SECONDS = 72000 (20h, matching WFM timeout)."""
         from src.mcp.inbox_server import SESSION_IDLE_TIMEOUT_SECONDS
 
         assert SESSION_IDLE_TIMEOUT_SECONDS == EXPECTED_SESSION_IDLE_TIMEOUT_SECONDS, (
             f"Expected SESSION_IDLE_TIMEOUT_SECONDS == {EXPECTED_SESSION_IDLE_TIMEOUT_SECONDS} "
-            f"(30 minutes per SDK recommendation); got {SESSION_IDLE_TIMEOUT_SECONDS}"
+            f"(20 hours, matching WFM default; 1800s caused crash loops in #1873); "
+            f"got {SESSION_IDLE_TIMEOUT_SECONDS}"
         )
 
 
@@ -41,8 +47,9 @@ class TestHttpSessionManagerIdleTimeout:
 
         Without session_idle_timeout, anyio task groups accumulate for each
         long-lived dispatcher session and can stall the event loop for minutes
-        (issue #1823).  Providing idle_timeout=1800 ensures stale sessions are
-        reaped via anyio.CancelScope deadline rather than accumulating forever.
+        (issue #1823).  Providing idle_timeout=72000 (20h, matching WFM default)
+        ensures stale sessions are reaped via anyio.CancelScope deadline while
+        surviving dispatcher idle waits.  1800s was too short (#1873).
         """
         captured_calls = []
 

--- a/tests/unit/test_mcp_server/test_http_session_idle_timeout.py
+++ b/tests/unit/test_mcp_server/test_http_session_idle_timeout.py
@@ -1,0 +1,94 @@
+"""
+Tests for HTTP session idle timeout configuration (issue #1823).
+
+The MCP server's stateful HTTP transport must be constructed with
+session_idle_timeout=SESSION_IDLE_TIMEOUT_SECONDS to prevent anyio task
+group accumulation in the StreamableHTTPSessionManager — the root cause of
+the 4-minute asyncio stall observed on 2026-04-26.
+
+The constant SESSION_IDLE_TIMEOUT_SECONDS must be defined at module level so
+health checks and tests can reference it without hardcoding the literal 1800.
+"""
+
+import asyncio
+import contextlib
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# Expected values — must match the spec in issue #1823 and the SDK recommendation.
+EXPECTED_SESSION_IDLE_TIMEOUT_SECONDS = 1800  # 30 minutes per SDK docs
+
+
+class TestSessionIdleTimeoutConstant:
+    """SESSION_IDLE_TIMEOUT_SECONDS must be exported from inbox_server."""
+
+    def test_constant_is_defined_and_correct(self):
+        """MODULE must export SESSION_IDLE_TIMEOUT_SECONDS = 1800."""
+        from src.mcp.inbox_server import SESSION_IDLE_TIMEOUT_SECONDS
+
+        assert SESSION_IDLE_TIMEOUT_SECONDS == EXPECTED_SESSION_IDLE_TIMEOUT_SECONDS, (
+            f"Expected SESSION_IDLE_TIMEOUT_SECONDS == {EXPECTED_SESSION_IDLE_TIMEOUT_SECONDS} "
+            f"(30 minutes per SDK recommendation); got {SESSION_IDLE_TIMEOUT_SECONDS}"
+        )
+
+
+class TestHttpSessionManagerIdleTimeout:
+    """The stateful HTTP session manager must be constructed with idle timeout."""
+
+    def test_main_passes_session_idle_timeout_to_constructor(self, monkeypatch):
+        """main() in HTTP mode must pass session_idle_timeout to StreamableHTTPSessionManager.
+
+        Without session_idle_timeout, anyio task groups accumulate for each
+        long-lived dispatcher session and can stall the event loop for minutes
+        (issue #1823).  Providing idle_timeout=1800 ensures stale sessions are
+        reaped via anyio.CancelScope deadline rather than accumulating forever.
+        """
+        captured_calls = []
+
+        class CapturingSessionManager:
+            """Records constructor kwargs so we can assert on them."""
+            def __init__(self, **kwargs):
+                captured_calls.append(kwargs)
+
+            @contextlib.asynccontextmanager
+            async def run(self):
+                yield
+
+        # inbox_server imports StreamableHTTPSessionManager locally inside main()
+        # via: from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+        # Patching the source module is the correct intercept point.
+        mock_streamable_module = MagicMock()
+        mock_streamable_module.StreamableHTTPSessionManager = CapturingSessionManager
+
+        mock_uvicorn_server = MagicMock()
+        mock_uvicorn_server.serve = AsyncMock(return_value=None)
+
+        monkeypatch.setitem(sys.modules, "mcp.server.streamable_http_manager", mock_streamable_module)
+        monkeypatch.setattr(sys, "argv", ["inbox_server.py", "--http"])
+
+        with (
+            patch("uvicorn.Config", return_value=MagicMock()),
+            patch("uvicorn.Server", return_value=mock_uvicorn_server),
+        ):
+            import src.mcp.inbox_server as mod
+            asyncio.run(mod.main())
+
+        assert captured_calls, (
+            "StreamableHTTPSessionManager was never constructed — "
+            "did main() fail to enter HTTP mode?"
+        )
+        kwargs = captured_calls[0]
+
+        assert "session_idle_timeout" in kwargs, (
+            "StreamableHTTPSessionManager must receive session_idle_timeout; "
+            "omitting it causes anyio task group accumulation (issue #1823)"
+        )
+        assert kwargs["session_idle_timeout"] == EXPECTED_SESSION_IDLE_TIMEOUT_SECONDS, (
+            f"session_idle_timeout must be {EXPECTED_SESSION_IDLE_TIMEOUT_SECONDS}s; "
+            f"got {kwargs['session_idle_timeout']}"
+        )
+        assert kwargs.get("stateless") is False, (
+            "The dispatcher session manager must be stateful (stateless=False); "
+            "combining stateless=True with session_idle_timeout raises RuntimeError"
+        )

--- a/tests/unit/test_mcp_server/test_http_session_idle_timeout.py
+++ b/tests/unit/test_mcp_server/test_http_session_idle_timeout.py
@@ -19,21 +19,16 @@ import contextlib
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
-
-# Expected values — must be >= WFM timeout (72000s) so sessions survive
-# dispatcher idle waits.  1800s was too short and caused crash loops (#1873).
-EXPECTED_SESSION_IDLE_TIMEOUT_SECONDS = 72000  # 20 hours, matching WFM default
+from src.mcp.inbox_server import SESSION_IDLE_TIMEOUT_SECONDS
 
 
 class TestSessionIdleTimeoutConstant:
     """SESSION_IDLE_TIMEOUT_SECONDS must be exported from inbox_server."""
 
     def test_constant_is_defined_and_correct(self):
-        """MODULE must export SESSION_IDLE_TIMEOUT_SECONDS = 72000 (20h, matching WFM timeout)."""
-        from src.mcp.inbox_server import SESSION_IDLE_TIMEOUT_SECONDS
-
-        assert SESSION_IDLE_TIMEOUT_SECONDS == EXPECTED_SESSION_IDLE_TIMEOUT_SECONDS, (
-            f"Expected SESSION_IDLE_TIMEOUT_SECONDS == {EXPECTED_SESSION_IDLE_TIMEOUT_SECONDS} "
+        """MODULE must export SESSION_IDLE_TIMEOUT_SECONDS >= 72000 (20h, matching WFM timeout)."""
+        assert SESSION_IDLE_TIMEOUT_SECONDS >= 72000, (
+            f"Expected SESSION_IDLE_TIMEOUT_SECONDS >= 72000 "
             f"(20 hours, matching WFM default; 1800s caused crash loops in #1873); "
             f"got {SESSION_IDLE_TIMEOUT_SECONDS}"
         )
@@ -91,8 +86,9 @@ class TestHttpSessionManagerIdleTimeout:
             "StreamableHTTPSessionManager must receive session_idle_timeout; "
             "omitting it causes anyio task group accumulation (issue #1823)"
         )
-        assert kwargs["session_idle_timeout"] == EXPECTED_SESSION_IDLE_TIMEOUT_SECONDS, (
-            f"session_idle_timeout must be {EXPECTED_SESSION_IDLE_TIMEOUT_SECONDS}s; "
+        assert kwargs["session_idle_timeout"] == SESSION_IDLE_TIMEOUT_SECONDS, (
+            f"session_idle_timeout must be {SESSION_IDLE_TIMEOUT_SECONDS}s "
+            f"(from inbox_server.SESSION_IDLE_TIMEOUT_SECONDS); "
             f"got {kwargs['session_idle_timeout']}"
         )
         assert kwargs.get("stateless") is False, (

--- a/uv.lock
+++ b/uv.lock
@@ -917,7 +917,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "fastembed", specifier = ">=0.3.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "mcp", specifier = ">=1.0.0" },
+    { name = "mcp", specifier = ">=1.27.0" },
     { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.40.0" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
@@ -971,7 +971,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -989,9 +989,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The MCP server's asyncio event loop stalled for ~4 minutes on 2026-04-26 while the dispatcher was alive. The WFM-active heartbeat stopped, triggering a false health-check restart. Root cause: MCP SDK v1.26.0's \`StreamableHTTPSessionManager\` accumulates anyio task groups for long-lived stateful sessions with no reap deadline. When a task group blocks internally (session creation lock or cancel scope awaitable), the event loop starves — no timeouts, no errors, no output.

## What changed

**MCP SDK upgraded from v1.26.0 to v1.27.0.** v1.27.0 adds \`session_idle_timeout\` to \`StreamableHTTPSessionManager\`. When set, it uses \`anyio.CancelScope\` to reap sessions that have been idle longer than the threshold.

**\`SESSION_IDLE_TIMEOUT_SECONDS = 72000\`** added as a named module-level constant in \`inbox_server.py\` (near other heartbeat constants). This value (20 hours) must be >= the \`wait_for_messages\` timeout (72000s) so the MCP session is never reaped while the dispatcher is idle in WFM. The original 1800s value caused dispatcher crash loops overnight (issue #1873).

**\`StreamableHTTPSessionManager\` now receives \`session_idle_timeout=SESSION_IDLE_TIMEOUT_SECONDS\`** in the stateful HTTP mode constructor. The stateless HTTP bridge (\`inbox_server_http.py\`) is unchanged — combining \`stateless=True\` with \`session_idle_timeout\` raises \`RuntimeError\` per SDK contract.

## Before / after

```
BEFORE (v1.26.0):
  StreamableHTTPSessionManager(app=server, stateless=False)
  → no reap deadline → task groups accumulate → event loop starves → 4-min stall

AFTER (v1.27.0):
  StreamableHTTPSessionManager(app=server, stateless=False, session_idle_timeout=72000)
  → anyio.CancelScope deadline = now + 72000s → idle sessions reaped automatically
  → event loop stays unblocked
  → session survives dispatcher idle waits in WFM (1800s caused crash loops #1873)
```

## What is NOT changed

- \`inbox_server_http.py\` (stateless bridge) — untouched
- WFM heartbeat interval or health-check thresholds — untouched
- All other session manager behavior — only the idle timeout is added

## Functional patterns

Pure function reasoning: \`SESSION_IDLE_TIMEOUT_SECONDS\` is a named constant, not a magic literal. The idle timeout mechanism is entirely internal to the SDK — no new coroutines or mutable state added to the codebase.

## Tests run

- [x] \`uv run pytest tests/unit/test_mcp_server/test_http_session_idle_timeout.py -v\` — 2 passed (new tests, verified red before green)
- [x] \`uv run pytest tests/unit/ -x -q\` — 2999 passed, 24 skipped, 0 failed

## Manual test

N/A — this change is entirely internal to the MCP session manager constructor. No Telegram output, no external service calls, no file I/O affecting runtime state. The effect (preventing event loop stalls) is observable only by the absence of future asyncio stalls. The SDK upgrade itself is low-risk: only the session manager constructor call site is affected.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (internal SDK change, no external services)
- [x] User-visible outcome: stall was invisible to user except via health-check restarts — no direct user-visible output to verify
- [x] Side-effect audit: no floods, no writes, no unintended volume — constructor-only change
- [x] External service calls: none

Closes #1823
Fixes #1873