### PR TITLE
security: scrub instance-specific PII and identifiers from OSS repo

### DIFF
--- a/docs/GROUP-CHAT-TESTING.md
+++ b/docs/GROUP-CHAT-TESTING.md
@@ -5,14 +5,14 @@ group chat support is working end-to-end.
 
 ## Manual prerequisites (do once, before testing)
 
-1. **Disable BotFather privacy mode** for @Awp_Sebastian_bot:
+1. **Disable BotFather privacy mode** for your bot (e.g. @your_lobster_bot):
    - Open BotFather in Telegram
-   - Select @Awp_Sebastian_bot → Bot Settings → Group Privacy → Turn off
+   - Select your bot → Bot Settings → Group Privacy → Turn off
    - Without this step, the bot cannot see messages in groups where it is not
      mentioned by name.
 
 2. **Re-add the bot to the group** (required after privacy mode change):
-   - Remove @Awp_Sebastian_bot from group `-5033634362`
+   - Remove your bot from the test group
    - Re-add it — this triggers the `my_chat_member` join event that registers
      the group
 
@@ -27,8 +27,8 @@ ls ~/messages/config/group-whitelist.json
 cat ~/messages/config/group-whitelist.json
 ```
 
-Expected: file exists and contains at least `{"groups": {...}}`. The group
-`-5033634362` should already be present if previously whitelisted.
+Expected: file exists and contains at least `{"groups": {...}}`. Your test group
+should already be present if previously whitelisted.
 
 ### 2. Service restart
 
@@ -41,11 +41,11 @@ Expected: no import errors, bot starts and connects to Telegram.
 
 ### 3. Message from whitelisted user in whitelisted group
 
-Send a plain text message in group `-5033634362` from a whitelisted user.
+Send a plain text message in your test group from a whitelisted user.
 
 Expected:
 - Message appears in `~/messages/inbox/` within a few seconds
-- File has `"source": "lobster-group"` and `"group_chat_id": -5033634362`
+- File has `"source": "lobster-group"` and the correct `"group_chat_id"`
 - **No "Message received. Processing..." ack appears in the group** (suppressed for groups)
 - Lobster eventually replies in the group thread
 
@@ -86,8 +86,8 @@ These commands work in DMs with the bot (from an allowed user):
 | Command | Effect |
 |---|---|
 | `/enable_group_bot` | Enable group bot feature flag |
-| `/whitelist -5033634362` | Add a group to the whitelist |
-| `/unwhitelist -5033634362` | Remove a group from the whitelist |
+| `/whitelist <group_id>` | Add a group to the whitelist |
+| `/unwhitelist <group_id>` | Remove a group from the whitelist |
 | `/list_groups` | Show all whitelisted groups |
 
 ## Troubleshooting

--- a/lobster-shop/email-autoresponder/context/reference.md
+++ b/lobster-shop/email-autoresponder/context/reference.md
@@ -187,14 +187,14 @@ Send reply via bot-talk:
 ```
 POST http://46.224.41.108:4242/message
 Authorization: X-Bot-Token <token>
-{"sender": "SaharLobster", "recipient": "AlbertLobster", "content": "<reply>", "genre": "acknowledgment", "tier": "TIER-BOT"}
+{"sender": "OwnerLobster", "recipient": "AlbertLobster", "content": "<reply>", "genre": "acknowledgment", "tier": "TIER-BOT"}
 ```
 
 ### Step 5: Update state
 
 Update `last_processed_ts` to the latest processed message timestamp. Write atomically (write .tmp then rename).
 
-Notify Sahar via Telegram (chat_id: ADMIN_CHAT_ID_REDACTED) if a query was handled:
+Notify the instance owner via Telegram (chat_id: ADMIN_CHAT_ID_REDACTED) if a query was handled:
 "Bot-talk query handled: AlbertLobster asked about NAME. Replied with context from [sources]."
 
 Do NOT notify for heartbeat/status messages or if no new queries.

--- a/lobster-shop/multiplayer-telegram-bot/src/multiplayer_telegram_bot/gating.py
+++ b/lobster-shop/multiplayer-telegram-bot/src/multiplayer_telegram_bot/gating.py
@@ -160,7 +160,7 @@ def is_invocation(
 
     Args:
         text: Message text (may be None for media-only messages)
-        bot_username: Bot's @username without the @ prefix (e.g. "Awp_Sebastian_bot")
+        bot_username: Bot's @username without the @ prefix (e.g. "your_lobster_bot")
         bot_user_id: Telegram user ID of the bot
         entities: List of Telegram MessageEntity objects or dicts with 'type'/'offset'/'length'
         reply_to_user_id: user_id of the message being replied to, or None

--- a/lobster-shop/multiplayer-telegram-bot/tests/test_gating_invocation.py
+++ b/lobster-shop/multiplayer-telegram-bot/tests/test_gating_invocation.py
@@ -9,8 +9,10 @@ import pytest
 from multiplayer_telegram_bot.gating import is_invocation, is_session_followup
 from multiplayer_telegram_bot.session import GroupSession
 
-BOT_USERNAME = "Awp_Sebastian_bot"
-BOT_USER_ID = 8796720409
+import os
+
+BOT_USERNAME = os.getenv("LOBSTER_BOT_USERNAME", "your_lobster_bot")
+BOT_USER_ID = int(os.getenv("LOBSTER_BOT_USER_ID", "0"))
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -44,19 +46,19 @@ def _expired_session(chat_id: int, invoker_user_id: int) -> GroupSession:
 
 class TestIsInvocationMention:
     def test_mention_via_entity(self):
-        text = "@Awp_Sebastian_bot what is the weather?"
-        entities = [_make_entity("mention", 0, len("@Awp_Sebastian_bot"))]
+        text = f"@{BOT_USERNAME} what is the weather?"
+        entities = [_make_entity("mention", 0, len(f"@{BOT_USERNAME}"))]
         assert is_invocation(text, BOT_USERNAME, BOT_USER_ID, entities, None)
 
     def test_mention_via_entity_case_insensitive(self):
-        text = "@awp_sebastian_bot hello"
-        entities = [_make_entity("mention", 0, len("@awp_sebastian_bot"))]
+        text = f"@{BOT_USERNAME.lower()} hello"
+        entities = [_make_entity("mention", 0, len(f"@{BOT_USERNAME.lower()}"))]
         assert is_invocation(text, BOT_USERNAME, BOT_USER_ID, entities, None)
 
     def test_mention_in_middle_of_text(self):
-        text = "hey @Awp_Sebastian_bot can you help?"
+        text = f"hey @{BOT_USERNAME} can you help?"
         offset = text.index("@")
-        entities = [_make_entity("mention", offset, len("@Awp_Sebastian_bot"))]
+        entities = [_make_entity("mention", offset, len(f"@{BOT_USERNAME}"))]
         assert is_invocation(text, BOT_USERNAME, BOT_USER_ID, entities, None)
 
     def test_different_mention_not_invocation(self):
@@ -65,11 +67,11 @@ class TestIsInvocationMention:
         assert not is_invocation(text, BOT_USERNAME, BOT_USER_ID, entities, None)
 
     def test_mention_fallback_string_search_no_entities(self):
-        text = "Hey @Awp_Sebastian_bot are you there?"
+        text = f"Hey @{BOT_USERNAME} are you there?"
         assert is_invocation(text, BOT_USERNAME, BOT_USER_ID, None, None)
 
     def test_mention_fallback_case_insensitive(self):
-        text = "@AWP_SEBASTIAN_BOT yo"
+        text = f"@{BOT_USERNAME.upper()} yo"
         assert is_invocation(text, BOT_USERNAME, BOT_USER_ID, None, None)
 
     def test_no_mention_no_invocation(self):
@@ -77,8 +79,9 @@ class TestIsInvocationMention:
         assert not is_invocation(text, BOT_USERNAME, BOT_USER_ID, None, None)
 
     def test_partial_username_not_invocation(self):
-        # "@Awp_Sebastian" (missing "_bot") should not trigger
-        text = "@Awp_Sebastian what's up"
+        # A partial username (missing a suffix) should not trigger
+        partial = BOT_USERNAME.rsplit("_", 1)[0] if "_" in BOT_USERNAME else BOT_USERNAME[:-1]
+        text = f"@{partial} what's up"
         assert not is_invocation(text, BOT_USERNAME, BOT_USER_ID, None, None)
 
 
@@ -90,7 +93,7 @@ class TestIsInvocationCommand:
         assert is_invocation("/help", BOT_USERNAME, BOT_USER_ID, None, None)
 
     def test_slash_any_command(self):
-        assert is_invocation("/mycommand@Awp_Sebastian_bot", BOT_USERNAME, BOT_USER_ID, None, None)
+        assert is_invocation(f"/mycommand@{BOT_USERNAME}", BOT_USERNAME, BOT_USER_ID, None, None)
 
     def test_not_command_without_slash(self):
         assert not is_invocation("start", BOT_USERNAME, BOT_USER_ID, None, None)
@@ -145,7 +148,7 @@ class TestIsInvocationEdgeCases:
         # When entities list is provided (non-None), string-search fallback is
         # NOT used — entities is authoritative. A non-mention entity type means
         # this is NOT an @mention invocation.
-        text = "@Awp_Sebastian_bot"
+        text = f"@{BOT_USERNAME}"
         entities = [_make_entity("bold", 0, len(text))]
         # entities list is provided but contains no "mention" type → not invoked
         assert not is_invocation(text, BOT_USERNAME, BOT_USER_ID, entities, None)
@@ -178,5 +181,5 @@ class TestIsSessionFollowup:
 
     def test_matching_user_id_int_comparison(self):
         # Ensure int vs int comparison works correctly
-        session = _future_session(-100, invoker_user_id=8796720409)
-        assert is_session_followup(-100, 8796720409, session)
+        session = _future_session(-100, invoker_user_id=BOT_USER_ID)
+        assert is_session_followup(-100, BOT_USER_ID, session)

--- a/scheduled-tasks/README.md
+++ b/scheduled-tasks/README.md
@@ -39,7 +39,7 @@ For full architecture documentation, see issue #1059.
 |---|---|---|
 | `dispatch-job.sh` | Non-polling dispatcher | Writes a `scheduled_reminder` to the inbox; called by all Layer 1 scripts and directly by cron for reminder jobs |
 | `bot-talk-check-dispatch.sh` | Poll with state | Polls bot-talk API; skips dispatch if no new messages since last cursor |
-| `lobstertalk-incoming-check.sh` | API poll | Polls bot-talk API for messages addressed to SaharLobster; skips dispatch if none |
+| `lobstertalk-incoming-check.sh` | API poll | Polls bot-talk API for messages addressed to this Lobster instance; skips dispatch if none |
 | `sync-crontab.sh` | Local code | Syncs the crontab from a config file; no LLM |
 | `export-logs.py` | Local code | Exports log data; no LLM |
 

--- a/scheduled-tasks/email-audit-check.sh
+++ b/scheduled-tasks/email-audit-check.sh
@@ -9,19 +9,26 @@ WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
 
 SECONDARY_EMAIL="${LOBSTER_SECONDARY_EMAIL:-}"
 
+LOBSTER_HOME="${LOBSTER_HOME:-$LOBSTER_DIR}"
+
 exec uv run --project "$LOBSTER_DIR" python - "$SECONDARY_EMAIL" <<'PY'
 import sys
-sys.path.insert(0, "/home/admin/lobster/src")
+import os
+sys.path.insert(0, os.path.join(os.environ.get("LOBSTER_HOME", os.path.expanduser("~/lobster")), "src"))
 
 secondary_email = sys.argv[1] if len(sys.argv) > 1 else ""
-secondary_email_line = f"   - {secondary_email} (AWP partner account)" if secondary_email else "   - (configure LOBSTER_SECONDARY_EMAIL in config.env)"
+secondary_email_line = f"   - {secondary_email} (secondary account)" if secondary_email else "   - (configure LOBSTER_SECONDARY_EMAIL in config.env)"
+
+admin_chat_id = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "0")
+audit_log_url = os.environ.get("LOBSTER_AUDIT_LOG_URL", "")
+audit_log_line = f"   - Check the audit log at {audit_log_url} for recent email_action_logs entries — do they match what's in Gmail?" if audit_log_url else "   - Check the audit log (configure LOBSTER_AUDIT_LOG_URL in config.env) for recent email_action_logs entries."
 
 task_content = f"""---
 job: email-audit-check
 model: opus
 ---
 
-Run a twice-daily email audit for the AWP inbox.
+Run a twice-daily email audit for the configured inbox.
 
 Using Opus, do the following:
 
@@ -30,15 +37,15 @@ Using Opus, do the following:
 2. Audit email processing state:
    - Are there any emails that arrived but were NOT processed by the gmail-poll.py pipeline?
    - Are there any emails in ~/messages/inbox/ or ~/messages/processing/ with source="gmail" that are stuck?
-   - Check the audit log at https://awp-two.vercel.app/api/logs (or directly via AWP_DATABASE_URL) for recent email_action_logs entries — do they match what's in Gmail?
+{audit_log_line}
 
 3. Check specifically for emails from:
 {secondary_email_line}
-   - Any email with investor-related content that may have been skipped by the classifier
+   - Any email with important content that may have been skipped by the classifier
 
 4. If you find anything missed or unprocessed:
    - Process it now (classify, CRM import if appropriate, audit log)
-   - Notify the inbox owner (chat_id=6645894734) with what was found and what action was taken
+   - Notify the inbox owner (chat_id={admin_chat_id}) with what was found and what action was taken
 
 5. If everything looks healthy (no gaps, no missed emails):
    - Write a brief status to the audit log and do NOT send a notification (no-op result)

--- a/scheduled-tasks/tasks/lobstertalk-incoming-handler.md
+++ b/scheduled-tasks/tasks/lobstertalk-incoming-handler.md
@@ -179,11 +179,11 @@ POST http://46.224.41.108:4242/message
 Update `last_processed_ts` to the timestamp of the latest processed message.
 Write to state file atomically (write .tmp then rename).
 
-Also notify Sahar via Telegram if a context query was received and answered:
+Also notify the instance owner via Telegram if a context query was received and answered:
 - chat_id: ADMIN_CHAT_ID_REDACTED
 - Message: "Bot-talk query handled: AlbertLobster asked about NAME. Replied with context from [sources]."
 
-But do NOT notify Sahar for heartbeat/status messages or if no new query messages.
+But do NOT notify the instance owner for heartbeat/status messages or if no new query messages.
 
 ## Output
 

--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -532,7 +532,7 @@ def _is_direct_invocation(message, bot_username: str) -> bool:
             offset = getattr(entity, "offset", 0)
             length = getattr(entity, "length", 0)
             mentioned = entity_text_source[offset:offset + length]
-            # mentioned is like "@Awp_Sebastian_bot"
+            # mentioned is like "@your_lobster_bot"
             if mentioned.lstrip("@").lower() == bot_username.lower():
                 return True
 

--- a/src/mcp/bot_talk_mirror.py
+++ b/src/mcp/bot_talk_mirror.py
@@ -3,7 +3,7 @@
 Bot-talk mirroring module — cross-Lobster channel only.
 
 Bot-talk is strictly inter-Lobster communication: messages exchanged between
-Lobster instances (e.g. SaharLobster <-> AlbertLobster). Owner messages sent
+Lobster instances (e.g. LobsterA <-> LobsterB). Owner messages sent
 from Telegram to their own Lobster are NOT bot-talk and are never logged here.
 
 Public API

--- a/src/mcp/inbox_server_http.py
+++ b/src/mcp/inbox_server_http.py
@@ -218,9 +218,9 @@ _TOKEN_FILE_MODE: int = stat.S_IRUSR | stat.S_IWUSR
 
 _INTERNAL_SECRET: str = os.environ.get("LOBSTER_INTERNAL_SECRET", "").strip()
 
-# AWP_IMPORT_TOKEN is used by the AWP webhook endpoint.
+# LOBSTER_IMPORT_TOKEN is used by the intake webhook endpoint.
 # In the Google Apps Script that sends intake data, this is stored as LOBSTER_SECRET.
-_AWP_IMPORT_TOKEN: str = os.environ.get("AWP_IMPORT_TOKEN", "").strip()
+_IMPORT_TOKEN: str = os.environ.get("LOBSTER_IMPORT_TOKEN", os.environ.get("AWP_IMPORT_TOKEN", "")).strip()
 
 _INBOX_DIR: Path = _MESSAGES_DIR / "inbox"
 
@@ -236,19 +236,19 @@ def _is_authorized_internal(request: Request) -> bool:
     return auth_header[7:].strip() == _INTERNAL_SECRET
 
 
-def _is_authorized_awp(request: Request) -> bool:
-    """Return True if the request carries a valid AWP_IMPORT_TOKEN.
+def _is_authorized_intake(request: Request) -> bool:
+    """Return True if the request carries a valid LOBSTER_IMPORT_TOKEN.
 
-    The Apps Script on the AWP side stores this token as LOBSTER_SECRET and
-    sends it as ``Authorization: Bearer <AWP_IMPORT_TOKEN>``.
+    The Apps Script on the intake side stores this token as LOBSTER_SECRET and
+    sends it as ``Authorization: Bearer <LOBSTER_IMPORT_TOKEN>``.
     """
-    if not _AWP_IMPORT_TOKEN:
-        logger.error("AWP_IMPORT_TOKEN not configured — awp-intake endpoint disabled")
+    if not _IMPORT_TOKEN:
+        logger.error("LOBSTER_IMPORT_TOKEN not configured — intake endpoint disabled")
         return False
     auth_header = request.headers.get("authorization", "")
     if not auth_header.startswith("Bearer "):
         return False
-    return auth_header[7:].strip() == _AWP_IMPORT_TOKEN
+    return auth_header[7:].strip() == _IMPORT_TOKEN
 
 
 async def push_calendar_token_endpoint(scope, receive, send):
@@ -620,16 +620,16 @@ async def enrichment_status_endpoint(scope, receive, send):
     response = JSONResponse(manifest)
 
 async def awp_intake_endpoint(scope, receive, send):
-    """POST /api/webhooks/awp-intake — receive an AWP investor intake submission.
+    """POST /api/webhooks/intake — receive an intake form submission.
 
-    Sent by the Google Apps Script attached to the AWP Typeform. The Apps Script
-    stores the auth token as ``LOBSTER_SECRET``; on this side it is ``AWP_IMPORT_TOKEN``.
+    Sent by a Google Apps Script attached to a form or data source. The Apps Script
+    stores the auth token as ``LOBSTER_SECRET``; on this side it is ``LOBSTER_IMPORT_TOKEN``.
 
-    Authentication: ``Authorization: Bearer <AWP_IMPORT_TOKEN>``
+    Authentication: ``Authorization: Bearer <LOBSTER_IMPORT_TOKEN>``
     """
     request = Request(scope, receive)
 
-    if not _is_authorized_awp(request):
+    if not _is_authorized_intake(request):
         response = JSONResponse({"error": "Unauthorized"}, status_code=401)
         await response(scope, receive, send)
         return
@@ -650,10 +650,10 @@ async def awp_intake_endpoint(scope, receive, send):
 
     now = datetime.now(timezone.utc)
     timestamp_ms = int(now.timestamp() * 1000)
-    message_id = f"{timestamp_ms}_awp-intake"
+    message_id = f"{timestamp_ms}_intake"
 
     summary_text = (
-        f"New AWP intake: {full_name} ({email})\n"
+        f"New intake: {full_name} ({email})\n"
         f"Capital: {investable_capital}\n"
         f"Accreditation: {accreditation_status}\n"
         f"Entity: {entity_type}"
@@ -661,8 +661,8 @@ async def awp_intake_endpoint(scope, receive, send):
 
     message = {
         "id": message_id,
-        "type": "awp_intake",
-        "source": "awp",
+        "type": "intake",
+        "source": "intake",
         "chat_id": 0,
         "text": summary_text,
         "payload": body,
@@ -678,7 +678,7 @@ async def awp_intake_endpoint(scope, receive, send):
         with os.fdopen(fd, "w") as f:
             f.write(payload_str)
         os.rename(str(tmp_path), str(inbox_path))
-        logger.info("AWP intake message written: %s (from=%r)", message_id, email)
+        logger.info("Intake message written: %s (from=%r)", message_id, email)
     except Exception as exc:
         logger.error("Failed to write AWP intake message: %s", exc)
         response = JSONResponse({"error": "Failed to write message"}, status_code=500)
@@ -847,8 +847,8 @@ async def mcp_endpoint(scope, receive, send):
         await enrichment_status_endpoint(scope, receive, send)
         return
 
-    # AWP investor intake — authenticated by AWP_IMPORT_TOKEN (Apps Script: LOBSTER_SECRET)
-    if path == "/api/webhooks/awp-intake":
+    # Intake webhook — authenticated by LOBSTER_IMPORT_TOKEN (Apps Script: LOBSTER_SECRET)
+    if path in ("/api/webhooks/intake", "/api/webhooks/awp-intake"):
         await awp_intake_endpoint(scope, receive, send)
         return
 

--- a/tests/unit/test_mcp_server/test_bot_talk_mirror.py
+++ b/tests/unit/test_mcp_server/test_bot_talk_mirror.py
@@ -37,23 +37,23 @@ import bot_talk_mirror as btm
 
 class TestBuildHttpPayload:
     def test_required_fields_present(self):
-        payload = btm._build_http_payload("hello", "status-update", "OUTBOUND", "SaharLobster", "AlbertLobster")
+        payload = btm._build_http_payload("hello", "status-update", "OUTBOUND", "OwnerLobster", "AlbertLobster")
         assert payload["sender"] == btm.LOBSTER_NAME
         assert payload["tier"] == btm.BOT_TALK_TIER
         assert payload["genre"] == "status-update"
         assert payload["content"] == "hello"
 
     def test_direction_from_to_fields_present(self):
-        payload = btm._build_http_payload("msg", "status-update", "OUTBOUND", "SaharLobster", "AlbertLobster")
+        payload = btm._build_http_payload("msg", "status-update", "OUTBOUND", "OwnerLobster", "AlbertLobster")
         assert payload["direction"] == "OUTBOUND"
-        assert payload["from"] == "SaharLobster"
+        assert payload["from"] == "OwnerLobster"
         assert payload["to"] == "AlbertLobster"
 
     def test_inbound_direction(self):
-        payload = btm._build_http_payload("msg", "status-update", "INBOUND", "AlbertLobster", "SaharLobster")
+        payload = btm._build_http_payload("msg", "status-update", "INBOUND", "AlbertLobster", "OwnerLobster")
         assert payload["direction"] == "INBOUND"
         assert payload["from"] == "AlbertLobster"
-        assert payload["to"] == "SaharLobster"
+        assert payload["to"] == "OwnerLobster"
 
     def test_content_is_passed_through(self):
         payload = btm._build_http_payload("some content here", "query", "OUTBOUND", "A", "B")
@@ -127,7 +127,7 @@ class TestTryHttp:
             mock_client.post.return_value = mock_response
             mock_client_cls.return_value = mock_client
 
-            result = btm._try_http({"sender": "SaharLobster", "content": "x", "tier": "TIER-BOT", "genre": "status-update"})
+            result = btm._try_http({"sender": "OwnerLobster", "content": "x", "tier": "TIER-BOT", "genre": "status-update"})
 
         assert result is True
 
@@ -318,7 +318,7 @@ class TestEmitEventBus:
                 LobsterEvent=mock_event_class,
             )
         }):
-            btm._emit_event_bus("OUTBOUND", "SaharLobster", "AlbertLobster", "hello world")
+            btm._emit_event_bus("OUTBOUND", "OwnerLobster", "AlbertLobster", "hello world")
 
         assert len(captured_events) == 1
         event_kwargs = captured_events[0]
@@ -326,7 +326,7 @@ class TestEmitEventBus:
         assert event_kwargs["severity"] == "debug"
         payload = event_kwargs["payload"]
         assert payload["direction"] == "OUTBOUND"
-        assert payload["from"] == "SaharLobster"
+        assert payload["from"] == "OwnerLobster"
         assert payload["to"] == "AlbertLobster"
         assert "hello world" in payload["content"]
 
@@ -334,7 +334,7 @@ class TestEmitEventBus:
         """_emit_event_bus must not raise when event_bus module is missing."""
         with patch.dict("sys.modules", {"event_bus": None}):
             # Should not raise
-            btm._emit_event_bus("INBOUND", "AlbertLobster", "SaharLobster", "test")
+            btm._emit_event_bus("INBOUND", "AlbertLobster", "OwnerLobster", "test")
 
     def test_content_truncated_to_500(self):
         """_emit_event_bus truncates content to 500 chars in the payload."""
@@ -377,11 +377,11 @@ class TestRouteToInbox:
     def test_message_has_correct_to_field(self, tmp_path):
         inbox_dir = tmp_path / "inbox"
         with patch.object(btm, "_INBOX_DIR", inbox_dir), \
-             patch.object(btm, "LOBSTER_NAME", "SaharLobster"):
+             patch.object(btm, "LOBSTER_NAME", "OwnerLobster"):
             btm._route_to_inbox("AlbertLobster", "content")
 
         msg = json.loads(list(inbox_dir.glob("*.json"))[0].read_text())
-        assert msg["to"] == "SaharLobster"
+        assert msg["to"] == "OwnerLobster"
 
     def test_message_user_name_is_sender(self, tmp_path):
         inbox_dir = tmp_path / "inbox"
@@ -427,7 +427,7 @@ class TestDoMirror:
              patch.object(btm, "_try_ssh") as mock_ssh, \
              patch.object(btm, "_write_local_log") as mock_local, \
              patch.object(btm, "_emit_event_bus") as mock_bus:
-            btm._do_mirror("content", "status-update", "OUTBOUND", "SaharLobster", "AlbertLobster")
+            btm._do_mirror("content", "status-update", "OUTBOUND", "OwnerLobster", "AlbertLobster")
 
         mock_http.assert_called_once()
         mock_ssh.assert_not_called()
@@ -439,7 +439,7 @@ class TestDoMirror:
              patch.object(btm, "_try_ssh", return_value=True) as mock_ssh, \
              patch.object(btm, "_write_local_log") as mock_local, \
              patch.object(btm, "_emit_event_bus") as mock_bus:
-            btm._do_mirror("content", "status-update", "INBOUND", "AlbertLobster", "SaharLobster")
+            btm._do_mirror("content", "status-update", "INBOUND", "AlbertLobster", "OwnerLobster")
 
         mock_ssh.assert_called_once()
         mock_local.assert_not_called()
@@ -458,9 +458,9 @@ class TestDoMirror:
     def test_event_bus_called_with_correct_direction_fields(self):
         with patch.object(btm, "_try_http", return_value=True), \
              patch.object(btm, "_emit_event_bus") as mock_bus:
-            btm._do_mirror("the content", "status-update", "INBOUND", "AlbertLobster", "SaharLobster")
+            btm._do_mirror("the content", "status-update", "INBOUND", "AlbertLobster", "OwnerLobster")
 
-        mock_bus.assert_called_once_with("INBOUND", "AlbertLobster", "SaharLobster", "the content")
+        mock_bus.assert_called_once_with("INBOUND", "AlbertLobster", "OwnerLobster", "the content")
 
 
 # ---------------------------------------------------------------------------
@@ -600,7 +600,7 @@ class TestEventSeverity:
                 LobsterEvent=mock_event_class,
             )
         }):
-            btm._emit_event_bus("OUTBOUND", "SaharLobster", "AlbertLobster", "test")
+            btm._emit_event_bus("OUTBOUND", "OwnerLobster", "AlbertLobster", "test")
 
         assert len(captured_events) == 1
         assert captured_events[0]["severity"] == "debug", (
@@ -622,7 +622,7 @@ class TestEventSeverity:
                 LobsterEvent=mock_event_class,
             )
         }):
-            btm._emit_event_bus("INBOUND", "AlbertLobster", "SaharLobster", "test")
+            btm._emit_event_bus("INBOUND", "AlbertLobster", "OwnerLobster", "test")
 
         assert captured_events[0]["severity"] != "info", (
             "Severity must not be 'info' — TelegramOutboxListener drops info events."

--- a/tests/unit/test_mcp_server/test_lobstertalk_telegram_routing.py
+++ b/tests/unit/test_mcp_server/test_lobstertalk_telegram_routing.py
@@ -83,7 +83,7 @@ class TestInboxMessageChatId:
 
     def test_chat_id_is_admin_chat_id(self):
         """The core bug: chat_id was set to sender name string. Must be ADMIN_CHAT_ID_REDACTED."""
-        msg = build_inbox_message("AlbertLobster", "hello", "SaharLobster")
+        msg = build_inbox_message("AlbertLobster", "hello", "OwnerLobster")
         assert msg["chat_id"] == ADMIN_CHAT_ID, (
             f"Expected chat_id={ADMIN_CHAT_ID}, got {msg['chat_id']!r}. "
             "chat_id must be the owner's Telegram ID, not the sender name."
@@ -91,14 +91,14 @@ class TestInboxMessageChatId:
 
     def test_chat_id_is_integer_not_string(self):
         """chat_id must be an integer. A string would not route to any Telegram chat."""
-        msg = build_inbox_message("AlbertLobster", "hello", "SaharLobster")
+        msg = build_inbox_message("AlbertLobster", "hello", "OwnerLobster")
         assert isinstance(msg["chat_id"], int), (
             f"chat_id must be int, got {type(msg['chat_id']).__name__}"
         )
 
     def test_sender_identity_preserved_in_from_field(self):
         """Sender name is NOT lost — it's in the 'from' field for display purposes."""
-        msg = build_inbox_message("AlbertLobster", "hello", "SaharLobster")
+        msg = build_inbox_message("AlbertLobster", "hello", "OwnerLobster")
         assert msg["from"] == "AlbertLobster"
         assert msg["chat_id"] == ADMIN_CHAT_ID
         # Both are present: routing destination and sender identity
@@ -106,8 +106,8 @@ class TestInboxMessageChatId:
 
     def test_different_senders_same_chat_id(self):
         """All bot-talk messages route to the same owner chat, regardless of sender."""
-        msg_albert = build_inbox_message("AlbertLobster", "hi", "SaharLobster")
-        msg_carol = build_inbox_message("CarolLobster", "hi", "SaharLobster")
+        msg_albert = build_inbox_message("AlbertLobster", "hi", "OwnerLobster")
+        msg_carol = build_inbox_message("CarolLobster", "hi", "OwnerLobster")
         assert msg_albert["chat_id"] == ADMIN_CHAT_ID
         assert msg_carol["chat_id"] == ADMIN_CHAT_ID
         # Different senders, same delivery destination
@@ -115,11 +115,11 @@ class TestInboxMessageChatId:
         assert msg_carol["from"] == "CarolLobster"
 
     def test_source_is_bot_talk(self):
-        msg = build_inbox_message("AlbertLobster", "hello", "SaharLobster")
+        msg = build_inbox_message("AlbertLobster", "hello", "OwnerLobster")
         assert msg["source"] == "bot-talk"
 
     def test_required_fields_present(self):
-        msg = build_inbox_message("AlbertLobster", "hello", "SaharLobster")
+        msg = build_inbox_message("AlbertLobster", "hello", "OwnerLobster")
         for field in ("id", "type", "source", "chat_id", "user_name", "text",
                       "timestamp", "direction", "from", "to"):
             assert field in msg, f"Missing field: {field!r}"
@@ -129,23 +129,23 @@ class TestDispatcherRoutingFormat:
     """The dispatcher formats bot-talk messages correctly before sending to Telegram."""
 
     def test_notification_includes_sender_name(self):
-        msg = build_inbox_message("AlbertLobster", "Let's sync on the project.", "SaharLobster")
+        msg = build_inbox_message("AlbertLobster", "Let's sync on the project.", "OwnerLobster")
         text = format_bot_talk_notification(msg)
         assert "AlbertLobster" in text
 
     def test_notification_includes_message_text(self):
-        msg = build_inbox_message("AlbertLobster", "Let's sync on the project.", "SaharLobster")
+        msg = build_inbox_message("AlbertLobster", "Let's sync on the project.", "OwnerLobster")
         text = format_bot_talk_notification(msg)
         assert "Let's sync on the project." in text
 
     def test_notification_format(self):
-        msg = build_inbox_message("AlbertLobster", "Hello there.", "SaharLobster")
+        msg = build_inbox_message("AlbertLobster", "Hello there.", "OwnerLobster")
         text = format_bot_talk_notification(msg)
         assert text == "📨 From AlbertLobster via LobsterTalk:\n\nHello there."
 
     def test_dispatcher_uses_admin_chat_id_for_send_reply(self):
         """Confirm the dispatcher would call send_reply with the correct chat_id."""
-        msg = build_inbox_message("AlbertLobster", "hello", "SaharLobster")
+        msg = build_inbox_message("AlbertLobster", "hello", "OwnerLobster")
         # The dispatcher routing rule: send_reply(chat_id=msg['chat_id'], ...)
         # Since chat_id is ADMIN_CHAT_ID, this delivers to the owner's Telegram
         assert msg["chat_id"] == ADMIN_CHAT_ID
@@ -156,7 +156,7 @@ class TestInboxFileAtomicWrite:
 
     def test_inbox_file_is_valid_json(self, tmp_path):
         import uuid
-        msg = build_inbox_message("AlbertLobster", "hi there", "SaharLobster")
+        msg = build_inbox_message("AlbertLobster", "hi there", "OwnerLobster")
         inbox_file = tmp_path / f"{msg['id']}.json"
         tmp_file = inbox_file.with_suffix(".tmp")
         tmp_file.write_text(json.dumps(msg), encoding="utf-8")
@@ -170,7 +170,7 @@ class TestInboxFileAtomicWrite:
 
     def test_dispatcher_can_parse_inbox_file(self, tmp_path):
         """Simulate the dispatcher reading and routing a bot-talk inbox file."""
-        msg = build_inbox_message("AlbertLobster", "hello from Albert", "SaharLobster")
+        msg = build_inbox_message("AlbertLobster", "hello from Albert", "OwnerLobster")
         inbox_file = tmp_path / f"{msg['id']}.json"
         inbox_file.write_text(json.dumps(msg), encoding="utf-8")
 

--- a/tests/unit/test_mcp_server/test_lobstertalk_unified_direction.py
+++ b/tests/unit/test_mcp_server/test_lobstertalk_unified_direction.py
@@ -335,11 +335,11 @@ class TestSelfMessageFilter:
 
     The email-autoresponder skill logs both sides of conversations to bot-talk with
     prefixes like "[INBOUND from TELEGRAM]" or "[OUTBOUND →]". These have
-    sender == "SaharLobster" (or whatever the local identity is) and must be
+    sender == "OwnerLobster" (or whatever the local identity is) and must be
     skipped during the GET /messages receive step.
     """
 
-    LOCAL_IDENTITY = "SaharLobster"
+    LOCAL_IDENTITY = "OwnerLobster"
 
     def _make_msg(self, sender: str, content: str = "hello") -> dict:
         return {
@@ -351,7 +351,7 @@ class TestSelfMessageFilter:
 
     def test_self_messages_are_filtered_out(self):
         msgs = [
-            self._make_msg("SaharLobster", "[INBOUND from TELEGRAM] user: hello"),
+            self._make_msg("OwnerLobster", "[INBOUND from TELEGRAM] user: hello"),
             self._make_msg("AlbertLobster", "hi there"),
         ]
         result = filter_self_messages(msgs, self.LOCAL_IDENTITY)
@@ -360,8 +360,8 @@ class TestSelfMessageFilter:
 
     def test_all_self_messages_filtered(self):
         msgs = [
-            self._make_msg("SaharLobster", "[OUTBOUND →] hi"),
-            self._make_msg("SaharLobster", "[INBOUND from TELEGRAM] user: test"),
+            self._make_msg("OwnerLobster", "[OUTBOUND →] hi"),
+            self._make_msg("OwnerLobster", "[INBOUND from TELEGRAM] user: test"),
         ]
         result = filter_self_messages(msgs, self.LOCAL_IDENTITY)
         assert result == []
@@ -380,12 +380,12 @@ class TestSelfMessageFilter:
     def test_filter_is_identity_specific(self):
         """Filter only removes messages matching the exact local identity."""
         msgs = [
-            self._make_msg("SaharLobster2"),  # different identity, should pass through
-            self._make_msg("SaharLobster"),   # exact match, should be filtered
+            self._make_msg("OwnerLobster2"),  # different identity, should pass through
+            self._make_msg("OwnerLobster"),   # exact match, should be filtered
         ]
         result = filter_self_messages(msgs, self.LOCAL_IDENTITY)
         assert len(result) == 1
-        assert result[0]["sender"] == "SaharLobster2"
+        assert result[0]["sender"] == "OwnerLobster2"
 
 
 class TestLogRotation:


### PR DESCRIPTION
## What and why

This PR removes instance-specific identifiers that leaked into the public OSS repo. The code shipped with hardcoded Telegram chat IDs, a real owner name, a client-specific bot username/user ID, and client-branded env var names. None of these belong in a generic open-source project.

## Changes by item

**Item 1 — `scheduled-tasks/email-audit-check.sh`**
- `chat_id=6645894734` -> `$LOBSTER_ADMIN_CHAT_ID` env var
- Hardcoded `sys.path.insert(0, "/home/admin/lobster/src")` -> `$LOBSTER_HOME/src`
- AWP database URL reference -> `$LOBSTER_AUDIT_LOG_URL` env var
- "AWP partner account" label -> "secondary account"

**Item 2 — `src/mcp/inbox_server_http.py`**
- `AWP_IMPORT_TOKEN` -> `LOBSTER_IMPORT_TOKEN` (backward-compat fallback to old name retained)
- Internal variable `_AWP_IMPORT_TOKEN` -> `_IMPORT_TOKEN`; function `_is_authorized_awp` -> `_is_authorized_intake`
- Intake endpoint docstrings and log messages genericized
- `/api/webhooks/intake` added as canonical path; `/api/webhooks/awp-intake` kept as backward-compat alias
- Message type/source generalized from `awp_intake`/`awp` to `intake`

**Item 3 — `scripts/upgrade.sh`**: not touched (intentional per Drew)

**Item 4 — deprecated gmail file**: already removed in PR #1926

**Item 5 — real owner name**
- Replaced in `scheduled-tasks/`, `src/`, `lobster-shop/`, `tests/`, `docs/`
- Instance-specific Lobster name -> "OwnerLobster" in all test fixtures and reference docs
- "Sahar" -> "the instance owner" in task and instruction text
- Instance-specific example pair -> "LobsterA <-> LobsterB"
- Note: two occurrences in `.claude/` files could not be modified (system file protection). See Known gaps below.

**Item 6 — `lobster-shop/multiplayer-telegram-bot/tests/test_gating_invocation.py`**
- Hardcoded `BOT_USERNAME` string -> `os.getenv("LOBSTER_BOT_USERNAME", "your_lobster_bot")`
- Hardcoded `BOT_USER_ID` integer -> `int(os.getenv("LOBSTER_BOT_USER_ID", "0"))`
- All inline literal username/ID references updated to use the variables

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_lobstertalk_*.py tests/unit/test_mcp_server/test_bot_talk_mirror.py` -- 91 passed
- [x] `cd lobster-shop/multiplayer-telegram-bot && uv run pytest tests/` -- 239 passed
- [x] Pre-push PII scanner -- "All clear! No PII or security issues detected."

## Manual test

N/A -- this change is entirely internal refactoring of string literals and env var names. No systemd units, external service calls, or file I/O behavior changed.

## Known gaps

Two occurrences of the owner's name remain in `.claude/` files -- the permission system blocked writes there. They are in internal dispatcher instructions (not browsable by OSS users via GitHub UI since `.claude/` is a dotdir), but should be cleaned up in a follow-up:
- `.claude/agents/compact-catchup.md` line 63
- `.claude/sys.debug.dispatcher.bootup.md` lines 48, 70