### PR TITLE
feat: add awp-poll-calendar scheduled task — Lobster-side 15-min poll (BIS-133)

### DIFF
--- a/config/config.env.example
+++ b/config/config.env.example
@@ -148,3 +148,17 @@ LOBSTER_INSTANCE_URL=
 # BOT_TALK_HTTP_URL=http://your-bot-talk-server:4242/message
 # BOT_TALK_SSH_HOST=sharedLobster
 # BOT_TALK_SSH_LOG_PATH=/home/shared/bot-talk/log.txt
+
+# AWP (Aeschylus Web Platform) calendar polling (BIS-133)
+# Required by scheduled-tasks/awp-poll-calendar.sh — the Lobster-side
+# primary cron trigger for the AWP poll-calendar pipeline.
+#
+# AWP_BASE_URL: Root URL of the AWP Vercel deployment (no trailing slash).
+#   Find it in your Vercel project dashboard under "Domains".
+#   Example: https://my-awp-app.vercel.app
+# AWP_CRON_SECRET: The value of the CRON_SECRET env var on the AWP Vercel
+#   project. Used as a Bearer token to authenticate cron requests.
+#   Find it in the Vercel project → Settings → Environment Variables.
+#   Leave unset (or empty) only if the AWP endpoint allows unauthenticated access.
+AWP_BASE_URL=https://your-awp-app.vercel.app
+# AWP_CRON_SECRET=your_cron_secret_here

--- a/scheduled-tasks/awp-poll-calendar.sh
+++ b/scheduled-tasks/awp-poll-calendar.sh
@@ -6,7 +6,7 @@
 # pipeline runs even if Vercel silently fails.
 #
 # Required config (in ~/lobster-config/config.env):
-#   AWP_BASE_URL=https://awp-two.vercel.app
+#   AWP_BASE_URL=<your AWP Vercel URL>
 #   AWP_CRON_SECRET=<value of CRON_SECRET from Vercel environment>
 #
 # Optional: AWP_CRON_SECRET may be omitted if the Vercel endpoint allows

--- a/scheduled-tasks/awp-poll-calendar.sh
+++ b/scheduled-tasks/awp-poll-calendar.sh
@@ -2,8 +2,13 @@
 # awp-poll-calendar.sh — Poll AWP calendar every 15 minutes (BIS-133)
 #
 # Calls the AWP /api/cron/poll-calendar endpoint to detect new investor meetings.
-# This is the Lobster-side fallback for the Vercel Cron trigger, ensuring the
-# pipeline runs even if Vercel silently fails.
+#
+# DEPLOYMENT NOTE — primary trigger, not a fallback:
+# This Lobster job IS the primary cron trigger for the poll-calendar pipeline.
+# The Vercel Cron trigger on the AWP project MUST be disabled (or set to a
+# safe low-frequency schedule such as every 6 hours) before deploying this job.
+# Running both at 15-minute intervals causes double-firing and potential race
+# conditions in the meeting-brief pipeline.
 #
 # Required config (in ~/lobster-config/config.env):
 #   AWP_BASE_URL=<your AWP Vercel URL>

--- a/scheduled-tasks/awp-poll-calendar.sh
+++ b/scheduled-tasks/awp-poll-calendar.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# awp-poll-calendar.sh — Poll AWP calendar every 15 minutes (BIS-133)
+#
+# Calls the AWP /api/cron/poll-calendar endpoint to detect new investor meetings.
+# This is the Lobster-side fallback for the Vercel Cron trigger, ensuring the
+# pipeline runs even if Vercel silently fails.
+#
+# Required config (in ~/lobster-config/config.env):
+#   AWP_BASE_URL=https://awp-two.vercel.app
+#   AWP_CRON_SECRET=<value of CRON_SECRET from Vercel environment>
+#
+# Optional: AWP_CRON_SECRET may be omitted if the Vercel endpoint allows
+# unauthenticated access (i.e. CRON_SECRET is not set on the Vercel project).
+#
+# Schedule: every 15 minutes (managed by Lobster systemd timer)
+# Logs: ~/lobster-workspace/scheduled-jobs/logs/awp-poll-calendar-*.log
+
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
+
+# ── Load env ───────────────────────────────────────────────────────────────────
+
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+for _env_file in "$CONFIG_DIR/config.env" "$CONFIG_DIR/global.env"; do
+    if [ -f "$_env_file" ]; then
+        set -a
+        # shellcheck source=/dev/null
+        source "$_env_file"
+        set +a
+    fi
+done
+
+# ── Validate required env ──────────────────────────────────────────────────────
+
+AWP_BASE_URL="${AWP_BASE_URL:-}"
+if [ -z "$AWP_BASE_URL" ]; then
+    echo "[awp-poll-calendar] ERROR: AWP_BASE_URL is not set in config.env" >&2
+    exit 1
+fi
+
+# ── Build request ──────────────────────────────────────────────────────────────
+
+ENDPOINT="${AWP_BASE_URL}/api/cron/poll-calendar"
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+echo "[awp-poll-calendar] $TIMESTAMP — Polling $ENDPOINT"
+
+# Include CRON_SECRET auth header if configured
+AUTH_ARGS=()
+if [ -n "${AWP_CRON_SECRET:-}" ]; then
+    AUTH_ARGS+=(--header "Authorization: Bearer $AWP_CRON_SECRET")
+fi
+
+# ── Call endpoint ──────────────────────────────────────────────────────────────
+
+HTTP_RESPONSE=$(
+    curl \
+        --silent \
+        --show-error \
+        --max-time 30 \
+        --write-out "\n%{http_code}" \
+        "${AUTH_ARGS[@]}" \
+        --header "User-Agent: Lobster/awp-poll-calendar" \
+        --get \
+        "$ENDPOINT" \
+    2>&1
+)
+
+# Split body and HTTP status code
+HTTP_STATUS=$(echo "$HTTP_RESPONSE" | tail -n1)
+HTTP_BODY=$(echo "$HTTP_RESPONSE" | head -n -1)
+
+echo "[awp-poll-calendar] Status: $HTTP_STATUS"
+echo "[awp-poll-calendar] Response: $HTTP_BODY"
+
+# ── Check result ───────────────────────────────────────────────────────────────
+
+if [ "$HTTP_STATUS" -ne 200 ]; then
+    echo "[awp-poll-calendar] ERROR: Non-200 response ($HTTP_STATUS)" >&2
+    exit 1
+fi
+
+echo "[awp-poll-calendar] Done."


### PR DESCRIPTION
## Summary

Adds a Lobster-managed scheduled task that calls the AWP `/api/cron/poll-calendar` endpoint every 15 minutes. This is the Lobster-side counterpart to the Vercel Cron trigger — ensuring the AWP meeting detection pipeline fires even if Vercel silently fails.

Part of the pre-meeting brief pipeline simplification epic (BIS-133 / Bisque-Labs/awp#132).

## What this adds

`scheduled-tasks/awp-poll-calendar.sh` — a bash script that:
- Reads `AWP_BASE_URL` from `~/lobster-config/config.env`
- Optionally reads `AWP_CRON_SECRET` for authenticated calls
- GETs `/api/cron/poll-calendar` with a 30-second timeout
- Logs status and response body
- Exits non-zero on HTTP error (so systemd marks the run as failed)

Register via `create_scheduled_job` MCP tool with schedule `*/15 * * * *`.

## Test plan

- [ ] Script runs manually: `bash ~/lobster/scheduled-tasks/awp-poll-calendar.sh` returns 200
- [ ] With `AWP_CRON_SECRET` unset: request goes through (Vercel skips auth check when not configured)
- [ ] With `AWP_CRON_SECRET` set: Authorization header is included
- [ ] Missing `AWP_BASE_URL`: exits 1 with clear error message
- [ ] Non-200 response: exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)