### PR TITLE
feat(context-monitor): display raw token count instead of percentage in warnings

### DIFF
--- a/hooks/context-monitor.py
+++ b/hooks/context-monitor.py
@@ -90,10 +90,12 @@ def _model_max_context(model: str) -> int:
 
 def _read_transcript_usage(
     transcript_path: str | None,
-) -> "tuple[float, float, str] | None":
+) -> "tuple[float, float, str, int] | None":
     """Read the last assistant usage entry from the transcript JSONL.
 
-    Returns (used_pct, remaining_pct, model) or None if data is unavailable.
+    Returns (used_pct, remaining_pct, model, total_tokens) or None if data
+    is unavailable. total_tokens is the raw token count (input + cache), which
+    is always accurate regardless of the assumed max context window.
 
     Reads the file line-by-line, keeping only the last assistant entry with a
     usage block. This is O(n) in lines but O(1) in memory — suitable for large
@@ -157,7 +159,7 @@ def _read_transcript_usage(
     used_pct = (total_used / model_max) * 100.0
     remaining_pct = 100.0 - used_pct
 
-    return (used_pct, remaining_pct, last_model)
+    return (used_pct, remaining_pct, last_model, total_used)
 
 
 def _log_usage(log_dir: Path, entry: dict) -> None:
@@ -200,15 +202,26 @@ def _build_absent_context_entry(tool_name: str, reason: str = "") -> dict:
     }
 
 
-def _build_warning_message(used_pct: float) -> dict:
-    """Return the context_warning inbox message payload."""
+def _build_warning_message(used_pct: float, total_tokens: int = 0) -> dict:
+    """Return the context_warning inbox message payload.
+
+    The message text leads with the raw token count (always accurate) and
+    includes the percentage as secondary context (only meaningful if the assumed
+    max window is correct). See issue #1956.
+    """
+    token_str = f"{total_tokens:,}"
+    text = (
+        f"Context at {token_str} tokens ({used_pct:.1f}% of 200k default window)"
+        " — entering wind-down mode"
+    )
     return {
         "id": str(uuid.uuid4()),
         "type": "context_warning",
         "source": "system",
         "chat_id": 0,
-        "text": f"Context window at {used_pct:.1f}% — entering wind-down mode",
+        "text": text,
         "used_percentage": used_pct,
+        "total_tokens": total_tokens,
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
@@ -255,7 +268,7 @@ def _handle_payload(
         _log_usage(log_dir, entry)
         return
 
-    used_pct, remaining_pct, model = result
+    used_pct, remaining_pct, model, total_tokens = result
 
     entry = _build_log_entry(tool_name, used_pct, remaining_pct, model)
     _log_usage(log_dir, entry)
@@ -267,7 +280,7 @@ def _handle_payload(
     if DEDUP_FLAG.exists():
         return
 
-    message = _build_warning_message(used_pct)
+    message = _build_warning_message(used_pct, total_tokens)
     _write_warning_to_inbox(inbox_dir, message)
     DEDUP_FLAG.touch()
     # Transition dispatcher state to WINDING_DOWN (issue #1918).

--- a/tests/unit/test_hooks/test_context_monitor.py
+++ b/tests/unit/test_hooks/test_context_monitor.py
@@ -99,10 +99,11 @@ class TestTranscriptUsageReading:
         ])
         result = mod._read_transcript_usage(str(transcript))
         assert result is not None, "Expected usage data from transcript"
-        used_pct, remaining_pct, model = result
+        used_pct, remaining_pct, model, total_tokens = result
         assert abs(used_pct - 50.0) < 0.01, f"Expected 50% used, got {used_pct}"
         assert abs(remaining_pct - 50.0) < 0.01
         assert model == "claude-sonnet-4-6"
+        assert total_tokens == 100_000, f"Expected 100_000 raw tokens, got {total_tokens}"
 
     def test_last_turn_wins_when_multiple_turns_exist(self, tmp_path):
         """When multiple assistant turns exist, the last one's usage is returned."""
@@ -127,10 +128,11 @@ class TestTranscriptUsageReading:
         ])
         result = mod._read_transcript_usage(str(transcript))
         assert result is not None
-        used_pct, _, _ = result
+        used_pct, _, _, total_tokens = result
         assert abs(used_pct - 80.0) < 0.01, (
             f"Expected 80% from last turn, got {used_pct}"
         )
+        assert total_tokens == 160_000, f"Expected 160_000 raw tokens from last turn, got {total_tokens}"
 
     def test_returns_none_when_transcript_path_is_none(self, tmp_path):
         """No transcript_path → returns None (caller logs WARN)."""
@@ -173,9 +175,10 @@ class TestTranscriptUsageReading:
         ])
         result = mod._read_transcript_usage(str(transcript))
         assert result is not None
-        used_pct, _, model = result
+        used_pct, _, model, total_tokens = result
         assert abs(used_pct - 100.0) < 0.01, f"Expected 100%, got {used_pct}"
         assert model == "claude-haiku-4-5"
+        assert total_tokens == 200_000, f"Expected 200_000 raw tokens, got {total_tokens}"
 
 
 class TestModelContextLookup:
@@ -373,3 +376,75 @@ class TestHandlePayloadSignature:
         assert "inbox_dir" in sig.parameters, (
             "_handle_payload() must accept inbox_dir= for testability"
         )
+
+
+class TestTokenCountDisplay:
+    """Warning message leads with raw token count, not percentage (issue #1956).
+
+    Percentage is fragile: it depends on the assumed max window, which varies.
+    Raw token count is always accurate.
+    """
+
+    def test_warning_message_leads_with_token_count(self):
+        """_build_warning_message() text starts with token count, not percentage."""
+        mod = _load_hook()
+        # 168_000 tokens → "Context at 168,000 tokens (...)"
+        msg = mod._build_warning_message(84.0, total_tokens=168_000)
+        assert msg["text"].startswith("Context at 168,000 tokens"), (
+            f"Expected text to lead with token count, got: {msg['text']!r}"
+        )
+
+    def test_warning_message_includes_percentage_as_secondary(self):
+        """_build_warning_message() includes percentage in parentheses after the count."""
+        mod = _load_hook()
+        msg = mod._build_warning_message(84.0, total_tokens=168_000)
+        assert "84.0%" in msg["text"], (
+            f"Expected percentage as secondary context in: {msg['text']!r}"
+        )
+
+    def test_warning_message_stores_total_tokens_field(self):
+        """_build_warning_message() stores total_tokens as a top-level field for consumers."""
+        mod = _load_hook()
+        msg = mod._build_warning_message(80.0, total_tokens=160_000)
+        assert msg.get("total_tokens") == 160_000, (
+            f"Expected total_tokens=160_000, got: {msg.get('total_tokens')}"
+        )
+
+    def test_inbox_warning_contains_token_count_in_text(self, tmp_path):
+        """End-to-end: inbox warning message text leads with raw token count."""
+        mod = _load_hook()
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        dedup_flag = tmp_path / "context-warning-sent"
+
+        original_dedup = mod.DEDUP_FLAG
+        mod.DEDUP_FLAG = dedup_flag
+        try:
+            # 160k / 200k = 80% — above threshold, 160,000 raw tokens
+            transcript = _make_transcript(tmp_path, [
+                {
+                    "model": "claude-sonnet-4-6",
+                    "usage": {
+                        "input_tokens": 160_000,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                    },
+                }
+            ])
+            payload = {
+                "tool_name": "Bash",
+                "transcript_path": str(transcript),
+            }
+            mod._handle_payload(payload, log_dir=log_dir, inbox_dir=inbox_dir)
+        finally:
+            mod.DEDUP_FLAG = original_dedup
+
+        inbox_files = list(inbox_dir.glob("context-warning-*.json"))
+        assert len(inbox_files) == 1
+        msg = json.loads(inbox_files[0].read_text())
+        assert "160,000 tokens" in msg["text"], (
+            f"Expected '160,000 tokens' in warning text, got: {msg['text']!r}"
+        )
+        assert msg.get("total_tokens") == 160_000


### PR DESCRIPTION
## Problem

Context warning messages showed percentage of the context window used, but percentage is fragile: it depends on the assumed max window size, which varies (200k default, up to 1M in some modes). If the assumed denominator is wrong, the percentage is misleading. The raw token count is always accurate, regardless of what window size the model actually uses.

This was flagged in issue #1955 (which fixed 1M → 200k for Sonnet/Opus 4-6) and tracked in #1956.

## Change

**Before:**
> Context window at 84.0% — entering wind-down mode

**After:**
> Context at 168,000 tokens (84.0% of 200k default window) — entering wind-down mode

Token count leads. The percentage is preserved as secondary context for orientation, but the denominator is now labelled explicitly ("200k default window") so the reader knows what assumption it carries.

### Functional patterns used
- Pure functions: `_build_warning_message()` is a pure transformer from `(used_pct, total_tokens)` → message dict
- Immutability: return values are new dicts/tuples; no mutation of shared state
- Composable: `_read_transcript_usage()` now returns a 4-tuple; callers unpack what they need

### Scope
Only `hooks/context-monitor.py` and its unit test file are touched. No changes to the inbox server, state machine, or dedup logic.

### Before/after (no state transition change)
This change does not alter any state machine transitions, threshold values, or when warnings are written. It only changes the format of the `text` field in the context_warning inbox message. No diagram needed.

## Tests run
- [x] `uv run pytest tests/unit/test_hooks/test_context_monitor.py -v` — 23 passed, 0 failed
- [ ] Full test suite — not run (change is isolated to display string; existing tests cover all paths)

**New tests added (TestTokenCountDisplay):**
- `test_warning_message_leads_with_token_count` — text starts with "Context at N tokens"
- `test_warning_message_includes_percentage_as_secondary` — percentage appears in parentheses
- `test_warning_message_stores_total_tokens_field` — total_tokens stored as a top-level field
- `test_inbox_warning_contains_token_count_in_text` — end-to-end through _handle_payload

## Manual test
N/A — this change is entirely internal. The context_warning message is consumed by the dispatcher (not displayed directly to the user). No Telegram output to verify.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (internal message format, no external service)
- [x] User-visible outcome — N/A (context_warning is consumed internally by the dispatcher)
- [x] Side-effect audit: no external calls, no volume changes, no shared state written beyond the existing inbox message
- [x] External service calls: none

Closes #1956