### PR TITLE
fix(health-check): scope dispatcher heartbeat writes to dispatcher session only

### DIFF
--- a/hooks/pre-tool-heartbeat.py
+++ b/hooks/pre-tool-heartbeat.py
@@ -2,9 +2,9 @@
 """
 PreToolUse hook: dispatcher pre-tool heartbeat.
 
-Writes the current Unix epoch timestamp to a dedicated heartbeat file on every
-PreToolUse event. This complements thinking-heartbeat.py (PostToolUse) and narrows
-the detection window for inference-gap cases (issue #1695).
+Writes the current Unix epoch timestamp to a dedicated heartbeat file when the
+current session is the dispatcher. Subagent tool calls are silently ignored so
+they cannot keep the health check satisfied while the dispatcher is frozen or dead.
 
 Purpose
 -------
@@ -26,24 +26,46 @@ threshold (currently 1200s) risks false positives during legitimate long tool ca
 The pre-tool heartbeat lets us reduce that threshold safely — it confirms the
 dispatcher called the tool even if post-tool hasn't fired yet.
 
+Dispatcher-only guard (issue #1897):
+- PreToolUse fires for ALL sessions sharing the same Claude Code process,
+  including background subagents. Without this guard, a subagent doing heavy
+  tool work can keep the heartbeat fresh even if the dispatcher is dead.
+- The guard uses is_dispatcher_session() which checks: (0) agent_id fast path
+  (subagents always have agent_id in PreToolUse payloads), (1) MCP Claude UUID
+  state file, (2) hook marker file (dispatcher-session-id), (3) process-tree
+  walk as a last resort. All three state-file paths are written by the SessionStart
+  hook that fires for both claude-persistent.sh and claude-interactive.exp launchers.
+- Launcher-agnostic: works whether Lobster is started via claude-interactive.exp
+  or claude-persistent.sh.
+
 Design
 ------
 - Fires on every PreToolUse (matcher: "")
+- Guards on dispatcher session: reads hook input from stdin and calls
+  is_dispatcher_session(). Subagent calls exit 0 immediately without file I/O.
 - Atomic write: write to .tmp, then os.rename() to avoid partial reads
 - Single integer timestamp — no JSON parsing, no locking, no network
 - Silent on failure: health check degrades gracefully when file absent
 - < 1ms on warm OS (rename is a kernel atomic op on same-filesystem paths)
 
 File location: ~/lobster-workspace/logs/dispatcher-pre-tool-heartbeat
-Content: single Unix epoch integer (e.g. "1713456789\\n")
+Content: single Unix epoch integer (e.g. "1713456789\n")
 
-See issue #1786 (thinking-freeze mitigations) and #1695 (inference-gap detection).
+See issue #1786 (thinking-freeze mitigations) and #1695 (inference-gap detection),
+and #1897 (subagent-masking fix).
 """
 
+import json
 import os
 import sys
 import time
 from pathlib import Path
+
+# Allow imports from the hooks directory (session_role).
+_HOOKS_DIR = Path(__file__).parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import session_role  # noqa: E402 — path insert must precede this
 
 
 WORKSPACE_DIR = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
@@ -64,6 +86,20 @@ def write_heartbeat(heartbeat_file: Path) -> None:
 
 
 def main() -> None:
+    # Read hook input from stdin (provided by Claude Code on every PreToolUse).
+    # If stdin is empty or unparseable, treat as unknown session — skip heartbeat
+    # (conservative: better to miss one update than to falsely extend it for a subagent).
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        sys.exit(0)
+
+    # Guard: only write the heartbeat for the dispatcher session.
+    # is_dispatcher_session() uses: agent_id fast path (subagents always have it
+    # in PreToolUse payloads) → MCP state files → hook marker file → process-tree.
+    if not session_role.is_dispatcher_session(hook_input):
+        sys.exit(0)
+
     try:
         write_heartbeat(HEARTBEAT_FILE)
     except Exception:

--- a/hooks/thinking-heartbeat.py
+++ b/hooks/thinking-heartbeat.py
@@ -2,9 +2,9 @@
 """
 PostToolUse hook: dispatcher heartbeat.
 
-Writes the current Unix epoch timestamp to a single heartbeat file on every
-PostToolUse event. The health check reads this file to determine whether the
-dispatcher is alive.
+Writes the current Unix epoch timestamp to a single heartbeat file when the
+current session is the dispatcher. Subagent tool calls are silently ignored so
+they cannot keep the health check satisfied while the dispatcher is frozen or dead.
 
 Purpose: the dispatcher can spend 10+ minutes in a reasoning/catchup phase
 without touching wait_for_messages. Any tool call at all means the dispatcher
@@ -13,23 +13,44 @@ a single file containing a single integer (epoch seconds).
 
 Design:
 - Fires on every PostToolUse (no tool-name filtering needed)
+- Guards on dispatcher session: reads hook input from stdin, checks session_id
+  against the stored dispatcher session ID. Subagent calls exit 0 immediately.
 - Atomic write: write to .tmp, then os.rename() to avoid partial reads
 - Single integer timestamp — no JSON parsing, no merging, no state file locking
 - Silent on failure: health check degrades gracefully when file is absent
 - Threshold-based: the health check uses a 20-minute window that naturally
   covers compaction, catchup, and boot transitions without any suppression logic
 
+Dispatcher-only guard (issue #1897):
+- PostToolUse fires for ALL sessions sharing the same Claude Code process,
+  including background subagents. Without this guard, a subagent doing heavy
+  tool work can keep the heartbeat fresh even if the dispatcher is dead.
+- The guard reads hook_input["session_id"] and compares it against the
+  dispatcher-session-id file written by write-dispatcher-session-id.py at
+  dispatcher startup (SessionStart hook). If the session IDs do not match,
+  the current caller is a subagent and the heartbeat write is skipped.
+- Launcher-agnostic: works whether Lobster is started via claude-interactive.exp
+  or claude-persistent.sh, because both launchers trigger the same SessionStart
+  hook that writes the dispatcher session ID file.
+
 File location: ~/lobster-workspace/logs/dispatcher-heartbeat
 Content: single Unix epoch integer (e.g. "1713456789\n")
 
 Replaces the multi-signal approach (claude-heartbeat file + last_processed_at +
 last_thinking_at in lobster-state.json) with a single authoritative signal.
-See issue #1483.
+See issue #1483, #1897.
 """
 
+import json
 import os
 import sys
 from pathlib import Path
+
+# Allow imports from the hooks directory (session_role).
+_HOOKS_DIR = Path(__file__).parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import session_role  # noqa: E402 — path insert must precede this
 
 
 WORKSPACE_DIR = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
@@ -55,6 +76,21 @@ def write_heartbeat(heartbeat_file: Path) -> None:
 
 
 def main() -> None:
+    # Read hook input from stdin (provided by Claude Code on every PostToolUse).
+    # If stdin is empty or unparseable, treat as unknown session — skip heartbeat
+    # (conservative: better to miss one update than to falsely extend it for a subagent).
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        sys.exit(0)
+
+    # Guard: only write the heartbeat for the dispatcher session.
+    # is_dispatcher() compares hook_input["session_id"] against the stored
+    # dispatcher session ID file. Returns False for subagents and when the
+    # session ID is unavailable. Fails open (returns True) on I/O errors.
+    if not session_role.is_dispatcher(hook_input):
+        sys.exit(0)
+
     try:
         write_heartbeat(HEARTBEAT_FILE)
     except Exception:

--- a/tests/unit/test_hooks/test_pre_tool_heartbeat.py
+++ b/tests/unit/test_hooks/test_pre_tool_heartbeat.py
@@ -1,22 +1,32 @@
 """
 Unit tests for hooks/pre-tool-heartbeat.py
 
-Tests cover the PreToolUse heartbeat hook (issue #1786):
+Tests cover the PreToolUse heartbeat hook (issue #1786) and the
+dispatcher-only guard (issue #1897):
 - write_heartbeat() writes a Unix epoch integer to the heartbeat file
 - Atomic write: uses .tmp then rename, no .tmp left behind
 - Creates parent directory if absent
 - Overwrites existing content on each call
 - Timestamp is within a small window of time.time()
-- main() exits 0 on success
+- main() exits 0 on success (dispatcher session)
+- main() exits 0 without writing when called from a subagent session
 - main() exits 0 even when write fails (silent failure — never block tool use)
 - LOBSTER_PRE_TOOL_HEARTBEAT_OVERRIDE env var is respected
 - Written to a DIFFERENT file than the PostToolUse heartbeat
+- Subagent tool calls do NOT update the pre-tool heartbeat (issue #1897)
 
 The hook is intentionally symmetric with thinking-heartbeat.py (PostToolUse)
 but writes to dispatcher-pre-tool-heartbeat instead of dispatcher-heartbeat.
+
+Dispatcher-only guard (issue #1897):
+- Hooks now read stdin and call session_role.is_dispatcher_session() before writing.
+- Tests exercise: dispatcher writes, subagent skips, unknown-session skips.
+- agent_id fast path: subagents always have agent_id in PreToolUse payloads;
+  the hook exits 0 immediately without file I/O.
 """
 
 import importlib.util
+import json
 import os
 import sys
 import tempfile
@@ -33,19 +43,15 @@ HOOK_PATH = _HOOKS_DIR / "pre-tool-heartbeat.py"
 # How close (in seconds) the written timestamp must be to now.
 TIMESTAMP_TOLERANCE_SECONDS = 5
 
+# Fake session IDs used in tests.
+DISPATCHER_SESSION_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+SUBAGENT_SESSION_ID = "11111111-2222-3333-4444-555555555555"
+SUBAGENT_AGENT_ID = "agent-xyz-123"
+
 
 # ---------------------------------------------------------------------------
-# Module loader
+# Module loader helpers
 # ---------------------------------------------------------------------------
-
-def _load_module(monkeypatch, heartbeat_file: Path):
-    """Load pre-tool-heartbeat as a fresh module with heartbeat file override."""
-    monkeypatch.setenv("LOBSTER_PRE_TOOL_HEARTBEAT_OVERRIDE", str(heartbeat_file))
-    spec = importlib.util.spec_from_file_location("pre_tool_heartbeat", HOOK_PATH)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
 
 def _load_raw():
     """Load module without any env override (uses default paths internally)."""
@@ -53,6 +59,54 @@ def _load_raw():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+def _run_hook_with_input(
+    monkeypatch,
+    heartbeat_file: Path,
+    hook_input: dict,
+    is_dispatcher_session_return: bool = True,
+) -> tuple[int, str, str]:
+    """Execute the hook's main() with a given hook input dict and mocked is_dispatcher_session.
+
+    Mocks session_role.is_dispatcher_session to return is_dispatcher_session_return
+    so tests don't depend on filesystem state (dispatcher-session-id files).
+    """
+    monkeypatch.setenv("LOBSTER_PRE_TOOL_HEARTBEAT_OVERRIDE", str(heartbeat_file))
+
+    stdin_content = json.dumps(hook_input)
+
+    spec = importlib.util.spec_from_file_location("pre_tool_heartbeat", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+
+    stdout_cap = StringIO()
+    stderr_cap = StringIO()
+    exit_code = None
+
+    with (
+        patch("sys.stdout", stdout_cap),
+        patch("sys.stderr", stderr_cap),
+        patch("sys.stdin", StringIO(stdin_content)),
+    ):
+        try:
+            spec.loader.exec_module(mod)
+            # Patch is_dispatcher_session on the loaded module's session_role reference.
+            mod.session_role.is_dispatcher_session = lambda _: is_dispatcher_session_return
+            mod.main()
+        except SystemExit as e:
+            exit_code = e.code
+
+    return exit_code, stdout_cap.getvalue(), stderr_cap.getvalue()
+
+
+def _run_hook(monkeypatch, heartbeat_file: Path) -> tuple[int, str, str]:
+    """Run hook as the dispatcher (is_dispatcher_session returns True)."""
+    return _run_hook_with_input(
+        monkeypatch,
+        heartbeat_file,
+        hook_input={"session_id": DISPATCHER_SESSION_ID},
+        is_dispatcher_session_return=True,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -148,37 +202,14 @@ class TestHeartbeatFileSeparation:
 # Hook main() integration tests
 # ---------------------------------------------------------------------------
 
-def _run_hook(monkeypatch, heartbeat_file: Path) -> tuple[int, str, str]:
-    """Execute the hook's main() capturing exit code and stdio."""
-    monkeypatch.setenv("LOBSTER_PRE_TOOL_HEARTBEAT_OVERRIDE", str(heartbeat_file))
-
-    spec = importlib.util.spec_from_file_location("pre_tool_heartbeat", HOOK_PATH)
-    mod = importlib.util.module_from_spec(spec)
-
-    stdout_cap = StringIO()
-    stderr_cap = StringIO()
-
-    exit_code = None
-    with (
-        patch("sys.stdout", stdout_cap),
-        patch("sys.stderr", stderr_cap),
-    ):
-        try:
-            spec.loader.exec_module(mod)
-            mod.main()
-        except SystemExit as e:
-            exit_code = e.code
-
-    return exit_code, stdout_cap.getvalue(), stderr_cap.getvalue()
-
-
 class TestHookMain:
     def test_exits_zero_on_success(self, monkeypatch, tmp_path):
         hb = tmp_path / "dispatcher-pre-tool-heartbeat"
         code, _, _ = _run_hook(monkeypatch, hb)
         assert code == 0
 
-    def test_writes_heartbeat_on_success(self, monkeypatch, tmp_path):
+    def test_writes_heartbeat_when_dispatcher(self, monkeypatch, tmp_path):
+        """Heartbeat is written when the session is the dispatcher."""
         hb = tmp_path / "dispatcher-pre-tool-heartbeat"
         _run_hook(monkeypatch, hb)
         assert hb.exists()
@@ -216,3 +247,138 @@ class TestHookMain:
         hb = tmp_path / "dispatcher-pre-tool-heartbeat"
         _, _, stderr = _run_hook(monkeypatch, hb)
         assert stderr == ""
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher-only guard: subagent calls must NOT update the heartbeat
+# ---------------------------------------------------------------------------
+
+# Named constant from the spec (issue #1897): subagent activity masks dispatcher death.
+# The fix: heartbeat is only written when is_dispatcher_session() returns True.
+SUBAGENT_MUST_NOT_WRITE_HEARTBEAT = True
+
+
+class TestDispatcherOnlyGuard:
+    """Issue #1897: subagent tool calls must NOT update the pre-tool dispatcher heartbeat."""
+
+    def test_subagent_session_does_not_write_heartbeat(self, monkeypatch, tmp_path):
+        """When is_dispatcher_session returns False, heartbeat file is not created."""
+        hb = tmp_path / "dispatcher-pre-tool-heartbeat"
+        code, _, _ = _run_hook_with_input(
+            monkeypatch,
+            hb,
+            hook_input={"session_id": SUBAGENT_SESSION_ID},
+            is_dispatcher_session_return=False,
+        )
+        assert code == 0
+        assert not hb.exists(), (
+            "Subagent tool calls must not update the pre-tool heartbeat (issue #1897)"
+        )
+
+    def test_subagent_with_agent_id_does_not_write_heartbeat(self, monkeypatch, tmp_path):
+        """Subagent payloads include agent_id — hook must skip without file I/O.
+
+        The agent_id fast path in is_dispatcher_session() handles this, but
+        we verify the end-to-end behavior: any PreToolUse payload with agent_id
+        must not produce a heartbeat write.
+        """
+        hb = tmp_path / "dispatcher-pre-tool-heartbeat"
+        code, _, _ = _run_hook_with_input(
+            monkeypatch,
+            hb,
+            hook_input={
+                "session_id": SUBAGENT_SESSION_ID,
+                "agent_id": SUBAGENT_AGENT_ID,
+                "tool_name": "Bash",
+            },
+            is_dispatcher_session_return=False,
+        )
+        assert code == 0
+        assert not hb.exists(), (
+            "Subagent PreToolUse with agent_id must not write pre-tool heartbeat"
+        )
+
+    def test_subagent_does_not_overwrite_existing_heartbeat(self, monkeypatch, tmp_path):
+        """An existing heartbeat written by the dispatcher is not touched by subagent calls."""
+        hb = tmp_path / "dispatcher-pre-tool-heartbeat"
+        old_ts = 1700000000
+        hb.write_text(str(old_ts) + "\n")
+
+        code, _, _ = _run_hook_with_input(
+            monkeypatch,
+            hb,
+            hook_input={"session_id": SUBAGENT_SESSION_ID},
+            is_dispatcher_session_return=False,
+        )
+        assert code == 0
+        # File content must be unchanged.
+        assert int(hb.read_text().strip()) == old_ts, (
+            "Subagent call must not overwrite existing pre-tool heartbeat"
+        )
+
+    def test_dispatcher_session_writes_heartbeat(self, monkeypatch, tmp_path):
+        """When is_dispatcher_session returns True, the heartbeat IS written."""
+        hb = tmp_path / "dispatcher-pre-tool-heartbeat"
+        before = int(time.time())
+        _run_hook_with_input(
+            monkeypatch,
+            hb,
+            hook_input={"session_id": DISPATCHER_SESSION_ID},
+            is_dispatcher_session_return=True,
+        )
+        after = int(time.time())
+        assert hb.exists()
+        ts = int(hb.read_text().strip())
+        assert before <= ts <= after + 1
+
+    def test_empty_stdin_does_not_write_heartbeat(self, monkeypatch, tmp_path):
+        """When stdin is empty (unparseable JSON), no heartbeat is written (conservative)."""
+        hb = tmp_path / "dispatcher-pre-tool-heartbeat"
+        monkeypatch.setenv("LOBSTER_PRE_TOOL_HEARTBEAT_OVERRIDE", str(hb))
+
+        spec = importlib.util.spec_from_file_location("pre_tool_heartbeat", HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        exit_code = None
+
+        with patch("sys.stdin", StringIO("")):
+            try:
+                spec.loader.exec_module(mod)
+                mod.main()
+            except SystemExit as e:
+                exit_code = e.code
+
+        assert exit_code == 0
+        assert not hb.exists(), (
+            "Empty stdin must not write the heartbeat (conservative: unknown session = skip)"
+        )
+
+    def test_invalid_json_stdin_does_not_write_heartbeat(self, monkeypatch, tmp_path):
+        """When stdin contains invalid JSON, no heartbeat is written."""
+        hb = tmp_path / "dispatcher-pre-tool-heartbeat"
+        monkeypatch.setenv("LOBSTER_PRE_TOOL_HEARTBEAT_OVERRIDE", str(hb))
+
+        spec = importlib.util.spec_from_file_location("pre_tool_heartbeat", HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        exit_code = None
+
+        with patch("sys.stdin", StringIO("not valid json {")):
+            try:
+                spec.loader.exec_module(mod)
+                mod.main()
+            except SystemExit as e:
+                exit_code = e.code
+
+        assert exit_code == 0
+        assert not hb.exists()
+
+    def test_exits_zero_regardless_of_session_type(self, monkeypatch, tmp_path):
+        """Hook always exits 0, whether dispatcher or subagent (never blocks tool execution)."""
+        for is_disp in (True, False):
+            hb_i = tmp_path / f"heartbeat-{is_disp}"
+            code, _, _ = _run_hook_with_input(
+                monkeypatch,
+                hb_i,
+                hook_input={"session_id": DISPATCHER_SESSION_ID},
+                is_dispatcher_session_return=is_disp,
+            )
+            assert code == 0, f"Hook must exit 0 for is_dispatcher_session={is_disp}"

--- a/tests/unit/test_hooks/test_thinking_heartbeat.py
+++ b/tests/unit/test_hooks/test_thinking_heartbeat.py
@@ -1,23 +1,31 @@
 """
 Unit tests for hooks/thinking-heartbeat.py
 
-Tests cover the simplified sentinel design (issue #1483):
+Tests cover the simplified sentinel design (issue #1483) and the
+dispatcher-only guard (issue #1897):
 - write_heartbeat() writes a Unix epoch integer to the heartbeat file
 - Atomic write: uses .tmp then rename, no .tmp left behind
 - Creates parent directory if absent
 - Overwrites existing content on each call
 - Timestamp is within a small window of time.time()
-- main() exits 0 on success
+- main() exits 0 on success (dispatcher session)
+- main() exits 0 without writing when called from a subagent session
 - main() exits 0 even when write fails (silent failure — never block tool use)
 - LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE env var is respected
+- Subagent tool calls do NOT update the heartbeat (issue #1897)
 
 Design change from the original (lobster-state.json merge):
 - No JSON parsing or merging
 - Single integer epoch value, not ISO timestamp
 - Single file — no other state touched
+
+Dispatcher-only guard (issue #1897):
+- Hooks now read stdin and call session_role.is_dispatcher() before writing.
+- Tests exercise: dispatcher writes, subagent skips, unknown-session skips.
 """
 
 import importlib.util
+import json
 import os
 import sys
 import tempfile
@@ -36,6 +44,10 @@ TIMESTAMP_TOLERANCE_SECONDS = 5
 
 # The threshold documented in the hook (checked here to prevent silent drift).
 EXPECTED_STALE_THRESHOLD = 1200  # 20 minutes
+
+# Fake session IDs used in tests.
+DISPATCHER_SESSION_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+SUBAGENT_SESSION_ID = "11111111-2222-3333-4444-555555555555"
 
 
 # ---------------------------------------------------------------------------
@@ -128,31 +140,55 @@ class TestStaleThresholdConstant:
 
 
 # ---------------------------------------------------------------------------
-# Hook main() integration tests
+# Hook main() integration tests with dispatcher-only guard
 # ---------------------------------------------------------------------------
 
-def _run_hook(monkeypatch, heartbeat_file: Path) -> tuple[int, str, str]:
-    """Execute the hook's main() capturing exit code and stdio."""
+def _run_hook_with_input(
+    monkeypatch,
+    heartbeat_file: Path,
+    hook_input: dict,
+    is_dispatcher_return: bool = True,
+) -> tuple[int, str, str]:
+    """Execute the hook's main() with a given hook input dict and mocked is_dispatcher.
+
+    Mocks session_role.is_dispatcher to return is_dispatcher_return so tests
+    don't depend on filesystem state (dispatcher-session-id files).
+    """
     monkeypatch.setenv("LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE", str(heartbeat_file))
+
+    stdin_content = json.dumps(hook_input)
 
     spec = importlib.util.spec_from_file_location("thinking_heartbeat", HOOK_PATH)
     mod = importlib.util.module_from_spec(spec)
 
     stdout_cap = StringIO()
     stderr_cap = StringIO()
-
     exit_code = None
+
     with (
         patch("sys.stdout", stdout_cap),
         patch("sys.stderr", stderr_cap),
+        patch("sys.stdin", StringIO(stdin_content)),
     ):
         try:
             spec.loader.exec_module(mod)
+            # Patch is_dispatcher on the loaded module's session_role reference.
+            mod.session_role.is_dispatcher = lambda _: is_dispatcher_return
             mod.main()
         except SystemExit as e:
             exit_code = e.code
 
     return exit_code, stdout_cap.getvalue(), stderr_cap.getvalue()
+
+
+def _run_hook(monkeypatch, heartbeat_file: Path) -> tuple[int, str, str]:
+    """Run hook as the dispatcher (is_dispatcher returns True)."""
+    return _run_hook_with_input(
+        monkeypatch,
+        heartbeat_file,
+        hook_input={"session_id": DISPATCHER_SESSION_ID},
+        is_dispatcher_return=True,
+    )
 
 
 class TestHookMain:
@@ -161,7 +197,8 @@ class TestHookMain:
         code, _, _ = _run_hook(monkeypatch, hb)
         assert code == 0
 
-    def test_writes_heartbeat_on_success(self, monkeypatch, tmp_path):
+    def test_writes_heartbeat_when_dispatcher(self, monkeypatch, tmp_path):
+        """Heartbeat is written when the session is the dispatcher."""
         hb = tmp_path / "dispatcher-heartbeat"
         _run_hook(monkeypatch, hb)
         assert hb.exists()
@@ -187,6 +224,120 @@ class TestHookMain:
         code, _, _ = _run_hook(monkeypatch, custom)
         assert code == 0
         assert custom.exists()
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher-only guard: subagent calls must NOT update the heartbeat
+# ---------------------------------------------------------------------------
+
+# Named constant from the spec (issue #1897): subagent activity masks dispatcher death.
+# The fix: heartbeat is only written when is_dispatcher() returns True.
+SUBAGENT_MUST_NOT_WRITE_HEARTBEAT = True
+
+
+class TestDispatcherOnlyGuard:
+    """Issue #1897: subagent tool calls must NOT update the dispatcher heartbeat."""
+
+    def test_subagent_session_does_not_write_heartbeat(self, monkeypatch, tmp_path):
+        """When is_dispatcher returns False, heartbeat file is not created."""
+        hb = tmp_path / "dispatcher-heartbeat"
+        code, _, _ = _run_hook_with_input(
+            monkeypatch,
+            hb,
+            hook_input={"session_id": SUBAGENT_SESSION_ID},
+            is_dispatcher_return=False,
+        )
+        assert code == 0
+        assert not hb.exists(), (
+            "Subagent tool calls must not update the dispatcher heartbeat (issue #1897)"
+        )
+
+    def test_subagent_does_not_overwrite_existing_heartbeat(self, monkeypatch, tmp_path):
+        """An existing heartbeat written by the dispatcher is not touched by subagent calls."""
+        hb = tmp_path / "dispatcher-heartbeat"
+        old_ts = 1700000000
+        hb.write_text(str(old_ts) + "\n")
+
+        code, _, _ = _run_hook_with_input(
+            monkeypatch,
+            hb,
+            hook_input={"session_id": SUBAGENT_SESSION_ID},
+            is_dispatcher_return=False,
+        )
+        assert code == 0
+        # File content must be unchanged.
+        assert int(hb.read_text().strip()) == old_ts, (
+            "Subagent call must not overwrite existing dispatcher heartbeat"
+        )
+
+    def test_dispatcher_session_writes_heartbeat(self, monkeypatch, tmp_path):
+        """When is_dispatcher returns True, the heartbeat IS written."""
+        hb = tmp_path / "dispatcher-heartbeat"
+        before = int(time.time())
+        _run_hook_with_input(
+            monkeypatch,
+            hb,
+            hook_input={"session_id": DISPATCHER_SESSION_ID},
+            is_dispatcher_return=True,
+        )
+        after = int(time.time())
+        assert hb.exists()
+        ts = int(hb.read_text().strip())
+        assert before <= ts <= after + 1
+
+    def test_empty_stdin_does_not_write_heartbeat(self, monkeypatch, tmp_path):
+        """When stdin is empty (unparseable JSON), no heartbeat is written (conservative)."""
+        hb = tmp_path / "dispatcher-heartbeat"
+        monkeypatch.setenv("LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE", str(hb))
+
+        spec = importlib.util.spec_from_file_location("thinking_heartbeat", HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        exit_code = None
+
+        with patch("sys.stdin", StringIO("")):
+            try:
+                spec.loader.exec_module(mod)
+                mod.main()
+            except SystemExit as e:
+                exit_code = e.code
+
+        assert exit_code == 0
+        assert not hb.exists(), (
+            "Empty stdin must not write the heartbeat (conservative: unknown session = skip)"
+        )
+
+    def test_invalid_json_stdin_does_not_write_heartbeat(self, monkeypatch, tmp_path):
+        """When stdin contains invalid JSON, no heartbeat is written."""
+        hb = tmp_path / "dispatcher-heartbeat"
+        monkeypatch.setenv("LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE", str(hb))
+
+        spec = importlib.util.spec_from_file_location("thinking_heartbeat", HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        exit_code = None
+
+        with patch("sys.stdin", StringIO("not valid json {")):
+            try:
+                spec.loader.exec_module(mod)
+                mod.main()
+            except SystemExit as e:
+                exit_code = e.code
+
+        assert exit_code == 0
+        assert not hb.exists()
+
+    def test_exits_zero_regardless_of_session_type(self, monkeypatch, tmp_path):
+        """Hook always exits 0, whether dispatcher or subagent (never blocks tool execution)."""
+        hb = tmp_path / "dispatcher-heartbeat"
+
+        for is_dispatcher in (True, False):
+            hb_i = tmp_path / f"heartbeat-{is_dispatcher}"
+            code, _, _ = _run_hook_with_input(
+                monkeypatch,
+                hb_i,
+                hook_input={"session_id": DISPATCHER_SESSION_ID},
+                is_dispatcher_return=is_dispatcher,
+            )
+            assert code == 0, f"Hook must exit 0 for is_dispatcher={is_dispatcher}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The health check cannot distinguish dispatcher tool use from subagent tool use. When the dispatcher crashes, any still-running subagent keeps updating `dispatcher-heartbeat` and `dispatcher-pre-tool-heartbeat`, keeping the health check GREEN indefinitely. This was observed in the session 009 crash (2026-05-01): at 13:40:00 an investigation subagent's Bash call reset the heartbeat, so the health check reported GREEN instead of triggering a restart. MTTR in this failure mode is unbounded.

Root cause: `thinking-heartbeat.py` (PostToolUse) and `pre-tool-heartbeat.py` (PreToolUse) wrote their files unconditionally, with no mechanism to tell whether the hook was firing for the dispatcher or a subagent.

## Fix

Both hooks now read `hook_input` from stdin and check the current session against the stored dispatcher session ID before writing. Subagent calls exit 0 silently without touching the heartbeat files.

- `thinking-heartbeat.py` (PostToolUse): guards with `session_role.is_dispatcher()`, which compares `hook_input["session_id"]` against the MCP Claude UUID state file and the hook marker file.
- `pre-tool-heartbeat.py` (PreToolUse): guards with `session_role.is_dispatcher_session()`, which adds the `agent_id` fast path (subagents always carry `agent_id` in PreToolUse payloads, so the I/O check is skipped entirely for the common subagent case).

Conservative handling of bad input: empty or unparseable stdin exits 0 without writing. An unknown session never extends the heartbeat.

**Launcher-agnostic**: both `claude-persistent.sh` and `claude-interactive.exp` trigger the same `SessionStart` hook (`write-dispatcher-session-id.py`) that the `session_role` predicates rely on. The fix works regardless of which launcher starts Lobster.

## Before / After flow

```
Before:
  Dispatcher dead, subagent active
  → subagent Bash call → PostToolUse fires → thinking-heartbeat.py writes timestamp
  → health check reads fresh timestamp → GREEN (FALSE POSITIVE)

After:
  Dispatcher dead, subagent active
  → subagent Bash call → PostToolUse fires → thinking-heartbeat.py checks session_id
  → session_id != dispatcher session → exit 0, no write
  → health check reads stale timestamp → RED → restart triggered
```

## What is not changed

- `session_role.py` is not modified — this fix reuses the existing dispatcher detection infrastructure.
- Health check thresholds, WFM-active signal, and compaction suppression are untouched.
- The `write_heartbeat()` pure function is unchanged — the guard is only in `main()`.

## Functional patterns used

Pure function (`write_heartbeat`) isolated from the side-effect guard in `main()`. The dispatcher check is a pure predicate (returns bool) with no side effects, composed before the write operation. The `is_dispatcher` and `is_dispatcher_session` predicates are already well-tested in `session_role.py`; this PR treats them as trusted building blocks.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_thinking_heartbeat.py tests/unit/test_hooks/test_pre_tool_heartbeat.py -v` — 39 passed, 0 failed
- [x] `uv run pytest tests/unit/ -q` — 3412 passed, 37 failed (37 pre-existing failures on local-dev branch confirmed by running against unmodified local-dev; none are in heartbeat or session_role tests)

## Manual test

N/A — this change is entirely internal (filesystem writes guarded by a session ID check). No external service calls, no Telegram output, no DB schema changes. The health check reading of the heartbeat file is unchanged.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (pure hook guard, no external services)
- [x] User-visible outcome: health check will now correctly detect dispatcher death during subagent activity — verified indirectly via unit tests that confirm the file is not written for subagent sessions
- [x] Side-effect audit: change only reduces writes (subagent calls no longer write); no new writes, no new external calls, no flood risk
- [x] External service calls: none

Closes #1897