### PR TITLE
fix(health-check): treat fresh WFM tombstone as exempt to prevent midnight race (#1884)

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -108,6 +108,15 @@ DISPATCHER_HEARTBEAT_STALE_SECONDS=1200   # 20 min — covers compaction (~5m) +
 # File is deleted by the MCP server when WFM returns (message arrived or timeout).
 DISPATCHER_WFM_ACTIVE_FILE="${LOBSTER_WFM_ACTIVE_OVERRIDE:-$WORKSPACE_DIR/logs/dispatcher-wfm-active}"
 WFM_ACTIVE_STALE_SECONDS=180   # 3x WAIT_HEARTBEAT_INTERVAL (60s) — absorbs one missed tick
+# Grace window for WFM tombstone ("exited"): if the WFM-active file contains the
+# tombstone but was written within this many seconds, the dispatcher just left WFM
+# and is actively transitioning to message processing — grant the same exemption as
+# a live timestamp. This closes the midnight race (issue #1884): scheduled jobs fire
+# at 00:00Z, wake WFM, which writes "exited" to this file; the health-check cron
+# also fires at 00:00Z and previously declared RED when it saw "exited" instead of
+# a live integer.  A 30s window is well above the sub-second WFM→processing
+# transition but narrow enough to never mask a genuinely frozen dispatcher.
+WFM_TOMBSTONE_GRACE_SECONDS=30
 
 OUTBOX_DIR="$MESSAGES_DIR/outbox"
 OUTBOX_STALE_THRESHOLD_SECONDS=900   # 15 min = RED
@@ -1008,6 +1017,25 @@ check_dispatcher_heartbeat() {
             else
                 log_error "RED: dispatcher heartbeat stale (${age}s) and WFM-active also stale (${wfm_age}s, threshold: ${WFM_ACTIVE_STALE_SECONDS}s) — dispatcher appears frozen"
                 return 2
+            fi
+        fi
+        # Tombstone check (issue #1884 midnight race): inbox_server.py writes
+        # "exited" to WFM_ACTIVE_FILE when WFM returns (instead of deleting the
+        # file, to avoid the TOCTOU race fixed in issue #1730).  If the tombstone
+        # was written within WFM_TOMBSTONE_GRACE_SECONDS, the dispatcher just left
+        # WFM and is actively transitioning to message processing — this is healthy,
+        # not a freeze.  Only grant the exemption when the file mtime is fresh;
+        # an old tombstone (dispatcher has been processing for longer than the grace
+        # window) means the heartbeat staleness is genuinely suspicious.
+        if [[ "$wfm_active_ts" == "exited" ]]; then
+            local file_mtime
+            file_mtime=$(stat -c %Y "$DISPATCHER_WFM_ACTIVE_FILE" 2>/dev/null || echo 0)
+            local tombstone_age=$(( now - file_mtime ))
+            if [[ $tombstone_age -le $WFM_TOMBSTONE_GRACE_SECONDS ]]; then
+                log_info "Dispatcher heartbeat stale (${age}s) but WFM-active tombstone is fresh (written ${tombstone_age}s ago, grace: ${WFM_TOMBSTONE_GRACE_SECONDS}s) — dispatcher just left WFM, skipping RED"
+                return 0
+            else
+                log_info "Dispatcher heartbeat stale (${age}s) and WFM-active tombstone is old (${tombstone_age}s, grace: ${WFM_TOMBSTONE_GRACE_SECONDS}s) — treating as absent"
             fi
         fi
         log_error "RED: dispatcher heartbeat stale — last tool use ${age}s ago (threshold: ${DISPATCHER_HEARTBEAT_STALE_SECONDS}s)"

--- a/tests/test-health-check-wfm-active.sh
+++ b/tests/test-health-check-wfm-active.sh
@@ -18,10 +18,12 @@
 #   6. Fresh heartbeat ignores WFM-active (heartbeat alone = GREEN)
 #   7. LOBSTER_WFM_ACTIVE_OVERRIDE env var is respected
 #   8. WFM-active file with non-integer content → RED (treat as absent)
-#   9. WFM-active tombstone value 'exited' → RED (Fix 2: tombstone not absent)
-#  10. TOCTOU race: file deleted mid-read → RED, not crash (Fix 1 regression test)
+#   9. WFM-active tombstone ('exited') with FRESH mtime → GREEN (issue #1884 midnight race fix)
+#  10. WFM-active tombstone ('exited') with OLD mtime → RED (grace period expired, treat as absent)
+#  11. TOCTOU race: file deleted mid-read → RED, not crash (Fix 1 regression test)
 #
 # Usage: bash tests/test-health-check-wfm-active.sh
+# Total tests: 11
 #===============================================================================
 
 set -u
@@ -60,6 +62,7 @@ assert_exit() {
 LOG_FILE="$TEST_LOG_DIR/health-check.log"
 DISPATCHER_HEARTBEAT_STALE_SECONDS=1200
 WFM_ACTIVE_STALE_SECONDS=180
+WFM_TOMBSTONE_GRACE_SECONDS=30
 
 log()       { echo "[$1] $2" >> "$LOG_FILE" 2>/dev/null; }
 log_info()  { log INFO "$1"; }
@@ -158,19 +161,44 @@ check_dispatcher_heartbeat && rc=$? || rc=$?
 assert_exit "$rc" 2
 
 # -------------------------------------------------------------------
-# Test 9: TOCTOU fix — tombstone value ("exited") → treated as absent → RED
-# The finally block in inbox_server.py writes "exited" instead of deleting
-# the file, so the health check never sees a missing file mid-read.
-# The non-integer tombstone must be treated as absent (= WFM not active).
+# Test 9: Midnight race fix (issue #1884) — tombstone ('exited') with FRESH
+# file mtime → GREEN.
+#
+# At 00:00Z, scheduled jobs fire and wake wait_for_messages(). WFM writes
+# "exited" to dispatcher-wfm-active as it transitions to active processing.
+# The health-check cron also fires at 00:00Z. Previously, seeing "exited"
+# caused an unconditional RED (false-positive kill). With the fix, a fresh
+# tombstone mtime means the dispatcher just left WFM — grant a grace period.
+#
+# We create the file, set its mtime to "now" (default), and verify GREEN.
 # -------------------------------------------------------------------
-begin_test "WFM-active tombstone value 'exited' → treated as absent → RED"
+begin_test "WFM-active tombstone 'exited' with fresh mtime → GREEN (midnight race fix)"
 write_stale_heartbeat
 echo "exited" > "$DISPATCHER_WFM_ACTIVE_FILE"
+# mtime is "now" by default — within WFM_TOMBSTONE_GRACE_SECONDS
+check_dispatcher_heartbeat && rc=$? || rc=$?
+assert_exit "$rc" 0
+
+# -------------------------------------------------------------------
+# Test 10: Tombstone ('exited') with OLD file mtime → RED (grace expired).
+#
+# If the tombstone was written longer ago than WFM_TOMBSTONE_GRACE_SECONDS,
+# the dispatcher has been in the processing phase for a while — heartbeat
+# staleness is genuinely suspicious, not a WFM→processing transition artifact.
+# Treat as absent → RED.
+#
+# We backdate the file mtime by 120s (well past the 30s grace window).
+# -------------------------------------------------------------------
+begin_test "WFM-active tombstone 'exited' with old mtime → RED (grace period expired)"
+write_stale_heartbeat
+echo "exited" > "$DISPATCHER_WFM_ACTIVE_FILE"
+# Backdate mtime by 120s — well past WFM_TOMBSTONE_GRACE_SECONDS=30
+touch -d "$(date -d '120 seconds ago' '+%Y-%m-%d %H:%M:%S')" "$DISPATCHER_WFM_ACTIVE_FILE"
 check_dispatcher_heartbeat && rc=$? || rc=$?
 assert_exit "$rc" 2
 
 # -------------------------------------------------------------------
-# Test 10: TOCTOU race scenario — file present at check start, absent at read
+# Test 11: TOCTOU race scenario — file present at check start, absent at read
 #
 # Simulates the race window that caused the 2026-04-22 false-positive restart:
 # the WFM-active file exists when the health check starts, but is deleted
@@ -215,5 +243,5 @@ assert_exit "$rc" 2
 # Summary
 # -------------------------------------------------------------------
 echo ""
-echo "Results: $PASS/$TOTAL passed, $FAIL failed"
+echo "Results: $PASS/$TOTAL passed, $FAIL failed  (expected 11)"
 [[ $FAIL -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Problem

At 00:00Z, the health-check cron kills a healthy dispatcher. Two events collide in the same sub-second window:

1. Scheduled jobs fire and deposit messages into the inbox, waking `wait_for_messages()`.
2. WFM transitions to active processing, writing the tombstone `"exited"` to `dispatcher-wfm-active` via `_clear_wfm_active_signal()`.
3. The health-check cron also fires at 00:00Z, reads `"exited"` from the file, rejects it as non-integer (the correct TOCTOU guard from issue #1730), and falls through to RED — killing the dispatcher even though it was alive and actively processing.

The dispatcher was genuinely healthy. The kill was a false positive caused by the health check seeing the WFM→processing transition tombstone at exactly the wrong moment. This was observed at 00:00Z on Apr 30 and May 1.

## Root cause

`check_dispatcher_heartbeat()` has two cases for the WFM-active file:
- Integer content → check file age against `WFM_ACTIVE_STALE_SECONDS` → exempt if fresh
- Non-integer content (including `"exited"`) → treat as absent → fall through to RED

The tombstone is written *because* the dispatcher just successfully exited WFM and started processing. It is a liveness signal, not an absence signal — but the health check was treating it as the latter.

## Fix

When `wfm_active_ts == "exited"`, check the **file mtime** against a new constant `WFM_TOMBSTONE_GRACE_SECONDS=30`. If the tombstone was written within 30 seconds, the dispatcher is in the WFM→processing transition — grant the same exemption as a live timestamp. If the tombstone is older than 30s, the dispatcher has been in the processing phase for a while and heartbeat staleness is genuinely suspicious, so treat as absent → RED.

30s is well above the sub-second WFM→processing transition window and well below any meaningful "dispatcher is frozen" duration.

## Before / after flow

```
Before (broken at midnight):
  heartbeat stale?
    yes → read wfm_active_file
      integer + fresh → GREEN
      integer + stale → RED
      "exited"        → RED  ← false positive: dispatcher just left WFM
      absent          → RED

After (this PR):
  heartbeat stale?
    yes → read wfm_active_file
      integer + fresh                    → GREEN
      integer + stale                    → RED
      "exited" + mtime fresh (<30s)      → GREEN  ← new: tombstone = recent WFM exit
      "exited" + mtime old   (>=30s)     → RED    ← old tombstone: suspect
      absent                             → RED
```

## Functional patterns

Pure function `check_dispatcher_heartbeat()` extended with a single new branch. Named constant `WFM_TOMBSTONE_GRACE_SECONDS` makes the spec directly reviewable in both implementation and tests — no magic literals.

## Tests run
- [x] `bash tests/test-health-check-wfm-active.sh` — 11/11 passed, 0 failed
  - Test 9 (was: tombstone → RED) is now "fresh tombstone → GREEN" — the race fix
  - Test 10 (new): "old tombstone → RED" — grace period expired
  - Test 11 (renumbered from 10): TOCTOU race regression test
- [x] `bash tests/test-health-check-dispatcher-heartbeat.sh` — 8/8 passed, 0 failed
- [x] `bash tests/test-health-check-boot-grace.sh` — 8/8 passed, 0 failed
- [x] `bash tests/test-health-check-inbox-drain.sh` — 19/19 passed, 0 failed

## Manual test
N/A — this change is entirely in a shell function (`check_dispatcher_heartbeat`) exercised by the test suite. The fix applies to a deterministic file-read path with no external service calls. No systemd, no Telegram API, no DB writes.

## Definition of Done
- [x] Unit tests pass (bash test suite, all 4 suites green)
- [x] Integration/manual test — N/A (deterministic file logic, covered by test suite)
- [x] User-visible outcome: prevents false-positive dispatcher kill at midnight — no Telegram "System recovered automatically" false alarms at 00:00Z
- [x] Side-effect audit: no floods, no shared state writes, no production hits
- [x] External service calls: none

Closes #1884