### PR TITLE
fix(dashboard): use dispatcher-heartbeat with 20-min stale threshold (#1822)

### DIFF
--- a/src/dashboard/collectors.py
+++ b/src/dashboard/collectors.py
@@ -57,6 +57,19 @@ SENT_DIR = _MESSAGES / "sent"
 TASK_OUTPUTS_DIR = _MESSAGES / "task-outputs"
 TASKS_FILE = _MESSAGES / "tasks.json"
 
+# Threshold (in seconds) above which the dispatcher heartbeat is considered stale.
+#
+# Aligned with DISPATCHER_HEARTBEAT_STALE_SECONDS in hooks/thinking-heartbeat.py
+# and DISPATCHER_HEARTBEAT_STALE_SECONDS in scripts/health-check-v3.sh (both 1200s).
+#
+# The previous value (300s / 5 min) caused false-positive STALE during context
+# compaction phases, which can last 10+ minutes without any PostToolUse events
+# firing — so the heartbeat inevitably goes stale even though the dispatcher is
+# healthy and actively running.  20 minutes aligns with the documented 20-minute
+# health-check window and absorbs the longest observed compaction phases.
+# See: issue #1822.
+HEARTBEAT_STALE_THRESHOLD = 1200  # 20 minutes — matches thinking-heartbeat.py
+
 
 def _count_files(directory: Path) -> int:
     """Count JSON files in a directory (non-recursive)."""
@@ -368,7 +381,16 @@ def collect_filesystem_overview() -> list[dict]:
 
 def collect_health() -> dict:
     """Check Lobster health indicators."""
-    heartbeat_file = _WORKSPACE / "logs" / "claude-heartbeat"
+    # Read dispatcher-heartbeat — the authoritative "dispatcher alive" signal,
+    # written by hooks/thinking-heartbeat.py on every PostToolUse event.
+    #
+    # Previously read claude-heartbeat (WFM-active signal, written only during
+    # wait_for_messages blocking calls).  That signal goes stale during compaction
+    # phases (no WFM calls fire) even when the dispatcher is healthy, causing
+    # false-positive STALE in status reports.  dispatcher-heartbeat is refreshed
+    # by any tool call at all, so it correctly reflects dispatcher liveness across
+    # all phases including compaction.  See issue #1822.
+    heartbeat_file = _WORKSPACE / "logs" / "dispatcher-heartbeat"
     heartbeat_age = None
     if heartbeat_file.is_file():
         heartbeat_age = int(time.time() - heartbeat_file.stat().st_mtime)
@@ -386,7 +408,7 @@ def collect_health() -> dict:
 
     return {
         "heartbeat_age_seconds": heartbeat_age,
-        "heartbeat_stale": heartbeat_age is not None and heartbeat_age > 300,
+        "heartbeat_stale": heartbeat_age is not None and heartbeat_age > HEARTBEAT_STALE_THRESHOLD,
         "telegram_bot_running": telegram_bot_running,
     }
 

--- a/tests/unit/test_dashboard_health_collector.py
+++ b/tests/unit/test_dashboard_health_collector.py
@@ -1,0 +1,173 @@
+"""
+Tests for dashboard collect_health() heartbeat logic.
+
+Verifies that:
+- collect_health() reads dispatcher-heartbeat (not claude-heartbeat) — the
+  authoritative "dispatcher alive" signal written by thinking-heartbeat.py on
+  every PostToolUse event.
+- heartbeat_stale uses DISPATCHER_HEARTBEAT_STALE_SECONDS (1200s / 20 min), not
+  the old 300s threshold that caused false-positive STALE during compaction phases.
+
+Issue: #1822 — frozen-dispatcher threshold (5min) may misfire during long compaction phases.
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# We need the dashboard module on sys.path
+import sys
+import os
+
+LOBSTER_SRC = Path(__file__).parent.parent.parent / "src"
+sys.path.insert(0, str(LOBSTER_SRC))
+
+
+def _make_fresh_heartbeat_file(tmp_path: Path, age_seconds: int) -> Path:
+    """Create a heartbeat file with the given age (mtime set to now - age)."""
+    hb_file = tmp_path / "dispatcher-heartbeat"
+    hb_file.write_text(str(int(time.time() - age_seconds)) + "\n")
+    # Touch the file to set mtime precisely
+    target_mtime = time.time() - age_seconds
+    os.utime(str(hb_file), (target_mtime, target_mtime))
+    return hb_file
+
+
+class TestCollectHealthHeartbeatFile:
+    """collect_health() must read dispatcher-heartbeat, not claude-heartbeat."""
+
+    def test_reads_dispatcher_heartbeat_file(self, tmp_path):
+        """Heartbeat age is measured from the dispatcher-heartbeat file."""
+        dispatcher_hb = _make_fresh_heartbeat_file(tmp_path, age_seconds=30)
+        old_claude_hb = tmp_path / "claude-heartbeat"
+        # claude-heartbeat is very stale (older than any threshold)
+        old_claude_hb.write_text("0\n")
+        os.utime(str(old_claude_hb), (1.0, 1.0))
+
+        with patch("dashboard.collectors._WORKSPACE", tmp_path):
+            # Make sure the logs subdir exists so Path construction works
+            (tmp_path / "logs").mkdir(exist_ok=True)
+            dispatcher_hb_in_logs = tmp_path / "logs" / "dispatcher-heartbeat"
+            dispatcher_hb_in_logs.write_text(str(int(time.time() - 30)) + "\n")
+            os.utime(str(dispatcher_hb_in_logs), (time.time() - 30, time.time() - 30))
+
+            from dashboard import collectors
+            # Patch psutil to avoid actual process scanning
+            with patch.object(collectors.psutil, "process_iter", return_value=[]):
+                result = collectors.collect_health()
+
+        # Age should be ~30s (from dispatcher-heartbeat), not years (from claude-heartbeat)
+        assert result["heartbeat_age_seconds"] is not None
+        assert result["heartbeat_age_seconds"] < 60, (
+            "heartbeat_age should reflect dispatcher-heartbeat (~30s), "
+            f"got {result['heartbeat_age_seconds']}s — "
+            "collect_health() is likely still reading claude-heartbeat"
+        )
+
+    def test_absent_dispatcher_heartbeat_returns_none(self, tmp_path):
+        """When dispatcher-heartbeat is absent, heartbeat_age_seconds is None."""
+        (tmp_path / "logs").mkdir(exist_ok=True)
+        # No dispatcher-heartbeat file
+
+        with patch("dashboard.collectors._WORKSPACE", tmp_path):
+            from dashboard import collectors
+            with patch.object(collectors.psutil, "process_iter", return_value=[]):
+                result = collectors.collect_health()
+
+        assert result["heartbeat_age_seconds"] is None
+        assert result["heartbeat_stale"] is False
+
+
+class TestCollectHealthStaleThreshold:
+    """heartbeat_stale must use the 20-minute threshold, not the 5-minute one.
+
+    The 5-minute threshold caused false-positive STALE during compaction phases,
+    which can last 10+ minutes. The authoritative threshold is
+    DISPATCHER_HEARTBEAT_STALE_SECONDS = 1200 from thinking-heartbeat.py.
+    """
+
+    # Aligned with DISPATCHER_HEARTBEAT_STALE_SECONDS in thinking-heartbeat.py
+    DISPATCHER_HEARTBEAT_STALE_SECONDS = 1200
+
+    def _collect_with_age(self, tmp_path: Path, age_seconds: int) -> dict:
+        (tmp_path / "logs").mkdir(exist_ok=True)
+        hb = tmp_path / "logs" / "dispatcher-heartbeat"
+        hb.write_text(str(int(time.time() - age_seconds)) + "\n")
+        os.utime(str(hb), (time.time() - age_seconds, time.time() - age_seconds))
+
+        with patch("dashboard.collectors._WORKSPACE", tmp_path):
+            from dashboard import collectors
+            with patch.object(collectors.psutil, "process_iter", return_value=[]):
+                return collectors.collect_health()
+
+    def test_not_stale_during_compaction_window(self, tmp_path):
+        """A 10-minute-old heartbeat must NOT be stale — compaction can last this long."""
+        COMPACTION_MAX_DURATION_SECONDS = 10 * 60  # 10 minutes
+        result = self._collect_with_age(tmp_path, age_seconds=COMPACTION_MAX_DURATION_SECONDS)
+
+        assert result["heartbeat_stale"] is False, (
+            f"heartbeat_stale should be False for a {COMPACTION_MAX_DURATION_SECONDS}s-old "
+            "heartbeat (dispatcher may be in compaction). "
+            f"Got heartbeat_stale=True — threshold is still too low "
+            f"(old 300s threshold fires false positives during compaction)"
+        )
+
+    def test_not_stale_at_old_5min_threshold(self, tmp_path):
+        """Heartbeat at 6 minutes old must NOT be stale.
+
+        The old threshold (300s / 5min) would mark this stale. The new threshold
+        (1200s / 20min) must not.
+        """
+        age_just_past_old_threshold = 360  # 6 minutes
+        result = self._collect_with_age(tmp_path, age_seconds=age_just_past_old_threshold)
+
+        assert result["heartbeat_stale"] is False, (
+            f"heartbeat_stale should be False at {age_just_past_old_threshold}s "
+            "(old 5-min threshold was too aggressive — compaction takes 10+ min). "
+            "This is the false-positive that issue #1822 reports."
+        )
+
+    def test_stale_past_20min_threshold(self, tmp_path):
+        """Heartbeat older than 20 minutes IS stale — dispatcher is genuinely dead."""
+        age_past_threshold = self.DISPATCHER_HEARTBEAT_STALE_SECONDS + 60  # 1260s
+        result = self._collect_with_age(tmp_path, age_seconds=age_past_threshold)
+
+        assert result["heartbeat_stale"] is True, (
+            f"heartbeat_stale should be True at {age_past_threshold}s "
+            f"(exceeds DISPATCHER_HEARTBEAT_STALE_SECONDS={self.DISPATCHER_HEARTBEAT_STALE_SECONDS}s)"
+        )
+
+    def test_not_stale_just_below_20min_threshold(self, tmp_path):
+        """Heartbeat just below 20 minutes is NOT stale."""
+        age_just_below = self.DISPATCHER_HEARTBEAT_STALE_SECONDS - 60  # 1140s
+        result = self._collect_with_age(tmp_path, age_seconds=age_just_below)
+
+        assert result["heartbeat_stale"] is False, (
+            f"heartbeat_stale should be False at {age_just_below}s "
+            f"(below DISPATCHER_HEARTBEAT_STALE_SECONDS={self.DISPATCHER_HEARTBEAT_STALE_SECONDS}s)"
+        )
+
+
+class TestCollectHealthConstantAlignment:
+    """HEARTBEAT_STALE_THRESHOLD in collectors.py must match thinking-heartbeat.py."""
+
+    def test_heartbeat_stale_threshold_constant_exists(self):
+        """collectors.py must export HEARTBEAT_STALE_THRESHOLD as a named constant."""
+        from dashboard import collectors
+        assert hasattr(collectors, "HEARTBEAT_STALE_THRESHOLD"), (
+            "collectors.py should export HEARTBEAT_STALE_THRESHOLD "
+            "so readers can verify it aligns with thinking-heartbeat.py's "
+            "DISPATCHER_HEARTBEAT_STALE_SECONDS=1200"
+        )
+
+    def test_heartbeat_stale_threshold_equals_1200(self):
+        """HEARTBEAT_STALE_THRESHOLD must equal 1200 (matching thinking-heartbeat.py)."""
+        from dashboard import collectors
+        assert collectors.HEARTBEAT_STALE_THRESHOLD == 1200, (
+            f"Expected HEARTBEAT_STALE_THRESHOLD=1200 (aligned with "
+            f"thinking-heartbeat.py DISPATCHER_HEARTBEAT_STALE_SECONDS=1200), "
+            f"got {collectors.HEARTBEAT_STALE_THRESHOLD}"
+        )

--- a/tests/unit/test_dashboard_health_collector.py
+++ b/tests/unit/test_dashboard_health_collector.py
@@ -41,7 +41,6 @@ class TestCollectHealthHeartbeatFile:
 
     def test_reads_dispatcher_heartbeat_file(self, tmp_path):
         """Heartbeat age is measured from the dispatcher-heartbeat file."""
-        dispatcher_hb = _make_fresh_heartbeat_file(tmp_path, age_seconds=30)
         old_claude_hb = tmp_path / "claude-heartbeat"
         # claude-heartbeat is very stale (older than any threshold)
         old_claude_hb.write_text("0\n")


### PR DESCRIPTION
## What this fixes

The status report (from `lobster-status`) showed `(STALE)` on the heartbeat line during context compaction phases — even when the dispatcher was healthy and actively running. This was a false positive that could mislead debugging.

**Root cause:** `dashboard/collectors.py → collect_health()` read `claude-heartbeat` (the WFM-active signal, written only during `wait_for_messages` blocking calls) and marked it stale after 300s (5 min). During context compaction, no `wait_for_messages` calls fire, so the heartbeat stops updating for the full duration of the compaction — which can run 10+ minutes. The threshold fired false-positive well before compaction ended.

**Fix:** Switch to `dispatcher-heartbeat` (the authoritative dispatcher-alive signal, written by `hooks/thinking-heartbeat.py` on *every* PostToolUse event) and raise the stale threshold from 300s to `HEARTBEAT_STALE_THRESHOLD = 1200s` (20 min). Both values are now aligned with `DISPATCHER_HEARTBEAT_STALE_SECONDS = 1200` in `thinking-heartbeat.py` and `health-check-v3.sh`.

## Before / after

\`\`\`
Before:
  compaction fires → no WFM calls → claude-heartbeat goes stale after 5min
    → status: "Heartbeat: 7m ago (STALE)"   ← false positive
    → dispatcher still healthy, mid-compaction

After:
  compaction fires → no WFM calls → dispatcher-heartbeat still fresh
    (PostToolUse heartbeats fire during catchup/context processing)
    → status: "Heartbeat: 7m ago"            ← no false STALE
    → only shows STALE after 20+ min with no tool activity at all
\`\`\`

## What changed

**`src/dashboard/collectors.py`**
- Added `HEARTBEAT_STALE_THRESHOLD = 1200` named constant (with comment explaining alignment to `thinking-heartbeat.py`)
- Changed heartbeat file from `logs/claude-heartbeat` to `logs/dispatcher-heartbeat`
- Changed stale check from `> 300` to `> HEARTBEAT_STALE_THRESHOLD`

**`tests/unit/test_dashboard_health_collector.py`** (new file — 8 tests)
- Correct file is read (dispatcher-heartbeat, not claude-heartbeat)
- Absent file returns `heartbeat_age_seconds=None`, `heartbeat_stale=False`
- No false-positive STALE during a 10-min compaction window
- No false-positive at 6 min (the old 5-min threshold boundary)
- True STALE at 21 min (past the 20-min threshold)
- No STALE at 19 min (just below threshold)
- `HEARTBEAT_STALE_THRESHOLD` constant exists and equals 1200

## Functional patterns

`collect_health()` is a pure function: takes no arguments, reads filesystem state, returns a plain dict. The threshold comparison is now a named-constant reference rather than a magic literal, making the alignment with `thinking-heartbeat.py` explicit and verifiable.

## Tests run

- [x] `uv run pytest tests/unit/test_dashboard_health_collector.py -v` — 8 passed, 0 failed
- [x] `uv run pytest tests/unit/ --ignore=tests/unit/test_hooks/test_require_background_agent.py -q --tb=no` — 2992 passed, 24 skipped, 0 failed

## Manual test

N/A — `collect_health()` is internal dashboard logic. No external services, systemd units, cron entries, or DB schema changes. The user-visible outcome (no `(STALE)` marker during compaction) requires an active dispatcher session going through compaction; this cannot be simulated in unit tests but is verified by the threshold-alignment tests.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (pure function, internal data only)
- [x] User-visible outcome: `(STALE)` no longer appears during compaction phases — not directly verifiable in isolation, but the threshold and file-selection fixes are confirmed by the 8 new tests
- [x] Side-effect audit: read-only change to a dashboard collector; no writes, no service calls, no shared state mutations
- [x] External service calls: none

Closes #1822