### PR TITLE
fix(health-check): raise WFM_ACTIVE_STALE_SECONDS 180s→600s (#1885)

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -104,10 +104,12 @@ DISPATCHER_HEARTBEAT_STALE_SECONDS=1200   # 20 min — covers compaction (~5m) +
 # a Unix epoch timestamp when wait_for_messages begins blocking and refreshes it
 # every WAIT_HEARTBEAT_INTERVAL (60s). When this file is fresh, the dispatcher is
 # alive and waiting for messages — heartbeat staleness is expected, not a problem.
-# Threshold: 3x WAIT_HEARTBEAT_INTERVAL to absorb one missed refresh cycle.
+# Threshold: 10x WAIT_HEARTBEAT_INTERVAL — gives the dispatcher a 10-minute window
+# to be outside WFM (e.g. processing a message, startup compact-catchup) before
+# the health check fires.  3x was too tight and produced false-positive kills.
 # File is deleted by the MCP server when WFM returns (message arrived or timeout).
 DISPATCHER_WFM_ACTIVE_FILE="${LOBSTER_WFM_ACTIVE_OVERRIDE:-$WORKSPACE_DIR/logs/dispatcher-wfm-active}"
-WFM_ACTIVE_STALE_SECONDS=180   # 3x WAIT_HEARTBEAT_INTERVAL (60s) — absorbs one missed tick
+WFM_ACTIVE_STALE_SECONDS=600   # 10x WAIT_HEARTBEAT_INTERVAL (60s) — 10-minute window
 
 OUTBOX_DIR="$MESSAGES_DIR/outbox"
 OUTBOX_STALE_THRESHOLD_SECONDS=900   # 15 min = RED

--- a/tests/test-health-check-dispatcher-heartbeat.sh
+++ b/tests/test-health-check-dispatcher-heartbeat.sh
@@ -59,7 +59,7 @@ DISPATCHER_HEARTBEAT_STALE_SECONDS=1200
 # WFM-active variables (issue #1713): must match the values in health-check-v3.sh.
 # Default to an absent file so existing heartbeat tests are unaffected.
 DISPATCHER_WFM_ACTIVE_FILE="$TEST_LOG_DIR/dispatcher-wfm-active-ABSENT"
-WFM_ACTIVE_STALE_SECONDS=180
+WFM_ACTIVE_STALE_SECONDS=600
 
 log()       { echo "[$1] $2" >> "$LOG_FILE" 2>/dev/null; }
 log_info()  { log INFO "$1"; }

--- a/tests/test-health-check-wfm-active.sh
+++ b/tests/test-health-check-wfm-active.sh
@@ -59,7 +59,7 @@ assert_exit() {
 # Source check_dispatcher_heartbeat() from the health check script.
 LOG_FILE="$TEST_LOG_DIR/health-check.log"
 DISPATCHER_HEARTBEAT_STALE_SECONDS=1200
-WFM_ACTIVE_STALE_SECONDS=180
+WFM_ACTIVE_STALE_SECONDS=600
 
 log()       { echo "[$1] $2" >> "$LOG_FILE" 2>/dev/null; }
 log_info()  { log INFO "$1"; }
@@ -102,9 +102,9 @@ assert_exit "$rc" 0
 # -------------------------------------------------------------------
 # Test 3: Stale heartbeat + stale WFM-active → RED (both stale = frozen)
 # -------------------------------------------------------------------
-begin_test "Stale heartbeat + stale WFM-active (600s old) → RED"
+begin_test "Stale heartbeat + stale WFM-active ($(( WFM_ACTIVE_STALE_SECONDS + 120 ))s old) → RED"
 write_stale_heartbeat
-echo "$(( $(date +%s) - 600 ))" > "$DISPATCHER_WFM_ACTIVE_FILE"
+echo "$(( $(date +%s) - (WFM_ACTIVE_STALE_SECONDS + 120) ))" > "$DISPATCHER_WFM_ACTIVE_FILE"
 check_dispatcher_heartbeat && rc=$? || rc=$?
 assert_exit "$rc" 2
 
@@ -131,7 +131,7 @@ assert_exit "$rc" 0
 # -------------------------------------------------------------------
 begin_test "Fresh heartbeat → GREEN regardless of WFM-active"
 write_fresh_heartbeat
-echo "$(( $(date +%s) - 600 ))" > "$DISPATCHER_WFM_ACTIVE_FILE"  # stale WFM-active
+echo "$(( $(date +%s) - (WFM_ACTIVE_STALE_SECONDS + 120) ))" > "$DISPATCHER_WFM_ACTIVE_FILE"  # stale WFM-active
 check_dispatcher_heartbeat && rc=$? || rc=$?
 assert_exit "$rc" 0
 

--- a/tests/unit/test_wfm_active_signal.py
+++ b/tests/unit/test_wfm_active_signal.py
@@ -5,7 +5,7 @@ Verifies that:
 - _write_wfm_active_signal() writes a single Unix epoch integer
 - WFM_ACTIVE_FILE path is ~/lobster-workspace/logs/dispatcher-wfm-active
 - LOBSTER_WFM_ACTIVE_OVERRIDE env var overrides the path (test isolation)
-- WAIT_HEARTBEAT_INTERVAL is 60s (matches health-check's WFM_ACTIVE_STALE_SECONDS/3)
+- WAIT_HEARTBEAT_INTERVAL is 60s (health-check WFM_ACTIVE_STALE_SECONDS is 10x this value)
 - The written timestamp is within 2 seconds of now
 - Atomic write: a .tmp file is never left behind
 - The file is writable before the wait loop starts
@@ -58,13 +58,13 @@ def test_wfm_active_file_path_is_workspace_logs(tmp_path):
 
 
 def test_wait_heartbeat_interval_is_60():
-    """WAIT_HEARTBEAT_INTERVAL must be 60s to match health-check's 3x WFM_ACTIVE_STALE_SECONDS expectation."""
+    """WAIT_HEARTBEAT_INTERVAL must be 60s (health-check WFM_ACTIVE_STALE_SECONDS=600 is 10x this value)."""
     mcp_dir = str(Path(__file__).resolve().parent.parent.parent / "src" / "mcp")
     if mcp_dir not in sys.path:
         sys.path.insert(0, mcp_dir)
     import inbox_server
     assert inbox_server.WAIT_HEARTBEAT_INTERVAL == 60, (
-        "WAIT_HEARTBEAT_INTERVAL must be 60s — health-check WFM_ACTIVE_STALE_SECONDS=180 is 3x this value"
+        "WAIT_HEARTBEAT_INTERVAL must be 60s — health-check WFM_ACTIVE_STALE_SECONDS=600 is 10x this value"
     )
 
 


### PR DESCRIPTION
## Problem

The health-check kills the dispatcher when the WFM-active file is older than `WFM_ACTIVE_STALE_SECONDS`. At 180s (3 minutes), the check fires false positives: the dispatcher can legitimately be outside `wait_for_messages` for several minutes during startup compact-catchup or while processing a long message. This was killing a healthy dispatcher.

## What changed

`WFM_ACTIVE_STALE_SECONDS` raised from 180s to 600s (10 minutes = 10× `WAIT_HEARTBEAT_INTERVAL`). No behavior change while WFM is active — a fresh file always suppresses the kill. This only widens the false-positive kill window when the dispatcher is legitimately outside WFM.

## Files

- `scripts/health-check-v3.sh` — `WFM_ACTIVE_STALE_SECONDS=180` → `600`, comment updated from "3x" to "10x"
- `tests/test-health-check-wfm-active.sh` — constant synced; test 3 updated to use `WFM_ACTIVE_STALE_SECONDS+120` (previously hardcoded `600` which is now exactly at the boundary and would have been GREEN, not RED)
- `tests/test-health-check-dispatcher-heartbeat.sh` — constant synced
- `tests/unit/test_wfm_active_signal.py` — docstring and assertion message updated to reference 10x / 600 instead of 3x / 180

`agent-monitor.py` and `tests/unit/test_ghost_detector_filesystem.py` also have copies of this constant (added in the unmerged PR #1882 branch) — those will need to be updated when that branch is rebased or merged.

## Functional patterns

Pure value change in a bash constant plus propagation to test fixtures. No logic modified; the comparison `wfm_age -le WFM_ACTIVE_STALE_SECONDS` is unchanged.

## Tests run

- [x] `bash tests/test-health-check-wfm-active.sh` — 10/10 passed
- [x] `bash tests/test-health-check-dispatcher-heartbeat.sh` — 8/8 passed
- [x] `uv run pytest tests/unit/test_wfm_active_signal.py -v` — 11/11 passed
- [x] `uv run pytest tests/unit/ -v` — 3051 passed, 24 skipped; 6 pre-existing failures in `test_require_background_agent` / `test_require_write_result` unrelated to this change (confirmed by running same tests on origin/main baseline before this change)

## Manual test

N/A — this is a constant change in a bash script. The health-check runs as a cron job; it reads `WFM_ACTIVE_STALE_SECONDS` at runtime, so the new value takes effect on the next cron tick after deploy. No service restart required.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (constant change, no external service calls)
- [x] User-visible outcome: fewer false-positive dispatcher kills — not directly verifiable in a test, but the root cause (threshold too tight) is addressed
- [x] Side-effect audit: no floods, no writes, no volume impact
- [x] External service calls: none

Closes #1885