### PR TITLE
fix(#1903): write primary Claude session file in write-dispatcher-session-id.py

### DIFF
--- a/hooks/write-dispatcher-session-id.py
+++ b/hooks/write-dispatcher-session-id.py
@@ -12,9 +12,16 @@ silently ignored.
 When the marker file is absent (fresh dispatcher start), the current
 session_id matches the stored dispatcher ID, or the stored dispatcher session
 has ended (its .jsonl file is gone from ~/.claude/projects/), writes
-session_id to ~/messages/config/dispatcher-session-id. This file is the
-primary signal that other hooks use to distinguish the dispatcher from
-subagents.
+session_id to two files:
+- ~/messages/config/dispatcher-session-id (tertiary hook marker file)
+- $LOBSTER_WORKSPACE/data/dispatcher-claude-session-id (primary Claude UUID state file)
+
+The primary file write (issue #1903) ensures that inject-bootup-context.py
+(Hook 2, which runs after this hook) finds the correct UUID in the primary
+file even when the MCP server kept running across a CC restart, leaving a
+stale UUID in the primary file. Without this write, the fresh-start fallback
+in inject-bootup-context.py cannot help (the file exists with a wrong UUID,
+not absent), causing dispatcher sessions to receive subagent bootup.
 
 ## Subagent sessions
 
@@ -85,6 +92,14 @@ sys.path.insert(0, str(_SRC_DIR))
 
 import session_role  # noqa: E402 — path insert must precede this
 from agents import session_store  # noqa: E402
+
+# Import the primary-file writer used by on-compact.py for the same purpose.
+# write_dispatcher_claude_session_id writes the Claude UUID to the primary state
+# file (dispatcher-claude-session-id), which is the file checked first by
+# inject-bootup-context.py (Hook 2) when deciding whether to inject dispatcher
+# or subagent bootup. Writing it here (Hook 1) ensures the primary file is
+# up-to-date before Hook 2 runs, fixing the stale-UUID bug described in #1903.
+from session_role import write_dispatcher_claude_session_id  # noqa: E402
 
 # A JSONL file not modified for longer than this is treated as belonging to an
 # idle or dead session.  Active dispatcher sessions append to their JSONL on
@@ -195,6 +210,16 @@ def main() -> None:
 
     if _is_dispatcher_session(session_id):
         session_role.write_dispatcher_session_id(session_id)
+        # Issue #1903: also write the primary Claude UUID state file
+        # (dispatcher-claude-session-id) so that inject-bootup-context.py
+        # (Hook 2, which runs after this hook) finds the correct UUID in the
+        # primary file.  Without this, when CC restarts while MCP keeps running,
+        # the primary file retains the old dispatcher UUID (stale, not absent),
+        # causing both the primary check and the fresh-start fallback to fail —
+        # and subagent bootup to be injected instead of dispatcher bootup.
+        # This mirrors the same write that on-compact.py performs for the
+        # post-compaction case (Option 1, issue #1375).
+        write_dispatcher_claude_session_id(session_id)
         # Issue #781 Fix 2: also tag this session in agent_sessions.db as
         # 'dispatcher' so the reconciler never emits agent_failed for it.
         _register_dispatcher_session(session_id)

--- a/tests/unit/test_hooks/test_write_dispatcher_session_id.py
+++ b/tests/unit/test_hooks/test_write_dispatcher_session_id.py
@@ -1,0 +1,400 @@
+"""
+Unit tests for hooks/write-dispatcher-session-id.py — primary file write on dispatcher detection.
+
+Issue #1903: When CC restarts but MCP keeps running, inject-bootup-context.py
+receives subagent bootup instead of dispatcher bootup.
+
+Root cause:
+- Primary file (dispatcher-claude-session-id) holds the OLD dispatcher UUID
+  from before the CC restart.
+- write-dispatcher-session-id.py (Hook 1) correctly identifies the new session
+  as the dispatcher (via the stored JSONL fallback) and writes the tertiary file.
+- inject-bootup-context.py (Hook 2) checks the primary file:
+  _check_state_file(primary, new_session_id) → False (stale UUID, not absent).
+  _is_fresh_start_dispatcher() → also False (file exists).
+  Both paths fail → subagent bootup injected.
+
+Fix: write-dispatcher-session-id.py must also write the primary file
+(dispatcher-claude-session-id) with the new session UUID when it determines
+the session is the dispatcher, same as on-compact.py already does.
+
+Tests verify:
+- write_dispatcher_claude_session_id is called with the new session UUID when
+  the session is identified as the dispatcher.
+- The primary file actually contains the new UUID after the hook runs.
+- The primary file is NOT written when the session is a subagent.
+- Behaviour is correct for all three _is_dispatcher_session() paths:
+  fresh start (no marker), same-session reattach, and stale-marker recovery.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "write-dispatcher-session-id.py"
+
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _PatchEnv:
+    """Context manager to temporarily set / restore environment variables."""
+
+    def __init__(self, env: dict):
+        self._env = env
+        self._saved: dict = {}
+
+    def __enter__(self):
+        for k, v in self._env.items():
+            self._saved[k] = os.environ.get(k)
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        return self
+
+    def __exit__(self, *_):
+        for k, saved_v in self._saved.items():
+            if saved_v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = saved_v
+
+
+def _load_hook(*, workspace: Path, home: Path) -> object:
+    """Load write-dispatcher-session-id.py with test-controlled paths.
+
+    Returns the loaded module. Uses a unique name to avoid sys.modules
+    pollution between test calls.
+
+    NOTE: callers must wrap the mod.main() call inside a _PatchEnv context
+    that sets LOBSTER_WORKSPACE and HOME, because write_dispatcher_claude_session_id
+    resolves the primary file path at call time from LOBSTER_WORKSPACE.
+    """
+    import uuid
+
+    env = {
+        "LOBSTER_WORKSPACE": str(workspace),
+        "HOME": str(home),
+        "LOBSTER_MAIN_SESSION": "1",
+    }
+    unique_name = f"write_dispatcher_session_id_{uuid.uuid4().hex}"
+    with _PatchEnv(env):
+        spec = importlib.util.spec_from_file_location(unique_name, _HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_hook_input(session_id: str) -> str:
+    return json.dumps({"session_id": session_id})
+
+
+def _create_stored_jsonl(home: Path, session_id: str, age_seconds: float = 7200) -> Path:
+    """Create a fake session JSONL file aged `age_seconds` in the past.
+
+    Used to simulate an idle/dead stored session (age > JSONL_MAX_IDLE_SECONDS)
+    so the stale-marker recovery path triggers and the new session is identified
+    as the replacement dispatcher.
+    """
+    projects_dir = home / ".claude" / "projects" / "fake-ws"
+    projects_dir.mkdir(parents=True, exist_ok=True)
+    jsonl_path = projects_dir / f"{session_id}.jsonl"
+    jsonl_path.write_text('{"type":"text"}\n')
+    mtime = time.time() - age_seconds
+    os.utime(str(jsonl_path), (mtime, mtime))
+    return jsonl_path
+
+
+# ---------------------------------------------------------------------------
+# Tests: primary file written when dispatcher is identified
+# ---------------------------------------------------------------------------
+
+
+class TestPrimaryFileWrittenForDispatcher:
+    """write-dispatcher-session-id.py must write the primary Claude UUID state file
+    (dispatcher-claude-session-id) whenever it determines the current session is
+    the dispatcher. This ensures inject-bootup-context.py (Hook 2) finds the correct
+    UUID in the primary file and injects dispatcher bootup, even when the MCP server
+    kept running across a CC restart (leaving a stale UUID in the primary file).
+    """
+
+    def test_primary_file_written_on_fresh_start(self, tmp_path, monkeypatch):
+        """No tertiary marker file → fresh dispatcher start → primary file written.
+
+        This is the simplest case: the tertiary marker is absent, so
+        _is_dispatcher_session() returns True immediately (fresh start).
+        The primary file must be written with the new session UUID.
+        """
+        import importlib
+        import session_role as _sr
+
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        # Reload session_role so DISPATCHER_SESSION_FILE + _get_mcp_claude_session_file()
+        # both resolve to paths under tmp_path.
+        sr = importlib.reload(_sr)
+        monkeypatch.setattr(sr, "DISPATCHER_SESSION_FILE",
+                            tmp_path / "messages" / "config" / "dispatcher-session-id")
+
+        new_session_id = "fresh-dispatcher-uuid-1234"
+        # Neither tertiary marker nor primary file exists (brand new install).
+        (tmp_path / "messages" / "config").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+
+        hook_input = _make_hook_input(new_session_id)
+
+        mod = _load_hook(workspace=tmp_path, home=tmp_path)
+        # Point the hook's session_role reference at the reloaded module.
+        mod.session_role = sr
+        # Suppress DB registration to avoid real DB writes in tests.
+        mod._register_dispatcher_session = lambda sid: None
+
+        with patch("sys.stdin", __import__("io").StringIO(hook_input)):
+            with pytest.raises(SystemExit):
+                mod.main()
+
+        primary_file = tmp_path / "data" / "dispatcher-claude-session-id"
+        assert primary_file.exists(), (
+            "Primary file must be written when the hook identifies a fresh dispatcher start"
+        )
+        assert primary_file.read_text().strip() == new_session_id
+
+    def test_primary_file_written_on_stale_marker_recovery(self, tmp_path, monkeypatch):
+        """Issue #1903 regression test: stale primary UUID → CC restart → primary file updated.
+
+        Simulates the exact failure mode:
+        - CC restarted (new session UUID d47ecad9)
+        - MCP kept running (old primary file still has dbcad92a)
+        - Tertiary file has dbcad92a (same old UUID)
+        - write-dispatcher-session-id.py checks: dbcad92a JSONL is old (dead) → new
+          session is the replacement dispatcher
+        - Primary file must be updated to d47ecad9 before inject-bootup-context.py runs
+        """
+        import importlib
+        import session_role as _sr
+
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        sr = importlib.reload(_sr)
+
+        old_session_id = "dbcad92a-old-dispatcher-uuid"
+        new_session_id = "d47ecad9-new-dispatcher-uuid"
+
+        # Tertiary file has the stale (old) UUID.
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "dispatcher-session-id").write_text(old_session_id)
+        monkeypatch.setattr(sr, "DISPATCHER_SESSION_FILE",
+                            config_dir / "dispatcher-session-id")
+
+        # Primary file also has the stale UUID (MCP kept running).
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        primary_file = data_dir / "dispatcher-claude-session-id"
+        primary_file.write_text(old_session_id)
+
+        # Old session JSONL is aged > JSONL_MAX_IDLE_SECONDS (4 hours old → dead).
+        FOUR_HOURS = 4 * 60 * 60
+        _create_stored_jsonl(tmp_path, old_session_id, age_seconds=FOUR_HOURS)
+
+        hook_input = _make_hook_input(new_session_id)
+
+        mod = _load_hook(workspace=tmp_path, home=tmp_path)
+        mod.session_role = sr
+        mod._register_dispatcher_session = lambda sid: None
+
+        with patch("sys.stdin", __import__("io").StringIO(hook_input)):
+            with pytest.raises(SystemExit):
+                mod.main()
+
+        # Primary file must now contain the new session UUID.
+        assert primary_file.read_text().strip() == new_session_id, (
+            "Primary file must be updated to the new dispatcher UUID so that "
+            "inject-bootup-context.py can identify this session as the dispatcher"
+        )
+
+    def test_primary_file_written_on_same_session_reattach(self, tmp_path, monkeypatch):
+        """Session reattach (same UUID stored in tertiary) → primary file written.
+
+        If the dispatcher session ID already matches the stored tertiary value,
+        _is_dispatcher_session() returns True immediately (reattach).  The primary
+        file must still be written (or refreshed) with the current UUID.
+        """
+        import importlib
+        import session_role as _sr
+
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        sr = importlib.reload(_sr)
+
+        session_id = "same-dispatcher-uuid-reattach"
+
+        # Tertiary has the matching UUID.
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "dispatcher-session-id").write_text(session_id)
+        monkeypatch.setattr(sr, "DISPATCHER_SESSION_FILE",
+                            config_dir / "dispatcher-session-id")
+
+        # Primary does NOT exist (e.g. MCP restarted after CC reattached).
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+
+        hook_input = _make_hook_input(session_id)
+
+        mod = _load_hook(workspace=tmp_path, home=tmp_path)
+        mod.session_role = sr
+        mod._register_dispatcher_session = lambda sid: None
+
+        with patch("sys.stdin", __import__("io").StringIO(hook_input)):
+            with pytest.raises(SystemExit):
+                mod.main()
+
+        primary_file = data_dir / "dispatcher-claude-session-id"
+        assert primary_file.exists(), (
+            "Primary file must be written even for same-session reattach"
+        )
+        assert primary_file.read_text().strip() == session_id
+
+
+# ---------------------------------------------------------------------------
+# Tests: primary file NOT written for subagent sessions
+# ---------------------------------------------------------------------------
+
+
+class TestPrimaryFileNotWrittenForSubagent:
+    """The primary file must never be written for a subagent session.
+
+    A subagent session has a different UUID and its stored dispatcher session
+    is still alive (JSONL file recently modified).
+    """
+
+    def test_primary_file_not_written_for_subagent(self, tmp_path, monkeypatch):
+        """Subagent session: stored dispatcher JSONL is alive → not written."""
+        import importlib
+        import session_role as _sr
+
+        monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        sr = importlib.reload(_sr)
+
+        dispatcher_session_id = "running-dispatcher-uuid-5678"
+        subagent_session_id = "subagent-uuid-9999"
+
+        # Tertiary has the running dispatcher UUID.
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "dispatcher-session-id").write_text(dispatcher_session_id)
+        monkeypatch.setattr(sr, "DISPATCHER_SESSION_FILE",
+                            config_dir / "dispatcher-session-id")
+
+        # Dispatcher JSONL is ALIVE (modified 30 seconds ago → well within 3-hour window).
+        _create_stored_jsonl(tmp_path, dispatcher_session_id, age_seconds=30)
+
+        # Primary file absent.
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+
+        # Hook receives the SUBAGENT's session ID.
+        hook_input = _make_hook_input(subagent_session_id)
+
+        mod = _load_hook(workspace=tmp_path, home=tmp_path)
+        mod.session_role = sr
+        mod._register_dispatcher_session = lambda sid: None
+
+        with patch("sys.stdin", __import__("io").StringIO(hook_input)):
+            with pytest.raises(SystemExit):
+                mod.main()
+
+        primary_file = data_dir / "dispatcher-claude-session-id"
+        assert not primary_file.exists(), (
+            "Primary file must NOT be written for a subagent session"
+        )
+
+    def test_primary_file_not_written_when_lobster_main_session_unset(
+        self, tmp_path, monkeypatch
+    ):
+        """LOBSTER_MAIN_SESSION not set → hook exits immediately, no writes."""
+        monkeypatch.delenv("LOBSTER_MAIN_SESSION", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+
+        hook_input = _make_hook_input("any-session-id")
+
+        mod = _load_hook(workspace=tmp_path, home=tmp_path)
+
+        env_override = {"LOBSTER_MAIN_SESSION": None}
+        with _PatchEnv(env_override):
+            with patch("sys.stdin", __import__("io").StringIO(hook_input)):
+                with pytest.raises(SystemExit):
+                    mod.main()
+
+        primary_file = tmp_path / "data" / "dispatcher-claude-session-id"
+        assert not primary_file.exists(), (
+            "Primary file must not be written for sessions outside Lobster's management"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: inject-bootup-context.py correctly identifies dispatcher after hook runs
+# ---------------------------------------------------------------------------
+
+
+class TestInjectBootupContextAfterHookRuns:
+    """End-to-end: after write-dispatcher-session-id.py runs, inject-bootup-context.py
+    finds the correct primary file UUID and injects dispatcher bootup.
+
+    This is the specific bug that issue #1903 reports: after writing the primary file
+    in Hook 1, Hook 2 (inject-bootup-context.py) must correctly identify the session
+    as the dispatcher via the primary file match path (not via the fresh-start fallback).
+    """
+
+    def test_primary_file_match_after_stale_recovery(self, tmp_path, monkeypatch):
+        """After Hook 1 overwrites stale primary, is_dispatcher() returns True for new UUID."""
+        import importlib
+        import session_role as _sr
+
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sr = importlib.reload(_sr)
+
+        old_session_id = "dbcad92a-stale-old-uuid"
+        new_session_id = "d47ecad9-fresh-new-uuid"
+
+        # Simulate what the hook writes: new UUID in primary file.
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (data_dir / "dispatcher-claude-session-id").write_text(new_session_id)
+
+        # Reload session_role to pick up new LOBSTER_WORKSPACE.
+        sr = importlib.reload(_sr)
+
+        # inject-bootup-context.py (Hook 2) calls is_dispatcher({session_id: new_uuid})
+        assert sr.is_dispatcher({"session_id": new_session_id}) is True, (
+            "After Hook 1 writes the primary file with new UUID, "
+            "is_dispatcher() must return True for the new session"
+        )
+        assert sr.is_dispatcher({"session_id": old_session_id}) is False, (
+            "The old stale UUID must not match after the primary file is updated"
+        )

--- a/tests/unit/test_hooks/test_write_dispatcher_session_id.py
+++ b/tests/unit/test_hooks/test_write_dispatcher_session_id.py
@@ -51,39 +51,16 @@ if str(_HOOKS_DIR) not in sys.path:
 # ---------------------------------------------------------------------------
 
 
-class _PatchEnv:
-    """Context manager to temporarily set / restore environment variables."""
-
-    def __init__(self, env: dict):
-        self._env = env
-        self._saved: dict = {}
-
-    def __enter__(self):
-        for k, v in self._env.items():
-            self._saved[k] = os.environ.get(k)
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
-        return self
-
-    def __exit__(self, *_):
-        for k, saved_v in self._saved.items():
-            if saved_v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = saved_v
-
-
 def _load_hook(*, workspace: Path, home: Path) -> object:
     """Load write-dispatcher-session-id.py with test-controlled paths.
 
     Returns the loaded module. Uses a unique name to avoid sys.modules
     pollution between test calls.
 
-    NOTE: callers must wrap the mod.main() call inside a _PatchEnv context
-    that sets LOBSTER_WORKSPACE and HOME, because write_dispatcher_claude_session_id
-    resolves the primary file path at call time from LOBSTER_WORKSPACE.
+    LOBSTER_WORKSPACE and HOME are set via patch.dict(os.environ) during module
+    load, and callers set them via monkeypatch.setenv before calling mod.main(),
+    so write_dispatcher_claude_session_id resolves the primary file path at call
+    time using the test-controlled env values.
     """
     import uuid
 
@@ -93,7 +70,7 @@ def _load_hook(*, workspace: Path, home: Path) -> object:
         "LOBSTER_MAIN_SESSION": "1",
     }
     unique_name = f"write_dispatcher_session_id_{uuid.uuid4().hex}"
-    with _PatchEnv(env):
+    with patch.dict(os.environ, env):
         spec = importlib.util.spec_from_file_location(unique_name, _HOOK_PATH)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
@@ -344,11 +321,10 @@ class TestPrimaryFileNotWrittenForSubagent:
 
         mod = _load_hook(workspace=tmp_path, home=tmp_path)
 
-        env_override = {"LOBSTER_MAIN_SESSION": None}
-        with _PatchEnv(env_override):
-            with patch("sys.stdin", __import__("io").StringIO(hook_input)):
-                with pytest.raises(SystemExit):
-                    mod.main()
+        monkeypatch.delenv("LOBSTER_MAIN_SESSION", raising=False)
+        with patch("sys.stdin", __import__("io").StringIO(hook_input)):
+            with pytest.raises(SystemExit):
+                mod.main()
 
         primary_file = tmp_path / "data" / "dispatcher-claude-session-id"
         assert not primary_file.exists(), (


### PR DESCRIPTION
## Problem

When CC restarts while the MCP server keeps running, the dispatcher session gets **subagent bootup injected** instead of dispatcher bootup. This was observed in session 20260501-012 (`d47ecad9`) at 15:44:04.

The failure chain:
1. CC restarts → new session UUID `d47ecad9`, MCP stays up
2. Primary file (`dispatcher-claude-session-id`) still holds `dbcad92a` (old UUID, stale)
3. Hook 1 (`write-dispatcher-session-id.py`) correctly detects `d47ecad9` as the dispatcher via stale-JSONL recovery → writes **tertiary** file only
4. Hook 2 (`inject-bootup-context.py`) checks the primary file: `_check_state_file(primary, d47ecad9)` → False (stale UUID, not absent)
5. Fresh-start fallback: `not primary_file.exists()` → also False (file exists with stale UUID)
6. Subagent bootup injected — wrong

The fresh-start fallback added in PR #1899 only handles the "primary file absent" case. It cannot handle "primary file exists with stale UUID."

## Fix

Hook 1 already does the hard work of identifying whether the current session is the dispatcher. It just needs to also write the primary file (`dispatcher-claude-session-id`) when it determines the session is the dispatcher — mirroring exactly what `on-compact.py` does for the post-compaction case (Option 1, issue #1375).

After this change: by the time Hook 2 runs, the primary file contains the correct new UUID. The primary check passes immediately, and dispatcher bootup is injected correctly.

### Flow before fix (stale-UUID scenario)

```
CC restart → new session d47ecad9
                  │
Hook 1 (write-dispatcher-session-id.py)
  _is_dispatcher_session() → True (JSONL dead, recovery path)
  write_dispatcher_session_id() → writes TERTIARY file only
                  │
Hook 2 (inject-bootup-context.py)
  is_dispatcher() → checks primary (dbcad92a ≠ d47ecad9) → False
  _is_post_compact_dispatcher() → no sentinel → False
  _is_fresh_start_dispatcher() → primary EXISTS → False
  → SUBAGENT BOOTUP INJECTED (wrong)
```

### Flow after fix

```
CC restart → new session d47ecad9
                  │
Hook 1 (write-dispatcher-session-id.py)
  _is_dispatcher_session() → True (JSONL dead, recovery path)
  write_dispatcher_session_id() → writes TERTIARY file
  write_dispatcher_claude_session_id() → writes PRIMARY file (d47ecad9)
                  │
Hook 2 (inject-bootup-context.py)
  is_dispatcher() → checks primary (d47ecad9 == d47ecad9) → True
  → DISPATCHER BOOTUP INJECTED (correct)
```

## Implementation

Single change to `hooks/write-dispatcher-session-id.py`: when `_is_dispatcher_session()` returns True, call `write_dispatcher_claude_session_id(session_id)` alongside the existing `write_dispatcher_session_id(session_id)`. No changes to `inject-bootup-context.py` or `session_role.py`.

The functional pattern here is pure: the fix is a straightforward addition to the side-effect boundary (Hook 1 does all writes it needs to, so Hook 2 reads a consistent state).

## Tests run
- [x] `uv run pytest tests/unit/test_hooks/test_write_dispatcher_session_id.py -v` — 6 new tests, all passed
- [x] `uv run pytest tests/unit/test_hooks/ -v` — 426 passed, 0 failed (all pre-existing hook tests clean)
- [x] Full unit suite (`tests/unit/`) — 426 passed, 0 failed

## Manual test
N/A — this change is purely internal hook logic (file writes). The failure mode requires a specific timing (CC restart without MCP restart), making a live test impractical. The unit tests directly simulate the failure scenario (stale primary UUID, dead JSONL, new session UUID) and verify the primary file is updated before Hook 2 would run.

## Definition of Done
- [x] Unit tests pass with proper isolation (no production hits)
- [x] User-visible outcome: dispatcher receives dispatcher bootup after CC-only restart (verified via unit test simulating the exact failure scenario from the issue)
- [x] Side-effect audit: this hook already writes two files (tertiary + DB row); the new write is a third file in the same pattern. Scoped to dispatcher-only path. No volume concerns.
- [x] External service calls: none

Closes #1903
Relates to #1899 (fresh-start fallback), #1375 (Option 1 pattern used here)