### PR TITLE
fix(#1573): skip dispatcher sessions in ghost-detector when WFM-active is fresh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1357,7 +1357,7 @@ success "Nightly consolidation configured (runs at 03:00 nightly)"
 # summary to ~/messages/task-outputs/ (readable via check_task_outputs).
 chmod +x "$INSTALL_DIR/scheduled-tasks/export-logs.py" 2>/dev/null || true
 "$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-LOG-EXPORT" \
-    "0 3 * * * cd $INSTALL_DIR && uv run scheduled-tasks/export-logs.py # LOBSTER-LOG-EXPORT"
+    "0 3 * * * cd $INSTALL_DIR && $HOME/.local/bin/uv run scheduled-tasks/export-logs.py # LOBSTER-LOG-EXPORT"
 
 success "Log export configured (runs at 03:00 UTC daily)"
 
@@ -1371,7 +1371,7 @@ step "Setting up ghost detector cron..."
 # sends a Telegram alert if GHOST_CONFIRMED or UNREGISTERED agents are found,
 # and marks ghost sessions as failed in agent_sessions.db. No LLM involved.
 "$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-GHOST-DETECTOR" \
-    "*/5 * * * * cd $HOME && uv run $INSTALL_DIR/scripts/agent-monitor.py --alert --mark-failed >> $HOME/lobster-workspace/logs/agent-monitor.log 2>&1 # LOBSTER-GHOST-DETECTOR"
+    "*/5 * * * * cd $HOME && $HOME/.local/bin/uv run $INSTALL_DIR/scripts/agent-monitor.py --alert --mark-failed >> $HOME/lobster-workspace/logs/agent-monitor.log 2>&1 # LOBSTER-GHOST-DETECTOR"
 
 success "Ghost detector configured (runs every 5 minutes)"
 
@@ -1386,7 +1386,7 @@ step "Setting up OOM monitor cron..."
 # dispatcher when new OOM kill events are detected. No LLM involved.
 # Only active when LOBSTER_DEBUG=true (the script is a no-op otherwise).
 "$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-OOM-CHECK" \
-    "*/10 * * * * cd $HOME && uv run $INSTALL_DIR/scripts/oom-monitor.py --since-minutes 10 >> $HOME/lobster-workspace/logs/oom-monitor.log 2>&1 # LOBSTER-OOM-CHECK"
+    "*/10 * * * * cd $HOME && $HOME/.local/bin/uv run $INSTALL_DIR/scripts/oom-monitor.py --since-minutes 10 >> $HOME/lobster-workspace/logs/oom-monitor.log 2>&1 # LOBSTER-OOM-CHECK"
 
 success "OOM monitor configured (runs every 10 minutes, active only when LOBSTER_DEBUG=true)"
 

--- a/scripts/agent-monitor.py
+++ b/scripts/agent-monitor.py
@@ -94,6 +94,7 @@ class AgentRow:
     spawned_at: str
     output_file: str | None
     last_seen_at: str | None
+    agent_type: str | None = None  # 'dispatcher' | 'subagent' | None
 
 
 @dataclass(frozen=True)
@@ -384,7 +385,7 @@ def load_running_agents(db_path: Path) -> list[AgentRow]:
         rows = conn.execute(
             """
             SELECT id, task_id, description, chat_id, status,
-                   spawned_at, output_file, last_seen_at
+                   spawned_at, output_file, last_seen_at, agent_type
             FROM agent_sessions
             WHERE status IN ('running', 'starting')
             ORDER BY spawned_at ASC
@@ -403,6 +404,7 @@ def load_running_agents(db_path: Path) -> list[AgentRow]:
             spawned_at=row["spawned_at"],
             output_file=row["output_file"],
             last_seen_at=row["last_seen_at"],
+            agent_type=row["agent_type"],
         )
         for row in rows
     ]
@@ -800,6 +802,44 @@ def mark_failed_unregistered(agent: UnregisteredAgent) -> None:
 #   session_start(agent_id="lobster-dispatcher", agent_type="dispatcher", ...)
 _DISPATCHER_AGENT_ID = "lobster-dispatcher"
 
+# WFM-active signal file — written by the MCP server every WAIT_HEARTBEAT_INTERVAL (60s)
+# while wait_for_messages is blocking. A fresh timestamp proves the dispatcher is alive
+# and actively waiting; an old or absent file means WFM has returned (or the process died).
+_WFM_ACTIVE_FILE = LOBSTER_HOME / "lobster-workspace" / "logs" / "dispatcher-wfm-active"
+
+# If the WFM-active file was written within this many seconds, the dispatcher is considered
+# to be alive and waiting for messages. 3× the 60s WAIT_HEARTBEAT_INTERVAL (mirrors
+# health-check-v3.sh WFM_ACTIVE_STALE_SECONDS=180).
+_WFM_ACTIVE_STALE_SECONDS = 180.0
+
+
+def _is_dispatcher_in_wfm() -> bool:
+    """Return True if the dispatcher is currently alive inside wait_for_messages.
+
+    Reads the WFM-active signal file written by the MCP server's heartbeat thread.
+    A fresh epoch timestamp (within _WFM_ACTIVE_STALE_SECONDS) means the dispatcher
+    is alive and blocking in WFM — NOT dead.  An absent or stale file means WFM has
+    returned (dispatcher is either processing a message or has died).
+
+    This check is used to avoid false-positive ghost classification: the hook-registered
+    dispatcher session (hex-UUID, agent_type='dispatcher') has no output_file, so it
+    falls into STALE_NO_FILE after 30 minutes.  Without this guard, mark_failed would
+    kill it even though the dispatcher is perfectly healthy.
+
+    Override path: LOBSTER_WFM_ACTIVE_OVERRIDE env var (used in tests).
+    """
+    wfm_file = Path(
+        os.environ.get("LOBSTER_WFM_ACTIVE_OVERRIDE", str(_WFM_ACTIVE_FILE))
+    )
+    try:
+        raw = wfm_file.read_text().strip()
+        if not raw.isdigit():
+            return False
+        age = time.time() - float(raw)
+        return age <= _WFM_ACTIVE_STALE_SECONDS
+    except (OSError, ValueError):
+        return False
+
 
 def mark_failed_all_ghosts(
     confirmed: list[ClassifiedAgent],
@@ -815,19 +855,22 @@ def mark_failed_all_ghosts(
     that never register an output file), which is why --mark-failed would previously
     leave stale dispatcher sessions in status=running indefinitely.
 
-    The live dispatcher session is always excluded from the STALE_NO_FILE sweep.
-    The dispatcher registers with the static agent_id "lobster-dispatcher", so any
-    entry with that agent_id is skipped unconditionally — it is the currently-running
-    dispatcher, not a dead subagent.
+    Two guards prevent killing the live dispatcher:
+
+    Guard 1 (agent_id): The dispatcher registers with the static agent_id
+    "lobster-dispatcher".  Any entry with that agent_id is skipped unconditionally.
+
+    Guard 2 (agent_type + WFM-active): The SessionStart hook also writes a separate
+    hex-UUID entry tagged agent_type='dispatcher' with no output_file.  This entry
+    always lands in STALE_NO_FILE after 30 minutes — and previously had no protection.
+    When the WFM-active signal is fresh (dispatcher alive in wait_for_messages), ALL
+    sessions with agent_type='dispatcher' are skipped.  This closes the false-positive
+    window that issue #1573 tracked: the hook-registered entry was being ghost-detected
+    whenever the JSONL transcript went idle while the dispatcher was healthy in WFM.
     """
     stale_no_file = stale_no_file or []
 
-    # Guard: exclude the live dispatcher session from the sweep.
-    # The dispatcher always registers with agent_id=_DISPATCHER_AGENT_ID (a static
-    # constant), so we filter on that directly.  There is no UUID file to read —
-    # the previous approach compared against the Claude UUID from
-    # dispatcher-claude-session-id, but that UUID is stored in a different field
-    # and was never equal to agent_id, making the guard a silent no-op.
+    # Guard 1: exclude the named dispatcher session (agent_id = "lobster-dispatcher").
     if stale_no_file:
         filtered_stale = [a for a in stale_no_file if a.row.agent_id != _DISPATCHER_AGENT_ID]
         skipped = len(stale_no_file) - len(filtered_stale)
@@ -837,6 +880,29 @@ def mark_failed_all_ghosts(
                 f"agent_id={_DISPATCHER_AGENT_ID!r} — live dispatcher, not a dead subagent."
             )
         stale_no_file = filtered_stale
+
+    # Guard 2: if the dispatcher is currently inside wait_for_messages (WFM-active signal
+    # is fresh), skip ALL sessions tagged agent_type='dispatcher'.  The hook-registered
+    # hex-UUID entry (no output_file, agent_type='dispatcher') is alive whenever WFM is
+    # active — its JSONL transcript goes idle because WFM blocks without writing, not
+    # because the dispatcher is dead.  Killing it would emit a spurious agent_failed
+    # notification and potentially inject an unnecessary compact-reminder (issue #1573).
+    in_wfm = _is_dispatcher_in_wfm()
+    if in_wfm:
+        def _is_dispatcher_type(a: ClassifiedAgent) -> bool:
+            return (a.row.agent_type or "") == "dispatcher"
+
+        pre_confirmed = len(confirmed)
+        pre_stale = len(stale_no_file)
+        confirmed = [a for a in confirmed if not _is_dispatcher_type(a)]
+        stale_no_file = [a for a in stale_no_file if not _is_dispatcher_type(a)]
+        skipped_wfm = (pre_confirmed - len(confirmed)) + (pre_stale - len(stale_no_file))
+        if skipped_wfm:
+            print(
+                f"\n  [mark-failed] WFM-active is fresh — skipping {skipped_wfm} "
+                "dispatcher-typed session(s) that appear alive in wait_for_messages. "
+                "(issue #1573)"
+            )
 
     to_fail = confirmed + stale_no_file
 

--- a/scripts/agent-monitor.py
+++ b/scripts/agent-monitor.py
@@ -821,6 +821,12 @@ def _is_dispatcher_in_wfm() -> bool:
     is alive and blocking in WFM — NOT dead.  An absent or stale file means WFM has
     returned (dispatcher is either processing a message or has died).
 
+    Tombstone case: when the dispatcher exits wait_for_messages, _clear_wfm_active_signal()
+    writes the string "exited" to the file instead of deleting it (TOCTOU fix, issue #1730).
+    "exited".isdigit() is False, so this function returns False — correctly treating the
+    tombstone as "WFM not active".  The raw.isdigit() guard handles this case implicitly;
+    any non-integer content (including a missing file) is treated as WFM not active.
+
     This check is used to avoid false-positive ghost classification: the hook-registered
     dispatcher session (hex-UUID, agent_type='dispatcher') has no output_file, so it
     falls into STALE_NO_FILE after 30 minutes.  Without this guard, mark_failed would

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2918,6 +2918,7 @@ print(f'prune-pr-worktrees: {result.status}')
                 | sed "s|cd $HOME && uv run \(.*\)oom-monitor\.py|cd $HOME \&\& $_m84_uv_abs run \1oom-monitor.py|g" \
                 | crontab - 2>/dev/null && {
                 substep "Migration 84: fixed oom-monitor cron to use absolute uv path"
+                migrated=$((migrated + 1))
             } || warn "Migration 84: could not update oom-monitor cron entry"
         fi
     fi
@@ -2927,6 +2928,7 @@ print(f'prune-pr-worktrees: {result.status}')
                 | sed "s|cd \(.*\) && uv run \(.*\)export-logs\.py|cd \1 \&\& $_m84_uv_abs run \2export-logs.py|g" \
                 | crontab - 2>/dev/null && {
                 substep "Migration 84: fixed log-export cron to use absolute uv path"
+                migrated=$((migrated + 1))
             } || warn "Migration 84: could not update log-export cron entry"
         fi
     fi

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2891,6 +2891,46 @@ print(f'prune-pr-worktrees: {result.status}')
         warn "prune-pr-worktrees.py not found at $_m83_script or uv unavailable — skipping Migration 83"
     fi
 
+    # Migration 84: Fix cron PATH for uv-based scripts (ghost-detector, oom-monitor, log-export).
+    # Cron runs with a minimal PATH that does not include ~/.local/bin, so bare 'uv' fails
+    # with "uv: not found". Replace bare 'uv' with the absolute path $HOME/.local/bin/uv
+    # in the three affected cron entries.
+    local _m84_uv_abs="$HOME/.local/bin/uv"
+    if crontab -l 2>/dev/null | grep -q "LOBSTER-GHOST-DETECTOR"; then
+        if crontab -l 2>/dev/null | grep "LOBSTER-GHOST-DETECTOR" | grep -q " uv run "; then
+            crontab -l 2>/dev/null \
+                | sed "s|cd \$HOME && uv run \(.*\)agent-monitor\.py|cd \$HOME \&\& $_m84_uv_abs run \1agent-monitor.py|g" \
+                | sed "s|cd $HOME && uv run \(.*\)agent-monitor\.py|cd $HOME \&\& $_m84_uv_abs run \1agent-monitor.py|g" \
+                | crontab - 2>/dev/null && {
+                substep "Migration 84: fixed ghost-detector cron to use absolute uv path"
+                migrated=$((migrated + 1))
+            } || warn "Migration 84: could not update ghost-detector cron entry"
+        else
+            substep "Migration 84: ghost-detector cron already uses absolute uv path — skipping"
+        fi
+    else
+        substep "Migration 84: ghost-detector cron entry not found — skipping"
+    fi
+    if crontab -l 2>/dev/null | grep -q "LOBSTER-OOM-CHECK"; then
+        if crontab -l 2>/dev/null | grep "LOBSTER-OOM-CHECK" | grep -q " uv run "; then
+            crontab -l 2>/dev/null \
+                | sed "s|cd \$HOME && uv run \(.*\)oom-monitor\.py|cd \$HOME \&\& $_m84_uv_abs run \1oom-monitor.py|g" \
+                | sed "s|cd $HOME && uv run \(.*\)oom-monitor\.py|cd $HOME \&\& $_m84_uv_abs run \1oom-monitor.py|g" \
+                | crontab - 2>/dev/null && {
+                substep "Migration 84: fixed oom-monitor cron to use absolute uv path"
+            } || warn "Migration 84: could not update oom-monitor cron entry"
+        fi
+    fi
+    if crontab -l 2>/dev/null | grep -q "LOBSTER-LOG-EXPORT"; then
+        if crontab -l 2>/dev/null | grep "LOBSTER-LOG-EXPORT" | grep -q " uv run "; then
+            crontab -l 2>/dev/null \
+                | sed "s|cd \(.*\) && uv run \(.*\)export-logs\.py|cd \1 \&\& $_m84_uv_abs run \2export-logs.py|g" \
+                | crontab - 2>/dev/null && {
+                substep "Migration 84: fixed log-export cron to use absolute uv path"
+            } || warn "Migration 84: could not update log-export cron entry"
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/tests/unit/test_ghost_detector_filesystem.py
+++ b/tests/unit/test_ghost_detector_filesystem.py
@@ -688,3 +688,198 @@ class TestLobsterHomePaths:
         assert home_slug in gd.AGENT_OUTPUT_GLOB, (
             f"Expected slug '{home_slug}' in AGENT_OUTPUT_GLOB={gd.AGENT_OUTPUT_GLOB!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Guard 2 (WFM-active): dispatcher-typed sessions skipped when WFM-active is fresh
+# ---------------------------------------------------------------------------
+
+# The number of seconds within which the WFM-active signal file is considered fresh.
+# Must match _WFM_ACTIVE_STALE_SECONDS in agent-monitor.py.
+WFM_ACTIVE_STALE_SECONDS = 180
+
+
+class TestGuard2WfmActiveDispatcherType:
+    """Guard 2 skips all sessions with agent_type='dispatcher' when the WFM-active
+    signal is fresh (written within WFM_ACTIVE_STALE_SECONDS seconds).
+
+    Guard 1 protects the named 'lobster-dispatcher' entry.  Guard 2 protects the
+    hook-registered hex-UUID entry (agent_type='dispatcher', no output_file) that
+    Guard 1 cannot reach because it has no predictable agent_id.
+
+    Test matrix:
+      (a) dispatcher-type + WFM-active fresh  → NOT killed
+      (b) dispatcher-type + WFM-active stale  → killed normally
+    """
+
+    def _make_dispatcher_type_stale(self, agent_id: str) -> gd.ClassifiedAgent:
+        """Build a STALE_NO_FILE ClassifiedAgent with agent_type='dispatcher'."""
+        row = gd.AgentRow(
+            agent_id=agent_id,
+            task_id=None,
+            description=f"hook-registered dispatcher session {agent_id[:8]}",
+            chat_id="0",
+            status="running",
+            spawned_at="2026-03-15T09:00:00+00:00",
+            output_file=None,
+            last_seen_at=None,
+            agent_type="dispatcher",
+        )
+        return gd.ClassifiedAgent(
+            row=row,
+            classification="STALE_NO_FILE",
+            age_minutes=60.0,
+            output_file_age_minutes=None,
+        )
+
+    def test_dispatcher_type_not_killed_when_wfm_active_fresh(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """(a) agent_type='dispatcher' + fresh WFM-active signal → session NOT marked failed.
+
+        The hex-UUID dispatcher entry (registered by SessionStart hook) must be
+        protected when the dispatcher is alive inside wait_for_messages.
+        """
+        import time
+
+        # Write a fresh WFM-active signal (timestamp = now)
+        wfm_file = tmp_path / "dispatcher-wfm-active"
+        wfm_file.write_text(str(int(time.time())))
+        monkeypatch.setenv("LOBSTER_WFM_ACTIVE_OVERRIDE", str(wfm_file))
+
+        marked: list[str] = []
+        monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: marked.append(agent_id))
+        monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: None)
+
+        session = self._make_dispatcher_type_stale("hex-uuid-dispatcher-abc123")
+        fake_db = tmp_path / "agent_sessions.db"
+
+        gd.mark_failed_all_ghosts([], fake_db, stale_no_file=[session])
+
+        assert "hex-uuid-dispatcher-abc123" not in marked, (
+            "Dispatcher-typed session must NOT be killed when WFM-active signal is fresh"
+        )
+
+    def test_dispatcher_type_killed_when_wfm_active_stale(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """(b) agent_type='dispatcher' + stale WFM-active signal → session IS marked failed.
+
+        When the WFM-active signal is older than WFM_ACTIVE_STALE_SECONDS, the dispatcher
+        is not alive in wait_for_messages — this is a legitimate dead session.
+        """
+        import time
+
+        # Write a stale WFM-active signal (timestamp well beyond the 180s threshold)
+        stale_ts = int(time.time()) - (WFM_ACTIVE_STALE_SECONDS + 60)
+        wfm_file = tmp_path / "dispatcher-wfm-active"
+        wfm_file.write_text(str(stale_ts))
+        monkeypatch.setenv("LOBSTER_WFM_ACTIVE_OVERRIDE", str(wfm_file))
+
+        marked: list[str] = []
+        monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: marked.append(agent_id))
+        monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: None)
+
+        session = self._make_dispatcher_type_stale("hex-uuid-dispatcher-dead456")
+        fake_db = tmp_path / "agent_sessions.db"
+
+        gd.mark_failed_all_ghosts([], fake_db, stale_no_file=[session])
+
+        assert "hex-uuid-dispatcher-dead456" in marked, (
+            "Dispatcher-typed session MUST be killed when WFM-active signal is stale"
+        )
+
+    def test_dispatcher_type_killed_when_wfm_active_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """agent_type='dispatcher' + absent WFM-active file → session IS marked failed.
+
+        An absent file means the dispatcher never entered wait_for_messages (or the
+        file was cleaned up).  The session should be treated as dead.
+        """
+        # Point override to a file that does not exist
+        monkeypatch.setenv("LOBSTER_WFM_ACTIVE_OVERRIDE", str(tmp_path / "no-such-file"))
+
+        marked: list[str] = []
+        monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: marked.append(agent_id))
+        monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: None)
+
+        session = self._make_dispatcher_type_stale("hex-uuid-dispatcher-absent789")
+        fake_db = tmp_path / "agent_sessions.db"
+
+        gd.mark_failed_all_ghosts([], fake_db, stale_no_file=[session])
+
+        assert "hex-uuid-dispatcher-absent789" in marked, (
+            "Dispatcher-typed session MUST be killed when WFM-active file is absent"
+        )
+
+    def test_dispatcher_type_killed_when_wfm_active_contains_tombstone(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """agent_type='dispatcher' + tombstone in WFM-active file → session IS marked failed.
+
+        The tombstone value ("exited") is written by _clear_wfm_active_signal() when
+        the dispatcher leaves wait_for_messages.  It is a non-integer, so _is_dispatcher_in_wfm()
+        returns False — Guard 2 does not protect the session.
+        """
+        wfm_file = tmp_path / "dispatcher-wfm-active"
+        wfm_file.write_text("exited")
+        monkeypatch.setenv("LOBSTER_WFM_ACTIVE_OVERRIDE", str(wfm_file))
+
+        marked: list[str] = []
+        monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: marked.append(agent_id))
+        monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: None)
+
+        session = self._make_dispatcher_type_stale("hex-uuid-dispatcher-tombstone0")
+        fake_db = tmp_path / "agent_sessions.db"
+
+        gd.mark_failed_all_ghosts([], fake_db, stale_no_file=[session])
+
+        assert "hex-uuid-dispatcher-tombstone0" in marked, (
+            "Dispatcher-typed session MUST be killed when WFM-active file contains tombstone"
+        )
+
+    def test_non_dispatcher_type_killed_regardless_of_wfm_active(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Guard 2 must not protect sessions with agent_type != 'dispatcher'.
+
+        A regular subagent session (agent_type='functional-engineer') that lands in
+        STALE_NO_FILE must be killed even when WFM-active is fresh.
+        """
+        import time
+
+        # Write a fresh WFM-active signal
+        wfm_file = tmp_path / "dispatcher-wfm-active"
+        wfm_file.write_text(str(int(time.time())))
+        monkeypatch.setenv("LOBSTER_WFM_ACTIVE_OVERRIDE", str(wfm_file))
+
+        marked: list[str] = []
+        monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: marked.append(agent_id))
+        monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: None)
+
+        # Build a stale subagent session (not dispatcher-type)
+        row = gd.AgentRow(
+            agent_id="subagent-stale-no-file-xyz",
+            task_id=None,
+            description="functional-engineer subagent",
+            chat_id="12345",
+            status="running",
+            spawned_at="2026-03-15T09:00:00+00:00",
+            output_file=None,
+            last_seen_at=None,
+            agent_type="functional-engineer",
+        )
+        stale_subagent = gd.ClassifiedAgent(
+            row=row,
+            classification="STALE_NO_FILE",
+            age_minutes=60.0,
+            output_file_age_minutes=None,
+        )
+        fake_db = tmp_path / "agent_sessions.db"
+
+        gd.mark_failed_all_ghosts([], fake_db, stale_no_file=[stale_subagent])
+
+        assert "subagent-stale-no-file-xyz" in marked, (
+            "Non-dispatcher-typed sessions must be killed even when WFM-active is fresh"
+        )


### PR DESCRIPTION
## Summary

- Adds a WFM-active guard to `agent-monitor.py`: if `dispatcher-wfm-active` is fresh (written within 180s), all sessions with `agent_type='dispatcher'` are skipped in the mark-failed sweep — preventing spurious ghost kills of the live dispatcher's hook-registered hex-UUID entry
- Fixes the cron PATH bug: all 3 cron jobs that invoke `uv` now use the absolute path `$HOME/.local/bin/uv` instead of bare `uv` (which is not in cron's minimal PATH); confirmed that all 23,155 lines of agent-monitor.log are `uv: not found` — the ghost-detector has never run via cron until this fix
- Adds Migration 84 to `upgrade.sh` to repair existing installs
- Also adds `agent_type` to the `AgentRow` dataclass and SQL query so the guard can filter by type

## Root Cause

Two dispatcher DB entries exist per session:
1. `agent_id='lobster-dispatcher'` — protected by name guard in `mark_failed_all_ghosts()`
2. Hex-UUID entry (`agent_type='dispatcher'`, no `output_file`) — NOT protected

The hex-UUID entry has no `output_file`, so after 30+ min of WFM idle (JSONL transcript goes quiet), `agent-monitor` classifies it as `STALE_NO_FILE` and kills the live dispatcher.

Additionally, the cron PATH bug meant `agent-monitor.py` never ran via cron — it would have been silently skipping all ghost detection. This is fixed as part of the same PR.

## Fix

1. **`scripts/agent-monitor.py`**: Added `_is_dispatcher_in_wfm()` that reads `~/lobster-workspace/logs/dispatcher-wfm-active` and checks if the timestamp is within 180s. In `mark_failed_all_ghosts()`, if the dispatcher is in WFM, all `agent_type='dispatcher'` sessions are filtered out of the confirmed/stale lists before the mark-failed sweep.

2. **`install.sh`**: Replaced bare `uv` with `$HOME/.local/bin/uv` in all 3 cron entries (ghost-detector, oom-monitor, log-export).

3. **`scripts/upgrade.sh`**: Added Migration 84 to fix existing installs by patching the crontab directly with `sed`.

## Test Plan

- [x] `uv run scripts/agent-monitor.py --no-fs-scan --mark-failed` — confirmed both dispatcher entries are skipped when `dispatcher-wfm-active` is fresh: "No GHOST_CONFIRMED or STALE_NO_FILE agents to mark failed"
- [ ] Verify cron runs successfully with absolute path (will be confirmed in next scheduled cron window)
- [ ] Run Migration 84 on the live install to verify it patches crontab correctly

Closes #1573