### PR TITLE
feat(debug): inject source label on replies when LOBSTER_DEBUG=true

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -4886,6 +4886,31 @@ async def handle_check_inbox(args: dict) -> list[TextContent]:
 
 
 
+# Maximum characters of task_id to include in the debug label — keeps labels
+# readable on mobile without truncating meaningful identifiers.
+_DEBUG_LABEL_TASK_ID_MAX_LEN = 20
+
+
+def _build_debug_source_label(task_id: str) -> str | None:
+    """Return a debug label string when LOBSTER_DEBUG=true, else None.
+
+    Pure function: reads env at call time so tests can patch os.environ freely.
+
+    When task_id is non-empty the caller is a subagent → label is
+    ``[agent:<task_id_truncated>]``.  When task_id is empty the caller is the
+    dispatcher → label is ``[dispatcher]``.
+
+    Returns None when LOBSTER_DEBUG is not 'true', so callers can skip the
+    string concatenation entirely in production.
+    """
+    if os.environ.get("LOBSTER_DEBUG", "").lower() != "true":
+        return None
+    if task_id:
+        short_id = task_id[:_DEBUG_LABEL_TASK_ID_MAX_LEN]
+        return f"[agent:{short_id}]"
+    return "[dispatcher]"
+
+
 async def handle_send_reply(args: dict) -> list[TextContent]:
     """Send a reply to a message with input validation."""
     # Validate inputs — return error TextContent instead of raising so callers
@@ -4899,6 +4924,14 @@ async def handle_send_reply(args: dict) -> list[TextContent]:
     source = args["source"]
     buttons = args.get("buttons")
     thread_ts = args.get("thread_ts")
+
+    # Debug source label: prepend [dispatcher] or [agent:<task_id>] when
+    # LOBSTER_DEBUG=true so the operator can see at a glance which component replied.
+    # No-op in production (label is None when debug mode is off).
+    task_id_for_label = (args.get("task_id") or "").strip()
+    debug_label = _build_debug_source_label(task_id_for_label)
+    if debug_label is not None:
+        text = f"{debug_label} {text}"
 
     # Create reply file in outbox
     reply_id = f"{int(time.time() * 1000)}_{source}"

--- a/tests/unit/test_mcp_server/conftest.py
+++ b/tests/unit/test_mcp_server/conftest.py
@@ -9,11 +9,18 @@ credentials (TELEGRAM_BOT_TOKEN, LOBSTER_SLACK_BOT_TOKEN) from being used
 during tests, ensuring debug alerts are disabled even when LOBSTER_DEBUG=true
 is set in the environment.
 
+It also clears LOBSTER_DEBUG from the test environment so that debug-mode
+features (e.g. source label injection in send_reply, #1789) do not affect
+tests that are not specifically testing debug behaviour.  Tests that need
+LOBSTER_DEBUG=true must set it explicitly via ``patch.dict(os.environ,
+{"LOBSTER_DEBUG": "true"})``.
+
 Note: the older _DEBUG_RESOLVED / _DEBUG_MODE / _DEBUG_ALERTS_ENABLED globals
 were removed as part of the debug observability refactor (issue #891). Only
 _CONFIG_DIR isolation is needed now.
 """
 
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -22,11 +29,19 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def isolate_debug_config(tmp_path):
-    """Redirect _CONFIG_DIR to an empty temp dir for each test.
+    """Redirect _CONFIG_DIR to an empty temp dir and clear LOBSTER_DEBUG.
 
     Pointing _CONFIG_DIR at an empty directory means no TELEGRAM_BOT_TOKEN or
     LOBSTER_SLACK_BOT_TOKEN is found during config resolution, so debug alerts
     stay disabled even when LOBSTER_DEBUG=true is set in the host environment.
+
+    Clearing LOBSTER_DEBUG prevents debug-mode features (such as source label
+    injection in send_reply) from affecting tests that are not explicitly
+    testing debug behaviour.
     """
     with patch("src.mcp.inbox_server._CONFIG_DIR", tmp_path):
-        yield
+        # Remove LOBSTER_DEBUG from the environment for the duration of each
+        # test.  Tests that need it must patch it back in themselves.
+        env_without_debug = {k: v for k, v in os.environ.items() if k != "LOBSTER_DEBUG"}
+        with patch.dict(os.environ, env_without_debug, clear=True):
+            yield

--- a/tests/unit/test_mcp_server/test_debug_source_label.py
+++ b/tests/unit/test_mcp_server/test_debug_source_label.py
@@ -1,0 +1,210 @@
+"""
+Tests for debug source label injection in send_reply (#1789).
+
+When LOBSTER_DEBUG=true, send_reply prepends a label to the outgoing text
+indicating whether the reply originated from the dispatcher (no task_id) or
+a subagent (task_id provided). In production (LOBSTER_DEBUG != 'true'), text
+is delivered unchanged.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure src/mcp is on sys.path (mirrors the pattern used throughout this package).
+_MCP_DIR = Path(__file__).parent.parent.parent.parent / "src" / "mcp"
+if str(_MCP_DIR) not in sys.path:
+    sys.path.insert(0, str(_MCP_DIR))
+
+import src.mcp.inbox_server  # noqa: F401 — pre-load for patch.multiple resolution
+
+
+# ---------------------------------------------------------------------------
+# Label format constants (mirror the implementation so tests document intent)
+# ---------------------------------------------------------------------------
+
+DISPATCHER_LABEL = "[dispatcher]"
+AGENT_LABEL_PREFIX = "[agent:"
+
+
+@pytest.fixture
+def dirs(tmp_path):
+    """Create the directories needed by handle_send_reply."""
+    outbox = tmp_path / "outbox"
+    sent = tmp_path / "sent"
+    processing = tmp_path / "processing"
+    processed = tmp_path / "processed"
+    for d in (outbox, sent, processing, processed):
+        d.mkdir(parents=True, exist_ok=True)
+    return outbox, sent, processing, processed
+
+
+def _read_outbox_text(outbox: Path) -> str:
+    """Read the text field from the single outbox file."""
+    files = list(outbox.glob("*.json"))
+    assert len(files) == 1, f"Expected 1 outbox file, found {len(files)}"
+    return json.loads(files[0].read_text())["text"]
+
+
+class TestDebugSourceLabel:
+    """Debug source label is prepended when LOBSTER_DEBUG=true."""
+
+    def test_dispatcher_reply_gets_dispatcher_label(self, dirs):
+        """A send_reply call without task_id is from the dispatcher — label is [dispatcher]."""
+        outbox, sent, processing, processed = dirs
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            OUTBOX_DIR=outbox,
+            SENT_DIR=sent,
+            PROCESSING_DIR=processing,
+            PROCESSED_DIR=processed,
+        ), patch.dict(os.environ, {"LOBSTER_DEBUG": "true"}):
+            from src.mcp.inbox_server import handle_send_reply
+
+            asyncio.run(handle_send_reply({
+                "chat_id": 12345,
+                "text": "Hello from dispatcher",
+                "source": "telegram",
+            }))
+
+        text = _read_outbox_text(outbox)
+        assert text.startswith(DISPATCHER_LABEL), (
+            f"Expected text to start with '{DISPATCHER_LABEL}', got: {text!r}"
+        )
+        assert "Hello from dispatcher" in text
+
+    def test_subagent_reply_gets_agent_label(self, dirs):
+        """A send_reply call with task_id is from a subagent — label is [agent:<task_id>]."""
+        outbox, sent, processing, processed = dirs
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            OUTBOX_DIR=outbox,
+            SENT_DIR=sent,
+            PROCESSING_DIR=processing,
+            PROCESSED_DIR=processed,
+        ), patch.dict(os.environ, {"LOBSTER_DEBUG": "true"}):
+            from src.mcp.inbox_server import handle_send_reply
+
+            asyncio.run(handle_send_reply({
+                "chat_id": 12345,
+                "text": "Hello from subagent",
+                "source": "telegram",
+                "task_id": "code-review-42",
+            }))
+
+        text = _read_outbox_text(outbox)
+        assert text.startswith(AGENT_LABEL_PREFIX), (
+            f"Expected text to start with '{AGENT_LABEL_PREFIX}', got: {text!r}"
+        )
+        assert "code-review-42" in text
+        assert "Hello from subagent" in text
+
+    def test_long_task_id_is_truncated_in_label(self, dirs):
+        """task_id values longer than 20 chars are truncated to keep labels readable."""
+        outbox, sent, processing, processed = dirs
+        long_task_id = "sprint-issue-99-very-long-task-identifier"
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            OUTBOX_DIR=outbox,
+            SENT_DIR=sent,
+            PROCESSING_DIR=processing,
+            PROCESSED_DIR=processed,
+        ), patch.dict(os.environ, {"LOBSTER_DEBUG": "true"}):
+            from src.mcp.inbox_server import handle_send_reply
+
+            asyncio.run(handle_send_reply({
+                "chat_id": 12345,
+                "text": "Hello",
+                "source": "telegram",
+                "task_id": long_task_id,
+            }))
+
+        text = _read_outbox_text(outbox)
+        # Label must not contain the full 40-char task_id — it should be cut off
+        assert long_task_id not in text.split("\n")[0], (
+            "Label line should not contain the full long task_id"
+        )
+        # But the first 20 chars should be present
+        assert long_task_id[:20] in text
+
+
+class TestDebugSourceLabelOff:
+    """No label is injected when LOBSTER_DEBUG is not 'true'."""
+
+    def test_no_label_when_debug_false(self, dirs):
+        """Text is unchanged when LOBSTER_DEBUG=false."""
+        outbox, sent, processing, processed = dirs
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            OUTBOX_DIR=outbox,
+            SENT_DIR=sent,
+            PROCESSING_DIR=processing,
+            PROCESSED_DIR=processed,
+        ), patch.dict(os.environ, {"LOBSTER_DEBUG": "false"}):
+            from src.mcp.inbox_server import handle_send_reply
+
+            asyncio.run(handle_send_reply({
+                "chat_id": 12345,
+                "text": "Clean production message",
+                "source": "telegram",
+            }))
+
+        text = _read_outbox_text(outbox)
+        assert text == "Clean production message", (
+            f"Text should be unchanged in non-debug mode, got: {text!r}"
+        )
+
+    def test_no_label_when_debug_env_absent(self, dirs):
+        """Text is unchanged when LOBSTER_DEBUG env var is not set."""
+        outbox, sent, processing, processed = dirs
+
+        env = {k: v for k, v in os.environ.items() if k != "LOBSTER_DEBUG"}
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            OUTBOX_DIR=outbox,
+            SENT_DIR=sent,
+            PROCESSING_DIR=processing,
+            PROCESSED_DIR=processed,
+        ), patch.dict(os.environ, env, clear=True):
+            from src.mcp.inbox_server import handle_send_reply
+
+            asyncio.run(handle_send_reply({
+                "chat_id": 12345,
+                "text": "No debug env var",
+                "source": "telegram",
+            }))
+
+        text = _read_outbox_text(outbox)
+        assert text == "No debug env var"
+
+    def test_no_label_when_debug_has_task_id_but_debug_off(self, dirs):
+        """task_id present but debug=false — no label injected."""
+        outbox, sent, processing, processed = dirs
+
+        with patch.multiple(
+            "src.mcp.inbox_server",
+            OUTBOX_DIR=outbox,
+            SENT_DIR=sent,
+            PROCESSING_DIR=processing,
+            PROCESSED_DIR=processed,
+        ), patch.dict(os.environ, {"LOBSTER_DEBUG": "false"}):
+            from src.mcp.inbox_server import handle_send_reply
+
+            asyncio.run(handle_send_reply({
+                "chat_id": 12345,
+                "text": "Subagent message in prod",
+                "source": "telegram",
+                "task_id": "some-task",
+            }))
+
+        text = _read_outbox_text(outbox)
+        assert text == "Subagent message in prod"

--- a/tests/unit/test_mcp_server/test_debug_source_label.py
+++ b/tests/unit/test_mcp_server/test_debug_source_label.py
@@ -22,6 +22,7 @@ if str(_MCP_DIR) not in sys.path:
     sys.path.insert(0, str(_MCP_DIR))
 
 import src.mcp.inbox_server  # noqa: F401 — pre-load for patch.multiple resolution
+from src.mcp.inbox_server import _DEBUG_LABEL_TASK_ID_MAX_LEN
 
 
 # ---------------------------------------------------------------------------
@@ -129,11 +130,11 @@ class TestDebugSourceLabel:
 
         text = _read_outbox_text(outbox)
         # Label must not contain the full 40-char task_id — it should be cut off
-        assert long_task_id not in text.split("\n")[0], (
+        assert long_task_id not in text, (
             "Label line should not contain the full long task_id"
         )
-        # But the first 20 chars should be present
-        assert long_task_id[:20] in text
+        # But the first _DEBUG_LABEL_TASK_ID_MAX_LEN chars should be present
+        assert long_task_id[:_DEBUG_LABEL_TASK_ID_MAX_LEN] in text
 
 
 class TestDebugSourceLabelOff:


### PR DESCRIPTION
## What problem this solves

In debug mode, all replies look identical regardless of whether they came from the dispatcher or a background subagent. When diagnosing routing issues or understanding system behavior, there was no way to distinguish the two without reading logs.

## What changed

When `LOBSTER_DEBUG=true`, `send_reply` now prepends a label to the outgoing text before writing to the outbox:

- Dispatcher replies (no `task_id`): `[dispatcher] Your message here`
- Subagent replies (with `task_id`): `[agent:code-review-42] Your message here`

The label uses at most 20 characters of `task_id` to stay readable on mobile.

**In production (`LOBSTER_DEBUG != 'true'`), text is written unchanged.** The new `_build_debug_source_label` pure function returns `None` in production mode, so the string concatenation is skipped entirely. Zero production impact.

## Design

Option A from the issue: server-side injection using the `task_id` presence as the caller discriminator. No changes needed in dispatcher or subagent code — the label is injected automatically based on whether `task_id` was passed to `send_reply`.

Flow:
```
send_reply(task_id="code-review-42")
  → _build_debug_source_label("code-review-42")
      → LOBSTER_DEBUG=true? → "[agent:code-review-42]"
  → text = "[agent:code-review-42] <original text>"
  → written to outbox → delivered to Telegram
```

Functional patterns: `_build_debug_source_label` is a pure function (no side effects, reads env at call time so tests can patch freely, returns a value or None). The caller short-circuits on `None` without needing an explicit branch for every case.

## Conftest change

The `test_mcp_server` autouse fixture now also clears `LOBSTER_DEBUG` from the environment. Previously the fixture only isolated `_CONFIG_DIR` to prevent live credential use in debug alerts. With source label injection reading `os.environ` directly, tests that assert exact outbox text would fail if the host has `LOBSTER_DEBUG=true`. The conftest fix makes all non-debug tests immune to the host environment. Tests that need debug mode explicitly set it via `patch.dict(os.environ, {"LOBSTER_DEBUG": "true"})`.

## Tests run
- [x] `uv run pytest tests/unit/test_mcp_server/test_debug_source_label.py -v` — 6 passed (3 debug-on, 3 debug-off)
- [x] `uv run pytest tests/unit/ tests/test_require_write_result.py tests/test_secret_scanner.py --tb=no -q` — 3066 passed, 24 skipped

## Manual test
N/A — this change is entirely internal to the MCP server. The label is injected into the outbox JSON file; actual Telegram delivery uses the unchanged outbox watcher. No live Telegram test run performed (no test token available in this environment).

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [ ] Integration/manual test — not applicable (no Telegram token in env; change is additive-only, non-breaking)
- [x] User-visible outcome: label delivery relies on existing outbox watcher (unchanged); production behavior unchanged
- [x] Side-effect audit: no new floods, writes, or volume introduced
- [x] External service calls: none added

Closes #1789