### PR TITLE
fix(debug): write dispatcher startup flag in claude-wrapper.exp

### DIFF
--- a/scripts/claude-wrapper.exp
+++ b/scripts/claude-wrapper.exp
@@ -68,6 +68,30 @@ if {[file readable $config_file]} {
 # Start Claude with bypass permissions
 spawn claude --dangerously-skip-permissions
 
+# Write the dispatcher startup flag so inject-bootup-context.py can identify
+# this session as the dispatcher. Mirrors what claude-persistent.sh does before
+# exec-ing claude: writes the launcher PID to
+# ~/lobster-workspace/data/dispatcher-startup-flag.
+#
+# In debug mode, $spawn_pid is the PID of the spawned claude process. We write
+# it immediately after spawn so the flag is present before Claude's SessionStart
+# hook fires (the hook fires during Claude's startup sequence, well after spawn
+# returns). inject-bootup-context.py checks kill -0 on this PID to confirm
+# liveness, then deletes the flag — exactly the same contract as persistent mode.
+#
+# Without this write, is_dispatcher() returns False for every debug-mode session
+# because the flag never exists, causing thinking-heartbeat.py to skip the
+# heartbeat write, which triggers the health-check cascade restart loop.
+set workspace [expr {[info exists ::env(LOBSTER_WORKSPACE)] ? $::env(LOBSTER_WORKSPACE) : "$::env(HOME)/lobster-workspace"}]
+set flag_dir [file join $workspace "data"]
+set flag_file [file join $flag_dir "dispatcher-startup-flag"]
+catch { file mkdir $flag_dir }
+catch {
+    set fh [open $flag_file w]
+    puts $fh $spawn_pid
+    close $fh
+}
+
 # Wait for either the permissions dialog OR the ready prompt.
 #
 # The ❯ (U+276F) character appears in the prompt area surrounded by ANSI escape


### PR DESCRIPTION
## Root cause

In debug mode (`LOBSTER_DEBUG=true`), the dispatcher is launched via `claude-wrapper.exp` instead of `claude-persistent.sh`. The wrapper script never wrote the `dispatcher-startup-flag` file.

Since PR #1908 (simplified dispatcher detection), `is_dispatcher()` reads **only** the startup flag file to determine whether the current session is the dispatcher. With the flag never written in debug mode, `is_dispatcher()` always returns `False` for debug sessions.

This breaks `thinking-heartbeat.py` (PostToolUse hook): it calls `is_dispatcher()` before writing the heartbeat, and skips the write when `False`. The heartbeat file goes stale, the health check sees it as stale, and triggers a cascade restart loop.

## The fix

Write `$spawn_pid` to `~/lobster-workspace/data/dispatcher-startup-flag` immediately after `spawn claude --dangerously-skip-permissions`. This mirrors exactly what `claude-persistent.sh` does (`echo "$BASHPID" > dispatcher-startup-flag` before `exec claude`).

The timing contract is preserved:
- Flag is written immediately after `spawn` returns
- Claude's `SessionStart` hook (`inject-bootup-context.py`) fires during startup, after the flag is present
- The hook reads the flag, checks `kill -0 $spawn_pid` for liveness, injects dispatcher bootup context, and deletes the flag

## What didn't change

- No changes to `session_role.py`, `inject-bootup-context.py`, or any hooks
- No behavior change in persistent mode (only `claude-wrapper.exp` is modified)
- Subagents spawned by the debug-mode dispatcher are unaffected: by the time their `SessionStart` fires, the flag has already been consumed by the dispatcher's hook

## Tests

All 322 hook unit tests pass in Docker:

```
flock /tmp/lobster-docker.lock docker compose -f tests/docker/docker-compose.test.yml run --rm unit-tests \
  .venv/bin/pytest tests/unit/test_hooks/ -q --tb=short
322 passed in 6.47s
```

No new test files needed — this is a shell script fix with a straightforward behavioral contract already tested by `test_startup_flag_dispatcher_detection.py` (the Python side). The `.exp` script cannot be unit-tested without spawning a live Claude process.

## Definition of done
- [x] Root cause identified and confirmed
- [x] Minimal fix applied to `claude-wrapper.exp`
- [x] 322 hook unit tests pass in Docker
- [x] No regressions in existing test suite

Closes the cascade-restart-in-debug-mode issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)