### PR TITLE
fix: patch DISPATCHER_SESSION_FILE in tests to prevent production state corruption

### DIFF
--- a/tests/unit/test_hooks/test_inject_bootup_context_sentinel.py
+++ b/tests/unit/test_hooks/test_inject_bootup_context_sentinel.py
@@ -207,6 +207,12 @@ class TestMainSentinelFallback:
             mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
             mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
             mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+            # Redirect DISPATCHER_SESSION_FILE to tmp_path so the sentinel-triggered
+            # write_dispatcher_session_id() call does not corrupt the production state
+            # file at ~/messages/config/dispatcher-session-id.
+            mod.session_role.DISPATCHER_SESSION_FILE = (
+                tmp_path / "messages" / "config" / "dispatcher-session-id"
+            )
 
             with patch("sys.stdin", io.StringIO(hook_input)):
                 with pytest.raises(SystemExit):
@@ -248,6 +254,11 @@ class TestMainSentinelFallback:
             mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
             mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
             mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+            # Redirect DISPATCHER_SESSION_FILE defensively even though is_dispatcher()
+            # returns False here (no write occurs), so future changes can't regress.
+            mod.session_role.DISPATCHER_SESSION_FILE = (
+                tmp_path / "messages" / "config" / "dispatcher-session-id"
+            )
 
             with patch("sys.stdin", io.StringIO(hook_input)):
                 with pytest.raises(SystemExit):
@@ -293,6 +304,11 @@ class TestMainSentinelFallback:
             mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
             mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
             mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+            # Redirect DISPATCHER_SESSION_FILE defensively even though is_dispatcher()
+            # returns False here (no write occurs), so future changes can't regress.
+            mod.session_role.DISPATCHER_SESSION_FILE = (
+                tmp_path / "messages" / "config" / "dispatcher-session-id"
+            )
 
             with patch("sys.stdin", io.StringIO(hook_input)):
                 with pytest.raises(SystemExit):
@@ -337,6 +353,15 @@ class TestMainSentinelFallback:
             mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
             mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
             mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+            # Redirect DISPATCHER_SESSION_FILE to tmp_path so the dispatcher write
+            # that happens when is_dispatcher() returns True does not corrupt the
+            # production state file at ~/messages/config/dispatcher-session-id.
+            # This is the test that caused the 2026-05-01 incident: the primary
+            # file matched "known-dispatcher-uuid-abc", triggering write_dispatcher_
+            # session_id() which overwrote the live dispatcher's session ID.
+            mod.session_role.DISPATCHER_SESSION_FILE = (
+                tmp_path / "messages" / "config" / "dispatcher-session-id"
+            )
 
             with patch("sys.stdin", io.StringIO(hook_input)):
                 with pytest.raises(SystemExit):


### PR DESCRIPTION
## What problem does this solve?

Tests that exercise `inject-bootup-context.py` via `main()` were writing to the live production file `~/messages/config/dispatcher-session-id`, overwriting the running dispatcher's session ID.

On 2026-05-01 this caused an incident: the test UUID `"known-dispatcher-uuid-abc"` was written atomically to `~/messages/config/dispatcher-session-id`, corrupting the live dispatcher's state. The hook-marker-file (tertiary) dispatcher detection then failed for all subsequent SessionStart hooks, stopping heartbeat writes for ~20 minutes until the dispatcher restarted.

## Root cause

`session_role.DISPATCHER_SESSION_FILE` is a module-level constant resolved at import time:

```python
DISPATCHER_SESSION_FILE = Path(os.path.expanduser("~/messages/config/dispatcher-session-id"))
```

When `inject-bootup-context.py` is loaded dynamically in tests via `importlib`, the `session_role` it imports is the **cached** version from `sys.modules` — with the production path baked in. Even though tests patch `HOME` and `LOBSTER_WORKSPACE` for the primary-file lookups, those env vars do not affect the module-level constant.

Two tests in `TestMainSentinelFallback` trigger the write:
- `test_sentinel_fallback_injects_dispatcher_bootup`: sentinel fallback fires → `is_dispatcher=True` → `write_dispatcher_session_id("unknown-post-compact-uuid")` written to production
- `test_primary_file_match_still_works_without_sentinel`: primary file matches → `is_dispatcher=True` → `write_dispatcher_session_id("known-dispatcher-uuid-abc")` written to production (the incident)

## Fix

In all four `TestMainSentinelFallback` tests, after loading the hook module and before calling `main()`, redirect `mod.session_role.DISPATCHER_SESSION_FILE` to a path under `tmp_path`:

```python
mod.session_role.DISPATCHER_SESSION_FILE = (
    tmp_path / "messages" / "config" / "dispatcher-session-id"
)
```

This is applied to all four tests (not just the two directly implicated) so that future changes to `is_dispatcher` logic cannot introduce a new regression.

The fix is purely in the test file — no production code changes.

**Functional patterns used:** Pure attribute reassignment on the loaded module's namespace; no mock objects or complex patching machinery needed since `session_role` is accessed as an attribute of the dynamically loaded module.

## Before / after

**Before:** `main()` calls `session_role.write_dispatcher_session_id(session_id)` → writes to real `~/messages/config/dispatcher-session-id` via the cached module-level constant.

**After:** `mod.session_role.DISPATCHER_SESSION_FILE` is redirected to `tmp_path/messages/config/dispatcher-session-id` before `main()` is called → write goes to the isolated temp directory.

## Tests run
- [x] `uv run pytest tests/unit/test_hooks/test_inject_bootup_context_sentinel.py -v` — 9 passed, 0 failed
- [x] `uv run pytest tests/unit/test_hooks/test_session_role_state_file.py -v` — 33 passed, 0 failed
- [x] `uv run pytest tests/unit/test_hooks/ -v` — 316 passed, 6 pre-existing failures (unrelated to this change, confirmed by running against upstream main without the fix)
- [x] Production file `~/messages/config/dispatcher-session-id` verified unchanged after test run (retains the live dispatcher's real UUID, not `"known-dispatcher-uuid-abc"`)

## Manual test
N/A — this change is entirely internal to test isolation; no external services, no systemd units, no runtime file I/O beyond tmp_path.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (test-only change)
- [x] User-visible outcome verified — N/A (this fixes test isolation, not a user-facing feature)
- [x] Side-effect audit complete: tests now write only to tmp_path, not production paths
- [x] External service calls: none

Fixes the 2026-05-01 incident where `~/messages/config/dispatcher-session-id` was overwritten with `"known-dispatcher-uuid-abc"` during a test run, stopping dispatcher heartbeats for ~20 minutes.