### PR TITLE
fix(hooks): restore startup_cause functions dropped in #1978 merge

### DIFF
--- a/hooks/inject-bootup-context.py
+++ b/hooks/inject-bootup-context.py
@@ -48,6 +48,7 @@ or the key is missing, injection is silently skipped — bootup still proceeds.
 import json
 import os
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -254,6 +255,73 @@ def _append_injection_log(
         pass  # logging must not break injection
 
 
+def read_and_reset_startup_cause() -> str:
+    """Read last-startup-cause.json and return the startup cause as a string.
+
+    Returns "compaction" if:
+      - The file exists AND cause == "compaction" AND ts is within the last
+        COMPACTION_CAUSE_WINDOW_SECONDS seconds.
+
+    Returns "restart" for all other cases:
+      - File absent
+      - File corrupt / unparseable JSON
+      - cause == "restart"
+      - cause == "compaction" but ts is stale (>= COMPACTION_CAUSE_WINDOW_SECONDS)
+
+    After reading, always overwrites the file with {"cause": "restart", "ts": "<now>"}
+    so the next startup defaults to "restart" unless on-compact.py fires first.
+    The overwrite is silent on failure — the return value is still correct.
+
+    This function is the ONLY place the dispatcher reads startup cause.  Do not
+    read last-startup-cause.json anywhere else.
+    """
+    cause: str = "restart"
+
+    try:
+        if STARTUP_CAUSE_FILE.exists():
+            raw = STARTUP_CAUSE_FILE.read_text()
+            data = json.loads(raw)
+            file_cause = data.get("cause", "restart")
+            if file_cause == "compaction":
+                ts_str = data.get("ts", "")
+                try:
+                    ts_dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                    age_seconds = (datetime.now(timezone.utc) - ts_dt).total_seconds()
+                    if age_seconds < COMPACTION_CAUSE_WINDOW_SECONDS:
+                        cause = "compaction"
+                except (ValueError, AttributeError):
+                    pass  # unparseable ts → keep cause = "restart"
+    except Exception:  # noqa: BLE001
+        pass  # any read failure → keep cause = "restart"
+
+    # Always reset to "restart" so subsequent startups default correctly.
+    _reset_startup_cause_to_restart()
+
+    return cause
+
+
+def _reset_startup_cause_to_restart() -> None:
+    """Overwrite last-startup-cause.json with cause=restart and the current timestamp.
+
+    Called unconditionally after read_and_reset_startup_cause() reads the file,
+    ensuring that the next startup defaults to "restart" unless on-compact.py
+    fires first and writes cause=compaction.
+
+    Silent on any failure — must never crash the hook.
+    """
+    try:
+        STARTUP_CAUSE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "cause": "restart",
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+        tmp_path = STARTUP_CAUSE_FILE.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(payload, indent=2) + "\n")
+        tmp_path.replace(STARTUP_CAUSE_FILE)  # atomic on Linux (same filesystem)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def main() -> None:
     # Read hook input from stdin (provides session_id for logging).
     try:
@@ -287,6 +355,17 @@ def main() -> None:
         state_machine.write_state(
             state_machine.STARTING,
             session_id=real_session_id,
+        )
+
+    # Read and reset last-startup-cause.json (issue #1972).
+    # Always runs (both dispatcher and subagent) so the file is reset on every
+    # startup and never accumulates a stale "compaction" entry.
+    # Only the dispatcher acts on the cause — subagents ignore it.
+    startup_cause = read_and_reset_startup_cause()
+    if is_dispatcher:
+        print(
+            f"[{HOOK_NAME}] startup cause: {startup_cause}",
+            file=sys.stderr,
         )
 
     role = "dispatcher" if is_dispatcher else "subagent"


### PR DESCRIPTION
## What broke and why

PR #1978 (inject ADMIN_CHAT_ID at startup) was merged on May 8 but accidentally dropped code introduced by PR #1973. The merge lost three things that `main()` depends on:

1. `import time` — missing from the imports block
2. `read_and_reset_startup_cause()` — the function that reads and resets `last-startup-cause.json`
3. `_reset_startup_cause_to_restart()` — the helper that atomically overwrites the file

Lines 322-328 (the cause-banner block) reference `time.strftime()` and `startup_cause`, but `startup_cause` was never assigned and `time` was never imported. Every dispatcher startup crashed with `NameError` before injecting any bootup context.

## What this restores

All three items above, recovered verbatim from commit `f04be65a` (the #1973 merge). Also restores the `startup_cause = read_and_reset_startup_cause()` call in `main()` with its stderr log line — this runs unconditionally on both dispatcher and subagent starts so the cause file is always reset, even if the dispatcher never uses it.

No behavior added or changed relative to the intended post-#1978 state. The ADMIN_CHAT_ID injection from #1978 is untouched.

## Functional patterns used

Pure function (`read_and_reset_startup_cause` returns a value without touching global state beyond the file write), isolated side effect (`_reset_startup_cause_to_restart` handles all I/O with a silent-on-failure wrapper).

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_startup_cause.py -v` — 11 passed (the `TestReadAndResetStartupCause` suite, all of which were failing before this fix due to the missing function); 5 pre-existing failures in `TestWriteStartupCause` testing `on_compact.py::write_startup_cause`, unrelated to this PR
- [x] `uv run pytest tests/unit/test_hooks/ -q` — 533 passed, 2 skipped, 5 pre-existing failures (same 5 as above)
- [x] Python syntax check (`ast.parse`) — clean

**Blocked items needing attention before merge:** none

## Manual test

N/A — this change is internal hook logic with no external service calls, no file system side effects beyond the existing `last-startup-cause.json` write, and no Telegram output. The crash is provable from reading the code; the fix is provable from the test suite restoration.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (no external services touched)
- [x] User-visible outcome — crash-on-startup eliminated; dispatcher bootup context now injects correctly
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none

Fixes the regression introduced by #1978.