### PR TITLE
fix: replace unset VENV_DIR with uv run in prune-pr-worktrees command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -222,7 +222,7 @@ apply_private_overlay() {
     step "Applying private configuration overlay from: $config_dir"
 
     # Copy config.env if exists
-    if [ -f "$config_dir/config.env" ]; then
+    if [ -f "$config_dir/config.env" ] && [ "$(realpath "$config_dir/config.env")" != "$(realpath "$CONFIG_DIR/config.env" 2>/dev/null)" ]; then
         cp "$config_dir/config.env" "$CONFIG_DIR/config.env"
         success "Applied: config.env"
     fi

--- a/install.sh
+++ b/install.sh
@@ -1413,7 +1413,7 @@ step "Registering prune-pr-worktrees MCP scheduled job..."
 # prune-pr-worktrees runs daily at 03:00 UTC via a systemd timer managed by the
 # MCP create_scheduled_job infrastructure. It removes git worktrees for merged or
 # closed PRs that are at least 7 days old, logging results to prune-worktrees.log.
-_PRUNE_CMD="$VENV_DIR/bin/python $INSTALL_DIR/scripts/prune-pr-worktrees.py --age-days 7"
+_PRUNE_CMD="uv run $INSTALL_DIR/scripts/prune-pr-worktrees.py --age-days 7"
 if command -v uv &>/dev/null && [ -f "$INSTALL_DIR/scripts/prune-pr-worktrees.py" ]; then
     if systemctl is-enabled "lobster-prune-pr-worktrees.timer" &>/dev/null; then
         substep "prune-pr-worktrees systemd timer already enabled — skipping"


### PR DESCRIPTION
## Problem

Fresh installs crash before completing because of two bugs in install.sh that were masked from each other:

1. **VENV_DIR unset (line 1416)** — `$VENV_DIR/bin/python` is referenced but VENV_DIR is never set. With `set -u` active, this is an unbound variable crash. This was the original reported failure.

2. **cp self-copy in apply_private_overlay** — after fixing (1), the install-test revealed a second crash: `apply_private_overlay()` calls `cp "$config_dir/config.env" "$CONFIG_DIR/config.env"` where both paths default to `$HOME/lobster-config`. When they resolve to the same file, `cp` exits non-zero under `set -e`. This was latent but only surfaced after (1) was removed.

The `lobster-staging` container is unaffected because its Dockerfile path skips these sections.

## Fix

Two one-line changes:

**Fix 1:** Replace `$VENV_DIR/bin/python` with `uv run`, matching the pattern used by all other scheduled-job commands in the same file (lines 1360, 1374, 1389):
```bash
_PRUNE_CMD="uv run $INSTALL_DIR/scripts/prune-pr-worktrees.py --age-days 7"
```

**Fix 2:** Add a `realpath` guard in `apply_private_overlay` to skip the copy when source and destination are the same path:
```bash
if [ -f "$config_dir/config.env" ] && [ "$(realpath "$config_dir/config.env")" != "$(realpath "$CONFIG_DIR/config.env" 2>/dev/null)" ]; then
```

Both changes are pure substitutions with no control flow impact on the normal code paths.

## Tests run
- [x] `docker compose -f tests/docker/docker-compose.test.yml up install-test --build` — **PASSED** (exit code 0). Ran from the fix branch worktree. Output confirmed: "OK: MCP import OK", "OK: Telegram import OK", "=== Installation Test PASSED ==="
- [x] Verified `grep -n "VENV_DIR" install.sh` returns no remaining unset references
- [x] Confirmed main branch still fails at line 1416 (VENV_DIR) — fix branch advances past it

## Manual test
N/A — purely internal shell variable/control-flow fixes. No external services, no Telegram output, no file I/O at runtime.

## Definition of Done
- [x] docker-install-test: PASSED (exit code 0)
- [x] Side-effect audit: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none affected
- [x] User-visible outcome: not applicable (infrastructure fix)

Closes #1943