### PR TITLE
chore: remove user PII from buy-things skill files

### DIFF
--- a/.githooks/security-allowlist.txt
+++ b/.githooks/security-allowlist.txt
@@ -53,10 +53,8 @@ lobster-shop/kissinger/bin/kissinger:Email address
 lobster-shop/kissinger/bin/kissinger-mcp:Email address
 
 # WhatsApp connector config examples use example JID format strings (digits@c.us) in comments/docs
-# and index.js uses a personal name in documentation comments — these are placeholder examples
 connectors/whatsapp/config.example.env:Email address
 connectors/whatsapp/setup.sh:Email address
-connectors/whatsapp/index.js:Personal name (drew)
 scripts/lobster-whatsapp-qr:Email address
 
 # google calendar callback and client test files use fake/mock tokens for unit tests
@@ -97,10 +95,6 @@ lobster-shop/slack-connector/src/onboarding.py:Email address
 # step-name identifier strings (wizard state machine steps), not hardcoded credential values
 lobster-shop/slack-connector/src/onboarding.py:Hardcoded token
 
-# periodic-self-check.sh contains a pre-existing comment referencing a name as a role
-# description — this is a code comment, not a secret or PII in the data sense
-scripts/periodic-self-check.sh:Personal name (drew)
-
 # find_supply_chain_contacts uses a Chrome User-Agent string containing a fake version
 # number "122.0.0.0" that looks like an IP address — it is not an IP, it is a browser
 # version string used to avoid bot detection in DuckDuckGo HTML requests
@@ -118,6 +112,3 @@ scheduled-tasks/lobstertalk-incoming-handler.py:Email address
 # API connectivity, not a secret or private PII
 src/integrations/clay/client.py:Email address
 
-# buy-things skill has a default_shipping_name config value that references a personal name
-# as a placeholder — this is user-facing configuration, not a secret or credential
-lobster-shop/buy-things/preferences/defaults.toml:Personal name (drew)

--- a/connectors/whatsapp/index.js
+++ b/connectors/whatsapp/index.js
@@ -208,7 +208,7 @@ function touchHeartbeat() {
  * Render a QR code string to a PNG file and emit a qr_ready system event.
  *
  * The qr_ready event is picked up by whatsapp_bridge_adapter.py, which writes
- * a Telegram outbox message containing the PNG so Drew can scan it on his phone
+ * a Telegram outbox message containing the PNG so the user can scan it on their phone
  * without any terminal or SSH access.
  *
  * Falls back to a text-only qr_ready event (no image_path) if PNG generation fails,
@@ -313,7 +313,7 @@ function startBridge() {
     // ---------------------------------------------------------------------------
     // QR code — first-run authentication
     //
-    // Renders the QR as a PNG and delivers it to Drew's Telegram chat via the
+    // Renders the QR as a PNG and delivers it to the user's Telegram chat via the
     // whatsapp_bridge_adapter.py qr_ready event handler — no terminal needed.
     // ---------------------------------------------------------------------------
 
@@ -400,7 +400,7 @@ function startBridge() {
                 console.error('[SESSION] Could not delete session:', e.message);
             }
 
-            // Notify Drew via the event bus
+            // Notify the user via the event bus
             emitSystemEvent(
                 'session_expired',
                 'Session expired — QR scan required. Restart the service: sudo systemctl restart lobster-whatsapp-bridge'


### PR DESCRIPTION
## What and why

A real user's full name ("Drew Winget") was hardcoded in public OSS skill files. Prior commit 983b811 caught the data values (defaults.toml, README, camofox_checkout.md, obsidian-km.md). This PR removes the three remaining occurrences — all in code comments in the WhatsApp connector — and drops the now-stale allowlist entries that previously exempted those files.

## Changes

**`connectors/whatsapp/index.js`** — three code comments:
- JSDoc: "so Drew can scan it on his phone" → "so the user can scan it on their phone"
- Section comment: "Drew's Telegram chat" → "the user's Telegram chat"
- Inline comment: "Notify Drew via the event bus" → "Notify the user via the event bus"

**`.githooks/security-allowlist.txt`** — removed three stale exemption entries:
- `connectors/whatsapp/index.js:Personal name (drew)` — no longer needed, name is gone
- `scripts/periodic-self-check.sh:Personal name (drew)` — script never contained the name; the entry was erroneous from the start
- `lobster-shop/buy-things/preferences/defaults.toml:Personal name (drew)` — 983b811 already replaced it with `"Your Name"`

## Verification

Final grep for `Drew Winget`, `Drew's`, `Drew can`, `Drew sends`, `Drew via` (case-insensitive) across the repo: **no matches**.

Pre-push security scanner: **All clear. No PII or security issues detected.**

## Tests run
- [x] Pre-push security/PII scanner — passed, all clear
- [x] Manual grep for remaining PII patterns — 0 matches

## Manual test
N/A — no external services, no runtime behavior changed. This is comment and config text only.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests) — N/A, no code logic changed
- [x] Integration/manual test run — N/A
- [x] User-visible outcome verified — not applicable, internal comment text only
- [x] Side-effect audit complete — no floods, no writes, no production impact
- [x] External service calls — none