### PR TITLE
fix(tests): isolate inject-bootup-context dispatcher tests from production state files

### DIFF
--- a/tests/unit/test_hooks/test_startup_flag_dispatcher_detection.py
+++ b/tests/unit/test_hooks/test_startup_flag_dispatcher_detection.py
@@ -80,12 +80,19 @@ class _PatchEnv:
                 os.environ[k] = saved_v
 
 
-def _load_inject_hook(*, workspace: Path) -> object:
-    """Load inject-bootup-context.py with a controlled LOBSTER_WORKSPACE."""
+def _load_inject_hook(*, workspace: Path, home: "Path | None" = None) -> object:
+    """Load inject-bootup-context.py with a controlled LOBSTER_WORKSPACE (and HOME).
+
+    Pass home= to prevent HOME-derived paths (e.g. session_role.DISPATCHER_SESSION_FILE)
+    from resolving to production paths when the hook calls write_dispatcher_session_id().
+    """
     import uuid
 
     unique_name = f"inject_bootup_{uuid.uuid4().hex}"
-    with _PatchEnv({"LOBSTER_WORKSPACE": str(workspace)}):
+    env: dict = {"LOBSTER_WORKSPACE": str(workspace)}
+    if home is not None:
+        env["HOME"] = str(home)
+    with _PatchEnv(env):
         spec = importlib.util.spec_from_file_location(unique_name, _INJECT_HOOK_PATH)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
@@ -243,7 +250,15 @@ class TestStartupFlagDeletion:
 
         hook_input = json.dumps({"session_id": "dispatcher-uuid-abc"})
 
-        with _PatchEnv({"LOBSTER_WORKSPACE": str(tmp_path)}):
+        # HOME must be patched so write_dispatcher_session_id() and
+        # state_machine.write_state() resolve their paths under tmp_path,
+        # not under the real HOME — preventing production file corruption.
+        with _PatchEnv(
+            {
+                "HOME": str(tmp_path),
+                "LOBSTER_WORKSPACE": str(tmp_path),
+            }
+        ):
             spec = importlib.util.spec_from_file_location(
                 "inject_flag_delete_test", _INJECT_HOOK_PATH
             )
@@ -256,6 +271,14 @@ class TestStartupFlagDeletion:
             mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
             mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
             mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+            mod.CONTEXT_INJECTION_LOG = tmp_path / "logs" / "context-injection.log"
+            # Redirect the dispatcher session-id file so write_dispatcher_session_id()
+            # never touches ~/messages/config/dispatcher-session-id.
+            mod.session_role.DISPATCHER_SESSION_FILE = (
+                tmp_path / "messages" / "config" / "dispatcher-session-id"
+            )
+            # Redirect state machine write so it doesn't touch production state file.
+            mod.state_machine.STATE_FILE = tmp_path / "data" / "dispatcher-state.json"
 
             with patch("sys.stdin", io.StringIO(hook_input)):
                 with pytest.raises(SystemExit):
@@ -286,7 +309,7 @@ class TestStartupFlagDeletion:
 
         hook_input = json.dumps({"session_id": "some-subagent-uuid"})
 
-        with _PatchEnv({"LOBSTER_WORKSPACE": str(tmp_path)}):
+        with _PatchEnv({"HOME": str(tmp_path), "LOBSTER_WORKSPACE": str(tmp_path)}):
             spec = importlib.util.spec_from_file_location(
                 "inject_no_delete_test", _INJECT_HOOK_PATH
             )
@@ -299,6 +322,7 @@ class TestStartupFlagDeletion:
             mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
             mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
             mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+            mod.CONTEXT_INJECTION_LOG = tmp_path / "logs" / "context-injection.log"
 
             with patch("sys.stdin", io.StringIO(hook_input)):
                 with pytest.raises(SystemExit):
@@ -329,7 +353,10 @@ class TestMainRoutingViaStartupFlag:
         dispatcher_bootup, subagent_bootup = self._setup_bootup_files(tmp_path)
         hook_input = json.dumps({"session_id": session_id})
 
-        with _PatchEnv({"LOBSTER_WORKSPACE": str(tmp_path)}):
+        # HOME must be patched alongside LOBSTER_WORKSPACE so that any
+        # HOME-derived module-level constants (e.g. session_role.DISPATCHER_SESSION_FILE)
+        # resolved during exec_module do not point at production paths.
+        with _PatchEnv({"HOME": str(tmp_path), "LOBSTER_WORKSPACE": str(tmp_path)}):
             spec = importlib.util.spec_from_file_location(
                 f"inject_routing_{session_id[:8]}", _INJECT_HOOK_PATH
             )
@@ -342,6 +369,14 @@ class TestMainRoutingViaStartupFlag:
             mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
             mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
             mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+            mod.CONTEXT_INJECTION_LOG = tmp_path / "logs" / "context-injection.log"
+            # Redirect writes to production state files so tests never corrupt
+            # ~/messages/config/dispatcher-session-id or
+            # ~/lobster-workspace/data/dispatcher-state.json.
+            mod.session_role.DISPATCHER_SESSION_FILE = (
+                tmp_path / "messages" / "config" / "dispatcher-session-id"
+            )
+            mod.state_machine.STATE_FILE = tmp_path / "data" / "dispatcher-state.json"
 
             import io as _io
             from contextlib import redirect_stdout
@@ -361,7 +396,12 @@ class TestMainRoutingViaStartupFlag:
         self._setup_bootup_files(tmp_path)
         hook_input = json.dumps({"session_id": "any-session-uuid"})
 
-        with _PatchEnv({"LOBSTER_WORKSPACE": str(tmp_path)}):
+        # HOME must be patched so that write_dispatcher_session_id() and
+        # state_machine.write_state() write to tmp paths, not production files.
+        # Without HOME patching, session_role.DISPATCHER_SESSION_FILE resolves to
+        # ~/messages/config/dispatcher-session-id (production), corrupting session
+        # role detection for the running dispatcher.
+        with _PatchEnv({"HOME": str(tmp_path), "LOBSTER_WORKSPACE": str(tmp_path)}):
             spec = importlib.util.spec_from_file_location(
                 "inject_live_flag_test", _INJECT_HOOK_PATH
             )
@@ -374,6 +414,14 @@ class TestMainRoutingViaStartupFlag:
             mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
             mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
             mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+            mod.CONTEXT_INJECTION_LOG = tmp_path / "logs" / "context-injection.log"
+            # Redirect writes to production state files so tests never corrupt
+            # ~/messages/config/dispatcher-session-id or
+            # ~/lobster-workspace/data/dispatcher-state.json.
+            mod.session_role.DISPATCHER_SESSION_FILE = (
+                tmp_path / "messages" / "config" / "dispatcher-session-id"
+            )
+            mod.state_machine.STATE_FILE = tmp_path / "data" / "dispatcher-state.json"
 
             with patch("sys.stdin", io.StringIO(hook_input)):
                 with pytest.raises(SystemExit):
@@ -392,7 +440,7 @@ class TestMainRoutingViaStartupFlag:
         self._setup_bootup_files(tmp_path)
         hook_input = json.dumps({"session_id": "subagent-uuid-1234"})
 
-        with _PatchEnv({"LOBSTER_WORKSPACE": str(tmp_path)}):
+        with _PatchEnv({"HOME": str(tmp_path), "LOBSTER_WORKSPACE": str(tmp_path)}):
             spec = importlib.util.spec_from_file_location(
                 "inject_no_flag_test", _INJECT_HOOK_PATH
             )
@@ -405,6 +453,7 @@ class TestMainRoutingViaStartupFlag:
             mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
             mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
             mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+            mod.CONTEXT_INJECTION_LOG = tmp_path / "logs" / "context-injection.log"
 
             with patch("sys.stdin", io.StringIO(hook_input)):
                 with pytest.raises(SystemExit):
@@ -423,7 +472,7 @@ class TestMainRoutingViaStartupFlag:
         self._setup_bootup_files(tmp_path)
         hook_input = json.dumps({"session_id": "stale-flag-session-uuid"})
 
-        with _PatchEnv({"LOBSTER_WORKSPACE": str(tmp_path)}):
+        with _PatchEnv({"HOME": str(tmp_path), "LOBSTER_WORKSPACE": str(tmp_path)}):
             spec = importlib.util.spec_from_file_location(
                 "inject_stale_flag_test", _INJECT_HOOK_PATH
             )
@@ -436,6 +485,7 @@ class TestMainRoutingViaStartupFlag:
             mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
             mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
             mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+            mod.CONTEXT_INJECTION_LOG = tmp_path / "logs" / "context-injection.log"
 
             with patch("sys.stdin", io.StringIO(hook_input)):
                 with pytest.raises(SystemExit):


### PR DESCRIPTION
## Problem

Tests in `test_startup_flag_dispatcher_detection.py` that exercised the dispatcher path of `main()` in `inject-bootup-context.py` were writing to production files on every test run:

- `~/messages/config/dispatcher-session-id` — overwritten with `any-session-uuid`
- `~/lobster-workspace/data/dispatcher-state.json` — overwritten with `STARTING` state + test session ID

This caused the live dispatcher's session role detection to see a stale `STARTING` state (production `dispatcher-state.json` was briefly corrupted), which is what Sahar observed at 18:07 UTC today.

**Root cause:** `_PatchEnv` in these tests patched `LOBSTER_WORKSPACE` but not `HOME`. Two module-level constants in already-cached modules are derived from `HOME`:

- `session_role.DISPATCHER_SESSION_FILE = os.path.expanduser("~/messages/config/dispatcher-session-id")` — evaluated once at import, not affected by `LOBSTER_WORKSPACE` override
- `state_machine.STATE_FILE` — evaluated from `LOBSTER_WORKSPACE` at import time, but `state_machine` was imported before the test's `_PatchEnv` took effect

When `inject-bootup-context.py` detected a live-PID startup flag and called `session_role.write_dispatcher_session_id(real_session_id)` and `state_machine.write_state(STARTING, ...)`, both writes went to the production paths.

## Fix

Three-part fix for all integration tests that call `main()` via the dispatcher path:

1. **Add `HOME` to `_PatchEnv`** — so that any HOME-derived paths resolved during `exec_module` go to `tmp_path`, not production
2. **Set `mod.session_role.DISPATCHER_SESSION_FILE`** to a tmp path after loading the module — redirects `write_dispatcher_session_id()` away from `~/messages/config/dispatcher-session-id`
3. **Set `mod.state_machine.STATE_FILE`** to a tmp path after loading the module — redirects `write_state()` away from `~/lobster-workspace/data/dispatcher-state.json`

Also adds `mod.CONTEXT_INJECTION_LOG` redirection in all affected tests for consistency (previously set by the sentinel tests, missing here).

This is exactly the isolation pattern already established in `test_inject_bootup_context_sentinel.py` — that file was already correct. The startup-flag detection tests added in PR #1960 didn't follow the same pattern.

No production code is modified.

**Before/after flow:**

```
Before (broken):
  test sets LOBSTER_WORKSPACE=tmp_path
  exec_module(inject-bootup-context.py)
  → imports session_role (cached; DISPATCHER_SESSION_FILE = ~/messages/config/...)
  → imports state_machine (cached; STATE_FILE = ~/lobster-workspace/data/...)
  main() detects live PID → dispatcher path
    → write_dispatcher_session_id() → ~/messages/config/dispatcher-session-id  [PRODUCTION]
    → state_machine.write_state()   → ~/lobster-workspace/data/dispatcher-state.json  [PRODUCTION]

After (fixed):
  test sets HOME=tmp_path, LOBSTER_WORKSPACE=tmp_path
  exec_module(inject-bootup-context.py)
  mod.session_role.DISPATCHER_SESSION_FILE = tmp_path/messages/config/dispatcher-session-id
  mod.state_machine.STATE_FILE = tmp_path/data/dispatcher-state.json
  main() detects live PID → dispatcher path
    → write_dispatcher_session_id() → tmp_path/messages/config/...  [ISOLATED]
    → state_machine.write_state()   → tmp_path/data/...  [ISOLATED]
```

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_startup_flag_dispatcher_detection.py -v` — 15 passed, 0 failed
- [x] `uv run pytest tests/unit/ -v` — 3495 passed, 26 skipped in 160s
- [x] Manual verification: wrote sentinel value to `~/messages/config/dispatcher-session-id`, ran the previously-failing test, confirmed sentinel unchanged after the test

## Manual test

N/A — this is a test isolation fix. No production code is modified, no external services are called, no runtime file state changes.

## Definition of Done
- [x] Unit tests pass with proper isolation (no production hits)
- [x] User-visible outcome: N/A — test isolation fix with no user-visible behavior change
- [x] Side-effect audit: fix eliminates unscoped writes; no new writes introduced