### PR TITLE
fix: transcription worker service hardcoded 'lobster' user — add template

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2877,6 +2877,14 @@ if [ -f "$OBSERVABILITY_TEMPLATE" ]; then
         "$INSTALL_DIR/services/lobster-observability.service"
 fi
 
+# Generate transcription worker service if template exists
+TRANSCRIPTION_TEMPLATE="$INSTALL_DIR/services/lobster-transcription.service.template"
+if [ -f "$TRANSCRIPTION_TEMPLATE" ]; then
+    generate_from_template \
+        "$TRANSCRIPTION_TEMPLATE" \
+        "$INSTALL_DIR/services/lobster-transcription.service"
+fi
+
 #===============================================================================
 # Install Services
 #===============================================================================

--- a/services/lobster-transcription.service.template
+++ b/services/lobster-transcription.service.template
@@ -1,0 +1,42 @@
+[Unit]
+Description=Lobster Transcription Worker - whisper.cpp voice-to-text pipeline
+After=network.target lobster-router.service
+# The worker only needs the router up so AUDIO_DIR exists; it doesn't call the bot
+Wants=lobster-router.service
+
+[Service]
+Type=simple
+User={{USER}}
+Group={{GROUP}}
+WorkingDirectory={{INSTALL_DIR}}
+
+# Inherit the same PATH / environment as the router so ffmpeg and whisper-cli resolve
+Environment=PATH={{HOME}}/.local/bin:{{HOME}}/.cargo/bin:/usr/local/bin:/usr/bin:/bin
+Environment=HOME={{HOME}}
+Environment=LOBSTER_CONFIG_DIR={{CONFIG_DIR}}
+Environment=LOBSTER_INSTALL_DIR={{INSTALL_DIR}}
+Environment=LOBSTER_MESSAGES={{MESSAGES_DIR}}
+Environment=LOBSTER_WORKSPACE={{WORKSPACE_DIR}}
+EnvironmentFile=-{{INSTALL_DIR}}/config/config.env
+EnvironmentFile={{CONFIG_DIR}}/config.env
+EnvironmentFile=-{{CONFIG_DIR}}/global.env
+
+ExecStart={{INSTALL_DIR}}/.venv/bin/python {{INSTALL_DIR}}/src/transcription/worker.py
+
+# Restart on any failure; voice messages accumulate safely in pending-transcription/
+Restart=always
+RestartSec=10
+
+# Limit whisper.cpp memory in case a corrupt audio file causes a runaway
+MemoryMax=2G
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=lobster-transcription
+
+# Security hardening (mirror of lobster-router.service)
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Problem

The `lobster-transcription.service` unit was committed with `User=lobster` and `/home/lobster/` paths hardcoded. On this install (and likely all installs using any username other than `lobster`), the service failed immediately with:

```
Failed to load environment files: No such file or directory
Failed to run 'start' task: No such file or directory
```

The service hit restart counter 91,485 before this was caught. All voice messages were silently accumulating in `~/messages/pending-transcription/` — two messages were stuck there (one from April 29, one from May 3).

## Root cause

Every other service has a `.template` file with `{{USER}}`, `{{HOME}}`, `{{INSTALL_DIR}}`, etc. placeholders that `install.sh` renders via `generate_from_template`. The transcription worker service was added without a template — `install.sh` directly copied the hardcoded `.service` file.

## Fix

- Add `services/lobster-transcription.service.template` using the same `{{USER}}`/`{{GROUP}}`/`{{INSTALL_DIR}}`/`{{HOME}}`/`{{CONFIG_DIR}}`/`{{MESSAGES_DIR}}`/`{{WORKSPACE_DIR}}` template variables as all other services
- Add a `generate_from_template` call for the transcription service in `install.sh` (before the Install Services section, matching the observability service pattern)

## Testing

Fixed the live `/etc/systemd/system/lobster-transcription.service` to use `admin` user/paths. Service started immediately, picked up both stuck voice messages, and transcribed them successfully within ~90 seconds. Both are now in `~/messages/inbox/` ready for the dispatcher.