### PR TITLE
fix(debug): use [exp_pid] instead of $spawn_pid in claude-wrapper.exp

### DIFF
--- a/scripts/claude-wrapper.exp
+++ b/scripts/claude-wrapper.exp
@@ -73,11 +73,17 @@ spawn claude --dangerously-skip-permissions
 # exec-ing claude: writes the launcher PID to
 # ~/lobster-workspace/data/dispatcher-startup-flag.
 #
-# In debug mode, $spawn_pid is the PID of the spawned claude process. We write
-# it immediately after spawn so the flag is present before Claude's SessionStart
-# hook fires (the hook fires during Claude's startup sequence, well after spawn
-# returns). inject-bootup-context.py checks kill -0 on this PID to confirm
-# liveness, then deletes the flag — exactly the same contract as persistent mode.
+# In debug mode, [exp_pid] returns the PID of the spawned claude process. We
+# write it immediately after spawn so the flag is present before Claude's
+# SessionStart hook fires (the hook fires during Claude's startup sequence,
+# well after spawn returns). inject-bootup-context.py checks kill -0 on this
+# PID to confirm liveness, then deletes the flag — exactly the same contract
+# as persistent mode.
+#
+# NOTE: use [exp_pid] — NOT $spawn_pid. In Tcl/expect, $spawn_pid does not
+# exist as a variable; it produces a "can't read spawn_pid: no such variable"
+# error that is silently swallowed by catch, leaving the flag file empty (0
+# bytes). [exp_pid] is the correct expect built-in for the spawned process PID.
 #
 # Without this write, is_dispatcher() returns False for every debug-mode session
 # because the flag never exists, causing thinking-heartbeat.py to skip the
@@ -88,7 +94,7 @@ set flag_file [file join $flag_dir "dispatcher-startup-flag"]
 catch { file mkdir $flag_dir }
 catch {
     set fh [open $flag_file w]
-    puts $fh $spawn_pid
+    puts $fh [exp_pid]
     close $fh
 }
 

--- a/tests/unit/test_hooks/test_claude_wrapper_exp_spawn_pid.py
+++ b/tests/unit/test_hooks/test_claude_wrapper_exp_spawn_pid.py
@@ -1,0 +1,173 @@
+"""
+Tests verifying that claude-wrapper.exp writes a valid PID to the dispatcher
+startup flag file (regression test for the $spawn_pid vs [exp_pid] bug).
+
+Root cause (fixed in this PR):
+  In Tcl/expect, $spawn_pid does not exist as a variable — it is silently
+  unset. When claude-wrapper.exp used `puts $fh $spawn_pid`, the catch block
+  swallowed the "can't read spawn_pid: no such variable" error, leaving the
+  file at 0 bytes (open truncated it; puts never ran). The hook then read the
+  empty flag and returned False, injecting the subagent bootup file for every
+  debug-mode dispatcher session.
+
+  The correct expect built-in is [exp_pid], which returns the PID of the
+  most-recently-spawned process.
+
+These tests use `expect -c` to run Tcl/expect snippets in isolation:
+1. Confirm $spawn_pid causes an empty file (the original bug)
+2. Confirm [exp_pid] writes a valid PID (the fix)
+3. Confirm the actual claude-wrapper.exp script contains [exp_pid], not $spawn_pid
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Path to claude-wrapper.exp — repo root is 3 levels above tests/unit/test_hooks/
+_REPO_ROOT = Path(__file__).parents[3]
+CLAUDE_WRAPPER_EXP = _REPO_ROOT / "scripts" / "claude-wrapper.exp"
+
+# Guard: skip all tests if expect is not installed on this system.
+_EXPECT_AVAILABLE = shutil.which("expect") is not None
+
+
+@pytest.mark.skipif(not _EXPECT_AVAILABLE, reason="expect not installed")
+class TestSpawnPidVsExpPid:
+    """Regression tests confirming [exp_pid] writes a valid PID, not an empty file."""
+
+    def test_spawn_pid_variable_does_not_exist_in_tcl(self, tmp_path):
+        """$spawn_pid is not a valid Tcl variable in expect after spawn.
+
+        This documents the original bug: using $spawn_pid causes the catch block
+        to silently swallow the error and leave the flag file empty.
+        """
+        flag = tmp_path / "dispatcher-startup-flag"
+        # Reproduce the original buggy code: open the file, then try to write $spawn_pid
+        script = f"""
+spawn sh -c "echo hello"
+catch {{
+    set fh [open {flag} w]
+    puts $fh $spawn_pid
+    close $fh
+}}
+"""
+        result = subprocess.run(
+            ["expect", "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        # The file must exist (open creates it) but be empty (puts failed)
+        assert flag.exists(), "flag file should have been created by 'open'"
+        assert flag.stat().st_size == 0, (
+            "flag must be 0 bytes when $spawn_pid is used — "
+            "puts fails silently due to undefined variable, original bug"
+        )
+
+    def test_exp_pid_writes_valid_integer_pid(self, tmp_path):
+        """[exp_pid] correctly writes the spawned process PID to the flag file.
+
+        This is the fix: replacing $spawn_pid with [exp_pid] in claude-wrapper.exp.
+        """
+        flag = tmp_path / "dispatcher-startup-flag"
+        script = f"""
+spawn sh -c "echo hello"
+catch {{
+    set fh [open {flag} w]
+    puts $fh [exp_pid]
+    close $fh
+}}
+"""
+        result = subprocess.run(
+            ["expect", "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert flag.exists(), "flag file should exist after [exp_pid] write"
+        content = flag.read_text().strip()
+        assert content, "flag file must not be empty when [exp_pid] is used"
+        assert content.isdigit(), (
+            f"flag file must contain a valid integer PID, got: {content!r}"
+        )
+        pid = int(content)
+        assert pid > 0, f"PID must be positive, got: {pid}"
+
+    def test_exp_pid_writes_pid_that_was_alive(self, tmp_path):
+        """The PID written by [exp_pid] is a real process PID (was alive at write time).
+
+        We spawn a process that sleeps briefly so we can verify the PID existed.
+        After the process exits, kill -0 will fail — we just verify the PID is
+        a plausible integer (positive, within range).
+        """
+        flag = tmp_path / "dispatcher-startup-flag"
+        script = f"""
+spawn sh -c "sleep 0.1"
+catch {{
+    set fh [open {flag} w]
+    puts $fh [exp_pid]
+    close $fh
+}}
+"""
+        result = subprocess.run(
+            ["expect", "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        content = flag.read_text().strip()
+        pid = int(content)
+        # Valid PID range on Linux: 1 < pid < 4194304 (PID_MAX_LIMIT)
+        assert 1 < pid < 4_194_304, f"PID {pid} is outside valid Linux range"
+
+
+class TestClaudeWrapperExpContainsFix:
+    """Static check: claude-wrapper.exp must use [exp_pid] and not $spawn_pid."""
+
+    def test_script_uses_exp_pid_not_spawn_pid(self):
+        """claude-wrapper.exp must reference [exp_pid] for the startup flag write.
+
+        This is a static text check — it ensures the fix is present and cannot
+        regress to the broken $spawn_pid form without this test failing.
+        """
+        assert CLAUDE_WRAPPER_EXP.exists(), (
+            f"claude-wrapper.exp not found at {CLAUDE_WRAPPER_EXP}"
+        )
+        content = CLAUDE_WRAPPER_EXP.read_text()
+
+        # The fix: [exp_pid] must appear in the startup flag write block
+        assert "[exp_pid]" in content, (
+            "claude-wrapper.exp must use [exp_pid] to write the startup flag PID. "
+            "The broken form was 'puts $fh $spawn_pid' — $spawn_pid does not exist "
+            "in Tcl/expect, silently leaving the flag file empty."
+        )
+
+    def test_script_does_not_use_spawn_pid_variable(self):
+        """claude-wrapper.exp must not use $spawn_pid (undefined Tcl variable).
+
+        $spawn_pid is not set by expect's spawn command. Using it causes a silent
+        failure: the catch block swallows the error and the flag file is left empty.
+        """
+        assert CLAUDE_WRAPPER_EXP.exists(), (
+            f"claude-wrapper.exp not found at {CLAUDE_WRAPPER_EXP}"
+        )
+        content = CLAUDE_WRAPPER_EXP.read_text()
+
+        # Filter out comment lines (lines starting with #)
+        non_comment_lines = [
+            line for line in content.splitlines()
+            if not line.strip().startswith("#")
+        ]
+        non_comment_content = "\n".join(non_comment_lines)
+
+        assert "$spawn_pid" not in non_comment_content, (
+            "claude-wrapper.exp must not use $spawn_pid in executable code. "
+            "This variable does not exist in Tcl/expect and silently produces "
+            "an empty startup flag file, causing the dispatcher to be misidentified "
+            "as a subagent and receive the wrong bootup context."
+        )


### PR DESCRIPTION
## What broke and why

Every debug-mode dispatcher session since May 2 has been receiving `sys.subagent.bootup.md` instead of `sys.dispatcher.bootup.md`. The context injection log confirms: every entry after May 2 shows `role=subagent`.

The dispatcher-startup-flag detection mechanism works like this: the launcher writes the claude process PID to `~/lobster-workspace/data/dispatcher-startup-flag` before Claude's SessionStart hook fires. `inject-bootup-context.py` reads the flag, checks `kill -0` on the PID to confirm liveness, then injects the right bootup file.

In debug mode (`LOBSTER_DEBUG=true`), the launcher is `claude-wrapper.exp` (expect script), not `claude-persistent.sh`. PR #1915 added the flag write to the expect script using:

```tcl
catch {
    set fh [open $flag_file w]
    puts $fh $spawn_pid   # BUG
    close $fh
}
```

**`$spawn_pid` does not exist in Tcl/expect.** The correct built-in is `[exp_pid]`. When `puts $fh $spawn_pid` runs, Tcl throws `can't read "spawn_pid": no such variable`. The `catch` block silently swallows this error. The file was already created (0 bytes) by `open $flag_file w` — so it persists as an empty file.

The hook then reads the empty flag, finds `raw = ""`, and returns `False` → subagent bootup injected.

## The fix

One-character change in `claude-wrapper.exp`: `$spawn_pid` → `[exp_pid]`. A comment explaining the trap was also added so this does not regress.

## Tests

Three behavioral tests (using `expect -c` to run Tcl snippets in isolation):
- `test_spawn_pid_variable_does_not_exist_in_tcl`: documents the original bug — confirms $spawn_pid leaves the file at 0 bytes
- `test_exp_pid_writes_valid_integer_pid`: confirms [exp_pid] writes a real PID
- `test_exp_pid_writes_pid_that_was_alive`: confirms the PID is in valid range

Two static checks:
- `test_script_uses_exp_pid_not_spawn_pid`: asserts `[exp_pid]` appears in the script
- `test_script_does_not_use_spawn_pid_variable`: asserts `$spawn_pid` does not appear in executable code

## Scope

This only touches `scripts/claude-wrapper.exp` (one line changed) and adds a new test file. The persistent-mode launcher (`claude-persistent.sh`) uses `$BASHPID` in bash, which is correct and unaffected. No hook Python code changes.

## Before/after

```
Before (debug mode):
  launcher writes flag → open creates 0-byte file → puts $spawn_pid throws → catch suppresses → file stays 0 bytes
  inject hook reads empty flag → is_dispatcher() = False → injects sys.subagent.bootup.md (WRONG)

After (debug mode):
  launcher writes flag → open creates file → puts [exp_pid] writes PID → file has valid PID
  inject hook reads flag → kill -0 confirms PID alive → is_dispatcher() = True → injects sys.dispatcher.bootup.md (CORRECT)
```

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_claude_wrapper_exp_spawn_pid.py -v` — 5 passed
- [x] `uv run pytest tests/unit/test_hooks/ -q` — 413 passed, 7 skipped
- [x] `uv run pytest tests/unit/ -q` — 3246 passed, 31 skipped

## Manual test

Not applicable — this change only affects `claude-wrapper.exp` which is the debug-mode launcher. The fix can be verified by checking the context injection log after the next debug-mode restart: `role=dispatcher` should appear for the first session, and the `dispatcher-startup-flag` file should be non-empty after the write and absent after the hook consumes it.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] User-visible outcome: next debug-mode session receives `sys.dispatcher.bootup.md` instead of `sys.subagent.bootup.md` — verifiable from context-injection.log
- [x] Side-effect audit: single-line change in launcher script, no external service calls, no shared state writes beyond the flag file (which is the intended behavior)
- [x] External service calls: none

Closes #1958