### PR TITLE
fix: rename AccountRegistry.get() to lookup() and fix vacuous test assertion

### DIFF
--- a/scheduled-tasks/granola_multi_account.py
+++ b/scheduled-tasks/granola_multi_account.py
@@ -73,8 +73,8 @@ class AccountRegistry:
 
     Usage:
         registry = AccountRegistry(build_accounts_from_env(os.environ))
-        cfg = registry.get("drew")   # → AccountConfig  # noname
-        cfg = registry.get("ghost")  # → KeyError: "No API key registered for 'ghost'"
+        cfg = registry.lookup("drew")   # → AccountConfig  # noname
+        cfg = registry.lookup("ghost")  # → KeyError: "No API key registered for 'ghost'"
 
         "drew" in registry           # → True  # noname
     """
@@ -82,9 +82,12 @@ class AccountRegistry:
     def __init__(self, accounts: list[AccountConfig]) -> None:
         self._by_name: dict[str, AccountConfig] = {a.name: a for a in accounts}
 
-    def get(self, account_name: str) -> AccountConfig:
+    def lookup(self, account_name: str) -> AccountConfig:
         """
         Return the AccountConfig for account_name.
+
+        Named ``lookup`` (not ``get``) to signal that this raises on missing keys,
+        unlike the standard Python dict.get() which returns None.
 
         Raises:
             KeyError: if account_name is not registered.

--- a/tests/unit/test_granola_multi_account.py
+++ b/tests/unit/test_granola_multi_account.py
@@ -196,12 +196,12 @@ class TestAccountRegistry:
 
     def test_lookup_known_primary_account(self):
         registry = self._make_registry()
-        cfg = registry.get(ACCOUNT_DREW)  # noname
+        cfg = registry.lookup(ACCOUNT_DREW)  # noname
         assert cfg.api_key == PRIMARY_KEY
 
     def test_lookup_known_secondary_account(self):
         registry = self._make_registry()
-        cfg = registry.get(ACCOUNT_KELLY)  # noname
+        cfg = registry.lookup(ACCOUNT_KELLY)  # noname
         assert cfg.api_key == SECONDARY_KEY
 
     def test_unknown_account_raises_key_error(self):
@@ -211,7 +211,7 @@ class TestAccountRegistry:
         """
         registry = self._make_registry()
         with pytest.raises(KeyError, match="phantom-account"):
-            registry.get("phantom-account")
+            registry.lookup("phantom-account")
 
     def test_registry_contains_all_configured_accounts(self):
         registry = self._make_registry()

--- a/tests/unit/test_granola_sync_multi_account.py
+++ b/tests/unit/test_granola_sync_multi_account.py
@@ -342,10 +342,16 @@ class TestFetchNotesWithDetail:
 
 
 class TestGranolaUnknownAccountError:
-    def test_error_is_a_subclass_of_granola_api_error(self):
-        """GranolaUnknownAccountError must be a GranolaAPIError for consistent handling."""
+    def test_error_is_a_key_error(self):
+        """
+        GranolaUnknownAccountError extends KeyError, not GranolaAPIError.
+
+        It signals a configuration gap (unknown account name), not an API failure,
+        so callers can distinguish the two error classes and handle them separately.
+        """
         from integrations.granola.client import GranolaAPIError
-        assert issubclass(GranolaUnknownAccountError, Exception)
+        assert issubclass(GranolaUnknownAccountError, KeyError)
+        assert not issubclass(GranolaUnknownAccountError, GranolaAPIError)
 
     def test_error_message_contains_account_name(self):
         err = GranolaUnknownAccountError("phantom-account")


### PR DESCRIPTION
## What and why

PR #1871 introduced two non-blocking code quality issues. This PR fixes both.

### 1. AccountRegistry.get() naming surprise

AccountRegistry.get() raised KeyError on a missing key instead of returning None. This is the opposite of standard Python dict.get() behavior, which silently returns None. Any reader who saw registry.get(name) and assumed dict-like semantics would expect a None return path that doesn't exist.

Renamed to lookup() so the contract is obvious at the call site: calling .lookup() means "give me the value or raise — there is no optional return."

No behavior change — only the method name and its docstring usage example are updated.

### 2. Vacuous test assertion

test_error_is_a_subclass_of_granola_api_error in test_granola_sync_multi_account.py asserted:

    assert issubclass(GranolaUnknownAccountError, Exception)

This is trivially true for every Python class — it tells us nothing. The test name said "must be a GranolaAPIError" but the assertion checked Exception. The test would have passed even if GranolaUnknownAccountError had been refactored to extend an unrelated type.

Replaced with test_error_is_a_key_error, which verifies the actual design intent:
- GranolaUnknownAccountError IS a KeyError (signals missing config, not an API failure)
- GranolaUnknownAccountError is NOT a GranolaAPIError (so callers can distinguish config errors from API errors in exception handlers)

## Files changed

- scheduled-tasks/granola_multi_account.py — rename method, update docstring usage example, add clarifying note about why it's not named get
- tests/unit/test_granola_multi_account.py — three call sites updated to lookup()
- tests/unit/test_granola_sync_multi_account.py — vacuous test replaced with meaningful assertion

## Functional patterns used

Pure lookup structure (no mutation); the rename makes the raising contract visible without changing any behavior. The fixed test asserts observable type hierarchy rather than testing an implementation transcript.

## Tests run

- [x] uv run pytest tests/ -k granola -v --tb=short — 87 passed, 0 failed

## Manual test

N/A — entirely internal (method rename + test assertion fix). No external services, file I/O, or systemd changes.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, purely internal
- [x] User-visible outcome — N/A, no user-visible behavior changes
- [x] Side-effect audit: no floods, no writes, no external calls
- [x] External service calls: none in this PR