### PR TITLE
fix: Telegram bot skips non-Telegram outbox files

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -1866,6 +1866,14 @@ class OutboxHandler(FileSystemEventHandler):
                     pass
                 return
 
+            # Skip outbox files destined for other channels (Slack, SMS, WhatsApp, etc.)
+            # Those routers watch the same shared outbox directory and handle their own files.
+            source = reply.get('source', 'telegram')
+            if source not in ('telegram', 'lobster-group', ''):
+                log.debug(f"process_reply: skipping non-Telegram file {filepath} (source={source!r})")
+                _processing_files.discard(filepath)
+                return
+
             chat_id = reply.get('chat_id')
             text = reply.get('text', '')
             buttons = reply.get('buttons')


### PR DESCRIPTION
## Problem

The Telegram router's outbox sweep processed every `.json` file in the shared `~/messages/outbox/` directory regardless of the `source` field. When a Slack reply was written (`source="slack"`), the Telegram bot picked it up first, tried to deliver it to Telegram using a Slack channel ID (`D0B1L2Q99UN`) as the `chat_id`, got "Chat not found" errors 5 times, then dead-lettered it — preventing the Slack router from ever delivering it.

Confirmed by logs:
```
May 05 04:02:24  Sweep: failed to process 1777953733284_slack.json (attempt 1/5): Chat not found
...
May 05 04:03:08  Moved to dead-letter after 5 failures: 1777953733284_slack.json
```

The Slack router log showed zero delivery attempts for the same file.

## Fix

Add a source check in `process_reply()` so the Telegram bot immediately returns (without deleting or dead-lettering the file) for any `source` not in `('telegram', 'lobster-group', '')`. The Slack/SMS/WhatsApp routers watching the same directory handle their own files.

The `sweep_outbox()` function calls `process_reply()`, so it gets the filter for free with no additional changes.

## Test plan

- [ ] Deploy and restart `lobster-router`
- [ ] Send a Slack DM to Sebastian; verify the reply appears in Slack (not dead-lettered)
- [ ] Verify Telegram replies still work normally
- [ ] Check `lobster-router` logs show debug skips for slack files, not sweep failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)