### PR TITLE
refactor(slack): extract _remap_channel() shared helper (PR 2)

### DIFF
--- a/src/bot/slack_router.py
+++ b/src/bot/slack_router.py
@@ -119,6 +119,20 @@ CHANNEL_REMAP: dict = parse_channel_remap(
     os.environ.get("LOBSTER_SLACK_CHANNEL_REMAP", "")
 )
 
+
+def _remap_channel(channel_id: str) -> str:
+    """Return the remapped channel ID, or *channel_id* unchanged if no mapping exists.
+
+    Both the inbound (Socket Mode) and outbound (chat_postMessage) paths share
+    this helper so the remap logic lives in exactly one place.
+
+    The mapping is workspace-specific and comes entirely from the
+    ``LOBSTER_SLACK_CHANNEL_REMAP`` config variable — see ``parse_channel_remap``
+    for the format.  A typical deployment maps the bot-DM channel (which the
+    xoxp- user token cannot post to) to the user-DM channel.
+    """
+    return CHANNEL_REMAP.get(channel_id, channel_id)
+
 # Directories
 _MESSAGES = Path(os.environ.get("LOBSTER_MESSAGES", Path.home() / "messages"))
 _WORKSPACE = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
@@ -374,12 +388,9 @@ def handle_message_events(body, say, logger):
     # on the bot-DM channel while the canonical user-facing channel is the
     # user-DM channel — the xoxp- token cannot reply to the bot-DM channel, so
     # all inbox entries should reference the user-DM channel ID instead.
-    if channel_id in CHANNEL_REMAP:
-        remapped_id = CHANNEL_REMAP[channel_id]
-        log.info(
-            "Inbound: remapping channel %s → %s",
-            channel_id, remapped_id,
-        )
+    remapped_id = _remap_channel(channel_id)
+    if remapped_id != channel_id:
+        log.info("Inbound: remapping channel %s → %s", channel_id, remapped_id)
         channel_id = remapped_id
 
     # Generate message ID
@@ -487,12 +498,9 @@ def _send_slack_reply(reply: dict) -> bool:
     thread_ts = reply.get("thread_ts")
 
     # Apply outbound channel remap from config — no hardcoded channel IDs.
-    if channel_id in CHANNEL_REMAP:
-        remapped = CHANNEL_REMAP[channel_id]
-        log.info(
-            "Outbound: remapping channel %s → %s",
-            channel_id, remapped,
-        )
+    remapped = _remap_channel(channel_id)
+    if remapped != channel_id:
+        log.info("Outbound: remapping channel %s → %s", channel_id, remapped)
         channel_id = remapped
 
     try:

--- a/tests/unit/test_bot/test_slack_router_config.py
+++ b/tests/unit/test_bot/test_slack_router_config.py
@@ -388,3 +388,85 @@ class TestOutboundChannelRemap:
 
         posted_channel = m.user_client.chat_postMessage.call_args[1]["channel"]
         assert posted_channel == "DUNKNOWN001"
+
+
+# ---------------------------------------------------------------------------
+# 6. _remap_channel helper (PR 2)
+# ---------------------------------------------------------------------------
+
+class TestRemapChannelHelper:
+    """_remap_channel is the single shared lookup for both inbound and outbound paths."""
+
+    def test_remap_channel_maps_src_to_dst(self):
+        """Source channel is mapped to its destination."""
+        m = _load_module(_minimal_env())
+        assert m._remap_channel(FAKE_BOT_CHANNEL) == FAKE_USER_CHANNEL
+
+    def test_remap_channel_returns_unchanged_when_not_in_map(self):
+        """An unknown channel is returned unchanged."""
+        m = _load_module(_minimal_env())
+        assert m._remap_channel("DUNKNOWN999") == "DUNKNOWN999"
+
+    def test_remap_channel_returns_unchanged_when_map_empty(self):
+        """When CHANNEL_REMAP is empty, all channels are returned unchanged."""
+        env = _minimal_env()
+        del env["LOBSTER_SLACK_CHANNEL_REMAP"]
+        m = _load_module(env)
+        assert m._remap_channel(FAKE_BOT_CHANNEL) == FAKE_BOT_CHANNEL
+
+    def test_inbound_and_outbound_use_same_remap_table(self):
+        """Both inbound handler and outbound send function call _remap_channel.
+
+        Verified by monkey-patching _remap_channel and confirming both paths
+        reach it.  This is the key invariant: the single helper eliminates
+        any risk of the two call sites drifting out of sync.
+        """
+        m = _load_module(_minimal_env())
+
+        calls = []
+
+        def tracking_remap(channel_id):
+            calls.append(("remap_called", channel_id))
+            return m.CHANNEL_REMAP.get(channel_id, channel_id)
+
+        # Patch the helper on the module
+        import types
+        m._remap_channel = tracking_remap
+
+        # Trigger inbound path
+        written = {}
+
+        def fake_write(msg_data):
+            written.update(msg_data)
+
+        m.write_message_to_inbox = fake_write
+        m.get_user_info = lambda uid: {"name": "u", "profile": {}, "real_name": "U"}
+        m.get_channel_info = lambda cid: {"name": "dm", "is_im": True}
+        m._channel_config = None
+        m._CHANNEL_CONFIG_ENABLED = False
+        m._INGRESS_LOGGING_ENABLED = False
+        m.ALLOWED_CHANNELS = []
+        m.ALLOWED_USERS = []
+
+        body = {
+            "event": {
+                "user": "USENDER001",
+                "channel": FAKE_BOT_CHANNEL,
+                "text": "hello",
+                "ts": "1234567890.000200",
+                "thread_ts": None,
+            }
+        }
+        m.handle_message_events(body=body, say=MagicMock(), logger=MagicMock())
+
+        # Trigger outbound path
+        m.user_client.chat_postMessage.reset_mock()
+        reply = {"chat_id": FAKE_BOT_CHANNEL, "text": "reply", "source": "slack"}
+        m._send_slack_reply(reply)
+
+        # Both paths must have called our tracking remap
+        call_channels = [c for _, c in calls]
+        assert FAKE_BOT_CHANNEL in call_channels, (
+            f"_remap_channel not called with {FAKE_BOT_CHANNEL!r}; calls={calls}"
+        )
+        assert len(calls) >= 2, f"Expected at least 2 remap calls, got {len(calls)}"


### PR DESCRIPTION
## What problem this solves

After PR #1931 introduced a single `CHANNEL_REMAP` dict, both the inbound and outbound paths still performed the dict lookup inline — two separate `CHANNEL_REMAP.get(channel_id, channel_id)` call sites. The remap logic was no longer duplicated in config, but was still duplicated in code. If either site were edited independently, they could silently diverge.

## What changed

Extracts `_remap_channel(channel_id: str) -> str` as a documented module-level helper. Both the inbound Socket Mode path (`handle_message_events`) and the outbound send path (`_send_slack_reply`) call this helper instead of inlining the lookup.

The function is generic and workspace-independent: it takes a channel ID, applies the `CHANNEL_REMAP` dict, and returns either the mapped destination or the original ID unchanged.

## What is out of scope

No config changes. No behavior change for any deployment — this is a pure refactor of two dict lookups into one function.

## Functional patterns

Pure function (`_remap_channel`) — no side effects, deterministic, testable in isolation. Composition: both message paths delegate to the same helper rather than duplicating the lookup.

## Flow: before vs after

The remap logic itself is unchanged. What changed is the structural guarantee:

**Before:**
```
handle_message_events → inline: CHANNEL_REMAP.get(channel_id, channel_id)
_send_slack_reply     → inline: CHANNEL_REMAP.get(channel_id, channel_id)
```

**After:**
```
handle_message_events → _remap_channel(channel_id)  ─┐
_send_slack_reply     → _remap_channel(channel_id)  ─┘  (same function)
```

## Tests run

- [x] `uv run pytest tests/unit/test_bot/test_slack_router_config.py -v` — 21 passed, 0 failed (17 from PR 1 + 4 new)
- [x] Pre-push PII scan — clean, no issues detected

New tests added (`TestRemapChannelHelper`):
- `test_remap_channel_maps_src_to_dst` — source channel returns destination
- `test_remap_channel_returns_unchanged_when_not_in_map` — unknown channel passes through unchanged
- `test_remap_channel_returns_unchanged_when_map_empty` — empty remap table is a no-op
- `test_inbound_and_outbound_use_same_remap_table` — monkey-patches `_remap_channel` and verifies both paths invoke it, enforcing the single-helper invariant

## Manual test

N/A — pure refactor, no external service calls, no changed behavior.

## Definition of Done

- [x] Unit tests pass with proper mocking
- [x] Integration/manual test — N/A (pure refactor)
- [x] User-visible outcome — N/A (no change in message routing or content)
- [x] Side-effect audit — no external calls, no state mutations added
- [x] PII/key scan — clean