### PR TITLE
feat(hooks): add context injection logging to inject-bootup-context.py

### DIFF
--- a/hooks/inject-bootup-context.py
+++ b/hooks/inject-bootup-context.py
@@ -36,6 +36,7 @@ case and ensures dispatcher bootup is always injected when it should be.
 import json
 import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 # Allow imports from the hooks directory (session_role).
@@ -54,6 +55,13 @@ USER_DISPATCHER_BOOTUP = USER_CONFIG_DIR / "user.dispatcher.bootup.md"
 USER_SUBAGENT_BOOTUP = USER_CONFIG_DIR / "user.subagent.bootup.md"
 
 HOOK_NAME = "inject-bootup-context"
+
+# Append-only log of context injections — one line per hook run.
+# Populated at import time so tests can override by setting mod.CONTEXT_INJECTION_LOG.
+_LOBSTER_WORKSPACE = Path(
+    os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace")
+)
+CONTEXT_INJECTION_LOG = _LOBSTER_WORKSPACE / "logs" / "context-injection.log"
 
 # Compact-pending sentinel written by on-compact.py for dispatcher compactions only.
 # Used as the Option 3 fallback: sentinel present + LOBSTER_MAIN_SESSION=1 → dispatcher.
@@ -108,19 +116,51 @@ def _read_file_safe(path: Path, label: str) -> str | None:
         return None
 
 
-def _inject_if_exists(path: Path, label: str) -> None:
-    """Read and print file contents if the file exists and is non-empty. Silent skip otherwise."""
+def _inject_if_exists(path: Path, label: str) -> bool:
+    """Read and print file contents if the file exists and is non-empty.
+
+    Returns True if the file was successfully injected, False otherwise.
+    Silent skip when the file is absent.
+    """
     if not path.exists():
-        return
+        return False
     try:
         content = path.read_text()
         if content.strip():
             print(content)
+            return True
+        return False
     except OSError as exc:
         print(
             f"[{HOOK_NAME}] WARNING: could not read {path} ({label}): {exc}",
             file=sys.stderr,
         )
+        return False
+
+
+def _append_injection_log(
+    session_id: str,
+    role: str,
+    injected_files: list[str],
+) -> None:
+    """Append one line to the context injection log.
+
+    Format:
+      <ISO UTC timestamp> | session=<id> | role=<role> | injected=[file1, file2, ...]
+
+    Creates the log file and any missing parent directories if needed.
+    Errors are swallowed — logging must never break the hook.
+    """
+    try:
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        files_repr = "[" + ", ".join(injected_files) + "]"
+        line = f"{timestamp} | session={session_id} | role={role} | injected={files_repr}\n"
+        log_path = CONTEXT_INJECTION_LOG
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a") as fh:
+            fh.write(line)
+    except Exception:  # noqa: BLE001
+        pass  # logging must not break injection
 
 
 def main() -> None:
@@ -129,6 +169,8 @@ def main() -> None:
         hook_input = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError):
         hook_input = {}
+
+    session_id = hook_input.get("session_id", "unknown")
 
     is_dispatcher = session_role.is_dispatcher(hook_input)
 
@@ -149,30 +191,41 @@ def main() -> None:
     # This makes the hook self-sufficient regardless of whether
     # write-dispatcher-session-id.py ran first. The write is idempotent.
     if is_dispatcher:
-        session_id = session_role.get_session_id(hook_input)
-        if session_id:
-            session_role.write_dispatcher_session_id(session_id)
+        sid = session_role.get_session_id(hook_input)
+        if sid:
+            session_role.write_dispatcher_session_id(sid)
+
+    role = "dispatcher" if is_dispatcher else "subagent"
+    injected: list[str] = []
 
     # 1. Inject system bootup file based on role.
     if is_dispatcher:
         content = _read_file_safe(DISPATCHER_BOOTUP, "sys.dispatcher.bootup.md")
+        system_file = DISPATCHER_BOOTUP
     else:
         content = _read_file_safe(SUBAGENT_BOOTUP, "sys.subagent.bootup.md")
+        system_file = SUBAGENT_BOOTUP
 
     if content is None:
+        _append_injection_log(session_id, role, injected)
         sys.exit(0)
 
     print(content)
+    injected.append(system_file.name)
 
     # 2. Inject user base bootup (both roles).
-    _inject_if_exists(USER_BASE_BOOTUP, "user.base.bootup.md")
+    if _inject_if_exists(USER_BASE_BOOTUP, "user.base.bootup.md"):
+        injected.append(USER_BASE_BOOTUP.name)
 
     # 3. Inject role-specific user bootup.
     if is_dispatcher:
-        _inject_if_exists(USER_DISPATCHER_BOOTUP, "user.dispatcher.bootup.md")
+        if _inject_if_exists(USER_DISPATCHER_BOOTUP, "user.dispatcher.bootup.md"):
+            injected.append(USER_DISPATCHER_BOOTUP.name)
     else:
-        _inject_if_exists(USER_SUBAGENT_BOOTUP, "user.subagent.bootup.md")
+        if _inject_if_exists(USER_SUBAGENT_BOOTUP, "user.subagent.bootup.md"):
+            injected.append(USER_SUBAGENT_BOOTUP.name)
 
+    _append_injection_log(session_id, role, injected)
     sys.exit(0)
 
 

--- a/tests/unit/test_hooks/test_inject_bootup_context_logging.py
+++ b/tests/unit/test_hooks/test_inject_bootup_context_logging.py
@@ -1,0 +1,561 @@
+"""
+Unit tests for context injection logging in inject-bootup-context.py.
+
+Issue #1889: add append-only logging so we can debug whether dispatchers
+received the correct bootup file.
+
+Every hook run must append exactly one line to the log file:
+  <ISO UTC timestamp> | session=<id> | role=<dispatcher|subagent> | injected=[file1, file2, ...]
+
+Tests verify:
+- Log file is created when absent
+- One line is written per hook run
+- Line format matches the spec
+- Only actually-injected files (exist + non-empty) appear in injected list
+- Role field is "dispatcher" or "subagent" depending on session type
+- session field is "unknown" when hook_input has no session_id
+- Existing log content is preserved (append-only)
+- No stdout pollution — injected content unchanged
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "inject-bootup-context.py"
+
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Helpers (shared with other inject-bootup-context test files)
+# ---------------------------------------------------------------------------
+
+
+class _PatchEnv:
+    """Context manager to temporarily set / restore environment variables."""
+
+    def __init__(self, env: dict):
+        self._env = env
+        self._saved: dict = {}
+
+    def __enter__(self):
+        for k, v in self._env.items():
+            self._saved[k] = os.environ.get(k)
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        return self
+
+    def __exit__(self, *_):
+        for k, saved_v in self._saved.items():
+            if saved_v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = saved_v
+
+
+def _make_bootup_files(claude_dir: Path) -> tuple[Path, Path]:
+    """Write minimal dispatcher and subagent bootup stubs."""
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    dispatcher_bootup = claude_dir / "sys.dispatcher.bootup.md"
+    subagent_bootup = claude_dir / "sys.subagent.bootup.md"
+    dispatcher_bootup.write_text("# DISPATCHER BOOTUP\n")
+    subagent_bootup.write_text("# SUBAGENT BOOTUP\n")
+    return dispatcher_bootup, subagent_bootup
+
+
+def _run_hook(
+    tmp_path: Path,
+    *,
+    hook_input: dict,
+    dispatcher_uuid: str | None = None,
+    is_dispatcher_session: bool = False,
+    log_path: Path | None = None,
+) -> tuple[object, Path]:
+    """Load and run inject-bootup-context.py in a controlled environment.
+
+    Returns (module, log_path).
+
+    Sets up minimal file structure: bootup files, primary state file if
+    dispatcher_uuid is given. Suppresses user config files.
+
+    The primary state file is written to $LOBSTER_WORKSPACE/data/
+    because session_role._get_mcp_claude_session_file() reads LOBSTER_WORKSPACE
+    from the environment at call time.
+    """
+    import uuid as _uuid
+
+    claude_dir = tmp_path / "lobster" / ".claude"
+    dispatcher_bootup, subagent_bootup = _make_bootup_files(claude_dir)
+
+    lobster_workspace = tmp_path / "lobster-workspace"
+    lobster_workspace.mkdir(parents=True, exist_ok=True)
+    (lobster_workspace / "logs").mkdir(parents=True, exist_ok=True)
+
+    # Primary state file must live under LOBSTER_WORKSPACE/data/
+    # (session_role reads LOBSTER_WORKSPACE from env at call time)
+    ws_data_dir = lobster_workspace / "data"
+    ws_data_dir.mkdir(parents=True, exist_ok=True)
+    if dispatcher_uuid:
+        (ws_data_dir / "dispatcher-claude-session-id").write_text(dispatcher_uuid)
+
+    config_dir = tmp_path / "messages" / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    if log_path is None:
+        log_path = lobster_workspace / "logs" / "context-injection.log"
+
+    unique_name = f"inject_log_test_{_uuid.uuid4().hex}"
+
+    with _PatchEnv(
+        {
+            "HOME": str(tmp_path),
+            "LOBSTER_WORKSPACE": str(lobster_workspace),
+            "LOBSTER_MAIN_SESSION": "1" if is_dispatcher_session else "0",
+        }
+    ):
+        spec = importlib.util.spec_from_file_location(unique_name, _HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        mod.DISPATCHER_BOOTUP = dispatcher_bootup
+        mod.SUBAGENT_BOOTUP = subagent_bootup
+        mod.COMPACT_PENDING_SENTINEL = tmp_path / "no-sentinel"
+        mod.USER_CONFIG_DIR = tmp_path / "no-user-config"
+        mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+        mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+        mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+        mod.CONTEXT_INJECTION_LOG = log_path
+
+        stdin_data = json.dumps(hook_input)
+        with patch("sys.stdin", io.StringIO(stdin_data)):
+            with pytest.raises(SystemExit):
+                mod.main()
+
+    return mod, log_path
+
+
+# ---------------------------------------------------------------------------
+# Tests: log file creation and line format
+# ---------------------------------------------------------------------------
+
+
+class TestLogFileCreation:
+    """Log file is created on first run and lines are appended on subsequent runs."""
+
+    def test_log_file_created_if_absent(self, tmp_path, capsys):
+        """Hook creates the log file when it does not exist yet."""
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "context-injection.log"
+        assert not log_path.exists()
+
+        _run_hook(
+            tmp_path,
+            hook_input={"session_id": "test-session-abc"},
+            log_path=log_path,
+        )
+
+        assert log_path.exists(), "Log file should be created if absent"
+
+    def test_each_run_appends_exactly_one_line(self, tmp_path, capsys):
+        """Each hook invocation appends exactly one line to the log."""
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "context-injection.log"
+
+        for i in range(3):
+            _run_hook(
+                tmp_path,
+                hook_input={"session_id": f"session-{i}"},
+                log_path=log_path,
+            )
+
+        lines = log_path.read_text().splitlines()
+        assert len(lines) == 3, f"Expected 3 log lines, got {len(lines)}"
+
+    def test_existing_log_content_preserved(self, tmp_path, capsys):
+        """Pre-existing log lines are not overwritten (append-only)."""
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "context-injection.log"
+        log_path.write_text("pre-existing line\n")
+
+        _run_hook(
+            tmp_path,
+            hook_input={"session_id": "new-session"},
+            log_path=log_path,
+        )
+
+        lines = log_path.read_text().splitlines()
+        assert lines[0] == "pre-existing line", "Pre-existing content must be preserved"
+        assert len(lines) == 2, "Should have original line + new line"
+
+
+# ---------------------------------------------------------------------------
+# Tests: log line format
+# ---------------------------------------------------------------------------
+
+
+class TestLogLineFormat:
+    """The format of each logged line matches the spec."""
+
+    def test_log_line_has_four_pipe_delimited_fields(self, tmp_path, capsys):
+        """Each log line has exactly 4 pipe-delimited fields."""
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "context-injection.log"
+
+        _run_hook(
+            tmp_path,
+            hook_input={"session_id": "abc-123"},
+            log_path=log_path,
+        )
+
+        line = log_path.read_text().strip()
+        fields = [f.strip() for f in line.split("|")]
+        assert len(fields) == 4, f"Expected 4 pipe-separated fields, got: {line!r}"
+
+    def test_session_field_contains_session_id(self, tmp_path, capsys):
+        """session= field contains the session_id from hook_input."""
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "context-injection.log"
+        session_id = "my-unique-session-id-xyz"
+
+        _run_hook(
+            tmp_path,
+            hook_input={"session_id": session_id},
+            log_path=log_path,
+        )
+
+        line = log_path.read_text().strip()
+        assert f"session={session_id}" in line, (
+            f"Expected 'session={session_id}' in log line, got: {line!r}"
+        )
+
+    def test_session_field_is_unknown_when_no_session_id(self, tmp_path, capsys):
+        """session=unknown when hook_input has no session_id key."""
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "context-injection.log"
+
+        _run_hook(
+            tmp_path,
+            hook_input={},  # no session_id
+            log_path=log_path,
+        )
+
+        line = log_path.read_text().strip()
+        assert "session=unknown" in line, (
+            f"Expected 'session=unknown' when no session_id, got: {line!r}"
+        )
+
+    def test_timestamp_field_is_iso_utc(self, tmp_path, capsys):
+        """First field is an ISO 8601 UTC timestamp (contains 'T' and 'Z')."""
+        import re
+
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "context-injection.log"
+
+        _run_hook(
+            tmp_path,
+            hook_input={"session_id": "ts-test"},
+            log_path=log_path,
+        )
+
+        line = log_path.read_text().strip()
+        timestamp = line.split("|")[0].strip()
+        # Must match ISO 8601 UTC pattern: YYYY-MM-DDTHH:MM:SS...Z
+        assert re.match(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", timestamp), (
+            f"Expected ISO 8601 timestamp, got: {timestamp!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: role field
+# ---------------------------------------------------------------------------
+
+
+class TestRoleField:
+    """role= field reflects the detected session role."""
+
+    def test_role_is_dispatcher_for_dispatcher_session(self, tmp_path, capsys):
+        """role=dispatcher when the session is identified as the dispatcher."""
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "context-injection.log"
+
+        dispatcher_uuid = "dispatcher-uuid-for-role-test"
+        _run_hook(
+            tmp_path,
+            hook_input={"session_id": dispatcher_uuid},
+            dispatcher_uuid=dispatcher_uuid,  # matches → is_dispatcher() returns True
+            is_dispatcher_session=True,
+            log_path=log_path,
+        )
+
+        line = log_path.read_text().strip()
+        assert "role=dispatcher" in line, (
+            f"Expected 'role=dispatcher' for dispatcher session, got: {line!r}"
+        )
+
+    def test_role_is_subagent_for_non_dispatcher_session(self, tmp_path, capsys):
+        """role=subagent when session UUID does not match dispatcher UUID."""
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "context-injection.log"
+
+        # Write dispatcher UUID to primary file — subagent has a different UUID
+        dispatcher_uuid = "real-dispatcher-uuid-abc"
+        _run_hook(
+            tmp_path,
+            hook_input={"session_id": "subagent-uuid-different"},
+            dispatcher_uuid=dispatcher_uuid,
+            is_dispatcher_session=True,
+            log_path=log_path,
+        )
+
+        line = log_path.read_text().strip()
+        assert "role=subagent" in line, (
+            f"Expected 'role=subagent' for non-dispatcher session, got: {line!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: injected files list
+# ---------------------------------------------------------------------------
+
+
+class TestInjectedFilesList:
+    """injected= field lists only files that exist and were actually read."""
+
+    def test_injected_contains_system_bootup_file_name(self, tmp_path, capsys):
+        """injected= includes the system bootup file name for subagent sessions."""
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "context-injection.log"
+
+        # Subagent session — primary file present with different UUID
+        dispatcher_uuid = "disp-uuid-xyz"
+        _run_hook(
+            tmp_path,
+            hook_input={"session_id": "subagent-session-id"},
+            dispatcher_uuid=dispatcher_uuid,
+            is_dispatcher_session=True,
+            log_path=log_path,
+        )
+
+        line = log_path.read_text().strip()
+        assert "sys.subagent.bootup.md" in line, (
+            f"Expected 'sys.subagent.bootup.md' in injected list, got: {line!r}"
+        )
+
+    def test_injected_contains_dispatcher_bootup_for_dispatcher_session(
+        self, tmp_path, capsys
+    ):
+        """injected= includes sys.dispatcher.bootup.md for dispatcher sessions."""
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "context-injection.log"
+
+        dispatcher_uuid = "disp-uuid-log-test"
+        _run_hook(
+            tmp_path,
+            hook_input={"session_id": dispatcher_uuid},
+            dispatcher_uuid=dispatcher_uuid,
+            is_dispatcher_session=True,
+            log_path=log_path,
+        )
+
+        line = log_path.read_text().strip()
+        assert "sys.dispatcher.bootup.md" in line, (
+            f"Expected 'sys.dispatcher.bootup.md' in injected list, got: {line!r}"
+        )
+
+    def test_injected_is_empty_list_when_no_files_injected(self, tmp_path, capsys):
+        """injected=[] when the system bootup file does not exist."""
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "context-injection.log"
+
+        import uuid as _uuid
+        unique_name = f"inject_log_empty_{_uuid.uuid4().hex}"
+        claude_dir = tmp_path / "lobster" / ".claude"
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        lobster_workspace = tmp_path / "lobster-workspace"
+        (lobster_workspace / "logs").mkdir(parents=True, exist_ok=True)
+        (lobster_workspace / "data").mkdir(parents=True, exist_ok=True)
+
+        # Bootup files do NOT exist
+        absent_dispatcher = claude_dir / "sys.dispatcher.bootup.md"
+        absent_subagent = claude_dir / "sys.subagent.bootup.md"
+
+        with _PatchEnv(
+            {
+                "HOME": str(tmp_path),
+                "LOBSTER_WORKSPACE": str(lobster_workspace),
+                "LOBSTER_MAIN_SESSION": "0",
+            }
+        ):
+            spec = importlib.util.spec_from_file_location(unique_name, _HOOK_PATH)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+
+            mod.DISPATCHER_BOOTUP = absent_dispatcher
+            mod.SUBAGENT_BOOTUP = absent_subagent
+            mod.COMPACT_PENDING_SENTINEL = tmp_path / "no-sentinel"
+            mod.USER_CONFIG_DIR = tmp_path / "no-user-config"
+            mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+            mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+            mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+            mod.CONTEXT_INJECTION_LOG = log_path
+
+            stdin_data = json.dumps({"session_id": "session-with-no-files"})
+            with patch("sys.stdin", io.StringIO(stdin_data)):
+                with pytest.raises(SystemExit):
+                    mod.main()
+
+        line = log_path.read_text().strip()
+        assert "injected=[]" in line, (
+            f"Expected 'injected=[]' when no bootup files exist, got: {line!r}"
+        )
+
+    def test_optional_user_bootup_file_included_when_exists(self, tmp_path, capsys):
+        """injected= includes user base bootup file when it exists."""
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "context-injection.log"
+
+        import uuid as _uuid
+        unique_name = f"inject_log_user_{_uuid.uuid4().hex}"
+        claude_dir = tmp_path / "lobster" / ".claude"
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        dispatcher_bootup = claude_dir / "sys.dispatcher.bootup.md"
+        subagent_bootup = claude_dir / "sys.subagent.bootup.md"
+        dispatcher_bootup.write_text("# DISPATCHER BOOTUP\n")
+        subagent_bootup.write_text("# SUBAGENT BOOTUP\n")
+
+        # Write user base bootup file
+        user_config_dir = tmp_path / "user-config" / "agents"
+        user_config_dir.mkdir(parents=True, exist_ok=True)
+        user_base = user_config_dir / "user.base.bootup.md"
+        user_base.write_text("# USER BASE BOOTUP\n")
+
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        lobster_workspace = tmp_path / "lobster-workspace"
+        (lobster_workspace / "logs").mkdir(parents=True, exist_ok=True)
+        (lobster_workspace / "data").mkdir(parents=True, exist_ok=True)
+
+        with _PatchEnv(
+            {
+                "HOME": str(tmp_path),
+                "LOBSTER_WORKSPACE": str(lobster_workspace),
+                "LOBSTER_MAIN_SESSION": "0",
+            }
+        ):
+            spec = importlib.util.spec_from_file_location(unique_name, _HOOK_PATH)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+
+            mod.DISPATCHER_BOOTUP = dispatcher_bootup
+            mod.SUBAGENT_BOOTUP = subagent_bootup
+            mod.COMPACT_PENDING_SENTINEL = tmp_path / "no-sentinel"
+            mod.USER_CONFIG_DIR = user_config_dir
+            mod.USER_BASE_BOOTUP = user_base
+            mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+            mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+            mod.CONTEXT_INJECTION_LOG = log_path
+
+            stdin_data = json.dumps({"session_id": "subagent-with-user-config"})
+            with patch("sys.stdin", io.StringIO(stdin_data)):
+                with pytest.raises(SystemExit):
+                    mod.main()
+
+        line = log_path.read_text().strip()
+        assert "user.base.bootup.md" in line, (
+            f"Expected 'user.base.bootup.md' in injected list when file exists, got: {line!r}"
+        )
+
+    def test_optional_user_bootup_file_excluded_when_absent(self, tmp_path, capsys):
+        """injected= does NOT include user base bootup file when it does not exist."""
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "context-injection.log"
+
+        _run_hook(
+            tmp_path,
+            hook_input={"session_id": "no-user-config-session"},
+            log_path=log_path,
+        )
+
+        line = log_path.read_text().strip()
+        assert "user.base.bootup.md" not in line, (
+            f"user.base.bootup.md must not appear in log when file is absent, got: {line!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: stdout is unchanged (no logging pollution)
+# ---------------------------------------------------------------------------
+
+
+class TestStdoutUnchanged:
+    """Adding a log line must not alter stdout output (bootup content unchanged)."""
+
+    def test_dispatcher_stdout_unchanged_by_logging(self, tmp_path, capsys):
+        """Adding log does not change what the dispatcher session sees in stdout."""
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "context-injection.log"
+
+        dispatcher_uuid = "stdout-test-dispatcher-uuid"
+        _run_hook(
+            tmp_path,
+            hook_input={"session_id": dispatcher_uuid},
+            dispatcher_uuid=dispatcher_uuid,
+            is_dispatcher_session=True,
+            log_path=log_path,
+        )
+
+        captured = capsys.readouterr()
+        assert "DISPATCHER BOOTUP" in captured.out
+        assert "context-injection.log" not in captured.out
+        assert "injected=" not in captured.out
+        assert "session=" not in captured.out
+
+    def test_subagent_stdout_unchanged_by_logging(self, tmp_path, capsys):
+        """Adding log does not change what a subagent session sees in stdout."""
+        log_dir = tmp_path / "lobster-workspace" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "context-injection.log"
+
+        dispatcher_uuid = "stdout-test-disp-for-subagent"
+        _run_hook(
+            tmp_path,
+            hook_input={"session_id": "subagent-stdout-test"},
+            dispatcher_uuid=dispatcher_uuid,
+            is_dispatcher_session=True,
+            log_path=log_path,
+        )
+
+        captured = capsys.readouterr()
+        assert "SUBAGENT BOOTUP" in captured.out
+        assert "context-injection.log" not in captured.out
+        assert "injected=" not in captured.out


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What this solves

Before this change, there was no record of which bootup files each agent session received. When debugging whether a dispatcher got the wrong bootup (e.g. subagent context instead of dispatcher context), the only option was to reproduce the problem — there was no history to inspect.

This adds an append-only log so that every SessionStart hook run leaves a one-line trace: what session ID, what role was detected, and which files were injected.

## What the log looks like

```
2026-05-01T18:23:41Z | session=abc-1234 | role=dispatcher | injected=[sys.dispatcher.bootup.md, user.base.bootup.md, user.dispatcher.bootup.md]
2026-05-01T18:24:02Z | session=xyz-5678 | role=subagent | injected=[sys.subagent.bootup.md, user.base.bootup.md]
2026-05-01T18:24:15Z | session=unknown | role=subagent | injected=[]
```

Log path: `~/lobster-workspace/logs/context-injection.log`

## Design choices

**`_inject_if_exists` now returns bool** — previously void. This is the minimal change needed to track which optional user config files were actually injected (as opposed to skipped because they don't exist). The function's external behavior is unchanged; the return value was previously discarded.

**`CONTEXT_INJECTION_LOG` is a module-level constant** — so tests can override it with `mod.CONTEXT_INJECTION_LOG = tmp_path / "test.log"` using the same pattern used by all other inject-bootup-context tests.

**Logging errors are silently swallowed** — the `except Exception: pass` in `_append_injection_log` ensures that a full disk, permissions error, or unexpected exception never prevents context from being injected. The hook's primary job is injection, not logging.

**Log is written after injection is complete** — the log entry captures what was actually injected, not what was attempted. If a file read fails mid-injection, that file is not in the injected list.

**Early exit path also writes a log entry** — when the system bootup file is missing (`content is None`), `_append_injection_log` is called before `sys.exit(0)` so the event is recorded with an empty injected list.

## Functional patterns used

Pure function for log line construction — `_append_injection_log` takes explicit inputs (session_id, role, injected list) and has no implicit dependencies. The module-level path constant is the only exception, and it is overridable in tests.

## What is NOT changed

- What gets injected and in what order is unchanged
- stdout output is identical — the log goes to a file, not stdout
- No bootup content files were modified
- No changes to `session_role.py` or any other hook

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_inject_bootup_context_logging.py -v` — 16 passed, 0 failed (new tests)
- [x] `uv run pytest tests/unit/test_hooks/test_inject_bootup_context_sentinel.py -v` — 9 passed, 0 failed (existing tests, unchanged)
- [x] `uv run pytest tests/unit/` — 3071 passed, 5 failed (same 5 pre-existing failures in `test_require_background_agent.py`, confirmed failing on `origin/main` before this change)

## Manual test

N/A — this change is purely an append to a local log file. No external services, no systemd, no cron, no database. The log path is under `~/lobster-workspace/logs/` which the system already owns and writes to.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, local file write only
- [x] User-visible outcome verified — N/A, internal diagnostic log
- [x] Side-effect audit complete: one append-only write per SessionStart; bounded, no volume risk
- [x] External service calls: none

Closes #1889