### PR TITLE
fix(bot): handle dict button format in build_inline_keyboard

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -1788,8 +1788,17 @@ def build_inline_keyboard(buttons: list) -> InlineKeyboardMarkup:
     """Build a Telegram InlineKeyboardMarkup from a nested list of button labels.
 
     Each inner list represents a row of buttons.  Each element in the row is
-    either a plain string label (callback_data == label) or a [label, data]
-    two-element list where data is the callback_data payload.
+    one of three supported formats:
+
+    1. Plain string — text == callback_data
+       e.g. ``"Yes"``
+
+    2. Two-element list/tuple — separate text and callback_data
+       e.g. ``["Vote Yes", "yes_cb"]``
+
+    3. Dict with a ``"text"`` key — complex format with optional separate callback_data
+       e.g. ``{"text": "Got it", "callback_data": "card1b_next"}``
+       If ``"callback_data"`` is absent, ``"text"`` is used as the callback value.
 
     Pure function: no side effects.
     """
@@ -1797,7 +1806,10 @@ def build_inline_keyboard(buttons: list) -> InlineKeyboardMarkup:
     for row in buttons:
         keyboard_row = []
         for item in row:
-            if isinstance(item, (list, tuple)) and len(item) == 2:
+            if isinstance(item, dict):
+                label = item["text"]
+                data = item.get("callback_data", label)
+            elif isinstance(item, (list, tuple)) and len(item) == 2:
                 label, data = item
             else:
                 label = str(item)

--- a/tests/unit/test_bot/test_outbox_watcher.py
+++ b/tests/unit/test_bot/test_outbox_watcher.py
@@ -835,3 +835,98 @@ class TestPrepareSendItems:
             # <pre><code> and </code></pre> tags must be balanced
             assert html.count("<pre>") == html.count("</pre>") or True  # HTML tags may differ
             assert len(html) <= bot_module.TELEGRAM_HARD_LIMIT
+
+
+class TestBuildInlineKeyboard:
+    """Tests for build_inline_keyboard — the button layout builder.
+
+    Covers all three button element formats documented in send_reply:
+      1. Plain string  — text == callback_data
+      2. [label, data] two-element list — separate text and callback_data
+      3. {"text": ..., "callback_data": ...} dict — explicit fields (complex format)
+    """
+
+    # Number of distinct button element formats the function must handle
+    SUPPORTED_ELEMENT_FORMATS = 3
+
+    @pytest.fixture
+    def build_keyboard(self):
+        """Return the build_inline_keyboard function from the bot module."""
+        return get_bot_module().build_inline_keyboard
+
+    def test_plain_string_button_text_equals_callback_data(self, build_keyboard):
+        """Plain string buttons use the string as both text and callback_data."""
+        markup = build_keyboard([["Yes", "No"]])
+        row = markup.inline_keyboard[0]
+        assert row[0].text == "Yes"
+        assert row[0].callback_data == "Yes"
+        assert row[1].text == "No"
+        assert row[1].callback_data == "No"
+
+    def test_list_button_separates_text_and_callback_data(self, build_keyboard):
+        """[label, data] two-element list buttons use label as text, data as callback_data."""
+        markup = build_keyboard([[["Vote Yes", "yes_cb"], ["Vote No", "no_cb"]]])
+        row = markup.inline_keyboard[0]
+        assert row[0].text == "Vote Yes"
+        assert row[0].callback_data == "yes_cb"
+        assert row[1].text == "Vote No"
+        assert row[1].callback_data == "no_cb"
+
+    def test_dict_button_uses_text_field_as_label(self, build_keyboard):
+        """Dict buttons must use the 'text' field as the button label.
+
+        Regression test for issue #1777: without the fix, str(dict) is used
+        as the label, producing raw JSON-like strings as button text.
+        """
+        markup = build_keyboard([[
+            {"text": "Got it", "callback_data": "card1b_next"},
+            {"text": "Sleep", "callback_data": "card1b_sleep"},
+        ]])
+        row = markup.inline_keyboard[0]
+        assert row[0].text == "Got it", (
+            f"Expected 'Got it' but got {row[0].text!r} — "
+            "dict button text field is not being extracted"
+        )
+        assert row[0].callback_data == "card1b_next"
+        assert row[1].text == "Sleep"
+        assert row[1].callback_data == "card1b_sleep"
+
+    def test_dict_button_without_callback_data_falls_back_to_text(self, build_keyboard):
+        """Dict button without 'callback_data' key uses 'text' as callback_data."""
+        markup = build_keyboard([[{"text": "OK"}]])
+        row = markup.inline_keyboard[0]
+        assert row[0].text == "OK"
+        assert row[0].callback_data == "OK"
+
+    def test_dict_button_does_not_render_raw_json_as_label(self, build_keyboard):
+        """The button label must NOT be the str() of the dict (the pre-fix bug)."""
+        markup = build_keyboard([[{"text": "Got it", "callback_data": "next"}]])
+        label = markup.inline_keyboard[0][0].text
+        assert "{" not in label, (
+            f"Button label contains '{{': {label!r} — looks like str(dict) was used"
+        )
+
+    def test_multiple_rows_preserved(self, build_keyboard):
+        """Multi-row layout is preserved for all button element formats."""
+        markup = build_keyboard([
+            [{"text": "Row 1 Btn A", "callback_data": "r1a"}, "Row 1 Btn B"],
+            [{"text": "Row 2 Only", "callback_data": "r2"}],
+        ])
+        assert len(markup.inline_keyboard) == 2
+        assert len(markup.inline_keyboard[0]) == 2
+        assert len(markup.inline_keyboard[1]) == 1
+        assert markup.inline_keyboard[0][0].text == "Row 1 Btn A"
+        assert markup.inline_keyboard[0][1].text == "Row 1 Btn B"
+        assert markup.inline_keyboard[1][0].text == "Row 2 Only"
+
+    def test_mixed_formats_in_same_row(self, build_keyboard):
+        """A single row may mix plain strings and dict buttons."""
+        markup = build_keyboard([[
+            "Simple",
+            {"text": "Complex", "callback_data": "complex_cb"},
+        ]])
+        row = markup.inline_keyboard[0]
+        assert row[0].text == "Simple"
+        assert row[0].callback_data == "Simple"
+        assert row[1].text == "Complex"
+        assert row[1].callback_data == "complex_cb"


### PR DESCRIPTION
## Problem solved

`send_reply` buttons using the complex dict format — `{"text": "Label", "callback_data": "value"}` — rendered with the full Python dict repr as the button label on the Telegram client (e.g. `{'text': 'Got it', 'callback_data': 'card1b_next'}`). Only the simple string format `"label"` and two-element list format `["label", "data"]` worked correctly.

## Root cause

`build_inline_keyboard` in `src/bot/lobster_bot.py` handled two element types per button: plain strings and `[label, data]` lists. Dicts fell through to the `else` branch, which called `str(item)` — converting the entire dict to its string representation, which became the button label.

## Fix

Added an explicit `isinstance(item, dict)` branch before the existing cases that extracts `item["text"]` as the label and `item.get("callback_data", label)` as the callback payload. If `"callback_data"` is absent, the text value is used as the fallback (consistent with how plain strings work).

All three documented formats now work:
1. `"label"` — text == callback_data
2. `["label", "data"]` — separate text and callback_data
3. `{"text": "label", "callback_data": "data"}` — dict with optional callback_data

The fix is 3 lines in a pure function with no side effects, no schema changes, and no service restarts needed.

## Functional patterns used

The implementation remains a pure function: no side effects, all state passed as arguments, composed from simple element-level dispatch. The new dict branch follows the same pattern as the existing `list/tuple` branch.

## Tests run

- [x] `uv run pytest tests/unit/test_bot/test_outbox_watcher.py::TestBuildInlineKeyboard -v` — 7 passed, 0 failed (5 tests were failing before the fix as designed; all pass after)
- [x] `uv run pytest tests/unit/test_bot/ --tb=short -q` — 203 passed, 0 failed
- [x] `uv run pytest tests/unit/test_mcp_server/ --tb=no -q` — 840 passed, 0 failed

## Manual test

N/A — the fix is entirely in `build_inline_keyboard`, a pure function that converts the buttons list to a `InlineKeyboardMarkup` object. The broken behavior (str(dict) as label) is directly observable in tests without hitting the Telegram API. The regression test `test_dict_button_does_not_render_raw_json_as_label` explicitly asserts that `{` does not appear in the button label.

The live Telegram behavior cannot be self-verified without a test bot session. A quick manual smoke test (send a message with dict-format buttons, confirm label renders correctly) is recommended before merge.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, pure function change; see note above
- [ ] User-visible outcome verified — blocked: requires sending a live Telegram message to confirm label renders. Flagged for reviewer attention.
- [x] Side-effect audit complete: change is confined to a pure function; no writes, no network calls, no shared state
- [x] External service calls: mocked in all tests

Closes #1777