### PR TITLE
fix(upgrade): add migration 91 for pretooluse-heartbeat hook + verify local-dev deployment

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -3187,6 +3187,51 @@ print(f'prune-pr-worktrees: {result.status}')
         substep "Migration 90: settings.json, jq, or wfm-lifecycle-logger.py not found — skipping"
     fi
 
+    # Migration 91: Register pretooluse-heartbeat.py PreToolUse hook (issue #1439).
+    # This hook was added to install.sh in PR #1896 but was missing from upgrade.sh,
+    # so existing installs never had it registered in settings.json.
+    # Writes last_pretooluse_at to lobster-state.json before every tool call, enabling
+    # narrower detection of MCP-disconnect freezes where PostToolUse never fires.
+    local _m91_hook="$LOBSTER_DIR/hooks/pretooluse-heartbeat.py"
+    if [ -f "$CLAUDE_SETTINGS" ] && command -v jq &>/dev/null && [ -f "$_m91_hook" ]; then
+        local _m91_present
+        _m91_present=$(jq -r '
+            [.hooks.PreToolUse[]?.hooks[]? |
+             select((.command // "") | contains("pretooluse-heartbeat"))]
+            | length' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+
+        if [[ "${_m91_present:-0}" -gt 0 ]]; then
+            substep "Migration 91: pretooluse-heartbeat hook already registered — skipping"
+        else
+            local _m91_tmp
+            _m91_tmp=$(mktemp)
+            local _m91_cmd="python3 $_m91_hook"
+
+            if jq --arg cmd "$_m91_cmd" '
+                .hooks.PreToolUse = (
+                    (.hooks.PreToolUse // []) +
+                    [{
+                        "matcher": "",
+                        "hooks": [{
+                            "type": "command",
+                            "command": $cmd,
+                            "timeout": 5
+                        }]
+                    }]
+                )
+            ' "$CLAUDE_SETTINGS" > "$_m91_tmp" \
+                && mv "$_m91_tmp" "$CLAUDE_SETTINGS" 2>/dev/null; then
+                substep "Migration 91: pretooluse-heartbeat hook registered in settings.json"
+                migrated=$((migrated + 1))
+            else
+                rm -f "$_m91_tmp" 2>/dev/null || true
+                warn "Migration 91: could not update settings.json — jq transform failed"
+            fi
+        fi
+    else
+        substep "Migration 91: settings.json, jq, or pretooluse-heartbeat.py not found — skipping"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## Problem solved

PR #1896 shipped two new hooks (`pretooluse-heartbeat.py` and `wfm-lifecycle-logger.py`) but neither was registered in `~/.claude/settings.json` on local-dev, so both features were silently inactive:

- **`pretooluse-heartbeat.py`** — added to `install.sh` only, with no upgrade.sh migration. Existing installs could never pick it up via `upgrade.sh`.
- **`wfm-lifecycle-logger.py`** — had migration 90 in `upgrade.sh`, but migration 90 was never actually run against local-dev. The lifecycle log at `~/lobster-workspace/logs/session-lifecycle.log` was never created.

An audit confirmed zero hooks registered for either tool in `~/.claude/settings.json`.

## What changed

**`scripts/upgrade.sh` — Migration 91 (new)**

Adds an idempotent migration that registers `pretooluse-heartbeat.py` as a PreToolUse hook with `matcher: ""` (fires on all tool calls), mirroring the install.sh entry that was already present. Skips cleanly if already registered.

Migration 90 (wfm-lifecycle-logger) was already in upgrade.sh from PR #1896 — it was simply never run.

**Deployed directly to local-dev (out of band)**

Both migrations were applied directly to `~/.claude/settings.json` before opening this PR, since the code was already present on local-dev:

- Migration 90 result: `wfm-lifecycle-logger` registered in PreToolUse (matcher: `mcp__lobster-inbox__wait_for_messages`) and PostToolUse
- Migration 91 result: `pretooluse-heartbeat` registered in PreToolUse (matcher: `""`)

## Functional patterns used

- Idempotent migration: reads current state before writing, skips if already registered — no double-registration possible
- Pure check: `jq` query confirms presence/absence before any write
- Fail-open: migration warns on jq failure rather than aborting the upgrade

## Before / after

Before:
```
settings.json hooks for wfm-lifecycle-logger:  PreToolUse: 0  PostToolUse: 0
settings.json hooks for pretooluse-heartbeat:  PreToolUse: 0
session-lifecycle.log:  (never created)
```

After (local-dev, applied directly):
```
settings.json hooks for wfm-lifecycle-logger:  PreToolUse: 1  PostToolUse: 1
settings.json hooks for pretooluse-heartbeat:  PreToolUse: 1
session-lifecycle.log:  will be created on next dispatcher WFM call
```

## Tests run

- [x] `bash -n scripts/upgrade.sh` — no syntax errors
- [x] Both jq transformations applied manually and verified with `jq` queries — counts show 1 for each hook
- [ ] Full `uv run pytest` — not run; this change is bash-only with no Python test coverage for upgrade.sh migrations (consistent with migrations 88-90 which also have no unit tests)

## Manual test

Applied migrations 90 and 91 directly to `~/.claude/settings.json` on local-dev. Verified via `jq` queries that all three hook entries are now present. The `session-lifecycle.log` file will be auto-created on the next dispatcher `wait_for_messages` call (the hook creates the directory with `mkdir -p` on first write).

Note: `pretooluse-heartbeat.py` and `wfm-lifecycle-logger.py` are guarded by `is_dispatcher_session()`, so they only fire in the actual dispatcher session — not in subagent hooks or manual tests. Outcome verification requires observing `~/lobster-workspace/logs/session-lifecycle.log` after the dispatcher's next WFM call.

## Definition of Done

- [x] Unit tests pass — N/A (bash migration, no Python tests for upgrade.sh)
- [x] Integration/manual test run — hook registration confirmed via jq queries
- [x] User-visible outcome — not applicable (internal logging only, no user-visible behavior)
- [x] Side-effect audit: migrations are idempotent append-only jq transforms; no risk of mass sends or shared state corruption
- [x] External service calls: none

Relates to #1895, fixes deployment gap from PR #1896