### PR TITLE
fix(dispatcher): proactively resume pending agenda items after startup catchup

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -80,7 +80,7 @@ When you first start (or after reading this file), follow these steps:
 - **Dispatcher-owes-user thread**: If session notes say "Await user response on X" but you are the one who owes the next action (e.g. you promised to follow up, or the prior session noted the dispatcher should resume), take it now.
 - **Critical distinction**: Do NOT resume items that are waiting for the *user's* decision or response (e.g. "awaiting sign-off on PR #NNNN", "waiting for user go-ahead"). Those are correctly passive. Only act on items where the dispatcher is the blocking party.
 
-If there is nothing to proactively resume, proceed to `wait_for_messages` normally. If there are items to resume, spawn the first one (or begin inline) before entering `wait_for_messages`.
+If there is nothing to proactively resume, proceed to `wait_for_messages` normally. If there are items to resume, spawn the first one (or begin inline) before entering `wait_for_messages`. **When multiple items qualify, take the earliest uncompleted agenda item by sequence number** (e.g. "Agenda item 3" before "Agenda item 5"). If the items are not sequentially numbered, take the topmost qualifying item in the Open Tasks list in `handoff.md`.
 
 **Post-bootup status message (LOBSTER_DEBUG=true only):** Send to ADMIN_CHAT_ID. Keep to 5-8 lines, mobile-friendly. Build it from `handoff.md` (just read for startup) and `msg["text"]` (the catchup summary). Format:
 

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -74,6 +74,14 @@ When you first start (or after reading this file), follow these steps:
 
 **When the startup catchup result arrives** (`task_id: "startup-catchup"`, `chat_id: 0`): read for situational awareness, update `handoff.md` if anything notable changed (failed subagents, open threads). Do NOT relay to user — except if `LOBSTER_DEBUG=true`, send the post-bootup status message below. Then `mark_processed`.
 
+**Proactive resumption after catchup (REQUIRED):** After marking the catchup processed, scan `handoff.md` and the current session file for pending items that require *your* action — not waiting for the user. Specifically:
+
+- **Active agenda in progress**: If there is a multi-item agenda (e.g. "Agenda item 3: planning/architect layer") where earlier items were completed but a later item was not started, AND no queued user message already covers it — begin working on it (spawn a subagent or proceed inline).
+- **Dispatcher-owes-user thread**: If session notes say "Await user response on X" but you are the one who owes the next action (e.g. you promised to follow up, or the prior session noted the dispatcher should resume), take it now.
+- **Critical distinction**: Do NOT resume items that are waiting for the *user's* decision or response (e.g. "awaiting sign-off on PR #NNNN", "waiting for user go-ahead"). Those are correctly passive. Only act on items where the dispatcher is the blocking party.
+
+If there is nothing to proactively resume, proceed to `wait_for_messages` normally. If there are items to resume, spawn the first one (or begin inline) before entering `wait_for_messages`.
+
 **Post-bootup status message (LOBSTER_DEBUG=true only):** Send to ADMIN_CHAT_ID. Keep to 5-8 lines, mobile-friendly. Build it from `handoff.md` (just read for startup) and `msg["text"]` (the catchup summary). Format:
 
 ```

--- a/install.sh
+++ b/install.sh
@@ -1357,7 +1357,7 @@ success "Nightly consolidation configured (runs at 03:00 nightly)"
 # summary to ~/messages/task-outputs/ (readable via check_task_outputs).
 chmod +x "$INSTALL_DIR/scheduled-tasks/export-logs.py" 2>/dev/null || true
 "$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-LOG-EXPORT" \
-    "0 3 * * * cd $INSTALL_DIR && uv run scheduled-tasks/export-logs.py # LOBSTER-LOG-EXPORT"
+    "0 3 * * * cd $INSTALL_DIR && $HOME/.local/bin/uv run scheduled-tasks/export-logs.py # LOBSTER-LOG-EXPORT"
 
 success "Log export configured (runs at 03:00 UTC daily)"
 
@@ -1371,7 +1371,7 @@ step "Setting up ghost detector cron..."
 # sends a Telegram alert if GHOST_CONFIRMED or UNREGISTERED agents are found,
 # and marks ghost sessions as failed in agent_sessions.db. No LLM involved.
 "$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-GHOST-DETECTOR" \
-    "*/5 * * * * cd $HOME && uv run $INSTALL_DIR/scripts/agent-monitor.py --alert --mark-failed >> $HOME/lobster-workspace/logs/agent-monitor.log 2>&1 # LOBSTER-GHOST-DETECTOR"
+    "*/5 * * * * cd $HOME && $HOME/.local/bin/uv run $INSTALL_DIR/scripts/agent-monitor.py --alert --mark-failed >> $HOME/lobster-workspace/logs/agent-monitor.log 2>&1 # LOBSTER-GHOST-DETECTOR"
 
 success "Ghost detector configured (runs every 5 minutes)"
 
@@ -1386,7 +1386,7 @@ step "Setting up OOM monitor cron..."
 # dispatcher when new OOM kill events are detected. No LLM involved.
 # Only active when LOBSTER_DEBUG=true (the script is a no-op otherwise).
 "$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-OOM-CHECK" \
-    "*/10 * * * * cd $HOME && uv run $INSTALL_DIR/scripts/oom-monitor.py --since-minutes 10 >> $HOME/lobster-workspace/logs/oom-monitor.log 2>&1 # LOBSTER-OOM-CHECK"
+    "*/10 * * * * cd $HOME && $HOME/.local/bin/uv run $INSTALL_DIR/scripts/oom-monitor.py --since-minutes 10 >> $HOME/lobster-workspace/logs/oom-monitor.log 2>&1 # LOBSTER-OOM-CHECK"
 
 success "OOM monitor configured (runs every 10 minutes, active only when LOBSTER_DEBUG=true)"
 

--- a/scripts/agent-monitor.py
+++ b/scripts/agent-monitor.py
@@ -94,6 +94,7 @@ class AgentRow:
     spawned_at: str
     output_file: str | None
     last_seen_at: str | None
+    agent_type: str | None = None  # 'dispatcher' | 'subagent' | None
 
 
 @dataclass(frozen=True)
@@ -384,7 +385,7 @@ def load_running_agents(db_path: Path) -> list[AgentRow]:
         rows = conn.execute(
             """
             SELECT id, task_id, description, chat_id, status,
-                   spawned_at, output_file, last_seen_at
+                   spawned_at, output_file, last_seen_at, agent_type
             FROM agent_sessions
             WHERE status IN ('running', 'starting')
             ORDER BY spawned_at ASC
@@ -403,6 +404,7 @@ def load_running_agents(db_path: Path) -> list[AgentRow]:
             spawned_at=row["spawned_at"],
             output_file=row["output_file"],
             last_seen_at=row["last_seen_at"],
+            agent_type=row["agent_type"],
         )
         for row in rows
     ]
@@ -800,6 +802,44 @@ def mark_failed_unregistered(agent: UnregisteredAgent) -> None:
 #   session_start(agent_id="lobster-dispatcher", agent_type="dispatcher", ...)
 _DISPATCHER_AGENT_ID = "lobster-dispatcher"
 
+# WFM-active signal file — written by the MCP server every WAIT_HEARTBEAT_INTERVAL (60s)
+# while wait_for_messages is blocking. A fresh timestamp proves the dispatcher is alive
+# and actively waiting; an old or absent file means WFM has returned (or the process died).
+_WFM_ACTIVE_FILE = LOBSTER_HOME / "lobster-workspace" / "logs" / "dispatcher-wfm-active"
+
+# If the WFM-active file was written within this many seconds, the dispatcher is considered
+# to be alive and waiting for messages. 3× the 60s WAIT_HEARTBEAT_INTERVAL (mirrors
+# health-check-v3.sh WFM_ACTIVE_STALE_SECONDS=180).
+_WFM_ACTIVE_STALE_SECONDS = 180.0
+
+
+def _is_dispatcher_in_wfm() -> bool:
+    """Return True if the dispatcher is currently alive inside wait_for_messages.
+
+    Reads the WFM-active signal file written by the MCP server's heartbeat thread.
+    A fresh epoch timestamp (within _WFM_ACTIVE_STALE_SECONDS) means the dispatcher
+    is alive and blocking in WFM — NOT dead.  An absent or stale file means WFM has
+    returned (dispatcher is either processing a message or has died).
+
+    This check is used to avoid false-positive ghost classification: the hook-registered
+    dispatcher session (hex-UUID, agent_type='dispatcher') has no output_file, so it
+    falls into STALE_NO_FILE after 30 minutes.  Without this guard, mark_failed would
+    kill it even though the dispatcher is perfectly healthy.
+
+    Override path: LOBSTER_WFM_ACTIVE_OVERRIDE env var (used in tests).
+    """
+    wfm_file = Path(
+        os.environ.get("LOBSTER_WFM_ACTIVE_OVERRIDE", str(_WFM_ACTIVE_FILE))
+    )
+    try:
+        raw = wfm_file.read_text().strip()
+        if not raw.isdigit():
+            return False
+        age = time.time() - float(raw)
+        return age <= _WFM_ACTIVE_STALE_SECONDS
+    except (OSError, ValueError):
+        return False
+
 
 def mark_failed_all_ghosts(
     confirmed: list[ClassifiedAgent],
@@ -815,19 +855,22 @@ def mark_failed_all_ghosts(
     that never register an output file), which is why --mark-failed would previously
     leave stale dispatcher sessions in status=running indefinitely.
 
-    The live dispatcher session is always excluded from the STALE_NO_FILE sweep.
-    The dispatcher registers with the static agent_id "lobster-dispatcher", so any
-    entry with that agent_id is skipped unconditionally — it is the currently-running
-    dispatcher, not a dead subagent.
+    Two guards prevent killing the live dispatcher:
+
+    Guard 1 (agent_id): The dispatcher registers with the static agent_id
+    "lobster-dispatcher".  Any entry with that agent_id is skipped unconditionally.
+
+    Guard 2 (agent_type + WFM-active): The SessionStart hook also writes a separate
+    hex-UUID entry tagged agent_type='dispatcher' with no output_file.  This entry
+    always lands in STALE_NO_FILE after 30 minutes — and previously had no protection.
+    When the WFM-active signal is fresh (dispatcher alive in wait_for_messages), ALL
+    sessions with agent_type='dispatcher' are skipped.  This closes the false-positive
+    window that issue #1573 tracked: the hook-registered entry was being ghost-detected
+    whenever the JSONL transcript went idle while the dispatcher was healthy in WFM.
     """
     stale_no_file = stale_no_file or []
 
-    # Guard: exclude the live dispatcher session from the sweep.
-    # The dispatcher always registers with agent_id=_DISPATCHER_AGENT_ID (a static
-    # constant), so we filter on that directly.  There is no UUID file to read —
-    # the previous approach compared against the Claude UUID from
-    # dispatcher-claude-session-id, but that UUID is stored in a different field
-    # and was never equal to agent_id, making the guard a silent no-op.
+    # Guard 1: exclude the named dispatcher session (agent_id = "lobster-dispatcher").
     if stale_no_file:
         filtered_stale = [a for a in stale_no_file if a.row.agent_id != _DISPATCHER_AGENT_ID]
         skipped = len(stale_no_file) - len(filtered_stale)
@@ -837,6 +880,29 @@ def mark_failed_all_ghosts(
                 f"agent_id={_DISPATCHER_AGENT_ID!r} — live dispatcher, not a dead subagent."
             )
         stale_no_file = filtered_stale
+
+    # Guard 2: if the dispatcher is currently inside wait_for_messages (WFM-active signal
+    # is fresh), skip ALL sessions tagged agent_type='dispatcher'.  The hook-registered
+    # hex-UUID entry (no output_file, agent_type='dispatcher') is alive whenever WFM is
+    # active — its JSONL transcript goes idle because WFM blocks without writing, not
+    # because the dispatcher is dead.  Killing it would emit a spurious agent_failed
+    # notification and potentially inject an unnecessary compact-reminder (issue #1573).
+    in_wfm = _is_dispatcher_in_wfm()
+    if in_wfm:
+        def _is_dispatcher_type(a: ClassifiedAgent) -> bool:
+            return (a.row.agent_type or "") == "dispatcher"
+
+        pre_confirmed = len(confirmed)
+        pre_stale = len(stale_no_file)
+        confirmed = [a for a in confirmed if not _is_dispatcher_type(a)]
+        stale_no_file = [a for a in stale_no_file if not _is_dispatcher_type(a)]
+        skipped_wfm = (pre_confirmed - len(confirmed)) + (pre_stale - len(stale_no_file))
+        if skipped_wfm:
+            print(
+                f"\n  [mark-failed] WFM-active is fresh — skipping {skipped_wfm} "
+                "dispatcher-typed session(s) that appear alive in wait_for_messages. "
+                "(issue #1573)"
+            )
 
     to_fail = confirmed + stale_no_file
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2918,8 +2918,13 @@ print(f'prune-pr-worktrees: {result.status}')
                 | sed "s|cd $HOME && uv run \(.*\)oom-monitor\.py|cd $HOME \&\& $_m84_uv_abs run \1oom-monitor.py|g" \
                 | crontab - 2>/dev/null && {
                 substep "Migration 84: fixed oom-monitor cron to use absolute uv path"
+                migrated=$((migrated + 1))
             } || warn "Migration 84: could not update oom-monitor cron entry"
+        else
+            substep "Migration 84: oom-monitor cron already uses absolute uv path — skipping"
         fi
+    else
+        substep "Migration 84: oom-monitor cron entry not found — skipping"
     fi
     if crontab -l 2>/dev/null | grep -q "LOBSTER-LOG-EXPORT"; then
         if crontab -l 2>/dev/null | grep "LOBSTER-LOG-EXPORT" | grep -q " uv run "; then
@@ -2927,8 +2932,13 @@ print(f'prune-pr-worktrees: {result.status}')
                 | sed "s|cd \(.*\) && uv run \(.*\)export-logs\.py|cd \1 \&\& $_m84_uv_abs run \2export-logs.py|g" \
                 | crontab - 2>/dev/null && {
                 substep "Migration 84: fixed log-export cron to use absolute uv path"
+                migrated=$((migrated + 1))
             } || warn "Migration 84: could not update log-export cron entry"
+        else
+            substep "Migration 84: log-export cron already uses absolute uv path — skipping"
         fi
+    else
+        substep "Migration 84: log-export cron entry not found — skipping"
     fi
 
     if [ "$migrated" -eq 0 ]; then

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2891,6 +2891,46 @@ print(f'prune-pr-worktrees: {result.status}')
         warn "prune-pr-worktrees.py not found at $_m83_script or uv unavailable — skipping Migration 83"
     fi
 
+    # Migration 84: Fix cron PATH for uv-based scripts (ghost-detector, oom-monitor, log-export).
+    # Cron runs with a minimal PATH that does not include ~/.local/bin, so bare 'uv' fails
+    # with "uv: not found". Replace bare 'uv' with the absolute path $HOME/.local/bin/uv
+    # in the three affected cron entries.
+    local _m84_uv_abs="$HOME/.local/bin/uv"
+    if crontab -l 2>/dev/null | grep -q "LOBSTER-GHOST-DETECTOR"; then
+        if crontab -l 2>/dev/null | grep "LOBSTER-GHOST-DETECTOR" | grep -q " uv run "; then
+            crontab -l 2>/dev/null \
+                | sed "s|cd \$HOME && uv run \(.*\)agent-monitor\.py|cd \$HOME \&\& $_m84_uv_abs run \1agent-monitor.py|g" \
+                | sed "s|cd $HOME && uv run \(.*\)agent-monitor\.py|cd $HOME \&\& $_m84_uv_abs run \1agent-monitor.py|g" \
+                | crontab - 2>/dev/null && {
+                substep "Migration 84: fixed ghost-detector cron to use absolute uv path"
+                migrated=$((migrated + 1))
+            } || warn "Migration 84: could not update ghost-detector cron entry"
+        else
+            substep "Migration 84: ghost-detector cron already uses absolute uv path — skipping"
+        fi
+    else
+        substep "Migration 84: ghost-detector cron entry not found — skipping"
+    fi
+    if crontab -l 2>/dev/null | grep -q "LOBSTER-OOM-CHECK"; then
+        if crontab -l 2>/dev/null | grep "LOBSTER-OOM-CHECK" | grep -q " uv run "; then
+            crontab -l 2>/dev/null \
+                | sed "s|cd \$HOME && uv run \(.*\)oom-monitor\.py|cd \$HOME \&\& $_m84_uv_abs run \1oom-monitor.py|g" \
+                | sed "s|cd $HOME && uv run \(.*\)oom-monitor\.py|cd $HOME \&\& $_m84_uv_abs run \1oom-monitor.py|g" \
+                | crontab - 2>/dev/null && {
+                substep "Migration 84: fixed oom-monitor cron to use absolute uv path"
+            } || warn "Migration 84: could not update oom-monitor cron entry"
+        fi
+    fi
+    if crontab -l 2>/dev/null | grep -q "LOBSTER-LOG-EXPORT"; then
+        if crontab -l 2>/dev/null | grep "LOBSTER-LOG-EXPORT" | grep -q " uv run "; then
+            crontab -l 2>/dev/null \
+                | sed "s|cd \(.*\) && uv run \(.*\)export-logs\.py|cd \1 \&\& $_m84_uv_abs run \2export-logs.py|g" \
+                | crontab - 2>/dev/null && {
+                substep "Migration 84: fixed log-export cron to use absolute uv path"
+            } || warn "Migration 84: could not update log-export cron entry"
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/tests/unit/test_ghost_detector_filesystem.py
+++ b/tests/unit/test_ghost_detector_filesystem.py
@@ -471,17 +471,18 @@ class TestMarkFailedAllGhostsStaleNoFile:
         agent_id: str,
         classification: str,
         output_file: str | None = None,
-        agent_type: str = "dispatcher",
+        agent_type: str | None = "dispatcher",
     ) -> gd.ClassifiedAgent:
         row = gd.AgentRow(
             agent_id=agent_id,
             task_id=None,
-            description=f"test-{agent_type}-{agent_id[:8]}",
+            description=f"test-{agent_type or 'agent'}-{agent_id[:8]}",
             chat_id="12345",
             status="running",
             spawned_at="2026-03-15T09:00:00+00:00",
             output_file=output_file,
             last_seen_at=None,
+            agent_type=agent_type,
         )
         return gd.ClassifiedAgent(
             row=row,
@@ -499,6 +500,9 @@ class TestMarkFailedAllGhostsStaleNoFile:
 
         monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: marked.append(agent_id))
         monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: dropped.append(payload))
+        # Force WFM-inactive so Guard 2 does not fire and cause environmental flakiness
+        # when tests run while the live dispatcher is in wait_for_messages.
+        monkeypatch.setattr(gd, "_is_dispatcher_in_wfm", lambda: False)
 
         stale = self._make_classified("dispatcher001", "STALE_NO_FILE")
         fake_db = tmp_path / "agent_sessions.db"
@@ -516,6 +520,7 @@ class TestMarkFailedAllGhostsStaleNoFile:
         marked: list[str] = []
         monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: marked.append(agent_id))
         monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: None)
+        monkeypatch.setattr(gd, "_is_dispatcher_in_wfm", lambda: False)
 
         confirmed = self._make_classified("subagent001", "GHOST_CONFIRMED", output_file="/tmp/out.jsonl")
         stale = self._make_classified("dispatcher002", "STALE_NO_FILE")
@@ -533,6 +538,7 @@ class TestMarkFailedAllGhostsStaleNoFile:
         marked: list[str] = []
         monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: marked.append(agent_id))
         monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: None)
+        monkeypatch.setattr(gd, "_is_dispatcher_in_wfm", lambda: False)
 
         confirmed = self._make_classified("subagent003", "GHOST_CONFIRMED", output_file="/tmp/out.jsonl")
         fake_db = tmp_path / "agent_sessions.db"
@@ -548,6 +554,7 @@ class TestMarkFailedAllGhostsStaleNoFile:
         marked: list[str] = []
         monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: marked.append(agent_id))
         monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: None)
+        monkeypatch.setattr(gd, "_is_dispatcher_in_wfm", lambda: False)
 
         fake_db = tmp_path / "agent_sessions.db"
         gd.mark_failed_all_ghosts([], fake_db, stale_no_file=[])
@@ -597,6 +604,7 @@ class TestLiveDispatcherGuard:
         marked: list[str] = []
         monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: marked.append(agent_id))
         monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: None)
+        monkeypatch.setattr(gd, "_is_dispatcher_in_wfm", lambda: False)
 
         live_session = self._make_stale_classified(self.DISPATCHER_AGENT_ID)
         fake_db = tmp_path / "agent_sessions.db"
@@ -613,6 +621,7 @@ class TestLiveDispatcherGuard:
         marked: list[str] = []
         monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: marked.append(agent_id))
         monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: None)
+        monkeypatch.setattr(gd, "_is_dispatcher_in_wfm", lambda: False)
 
         dead_session = self._make_stale_classified("some-dead-subagent-task-id")
         fake_db = tmp_path / "agent_sessions.db"
@@ -628,6 +637,7 @@ class TestLiveDispatcherGuard:
         marked: list[str] = []
         monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: marked.append(agent_id))
         monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: None)
+        monkeypatch.setattr(gd, "_is_dispatcher_in_wfm", lambda: False)
 
         dispatcher_session = self._make_stale_classified(self.DISPATCHER_AGENT_ID)
         dead_session = self._make_stale_classified("dead-subagent-task-abc123")
@@ -644,6 +654,7 @@ class TestLiveDispatcherGuard:
         """A skip notice is printed when the dispatcher session is excluded."""
         monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: None)
         monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: None)
+        monkeypatch.setattr(gd, "_is_dispatcher_in_wfm", lambda: False)
 
         dispatcher_session = self._make_stale_classified(self.DISPATCHER_AGENT_ID)
         fake_db = tmp_path / "agent_sessions.db"
@@ -653,6 +664,158 @@ class TestLiveDispatcherGuard:
         out = capsys.readouterr().out
         assert "Skipping" in out
         assert "dispatcher" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# Guard 2: WFM-active + agent_type='dispatcher' skips hex-UUID dispatcher entry
+# ---------------------------------------------------------------------------
+
+# A hex-UUID agent_id that does NOT match the static "lobster-dispatcher" constant.
+# The SessionStart hook registers the dispatcher's Claude session under a UUID-style
+# id alongside the static "lobster-dispatcher" entry.  Guard 1 protects the static id;
+# Guard 2 protects this UUID entry when WFM is active.
+_HEX_UUID_DISPATCHER_ID = "a3f9e1b2c4d5e6f700112233445566aa"
+
+
+class TestGuard2WfmActiveDispatcherType:
+    """Guard 2: when WFM-active is fresh, sessions with agent_type='dispatcher'
+    and a non-static (hex-UUID) agent_id are skipped by mark_failed_all_ghosts.
+
+    This guard closes the false-positive window that Guard 1 misses: the
+    SessionStart hook registers a new dispatcher row with agent_type='dispatcher'
+    and a UUID-style id each restart.  Without Guard 2, that row would be
+    ghost-detected after 30 idle minutes even though the dispatcher is healthy.
+    """
+
+    def _make_dispatcher_typed(
+        self, agent_id: str = _HEX_UUID_DISPATCHER_ID
+    ) -> gd.ClassifiedAgent:
+        """Build a STALE_NO_FILE ClassifiedAgent with agent_type='dispatcher' and a hex UUID id."""
+        row = gd.AgentRow(
+            agent_id=agent_id,
+            task_id=None,
+            description="auto-registered by SessionStart hook (dispatcher)",
+            chat_id="0",
+            status="running",
+            spawned_at="2026-03-15T09:00:00+00:00",
+            output_file=None,
+            last_seen_at=None,
+            agent_type="dispatcher",
+        )
+        return gd.ClassifiedAgent(
+            row=row,
+            classification="STALE_NO_FILE",
+            age_minutes=120.0,
+            output_file_age_minutes=None,
+        )
+
+    def test_wfm_active_fresh_skips_dispatcher_typed_uuid_session(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When WFM-active is fresh, a hex-UUID session with agent_type='dispatcher'
+        must NOT be marked failed — the dispatcher is alive in wait_for_messages."""
+        marked: list[str] = []
+        monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: marked.append(agent_id))
+        monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: None)
+        monkeypatch.setattr(gd, "_is_dispatcher_in_wfm", lambda: True)  # WFM is fresh
+
+        session = self._make_dispatcher_typed(_HEX_UUID_DISPATCHER_ID)
+        fake_db = tmp_path / "agent_sessions.db"
+
+        gd.mark_failed_all_ghosts([], fake_db, stale_no_file=[session])
+
+        assert _HEX_UUID_DISPATCHER_ID not in marked, (
+            "Guard 2 must skip dispatcher-typed UUID sessions when WFM is active"
+        )
+
+    def test_wfm_not_active_marks_dispatcher_typed_uuid_session_failed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When WFM-active is stale/absent, a hex-UUID dispatcher-typed session IS
+        marked failed — the dispatcher has exited WFM and this row is a dead ghost."""
+        marked: list[str] = []
+        monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: marked.append(agent_id))
+        monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: None)
+        monkeypatch.setattr(gd, "_is_dispatcher_in_wfm", lambda: False)  # WFM stale/absent
+
+        session = self._make_dispatcher_typed(_HEX_UUID_DISPATCHER_ID)
+        fake_db = tmp_path / "agent_sessions.db"
+
+        gd.mark_failed_all_ghosts([], fake_db, stale_no_file=[session])
+
+        assert _HEX_UUID_DISPATCHER_ID in marked, (
+            "Guard 2 must NOT protect dispatcher-typed sessions when WFM is absent/stale"
+        )
+
+    def test_wfm_active_does_not_protect_non_dispatcher_typed_sessions(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Guard 2 only filters agent_type='dispatcher'. Subagent-typed sessions with
+        UUID ids are still marked failed even when WFM is active."""
+        marked: list[str] = []
+        monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: marked.append(agent_id))
+        monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: None)
+        monkeypatch.setattr(gd, "_is_dispatcher_in_wfm", lambda: True)  # WFM is fresh
+
+        row = gd.AgentRow(
+            agent_id="deadbeef1234567890abcdef",
+            task_id="some-task",
+            description="a regular subagent",
+            chat_id="12345",
+            status="running",
+            spawned_at="2026-03-15T09:00:00+00:00",
+            output_file=None,
+            last_seen_at=None,
+            agent_type="subagent",
+        )
+        session = gd.ClassifiedAgent(
+            row=row,
+            classification="STALE_NO_FILE",
+            age_minutes=120.0,
+            output_file_age_minutes=None,
+        )
+        fake_db = tmp_path / "agent_sessions.db"
+
+        gd.mark_failed_all_ghosts([], fake_db, stale_no_file=[session])
+
+        assert "deadbeef1234567890abcdef" in marked, (
+            "Guard 2 must not protect non-dispatcher-typed sessions regardless of WFM state"
+        )
+
+    def test_wfm_active_skips_dispatcher_typed_in_confirmed_list_too(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Guard 2 applies to the confirmed list as well as stale_no_file.
+        A GHOST_CONFIRMED session with agent_type='dispatcher' is skipped when WFM is fresh."""
+        marked: list[str] = []
+        monkeypatch.setattr(gd, "mark_agent_failed", lambda db_path, agent_id: marked.append(agent_id))
+        monkeypatch.setattr(gd, "drop_inbox_message", lambda payload: None)
+        monkeypatch.setattr(gd, "_is_dispatcher_in_wfm", lambda: True)  # WFM is fresh
+
+        row = gd.AgentRow(
+            agent_id=_HEX_UUID_DISPATCHER_ID,
+            task_id=None,
+            description="dispatcher-typed confirmed ghost",
+            chat_id="0",
+            status="running",
+            spawned_at="2026-03-15T09:00:00+00:00",
+            output_file="/tmp/fake-output.jsonl",
+            last_seen_at=None,
+            agent_type="dispatcher",
+        )
+        confirmed_session = gd.ClassifiedAgent(
+            row=row,
+            classification="GHOST_CONFIRMED",
+            age_minutes=120.0,
+            output_file_age_minutes=None,
+        )
+        fake_db = tmp_path / "agent_sessions.db"
+
+        gd.mark_failed_all_ghosts([confirmed_session], fake_db)
+
+        assert _HEX_UUID_DISPATCHER_ID not in marked, (
+            "Guard 2 must also protect dispatcher-typed GHOST_CONFIRMED sessions when WFM is active"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds **Proactive resumption after catchup** block to `sys.dispatcher.bootup.md`
- After `startup-catchup` returns, the dispatcher now scans `handoff.md` and the session file for items where the dispatcher (not the user) is the blocking party
- Begins work on the first such item before entering `wait_for_messages`
- Items explicitly waiting for the user's decision are correctly excluded from resumption

## Root Cause

`sys.dispatcher.bootup.md` line 75 said "read for situational awareness... Then `mark_processed`." — no instruction to resume pending work. The dispatcher would passively enter `wait_for_messages` even when it had owned open tasks from the prior session (e.g. a multi-item agenda where it completed items 1-2 but not item 3). Users had to manually re-ask about pending items on every restart.

## Fix

Added a "Proactive resumption after catchup (REQUIRED)" section immediately after the existing startup-catchup handler. It defines:

1. **Active agenda in progress** — if a multi-item agenda had completed earlier items but not a later one, and no queued user message already covers it, begin work
2. **Dispatcher-owes-user thread** — if session notes show the dispatcher promised to follow up but didn't, take the action
3. **Critical distinction** — items waiting for the *user's* decision are correctly passive and excluded

## Test Plan

- [ ] On next restart, verify the dispatcher resumes agenda item 3 (planning/architect layer, msg 29189) without being re-asked
- [ ] Verify items marked "awaiting user sign-off" are NOT proactively acted on

Relates to dispatcher restart behavior — no issue number; behavior-only fix in bootup instructions.