### PR TITLE
docs: add inline comments explaining startup-flag detection constraint

### DIFF
--- a/hooks/inject-bootup-context.py
+++ b/hooks/inject-bootup-context.py
@@ -197,7 +197,12 @@ def main() -> None:
     is_dispatcher = _is_startup_flag_dispatcher()
 
     if is_dispatcher:
-        # Consume the flag so subsequent sessions (subagents) do not see it.
+        # Two-step handoff: the launcher wrote the startup flag (with its PID)
+        # BEFORE exec-ing claude, because the UUID is only known to CC after
+        # startup.  Now that CC has started and given us the UUID via hook_input,
+        # we delete the flag (so subagents never see it) and write the session-id
+        # marker file (so is_dispatcher_session() in later hooks can use the UUID
+        # directly without falling back to the slower process-tree walk).
         _consume_startup_flag()
         print(
             f"[{HOOK_NAME}] startup-flag detected live PID — injecting dispatcher bootup",

--- a/hooks/session_role.py
+++ b/hooks/session_role.py
@@ -4,28 +4,27 @@ Shared utility: dispatcher vs subagent session discrimination.
 
 ## Session-context API — `is_dispatcher(hook_input)`
 
-For use in **SessionStart / SubagentStop / Stop hooks**.
+For use in **SessionStart hooks only**.
 
 Simplified detection (issue #1908): checks the launcher-written startup flag
 file at ~/lobster-workspace/data/dispatcher-startup-flag. The launcher
 (claude-persistent.sh) writes its subshell PID to this file before exec-ing
 claude. If the file exists and the PID is still alive (kill -0), the session
-is the dispatcher. The flag is deleted by inject-bootup-context.py after
-detection so subagents never see it.
+is the dispatcher. The flag is deleted by inject-bootup-context.py at
+SessionStart — it is absent for all subsequent hook events (Stop,
+SubagentStop, PreToolUse, PostToolUse).
 
 ## Hook-process-context API — `is_dispatcher_session(hook_input)`
 
-For use in **PreToolUse hooks** where an `agent_id` field is injected by
-CC for subagent sessions (absent for the dispatcher), and where the
-process-tree can supplement the state-file check when the system is very
-early in boot (before `session_start` has been called).
+For use in **PreToolUse / Stop hooks** — any hook that fires AFTER the startup
+flag has been consumed at SessionStart.  Uses agent_id fast path, MCP state
+files, and a process-tree walk fallback.
 
 Strategy: agent_id fast path → MCP state files → process-tree walk →
 env-var-only fallback.
 
-Use `is_dispatcher_session` in PreToolUse hooks that guard dispatcher-only
-behaviour (e.g. post-compact-gate).  Use `is_dispatcher` for SessionStart /
-SubagentStop / Stop hooks.
+Use `is_dispatcher_session` in PreToolUse / Stop hooks.  Use `is_dispatcher`
+only in SessionStart hooks (where the flag is still present).
 
 NOTE: is_dispatcher_session() is intentionally left unchanged from the pre-
 simplification version (issue #1908 MUST-FIX). It is still needed by PreToolUse
@@ -101,11 +100,12 @@ def is_dispatcher(hook_input: dict) -> bool:  # noqa: ARG001
     hook_input is accepted for API compatibility but is not used — the startup
     flag is the sole detection signal for SessionStart hooks.
 
-    USE IN: SessionStart / SubagentStop / Stop hooks (early hook lifecycle, flag
-    still present).  NOT for PreToolUse — the flag is consumed at SessionStart
-    and is absent for all subsequent hooks.  The UUID cannot be used here instead
-    because CC generates it internally after exec; the launcher has no way to
-    predict it before writing the flag.
+    USE IN: SessionStart only — the flag is consumed (deleted) at SessionStart
+    and is absent for all subsequent hooks.  For Stop / PreToolUse hooks, use
+    is_dispatcher_session() which falls back to the session-ID state files and
+    the process-tree walk.  The UUID cannot be used here instead because CC
+    generates it internally after exec; the launcher has no way to predict it
+    before writing the flag.
     """
     try:
         if not STARTUP_FLAG_FILE.exists():

--- a/hooks/session_role.py
+++ b/hooks/session_role.py
@@ -100,6 +100,12 @@ def is_dispatcher(hook_input: dict) -> bool:  # noqa: ARG001
 
     hook_input is accepted for API compatibility but is not used — the startup
     flag is the sole detection signal for SessionStart hooks.
+
+    USE IN: SessionStart / SubagentStop / Stop hooks (early hook lifecycle, flag
+    still present).  NOT for PreToolUse — the flag is consumed at SessionStart
+    and is absent for all subsequent hooks.  The UUID cannot be used here instead
+    because CC generates it internally after exec; the launcher has no way to
+    predict it before writing the flag.
     """
     try:
         if not STARTUP_FLAG_FILE.exists():
@@ -275,9 +281,10 @@ def _is_dispatcher_by_process_tree() -> bool:
 def is_dispatcher_session(hook_input: dict) -> bool:
     """Return True when this hook is running inside the dispatcher Claude.
 
-    **For use in PreToolUse hooks** (hook-process context).  Adds a process-tree
-    walk fallback on top of the state-file checks in `is_dispatcher()`, for the
-    early-boot window before `session_start` has been called.
+    **For use in PreToolUse / Stop hooks** — i.e., any hook that fires AFTER
+    SessionStart has already consumed and deleted the startup flag.  Cannot use
+    is_dispatcher() here because the flag no longer exists by the time these
+    hooks run.  Falls back to session-ID state files and the process-tree walk.
 
     Detection strategy (in order):
       0. agent_id fast path: CC injects agent_id only into subagent PreToolUse
@@ -288,9 +295,6 @@ def is_dispatcher_session(hook_input: dict) -> bool:
       2. Process-tree walk: count consecutive claude ancestors before a tmux pane
          PID.  ≤1 ancestor → dispatcher; ≥2 → subagent.
       3. Env-var-only fallback: LOBSTER_MAIN_SESSION=1 without tmux confirmation.
-
-    For SessionStart / SubagentStop / Stop hooks, use the simpler `is_dispatcher()`
-    which checks the startup flag file.
 
     NOTE: Intentionally unchanged by issue #1908 — PreToolUse hooks depend on this
     function's process-tree + state-file logic during active processing (after the


### PR DESCRIPTION
Adds WHY comments to session_role.py, inject-bootup-context.py, and dispatcher-state-stop.py explaining the two-step startup-flag → session-id-marker handoff and why is_dispatcher() cannot be used in Stop hooks.

## Changes

- **session_role.py** — `is_dispatcher()`: added a USE IN note clarifying which hook lifecycle stages this applies to and why the UUID cannot be used as an alternative (CC generates it after exec, so the launcher cannot predict it before writing the flag). `is_dispatcher_session()`: updated the leading sentence to explicitly state it handles hooks AFTER the startup flag has been consumed.
- **inject-bootup-context.py** — replaced the brief "Consume the flag" comment with a two-sentence explanation of the two-step handoff: flag written before exec (no UUID possible), then deleted here and replaced with the session-id marker (UUID now known via hook_input).
- **dispatcher-state-stop.py** — already had the correct call-site comment; no change needed.

## Test plan
- [ ] Doc-only change; no functional change. Verify grep for `is_dispatcher\b` in hook call sites still shows the same callers.