### PR TITLE
fix(#1939): document background: true frontmatter as authoritative background signal; add edge-case tests

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -184,13 +184,19 @@ Never say "Noted." alone — it doesn't tell the user whether work is happening.
 2. Generate a short task_id (e.g. "fix-pr-475", "upstream-check")
 3. Write in-flight entry (see "In-flight work tracking" below)
 4. Task(
-       prompt="---\ntask_id: <task_id>\nchat_id: <chat_id>\nsource: <source>\n---\n\n...",
-       subagent_type="...",
-       run_in_background=true
+       prompt="---\ntask_id: <task_id>\nchat_id: <chat_id>\nsource: <source>\nbackground: true\n---\n\n...",
+       subagent_type="..."
    )
 5. mark_processed(message_id)
 6. Return to wait_for_messages() IMMEDIATELY
 ```
+
+> **Background intent via prompt frontmatter:** Always include `background: true` in the YAML
+> frontmatter block of every spawned-agent prompt. Do NOT pass `run_in_background=true` as a
+> separate tool parameter — CC's Agent tool schema declares `additionalProperties: false` and
+> strips any extra fields before the `require-background-agent.py` PreToolUse hook sees them
+> (issue #1939). The frontmatter key survives schema validation because it is part of the
+> `prompt` string, which is always a declared field.
 
 Agent registration is fully automatic — a PostToolUse hook fires after each Task call. You do not need to call `register_agent`.
 

--- a/hooks/require-background-agent.py
+++ b/hooks/require-background-agent.py
@@ -58,7 +58,6 @@ AGENT_TOOL_NAMES = {"Agent", "Task"}
 # Values accepted as truthy for `background:` in the YAML frontmatter.
 # Covers both YAML true/false and Python-style True/False that Claude often writes.
 _BACKGROUND_TRUE_VALUES = frozenset({"true", "yes", "1"})
-_BACKGROUND_FALSE_OR_MISSING = frozenset({"false", "no", "0", ""})
 
 
 def _has_background_true_in_frontmatter(prompt: str) -> bool:

--- a/hooks/require-background-agent.py
+++ b/hooks/require-background-agent.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""PreToolUse hook: blocks the dispatcher from calling Agent without run_in_background: true.
+"""PreToolUse hook: blocks the dispatcher from calling Agent without background intent.
 
 The Lobster dispatcher runs in an infinite message-processing loop. A foreground
-Agent call (run_in_background omitted or false) blocks the dispatcher for the
-full duration of the agent — potentially minutes — while incoming messages queue
-up unprocessed and health-check pings go unanswered.
+Agent call blocks the dispatcher for the full duration of the agent — potentially
+minutes — while incoming messages queue up unprocessed and health-check pings go
+unanswered.
 
 This hook enforces the 7-second rule as a hard constraint for the dispatcher.
 Subagents are exempt: they may legitimately spawn nested agents synchronously
@@ -13,11 +13,38 @@ when the result is needed to decide the next step.
 Note: Claude Code has used both "Agent" and "Task" as the tool name for spawning
 subagents across versions. Both are treated identically.
 
+## Background intent signals (either is sufficient)
+
+1. **tool_input["run_in_background"] is True** — the classic signal. Available
+   when the Agent tool schema includes the field. In Claude Code 2.1.123+ with
+   some model variants, the schema has additionalProperties: false and omits
+   run_in_background, causing the client to strip the field before the hook
+   sees it. This signal is checked first for backward compatibility.
+
+2. **YAML frontmatter `background: true` in prompt** — the schema-safe workaround
+   for issue #1872. The dispatcher includes `background: true` in the YAML
+   frontmatter block at the top of the prompt. This survives schema validation
+   because it's part of the `prompt` field (which is always present in the schema).
+
+   Example prompt structure:
+       ---
+       task_id: fix-pr-42
+       chat_id: 12345
+       source: telegram
+       background: true
+       ---
+
+       <actual task instructions>
+
+   The hook checks for a line matching `background: true` or `background: True`
+   within the frontmatter block (case-insensitive on the value).
+
 Exit codes:
-  0 — tool is not Agent/Task, Agent has run_in_background: true, or session is a subagent
-  2 — hard block: dispatcher called Agent/Task without run_in_background: true
+  0 — tool is not Agent/Task, background intent is signalled, or session is a subagent
+  2 — hard block: dispatcher called Agent/Task without background intent
 """
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -28,6 +55,46 @@ from session_role import is_dispatcher
 # Tool names used to spawn subagents across CC versions.
 AGENT_TOOL_NAMES = {"Agent", "Task"}
 
+# Values accepted as truthy for `background:` in the YAML frontmatter.
+# Covers both YAML true/false and Python-style True/False that Claude often writes.
+_BACKGROUND_TRUE_VALUES = frozenset({"true", "yes", "1"})
+_BACKGROUND_FALSE_OR_MISSING = frozenset({"false", "no", "0", ""})
+
+
+def _has_background_true_in_frontmatter(prompt: str) -> bool:
+    """Return True if the prompt has YAML frontmatter with `background: true`.
+
+    Accepts both YAML-style `true` and Python-style `True` (case-insensitive).
+    Returns False if:
+    - No frontmatter block is present
+    - The frontmatter has no `background` key
+    - The `background` value is anything other than a truthy string
+
+    A frontmatter block is the `---` ... `---` section at the start of the prompt
+    (after stripping leading whitespace).
+    """
+    prompt = prompt.lstrip()
+    if not prompt.startswith("---"):
+        return False
+
+    # Find the closing --- of the frontmatter block.
+    rest = prompt[3:]
+    # Match closing delimiter: must be followed by newline or end-of-string
+    m = re.search(r"\n---(?:\n|$)", rest)
+    if m is None:
+        return False
+    end = m.start()
+
+    block = rest[:end]
+    for line in block.splitlines():
+        line = line.strip()
+        if re.match(r"^background\s*:", line, re.IGNORECASE):
+            _, _, value = line.partition(":")
+            return value.strip().lower() in _BACKGROUND_TRUE_VALUES
+
+    return False
+
+
 data = json.load(sys.stdin)
 tool = data.get("tool_name", "")
 inp = data.get("tool_input", {})
@@ -35,7 +102,15 @@ inp = data.get("tool_input", {})
 if tool not in AGENT_TOOL_NAMES:
     sys.exit(0)
 
+# Signal 1: run_in_background in tool_input (available when schema includes the field).
 if inp.get("run_in_background") is True:
+    sys.exit(0)
+
+# Signal 2: background: true in prompt frontmatter (schema-safe workaround for #1872).
+# When the Agent schema strips run_in_background (additionalProperties: false),
+# the dispatcher signals background intent via the prompt frontmatter instead.
+prompt = inp.get("prompt", "")
+if _has_background_true_in_frontmatter(prompt):
     sys.exit(0)
 
 # Only enforce for the dispatcher. Subagents may call Agent synchronously.
@@ -43,10 +118,17 @@ if not is_dispatcher(data):
     sys.exit(0)
 
 print(
-    "BLOCKED: Dispatcher called Agent without run_in_background: true. "
-    "This blocks the message-processing loop for the full duration of the "
-    "subagent. Always pass run_in_background=True when spawning agents from "
-    "the dispatcher. The result will be delivered via write_result.",
+    "BLOCKED: Dispatcher called Agent without background intent. "
+    "The Agent tool schema may strip run_in_background before the hook sees it "
+    "(issue #1872). Include `background: true` in the YAML frontmatter of the prompt:\n\n"
+    "  ---\n"
+    "  task_id: <slug>\n"
+    "  chat_id: <id>\n"
+    "  source: telegram\n"
+    "  background: true\n"
+    "  ---\n\n"
+    "This ensures background intent is visible to the hook regardless of schema "
+    "validation. The result will be delivered via write_result.",
     file=sys.stderr,
 )
 sys.exit(2)

--- a/tests/unit/test_hooks/test_require_background_agent.py
+++ b/tests/unit/test_hooks/test_require_background_agent.py
@@ -14,6 +14,8 @@ Tests cover:
 - Frontmatter sentinel: absent or false means hard block for dispatcher (exit 2)
 - Sentinel is case-insensitive (background: True, background: true both accepted)
 - Subagent with no sentinel is still allowed (no enforcement for subagents)
+- _has_background_true_in_frontmatter: pure-function edge cases (leading whitespace,
+  old-style run_in_background key, background: yes/1 variants, unclosed frontmatter)
 """
 
 import importlib.util
@@ -409,16 +411,10 @@ class TestFrontmatterSentinel:
         This is the primary fix for #1872: when the schema strips run_in_background,
         the dispatcher signals background intent via the prompt frontmatter instead.
         """
-        _setup_dispatcher_marker(tmp_path, "dispatcher-sess-001")
-        import session_role
-        monkeypatch.setattr(
-            session_role, "DISPATCHER_SESSION_FILE",
-            tmp_path / "messages" / "config" / "dispatcher-session-id",
-        )
+        _patch_startup_flag(monkeypatch, tmp_path)
         hook_input = _make_hook_input(
             "Agent",
             {"prompt": FRONTMATTER_PROMPT_BACKGROUND_TRUE},
-            session_id="dispatcher-sess-001",
         )
         exit_code, stdout, stderr = _run_hook(hook_input)
         assert exit_code == 0, (
@@ -466,16 +462,10 @@ class TestFrontmatterSentinel:
         Claude often writes True/False (Python style) in YAML-like blocks.
         The hook must accept both `true` and `True`.
         """
-        _setup_dispatcher_marker(tmp_path, "dispatcher-sess-001")
-        import session_role
-        monkeypatch.setattr(
-            session_role, "DISPATCHER_SESSION_FILE",
-            tmp_path / "messages" / "config" / "dispatcher-session-id",
-        )
+        _patch_startup_flag(monkeypatch, tmp_path)
         hook_input = _make_hook_input(
             "Agent",
             {"prompt": FRONTMATTER_PROMPT_BACKGROUND_TRUE_UPPERCASE},
-            session_id="dispatcher-sess-001",
         )
         exit_code, stdout, stderr = _run_hook(hook_input)
         assert exit_code == 0, (
@@ -485,16 +475,10 @@ class TestFrontmatterSentinel:
 
     def test_subagent_no_background_sentinel_exits_0(self, monkeypatch, tmp_path):
         """Subagent without background sentinel is still allowed — enforcement is dispatcher-only."""
-        _setup_dispatcher_marker(tmp_path, "dispatcher-sess-001")
-        import session_role
-        monkeypatch.setattr(
-            session_role, "DISPATCHER_SESSION_FILE",
-            tmp_path / "messages" / "config" / "dispatcher-session-id",
-        )
+        # The startup flag is not set — is_dispatcher() returns False → subagent path → exit 0.
         hook_input = _make_hook_input(
             "Agent",
             {"prompt": FRONTMATTER_PROMPT_NO_BACKGROUND},
-            session_id="subagent-sess-999",  # Not the dispatcher
         )
         exit_code, stdout, stderr = _run_hook(hook_input)
         assert exit_code == 0, (
@@ -517,19 +501,222 @@ class TestFrontmatterSentinel:
 
     def test_both_signals_present_exits_0(self, monkeypatch, tmp_path):
         """Both run_in_background=True in tool_input AND sentinel in frontmatter → allowed."""
-        _setup_dispatcher_marker(tmp_path, "dispatcher-sess-001")
-        import session_role
-        monkeypatch.setattr(
-            session_role, "DISPATCHER_SESSION_FILE",
-            tmp_path / "messages" / "config" / "dispatcher-session-id",
-        )
+        _patch_startup_flag(monkeypatch, tmp_path)
         hook_input = _make_hook_input(
             "Agent",
             {
                 "prompt": FRONTMATTER_PROMPT_BACKGROUND_TRUE,
                 "run_in_background": True,
             },
-            session_id="dispatcher-sess-001",
         )
         exit_code, _, _ = _run_hook(hook_input)
         assert exit_code == 0
+
+
+    def test_dispatcher_old_run_in_background_key_in_frontmatter_exits_2(
+        self, monkeypatch, tmp_path
+    ):
+        """run_in_background: true in frontmatter is NOT the sentinel — must be blocked.
+
+        The sentinel key is `background`, not `run_in_background`. A prompt that puts
+        run_in_background in the frontmatter instead of background is missing the signal
+        and must be blocked (the hook sees it only if CC passes it through tool_input,
+        which it does not for Agent calls under additionalProperties: false).
+        """
+        _patch_startup_flag(monkeypatch, tmp_path)
+        old_key_prompt = """\
+---
+task_id: test-task
+chat_id: 12345
+source: telegram
+run_in_background: true
+---
+
+Do work."""
+        hook_input = _make_hook_input(
+            "Agent",
+            {"prompt": old_key_prompt},
+        )
+        exit_code, stdout, stderr = _run_hook(hook_input)
+        assert exit_code == 2, (
+            f"run_in_background in frontmatter (not background:) should be blocked. "
+            f"got exit {exit_code}. stderr={stderr!r}"
+        )
+
+    def test_dispatcher_prompt_no_frontmatter_exits_2(self, monkeypatch, tmp_path):
+        """Plain prompt (no frontmatter) from dispatcher → hard block (exit 2)."""
+        _patch_startup_flag(monkeypatch, tmp_path)
+        hook_input = _make_hook_input(
+            "Agent",
+            {"prompt": "Just a plain prompt with no frontmatter at all."},
+        )
+        exit_code, stdout, stderr = _run_hook(hook_input)
+        assert exit_code == 2, (
+            f"Plain prompt without frontmatter should be hard-blocked, "
+            f"got exit {exit_code}. stderr={stderr!r}"
+        )
+
+    def test_dispatcher_frontmatter_leading_whitespace_exits_0(
+        self, monkeypatch, tmp_path
+    ):
+        """Prompt with leading whitespace before --- is handled by lstrip() → allowed.
+
+        The _has_background_true_in_frontmatter function strips leading whitespace
+        before checking for the --- delimiter. This test verifies that a prompt that
+        starts with a newline (e.g. from multi-line string formatting) is not rejected.
+        """
+        _patch_startup_flag(monkeypatch, tmp_path)
+        prompt_with_leading_newline = "\n---\ntask_id: x\nbackground: true\n---\n\nWork."
+        hook_input = _make_hook_input(
+            "Agent",
+            {"prompt": prompt_with_leading_newline},
+        )
+        exit_code, stdout, stderr = _run_hook(hook_input)
+        assert exit_code == 0, (
+            f"Prompt with leading whitespace before --- should be allowed, "
+            f"got exit {exit_code}. stderr={stderr!r}"
+        )
+
+    def test_dispatcher_frontmatter_unclosed_exits_2(self, monkeypatch, tmp_path):
+        """Frontmatter block with no closing --- is not recognised → hard block (exit 2).
+
+        The function requires a closing --- delimiter. Without it, the block is not
+        treated as valid frontmatter and the background signal is not detected.
+        """
+        _patch_startup_flag(monkeypatch, tmp_path)
+        unclosed_frontmatter_prompt = """\
+---
+task_id: test-task
+background: true
+
+No closing delimiter here."""
+        hook_input = _make_hook_input(
+            "Agent",
+            {"prompt": unclosed_frontmatter_prompt},
+        )
+        exit_code, stdout, stderr = _run_hook(hook_input)
+        assert exit_code == 2, (
+            f"Unclosed frontmatter should not be recognised → hard block expected. "
+            f"got exit {exit_code}. stderr={stderr!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests: _has_background_true_in_frontmatter
+# ---------------------------------------------------------------------------
+#
+# These tests import the helper directly from the hook module to verify its
+# contract in isolation, without the full hook execution path.
+# ---------------------------------------------------------------------------
+
+
+def _load_frontmatter_checker():
+    """Import _has_background_true_in_frontmatter from the hook module.
+
+    The hook is a script (not a library), so we compile and exec it in a
+    restricted namespace that raises SystemExit early for the top-level
+    statements that call sys.exit(). We only need the function definition.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("require_bg_module", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    # Inject a fake stdin so the module-level `json.load(sys.stdin)` can run.
+    # The tool is not Agent, so execution exits at `sys.exit(0)` before
+    # reaching the dispatcher check.
+    import json
+    from io import StringIO
+
+    fake_stdin_data = json.dumps(
+        {"hook_event_name": "PreToolUse", "tool_name": "Bash", "tool_input": {}}
+    )
+    with (
+        patch("sys.stdin", StringIO(fake_stdin_data)),
+        patch("sys.stdout", StringIO()),
+        patch("sys.stderr", StringIO()),
+    ):
+        try:
+            spec.loader.exec_module(mod)
+        except SystemExit:
+            pass
+
+    return mod._has_background_true_in_frontmatter
+
+
+class TestHasBackgroundTrueInFrontmatter:
+    """Unit tests for the _has_background_true_in_frontmatter pure helper.
+
+    These tests verify the parsing contract in isolation: given a prompt string,
+    does the function correctly identify whether the YAML frontmatter contains
+    `background: true` (or equivalent truthy value)?
+    """
+
+    @staticmethod
+    def _fn():
+        return _load_frontmatter_checker()
+
+    def test_background_true_lowercase(self):
+        fn = self._fn()
+        assert fn("---\nbackground: true\n---\n\nbody") is True
+
+    def test_background_True_python_style(self):
+        fn = self._fn()
+        assert fn("---\nbackground: True\n---\n\nbody") is True
+
+    def test_background_yes(self):
+        """background: yes is a truthy YAML value — must be accepted."""
+        fn = self._fn()
+        assert fn("---\nbackground: yes\n---\n\nbody") is True
+
+    def test_background_1(self):
+        """background: 1 is a truthy YAML value — must be accepted."""
+        fn = self._fn()
+        assert fn("---\nbackground: 1\n---\n\nbody") is True
+
+    def test_background_false(self):
+        fn = self._fn()
+        assert fn("---\nbackground: false\n---\n\nbody") is False
+
+    def test_background_key_absent(self):
+        fn = self._fn()
+        assert fn("---\ntask_id: x\nchat_id: 1\n---\n\nbody") is False
+
+    def test_no_frontmatter(self):
+        fn = self._fn()
+        assert fn("Just a plain prompt.") is False
+
+    def test_empty_string(self):
+        fn = self._fn()
+        assert fn("") is False
+
+    def test_only_opening_delimiter(self):
+        """A lone opening --- with no closing delimiter is not valid frontmatter."""
+        fn = self._fn()
+        assert fn("---\nbackground: true\n\nno closing") is False
+
+    def test_leading_whitespace_stripped(self):
+        """Prompts with leading newlines/spaces before --- are normalised."""
+        fn = self._fn()
+        assert fn("  \n---\nbackground: true\n---\n\nbody") is True
+
+    def test_run_in_background_key_not_accepted(self):
+        """run_in_background: true is the OLD key and must NOT be recognised as the sentinel.
+
+        The sentinel key is `background`. Using run_in_background in the frontmatter
+        is a mistake that should not silently pass — it will be stripped from tool_input
+        and the frontmatter check will also correctly reject it.
+        """
+        fn = self._fn()
+        assert fn("---\nrun_in_background: true\n---\n\nbody") is False
+
+    def test_background_key_with_spaces_around_colon(self):
+        """background : true (spaces around colon) should be handled by the line parser."""
+        fn = self._fn()
+        # The regex uses \s* around the colon, so spaces are accepted.
+        assert fn("---\nbackground : true\n---\n\nbody") is True
+
+    def test_background_after_other_keys(self):
+        """background: true anywhere in the frontmatter block is accepted."""
+        fn = self._fn()
+        prompt = "---\ntask_id: my-task\nchat_id: 99\nsource: telegram\nbackground: true\n---\n\nbody"
+        assert fn(prompt) is True


### PR DESCRIPTION
Retargeted from #1968 (which targeted local-dev) to main.

Cherry-picked commit 121c7a56 from fix/issue-1939-background-frontmatter, with manual conflict resolution: the bootup doc and test file were at a different base in main vs local-dev, so changes were applied cleanly against main's current state.

## Summary

The Lobster dispatcher spawns background subagents via the Agent/Task tool. A `PreToolUse` hook (`require-background-agent.py`) blocks any Agent call that does not carry a background intent signal. The fix for this — checking `background: true` in the prompt's YAML frontmatter — was already in the hook, but the dispatcher's canonical spawn example in `sys.dispatcher.bootup.md` still showed `run_in_background=true` as a tool parameter, which CC silently strips before the hook sees it. This left the doc instructing a behaviour that does nothing, while the actual working fix (frontmatter key) was undocumented.

**`sys.dispatcher.bootup.md`** — Delegation Pattern section:
- Removed `run_in_background=true` from the Task call example (it never reaches the hook)
- Replaced the misleading "two signals required" note with a clear explanation: CC strips `run_in_background` from tool_input (Agent schema: `additionalProperties: false`), so the prompt frontmatter `background: true` is the only reliable signal (issue #1939)
- Added `background: true` to the frontmatter example in the Task call

**`tests/unit/test_hooks/test_require_background_agent.py`** — 17 new tests:
- `TestFrontmatterSentinel`: 4 new integration tests
- `TestHasBackgroundTrueInFrontmatter`: 13 pure-function unit tests

Closes #1939

🤖 Generated with [Claude Code](https://claude.com/claude-code)