### PR TITLE
fix(scripts): replace heredoc JSON with jq --arg pattern in 4 remaining scripts (#2004)

### DIFF
--- a/scripts/alert.sh
+++ b/scripts/alert.sh
@@ -29,13 +29,17 @@ echo "[$timestamp] ALERT: $message" >> "$ALERT_LOG"
 # Try to send via Telegram if admin chat ID is configured
 if [[ -n "$ADMIN_CHAT_ID" ]]; then
     alert_file="$OUTBOX_DIR/alert_$(date +%s%N).json"
-    cat > "$alert_file" << EOF
-{
-    "chat_id": $ADMIN_CHAT_ID,
-    "text": "🚨 **Lobster Alert**\n\n$message\n\n_$(date)_",
-    "source": "telegram"
-}
-EOF
+    alert_text="🚨 **Lobster Alert**
+
+$message
+
+_$(date)_"
+    jq -n \
+        --argjson chat_id "$ADMIN_CHAT_ID" \
+        --arg text        "$alert_text" \
+        --arg source      "telegram" \
+        '{chat_id: $chat_id, text: $text, source: $source}' \
+        > "$alert_file"
     echo "[$timestamp] Alert sent to Telegram chat $ADMIN_CHAT_ID" >> "$ALERT_LOG"
 fi
 

--- a/scripts/check-agent-outputs.sh
+++ b/scripts/check-agent-outputs.sh
@@ -115,19 +115,18 @@ while IFS= read -r agent_id; do
     # Safely escape agent_id for JSON (alphanumeric + hyphens only expected)
     SAFE_ID=$(echo "$agent_id" | tr -cd 'a-zA-Z0-9_-')
 
-    cat > "${INBOX_DIR}/${MSG_ID}.json" << EOF
-{
-  "id": "${MSG_ID}",
-  "source": "system",
-  "type": "health_check",
-  "chat_id": 0,
-  "user_id": 0,
-  "username": "lobster-system",
-  "user_name": "Agent Relay",
-  "text": "Agent relay check: ${SAFE_ID} output file appears complete. Check task-notifications and relay results to the user.",
-  "timestamp": "${TIMESTAMP}"
-}
-EOF
+    jq -n \
+        --arg id        "$MSG_ID" \
+        --arg source    "system" \
+        --arg type      "health_check" \
+        --argjson chat_id 0 \
+        --argjson user_id 0 \
+        --arg username  "lobster-system" \
+        --arg user_name "Agent Relay" \
+        --arg text      "Agent relay check: ${SAFE_ID} output file appears complete. Check task-notifications and relay results to the user." \
+        --arg timestamp "$TIMESTAMP" \
+        '{id: $id, source: $source, type: $type, chat_id: $chat_id, user_id: $user_id, username: $username, user_name: $user_name, text: $text, timestamp: $timestamp}' \
+        > "${INBOX_DIR}/${MSG_ID}.json"
 
     # Mark this agent as notified to prevent re-injection
     echo "$agent_id" >> "$NOTIFIED_FILE"

--- a/scripts/daily-update-check.sh
+++ b/scripts/daily-update-check.sh
@@ -28,16 +28,15 @@ if [ -d "$LOBSTER_DIR/.git" ]; then
     if [ "$LOCAL" != "$REMOTE" ]; then
         BEHIND=$(git rev-list --count "$LOCAL..$REMOTE")
         TIMESTAMP=$(date +%s%3N)
-        cat > "$INBOX/${TIMESTAMP}_update_available.json" << EOF
-{
-  "id": "${TIMESTAMP}_update_available",
-  "source": "system",
-  "chat_id": 0,
-  "type": "update_notification",
-  "text": "UPDATE AVAILABLE: Lobster is ${BEHIND} commits behind origin/local-dev. Use check_updates for details.",
-  "timestamp": "$(date -Iseconds)"
-}
-EOF
+        jq -n \
+            --arg id        "${TIMESTAMP}_update_available" \
+            --arg source    "system" \
+            --argjson chat_id 0 \
+            --arg type      "update_notification" \
+            --arg text      "UPDATE AVAILABLE: Lobster is ${BEHIND} commits behind origin/local-dev. Use check_updates for details." \
+            --arg timestamp "$(date -Iseconds)" \
+            '{id: $id, source: $source, chat_id: $chat_id, type: $type, text: $text, timestamp: $timestamp}' \
+            > "$INBOX/${TIMESTAMP}_update_available.json"
     fi
 else
     # Tarball mode: check GitHub Releases API
@@ -47,15 +46,14 @@ else
 
     if [ -n "$LATEST_VERSION" ] && [ "$LATEST_VERSION" != "$CURRENT_VERSION" ]; then
         TIMESTAMP=$(date +%s%3N)
-        cat > "$INBOX/${TIMESTAMP}_update_available.json" << EOF
-{
-  "id": "${TIMESTAMP}_update_available",
-  "source": "system",
-  "chat_id": 0,
-  "type": "update_notification",
-  "text": "UPDATE AVAILABLE: Lobster v${CURRENT_VERSION} -> v${LATEST_VERSION}. Use check_updates for details.",
-  "timestamp": "$(date -Iseconds)"
-}
-EOF
+        jq -n \
+            --arg id        "${TIMESTAMP}_update_available" \
+            --arg source    "system" \
+            --argjson chat_id 0 \
+            --arg type      "update_notification" \
+            --arg text      "UPDATE AVAILABLE: Lobster v${CURRENT_VERSION} -> v${LATEST_VERSION}. Use check_updates for details." \
+            --arg timestamp "$(date -Iseconds)" \
+            '{id: $id, source: $source, chat_id: $chat_id, type: $type, text: $text, timestamp: $timestamp}' \
+            > "$INBOX/${TIMESTAMP}_update_available.json"
     fi
 fi

--- a/scripts/periodic-self-check.sh
+++ b/scripts/periodic-self-check.sh
@@ -125,18 +125,17 @@ TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%S.%6N)
 EPOCH_MS=$(date +%s%3N)
 MSG_ID="${EPOCH_MS}_self"
 
-cat > "${INBOX_DIR}/${MSG_ID}.json" << EOF
-{
-  "id": "${MSG_ID}",
-  "source": "system",
-  "chat_id": 0,
-  "user_id": 0,
-  "username": "lobster-system",
-  "user_name": "Self-Check",
-  "text": "${SELF_CHECK_TEXT}",
-  "timestamp": "${TIMESTAMP}"
-}
-EOF
+jq -n \
+    --arg id        "$MSG_ID" \
+    --arg source    "system" \
+    --argjson chat_id 0 \
+    --argjson user_id 0 \
+    --arg username  "lobster-system" \
+    --arg user_name "Self-Check" \
+    --arg text      "$SELF_CHECK_TEXT" \
+    --arg timestamp "$TIMESTAMP" \
+    '{id: $id, source: $source, chat_id: $chat_id, user_id: $user_id, username: $username, user_name: $user_name, text: $text, timestamp: $timestamp}' \
+    > "${INBOX_DIR}/${MSG_ID}.json"
 
 # Record timestamp
 date +%s > "$LAST_CHECK_FILE"


### PR DESCRIPTION
## Problem

Scripts that write inbox messages via heredoc variable expansion embed literal newlines directly into JSON string values. When a variable like `$SELF_CHECK_TEXT` contains multi-line content (agent summaries, task descriptions), the resulting file is invalid JSON — `json.load()` throws "Invalid control character". This is the same root cause as the 2026-04-24/25 WFM tight-loop restart storm, which was fixed in `daily-health-check.sh` by PR #1808.

Four scripts still used the unsafe pattern.

## Fix

Replaced all four heredoc JSON construction sites with `jq -n --arg`/`--argjson`, which correctly escapes embedded newlines as `\n`, double-quotes, backslashes, and control characters.

Scripts changed:
- `scripts/periodic-self-check.sh` — **HIGH risk**: `$SELF_CHECK_TEXT` concatenates agent summaries from SQLite and scan output, very likely to contain newlines
- `scripts/alert.sh` — **MEDIUM risk**: `$message` is caller-controlled, can contain anything
- `scripts/check-agent-outputs.sh` — **LOW risk**: `$SAFE_ID` is sanitized to `[a-zA-Z0-9_-]`, but pattern is made uniform with the rest of the codebase
- `scripts/daily-update-check.sh` — **LOW risk**: version strings, but two heredoc sites fixed

No behavior change to the message content or structure — only the construction mechanism changes.

`upgrade.sh` not touched (parallel branch `fix/issue-1999-heartbeat-chain` owns that file per issue #2004 notes).

## Functional patterns

Pure transformation: each heredoc → `jq -n --arg …` substitution is a local rewrite with no side effects outside the file being written. The integer fields (`chat_id`, `user_id`) use `--argjson` to preserve JSON number type rather than quoting them as strings.

## Tests run

- [x] Manual `jq` invocation of each pattern with multi-line and special-character input — all produced valid JSON with correctly escaped `\n` sequences
- [x] `git diff` review — all four scripts have clean, symmetric replacements
- [ ] Shell `set -e` / `set -euo pipefail` regression — each script already aborts on error; `jq` exit code is non-zero on invalid input, so error propagation is preserved. No automated test suite for shell scripts in this repo.

## Manual test

Change is entirely internal to cron scripts that write JSON files to the inbox directory. The user-visible outcome (Lobster receiving the message and acting on it) is unchanged — only the serialization correctness is fixed. The old code produced invalid JSON; the new code produces valid JSON. No Telegram output to verify.

The fix is structurally identical to the already-merged PR #1808 (daily-health-check.sh), which has been running in production without regressions.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests) — N/A, shell scripts
- [x] Integration/manual test run — jq pattern validated with adversarial input (newlines, quotes, special chars)
- [x] User-visible outcome verified — not applicable (internal cron scripts, no direct user-visible output)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: not applicable

Closes #2004