### PR TITLE
fix: safe JSON construction in health check inbox message

### DIFF
--- a/scripts/daily-health-check.sh
+++ b/scripts/daily-health-check.sh
@@ -224,18 +224,24 @@ log "=== Health check complete: ${#FAILURES[@]} failure(s) ==="
 # On failure, write a message to the Lobster inbox so it gets picked up
 #-------------------------------------------------------------------------------
 if [ ${#FAILURES[@]} -gt 0 ]; then
-    FAIL_LIST=$(printf '%s\n' "${FAILURES[@]}" | sed 's/^/  - /')
-    MSG_FILE="$INBOX_DIR/daily-health-$(date +%Y%m%d-%H%M%S).json"
-    cat > "$MSG_FILE" << MSGEOF
-{
-  "type": "health_check",
-  "source": "system",
-  "timestamp": "$TIMESTAMP",
-  "subject": "Daily health check: ${#FAILURES[@]} failure(s)",
-  "body": "The daily dependency health check found problems:\n\n$FAIL_LIST\n\nCheck the log for details: $LOG_FILE",
-  "severity": "warning"
-}
-MSGEOF
+    # Build the inbox message using jq so that embedded newlines in $FAIL_LIST are
+    # properly escaped as \n in the JSON string.  A heredoc with bare variable
+    # expansion produces literal newlines inside a JSON string value, which makes
+    # json.load() throw "Invalid control character" — causing WFM to tight-loop
+    # and exhaust --max-turns (the 2026-04-24 / 2026-04-25 restart storm bug).
+    BODY="The daily dependency health check found problems:"$'\n\n'"$(printf '%s\n' "${FAILURES[@]}" | sed 's/^/  - /')"$'\n\n'"Check the log for details: $LOG_FILE"
+    MSG_ID="daily-health-$(date +%Y%m%d-%H%M%S)"
+    MSG_FILE="$INBOX_DIR/${MSG_ID}.json"
+    jq -n \
+        --arg id        "$MSG_ID" \
+        --arg type      "health_check" \
+        --arg source    "system" \
+        --arg timestamp "$TIMESTAMP" \
+        --arg subject   "Daily health check: ${#FAILURES[@]} failure(s)" \
+        --arg body      "$BODY" \
+        --arg severity  "warning" \
+        '{id: $id, type: $type, source: $source, timestamp: $timestamp, subject: $subject, body: $body, severity: $severity}' \
+        > "$MSG_FILE"
     log "Failure alert written to inbox: $MSG_FILE"
     exit 1
 fi


### PR DESCRIPTION
## Summary

The health check's failure notification used a heredoc with bare variable expansion to write inbox JSON. When failure names contained embedded newlines, the resulting JSON had literal newline control characters inside string values — making `json.load()` throw `Invalid control character`. This caused `wait_for_messages` to tight-loop and exhaust `--max-turns`, the root cause of the 2026-04-24/25 MCP restart storm (26 restarts).

The fix replaces the heredoc with `jq -n --arg` construction. `jq --arg` properly escapes all embedded newlines as `\n`, producing valid JSON regardless of what failure names contain. The output also gains an `id` field to align with the inbox message format.

This is a single-file, minimal change — no other diverged content from PR #1808 is included.

Supersedes #1808 — old branch had diverged 60+ files from main.

## Before / After

```
Before:
  cat > $MSG_FILE << MSGEOF
  { "body": "...problems:\n\n$FAIL_LIST\n\n..." }    ← literal \n in heredoc = literal newline in JSON
  MSGEOF
  → json.load() raises: Invalid control character at line N

After:
  BODY="...problems:"$'\n\n'"$(printf...)"$'\n\n'"..."
  jq -n --arg body "$BODY" '{ body: $body, ... }' > $MSG_FILE
  → jq escapes newlines as \n → valid JSON → json.load() succeeds
```

## Tests run
- [x] Manual: verified `jq -n --arg body "$BODY_WITH_NEWLINES" '{body: $body}'` produces valid JSON — `python3 -c "import json,sys; json.load(sys.stdin)"` exits 0
- [x] Confirmed body contains properly escaped `\n` sequences, not literal newlines
- [ ] Live health-check failure simulation — not run; would require deliberately breaking a dependency in production. The fix is a straightforward `cat` → `jq` substitution with no branching logic to cover beyond what the manual test above exercised.

## Manual test
Change is internal (file I/O that writes inbox JSON). Verified the `jq` command produces valid JSON with embedded newlines before opening this PR. No production health check run needed to verify the construction logic.

N/A for user-visible Telegram output — health check only writes to the inbox; the dispatcher reads and routes it.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Manual test run — see above
- [x] User-visible outcome: N/A (internal inbox write; format correctness verified via jq + python3 parse)
- [x] Side-effect audit: single file write to inbox, bounded by health check run frequency (once daily)
- [x] External service calls: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)