### PR TITLE
fix: graceful session-reap notification before idle timeout (#1876)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -725,6 +725,35 @@ Do NOT spawn during wind-down mode (`WIND_DOWN_MODE = True`) — session-note-po
 
 ---
 
+---
+
+### session-reap (`type: "session-reap"`)
+
+Written by `GracefulSessionManager` in `inbox_server.py` when the MCP server's
+`session_idle_timeout` fires.  This is a clean handoff signal — the dispatcher
+was idling normally, not crashing.  No re-orientation needed.
+
+**Why this exists:** `session_idle_timeout` applies equally to all MCP sessions —
+the dispatcher idling in `wait_for_messages()` and a crashed subagent look
+identical to the SDK.  Without this notification, the idle reap would sever the
+WFM connection silently, causing an unexplained "Session not found" 404 on the
+dispatcher's next tool call.
+
+**Handler (simple — no subagent needed):**
+
+```
+1. mark_processing(message_id)
+2. Log: "WFM session idle-reaped — reconnecting"
+3. mark_processed(message_id)
+4. Call wait_for_messages() again — this reopens the WFM connection
+   (DO NOT re-read bootup files; DO NOT spawn compact-catchup; the session
+   was not lost — only the idle timeout fired)
+```
+
+This is the dispatcher's only session-reap handler.  The main loop resumes
+normally after `wait_for_messages()` returns the next message.
+
+
 ## Message Source Handling
 
 Always pass the correct `source` parameter to `send_reply` — Telegram and Slack messages may arrive interleaved.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Always-on AI assistant with Telegram/Slack integration"
 requires-python = ">=3.11"
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.27.0",
     "httpx>=0.27.0",
     "watchdog>=4.0.0",
     "psutil>=5.9.0",

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -800,6 +800,17 @@ HEARTBEAT_FILE = _WORKSPACE / "logs" / "claude-heartbeat"
 # tests can verify it matches the health-check's WFM_ACTIVE_STALE_SECONDS.
 WAIT_HEARTBEAT_INTERVAL = 60
 
+# Idle timeout for the stateful StreamableHTTP session manager (issue #1876).
+# Sessions idle longer than this many seconds are reaped via anyio.CancelScope.
+# GracefulSessionManager writes a session-reap notification to the inbox before
+# terminating, giving the dispatcher advance notice to call wait_for_messages()
+# again cleanly.
+# Set to 20 hours (72000s) to match the WFM tool's own timeout so that under
+# normal conditions the dispatcher's WFM call always returns before the session
+# is reaped.  The notification is a safety net for edge cases (short timeouts,
+# brief reconnects) rather than the happy path.
+SESSION_IDLE_TIMEOUT_SECONDS = 72000
+
 # WFM-active signal file (issue #1713 / #949): written with a Unix epoch
 # timestamp when wait_for_messages begins blocking, refreshed every
 # WAIT_HEARTBEAT_INTERVAL seconds, and deleted when WFM returns.
@@ -1164,14 +1175,14 @@ def _drain_reconciler_ghosts() -> int:
 # either path updates the tag (CC restart recovery).
 #
 # _dispatcher_session_id: module-level str, set by Option A or B
-# _http_session_manager: reference to the StreamableHTTPSessionManager
+# _http_session_manager: reference to the GracefulSessionManager
 #   instance (set in main() when HTTP mode is active).  Non-None iff in HTTP
 #   mode.  Used by /dispatcher-session endpoint and by _dispatch_tool to
 #   select the correct guard path.
 # ---------------------------------------------------------------------------
 
 _dispatcher_session_id: str | None = None
-_http_session_manager = None  # Set to StreamableHTTPSessionManager in main() when HTTP mode is active
+_http_session_manager = None  # Set to GracefulSessionManager in main() when HTTP mode is active
 
 # State file: the dispatcher HTTP session ID persisted to disk so hooks can
 # read it without network calls or JSONL parsing.  Written atomically by
@@ -1309,6 +1320,54 @@ def _write_session_lost_reminder() -> None:
         log.info(f"[session-lost] Wrote session-lost-reminder to inbox: {reminder_id}")
     except Exception as exc:  # noqa: BLE001
         log.warning(f"[session-lost] Failed to write session-lost-reminder: {exc}")
+
+
+def _write_session_reap_notification() -> None:
+    """Write a session-reap message to the inbox before an idle session is reaped.
+
+    When session_idle_timeout fires in GracefulSessionManager, the anyio CancelScope
+    deadline cancels the active app.run() coroutine.  Without advance notice, the
+    dispatcher's in-flight WFM connection is severed and its next call returns a
+    "Session not found" 404.
+
+    This function writes a lightweight notification so the dispatcher can handle its
+    own reap cleanly: it sees the message via WFM (or on its next reconnect), calls
+    wait_for_messages() again, and resumes the main loop — no crash, no re-orient.
+
+    Motivation: session_idle_timeout applies equally to ALL sessions.  The dispatcher
+    idling in WFM and a crashed subagent look identical to the SDK.  The graceful
+    notification is the dispatcher's signal that the reap was intentional.
+
+    This is intentionally simpler than _write_session_lost_reminder():
+    - No PID guard — the dispatcher is alive and healthy, just being reaped
+    - Type is "session-reap" (NOT "compact-reminder") — the dispatcher does not
+      need to re-read bootup files, just call wait_for_messages() again
+    - Non-fatal: if the inbox write fails, log and proceed with reap anyway
+
+    Developer mode: when LOBSTER_DEV_MODE=true (or 1), the notification is suppressed.
+    """
+    if os.environ.get("LOBSTER_DEV_MODE", "").lower() in ("true", "1"):
+        log.info("[session-reap] LOBSTER_DEV_MODE active — skipping session-reap notification")
+        return
+    try:
+        now_utc = datetime.now(timezone.utc)
+        reap_id = f"session-reap-{int(now_utc.timestamp())}"
+        notification = {
+            "id": reap_id,
+            "source": "system",
+            "type": "session-reap",
+            "chat_id": 0,
+            "task_origin": "internal",
+            "text": (
+                "WFM connection closing. Reconnect when ready."
+            ),
+            "timestamp": now_utc.isoformat(),
+        }
+        inbox_file = INBOX_DIR / f"{reap_id}.json"
+        atomic_write_json(inbox_file, notification)
+        log.info(f"[session-reap] Wrote session-reap notification to inbox: {reap_id}")
+    except Exception as exc:  # noqa: BLE001
+        log.warning(f"[session-reap] Failed to write session-reap notification: {exc}")
 
 
 def _get_current_http_session_id() -> str | None:
@@ -9892,6 +9951,161 @@ async def reconcile_agent_sessions() -> None:
             log.error(f"[reconciler] Error in reconcile_agent_sessions: {exc}", exc_info=True)
 
 
+class GracefulSessionManager:
+    """StreamableHTTPSessionManager subclass that writes a session-reap notification
+    to the inbox before idle-reaped sessions are terminated.
+
+    The MCP SDK's session_idle_timeout fires when a session receives no HTTP requests
+    for N seconds.  The SDK applies this timeout equally to all sessions — the
+    dispatcher idling in wait_for_messages() and a crashed subagent look identical.
+    Without this subclass, an idle-reap severs the dispatcher's WFM connection with
+    no warning, causing an unexplained "Session not found" 404 on the next tool call.
+
+    This subclass overrides _handle_stateful_request so the run_server coroutine
+    calls _write_session_reap_notification() when idle_scope.cancelled_caught is True.
+    The notification lets the dispatcher handle its own reap cleanly: it receives the
+    message via WFM (or on reconnect), calls wait_for_messages() again, and resumes
+    the main loop — no crash, no re-orient, no bootup re-read needed.
+
+    The inbox write is non-fatal: if it fails (e.g. filesystem error), the exception
+    is caught and the reap proceeds normally — same as _write_session_lost_reminder().
+    """
+
+    # Import base class lazily so the top-level module doesn't hard-require uvicorn/starlette
+    # on non-HTTP transports.  The subclass is only instantiated in main() when use_http=True.
+    @staticmethod
+    def _get_base_class():
+        from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+        return StreamableHTTPSessionManager
+
+
+# Build the actual subclass at import time only if the SDK is available.
+# On environments without mcp[cli] this import may fail — catch and degrade gracefully.
+try:
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager as _BaseSessionManager
+
+    class GracefulSessionManager(_BaseSessionManager):  # type: ignore[no-redef]
+        """StreamableHTTPSessionManager that writes a session-reap notification on idle timeout."""
+
+        async def _handle_stateful_request(self, scope, receive, send):  # type: ignore[override]
+            """Override to inject graceful reap notification before idle termination."""
+            import anyio
+            from uuid import uuid4
+            from mcp.server.streamable_http import MCP_SESSION_ID_HEADER
+            from starlette.requests import Request
+
+            request = Request(scope, receive)
+            request_mcp_session_id = request.headers.get(MCP_SESSION_ID_HEADER)
+
+            # Existing session: delegate directly to parent logic for deadline refresh
+            if (
+                request_mcp_session_id is not None
+                and request_mcp_session_id in self._server_instances
+            ):
+                transport = self._server_instances[request_mcp_session_id]
+                if transport.idle_scope is not None and self.session_idle_timeout is not None:
+                    transport.idle_scope.deadline = anyio.current_time() + self.session_idle_timeout
+                await transport.handle_request(scope, receive, send)
+                return
+
+            if request_mcp_session_id is None:
+                # New session: mirror the parent logic but inject the reap hook
+                from mcp.server.streamable_http import StreamableHTTPServerTransport
+                from anyio.abc import TaskStatus
+
+                async with self._session_creation_lock:
+                    new_session_id = uuid4().hex
+                    http_transport = StreamableHTTPServerTransport(
+                        mcp_session_id=new_session_id,
+                        is_json_response_enabled=self.json_response,
+                        event_store=self.event_store,
+                        security_settings=self.security_settings,
+                        retry_interval=self.retry_interval,
+                    )
+
+                    assert http_transport.mcp_session_id is not None
+                    self._server_instances[http_transport.mcp_session_id] = http_transport
+
+                    async def run_server(
+                        *, task_status: TaskStatus[None] = anyio.TASK_STATUS_IGNORED
+                    ) -> None:
+                        async with http_transport.connect() as streams:
+                            read_stream, write_stream = streams
+                            task_status.started()
+                            try:
+                                idle_scope = anyio.CancelScope()
+                                if self.session_idle_timeout is not None:
+                                    idle_scope.deadline = (
+                                        anyio.current_time() + self.session_idle_timeout
+                                    )
+                                    http_transport.idle_scope = idle_scope
+
+                                with idle_scope:
+                                    await self.app.run(
+                                        read_stream,
+                                        write_stream,
+                                        self.app.create_initialization_options(),
+                                        stateless=False,
+                                    )
+
+                                if idle_scope.cancelled_caught:
+                                    # Idle timeout fired — write graceful notification BEFORE
+                                    # cleaning up the session so the dispatcher is informed.
+                                    _write_session_reap_notification()
+                                    assert http_transport.mcp_session_id is not None
+                                    log.info(
+                                        f"[session-reap] Session {http_transport.mcp_session_id} "
+                                        "idle-reaped; dispatcher notified via inbox"
+                                    )
+                                    self._server_instances.pop(http_transport.mcp_session_id, None)
+                                    await http_transport.terminate()
+                            except Exception:
+                                log.exception(
+                                    f"Session {http_transport.mcp_session_id} crashed"
+                                )
+                            finally:
+                                if (
+                                    http_transport.mcp_session_id
+                                    and http_transport.mcp_session_id in self._server_instances
+                                    and not http_transport.is_terminated
+                                ):
+                                    log.info(
+                                        "Cleaning up crashed session "
+                                        f"{http_transport.mcp_session_id} from "
+                                        "active instances."
+                                    )
+                                    del self._server_instances[http_transport.mcp_session_id]
+
+                    assert self._task_group is not None
+                    await self._task_group.start(run_server)
+                    await http_transport.handle_request(scope, receive, send)
+            else:
+                # Unknown or expired session: return 404 per MCP spec (same as parent)
+                from http import HTTPStatus
+                from mcp.types import INVALID_REQUEST, ErrorData, JSONRPCError
+                from starlette.responses import Response
+
+                error_response = JSONRPCError(
+                    jsonrpc="2.0",
+                    id="server-error",
+                    error=ErrorData(
+                        code=INVALID_REQUEST,
+                        message="Session not found",
+                    ),
+                )
+                response = Response(
+                    content=error_response.model_dump_json(by_alias=True, exclude_none=True),
+                    status_code=HTTPStatus.NOT_FOUND,
+                    media_type="application/json",
+                )
+                await response(scope, receive, send)
+
+except ImportError:
+    # MCP SDK not installed (e.g. stdio-only environment).
+    # GracefulSessionManager falls back to a stub — main() uses it only in HTTP mode.
+    pass  # GracefulSessionManager remains the static-method stub defined above
+
+
 async def main():
     """Run the MCP server."""
     setup_logging()
@@ -9967,7 +10181,9 @@ async def main():
         from starlette.applications import Starlette
         from starlette.requests import Request
         from starlette.responses import Response
-        from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+        # GracefulSessionManager is defined at module level (above main()).
+        # It subclasses StreamableHTTPSessionManager and writes a session-reap
+        # notification to the inbox before idle sessions are terminated.
 
         # Determine port (--port N or MCP_HTTP_PORT env, default 8766)
         port = int(os.environ.get("MCP_HTTP_PORT", 8766))
@@ -9977,7 +10193,11 @@ async def main():
             except (ValueError, IndexError):
                 pass
 
-        session_manager = StreamableHTTPSessionManager(app=server, stateless=False)
+        session_manager = GracefulSessionManager(
+            app=server,
+            stateless=False,
+            session_idle_timeout=SESSION_IDLE_TIMEOUT_SECONDS,
+        )
 
         # Publish the session_manager reference so tool handlers (and /dispatcher-session)
         # can inspect live session state without importing from main().

--- a/tests/unit/test_session_reap_notification.py
+++ b/tests/unit/test_session_reap_notification.py
@@ -1,0 +1,369 @@
+"""
+Unit tests for graceful session-reap notification (issue #1876).
+
+When session_idle_timeout fires in GracefulSessionManager._handle_stateful_request(),
+the server must write a `session-reap` message to the inbox BEFORE terminating the
+idle session.  This lets the dispatcher call wait_for_messages() cleanly rather than
+receiving an unexplained "Session not found" 404.
+
+Root cause: session_idle_timeout applies equally to ALL sessions — the dispatcher
+and a crashed subagent look identical to the SDK.  The graceful notification lets
+the dispatcher handle its own reap cleanly instead of crashing.
+
+Design:
+- GracefulSessionManager subclasses StreamableHTTPSessionManager
+- Overrides _handle_stateful_request so the run_server coroutine calls
+  _write_session_reap_notification() when idle_scope.cancelled_caught is True
+- Message type: "session-reap" (not "compact-reminder" — dispatcher needs no
+  re-orientation, just a signal to call wait_for_messages() again)
+- Non-fatal: if the inbox write fails, proceed with reap anyway
+
+Named constants matching the spec:
+- SESSION_REAP_MESSAGE_TYPE = "session-reap"
+- SESSION_REAP_MESSAGE_PREFIX = "session-reap-"
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock, AsyncMock, call
+from datetime import datetime, timezone
+
+import pytest
+
+_SRC_MCP_DIR = Path(__file__).parents[2] / "src" / "mcp"
+_SERVER_PATH = _SRC_MCP_DIR / "inbox_server.py"
+
+# Named constants matching the spec
+SESSION_REAP_MESSAGE_TYPE = "session-reap"
+SESSION_REAP_MESSAGE_PREFIX = "session-reap-"
+
+
+# ---------------------------------------------------------------------------
+# Helper: load the GracefulSessionManager class and _write_session_reap_notification
+# function from inbox_server module in a test-safe way.
+# ---------------------------------------------------------------------------
+
+def _get_inbox_server_module():
+    """Import inbox_server module, adding src/mcp to path if needed."""
+    mod = sys.modules.get("inbox_server")
+    if mod is None:
+        if str(_SRC_MCP_DIR) not in sys.path:
+            sys.path.insert(0, str(_SRC_MCP_DIR))
+        import importlib
+        mod = importlib.import_module("inbox_server")
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Tests for _write_session_reap_notification()
+# ---------------------------------------------------------------------------
+
+class TestWriteSessionReapNotification:
+    """_write_session_reap_notification() writes a session-reap message to the inbox."""
+
+    def test_writes_session_reap_message_to_inbox(self, tmp_path):
+        """When called, a session-reap message is written to the inbox dir."""
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir(parents=True)
+
+        mod = _get_inbox_server_module()
+        with patch.object(mod, "INBOX_DIR", inbox_dir):
+            mod._write_session_reap_notification()
+
+        files = list(inbox_dir.glob(f"{SESSION_REAP_MESSAGE_PREFIX}*.json"))
+        assert len(files) == 1, f"Expected exactly one {SESSION_REAP_MESSAGE_PREFIX}*.json file, got {files}"
+
+    def test_message_has_correct_type(self, tmp_path):
+        """Written message must have type 'session-reap', NOT 'compact-reminder'."""
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir(parents=True)
+
+        mod = _get_inbox_server_module()
+        with patch.object(mod, "INBOX_DIR", inbox_dir):
+            mod._write_session_reap_notification()
+
+        files = list(inbox_dir.glob(f"{SESSION_REAP_MESSAGE_PREFIX}*.json"))
+        msg = json.loads(files[0].read_text())
+        assert msg["type"] == SESSION_REAP_MESSAGE_TYPE, (
+            f"Expected type={SESSION_REAP_MESSAGE_TYPE!r}, got {msg['type']!r}. "
+            "This must NOT be 'compact-reminder' — the dispatcher was not restarted, "
+            "it was idle-reaped. No bootup re-read is required."
+        )
+
+    def test_message_has_system_source_and_zero_chat_id(self, tmp_path):
+        """Message must be an internal system message (source='system', chat_id=0)."""
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir(parents=True)
+
+        mod = _get_inbox_server_module()
+        with patch.object(mod, "INBOX_DIR", inbox_dir):
+            mod._write_session_reap_notification()
+
+        files = list(inbox_dir.glob(f"{SESSION_REAP_MESSAGE_PREFIX}*.json"))
+        msg = json.loads(files[0].read_text())
+        assert msg["source"] == "system"
+        assert msg["chat_id"] == 0
+        assert msg.get("task_origin") == "internal"
+
+    def test_message_text_indicates_wfm_reconnect(self, tmp_path):
+        """Message text must cue the dispatcher to call wait_for_messages(), not re-read bootup."""
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir(parents=True)
+
+        mod = _get_inbox_server_module()
+        with patch.object(mod, "INBOX_DIR", inbox_dir):
+            mod._write_session_reap_notification()
+
+        files = list(inbox_dir.glob(f"{SESSION_REAP_MESSAGE_PREFIX}*.json"))
+        msg = json.loads(files[0].read_text())
+        text = msg["text"].lower()
+        # Should mention reconnect/WFM/closing — NOT "SESSION LOST" or "re-orient"
+        assert any(word in text for word in ("reconnect", "closing", "wfm", "connection")), (
+            f"Message text should cue reconnect, not re-orientation. Got: {msg['text']!r}"
+        )
+        # Must NOT say SESSION LOST — that's for actual restarts
+        assert "session lost" not in text, (
+            f"Message text must not say 'SESSION LOST' — this is an idle reap, not a crash. "
+            f"Got: {msg['text']!r}"
+        )
+
+    def test_message_has_valid_timestamp_and_id(self, tmp_path):
+        """Written message must have a valid ISO timestamp and prefixed id."""
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir(parents=True)
+
+        mod = _get_inbox_server_module()
+        with patch.object(mod, "INBOX_DIR", inbox_dir):
+            mod._write_session_reap_notification()
+
+        files = list(inbox_dir.glob(f"{SESSION_REAP_MESSAGE_PREFIX}*.json"))
+        msg = json.loads(files[0].read_text())
+        assert msg["id"].startswith(SESSION_REAP_MESSAGE_PREFIX)
+        # Must parse as ISO datetime without raising
+        dt = datetime.fromisoformat(msg["timestamp"])
+        assert dt.tzinfo is not None, "Timestamp must be timezone-aware"
+
+    def test_does_not_raise_when_inbox_write_fails(self, tmp_path):
+        """If inbox write fails, the function must NOT raise — the reap must still proceed."""
+        inbox_dir = tmp_path / "inbox"
+        # Deliberately omit mkdir() so atomic_write_json will fail
+
+        mod = _get_inbox_server_module()
+        with patch.object(mod, "INBOX_DIR", inbox_dir):
+            # Must not raise even if the inbox dir is missing
+            mod._write_session_reap_notification()  # should not raise
+
+    def test_suppressed_in_dev_mode(self, tmp_path):
+        """LOBSTER_DEV_MODE=true must suppress the session-reap notification."""
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir(parents=True)
+
+        mod = _get_inbox_server_module()
+        old_dev = os.environ.get("LOBSTER_DEV_MODE")
+        try:
+            os.environ["LOBSTER_DEV_MODE"] = "true"
+            with patch.object(mod, "INBOX_DIR", inbox_dir):
+                mod._write_session_reap_notification()
+        finally:
+            if old_dev is None:
+                os.environ.pop("LOBSTER_DEV_MODE", None)
+            else:
+                os.environ["LOBSTER_DEV_MODE"] = old_dev
+
+        files = list(inbox_dir.glob(f"{SESSION_REAP_MESSAGE_PREFIX}*.json"))
+        assert len(files) == 0, "Dev mode must suppress session-reap notification"
+
+
+# ---------------------------------------------------------------------------
+# Tests for GracefulSessionManager
+# ---------------------------------------------------------------------------
+
+class TestGracefulSessionManagerExists:
+    """GracefulSessionManager subclass is defined in inbox_server."""
+
+    def test_graceful_session_manager_class_exists(self):
+        """inbox_server must define a GracefulSessionManager class."""
+        mod = _get_inbox_server_module()
+        assert hasattr(mod, "GracefulSessionManager"), (
+            "GracefulSessionManager class not found in inbox_server.py"
+        )
+
+    def test_graceful_session_manager_is_subclass(self):
+        """GracefulSessionManager must be a subclass of StreamableHTTPSessionManager."""
+        from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+        mod = _get_inbox_server_module()
+        GracefulSessionManager = mod.GracefulSessionManager
+        assert issubclass(GracefulSessionManager, StreamableHTTPSessionManager), (
+            "GracefulSessionManager must subclass StreamableHTTPSessionManager"
+        )
+
+    def test_main_uses_graceful_session_manager(self):
+        """inbox_server.py must instantiate GracefulSessionManager, not the base class."""
+        src = _SERVER_PATH.read_text()
+        assert "GracefulSessionManager(" in src, (
+            "inbox_server.py must use GracefulSessionManager() not StreamableHTTPSessionManager() "
+            "directly so the graceful reap hook fires."
+        )
+        # Also verify the base class is still imported (for the subclass to inherit)
+        assert "StreamableHTTPSessionManager" in src
+
+
+# ---------------------------------------------------------------------------
+# Integration-style test: GracefulSessionManager calls _write_session_reap_notification
+# when idle_scope.cancelled_caught is True
+# ---------------------------------------------------------------------------
+
+class TestGracefulSessionManagerReapCallback:
+    """GracefulSessionManager writes session-reap notification on idle timeout."""
+
+    @pytest.mark.asyncio
+    async def test_session_reap_notification_called_on_idle_timeout(self, tmp_path):
+        """When idle_scope.cancelled_caught=True, _write_session_reap_notification fires.
+
+        This test exercises the async path without actually running a full HTTP server.
+        We mock the MCP app and the transport to simulate what happens when the idle
+        cancel scope catches a cancellation.
+        """
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir(parents=True)
+
+        mod = _get_inbox_server_module()
+
+        # Track calls to _write_session_reap_notification
+        reap_calls = []
+        original = mod._write_session_reap_notification
+
+        def _tracking_write():
+            reap_calls.append(True)
+            # Call original with patched INBOX_DIR
+            original()
+
+        import anyio
+        from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+        GracefulSessionManager = mod.GracefulSessionManager
+
+        # Create a mock MCP app whose run() immediately returns (simulating idle timeout
+        # by relying on the cancel scope being pre-cancelled below).
+        mock_app = MagicMock()
+        mock_app.create_initialization_options.return_value = {}
+
+        async def mock_run(read, write, opts, stateless=False):
+            # Simulate idling until cancelled by the scope
+            await anyio.sleep_forever()
+
+        mock_app.run = mock_run
+
+        manager = GracefulSessionManager(
+            app=mock_app,
+            stateless=False,
+            session_idle_timeout=0.05,  # 50ms — fires almost immediately in test
+        )
+
+        # We only test that _write_session_reap_notification is invoked on idle reap.
+        # Simulate the full session lifecycle: run the manager, connect a session,
+        # wait for the idle timeout to fire, then verify the notification was written.
+        with patch.object(mod, "INBOX_DIR", inbox_dir), \
+             patch.object(mod, "_write_session_reap_notification", side_effect=_tracking_write):
+
+            async with anyio.create_task_group() as tg:
+                async with manager.run():
+                    # Fake a new-session ASGI request so _handle_stateful_request
+                    # creates a session and starts the run_server task.
+                    scope = {
+                        "type": "http",
+                        "method": "POST",
+                        "path": "/mcp",
+                        "query_string": b"",
+                        "headers": [],
+                    }
+
+                    # receive() returns a minimal HTTP body
+                    async def receive():
+                        return {"type": "http.request", "body": b'{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}', "more_body": False}
+
+                    sent_responses = []
+
+                    async def send(event):
+                        sent_responses.append(event)
+
+                    # Trigger session creation (POST /mcp with no session-id header)
+                    try:
+                        await manager.handle_request(scope, receive, send)
+                    except Exception:
+                        pass  # Expected — we're not running a real server
+
+                    # Wait long enough for the 50ms idle timeout to fire and the
+                    # reap notification to be written
+                    await anyio.sleep(0.3)
+
+        # After the session manager exits, verify the notification was called
+        files = list(inbox_dir.glob(f"{SESSION_REAP_MESSAGE_PREFIX}*.json"))
+        assert len(files) >= 1, (
+            "Expected at least one session-reap notification in the inbox after idle timeout. "
+            f"reap_calls={reap_calls}, files={files}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_reap_notification_when_app_exits_normally(self, tmp_path):
+        """When app.run() returns without idle timeout, no session-reap is written.
+
+        Normal termination (e.g. client disconnect) should NOT trigger the notification.
+        Only idle-timeout reap fires it.
+        """
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir(parents=True)
+
+        mod = _get_inbox_server_module()
+
+        import anyio
+        GracefulSessionManager = mod.GracefulSessionManager
+
+        mock_app = MagicMock()
+        mock_app.create_initialization_options.return_value = {}
+
+        async def mock_run_normal_exit(read, write, opts, stateless=False):
+            # Returns immediately — simulates normal app shutdown (no idle timeout)
+            return
+
+        mock_app.run = mock_run_normal_exit
+
+        manager = GracefulSessionManager(
+            app=mock_app,
+            stateless=False,
+            session_idle_timeout=60.0,  # long — won't fire during this test
+        )
+
+        with patch.object(mod, "INBOX_DIR", inbox_dir):
+            async with anyio.create_task_group() as tg:
+                async with manager.run():
+                    scope = {
+                        "type": "http",
+                        "method": "POST",
+                        "path": "/mcp",
+                        "query_string": b"",
+                        "headers": [],
+                    }
+
+                    async def receive():
+                        return {"type": "http.request", "body": b'{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}', "more_body": False}
+
+                    async def send(event):
+                        pass
+
+                    try:
+                        await manager.handle_request(scope, receive, send)
+                    except Exception:
+                        pass
+
+                    # Brief pause — no reap should fire
+                    await anyio.sleep(0.1)
+
+        # Normal exit must NOT write a session-reap notification
+        files = list(inbox_dir.glob(f"{SESSION_REAP_MESSAGE_PREFIX}*.json"))
+        assert len(files) == 0, (
+            "session-reap notification must NOT be written on normal app exit. "
+            f"files={files}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -917,7 +917,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "fastembed", specifier = ">=0.3.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "mcp", specifier = ">=1.0.0" },
+    { name = "mcp", specifier = ">=1.27.0" },
     { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.40.0" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
@@ -971,7 +971,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -989,9 +989,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this fixes

Without this change, when `session_idle_timeout` fires, the MCP server silently severs the dispatcher's WFM connection. The dispatcher's next tool call gets a \"Session not found\" 404 — indistinguishable from an unexpected crash.

The underlying cause: `session_idle_timeout` applies equally to **all** MCP sessions. The dispatcher idling normally in `wait_for_messages()` and a crashed subagent look identical to the SDK. There is no mechanism to distinguish an intentional idle reap from a crash.

This PR makes idle reaps visible: the server writes a `session-reap` message to the inbox before terminating, the dispatcher sees it via WFM (or on its next reconnect), calls `wait_for_messages()` again, and resumes normally — no crash, no re-orient.

## Implementation

**`GracefulSessionManager`** subclasses `StreamableHTTPSessionManager` and overrides `_handle_stateful_request`. The `run_server` coroutine calls `_write_session_reap_notification()` when `idle_scope.cancelled_caught` is True — before cleaning up the session.

**`_write_session_reap_notification()`** writes a `session-reap` message to the inbox. This is intentionally lighter than `_write_session_lost_reminder()`:
- No PID guard — the dispatcher is alive and healthy, just being reaped
- `type: "session-reap"` (not `compact-reminder`) — no bootup re-read needed
- Non-fatal — if inbox write fails, log and proceed with reap

**`SESSION_IDLE_TIMEOUT_SECONDS = 72000`** (20h) matches the WFM tool's own timeout. Under normal conditions the dispatcher's WFM call returns before the session is ever reaped — the notification is a safety net for edge cases.

**Dispatcher bootup doc** updated with a `session-reap` handler: `mark_processing` → `mark_processed` → `wait_for_messages()` — that's it, no catchup, no re-read.

**Functional patterns:** pure notification function (`_write_session_reap_notification`), composition via subclass override instead of modifying SDK internals, side-effect isolation (notification fires before cleanup).

## Before / After

```
Before:
  Dispatcher in WFM (blocking)
  → idle_scope deadline fires
  → SDK cancels app.run()
  → session removed, transport terminated
  → dispatcher gets "Session not found" 404 on next call
  → crash / unguided recovery

After:
  Dispatcher in WFM (blocking)
  → idle_scope deadline fires
  → GracefulSessionManager._write_session_reap_notification() writes inbox message
  → SDK cancels app.run()
  → session removed, transport terminated
  → dispatcher receives "WFM connection closing. Reconnect when ready." via WFM or inbox
  → dispatcher calls wait_for_messages() → clean reconnect → main loop resumes
```

## Tests run

- [x] `uv run pytest tests/unit/test_session_reap_notification.py -v` — 12 passed, 0 failed
- [x] `uv run pytest tests/unit/ --tb=no -q` — 3058 passed, 24 skipped, 0 failed
- [x] Manual integration test (0.2s timeout, see below) — PASS

## Manual test

Ran `/tmp/test_session_reap.py` against the deployed `~/lobster/src/mcp/inbox_server.py` (deployed via cp-then-test pattern, MCP restarted via `restart-mcp.sh`).

What I ran: created a `GracefulSessionManager` with `session_idle_timeout=0.2s`, made a mock session request, waited 500ms, verified inbox.

What I observed:
```
[session-reap] Wrote session-reap notification to inbox: session-reap-1777556451
[session-reap] Session e5a1dac... idle-reaped; dispatcher notified via inbox
[test] PASS: session-reap notification written to inbox
Message: {
  "id": "session-reap-1777556451",
  "type": "session-reap",
  "source": "system",
  "chat_id": 0,
  "text": "WFM connection closing. Reconnect when ready."
}
```

This is entirely internal (no Telegram output) — the notification sits in the inbox for the dispatcher to pick up on its next WFM call. No user-visible verification required.

Side-effect audit: no floods, no unscoped writes, no production Telegram messages. The notification is a single file write to a temp inbox dir in this test.

## Definition of Done
- [x] Unit tests pass with proper mocking
- [x] Manual integration test run — see above
- [x] User-visible outcome: N/A — this is an internal reliability fix, not user-facing
- [x] Side-effect audit: single inbox file write on idle reap — no volume risk
- [x] External service calls: none in tests; no external services involved

Closes #1876

🤖 Generated with [Claude Code](https://claude.com/claude-code)