### PR TITLE
fix(context-monitor): wire WINDING_DOWN state on context threshold (issue #1918)

### DIFF
--- a/hooks/context-monitor.py
+++ b/hooks/context-monitor.py
@@ -13,8 +13,8 @@ Approach:
      contains a `message.usage` block.
   3. Compute total tokens = input_tokens + cache_creation_input_tokens
      + cache_read_input_tokens.
-  4. Look up the model's max context window from a known table (1M for Sonnet/Opus
-     4.x, 200k for Haiku or unknown models).
+  4. Look up the model's max context window from a known table (200k for all
+     current CC models; see MODEL_CONTEXT_SIZES for details).
   5. Compute used_pct and trigger wind-down mode if at or above WARNING_THRESHOLD.
 
 Below the warning threshold (default 70%): logs usage to context-monitor.log.
@@ -30,6 +30,34 @@ import uuid
 from pathlib import Path
 from datetime import datetime, timezone
 
+# Import state machine for WINDING_DOWN transition (issue #1918).
+# Imported lazily in _write_winding_down() so a missing/broken import never
+# blocks context monitoring. Silent on all errors.
+_STATE_MACHINE_LOADED = False
+_state_machine = None
+
+def _write_winding_down(session_id: str = "") -> None:
+    """Write WINDING_DOWN state to dispatcher-state.json (issue #1918).
+
+    Called once when the context_warning threshold is crossed. Silent on all
+    errors — must never interrupt context monitoring.
+    """
+    global _STATE_MACHINE_LOADED, _state_machine
+    try:
+        if not _STATE_MACHINE_LOADED:
+            import importlib.util
+            _hooks_dir = Path(__file__).parent
+            _src_dir = _hooks_dir.parent / "src"
+            if str(_src_dir) not in sys.path:
+                sys.path.insert(0, str(_src_dir))
+            import state_machine as _sm
+            _state_machine = _sm
+            _STATE_MACHINE_LOADED = True
+        if _state_machine is not None:
+            _state_machine.write_state(_state_machine.WINDING_DOWN, session_id=session_id)
+    except Exception:
+        pass
+
 WARNING_THRESHOLD = 70.0
 DEDUP_FLAG = Path("/tmp/lobster-context-warning-sent")
 
@@ -37,8 +65,12 @@ DEDUP_FLAG = Path("/tmp/lobster-context-warning-sent")
 # 'claude-haiku-4-5-20251001' resolve correctly.
 # Default fallback: 200_000 (conservative — avoids false negatives on unknown models).
 MODEL_CONTEXT_SIZES: list[tuple[str, int]] = [
-    ("claude-sonnet-4-6", 1_000_000),
-    ("claude-opus-4-6", 1_000_000),
+    # claude-sonnet-4-6 supports up to 1M tokens but CC's default window is 200k.
+    # Update when we can detect which mode is active.
+    ("claude-sonnet-4-6", 200_000),
+    # claude-opus-4-6 supports up to 1M tokens but CC's default window is 200k.
+    # Update when we can detect which mode is active.
+    ("claude-opus-4-6", 200_000),
     ("claude-haiku-4-5", 200_000),
 ]
 DEFAULT_CONTEXT_SIZE = 200_000
@@ -206,6 +238,7 @@ def _handle_payload(
 
     tool_name = data.get("tool_name", "unknown")
     transcript_path = data.get("transcript_path")
+    session_id = data.get("session_id", "")
 
     result = _read_transcript_usage(transcript_path)
 
@@ -237,6 +270,10 @@ def _handle_payload(
     message = _build_warning_message(used_pct)
     _write_warning_to_inbox(inbox_dir, message)
     DEDUP_FLAG.touch()
+    # Transition dispatcher state to WINDING_DOWN (issue #1918).
+    # Written after the inbox message so the dispatcher sees the context_warning
+    # before the health check reads WINDING_DOWN and suppresses restarts.
+    _write_winding_down(session_id=session_id)
 
 
 def main() -> None:

--- a/tests/unit/test_hooks/test_context_monitor.py
+++ b/tests/unit/test_hooks/test_context_monitor.py
@@ -13,7 +13,7 @@ Behaviors verified:
 1. Transcript present with usage → correct percentage computed from token counts.
 2. transcript_path absent → WARN logged, no crash.
 3. Last assistant turn is selected when multiple turns exist.
-4. Model lookup table: Sonnet 4.6 = 1M, Haiku 4.5 = 200k, unknown = 200k.
+4. Model lookup table: Sonnet 4.6 = 200k (CC default), Haiku 4.5 = 200k, unknown = 200k.
 5. At or above WARNING_THRESHOLD → context_warning written to inbox (once per session).
 6. Dedup flag suppresses second warning.
 7. _handle_payload() accepts injectable log_dir and inbox_dir.
@@ -33,7 +33,11 @@ _HOOK_PATH = _HOOKS_DIR / "context-monitor.py"
 # Named constants matching the spec — these are protocol-level values.
 WARN_PREFIX_ABSENT_CONTEXT = "[WARN] transcript usage unavailable"
 WARNING_THRESHOLD = 70.0
-SONNET_4_6_MAX_CONTEXT = 1_000_000
+# claude-sonnet-4-6 supports up to 1M tokens but CC's default window is 200k.
+# Update when we can detect which mode is active.
+SONNET_4_6_MAX_CONTEXT = 200_000
+# claude-opus-4-6 also uses CC's default 200k window.
+OPUS_4_6_MAX_CONTEXT = 200_000
 HAIKU_4_5_MAX_CONTEXT = 200_000
 DEFAULT_MAX_CONTEXT = 200_000
 
@@ -81,14 +85,14 @@ class TestTranscriptUsageReading:
     def test_returns_correct_percentage_from_transcript(self, tmp_path):
         """Transcript with usage block → percentage computed from token sum / model max."""
         mod = _load_hook()
-        # 500_000 tokens on a 1M-context Sonnet model → 50%
+        # 100_000 tokens on a 200k-context Sonnet model (CC default) → 50%
         transcript = _make_transcript(tmp_path, [
             {
                 "model": "claude-sonnet-4-6",
                 "usage": {
-                    "input_tokens": 100_000,
-                    "cache_creation_input_tokens": 200_000,
-                    "cache_read_input_tokens": 200_000,
+                    "input_tokens": 20_000,
+                    "cache_creation_input_tokens": 40_000,
+                    "cache_read_input_tokens": 40_000,
                     "output_tokens": 5_000,
                 },
             }
@@ -107,7 +111,7 @@ class TestTranscriptUsageReading:
             {
                 "model": "claude-sonnet-4-6",
                 "usage": {
-                    "input_tokens": 100_000,
+                    "input_tokens": 20_000,
                     "cache_creation_input_tokens": 0,
                     "cache_read_input_tokens": 0,
                 },
@@ -115,7 +119,7 @@ class TestTranscriptUsageReading:
             {
                 "model": "claude-sonnet-4-6",
                 "usage": {
-                    "input_tokens": 800_000,  # 80% — this is the last turn
+                    "input_tokens": 160_000,  # 80% of 200k CC window — this is the last turn
                     "cache_creation_input_tokens": 0,
                     "cache_read_input_tokens": 0,
                 },
@@ -177,15 +181,15 @@ class TestTranscriptUsageReading:
 class TestModelContextLookup:
     """_model_max_context() returns correct sizes for known and unknown models."""
 
-    def test_sonnet_4_6_returns_1m(self):
-        """claude-sonnet-4-6 → 1_000_000."""
+    def test_sonnet_4_6_returns_200k(self):
+        """claude-sonnet-4-6 → 200_000 (CC default window)."""
         mod = _load_hook()
         assert mod._model_max_context("claude-sonnet-4-6") == SONNET_4_6_MAX_CONTEXT
 
-    def test_opus_4_6_returns_1m(self):
-        """claude-opus-4-6 → 1_000_000."""
+    def test_opus_4_6_returns_200k(self):
+        """claude-opus-4-6 → 200_000 (CC default window)."""
         mod = _load_hook()
-        assert mod._model_max_context("claude-opus-4-6") == SONNET_4_6_MAX_CONTEXT
+        assert mod._model_max_context("claude-opus-4-6") == OPUS_4_6_MAX_CONTEXT
 
     def test_haiku_4_5_bare_returns_200k(self):
         """claude-haiku-4-5 → 200_000."""
@@ -217,14 +221,14 @@ class TestHandlePayloadTranscriptPath:
         log_dir = tmp_path / "lobster-workspace" / "logs"
         log_dir.mkdir(parents=True)
 
-        # 300k / 1M = 30%
+        # 60k / 200k (CC default) = 30%
         transcript = _make_transcript(tmp_path, [
             {
                 "model": "claude-sonnet-4-6",
                 "usage": {
-                    "input_tokens": 150_000,
-                    "cache_creation_input_tokens": 100_000,
-                    "cache_read_input_tokens": 50_000,
+                    "input_tokens": 30_000,
+                    "cache_creation_input_tokens": 20_000,
+                    "cache_read_input_tokens": 10_000,
                 },
             }
         ])
@@ -253,12 +257,12 @@ class TestHandlePayloadTranscriptPath:
         original_dedup = mod.DEDUP_FLAG
         mod.DEDUP_FLAG = dedup_flag
         try:
-            # 800k / 1M = 80% → above 70% threshold
+            # 160k / 200k (CC default) = 80% → above 70% threshold
             transcript = _make_transcript(tmp_path, [
                 {
                     "model": "claude-sonnet-4-6",
                     "usage": {
-                        "input_tokens": 800_000,
+                        "input_tokens": 160_000,
                         "cache_creation_input_tokens": 0,
                         "cache_read_input_tokens": 0,
                     },
@@ -291,11 +295,12 @@ class TestHandlePayloadTranscriptPath:
         original_dedup = mod.DEDUP_FLAG
         mod.DEDUP_FLAG = dedup_flag
         try:
+            # 180k / 200k (CC default) = 90% → above 70% threshold
             transcript = _make_transcript(tmp_path, [
                 {
                     "model": "claude-sonnet-4-6",
                     "usage": {
-                        "input_tokens": 900_000,
+                        "input_tokens": 180_000,
                         "cache_creation_input_tokens": 0,
                         "cache_read_input_tokens": 0,
                     },
@@ -368,3 +373,131 @@ class TestHandlePayloadSignature:
         assert "inbox_dir" in sig.parameters, (
             "_handle_payload() must accept inbox_dir= for testability"
         )
+
+
+class TestWindingDownStateTransition:
+    """_write_winding_down() writes WINDING_DOWN to dispatcher-state.json (issue #1918)."""
+
+    def test_winding_down_calls_write_state_on_threshold(self, tmp_path):
+        """When context_warning is triggered, write_state(WINDING_DOWN) is called.
+
+        Uses a mock state machine so the test doesn't depend on the real
+        state_machine module being on sys.path (it may not be on older branches).
+        """
+        mod = _load_hook()
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        dedup_flag = tmp_path / "context-warning-sent"
+
+        # Record calls to write_state via a mock state machine object
+        write_state_calls: list[dict] = []
+
+        class MockStateMachine:
+            WINDING_DOWN = "WINDING_DOWN"
+
+            @staticmethod
+            def write_state(state: str, session_id: str = "") -> None:
+                write_state_calls.append({"state": state, "session_id": session_id})
+
+        original_dedup = mod.DEDUP_FLAG
+        mod.DEDUP_FLAG = dedup_flag
+
+        # Inject mock directly — bypass the lazy import path
+        mod._STATE_MACHINE_LOADED = True
+        mod._state_machine = MockStateMachine
+
+        try:
+            # 160k / 200k (CC default) = 80% → triggers threshold
+            transcript = _make_transcript(tmp_path, [
+                {
+                    "model": "claude-sonnet-4-6",
+                    "usage": {
+                        "input_tokens": 160_000,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                    },
+                }
+            ])
+            payload = {
+                "tool_name": "Bash",
+                "transcript_path": str(transcript),
+                "session_id": "test-session-001",
+            }
+            mod._handle_payload(payload, log_dir=log_dir, inbox_dir=inbox_dir)
+        finally:
+            mod.DEDUP_FLAG = original_dedup
+            mod._STATE_MACHINE_LOADED = False
+            mod._state_machine = None
+
+        assert len(write_state_calls) == 1, (
+            f"Expected exactly one write_state call, got: {write_state_calls}"
+        )
+        assert write_state_calls[0]["state"] == "WINDING_DOWN", (
+            f"Expected WINDING_DOWN, got: {write_state_calls[0]['state']}"
+        )
+        assert write_state_calls[0]["session_id"] == "test-session-001"
+
+    def test_winding_down_not_called_below_threshold(self, tmp_path):
+        """write_state(WINDING_DOWN) must NOT be called when below threshold."""
+        mod = _load_hook()
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+
+        write_state_calls: list[dict] = []
+
+        class MockStateMachine:
+            WINDING_DOWN = "WINDING_DOWN"
+
+            @staticmethod
+            def write_state(state: str, session_id: str = "") -> None:
+                write_state_calls.append({"state": state, "session_id": session_id})
+
+        mod._STATE_MACHINE_LOADED = True
+        mod._state_machine = MockStateMachine
+
+        try:
+            # 60k / 200k (CC default) = 30% → below 70% threshold
+            transcript = _make_transcript(tmp_path, [
+                {
+                    "model": "claude-sonnet-4-6",
+                    "usage": {
+                        "input_tokens": 60_000,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                    },
+                }
+            ])
+            payload = {"tool_name": "Bash", "transcript_path": str(transcript)}
+            mod._handle_payload(payload, log_dir=log_dir, inbox_dir=inbox_dir)
+        finally:
+            mod._STATE_MACHINE_LOADED = False
+            mod._state_machine = None
+
+        assert len(write_state_calls) == 0, (
+            f"write_state must not be called below threshold, got: {write_state_calls}"
+        )
+
+    def test_winding_down_silent_on_import_error(self, tmp_path):
+        """_write_winding_down() must never raise — it is a best-effort write."""
+        mod = _load_hook()
+        # Ensure lazy-load state is reset so the import path is exercised
+        mod._STATE_MACHINE_LOADED = False
+        mod._state_machine = None
+
+        # Restrict sys.path to a location with no state_machine module
+        import sys
+        original_path = sys.path[:]
+        sys.path = [str(tmp_path)]  # empty dir, no state_machine
+        try:
+            # Must not raise
+            mod._write_winding_down(session_id="test")
+        except Exception as exc:
+            pytest.fail(f"_write_winding_down() must be silent on error, but raised: {exc}")
+        finally:
+            sys.path = original_path
+            mod._STATE_MACHINE_LOADED = False
+            mod._state_machine = None


### PR DESCRIPTION
## Summary

- `context-monitor.py` was not writing `WINDING_DOWN` to `dispatcher-state.json` when the 70% context threshold was crossed — the health check could not suppress restarts during graceful wind-down
- Also fixes `MODEL_CONTEXT_SIZES`: sonnet-4-6 and opus-4-6 were set to 1M instead of 200k (CC default window)

### Changes

- Add `_write_winding_down()` with lazy `state_machine` import (silent on all errors — must never interrupt context monitoring)
- Call `_write_winding_down(session_id)` after the inbox `context_warning` message is written, so the dispatcher sees the message before the health check reads `WINDING_DOWN`
- Fix `MODEL_CONTEXT_SIZES`: sonnet-4-6 and opus-4-6 → 200k (CC default)
- Add 3 new `TestWindingDownStateTransition` tests: called on threshold, not called below threshold, silent on import error (mock-based, no real `state_machine` module dependency)

### Context

Gap 4 from the state machine audit: the `_write_winding_down()` function existed on `local-dev` (merged via the state-machine gap-fix) but was never PRed to `main`. This closes that gap.

The `context_warning` inbox message write already worked deterministically (MCP-level write to filesystem). This PR makes the `WINDING_DOWN` state write equally reliable by ensuring it always fires after the inbox message.

## Test plan

- [x] 22 unit tests pass (`tests/unit/test_hooks/test_context_monitor.py`) — including 3 new `TestWindingDownStateTransition` tests
- [x] Mock-based tests: no dependency on `state_machine` module being present (safe to run on `main` without the state machine PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)