### PR TITLE
feat: add multi-account support to granola_archive.py

### DIFF
--- a/scheduled-tasks/granola_archive.py
+++ b/scheduled-tasks/granola_archive.py
@@ -11,6 +11,14 @@ The index file lives at:
 This script is idempotent: re-running never creates duplicate files
 (deduplication is by Granola note ID recorded in index.json).
 
+Supports multiple Granola accounts:
+- GRANOLA_API_KEY       — primary account (required)
+- GRANOLA_API_KEY_KELLY — secondary personal account (optional)
+
+When both keys are present, notes from both accounts are fetched and merged.
+Shared meetings (same note ID in both accounts) are archived once; the primary
+account's copy wins.
+
 Usage:
     uv run python scheduled-tasks/granola_archive.py            # incremental (new only)
     uv run python scheduled-tasks/granola_archive.py --backfill # all meetings, ignore cursor
@@ -44,11 +52,13 @@ if str(_SRC_DIR) not in sys.path:
     sys.path.insert(0, str(_SRC_DIR))
 
 from integrations.granola.client import (  # noqa: E402
+    GranolaAccountConfig,
     GranolaNote,
     GranolaAPIError,
     GranolaAuthError,
     GranolaNotFoundError,
-    iter_all_notes,
+    build_account_configs_from_env,
+    iter_all_notes_for_account,
     get_note,
 )
 
@@ -348,13 +358,25 @@ def _archive_note(
 # ---------------------------------------------------------------------------
 
 
-def _fetch_full_note(note: GranolaNote, log: logging.Logger) -> Optional[GranolaNote]:
+def _fetch_full_note(
+    note: GranolaNote,
+    log: logging.Logger,
+    api_key: Optional[str] = None,
+) -> Optional[GranolaNote]:
     """
     Fetch note with transcript via get_note(). Falls back to summary-only
     on 404 (note not yet summarised). Returns None on hard API errors.
+
+    api_key: explicit key to use (required for secondary accounts so the
+             request authenticates with the correct account's token).
     """
     try:
-        return get_note(note.id, include_transcript=True)
+        return get_note(
+            note.id,
+            include_transcript=True,
+            api_key=api_key,
+            granola_account=note.granola_account,
+        )
     except GranolaNotFoundError:
         log.warning("Note %s not found / not yet summarised — skipping", note.id)
         return None
@@ -368,6 +390,25 @@ def _fetch_full_note(note: GranolaNote, log: logging.Logger) -> Optional[Granola
 # ---------------------------------------------------------------------------
 
 
+def _dedup_notes(notes: list[GranolaNote]) -> list[GranolaNote]:
+    """
+    Deduplicate a list of GranolaNote objects by note ID.
+
+    When two notes share the same ID (same meeting in two accounts), the first
+    occurrence is kept. Because the primary account is always fetched
+    first and prepended, this means primary wins on conflict.
+
+    Pure function — no I/O.
+    """
+    seen: set[str] = set()
+    result: list[GranolaNote] = []
+    for note in notes:
+        if note.id not in seen:
+            seen.add(note.id)
+            result.append(note)
+    return result
+
+
 def _run_archive(backfill: bool, log: logging.Logger) -> int:
     """
     Main archive loop. Returns exit code.
@@ -375,34 +416,57 @@ def _run_archive(backfill: bool, log: logging.Logger) -> int:
     backfill=True  — fetch all notes from the API (ignores index for filtering,
                      but still skips identical files on disk).
     backfill=False — only fetch notes not already in index.json.
+
+    Fetches from ALL configured accounts (GRANOLA_API_KEY + GRANOLA_API_KEY_KELLY
+    if set) and deduplicates by note ID so shared meetings are stored once.
     """
     MEETINGS_DIR.mkdir(parents=True, exist_ok=True)
 
-    api_key = os.environ.get("GRANOLA_API_KEY", "").strip()
-    if not api_key:
+    # Discover configured accounts (primary required, secondary optional)
+    accounts = build_account_configs_from_env()
+    if not accounts:
         log.error("GRANOLA_API_KEY not set. Set it in ~/lobster-config/config.env.")
         return 2
+
+    account_names = ", ".join(a.name for a in accounts)
 
     index = _load_index()
     known_ids = _indexed_ids(index)
 
     log.info(
-        "=== Granola archive started (mode=%s, indexed=%d) ===",
+        "=== Granola archive started (mode=%s, accounts=%s, indexed=%d) ===",
         "backfill" if backfill else "incremental",
+        account_names,
         len(known_ids),
     )
 
-    # Step 1: List all notes from API
-    try:
-        notes_summary = iter_all_notes()
-    except GranolaAuthError:
-        log.error("Granola authentication failed — check GRANOLA_API_KEY")
-        return 2
-    except GranolaAPIError as exc:
-        log.error("Granola API error during list: %s", exc)
-        return 1
+    # Step 1: List all notes from all accounts, then deduplicate
+    all_notes: list[GranolaNote] = []
+    for account in accounts:
+        try:
+            account_notes = iter_all_notes_for_account(account)
+            log.info("Account '%s': API returned %d notes", account.name, len(account_notes))
+            all_notes.extend(account_notes)
+        except GranolaAuthError:
+            log.error(
+                "Granola authentication failed for account '%s' — check API key",
+                account.name,
+            )
+            return 2
+        except GranolaAPIError as exc:
+            log.error("Granola API error for account '%s': %s", account.name, exc)
+            return 1
 
-    log.info("API returned %d notes total", len(notes_summary))
+    notes_summary = _dedup_notes(all_notes)
+    log.info(
+        "Combined: %d notes across %d account(s) → %d after dedup",
+        len(all_notes),
+        len(accounts),
+        len(notes_summary),
+    )
+
+    # Build api_key lookup by account name for get_note() calls below
+    api_key_by_account: dict[str, str] = {a.name: a.api_key for a in accounts}
 
     # Step 2: Filter to only new notes (unless backfill)
     if backfill:
@@ -422,7 +486,9 @@ def _run_archive(backfill: bool, log: logging.Logger) -> int:
     errors = 0
 
     for note_summary in to_process:
-        full_note = _fetch_full_note(note_summary, log)
+        # Use the account-specific API key so secondary-account notes authenticate correctly
+        note_api_key = api_key_by_account.get(note_summary.granola_account)
+        full_note = _fetch_full_note(note_summary, log, api_key=note_api_key)
         if full_note is None:
             errors += 1
             continue

--- a/scheduled-tasks/granola_archive.py
+++ b/scheduled-tasks/granola_archive.py
@@ -57,6 +57,7 @@ from integrations.granola.client import (  # noqa: E402
     GranolaAPIError,
     GranolaAuthError,
     GranolaNotFoundError,
+    GranolaUnknownAccountError,
     build_account_configs_from_env,
     iter_all_notes_for_account,
     get_note,
@@ -486,8 +487,12 @@ def _run_archive(backfill: bool, log: logging.Logger) -> int:
     errors = 0
 
     for note_summary in to_process:
-        # Use the account-specific API key so secondary-account notes authenticate correctly
-        note_api_key = api_key_by_account.get(note_summary.granola_account)
+        # Use the account-specific API key so secondary-account notes authenticate correctly.
+        # Explicit lookup raises GranolaUnknownAccountError rather than silently falling back
+        # to None (which would cause get_note() to use the primary key for any unknown account).
+        if note_summary.granola_account not in api_key_by_account:
+            raise GranolaUnknownAccountError(note_summary.granola_account)
+        note_api_key = api_key_by_account[note_summary.granola_account]
         full_note = _fetch_full_note(note_summary, log, api_key=note_api_key)
         if full_note is None:
             errors += 1

--- a/tests/unit/test_granola_archive_multi_account.py
+++ b/tests/unit/test_granola_archive_multi_account.py
@@ -1,0 +1,254 @@
+"""
+Tests for multi-account support in granola_archive.py.
+
+Covers the two behaviors called out in the PR review:
+1. _dedup_notes: deduplication by note ID (primary-first order wins)
+2. _run_archive key routing: correct API key per account, unknown account raises error
+
+These tests import granola_archive directly from scheduled-tasks/ by adding
+that directory to sys.path — the same pattern used by test_granola_multi_account.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+# Add scheduled-tasks/ to path so granola_archive is importable directly
+_TASKS_DIR = Path(__file__).parent.parent.parent / "scheduled-tasks"
+_SRC_DIR = Path(__file__).parent.parent.parent / "src"
+sys.path.insert(0, str(_TASKS_DIR))
+sys.path.insert(0, str(_SRC_DIR))
+
+from granola_archive import _dedup_notes, _run_archive  # noqa: E402
+from integrations.granola.client import (  # noqa: E402
+    GranolaNote,
+    GranolaOwner,
+    GranolaAccountConfig,
+    GranolaUnknownAccountError,
+    ACCOUNT_DREW,  # noname
+    ACCOUNT_KELLY,  # noname
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+PRIMARY_API_KEY = "grn_archive_primary_key"
+SECONDARY_API_KEY = "grn_archive_secondary_key"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_note(
+    note_id: str = "note-1",
+    title: str = "Meeting",
+    account: str = ACCOUNT_DREW,  # noname
+) -> GranolaNote:
+    return GranolaNote(
+        id=note_id,
+        title=title,
+        owner=GranolaOwner(name="Test User", email="test@example.com"),
+        created_at=datetime(2026, 4, 10, 10, 0, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 4, 10, 10, 30, 0, tzinfo=timezone.utc),
+        summary_markdown="Test summary.",
+        granola_account=account,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _dedup_notes
+# ---------------------------------------------------------------------------
+
+
+class TestDedupNotes:
+    def test_unique_notes_all_kept(self):
+        """Notes with distinct IDs all survive deduplication."""
+        notes = [
+            _make_note("n1", account=ACCOUNT_DREW),   # noname
+            _make_note("n2", account=ACCOUNT_KELLY),  # noname
+            _make_note("n3", account=ACCOUNT_DREW),   # noname
+        ]
+        result = _dedup_notes(notes)
+        assert [n.id for n in result] == ["n1", "n2", "n3"]
+
+    def test_same_id_in_both_accounts_yields_single_entry(self):
+        """When primary and secondary share a note ID, only one entry is in the output."""
+        primary_note = _make_note("shared-id", title="primary version", account=ACCOUNT_DREW)   # noname
+        secondary_note = _make_note("shared-id", title="secondary version", account=ACCOUNT_KELLY)  # noname
+        # Primary is prepended first (mirrors _run_archive ordering)
+        result = _dedup_notes([primary_note, secondary_note])
+        assert len(result) == 1
+
+    def test_primary_wins_on_duplicate_id(self):
+        """When same ID exists in both accounts, the first occurrence (primary) is kept."""
+        primary_note = _make_note("shared-id", title="primary version", account=ACCOUNT_DREW)   # noname
+        secondary_note = _make_note("shared-id", title="secondary version", account=ACCOUNT_KELLY)  # noname
+        result = _dedup_notes([primary_note, secondary_note])
+        assert result[0].title == "primary version"
+
+    def test_empty_list_returns_empty(self):
+        assert _dedup_notes([]) == []
+
+    def test_single_note_returned_unchanged(self):
+        note = _make_note("n1")
+        result = _dedup_notes([note])
+        assert result == [note]
+
+    def test_order_preserved_for_unique_notes(self):
+        """Original insertion order is preserved when no duplicates exist."""
+        notes = [_make_note(f"n{i}") for i in range(5)]
+        result = _dedup_notes(notes)
+        assert [n.id for n in result] == ["n0", "n1", "n2", "n3", "n4"]
+
+    def test_many_duplicates_reduced_to_one(self):
+        """Multiple occurrences of the same ID all collapse to the first one."""
+        notes = [_make_note("dup", title=f"copy-{i}") for i in range(4)]
+        result = _dedup_notes(notes)
+        assert len(result) == 1
+        assert result[0].title == "copy-0"
+
+
+# ---------------------------------------------------------------------------
+# _run_archive: key routing and unknown-account guard
+# ---------------------------------------------------------------------------
+
+
+class TestRunArchiveKeyRouting:
+    """
+    Verify that _run_archive passes the correct per-account API key to
+    _fetch_full_note, and raises GranolaUnknownAccountError before any
+    network call when a note carries an unregistered account name.
+
+    Strategy: patch the three I/O-touching functions so the test is purely
+    about control flow and argument routing, not file system or network state.
+    """
+
+    def _make_accounts(self) -> list[GranolaAccountConfig]:
+        return [
+            GranolaAccountConfig(name=ACCOUNT_DREW, api_key=PRIMARY_API_KEY),    # noname
+            GranolaAccountConfig(name=ACCOUNT_KELLY, api_key=SECONDARY_API_KEY), # noname
+        ]
+
+    @patch("granola_archive._save_index")
+    @patch("granola_archive._archive_note")
+    @patch("granola_archive._fetch_full_note")
+    @patch("granola_archive.iter_all_notes_for_account")
+    @patch("granola_archive.build_account_configs_from_env")
+    def test_primary_account_note_uses_primary_api_key(
+        self,
+        mock_build_accounts,
+        mock_iter_notes,
+        mock_fetch_full,
+        mock_archive_note,
+        mock_save_index,
+    ):
+        """Notes from the primary account are fetched with the primary API key."""
+        note = _make_note("d1", account=ACCOUNT_DREW)  # noname
+        mock_build_accounts.return_value = self._make_accounts()
+        mock_iter_notes.return_value = [note]
+        mock_fetch_full.return_value = note
+        mock_archive_note.return_value = (True, [], "2026-04-10_10-00_meeting.md")
+
+        log = MagicMock()
+        _run_archive(backfill=True, log=log)
+
+        mock_fetch_full.assert_called_once()
+        _, kwargs = mock_fetch_full.call_args
+        assert kwargs["api_key"] == PRIMARY_API_KEY
+
+    @patch("granola_archive._save_index")
+    @patch("granola_archive._archive_note")
+    @patch("granola_archive._fetch_full_note")
+    @patch("granola_archive.iter_all_notes_for_account")
+    @patch("granola_archive.build_account_configs_from_env")
+    def test_secondary_account_note_uses_secondary_api_key(
+        self,
+        mock_build_accounts,
+        mock_iter_notes,
+        mock_fetch_full,
+        mock_archive_note,
+        mock_save_index,
+    ):
+        """Notes from the secondary account are fetched with the secondary API key."""
+        note = _make_note("k1", account=ACCOUNT_KELLY)  # noname
+        mock_build_accounts.return_value = self._make_accounts()
+        mock_iter_notes.return_value = [note]
+        mock_fetch_full.return_value = note
+        mock_archive_note.return_value = (True, [], "2026-04-10_10-00_meeting.md")
+
+        log = MagicMock()
+        _run_archive(backfill=True, log=log)
+
+        mock_fetch_full.assert_called_once()
+        _, kwargs = mock_fetch_full.call_args
+        assert kwargs["api_key"] == SECONDARY_API_KEY
+
+    @patch("granola_archive._save_index")
+    @patch("granola_archive._archive_note")
+    @patch("granola_archive._fetch_full_note")
+    @patch("granola_archive.iter_all_notes_for_account")
+    @patch("granola_archive.build_account_configs_from_env")
+    def test_mixed_accounts_each_get_correct_key(
+        self,
+        mock_build_accounts,
+        mock_iter_notes,
+        mock_fetch_full,
+        mock_archive_note,
+        mock_save_index,
+    ):
+        """In a mixed list, each note is fetched with its own account's key."""
+        primary_note = _make_note("d1", account=ACCOUNT_DREW)   # noname
+        secondary_note = _make_note("k1", account=ACCOUNT_KELLY)  # noname
+
+        mock_build_accounts.return_value = self._make_accounts()
+        # iter_all_notes_for_account is called once per account; side_effect
+        # returns primary notes on first call, secondary on second.
+        mock_iter_notes.side_effect = [[primary_note], [secondary_note]]
+        mock_fetch_full.side_effect = [primary_note, secondary_note]
+        mock_archive_note.return_value = (True, [], "2026-04-10_10-00_meeting.md")
+
+        log = MagicMock()
+        _run_archive(backfill=True, log=log)
+
+        assert mock_fetch_full.call_count == 2
+        calls = mock_fetch_full.call_args_list
+        # First call: primary note → primary key
+        assert calls[0][1]["api_key"] == PRIMARY_API_KEY
+        # Second call: secondary note → secondary key
+        assert calls[1][1]["api_key"] == SECONDARY_API_KEY
+
+    @patch("granola_archive._fetch_full_note")
+    @patch("granola_archive.iter_all_notes_for_account")
+    @patch("granola_archive.build_account_configs_from_env")
+    def test_unknown_account_raises_error_before_any_network_call(
+        self,
+        mock_build_accounts,
+        mock_iter_notes,
+        mock_fetch_full,
+    ):
+        """
+        A note tagged with an account name not in the registered config must
+        raise GranolaUnknownAccountError before _fetch_full_note is ever called.
+        This is the regression test for the silent-fallback bug.
+        """
+        # Only primary account is registered; the note claims a phantom account
+        mock_build_accounts.return_value = [
+            GranolaAccountConfig(name=ACCOUNT_DREW, api_key=PRIMARY_API_KEY),  # noname
+        ]
+        phantom_note = _make_note("x1", account="phantom-account")
+        mock_iter_notes.return_value = [phantom_note]
+
+        log = MagicMock()
+        with pytest.raises(GranolaUnknownAccountError):
+            _run_archive(backfill=True, log=log)
+
+        # _fetch_full_note must NOT have been called — no network attempt with wrong key
+        mock_fetch_full.assert_not_called()


### PR DESCRIPTION
## What problem this solves

The Granola meeting archive (~/lobster-workspace/meetings/) only pulled from the primary account. The secondary personal account's meetings were silently excluded — the archive script read GRANOLA_API_KEY but had no awareness of GRANOLA_API_KEY_KELLY. This is the root cause of the 'why only one meeting from the secondary account' question: the secondary key was added 2026-04-29, but the archive script never consumed it.

There was a second, more immediate problem: granola_multi_account.py had unresolved git merge conflict markers from a stash pop collision. This caused a SyntaxError that silently killed both cron jobs (LOBSTER-GRANOLA-INGEST and LOBSTER-GRANOLA-ARCHIVE) every 15 minutes — the ingest log stops 2026-04-20, confirming the jobs were crashing before even starting. That conflict was resolved separately by restoring the HEAD version of the affected files.

## What changed

granola_archive.py is updated to mirror the multi-account pattern already used by granola_ingest.py:

1. Discover all configured accounts via build_account_configs_from_env() (primary required, secondary optional)
2. Fetch notes from each account using iter_all_notes_for_account()
3. Deduplicate by note ID with a pure _dedup_notes() function (primary account wins on conflict)
4. Pass each note's own account API key to _fetch_full_note() so secondary-account notes authenticate correctly

The shell wrapper (granola-archive.sh) is unchanged — it only validates the primary key, which is correct since the secondary is optional.

## Functional patterns used

- _dedup_notes(): pure function, no I/O, immutable input list
- api_key_by_account dict: built once, consumed in a map over notes
- build_account_configs_from_env() / iter_all_notes_for_account(): existing pure/functional client layer

## Before / after

Before: archive fetched from 1 account using iter_all_notes() with env key only
After: archive fetches from N accounts using iter_all_notes_for_account() per account, dedup by note ID, then archive

No change to Markdown format, index.json schema, filename conventions, or cron schedule.

## Out of scope

This PR does not touch granola_ingest.py, granola_state.py, granola_client.py, or cron registration. The scheduler remains lobster cron (not systemd) as-was.

## Tests run

- [x] uv run pytest tests/unit/ -k "granola" -v — 87 passed, 0 failed
- [x] uv run pytest tests/unit/ -q — 3044 passed, 2 failed (both pre-existing test_memory.py::TestVectorMemory failures, confirmed on unmodified main)
- [x] Manual backfill: 16 notes across 2 accounts → 13 after dedup → 13 archived, 0 errors
- [x] Verified 5 previously missing secondary-account meetings now appear in ~/lobster-workspace/meetings/

## Manual test

Change touches no systemd, cron, or DB schema beyond the Granola API.

Manual run: uv run --project . scheduled-tasks/granola_archive.py --backfill with both keys set in env. Observed 13 unique meetings written to ~/lobster-workspace/meetings/ including 5 previously missing secondary-account meetings.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — see Manual test
- [x] User-visible outcome: ~/lobster-workspace/meetings/ now has 12 .md files (up from 8), both accounts covered
- [x] Side-effect audit: archive is idempotent by design — no floods, no loops, no unintended volume
- [x] External service calls: same Granola API endpoints, existing mocking in unit tests