### PR TITLE
fix(memory): use k=? instead of LIMIT ? for sqlite-vec KNN queries

### DIFF
--- a/src/mcp/memory/vector_memory.py
+++ b/src/mcp/memory/vector_memory.py
@@ -258,14 +258,16 @@ class VectorMemory:
         vec_blob = _serialize_vector(query_embedding)
 
         # Get top candidates from vector search (fetch more than limit for merging)
+        # sqlite-vec v0.1.7-alpha+ requires `k = ?` in the WHERE clause for KNN
+        # queries with a bound parameter; `LIMIT ?` is not recognised.
         fetch_limit = limit * 3
         vec_results = self._conn.execute(
             """
             SELECT rowid, distance
             FROM events_vec
             WHERE embedding MATCH ?
+            AND k = ?
             ORDER BY distance
-            LIMIT ?
             """,
             (vec_blob, fetch_limit),
         ).fetchall()


### PR DESCRIPTION
## Problem

Two tests in `tests/unit/test_memory.py` were failing:

- `TestVectorMemory::test_search_returns_relevant`
- `TestVectorMemory::test_search_with_project_filter`

Both failed because `_hybrid_search` always fell through to the keyword-only fallback path, returning 0 results. The logged error:

```
WARNING: Hybrid search failed, falling back to keyword: A LIMIT or 'k = ?' constraint is required on vec0 knn queries.
```

## Root cause

`sqlite-vec v0.1.7-alpha.10` (currently installed) requires the neighbour count for KNN queries to be expressed as `k = ?` in the `WHERE` clause when using a bound parameter. The previous query used `LIMIT ?`, which this version does not recognise as a KNN bound:

```sql
-- Before (broken on v0.1.7-alpha.10+):
SELECT rowid, distance
FROM events_vec
WHERE embedding MATCH ?
ORDER BY distance
LIMIT ?

-- After (works):
SELECT rowid, distance
FROM events_vec
WHERE embedding MATCH ?
AND k = ?
ORDER BY distance
```

Note: `LIMIT 10` (inline integer) also fails; only `k = ?` with a bound parameter works in this version.

## Fix

One-line change to `src/mcp/memory/vector_memory.py`: replace `LIMIT ?` with `AND k = ?` in the vec0 KNN query. The `fetch_limit` parameter binding stays unchanged.

This is a pure function fix — no state changes, no side effects. The `_hybrid_search` function is stateless aside from the DB query.

## Tests run

- [x] `uv run pytest tests/unit/test_memory.py -q` — 40 passed, 0 failed (was 2 failed before fix)
- [x] `uv run pytest tests/unit/ -q` — 3060 passed, 24 skipped, 0 failed (full unit suite clean)

## Manual test

N/A — this change is entirely internal (no Telegram output, no file I/O, no external services).

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, change is internal DB query only
- [x] User-visible outcome verified — N/A (internal memory subsystem)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none