### PR TITLE
Add skill-builder skill

### DIFF
--- a/lobster-shop/INDEX.md
+++ b/lobster-shop/INDEX.md
@@ -18,6 +18,7 @@ Browse available skills for your Lobster assistant. Install any skill with one c
 | [Obsidian KM](./obsidian-km/) | Sync and access your Obsidian vault via Telegram — create, read, search, and manage notes from anywhere | Tool | In Dev |
 | [Buy Things](./buy-things/) | Purchase items via Telegram — search products, confirm with you, and complete checkout using Camofox browser automation | Tool | Available |
 | [Lobster Dev](./lobster-dev/) | Lobster development context — staging Docker setup, active dev patterns, and known dev environment quirks. Activate when developing or debugging Lobster itself. | Context | Available |
+| [Skill Builder](./skill-builder/) | Guides Lobster users through creating custom skills — scaffolds the correct file layout, explains the two-location model (repo vs instance), and wires MCP tool registration. | Workflow | Available |
 
 ## Templates
 

--- a/lobster-shop/skill-builder/behavior/system.md
+++ b/lobster-shop/skill-builder/behavior/system.md
@@ -14,12 +14,12 @@ Skills live in exactly one of two places — never both, never somewhere else.
 - Must be generic: no user-specific data, no instance-specific config, no private API keys
 
 **For instance-specific skills** (private to this Lobster install):
-- Location: `~/lobster-user-config/skills/<skill-name>/`
+- Location: `$LOBSTER_CONFIG_DIR/skills/<skill-name>/` (typically `~/lobster-config/skills/<skill-name>/`)
 - Never committed to any public repo — this path is private and gitignored
 - Activated via MCP tool: `activate_skill(name="<skill-name>")`
 - Lobster discovers skills from this path automatically at runtime
 
-**The critical rule:** NEVER put instance-specific skills in `~/lobster/`. If the skill contains anything personal, private, or instance-specific, it belongs in `~/lobster-user-config/skills/`.
+**The critical rule:** NEVER put instance-specific skills in `~/lobster/`. If the skill contains anything personal, private, or instance-specific, it belongs in `$LOBSTER_CONFIG_DIR/skills/` (typically `~/lobster-config/skills/`).
 
 ---
 
@@ -114,17 +114,17 @@ get_skill_preferences(name="skill-name")  # read per-skill settings
 set_skill_preference(name, key, value)    # write a per-skill setting
 ```
 
-After placing files in `~/lobster-user-config/skills/<skill-name>/`, call `activate_skill` — no restart needed.
+After placing files in `$LOBSTER_CONFIG_DIR/skills/<skill-name>/`, call `activate_skill` — no restart needed.
 
 ---
 
 ### Common mistakes
 
-- **Wrong location**: putting a private skill in `~/lobster/lobster-shop/`. Private skills must go in `~/lobster-user-config/skills/`.
+- **Wrong location**: putting a private skill in `~/lobster/lobster-shop/`. Private skills must go in `$LOBSTER_CONFIG_DIR/skills/` (typically `~/lobster-config/skills/`).
 - **Committing secrets**: API keys, personal tokens, and user-specific config must never appear in skill files. Skills in the lobster repo are public.
 - **Overly broad activation**: using `mode = "always"` for a skill that only applies in one context. Use `triggered` or `contextual` instead.
 - **One giant behavior file**: if `system.md` exceeds ~200 lines, the skill is likely covering too many concerns. Split it.
-- **Skipping `activate_skill`**: files in `~/lobster-user-config/skills/` are discovered but not automatically active. Call `activate_skill` after creating the files.
+- **Skipping `activate_skill`**: files in `$LOBSTER_CONFIG_DIR/skills/` are discovered but not automatically active. Call `activate_skill` after creating the files.
 
 ---
 
@@ -132,7 +132,7 @@ After placing files in `~/lobster-user-config/skills/<skill-name>/`, call `activ
 
 1. Create the directory:
    ```bash
-   mkdir -p ~/lobster-user-config/skills/<skill-name>/behavior
+   mkdir -p ~/lobster-config/skills/<skill-name>/behavior
    ```
 
 2. Write `skill.toml` with at minimum: `name`, `version`, `description`, `[activation]`, `[layering]`, `[provides]`.

--- a/lobster-shop/skill-builder/behavior/system.md
+++ b/lobster-shop/skill-builder/behavior/system.md
@@ -1,0 +1,152 @@
+## Lobster Skill Builder
+
+You are helping a Lobster user create a custom skill. Follow these rules strictly.
+
+---
+
+### Two-location model
+
+Skills live in exactly one of two places — never both, never somewhere else.
+
+**For skills contributed to the main Lobster repo** (available to all users via `/shop install`):
+- Location: `~/lobster/lobster-shop/<skill-name>/` inside the SiderealPress/lobster repo
+- Submit as a PR to SiderealPress/lobster
+- Must be generic: no user-specific data, no instance-specific config, no private API keys
+
+**For instance-specific skills** (private to this Lobster install):
+- Location: `~/lobster-user-config/skills/<skill-name>/`
+- Never committed to any public repo — this path is private and gitignored
+- Activated via MCP tool: `activate_skill(name="<skill-name>")`
+- Lobster discovers skills from this path automatically at runtime
+
+**The critical rule:** NEVER put instance-specific skills in `~/lobster/`. If the skill contains anything personal, private, or instance-specific, it belongs in `~/lobster-user-config/skills/`.
+
+---
+
+### Required file structure
+
+```
+<skill-name>/
+├── skill.toml              # Manifest: identity, activation, dependencies
+├── behavior/
+│   └── system.md           # Context injected into Lobster when skill is active
+├── context/
+│   └── <topic>.md          # Optional: reference docs the skill can fetch
+└── tools/
+    └── tools.yaml          # Optional: MCP tool access declarations
+```
+
+Only `skill.toml` and `behavior/system.md` are required. Add `context/` when the skill needs referenceable background knowledge. Add `tools/` when the skill registers or constrains MCP tool access.
+
+---
+
+### skill.toml — required fields
+
+```toml
+[skill]
+name = "skill-name"        # kebab-case, unique across the install
+version = "1.0.0"          # semver
+description = "..."        # One sentence, user-facing
+author = "Your Name"
+category = "workflow"      # behavioral | tool | context | workflow | integration
+
+[activation]
+mode = "triggered"         # always | triggered | contextual
+triggers = ["/command", "keyword phrase"]   # for triggered mode
+context_patterns = ["when user asks about X"]  # for contextual mode
+
+[layering]
+priority = 50              # 0-100; higher wins conflicts with other skills
+merge_strategy = "append"  # append | replace
+
+[provides]
+mcp_tools = []
+bot_commands = []
+
+[compatibility]
+enhances = []
+conflicts = []
+
+[dependencies]
+pip = []
+npm = []
+system = []
+api_keys = []
+
+[dependencies.runtime]
+python = ">=3.11"
+```
+
+---
+
+### Activation modes
+
+| Mode | When to use |
+|------|-------------|
+| `always` | Skill context should be present in every message (e.g., a persistent persona or system-wide rule) |
+| `triggered` | Skill activates only when the user says a specific command or phrase |
+| `contextual` | Skill activates based on message content patterns (e.g., "when user mentions calendar") |
+
+For most new skills, start with `triggered`. It is the least surprising to users and the easiest to test.
+
+---
+
+### behavior/system.md — what to put here
+
+This file is injected verbatim into Lobster's context when the skill is active. Write it as behavioral instructions addressed to Lobster (not the user):
+
+- Rules: "When X, do Y"
+- Reference material: tool names, API shapes, known URLs, common patterns
+- Constraints: things Lobster should never do in this context
+- Worked examples if the workflow is non-obvious
+
+Keep it focused. A behavior file that covers three unrelated topics should be split into three skills.
+
+---
+
+### MCP tools for skill management
+
+```python
+list_skills()                             # see all available and active skills
+activate_skill(name="skill-name")         # enable a skill for this session
+deactivate_skill(name="skill-name")       # disable a skill
+get_skill_preferences(name="skill-name")  # read per-skill settings
+set_skill_preference(name, key, value)    # write a per-skill setting
+```
+
+After placing files in `~/lobster-user-config/skills/<skill-name>/`, call `activate_skill` — no restart needed.
+
+---
+
+### Common mistakes
+
+- **Wrong location**: putting a private skill in `~/lobster/lobster-shop/`. Private skills must go in `~/lobster-user-config/skills/`.
+- **Committing secrets**: API keys, personal tokens, and user-specific config must never appear in skill files. Skills in the lobster repo are public.
+- **Overly broad activation**: using `mode = "always"` for a skill that only applies in one context. Use `triggered` or `contextual` instead.
+- **One giant behavior file**: if `system.md` exceeds ~200 lines, the skill is likely covering too many concerns. Split it.
+- **Skipping `activate_skill`**: files in `~/lobster-user-config/skills/` are discovered but not automatically active. Call `activate_skill` after creating the files.
+
+---
+
+### Scaffolding a new instance skill — quick steps
+
+1. Create the directory:
+   ```bash
+   mkdir -p ~/lobster-user-config/skills/<skill-name>/behavior
+   ```
+
+2. Write `skill.toml` with at minimum: `name`, `version`, `description`, `[activation]`, `[layering]`, `[provides]`.
+
+3. Write `behavior/system.md` with the instructions Lobster should follow when this skill is active.
+
+4. Activate it:
+   ```python
+   activate_skill(name="<skill-name>")
+   ```
+
+5. Verify it appears active:
+   ```python
+   list_skills()
+   ```
+
+For a skill to be contributed to the main repo, follow the same steps but in a worktree under `~/lobster-workspace/projects/<branch-name>/lobster-shop/<skill-name>/`, then open a PR to SiderealPress/lobster.

--- a/lobster-shop/skill-builder/skill.toml
+++ b/lobster-shop/skill-builder/skill.toml
@@ -1,0 +1,37 @@
+[skill]
+name = "skill-builder"
+version = "1.0.0"
+description = "Guides Lobster users through creating custom skills — scaffolds the correct file layout, explains the two-location model (repo vs instance), and wires MCP tool registration."
+author = "Lobster"
+category = "workflow"
+
+[activation]
+mode = "triggered"
+triggers = ["/skill-builder", "create skill", "new skill", "build a skill", "add skill", "make a skill", "write a skill", "create a skill"]
+context_patterns = [
+    "when user wants to create a custom skill",
+    "when user asks how to add a skill to Lobster",
+    "when user asks where skills live",
+    "when user asks how to register a skill",
+]
+
+[layering]
+priority = 50
+merge_strategy = "append"
+
+[provides]
+mcp_tools = []
+bot_commands = ["/skill-builder"]
+
+[compatibility]
+enhances = ["lobster-dev"]
+conflicts = []
+
+[dependencies]
+pip = []
+npm = []
+system = []
+api_keys = []
+
+[dependencies.runtime]
+python = ">=3.11"


### PR DESCRIPTION
## What this solves

When Lobster users want to create their own custom skills, there is no in-system guidance on the two-location model (repo vs instance), required file structure, or common mistakes like putting private skills in the wrong directory. Without this context, Lobster cannot reliably assist with skill creation.

This PR adds a triggered skill that injects the right guidance whenever a user asks Lobster to help them create a skill.

## What changed

A new `lobster-shop/skill-builder` skill with:

- **`skill.toml`** — triggered on phrases like "create skill", "new skill", "build a skill". Category: `workflow`.
- **`behavior/system.md`** — injected context covering:
  - The two-location model: `~/lobster/lobster-shop/<name>/` for repo contributions vs `~/lobster-user-config/skills/<name>/` for instance-private skills
  - Required file structure (`skill.toml`, `behavior/system.md`, optional `context/`, `tools/`)
  - All `skill.toml` required fields with annotated examples
  - Activation modes (`always`, `triggered`, `contextual`) with guidance on when to use each
  - MCP tools for skill management (`activate_skill`, `list_skills`, etc.)
  - Common mistakes (wrong location, committing secrets, overly broad activation, skipping `activate_skill`)
  - Quick-start scaffolding steps for both private and repo-contribution paths
- **`INDEX.md`** — skill-builder added to the available skills table

## Functional patterns

Pure declarative content — no code. The skill composes via the existing skill layering system (append strategy, priority 50).

## What is out of scope

This skill does not add any MCP tools, install scripts, or runtime code. It is behavioral context only. No changes to the dispatcher, skill manager, or install.sh are needed.

## Tests run

- [x] File structure verified to match existing skills (skill.toml fields, behavior/system.md layout)
- [ ] Live skill activation test — not run; this is a pure content skill with no executable components. The skill manager's loading behavior is covered by existing unit tests.

## Manual test

N/A — this change is entirely internal behavioral content. No external services, file system runtime state, or systemd units are touched.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests) — N/A, no code added
- [x] Integration/manual test run (if applicable) — N/A, content-only skill
- [x] User-visible outcome verified OR not applicable — not applicable; skill is triggered, user verifies by saying "create skill" to Lobster after install
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume — content-only, no side effects
- [x] External service calls: mocked in tests, explicitly scoped in any manual runs — N/A