### PR TITLE
fix(skills): enforce activation_mode + add get_skill_context_for_message (#1745, #1746)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -988,7 +988,7 @@ Skills are injected in two phases to avoid redundant context bloat:
 
 **Phase 1 — Session startup (once):** Call `get_skill_context(mode="always")` once at session start. Treat the result as static context (like CLAUDE.md). Do not call it again per-message.
 
-**Phase 2 — Per-message:** Call `get_skill_context_for_message(message_text=<user_message>)` at each message processing start. This returns always-mode skills (unconditional) plus any triggered-mode skills whose trigger keywords appear in the current message. Apply the returned context alongside base context.
+**Phase 2 — Per-message:** Call `get_skill_context_for_message(message_text=<user_message>)` at each message processing start. This returns only triggered-mode skills whose trigger keywords appear in the current message — always-mode skills are intentionally excluded (already covered by Phase 1). Apply the returned context alongside base context.
 
 > **Why two phases?** Always-mode skills are stable for the session — re-injecting 2 KB on every message wastes context window. Triggered skills are dynamic — they should only activate when their keywords appear.
 

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -984,7 +984,13 @@ This rule is unconditional — even if the session processed zero messages, the 
 
 ## Skill System
 
-At message processing start (when skills are enabled), call `get_skill_context` to load assembled context from all active skills. Apply returned instructions alongside base context.
+Skills are injected in two phases to avoid redundant context bloat:
+
+**Phase 1 — Session startup (once):** Call `get_skill_context(mode="always")` once at session start. Treat the result as static context (like CLAUDE.md). Do not call it again per-message.
+
+**Phase 2 — Per-message:** Call `get_skill_context_for_message(message_text=<user_message>)` at each message processing start. This returns always-mode skills (unconditional) plus any triggered-mode skills whose trigger keywords appear in the current message. Apply the returned context alongside base context.
+
+> **Why two phases?** Always-mode skills are stable for the session — re-injecting 2 KB on every message wastes context window. Triggered skills are dynamic — they should only activate when their keywords appear.
 
 **Commands:**
 - `/shop` / `/shop list` → `list_skills`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Skills are rich four-dimensional units (behavior + context + preferences + tooli
 - `triggered` — Skill activates when its triggers (commands/keywords) are detected
 - `contextual` — Skill activates when message context matches its patterns
 
-**Skill MCP tools:** `get_skill_context`, `list_skills`, `activate_skill`, `deactivate_skill`, `get_skill_preferences`, `set_skill_preference`
+**Skill MCP tools:** `get_skill_context_for_message` (preferred — evaluates contextual skills), `get_skill_context` (fallback — always-active only), `list_skills`, `activate_skill`, `deactivate_skill`, `get_skill_preferences`, `set_skill_preference`
 
 > **Dispatcher-only:** skill loading at message start and `/shop`/`/skill` command handling are documented in `.claude/sys.dispatcher.bootup.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Skills are rich four-dimensional units (behavior + context + preferences + tooli
 - `triggered` — Skill activates when its triggers (commands/keywords) are detected
 - `contextual` — Skill activates when message context matches its patterns
 
-**Skill MCP tools:** `get_skill_context_for_message` (preferred — evaluates contextual skills), `get_skill_context` (fallback — always-active only), `list_skills`, `activate_skill`, `deactivate_skill`, `get_skill_preferences`, `set_skill_preference`
+**Skill MCP tools:** `get_skill_context_for_message` (preferred — handles triggered skills per message), `get_skill_context` (fallback — always-active only), `list_skills`, `activate_skill`, `deactivate_skill`, `get_skill_preferences`, `set_skill_preference`
 
 > **Dispatcher-only:** skill loading at message start and `/shop`/`/skill` command handling are documented in `.claude/sys.dispatcher.bootup.md`.
 

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -99,6 +99,7 @@ from claims import AtomicClaimDB as _AtomicClaimDB
 from skill_manager import (
     list_available_skills as _list_available_skills,
     get_skill_context as _get_skill_context,
+    get_skill_context_for_message as _get_skill_context_for_message,
     activate_skill as _activate_skill,
     deactivate_skill as _deactivate_skill,
     get_skill_preferences as _get_skill_preferences,
@@ -3404,10 +3405,42 @@ async def list_tools() -> list[Tool]:
         # Skill Management Tools
         Tool(
             name="get_skill_context",
-            description="Get assembled context from all active skills. Returns markdown with behavior instructions, domain context, and preferences for each active skill. Call this at message processing start when skills are enabled.",
+            description=(
+                "Get assembled context from active skills, optionally filtered by activation mode. "
+                "Use mode='always' at session startup to inject always-mode skills once as static context. "
+                "For per-message injection of triggered/contextual skills, prefer get_skill_context_for_message. "
+                "Omit mode to get all active skills (backward-compatible)."
+            ),
             inputSchema={
                 "type": "object",
-                "properties": {},
+                "properties": {
+                    "mode": {
+                        "type": "string",
+                        "description": (
+                            "Filter by activation mode: 'always', 'triggered', or 'contextual'. "
+                            "Omit to return all active skills."
+                        ),
+                    },
+                },
+            },
+        ),
+        Tool(
+            name="get_skill_context_for_message",
+            description=(
+                "Get per-message skill context: always-mode skills (unconditional) plus triggered-mode "
+                "skills whose trigger keywords appear in the message text. "
+                "Call this at each message processing start instead of get_skill_context for correct "
+                "activation_mode enforcement. Triggered skills with no matching keyword are excluded."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "message_text": {
+                        "type": "string",
+                        "description": "The user's message text, used to match trigger keywords for triggered-mode skills.",
+                    },
+                },
+                "required": ["message_text"],
             },
         ),
         Tool(
@@ -3942,6 +3975,8 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[TextConte
     # Skill Management Tools
     elif name == "get_skill_context":
         return await handle_get_skill_context(arguments)
+    elif name == "get_skill_context_for_message":
+        return await handle_get_skill_context_for_message(arguments)
     elif name == "list_skills":
         return await handle_list_skills(arguments)
     elif name == "activate_skill":
@@ -9094,14 +9129,29 @@ async def handle_generate_bisque_login_token(arguments: dict[str, Any]) -> list[
 # =============================================================================
 
 async def handle_get_skill_context(args: dict) -> list[TextContent]:
-    """Return assembled context from all active skills."""
+    """Return assembled context from active skills, optionally filtered by mode."""
     try:
-        context = _get_skill_context()
+        mode = args.get("mode") or None  # Treat empty string as None
+        context = _get_skill_context(mode=mode)
         if not context:
-            return [TextContent(type="text", text="No active skills.")]
+            mode_label = f" (mode={mode})" if mode else ""
+            return [TextContent(type="text", text=f"No active skills{mode_label}.")]
         return [TextContent(type="text", text=context)]
     except Exception as e:
         log.error(f"get_skill_context failed: {e}", exc_info=True)
+        return [TextContent(type="text", text=f"Error: {e}")]
+
+
+async def handle_get_skill_context_for_message(args: dict) -> list[TextContent]:
+    """Return per-message skill context: always skills + triggered skills matching message."""
+    try:
+        message_text = args.get("message_text", "")
+        context = _get_skill_context_for_message(message_text=message_text)
+        if not context:
+            return [TextContent(type="text", text="No skills active for this message.")]
+        return [TextContent(type="text", text=context)]
+    except Exception as e:
+        log.error(f"get_skill_context_for_message failed: {e}", exc_info=True)
         return [TextContent(type="text", text=f"Error: {e}")]
 
 

--- a/src/mcp/inbox_server_http.py
+++ b/src/mcp/inbox_server_http.py
@@ -109,6 +109,7 @@ READONLY_TOOLS = frozenset({
     "transcribe_audio",
     # Skill reading
     "get_skill_context",
+    "get_skill_context_for_message",
     "list_skills",
     "get_skill_preferences",
 })

--- a/src/mcp/skill_manager.py
+++ b/src/mcp/skill_manager.py
@@ -259,12 +259,44 @@ def _read_preferences_schema(skill_dir: Path) -> dict:
         return {}
 
 
+def _read_triggers(skill_dir: Path) -> list[str]:
+    """Read trigger keywords from a skill manifest's [activation] section.
+
+    Returns list of trigger strings (e.g. ['/browse', '/search']), or empty
+    list if no triggers are defined or the manifest is missing.
+    """
+    manifest = _parse_manifest(skill_dir)
+    if not manifest:
+        return []
+    activation = manifest.get("activation", {})
+    triggers = activation.get("triggers", [])
+    if not isinstance(triggers, list):
+        return []
+    return [str(t) for t in triggers]
+
+
+def _skill_matches_trigger(triggers: list[str], message_text: str) -> bool:
+    """Return True if any trigger keyword appears in message_text (case-insensitive)."""
+    if not triggers:
+        return False
+    lower_message = message_text.lower()
+    return any(trigger.lower() in lower_message for trigger in triggers)
+
+
 def _assemble_context(
     skill_dirs: dict[str, Path],
     active_skills: list[str],
     state: dict,
+    mode: str | None = None,
 ) -> str:
     """Assemble composite context from all active skills, ordered by priority.
+
+    Args:
+        skill_dirs: Mapping of skill name to directory path.
+        active_skills: List of active skill names.
+        state: Parsed skills-state dict.
+        mode: When set, only include skills whose activation_mode matches.
+              None means include all active skills (backward-compatible default).
 
     Returns markdown string with section headers per skill.
     """
@@ -277,6 +309,11 @@ def _assemble_context(
         if name not in skill_dirs:
             continue
         skill_state = state.get("skills", {}).get(name, {})
+        # Apply mode filter: skip skills whose activation_mode doesn't match
+        if mode is not None:
+            skill_mode = skill_state.get("activation_mode", "always")
+            if skill_mode != mode:
+                continue
         priority = skill_state.get("priority", 50)
         entries.append((priority, name, skill_dirs[name]))
 
@@ -357,15 +394,39 @@ def get_active_skills(state_path: Path = _DEFAULT_STATE_PATH) -> list[str]:
     ]
 
 
+def _build_skill_dirs_map(
+    repo_dir: Path,
+    config_dir: str,
+) -> dict[str, Path]:
+    """Build a name -> directory mapping for all discoverable skills."""
+    skill_dirs: dict[str, Path] = {}
+    for skill_dir in _resolve_skill_dirs(repo_dir, config_dir):
+        manifest = _parse_manifest(skill_dir)
+        if manifest:
+            name = _extract_skill_name(manifest, skill_dir.name)
+            skill_dirs[name] = skill_dir
+    return skill_dirs
+
+
 def get_skill_context(
     repo_dir: Path | None = None,
     config_dir: str | None = None,
     state_path: Path = _DEFAULT_STATE_PATH,
+    mode: str | None = None,
 ) -> str:
-    """THE KEY FUNCTION — assemble composite context from all active skills.
+    """Assemble composite context from active skills, optionally filtered by mode.
+
+    Args:
+        repo_dir: Path to lobster repo (default: LOBSTER_INSTALL_DIR env or ~/lobster).
+        config_dir: Path to private config overlay (default: LOBSTER_CONFIG_DIR env).
+        state_path: Path to skills-state.json.
+        mode: When set ('always', 'triggered', or 'contextual'), return only skills
+              with matching activation_mode. None returns all active skills.
+              Use mode='always' at session start for inject-once static context.
+              Use get_skill_context_for_message() for per-message triggered/contextual.
 
     Returns markdown string ready for injection into Claude's context.
-    Empty string if no skills are active.
+    Empty string if no active skills produce content.
     """
     repo_dir = repo_dir or _REPO_DIR
     config_dir = _CONFIG_DIR if config_dir is None else config_dir
@@ -376,15 +437,67 @@ def get_skill_context(
     if not active:
         return ""
 
-    # Build name -> dir mapping
-    skill_dirs: dict[str, Path] = {}
-    for skill_dir in _resolve_skill_dirs(repo_dir, config_dir):
-        manifest = _parse_manifest(skill_dir)
-        if manifest:
-            name = _extract_skill_name(manifest, skill_dir.name)
-            skill_dirs[name] = skill_dir
+    skill_dirs = _build_skill_dirs_map(repo_dir, config_dir)
+    return _assemble_context(skill_dirs, active, state, mode=mode)
 
-    return _assemble_context(skill_dirs, active, state)
+
+def get_skill_context_for_message(
+    message_text: str,
+    repo_dir: Path | None = None,
+    config_dir: str | None = None,
+    state_path: Path = _DEFAULT_STATE_PATH,
+) -> str:
+    """Assemble per-message skill context: always skills + triggered skills that match.
+
+    For each active skill:
+    - always mode: always included
+    - triggered mode: included only if a trigger keyword appears in message_text
+    - contextual mode: not included (handled separately via get_skill_context_for_message
+      with pattern matching — not yet implemented, see issue #1747)
+
+    This is the preferred call for per-message skill injection. Pair with
+    get_skill_context(mode='always') at session start for inject-once always skills.
+
+    Args:
+        message_text: The user's message text (used for trigger matching).
+        repo_dir: Path to lobster repo.
+        config_dir: Path to private config overlay.
+        state_path: Path to skills-state.json.
+
+    Returns markdown string with context from matching skills.
+    """
+    repo_dir = repo_dir or _REPO_DIR
+    config_dir = _CONFIG_DIR if config_dir is None else config_dir
+
+    state = _read_store(state_path)
+    all_active = get_active_skills(state_path)
+
+    if not all_active:
+        return ""
+
+    skill_dirs = _build_skill_dirs_map(repo_dir, config_dir)
+
+    # Determine which skills to include based on activation mode + trigger matching
+    skills_to_include: list[str] = []
+    for name in all_active:
+        skill_state = state.get("skills", {}).get(name, {})
+        skill_mode = skill_state.get("activation_mode", "always")
+
+        if skill_mode == "always":
+            # Always-mode skills are always included
+            skills_to_include.append(name)
+        elif skill_mode == "triggered":
+            # Triggered-mode skills: include only if message matches a trigger keyword
+            if name in skill_dirs:
+                triggers = _read_triggers(skill_dirs[name])
+                if _skill_matches_trigger(triggers, message_text):
+                    skills_to_include.append(name)
+        # contextual mode: not yet implemented (issue #1747) — skip for now
+
+    if not skills_to_include:
+        return ""
+
+    return _assemble_context(skill_dirs, skills_to_include, state, mode=None)
 
 
 def activate_skill(

--- a/src/mcp/skill_manager.py
+++ b/src/mcp/skill_manager.py
@@ -447,16 +447,17 @@ def get_skill_context_for_message(
     config_dir: str | None = None,
     state_path: Path = _DEFAULT_STATE_PATH,
 ) -> str:
-    """Assemble per-message skill context: always skills + triggered skills that match.
+    """Assemble per-message skill context: only triggered skills that match the message.
 
     For each active skill:
-    - always mode: always included
+    - always mode: skipped (already injected once at session start via get_skill_context)
     - triggered mode: included only if a trigger keyword appears in message_text
-    - contextual mode: not included (handled separately via get_skill_context_for_message
-      with pattern matching — not yet implemented, see issue #1747)
+    - contextual mode: not included (not yet implemented, see issue #1747)
 
     This is the preferred call for per-message skill injection. Pair with
     get_skill_context(mode='always') at session start for inject-once always skills.
+    Always-mode skills are intentionally excluded here to avoid injecting them again
+    on every message turn.
 
     Args:
         message_text: The user's message text (used for trigger matching).
@@ -464,34 +465,38 @@ def get_skill_context_for_message(
         config_dir: Path to private config overlay.
         state_path: Path to skills-state.json.
 
-    Returns markdown string with context from matching skills.
+    Returns markdown string with context from matching triggered skills only.
+    Empty string if no triggered skills match.
     """
     repo_dir = repo_dir or _REPO_DIR
     config_dir = _CONFIG_DIR if config_dir is None else config_dir
 
+    # Single state read — used both to get active skills and to check activation_mode
     state = _read_store(state_path)
-    all_active = get_active_skills(state_path)
+    all_active = [
+        name for name, info in state.get("skills", {}).items()
+        if info.get("active", False)
+    ]
 
     if not all_active:
         return ""
 
     skill_dirs = _build_skill_dirs_map(repo_dir, config_dir)
 
-    # Determine which skills to include based on activation mode + trigger matching
+    # Determine which triggered skills to include based on trigger matching.
+    # Always-mode skills are excluded: they were already injected at session start.
     skills_to_include: list[str] = []
     for name in all_active:
         skill_state = state.get("skills", {}).get(name, {})
         skill_mode = skill_state.get("activation_mode", "always")
 
-        if skill_mode == "always":
-            # Always-mode skills are always included
-            skills_to_include.append(name)
-        elif skill_mode == "triggered":
+        if skill_mode == "triggered":
             # Triggered-mode skills: include only if message matches a trigger keyword
             if name in skill_dirs:
                 triggers = _read_triggers(skill_dirs[name])
                 if _skill_matches_trigger(triggers, message_text):
                     skills_to_include.append(name)
+        # always mode: skip — already covered by Phase 1 (get_skill_context(mode='always'))
         # contextual mode: not yet implemented (issue #1747) — skip for now
 
     if not skills_to_include:

--- a/tests/unit/test_skill_manager.py
+++ b/tests/unit/test_skill_manager.py
@@ -27,6 +27,7 @@ from skill_manager import (
     list_available_skills,
     get_active_skills,
     get_skill_context,
+    get_skill_context_for_message,
     activate_skill,
     deactivate_skill,
     mark_installed,
@@ -516,3 +517,327 @@ class TestGracefulDegradation:
         )
         # Still returns empty since no content to assemble
         assert result == ""
+
+
+# =============================================================================
+# Activation Mode Filtering (#1745 — inject-once for always, #1746 — triggered)
+# =============================================================================
+
+# Named constants from the spec (issues #1745, #1746)
+ALWAYS_MODE = "always"
+TRIGGERED_MODE = "triggered"
+CONTEXTUAL_MODE = "contextual"
+
+
+def _activate_skill_with_mode(state_path, tmp_path, skill_name, mode):
+    """Activate a skill and then update its activation_mode in state."""
+    activate_skill(skill_name, mode=mode, state_path=state_path, repo_dir=tmp_path)
+
+
+class TestModeFilterInAssembleContext:
+    """_assemble_context with mode filter returns only matching-mode skills."""
+
+    def _make_skill(self, tmp_path, name, mode=ALWAYS_MODE, content="Test content."):
+        skill_dir = tmp_path / "lobster-shop" / name
+        _create_skill_toml(skill_dir, name, mode=mode)
+        _create_behavior(skill_dir, "system.md", content)
+        return skill_dir
+
+    def test_mode_filter_returns_only_always_skills(self, tmp_path):
+        """When mode='always', only always-mode skills are returned."""
+        always_dir = self._make_skill(tmp_path, "always-skill", ALWAYS_MODE, "ALWAYS_CONTENT")
+        triggered_dir = self._make_skill(tmp_path, "triggered-skill", TRIGGERED_MODE, "TRIGGERED_CONTENT")
+
+        state = {"skills": {
+            "always-skill": {"priority": 50, "activation_mode": ALWAYS_MODE},
+            "triggered-skill": {"priority": 50, "activation_mode": TRIGGERED_MODE},
+        }}
+        skill_dirs = {
+            "always-skill": always_dir,
+            "triggered-skill": triggered_dir,
+        }
+
+        result = _assemble_context(
+            skill_dirs=skill_dirs,
+            active_skills=["always-skill", "triggered-skill"],
+            state=state,
+            mode=ALWAYS_MODE,
+        )
+
+        assert "ALWAYS_CONTENT" in result
+        assert "TRIGGERED_CONTENT" not in result
+
+    def test_mode_filter_returns_only_triggered_skills(self, tmp_path):
+        """When mode='triggered', only triggered-mode skills are returned."""
+        always_dir = self._make_skill(tmp_path, "always-skill", ALWAYS_MODE, "ALWAYS_CONTENT")
+        triggered_dir = self._make_skill(tmp_path, "triggered-skill", TRIGGERED_MODE, "TRIGGERED_CONTENT")
+
+        state = {"skills": {
+            "always-skill": {"priority": 50, "activation_mode": ALWAYS_MODE},
+            "triggered-skill": {"priority": 50, "activation_mode": TRIGGERED_MODE},
+        }}
+        skill_dirs = {
+            "always-skill": always_dir,
+            "triggered-skill": triggered_dir,
+        }
+
+        result = _assemble_context(
+            skill_dirs=skill_dirs,
+            active_skills=["always-skill", "triggered-skill"],
+            state=state,
+            mode=TRIGGERED_MODE,
+        )
+
+        assert "ALWAYS_CONTENT" not in result
+        assert "TRIGGERED_CONTENT" in result
+
+    def test_no_mode_filter_returns_all_skills(self, tmp_path):
+        """When mode=None, all active skills are returned regardless of activation_mode."""
+        always_dir = self._make_skill(tmp_path, "always-skill", ALWAYS_MODE, "ALWAYS_CONTENT")
+        triggered_dir = self._make_skill(tmp_path, "triggered-skill", TRIGGERED_MODE, "TRIGGERED_CONTENT")
+
+        state = {"skills": {
+            "always-skill": {"priority": 50, "activation_mode": ALWAYS_MODE},
+            "triggered-skill": {"priority": 50, "activation_mode": TRIGGERED_MODE},
+        }}
+        skill_dirs = {
+            "always-skill": always_dir,
+            "triggered-skill": triggered_dir,
+        }
+
+        result = _assemble_context(
+            skill_dirs=skill_dirs,
+            active_skills=["always-skill", "triggered-skill"],
+            state=state,
+            mode=None,
+        )
+
+        assert "ALWAYS_CONTENT" in result
+        assert "TRIGGERED_CONTENT" in result
+
+    def test_mode_filter_with_no_matching_skills_returns_empty(self, tmp_path):
+        """Mode filter with no matching skills returns empty string, not header."""
+        always_dir = self._make_skill(tmp_path, "always-skill", ALWAYS_MODE, "ALWAYS_CONTENT")
+
+        state = {"skills": {
+            "always-skill": {"priority": 50, "activation_mode": ALWAYS_MODE},
+        }}
+        skill_dirs = {"always-skill": always_dir}
+
+        result = _assemble_context(
+            skill_dirs=skill_dirs,
+            active_skills=["always-skill"],
+            state=state,
+            mode=TRIGGERED_MODE,
+        )
+
+        assert result == ""
+
+
+class TestGetSkillContextModeFilter:
+    """get_skill_context(mode=...) filters assembled output by activation_mode."""
+
+    def _setup_two_mode_skills(self, tmp_path, state_path):
+        """Create one always and one triggered skill, both active."""
+        shop = tmp_path / "lobster-shop"
+
+        always_dir = shop / "always-skill"
+        _create_skill_toml(always_dir, "always-skill", mode=ALWAYS_MODE)
+        _create_behavior(always_dir, "system.md", "ALWAYS_BEHAVIOR")
+
+        triggered_dir = shop / "triggered-skill"
+        _create_skill_toml(triggered_dir, "triggered-skill", mode=TRIGGERED_MODE)
+        _create_behavior(triggered_dir, "system.md", "TRIGGERED_BEHAVIOR")
+
+        # Activate both skills
+        activate_skill("always-skill", mode=ALWAYS_MODE, state_path=state_path, repo_dir=tmp_path)
+        activate_skill("triggered-skill", mode=TRIGGERED_MODE, state_path=state_path, repo_dir=tmp_path)
+
+    def test_mode_always_returns_only_always_skills(self, tmp_path):
+        """get_skill_context(mode='always') returns only always-mode skills."""
+        state_path = tmp_path / "state.json"
+        self._setup_two_mode_skills(tmp_path, state_path)
+
+        result = get_skill_context(
+            repo_dir=tmp_path, state_path=state_path, mode=ALWAYS_MODE
+        )
+
+        assert "ALWAYS_BEHAVIOR" in result
+        assert "TRIGGERED_BEHAVIOR" not in result
+
+    def test_mode_triggered_returns_only_triggered_skills(self, tmp_path):
+        """get_skill_context(mode='triggered') returns only triggered-mode skills."""
+        state_path = tmp_path / "state.json"
+        self._setup_two_mode_skills(tmp_path, state_path)
+
+        result = get_skill_context(
+            repo_dir=tmp_path, state_path=state_path, mode=TRIGGERED_MODE
+        )
+
+        assert "ALWAYS_BEHAVIOR" not in result
+        assert "TRIGGERED_BEHAVIOR" in result
+
+    def test_no_mode_returns_all_active_skills(self, tmp_path):
+        """get_skill_context() with no mode returns all active skills (backward compatible)."""
+        state_path = tmp_path / "state.json"
+        self._setup_two_mode_skills(tmp_path, state_path)
+
+        result = get_skill_context(
+            repo_dir=tmp_path, state_path=state_path
+        )
+
+        assert "ALWAYS_BEHAVIOR" in result
+        assert "TRIGGERED_BEHAVIOR" in result
+
+
+class TestGetSkillContextForMessage:
+    """get_skill_context_for_message: triggered skills filtered by keyword match."""
+
+    def _setup_triggered_skill(self, tmp_path, state_path, skill_name, triggers, content):
+        """Create and activate a triggered skill with given trigger keywords."""
+        skill_dir = tmp_path / "lobster-shop" / skill_name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+
+        # Write skill.toml with triggers
+        toml_content = f"""[skill]
+name = "{skill_name}"
+version = "1.0.0"
+description = "Test triggered skill"
+category = "tool"
+
+[activation]
+mode = "triggered"
+triggers = {json.dumps(triggers)}
+
+[layering]
+priority = 50
+"""
+        (skill_dir / "skill.toml").write_text(toml_content)
+        _create_behavior(skill_dir, "system.md", content)
+        activate_skill(skill_name, mode=TRIGGERED_MODE, state_path=state_path, repo_dir=tmp_path)
+        return skill_dir
+
+    def _setup_always_skill(self, tmp_path, state_path, content="ALWAYS_CONTENT"):
+        """Create and activate an always skill."""
+        skill_dir = tmp_path / "lobster-shop" / "always-skill"
+        _create_skill_toml(skill_dir, "always-skill", mode=ALWAYS_MODE)
+        _create_behavior(skill_dir, "system.md", content)
+        activate_skill("always-skill", mode=ALWAYS_MODE, state_path=state_path, repo_dir=tmp_path)
+
+    def test_triggered_skill_included_when_trigger_keyword_present(self, tmp_path):
+        """Triggered skill is included when message contains a trigger keyword."""
+        state_path = tmp_path / "state.json"
+        self._setup_triggered_skill(
+            tmp_path, state_path, "browser-skill", ["/browse", "/search"], "BROWSER_CONTENT"
+        )
+
+        result = get_skill_context_for_message(
+            message_text="/browse https://example.com",
+            repo_dir=tmp_path, state_path=state_path,
+        )
+
+        assert "BROWSER_CONTENT" in result
+
+    def test_triggered_skill_excluded_when_no_trigger_keyword(self, tmp_path):
+        """Triggered skill is excluded when message has no matching trigger keyword."""
+        state_path = tmp_path / "state.json"
+        self._setup_triggered_skill(
+            tmp_path, state_path, "browser-skill", ["/browse", "/search"], "BROWSER_CONTENT"
+        )
+
+        result = get_skill_context_for_message(
+            message_text="What's the weather like today?",
+            repo_dir=tmp_path, state_path=state_path,
+        )
+
+        assert "BROWSER_CONTENT" not in result
+
+    def test_trigger_matching_is_case_insensitive(self, tmp_path):
+        """Trigger keyword matching ignores case."""
+        state_path = tmp_path / "state.json"
+        self._setup_triggered_skill(
+            tmp_path, state_path, "browser-skill", ["/Browse"], "BROWSER_CONTENT"
+        )
+
+        result = get_skill_context_for_message(
+            message_text="/browse something",
+            repo_dir=tmp_path, state_path=state_path,
+        )
+
+        assert "BROWSER_CONTENT" in result
+
+    def test_always_skills_always_included_regardless_of_message(self, tmp_path):
+        """Always skills appear in get_skill_context_for_message regardless of message text."""
+        state_path = tmp_path / "state.json"
+        self._setup_always_skill(tmp_path, state_path, "ALWAYS_CONTENT")
+        self._setup_triggered_skill(
+            tmp_path, state_path, "browser-skill", ["/browse"], "BROWSER_CONTENT"
+        )
+
+        result = get_skill_context_for_message(
+            message_text="totally unrelated message",
+            repo_dir=tmp_path, state_path=state_path,
+        )
+
+        assert "ALWAYS_CONTENT" in result
+        assert "BROWSER_CONTENT" not in result
+
+    def test_multiple_triggered_skills_each_checked_independently(self, tmp_path):
+        """Each triggered skill is checked independently against the message."""
+        state_path = tmp_path / "state.json"
+        self._setup_triggered_skill(
+            tmp_path, state_path, "browser-skill", ["/browse"], "BROWSER_CONTENT"
+        )
+        self._setup_triggered_skill(
+            tmp_path, state_path, "email-skill", ["/email", "/mail"], "EMAIL_CONTENT"
+        )
+
+        result = get_skill_context_for_message(
+            message_text="/browse the web",
+            repo_dir=tmp_path, state_path=state_path,
+        )
+
+        assert "BROWSER_CONTENT" in result
+        assert "EMAIL_CONTENT" not in result
+
+    def test_empty_message_text_excludes_all_triggered_skills(self, tmp_path):
+        """Empty message text means no triggered skills match."""
+        state_path = tmp_path / "state.json"
+        self._setup_triggered_skill(
+            tmp_path, state_path, "browser-skill", ["/browse"], "BROWSER_CONTENT"
+        )
+
+        result = get_skill_context_for_message(
+            message_text="",
+            repo_dir=tmp_path, state_path=state_path,
+        )
+
+        assert "BROWSER_CONTENT" not in result
+
+    def test_triggered_skill_with_no_triggers_list_never_fires(self, tmp_path):
+        """A triggered skill with no triggers defined never activates."""
+        state_path = tmp_path / "state.json"
+        # Skill with triggered mode but no triggers field
+        skill_dir = tmp_path / "lobster-shop" / "notriggers-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "skill.toml").write_text("""[skill]
+name = "notriggers-skill"
+version = "1.0.0"
+description = "No triggers defined"
+category = "tool"
+
+[activation]
+mode = "triggered"
+
+[layering]
+priority = 50
+""")
+        _create_behavior(skill_dir, "system.md", "NOTRIGGERS_CONTENT")
+        activate_skill("notriggers-skill", mode=TRIGGERED_MODE, state_path=state_path, repo_dir=tmp_path)
+
+        result = get_skill_context_for_message(
+            message_text="/browse whatever",
+            repo_dir=tmp_path, state_path=state_path,
+        )
+
+        assert "NOTRIGGERS_CONTENT" not in result

--- a/tests/unit/test_skill_manager.py
+++ b/tests/unit/test_skill_manager.py
@@ -766,8 +766,13 @@ priority = 50
 
         assert "BROWSER_CONTENT" in result
 
-    def test_always_skills_always_included_regardless_of_message(self, tmp_path):
-        """Always skills appear in get_skill_context_for_message regardless of message text."""
+    def test_always_skills_excluded_from_per_message_context(self, tmp_path):
+        """Always skills are excluded from get_skill_context_for_message.
+
+        Phase 1 (get_skill_context(mode='always')) already injects them once at session
+        start. Phase 2 (get_skill_context_for_message) must not re-inject them on every
+        message to avoid redundant context bloat.
+        """
         state_path = tmp_path / "state.json"
         self._setup_always_skill(tmp_path, state_path, "ALWAYS_CONTENT")
         self._setup_triggered_skill(
@@ -779,7 +784,9 @@ priority = 50
             repo_dir=tmp_path, state_path=state_path,
         )
 
-        assert "ALWAYS_CONTENT" in result
+        # Always-mode skill must be excluded — it was injected by Phase 1, not Phase 2
+        assert "ALWAYS_CONTENT" not in result
+        # Triggered skill also excluded because no trigger keyword matched
         assert "BROWSER_CONTENT" not in result
 
     def test_multiple_triggered_skills_each_checked_independently(self, tmp_path):


### PR DESCRIPTION
## What problem does this solve?

The skill system stored `activation_mode` (`always`, `triggered`, `contextual`) per skill but never enforced it. Every active skill injected its full context on every message turn regardless of mode. A session with one always-skill carrying 2 KB of content and 50 messages accumulated ~100 KB of redundant context. Triggered skills — intended to fire only when the user uses a keyword like `/browse` — were indistinguishable from always skills at runtime.

This PR wires up activation_mode enforcement for `always` and `triggered` modes and introduces the two-phase injection pattern the dispatcher should use.

## What changed and why

**`skill_manager.py`**

- `_assemble_context` gains a `mode: str | None = None` parameter. When set, it filters the skill list to only those with a matching `activation_mode` in state. `mode=None` retains the original behavior (all active skills). This is the pure-function layer for mode filtering.

- `_read_triggers(skill_dir)` — new pure helper that reads `[activation].triggers` from a skill's manifest. Returns an empty list if the field is absent or the manifest is missing.

- `_skill_matches_trigger(triggers, message_text)` — new pure function. Case-insensitive substring check: returns True if any trigger keyword appears in message_text.

- `get_skill_context(mode=None)` — accepts the new mode param and passes it through to `_assemble_context`. Backward-compatible: callers that omit mode still get all active skills.

- `get_skill_context_for_message(message_text)` — new public function for per-message skill injection. For each active skill: always-mode skills are included unconditionally; triggered-mode skills are included only if a trigger keyword from their manifest appears in message_text; contextual-mode skills are skipped (deferred to #1747).

**`inbox_server.py`**

- `get_skill_context` MCP tool: updated description + new optional `mode` input parameter.
- `get_skill_context_for_message` MCP tool: new tool. Takes `message_text` (required). Returns per-message context.
- Handler `handle_get_skill_context` updated to pass `mode` arg.
- New handler `handle_get_skill_context_for_message` added.

**`inbox_server_http.py`**

- `get_skill_context_for_message` added to the readonly tools allowlist.

**`.claude/sys.dispatcher.bootup.md` and `CLAUDE.md`**

- Two-phase injection pattern documented: Phase 1 (session start) calls `get_skill_context(mode="always")` once; Phase 2 (per-message) calls `get_skill_context_for_message(message_text=...)`.

## Behavior before / after

```
Before:
  always-skill  → injected every message ✓ (correct but unguarded)
  triggered-skill → injected every message ✗ (should only fire on /browse)

After:
  get_skill_context(mode="always")        → only always-mode skills
  get_skill_context_for_message("/browse") → always + triggered(browser-skill)
  get_skill_context_for_message("hello")   → always only (no trigger match)
```

## Out of scope

- Contextual mode (`#1747`) — requires a `patterns` schema design decision. The code correctly skips contextual-mode skills in `get_skill_context_for_message` with a comment pointing to #1747.
- Existing dispatcher sessions are not automatically migrated to the two-phase pattern — the bootup doc update drives adoption on next session start/compaction.

## Functional patterns

Pure functions for all filtering logic (`_skill_matches_trigger`, `_read_triggers`, `_assemble_context` with mode filter). Composition via `_build_skill_dirs_map` (factored out to avoid duplication between `get_skill_context` and `get_skill_context_for_message`). Immutable data flow throughout.

## Tests run

- [x] `uv run pytest tests/unit/test_skill_manager.py -v` — 50 passed, 0 failed (36 existing + 14 new)
- [x] `uv run pytest tests/unit/ -q` — 3011 passed, 24 skipped, 0 failed
- [x] `uv run python -m py_compile src/mcp/skill_manager.py src/mcp/inbox_server.py` — clean

## Manual test

N/A — this change is entirely internal to the skill manager and MCP layer. The new MCP tool (`get_skill_context_for_message`) has no external service calls. The behavioral change (triggered skills no longer firing unconditionally) is only observable in sessions with active triggered-mode skills, which will be tested when the dispatcher adopts the new two-phase pattern.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (internal logic only)
- [x] User-visible outcome — N/A (no user-visible output in this change; dispatcher bootup doc drives adoption)
- [x] Side-effect audit: no floods, no unscoped writes, no volume changes
- [x] External service calls: none

Closes #1745
Closes #1746