### PR TITLE
test(#1662): add regression test for alwaysLoad metadata on core MCP tools

### DIFF
--- a/tests/unit/test_mcp_server/test_always_load_metadata.py
+++ b/tests/unit/test_mcp_server/test_always_load_metadata.py
@@ -1,0 +1,123 @@
+"""
+Tests for alwaysLoad metadata on core MCP tools.
+
+Context
+-------
+Claude Code defers all MCP tools by default (isMcp === true in the CC binary).
+When a deferred tool's schema has not been loaded via ToolSearch, the CC client
+coerces all arguments to strings, causing InputValidationError at runtime:
+
+    InputValidationError: '10' is not of type 'integer'
+    InputValidationError: 'true' is not of type 'boolean'
+
+The CC binary reads `_meta["anthropic/alwaysLoad"] === true` when mapping
+tool-list responses. If this flag is set, `isDeferredTool()` returns false and
+the tool is sent to the API with its full schema on every turn — no ToolSearch
+required.
+
+The 8 core tools below are called unconditionally on every dispatcher restart
+before any ToolSearch invocation. They must carry alwaysLoad=True to prevent
+startup failures. (PR #1703 added this; this test guards against regression.)
+
+ALWAYS_LOAD_TOOLS
+-----------------
+The constant below is the source of truth for which tools must be marked.
+Both the test assertions and any future code changes should reference it.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure src/mcp is on sys.path for inbox_server sibling imports
+_MCP_DIR = Path(__file__).parent.parent.parent.parent / "src" / "mcp"
+if str(_MCP_DIR) not in sys.path:
+    sys.path.insert(0, str(_MCP_DIR))
+
+import src.mcp.inbox_server  # noqa: F401  — pre-load for patch resolution
+
+# The 8 core tools that must opt out of deferred loading.
+# These are called unconditionally during dispatcher startup, before any
+# ToolSearch invocation can pre-load their schemas.
+ALWAYS_LOAD_TOOLS = frozenset(
+    {
+        "wait_for_messages",
+        "check_inbox",
+        "send_reply",
+        "mark_processed",
+        "mark_processing",
+        "session_start",
+        "get_conversation_history",
+        "list_rules",
+    }
+)
+
+
+class TestAlwaysLoadMetadata:
+    """Verify that core tools carry the alwaysLoad opt-out flag."""
+
+    @pytest.fixture
+    def all_tools(self):
+        """Return the full tool list from inbox_server.list_tools()."""
+        from src.mcp.inbox_server import list_tools
+
+        return asyncio.run(list_tools())
+
+    def test_always_load_tools_exist_in_tool_list(self, all_tools):
+        """All 8 ALWAYS_LOAD_TOOLS are present in the tool registry."""
+        tool_names = {t.name for t in all_tools}
+        missing = ALWAYS_LOAD_TOOLS - tool_names
+        assert not missing, (
+            f"Tools missing from list_tools() output: {missing}. "
+            "Each name in ALWAYS_LOAD_TOOLS must correspond to a registered tool."
+        )
+
+    def test_always_load_tools_have_meta_flag_set(self, all_tools):
+        """Each tool in ALWAYS_LOAD_TOOLS has _meta['anthropic/alwaysLoad'] == True.
+
+        The CC binary checks `O._meta?.['anthropic/alwaysLoad'] === true` when
+        mapping tools/list responses. If this is False or absent, the tool is
+        deferred and startup tool calls fail with InputValidationError.
+        """
+        tool_index = {t.name: t for t in all_tools}
+        failures = []
+
+        for name in sorted(ALWAYS_LOAD_TOOLS):
+            tool = tool_index[name]
+            meta = tool.meta  # MCP SDK exposes _meta as .meta
+            if meta is None or meta.get("anthropic/alwaysLoad") is not True:
+                failures.append(
+                    f"{name}: meta={meta!r} "
+                    f"(expected {{'anthropic/alwaysLoad': True}})"
+                )
+
+        assert not failures, (
+            "The following tools are missing alwaysLoad=True. "
+            "Without it the CC client defers them and coerces args to strings, "
+            "causing InputValidationError on every dispatcher restart:\n"
+            + "\n".join(f"  - {f}" for f in failures)
+        )
+
+    def test_non_core_tools_do_not_have_always_load(self, all_tools):
+        """Tools not in ALWAYS_LOAD_TOOLS must NOT carry alwaysLoad=True.
+
+        This is a soft sanity check: alwaysLoad increases token costs because
+        full schemas are sent on every API call. Only tools called before any
+        ToolSearch invocation should carry the flag.
+        """
+        unexpected = []
+        for tool in all_tools:
+            if tool.name in ALWAYS_LOAD_TOOLS:
+                continue
+            meta = tool.meta
+            if meta is not None and meta.get("anthropic/alwaysLoad") is True:
+                unexpected.append(tool.name)
+
+        assert not unexpected, (
+            "The following tools have alwaysLoad=True but are NOT in ALWAYS_LOAD_TOOLS. "
+            "This increases token cost for every API call. If these tools genuinely "
+            "need to be pre-loaded, add them to ALWAYS_LOAD_TOOLS:\n"
+            + "\n".join(f"  - {t}" for t in sorted(unexpected))
+        )


### PR DESCRIPTION
## Why this exists

CC defers all MCP tools by default (`isMcp === true`). When a deferred tool's schema hasn't been loaded via ToolSearch, the CC client's Zod validator coerces every argument to a string, causing `InputValidationError: '10' is not of type 'integer'` before any startup tools can run.

PR #1703 fixed this by adding `_meta={"anthropic/alwaysLoad": True}` to 8 core Tool() constructors. The CC binary reads `O._meta?.["anthropic/alwaysLoad"] === true` in its `isDeferredTool()` function — if set, the tool is sent with its full schema on every API call, making it immune to the deferred-loading problem.

This PR adds a test that would have caught any regression of that fix. The investigation that spawned this work (tracking the report that "alwaysLoad isn't working as of CC 2.1.119") confirmed via binary analysis that the mechanism is correctly implemented in the CC client. The root issue was the MCP server not having been restarted after PR #1703 deployed — the fix was already working.

## What changed

A new test module `tests/unit/test_mcp_server/test_always_load_metadata.py` with three assertions:

1. **All 8 core tools exist** in `list_tools()` output — catches tool renames/removals
2. **Each core tool has `_meta["anthropic/alwaysLoad"] == True`** — direct regression guard against the bug in #1662
3. **No non-core tool has the flag** — cost guard, since `alwaysLoad=True` sends full schemas on every API call

The `ALWAYS_LOAD_TOOLS` frozenset acts as the spec-level constant. Both the test assertions and any future code that adds or removes tools from this set should reference it.

## Investigation findings (for the record)

Binary analysis of CC 2.1.116, 2.1.118, and 2.1.119 confirmed:
- `isDeferredTool()` logic is identical across all three versions
- `O._meta?.["anthropic/alwaysLoad"] === true` is read correctly
- The `Da()` unicode sanitizer doesn't corrupt the `/` in `"anthropic/alwaysLoad"`
- The Zod schema (`qUK`) explicitly includes `_meta` — it's not stripped
- The live MCP server correctly sends `_meta: {"anthropic/alwaysLoad": true}` for all 8 tools

The fix from PR #1703 is working. The `alwaysLoad` mechanism was never broken in 2.1.119 — the deferred-tool system-reminder the observer saw was from a session started before the MCP server was restarted with the new code.

## Functional patterns

Pure functions throughout: `list_tools()` is called synchronously via `asyncio.run()`, tested with no mocking of the tool registry itself. The `ALWAYS_LOAD_TOOLS` frozenset makes the expected set immutable and shareable.

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_always_load_metadata.py -v` — 3 passed, 0 failed
- [x] `uv run pytest tests/unit/ -x -q` — 3244 passed, 31 skipped, 10 warnings

## Manual test

N/A — this PR only adds tests, no runtime behavior changes.

## Definition of Done

- [x] Unit tests pass (3/3)
- [x] Full suite clean (3244 passed)
- [x] No external service calls in tests
- [x] No side effects