### PR TITLE
fix(#1981): align review agent delivery pattern and fix reviewer_chat_id bug

### DIFF
--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -40,7 +40,7 @@ model: opus
 color: blue
 ---
 
-> **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `send_reply` then `write_result(sent_reply_to_user=True)` when your task is complete.
+> **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Do NOT call `send_reply` directly — the dispatcher relays your result to the user. Call `write_result` only when your task is complete (do NOT pass `sent_reply_to_user=True`).
 
 You are a senior reviewer. You operate in two modes — **code review** and **design review** — and self-detect which applies based on the prompt you receive.
 
@@ -301,7 +301,7 @@ If `LINEAR_API_KEY` is not set in the environment, note that Linear context was 
 - **Use `gh` CLI for posting reviews and comments** (not MCP tools). Examples:
   - Code review: `gh pr review 47 --repo <owner/repo> --comment --body "PASS/NEEDS-WORK/FAIL: ..."`
   - Design review: `gh issue comment 42 --repo <owner/repo> --body "APPROVE/MODIFY/REJECT: ..."`
-- **Deliver results in two steps:** call `send_reply(chat_id, text, source=source)` first (crash-safe), then call `write_result(..., sent_reply_to_user=True)` so the dispatcher marks processed without re-sending. Pass `source` through from your input.
+- **Deliver results via `write_result` only.** Do NOT call `send_reply` — the dispatcher reads your `write_result` and relays the verdict to the user. Pass `source` through from your input. Do NOT set `sent_reply_to_user=True` (leave it False so the dispatcher knows to relay).
 - If no PR is linked to a code review request, post a comment on the issue noting that and report back — don't silently fail.
 - If running in a context without a cloned repo, use `gh` and `curl` for all data access.
 - For design reviews with no associated GitHub issue or Linear ticket, include the full review verdict in the `write_result` text — the dispatcher will relay it to the user.

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -524,7 +524,7 @@ Background subagents call `write_result(task_id, chat_id, text, ...)`, which dro
                    subagent_type="review",
                    run_in_background=True,
                    prompt=(
-                       f"---\ntask_id: {reviewer_task_id}\nchat_id: {msg['chat_id']}\n"
+                       f"---\ntask_id: {reviewer_task_id}\nchat_id: {reviewer_chat_id}\n"
                        f"source: {msg.get('source', 'telegram')}\nbackground: true\n---\n\n"
                        f"Review PR {pr_url} and post findings as a GitHub comment.\n\n"
                        f"REVIEWER PROCESS (follow this order exactly):\n"


### PR DESCRIPTION
## Summary

The `review` agent existed but had two bugs that caused reviewer subagents to behave incorrectly when spawned by the dispatcher.

**Bug 1 — Wrong delivery pattern in review.md:** The agent's subagent note and constraints section instructed reviewers to call `send_reply` then `write_result(sent_reply_to_user=True)`. This contradicts the dispatcher's design, which expects reviewers to call `write_result` only — the dispatcher then relays the verdict to the user (see dispatcher bootup line 1389: "relay short review verdicts only"). Sending directly produced two problems:
- For user-facing reviews: duplicate messages (both the direct `send_reply` and the dispatcher's relay)
- For librarian/system-mode reviews: leaked the verdict to the user when `chat_id=0` should have kept it internal

**Bug 2 — reviewer_chat_id computed but not used in dispatcher:** `sys.dispatcher.bootup.md` correctly computes `reviewer_chat_id = 0` for librarian/system contexts and the user's `chat_id` otherwise. But the Task prompt frontmatter used `msg['chat_id']` instead of `reviewer_chat_id`. This meant librarian-mode reviewers received the user's `chat_id` in their prompt, causing them to attempt user delivery when results should be internal only.

## Changes

- `review.md`: corrected subagent note and constraints section to say `write_result` only, with `sent_reply_to_user=False` (default), so the dispatcher knows to relay the verdict
- `sys.dispatcher.bootup.md`: changed the Task prompt frontmatter from `msg['chat_id']` to `reviewer_chat_id` so librarian-mode reviewers correctly get `chat_id=0`

## Before / after flow

```
Before (broken):
  engineer write_result → dispatcher spawns reviewer with chat_id=user_chat_id
  → reviewer calls send_reply (direct to user) + write_result(sent_reply_to_user=True)
  → dispatcher relays again → DUPLICATE for user-facing
  AND: librarian-mode reviewer gets user's chat_id, sends direct when it should be internal

After (correct):
  engineer write_result → dispatcher spawns reviewer with chat_id=reviewer_chat_id
    (0 for librarian, user's chat_id for normal)
  → reviewer calls write_result only (sent_reply_to_user=False)
  → dispatcher receives result, relays short verdict if chat_id != 0
```

The `review.md` file itself was present — the "Agent type 'review' not found" error in the issue was from an older session state. The real bugs were in the delivery pattern and chat_id routing.

## Functional patterns used

Pure data transformation (chat_id routing), declarative frontmatter protocol, no shared mutable state.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/ -q --tb=short` — 580 passed, 2 failed (pre-existing on local-dev: `test_dispatcher_state_stop.py` and `test_dispatcher_state_stop_handoff.py`)
- [x] Full unit test suite — 3594 passed, 37 failed (all failures pre-existing: `test_slack_typing_indicator.py`, `test_slack_router_config.py`, `test_dispatch_job_deprecation.py`, `test_granola_*`)
- [ ] Live reviewer spawn test — skipped: requires running dispatcher session; change is in bootup docs and agent definition, not Python code

## Manual test

N/A — the changes are to markdown instruction files (review.md and sys.dispatcher.bootup.md). No systemd, cron, external API calls, or database schema changes. The reviewer spawn flow requires a live dispatcher session to test end-to-end.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits)
- [x] Integration/manual test — N/A (markdown instruction changes only)
- [x] User-visible outcome: reviewer results now correctly routed through dispatcher relay
- [x] Side-effect audit: no floods, no unscoped writes, no unintended volume
- [x] External service calls: not applicable

Closes #1981

> This PR was opened by Lobster (functional-engineer subagent) on behalf of @sayhar.