### PR TITLE
fix(#1898): re-add _is_fresh_start_dispatcher() to inject-bootup-context.py

### DIFF
--- a/hooks/inject-bootup-context.py
+++ b/hooks/inject-bootup-context.py
@@ -31,6 +31,19 @@ file.  If the sentinel exists AND LOBSTER_MAIN_SESSION=1, the session is
 treated as a post-compact dispatcher session regardless of the ID-match result.
 This bypasses the chicken-and-egg timing problem entirely for the post-compact
 case and ensures dispatcher bootup is always injected when it should be.
+
+Fresh-start fallback (issue #1868):
+On a genuine fresh restart (new process, MCP server restarted), the primary
+state file (dispatcher-claude-session-id) is cleared by the MCP server on
+startup and is absent until the dispatcher calls session_start().
+write-dispatcher-session-id.py may also skip updating the tertiary marker file
+if the previous session's JSONL has a recent mtime, leaving a stale UUID.
+Both state files then fail to identify the new dispatcher, causing is_dispatcher()
+to return False.  The sentinel fallback doesn't help (no compaction occurred).
+Fix: if the primary file is absent AND LOBSTER_MAIN_SESSION=1, treat the session
+as the dispatcher.  This is safe because subagents are only spawned after the
+dispatcher calls session_start() (which writes the primary file), and compaction
+events write the primary file proactively via on-compact.py.
 """
 
 import json
@@ -89,6 +102,40 @@ def _is_post_compact_dispatcher() -> bool:
     return COMPACT_PENDING_SENTINEL.exists()
 
 
+def _is_fresh_start_dispatcher() -> bool:
+    """Return True if this looks like a fresh-restart dispatcher session (issue #1868).
+
+    On a genuine fresh restart, the MCP server clears the primary state file
+    (dispatcher-claude-session-id) on startup.  That file is absent until the
+    dispatcher calls session_start().  write-dispatcher-session-id.py may also
+    skip updating the tertiary marker file if the previous session's JSONL has
+    a recent mtime, leaving a stale UUID in the tertiary file.
+
+    Consequence: is_dispatcher() finds no matching state file and returns False.
+    The compact-pending sentinel fallback (_is_post_compact_dispatcher) is also
+    inactive because no compaction occurred.  inject-bootup-context.py then
+    falls back to injecting subagent bootup — wrong for the dispatcher.
+
+    Fix: absent primary file + LOBSTER_MAIN_SESSION=1 → treat as dispatcher.
+
+    Why this is safe:
+    - Subagents are spawned only after the dispatcher calls session_start(),
+      which writes the primary file.  By the time any subagent SessionStart
+      fires, the primary file is present.
+    - Compaction events: on-compact.py proactively writes the primary file
+      with the new UUID before the post-compact SessionStart fires.  The
+      primary file is therefore present for compaction events, not absent.
+
+    Returns False on any OSError (cannot stat the primary file) — safe default.
+    """
+    if os.environ.get("LOBSTER_MAIN_SESSION", "") != "1":
+        return False
+    try:
+        return not session_role._get_mcp_claude_session_file().exists()
+    except OSError:
+        return False
+
+
 def _read_file_safe(path: Path, label: str) -> str | None:
     """Return file contents or None on any error or empty file, logging to stderr."""
     if not path.exists():
@@ -141,6 +188,21 @@ def main() -> None:
         print(
             f"[{HOOK_NAME}] sentinel fallback: compact-pending exists + "
             "LOBSTER_MAIN_SESSION=1; treating as post-compact dispatcher",
+            file=sys.stderr,
+        )
+        is_dispatcher = True
+
+    # Fresh-start fallback (issue #1868): if the primary state file is absent
+    # and LOBSTER_MAIN_SESSION=1, the MCP server has started but session_start()
+    # has not yet been called — this is the pre-session_start window that only
+    # exists during a genuine fresh restart.  Subagents cannot trigger this
+    # because they start only after the dispatcher has called session_start()
+    # (which writes the primary file).  Compaction events are also safe: on-compact.py
+    # writes the primary file proactively, so it is present for post-compact starts.
+    if not is_dispatcher and _is_fresh_start_dispatcher():
+        print(
+            f"[{HOOK_NAME}] fresh-start fallback: primary state file absent + "
+            "LOBSTER_MAIN_SESSION=1; treating as fresh-restart dispatcher",
             file=sys.stderr,
         )
         is_dispatcher = True

--- a/tests/unit/test_hooks/test_inject_bootup_context_fresh_start.py
+++ b/tests/unit/test_hooks/test_inject_bootup_context_fresh_start.py
@@ -1,0 +1,415 @@
+"""
+Unit tests for the fresh-dispatcher-start fallback in inject-bootup-context.py.
+
+Issue #1868 / regression from PR #1891 deploy (issue #1898):
+On a fresh restart (new process, MCP server restarted),
+inject-bootup-context.py injects the subagent bootup file instead of the
+dispatcher bootup file.
+
+Root cause (same as #1768, but not applied to this hook):
+- MCP server clears the primary state file (dispatcher-claude-session-id) on startup
+- write-dispatcher-session-id.py may skip writing the tertiary file when the
+  previous JSONL has a recent mtime
+- is_dispatcher() finds no matching file and returns False
+- inject-bootup-context.py injects subagent bootup instead of dispatcher bootup
+
+Fix: add _is_fresh_start_dispatcher() as a fallback. Absent primary file +
+LOBSTER_MAIN_SESSION=1 → treat as dispatcher. This is safe because:
+- subagents are spawned only after the dispatcher has called session_start(),
+  which writes the primary file
+- compactions are handled by the existing _is_post_compact_dispatcher()
+  sentinel fallback (on-compact.py writes the primary file proactively)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "inject-bootup-context.py"
+
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _PatchEnv:
+    """Context manager to temporarily set / restore environment variables."""
+
+    def __init__(self, env: dict):
+        self._env = env
+        self._saved: dict = {}
+
+    def __enter__(self):
+        for k, v in self._env.items():
+            self._saved[k] = os.environ.get(k)
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        return self
+
+    def __exit__(self, *_):
+        for k, saved_v in self._saved.items():
+            if saved_v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = saved_v
+
+
+def _load_inject_hook(
+    *,
+    home: Path,
+    workspace: Path,
+    lobster_main_session: str | None = "1",
+) -> object:
+    """Load inject-bootup-context.py in a controlled environment.
+
+    Returns the loaded module. Paths are set at import time via env vars.
+    Callers can override module-level path constants after loading.
+    """
+    import uuid as _uuid
+
+    env: dict = {
+        "HOME": str(home),
+        "LOBSTER_WORKSPACE": str(workspace),
+    }
+    if lobster_main_session is None:
+        env["LOBSTER_MAIN_SESSION"] = None  # remove from env
+    else:
+        env["LOBSTER_MAIN_SESSION"] = lobster_main_session
+
+    unique_name = f"inject_bootup_{_uuid.uuid4().hex}"
+    with _PatchEnv(env):
+        spec = importlib.util.spec_from_file_location(unique_name, _HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_bootup_files(claude_dir: Path) -> tuple[Path, Path]:
+    """Write minimal dispatcher and subagent bootup stubs."""
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    dispatcher_bootup = claude_dir / "sys.dispatcher.bootup.md"
+    subagent_bootup = claude_dir / "sys.subagent.bootup.md"
+    dispatcher_bootup.write_text("# DISPATCHER BOOTUP\n")
+    subagent_bootup.write_text("# SUBAGENT BOOTUP\n")
+    return dispatcher_bootup, subagent_bootup
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _is_fresh_start_dispatcher()
+# ---------------------------------------------------------------------------
+
+
+class TestIsFreshStartDispatcher:
+    """Unit tests for the _is_fresh_start_dispatcher() helper in inject-bootup-context.py."""
+
+    def test_returns_true_when_primary_file_absent_and_main_session(
+        self, tmp_path, monkeypatch
+    ):
+        """Primary file absent + LOBSTER_MAIN_SESSION=1 → fresh dispatcher start."""
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True)
+        absent_primary = data_dir / "dispatcher-claude-session-id"
+        # File does NOT exist
+
+        mod = _load_inject_hook(home=tmp_path, workspace=tmp_path)
+        import session_role as sr
+
+        with patch.object(sr, "_get_mcp_claude_session_file", return_value=absent_primary):
+            result = mod._is_fresh_start_dispatcher()
+
+        assert result is True
+
+    def test_returns_false_when_primary_file_present(self, tmp_path, monkeypatch):
+        """Primary file present → dispatcher already called session_start, not a fresh boot."""
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True)
+        primary_file = data_dir / "dispatcher-claude-session-id"
+        primary_file.write_text("some-session-uuid-1234")
+
+        mod = _load_inject_hook(home=tmp_path, workspace=tmp_path)
+        import session_role as sr
+
+        with patch.object(sr, "_get_mcp_claude_session_file", return_value=primary_file):
+            result = mod._is_fresh_start_dispatcher()
+
+        assert result is False
+
+    def test_returns_false_when_main_session_not_set(self, tmp_path, monkeypatch):
+        """LOBSTER_MAIN_SESSION not set → not a Lobster-managed session, return False."""
+        monkeypatch.delenv("LOBSTER_MAIN_SESSION", raising=False)
+
+        mod = _load_inject_hook(
+            home=tmp_path, workspace=tmp_path, lobster_main_session=None
+        )
+        result = mod._is_fresh_start_dispatcher()
+
+        assert result is False
+
+    def test_returns_false_when_main_session_is_zero(self, tmp_path, monkeypatch):
+        """LOBSTER_MAIN_SESSION=0 → return False."""
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "0")
+
+        mod = _load_inject_hook(
+            home=tmp_path, workspace=tmp_path, lobster_main_session="0"
+        )
+        result = mod._is_fresh_start_dispatcher()
+
+        assert result is False
+
+    def test_returns_false_on_oserror_stat(self, tmp_path, monkeypatch):
+        """OSError when checking primary file existence → return False (safe default)."""
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+
+        mod = _load_inject_hook(home=tmp_path, workspace=tmp_path)
+
+        mock_path = MagicMock(spec=Path)
+        mock_path.exists.side_effect = OSError("permission denied")
+
+        import session_role as sr
+
+        with patch.object(sr, "_get_mcp_claude_session_file", return_value=mock_path):
+            result = mod._is_fresh_start_dispatcher()
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: main() uses fresh-start fallback to inject dispatcher bootup
+# ---------------------------------------------------------------------------
+
+
+class TestMainFreshStartFallback:
+    """main() uses the fresh-start fallback to inject dispatcher bootup on fresh restarts."""
+
+    def test_fresh_start_fallback_injects_dispatcher_bootup(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Issue #1868 regression test: dispatcher gets dispatcher bootup on fresh restart.
+
+        Simulates the failure mode:
+        - write-dispatcher-session-id.py skips updating the tertiary file
+          (old JSONL has recent mtime), so tertiary file has the wrong UUID
+        - Primary file is absent (MCP server cleared it on startup)
+        - is_dispatcher() returns False
+        - compact-pending sentinel is absent (fresh restart, not compaction)
+        - _is_fresh_start_dispatcher() must detect this and return True
+        """
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+
+        # Set up bootup files in tmp structure
+        claude_dir = tmp_path / "lobster" / ".claude"
+        dispatcher_bootup, _ = _make_bootup_files(claude_dir)
+
+        # Primary file absent (MCP cleared it)
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True)
+        # No dispatcher-claude-session-id file
+
+        # Tertiary file has wrong (stale) UUID — so is_dispatcher() returns False
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "dispatcher-session-id").write_text("stale-old-uuid-from-dead-session")
+        # No compact-pending sentinel (this is a fresh restart, not a compaction)
+
+        hook_input = json.dumps({"session_id": "brand-new-dispatcher-uuid-5678"})
+
+        with _PatchEnv(
+            {
+                "HOME": str(tmp_path),
+                "LOBSTER_WORKSPACE": str(tmp_path),
+                "LOBSTER_MAIN_SESSION": "1",
+            }
+        ):
+            spec = importlib.util.spec_from_file_location(
+                "inject_fresh_start_test", _HOOK_PATH
+            )
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+
+            mod.DISPATCHER_BOOTUP = dispatcher_bootup
+            # No compact-pending sentinel
+            mod.COMPACT_PENDING_SENTINEL = tmp_path / "no-sentinel"
+            # Suppress user config files
+            mod.USER_CONFIG_DIR = tmp_path / "no-user-config"
+            mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+            mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+            mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+
+            with patch("sys.stdin", io.StringIO(hook_input)):
+                with pytest.raises(SystemExit):
+                    mod.main()
+
+        captured = capsys.readouterr()
+        assert "DISPATCHER BOOTUP" in captured.out, (
+            "Dispatcher bootup must be injected on fresh start even when "
+            "is_dispatcher() returns False and the compact-pending sentinel is absent"
+        )
+        assert "SUBAGENT BOOTUP" not in captured.out
+
+    def test_subagent_gets_subagent_bootup_when_primary_file_present(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """When the primary file is present, a non-matching session is a subagent.
+
+        The dispatcher has already called session_start() (writing the primary file),
+        so any session whose UUID does not match must be a subagent. The fresh-start
+        fallback must NOT fire.
+        """
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+
+        claude_dir = tmp_path / "lobster" / ".claude"
+        _, subagent_bootup = _make_bootup_files(claude_dir)
+
+        # Primary file present (dispatcher already started and called session_start)
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True)
+        (data_dir / "dispatcher-claude-session-id").write_text(
+            "dispatcher-uuid-already-registered"
+        )
+
+        # No sentinel
+        (tmp_path / "messages" / "config").mkdir(parents=True, exist_ok=True)
+
+        hook_input = json.dumps({"session_id": "subagent-uuid-different-from-dispatcher"})
+
+        with _PatchEnv(
+            {
+                "HOME": str(tmp_path),
+                "LOBSTER_WORKSPACE": str(tmp_path),
+                "LOBSTER_MAIN_SESSION": "1",
+            }
+        ):
+            spec = importlib.util.spec_from_file_location(
+                "inject_subagent_primary_present_test", _HOOK_PATH
+            )
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+
+            mod.SUBAGENT_BOOTUP = subagent_bootup
+            mod.COMPACT_PENDING_SENTINEL = tmp_path / "no-sentinel"
+            mod.USER_CONFIG_DIR = tmp_path / "no-user-config"
+            mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+            mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+            mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+
+            with patch("sys.stdin", io.StringIO(hook_input)):
+                with pytest.raises(SystemExit):
+                    mod.main()
+
+        captured = capsys.readouterr()
+        assert "SUBAGENT BOOTUP" in captured.out, (
+            "Subagent bootup must be injected when the primary file is present "
+            "and the session UUID does not match the dispatcher"
+        )
+        assert "DISPATCHER BOOTUP" not in captured.out
+
+    def test_fresh_start_fallback_does_not_fire_for_outside_lobster_sessions(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """LOBSTER_MAIN_SESSION not set → fresh-start fallback inactive, subagent bootup injected."""
+        monkeypatch.delenv("LOBSTER_MAIN_SESSION", raising=False)
+
+        claude_dir = tmp_path / "lobster" / ".claude"
+        _, subagent_bootup = _make_bootup_files(claude_dir)
+
+        # Primary file absent AND no sentinel — but not a Lobster-managed session
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "messages" / "config").mkdir(parents=True, exist_ok=True)
+
+        hook_input = json.dumps({"session_id": "some-external-session-uuid"})
+
+        with _PatchEnv(
+            {
+                "HOME": str(tmp_path),
+                "LOBSTER_WORKSPACE": str(tmp_path),
+                "LOBSTER_MAIN_SESSION": None,  # unset
+            }
+        ):
+            spec = importlib.util.spec_from_file_location(
+                "inject_external_session_test", _HOOK_PATH
+            )
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+
+            mod.SUBAGENT_BOOTUP = subagent_bootup
+            mod.COMPACT_PENDING_SENTINEL = tmp_path / "no-sentinel"
+            mod.USER_CONFIG_DIR = tmp_path / "no-user-config"
+            mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+            mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+            mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+
+            with patch("sys.stdin", io.StringIO(hook_input)):
+                with pytest.raises(SystemExit):
+                    mod.main()
+
+        captured = capsys.readouterr()
+        assert "SUBAGENT BOOTUP" in captured.out, (
+            "External (non-Lobster) sessions must get subagent bootup regardless "
+            "of the primary file state"
+        )
+        assert "DISPATCHER BOOTUP" not in captured.out
+
+    def test_primary_file_match_still_injects_dispatcher_without_fallback(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Happy path: primary file matches session UUID → dispatcher bootup, no fallback needed."""
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+
+        claude_dir = tmp_path / "lobster" / ".claude"
+        dispatcher_bootup, _ = _make_bootup_files(claude_dir)
+
+        dispatcher_uuid = "known-dispatcher-uuid-abc123"
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True)
+        (data_dir / "dispatcher-claude-session-id").write_text(dispatcher_uuid)
+
+        (tmp_path / "messages" / "config").mkdir(parents=True, exist_ok=True)
+
+        hook_input = json.dumps({"session_id": dispatcher_uuid})
+
+        with _PatchEnv(
+            {
+                "HOME": str(tmp_path),
+                "LOBSTER_WORKSPACE": str(tmp_path),
+                "LOBSTER_MAIN_SESSION": "1",
+            }
+        ):
+            spec = importlib.util.spec_from_file_location(
+                "inject_primary_match_test", _HOOK_PATH
+            )
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+
+            mod.DISPATCHER_BOOTUP = dispatcher_bootup
+            mod.COMPACT_PENDING_SENTINEL = tmp_path / "no-sentinel"
+            mod.USER_CONFIG_DIR = tmp_path / "no-user-config"
+            mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+            mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+            mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+
+            with patch("sys.stdin", io.StringIO(hook_input)):
+                with pytest.raises(SystemExit):
+                    mod.main()
+
+        captured = capsys.readouterr()
+        assert "DISPATCHER BOOTUP" in captured.out
+        assert "SUBAGENT BOOTUP" not in captured.out

--- a/tests/unit/test_hooks/test_inject_bootup_context_sentinel.py
+++ b/tests/unit/test_hooks/test_inject_bootup_context_sentinel.py
@@ -218,14 +218,29 @@ class TestMainSentinelFallback:
         )
         assert "SUBAGENT BOOTUP" not in captured.out
 
-    def test_no_sentinel_normal_subagent_gets_subagent_bootup(self, tmp_path, capsys):
-        """Without sentinel, an unrecognised session gets subagent bootup (normal path)."""
+    def test_no_sentinel_subagent_with_primary_file_present_gets_subagent_bootup(
+        self, tmp_path, capsys
+    ):
+        """Without sentinel, a non-matching session gets subagent bootup when primary file is present.
+
+        A real subagent session starts only after the dispatcher has already called
+        session_start(), which writes the primary state file (dispatcher-claude-session-id).
+        The subagent's UUID does not match the stored dispatcher UUID, so it correctly
+        receives subagent bootup.
+
+        Note: if the primary file were absent, the fresh-start fallback (#1868) would
+        treat the session as a fresh-restart dispatcher.  That scenario is tested in
+        test_inject_bootup_context_fresh_start.py.
+        """
         claude_dir = tmp_path / "lobster" / ".claude"
         claude_dir.mkdir(parents=True)
         _, subagent_bootup = self._make_bootup_files(claude_dir)
 
-        # No sentinel, no dispatcher session files.
-        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+        # Primary file present (dispatcher wrote it before spawning subagents).
+        # The subagent's UUID differs from the stored dispatcher UUID.
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (data_dir / "dispatcher-claude-session-id").write_text("dispatcher-uuid-abc")
 
         hook_input = json.dumps({"session_id": "random-subagent-uuid"})
 
@@ -255,7 +270,8 @@ class TestMainSentinelFallback:
 
         captured = capsys.readouterr()
         assert "SUBAGENT BOOTUP" in captured.out, (
-            "Subagent bootup should be injected for unrecognised session without sentinel"
+            "Subagent bootup should be injected when primary file is present "
+            "and the session UUID does not match the stored dispatcher UUID"
         )
         assert "DISPATCHER BOOTUP" not in captured.out
 


### PR DESCRIPTION
## What broke and why

PR #1891 (context injection logging) was developed on a branch forked before PR #1869 merged. When #1891 was deployed to local-dev (commit `a001527b` / `1c3f3065`), it overwrote `hooks/inject-bootup-context.py` with a version that pre-dates `449495ce`. The `_is_fresh_start_dispatcher()` function and its fallback call in `main()` — added by #1869 to fix issue #1868 — were silently removed.

**Result:** On every cold restart, the primary state file (`dispatcher-claude-session-id`) is absent until the dispatcher calls `session_start()`. Without the fallback, `is_dispatcher()` returns False and the dispatcher receives subagent bootup instead of dispatcher bootup.

## What this PR does

Re-adds the `_is_fresh_start_dispatcher()` function and its invocation in `main()` from commit `449495ce`. The fallback logic:
- If `LOBSTER_MAIN_SESSION=1` AND the primary state file does not exist → treat session as dispatcher
- This covers the pre-`session_start` window that only exists during a genuine fresh restart
- Subagents cannot trigger it: they start only after the dispatcher calls `session_start()`, which writes the primary file
- Compaction events are also safe: `on-compact.py` writes the primary file proactively before the post-compact SessionStart fires

The module docstring is updated to document both fallback paths (post-compact sentinel and fresh-start).

## Tests

Adds `tests/unit/test_hooks/test_inject_bootup_context_fresh_start.py` with 9 tests:

**`TestIsFreshStartDispatcher` (5 tests):**
- Primary file absent + `LOBSTER_MAIN_SESSION=1` → True (the fix)
- Primary file present → False (normal subagent case)
- `LOBSTER_MAIN_SESSION` not set → False (non-Lobster session)
- `LOBSTER_MAIN_SESSION=0` → False
- `OSError` on stat → False (safe default)

**`TestMainFreshStartFallback` (4 tests):**
- Issue #1868 regression test: fresh restart → dispatcher bootup injected
- Primary file present, UUID mismatch → subagent bootup
- `LOBSTER_MAIN_SESSION` not set → subagent bootup
- Primary file UUID match → dispatcher bootup (no fallback needed)

Also updates one pre-existing test in `test_inject_bootup_context_sentinel.py` whose premise described the now-fixed broken behaviour (absent primary file + `LOBSTER_MAIN_SESSION=1` was incorrectly expected to yield subagent bootup). The test is updated to use a present primary file, reflecting the actual subagent scenario.

**Functional pattern:** The fix uses pure predicate functions (`_is_fresh_start_dispatcher`, `_is_post_compact_dispatcher`) composed sequentially in `main()` — each responsible for one detection path, no shared mutable state.

## Before/after flow

```
Before (broken, post-#1891 deploy):
  SessionStart fires
  → is_dispatcher() checks primary file → absent → False
  → _is_post_compact_dispatcher() → no sentinel → False
  → [ _is_fresh_start_dispatcher() MISSING ]
  → inject subagent bootup  ← WRONG for dispatcher

After (fixed):
  SessionStart fires
  → is_dispatcher() checks primary file → absent → False
  → _is_post_compact_dispatcher() → no sentinel → False
  → _is_fresh_start_dispatcher() → absent + LOBSTER_MAIN_SESSION=1 → True
  → inject dispatcher bootup  ← CORRECT
```

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_inject_bootup_context_fresh_start.py -v` — 9 passed, 0 failed
- [x] `uv run pytest tests/unit/test_hooks/test_inject_bootup_context_sentinel.py -v` — 9 passed, 0 failed (including updated test)
- [x] `uv run pytest tests/unit/test_hooks/ -v --tb=short` — 324 passed, 7 failed (all 7 failures are pre-existing on `main`, unrelated to this change: 6 in `test_require_background_agent.py` and 1 in `test_require_write_result.py`)

## Manual test

N/A — this change is a hook logic fix. No external services, no file I/O affecting runtime state beyond the hook itself. The hook fires during SessionStart which cannot be triggered as a manual test in this environment without a real restart.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (hook fires on SessionStart only, covered by unit tests)
- [x] User-visible outcome verified — N/A (this is internal hook logic; correctness verified by unit tests covering all three detection paths)
- [x] Side-effect audit complete: no floods, no writes to shared state, no volume changes
- [x] External service calls: none

Closes #1898