### PR TITLE
refactor: extract hardcoded email address into instance config

### DIFF
--- a/.githooks/security-allowlist.txt
+++ b/.githooks/security-allowlist.txt
@@ -17,6 +17,8 @@ tests/unit/test_memory.py:test_data
 
 # Example config files (contain placeholder values)
 config/config.env.example:Hardcoded token
+# LOBSTER_SECONDARY_EMAIL example uses a placeholder address (partner@yourcompany.com) — not real
+config/config.env.example:Email address
 
 # Install script uses variable references that look like secrets
 install.sh:Hardcoded token

--- a/config/config.env.example
+++ b/config/config.env.example
@@ -111,6 +111,12 @@ LOBSTER_INSTANCE_URL=
 # GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE=$HOME/.config/gws/credentials.json
 # GOOGLE_WORKSPACE_CLI_KEYRING_BACKEND=file
 
+# Instance-specific email addresses — used by scheduled tasks like email-audit-check.
+# LOBSTER_SECONDARY_EMAIL is included in the twice-daily inbox audit as a sender to
+# watch specifically (e.g. a partner or secondary account).
+# Leave unset if not applicable.
+# LOBSTER_SECONDARY_EMAIL=partner@yourcompany.com
+
 # Lobster instance identity — used as the sender name in bot-talk messages
 # and anywhere else the instance needs to identify itself by name.
 # LOBSTER_NAME=MyLobster

--- a/scheduled-tasks/email-audit-check.sh
+++ b/scheduled-tasks/email-audit-check.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Email audit check — runs twice daily at 8am and 12pm CT
+# Writes a task to the Lobster inbox for the dispatcher to process with Opus
+
+set -euo pipefail
+
+LOBSTER_DIR="${LOBSTER_DIR:-$HOME/lobster}"
+WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+
+SECONDARY_EMAIL="${LOBSTER_SECONDARY_EMAIL:-}"
+
+exec uv run --project "$LOBSTER_DIR" python - "$SECONDARY_EMAIL" <<'PY'
+import sys
+sys.path.insert(0, "/home/admin/lobster/src")
+
+secondary_email = sys.argv[1] if len(sys.argv) > 1 else ""
+secondary_email_line = f"   - {secondary_email} (AWP partner account)" if secondary_email else "   - (configure LOBSTER_SECONDARY_EMAIL in config.env)"
+
+task_content = f"""---
+job: email-audit-check
+model: opus
+---
+
+Run a twice-daily email audit for the AWP inbox.
+
+Using Opus, do the following:
+
+1. Check the Gmail API for the last 24 hours of email activity. Use the auth from ~/lobster-config/config.env (GOOGLE_TOKEN_FILE).
+
+2. Audit email processing state:
+   - Are there any emails that arrived but were NOT processed by the gmail-poll.py pipeline?
+   - Are there any emails in ~/messages/inbox/ or ~/messages/processing/ with source="gmail" that are stuck?
+   - Check the audit log at https://awp-two.vercel.app/api/logs (or directly via AWP_DATABASE_URL) for recent email_action_logs entries — do they match what's in Gmail?
+
+3. Check specifically for emails from:
+{secondary_email_line}
+   - Any email with investor-related content that may have been skipped by the classifier
+
+4. If you find anything missed or unprocessed:
+   - Process it now (classify, CRM import if appropriate, audit log)
+   - Notify the inbox owner (chat_id=6645894734) with what was found and what action was taken
+
+5. If everything looks healthy (no gaps, no missed emails):
+   - Write a brief status to the audit log and do NOT send a notification (no-op result)
+   - Call write_result with chat_id=0 and "No action needed — inbox healthy"
+
+Call write_result when done.
+"""
+
+import os
+import json
+from datetime import datetime, timezone
+
+msg_id = f"scheduled-email-audit-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}"
+msg = {
+    "id": msg_id,
+    "type": "scheduled_reminder",
+    "job_name": "email-audit-check",
+    "reminder_type": "email-audit-check",
+    "task_content": task_content,
+    "timestamp": datetime.now(timezone.utc).isoformat(),
+    "source": "system",
+    "chat_id": 0
+}
+
+inbox_dir = os.path.expanduser("~/messages/inbox")
+os.makedirs(inbox_dir, exist_ok=True)
+path = os.path.join(inbox_dir, f"{msg_id}.json")
+with open(path, "w") as f:
+    json.dump(msg, f)
+print(f"Email audit check queued: {msg_id}")
+PY


### PR DESCRIPTION
## What problem does this solve?

`scheduled-tasks/email-audit-check.sh` was never committed to git. Adding it now, but it contained a hardcoded instance-specific email address as a literal string inside the audit task prompt. Since this is a public repo, instance-specific addresses must not appear in committed files.

## What changed

The hardcoded address is replaced with a `LOBSTER_SECONDARY_EMAIL` environment variable reference. The script reads the variable at runtime and injects it into the task prompt via Python `sys.argv`. When the variable is unset, the prompt degrades gracefully to a config reminder (`configure LOBSTER_SECONDARY_EMAIL in config.env`).

`config/config.env.example` gains a new optional section documenting `LOBSTER_SECONDARY_EMAIL` with a placeholder value. The security allowlist gains a matching entry so the pre-push scanner doesn't flag the placeholder.

The actual email value lives only in `~/lobster-config/config.env` (not in the repo).

## Scope

Three files changed:
- `scheduled-tasks/email-audit-check.sh` — new (was untracked), hardcoded address replaced with env var
- `config/config.env.example` — new optional `LOBSTER_SECONDARY_EMAIL` entry added
- `.githooks/security-allowlist.txt` — allowlist entry for the `@yourcompany.com` placeholder

No other code is touched. The rest of the codebase was scanned (`git grep`) and contains no tracked AWP or instance-specific email addresses — those were already scrubbed in the previous commit (91c9b19).

## Functional patterns

Pure data transformation: the email is injected as an argument into the Python heredoc, assembled into the task prompt via a pure f-string, and written to the inbox without side effects beyond the file write.

## Tests run

- [x] `uv run pytest tests/unit/test_scheduled_tasks/ tests/test_secret_scanner.py -v --tb=short` — 70 passed, 0 failed
- [x] `uv run pytest tests/` (partial run, confirmed clean through ~62% before timeout) — all passed up to timeout, no failures observed
- [x] Pre-push security scanner — clean after allowlist entry added
- [x] Manual verification: `grep -rn "alternativewealthpartners" . --include="*.py" --include="*.sh"` in worktree returns empty

## Manual test

N/A — this change does not touch external services, systemd, cron, or file I/O beyond the already-deployed inbox pattern. The modified script writes to `~/messages/inbox/` using the same code path as before; only the task prompt content changes (email inserted at runtime vs. hardcoded).

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (no external services touched)
- [x] User-visible outcome verified — N/A (this is a config hygiene change; no user-visible output changes)
- [x] Side-effect audit: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none in this change