### PR TITLE
fix(#1935): add outbox fallback scanner to survive inotify queue overflow

### DIFF
--- a/config/config.env.example
+++ b/config/config.env.example
@@ -56,6 +56,10 @@ OPENAI_API_KEY=your_openai_api_key_here
 # silence.  Requires LOBSTER_SLACK_USER_TOKEN (xoxp-) and chat.update permission.
 # Default: true.  Set to false if your Slack plan restricts chat.update.
 # LOBSTER_SLACK_TYPING_INDICATOR=true
+# Outbox fallback scanner interval in seconds (default: 30).
+# A background thread re-scans the outbox on this interval to catch files
+# missed by the inotify watcher (e.g. after a kernel queue overflow).
+# LOBSTER_SLACK_OUTBOX_SCAN_INTERVAL=30
 
 # Twilio (shared credentials for SMS and WhatsApp)
 # Sign up at https://twilio.com — SID and Auth Token at https://console.twilio.com

--- a/src/bot/slack_router.py
+++ b/src/bot/slack_router.py
@@ -624,6 +624,24 @@ _POLL_CHANNELS = [
 ]
 _POLL_INTERVAL = int(os.environ.get("LOBSTER_SLACK_POLL_INTERVAL", "10"))  # seconds
 
+# ---------------------------------------------------------------------------
+# Outbox fallback scanner: periodic re-scan to catch files missed by watchdog.
+#
+# The watchdog inotify Observer can stop delivering events silently when:
+#   - The kernel inotify queue overflows (IN_Q_OVERFLOW)
+#   - An unhandled exception kills the observer thread
+# In both cases the service stays alive but queued outbox files are not sent.
+#
+# This scanner runs in a separate thread and calls drain_outbox() on every
+# tick so that any files the watchdog missed are caught within one interval.
+# It also checks observer.is_alive() on every tick and logs a WARNING when
+# the observer thread has died, making the failure visible in logs rather than
+# silently accumulating queued messages.
+# ---------------------------------------------------------------------------
+OUTBOX_SCAN_INTERVAL: int = int(
+    os.environ.get("LOBSTER_SLACK_OUTBOX_SCAN_INTERVAL", "30")
+)
+
 # Warn at startup if the user token is configured but no poll channels are set.
 # Without poll channels, DMs sent to the user identity will not be received.
 if SLACK_USER_TOKEN and not _POLL_CHANNELS:
@@ -794,6 +812,38 @@ def _poll_user_dm_channels(stop_event: Event) -> None:
     log.info("User DM poller stopped")
 
 
+def _scan_outbox_periodically(stop_event: Event, observer: object) -> None:
+    """Periodically drain the outbox directory as a watchdog fallback.
+
+    The watchdog inotify Observer can silently stop delivering ``on_created``
+    events when the kernel inotify queue overflows or the observer thread
+    dies.  This function runs in a dedicated daemon thread and calls
+    ``drain_outbox`` on every ``OUTBOX_SCAN_INTERVAL``-second tick so that
+    any files the watchdog missed are delivered within one scan period.
+
+    On each tick it also calls ``observer.is_alive()`` and logs a WARNING
+    when the observer thread has died, surfacing the failure in the service
+    log rather than silently accumulating undelivered outbox files.
+
+    Args:
+        stop_event: Threading Event that signals the loop to exit.
+        observer:   The watchdog Observer instance whose liveness is checked.
+    """
+    log.info(
+        "Outbox fallback scanner started (interval=%ds)", OUTBOX_SCAN_INTERVAL
+    )
+    while not stop_event.is_set():
+        if not observer.is_alive():
+            log.warning(
+                "Outbox watcher (watchdog Observer) thread is no longer alive — "
+                "inotify events are not being delivered. "
+                "Fallback scanner is compensating; consider restarting the service."
+            )
+        drain_outbox(OUTBOX_DIR, source="slack", send_fn=_send_slack_reply, log=log)
+        stop_event.wait(timeout=OUTBOX_SCAN_INTERVAL)
+    log.info("Outbox fallback scanner stopped")
+
+
 def process_existing_outbox() -> None:
     """Process any Slack outbox files that exist on startup."""
     drain_outbox(OUTBOX_DIR, source="slack", send_fn=_send_slack_reply, log=log)
@@ -837,6 +887,19 @@ def main():
     )
     _poll_thread.start()
 
+    # Start outbox fallback scanner thread.
+    # This periodically re-scans the outbox directory to catch files missed by
+    # the watchdog Observer (e.g. after an inotify queue overflow or observer
+    # thread crash).  The shared stop event keeps shutdown clean.
+    _scan_stop = Event()
+    _scan_thread = Thread(
+        target=_scan_outbox_periodically,
+        args=(_scan_stop, observer),
+        daemon=True,
+        name="outbox-scan-fallback",
+    )
+    _scan_thread.start()
+
     # Start Socket Mode handler
     handler = SocketModeHandler(app, SLACK_APP_TOKEN)
 
@@ -847,7 +910,9 @@ def main():
         log.info("Shutting down...")
     finally:
         _poll_stop.set()
+        _scan_stop.set()
         _poll_thread.join(timeout=5)
+        _scan_thread.join(timeout=5)
         observer.stop()
         observer.join()
 

--- a/tests/unit/test_bot/test_slack_outbox_scan_fallback.py
+++ b/tests/unit/test_bot/test_slack_outbox_scan_fallback.py
@@ -17,7 +17,7 @@ import sys
 import time
 from pathlib import Path
 from threading import Event
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/unit/test_bot/test_slack_outbox_scan_fallback.py
+++ b/tests/unit/test_bot/test_slack_outbox_scan_fallback.py
@@ -1,0 +1,324 @@
+"""
+Tests for issue #1935: outbox fallback scanner in slack_router.py.
+
+The watchdog Observer can die silently when:
+  - The inotify kernel queue overflows (IN_Q_OVERFLOW)
+  - An unhandled exception kills the observer thread
+
+These tests verify the periodic fallback scanner that protects against
+missed outbox files and surfaces observer failures in logs.
+
+All Slack API calls are mocked — no production tokens are used.
+"""
+
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from threading import Event
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+# Ensure src is importable
+_SRC = Path(__file__).parent.parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# ---------------------------------------------------------------------------
+# Named constants (match the issue spec and implementation constants)
+# ---------------------------------------------------------------------------
+
+OUTBOX_SCAN_INTERVAL_DEFAULT = 30  # seconds — default from LOBSTER_SLACK_OUTBOX_SCAN_INTERVAL
+FAKE_BOT_CHANNEL = "DBOT000001"
+FAKE_USER_CHANNEL = "DUSER000001"
+
+
+# ---------------------------------------------------------------------------
+# Module loader (reused from test_slack_router_config.py pattern)
+# ---------------------------------------------------------------------------
+
+def _make_slack_mocks():
+    """Return module-level mock objects for all Slack dependencies."""
+    mock_app = MagicMock()
+    mock_app.event.side_effect = lambda *a, **kw: (lambda fn: fn)
+    mock_app_cls = MagicMock(return_value=mock_app)
+    mock_bolt_mod = MagicMock()
+    mock_bolt_mod.App = mock_app_cls
+
+    mock_sm_handler_cls = MagicMock()
+    mock_socket_mod = MagicMock()
+    mock_socket_mod.SocketModeHandler = mock_sm_handler_cls
+
+    mock_bot_client = MagicMock()
+    mock_bot_client.auth_test.return_value = {
+        "user_id": "UBOTAPP001",
+        "user": "lobster-bot",
+    }
+
+    mock_user_client = MagicMock()
+    mock_user_client.auth_test.return_value = {
+        "user_id": "USELF00001",
+        "user": "lobster-user",
+    }
+
+    _call_count = [0]
+
+    def _webclient_side_effect(token=None, **kw):
+        _call_count[0] += 1
+        if _call_count[0] == 1:
+            return mock_bot_client
+        return mock_user_client
+
+    mock_webclient_cls = MagicMock(side_effect=_webclient_side_effect)
+    mock_sdk_mod = MagicMock()
+    mock_sdk_mod.WebClient = mock_webclient_cls
+
+    mock_errors_mod = MagicMock()
+    mock_watchdog_obs = MagicMock()
+    mock_watchdog_events = MagicMock()
+
+    return {
+        "slack_bolt": mock_bolt_mod,
+        "slack_bolt.adapter": MagicMock(),
+        "slack_bolt.adapter.socket_mode": mock_socket_mod,
+        "slack_sdk": mock_sdk_mod,
+        "slack_sdk.errors": mock_errors_mod,
+        "watchdog": MagicMock(),
+        "watchdog.observers": mock_watchdog_obs,
+        "watchdog.events": mock_watchdog_events,
+        "_bot_client": mock_bot_client,
+        "_user_client": mock_user_client,
+    }
+
+
+def _minimal_env(**overrides):
+    base = {
+        "LOBSTER_SLACK_BOT_TOKEN": "xoxb-fake-bot-token",
+        "LOBSTER_SLACK_APP_TOKEN": "xapp-fake-app-token",
+        "LOBSTER_SLACK_USER_TOKEN": "xoxp-fake-user-token",
+        "LOBSTER_SLACK_POLL_CHANNELS": FAKE_USER_CHANNEL,
+        "LOBSTER_SLACK_CHANNEL_REMAP": f"{FAKE_BOT_CHANNEL}:{FAKE_USER_CHANNEL}",
+        "LOBSTER_MESSAGES": "/tmp/lobster-test-messages",
+        "LOBSTER_WORKSPACE": "/tmp/lobster-test-workspace",
+    }
+    base.update(overrides)
+    return base
+
+
+def _load_module(env: dict):
+    """Reload slack_router under a clean patched environment."""
+    for key in list(sys.modules.keys()):
+        if "slack_router" in key or key == "src.bot.slack_router":
+            del sys.modules[key]
+
+    mocks = _make_slack_mocks()
+    module_patches = {k: v for k, v in mocks.items() if not k.startswith("_")}
+
+    mock_outbox_mod = MagicMock()
+    mock_outbox_mod.OutboxFileHandler = MagicMock()
+    mock_outbox_mod.OutboxWatcher = MagicMock()
+    mock_outbox_mod.drain_outbox = MagicMock()
+    module_patches["channels.outbox"] = mock_outbox_mod
+
+    null_handler = logging.NullHandler()
+
+    with patch.dict(sys.modules, module_patches), \
+         patch.dict(os.environ, env, clear=True), \
+         patch("pathlib.Path.mkdir"), \
+         patch("logging.handlers.RotatingFileHandler", return_value=null_handler):
+        import src.bot.slack_router as m
+        m._test_outbox_mod = mock_outbox_mod
+        return m
+
+
+# ---------------------------------------------------------------------------
+# 1. OUTBOX_SCAN_INTERVAL constant exposed and configurable
+# ---------------------------------------------------------------------------
+
+class TestOutboxScanIntervalConfig:
+    """LOBSTER_SLACK_OUTBOX_SCAN_INTERVAL controls the fallback scan period."""
+
+    def test_default_scan_interval_is_30_seconds(self):
+        """When no env var is set, the scan interval defaults to 30 seconds."""
+        m = _load_module(_minimal_env())
+        assert m.OUTBOX_SCAN_INTERVAL == OUTBOX_SCAN_INTERVAL_DEFAULT
+
+    def test_scan_interval_overridable_via_env_var(self):
+        """LOBSTER_SLACK_OUTBOX_SCAN_INTERVAL sets the scan interval."""
+        m = _load_module(_minimal_env(LOBSTER_SLACK_OUTBOX_SCAN_INTERVAL="60"))
+        assert m.OUTBOX_SCAN_INTERVAL == 60
+
+    def test_scan_interval_is_integer(self):
+        """The parsed scan interval is an integer, not a string."""
+        m = _load_module(_minimal_env(LOBSTER_SLACK_OUTBOX_SCAN_INTERVAL="45"))
+        assert isinstance(m.OUTBOX_SCAN_INTERVAL, int)
+
+
+# ---------------------------------------------------------------------------
+# 2. _scan_outbox_periodically calls drain_outbox on each tick
+# ---------------------------------------------------------------------------
+
+class TestScanOutboxPeriodically:
+    """_scan_outbox_periodically drains the outbox on every interval tick."""
+
+    def test_scan_calls_drain_outbox_on_first_tick(self):
+        """The scan function calls drain_outbox at least once before being stopped."""
+        m = _load_module(_minimal_env())
+
+        stop = Event()
+        drain_calls = []
+
+        def fake_drain(outbox_dir, *, source, send_fn, log):
+            drain_calls.append((outbox_dir, source))
+
+        mock_observer = MagicMock()
+        mock_observer.is_alive.return_value = True
+
+        # Stop after first drain call
+        original_wait = Event.wait
+
+        call_count = [0]
+
+        def fake_scan_wait(self_evt, timeout=None):
+            call_count[0] += 1
+            # Signal stop after the first wait so the loop exits cleanly
+            stop.set()
+
+        with patch.object(m, "drain_outbox", fake_drain), \
+             patch("threading.Event.wait", fake_scan_wait):
+            m._scan_outbox_periodically(stop, mock_observer)
+
+        assert len(drain_calls) >= 1, "drain_outbox should be called at least once"
+        # Check drain was called with source="slack"
+        sources = [src for _, src in drain_calls]
+        assert all(s == "slack" for s in sources), (
+            f"Expected all drain_outbox calls to have source='slack', got: {sources}"
+        )
+
+    def test_scan_passes_send_slack_reply_to_drain(self):
+        """drain_outbox is called with the module's _send_slack_reply function."""
+        m = _load_module(_minimal_env())
+
+        stop = Event()
+        drain_send_fns = []
+
+        def fake_drain(outbox_dir, *, source, send_fn, log):
+            drain_send_fns.append(send_fn)
+            stop.set()  # stop after first call
+
+        mock_observer = MagicMock()
+        mock_observer.is_alive.return_value = True
+
+        with patch.object(m, "drain_outbox", fake_drain):
+            m._scan_outbox_periodically(stop, mock_observer)
+
+        assert len(drain_send_fns) >= 1
+        assert drain_send_fns[0] is m._send_slack_reply, (
+            "drain_outbox should be called with _send_slack_reply"
+        )
+
+    def test_scan_stops_when_stop_event_set(self):
+        """The scan loop exits when the stop event is set before the first tick."""
+        m = _load_module(_minimal_env())
+
+        stop = Event()
+        stop.set()  # Pre-set: loop should exit without calling drain
+
+        drain_calls = []
+
+        def fake_drain(outbox_dir, *, source, send_fn, log):
+            drain_calls.append(True)
+
+        mock_observer = MagicMock()
+        mock_observer.is_alive.return_value = True
+
+        with patch.object(m, "drain_outbox", fake_drain):
+            m._scan_outbox_periodically(stop, mock_observer)
+
+        assert len(drain_calls) == 0, (
+            "drain_outbox should not be called when stop is already set"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Observer health check: warning logged when observer thread dies
+# ---------------------------------------------------------------------------
+
+class TestObserverHealthCheck:
+    """The scan loop logs a warning when the observer thread is no longer alive."""
+
+    def test_logs_warning_when_observer_dead(self, caplog):
+        """When observer.is_alive() returns False, a WARNING is logged."""
+        m = _load_module(_minimal_env())
+
+        stop = Event()
+
+        # drain is a no-op; we only care about the health check log
+        def fake_drain(outbox_dir, *, source, send_fn, log):
+            stop.set()  # stop after first tick
+
+        mock_observer = MagicMock()
+        mock_observer.is_alive.return_value = False  # observer is dead
+
+        with patch.object(m, "drain_outbox", fake_drain), \
+             caplog.at_level(logging.WARNING, logger="lobster-slack"):
+            m._scan_outbox_periodically(stop, mock_observer)
+
+        warning_text = caplog.text.lower()
+        assert (
+            "observer" in warning_text or "watcher" in warning_text
+        ), f"Expected observer-dead warning, got: {caplog.text}"
+        assert any(
+            r.levelno >= logging.WARNING for r in caplog.records
+        ), "Expected at least one WARNING log record"
+
+    def test_no_warning_when_observer_alive(self, caplog):
+        """When observer.is_alive() returns True, no observer-dead warning is logged."""
+        m = _load_module(_minimal_env())
+
+        stop = Event()
+
+        def fake_drain(outbox_dir, *, source, send_fn, log):
+            stop.set()
+
+        mock_observer = MagicMock()
+        mock_observer.is_alive.return_value = True  # observer is healthy
+
+        with patch.object(m, "drain_outbox", fake_drain), \
+             caplog.at_level(logging.WARNING, logger="lobster-slack"):
+            m._scan_outbox_periodically(stop, mock_observer)
+
+        for record in caplog.records:
+            if record.levelno >= logging.WARNING:
+                msg = record.message.lower()
+                assert "observer" not in msg and "watcher" not in msg, (
+                    f"Unexpected observer warning when observer is alive: {record.message}"
+                )
+
+    def test_observer_health_checked_on_every_tick(self):
+        """observer.is_alive() is called once per scan tick, not just at startup."""
+        m = _load_module(_minimal_env())
+
+        stop = Event()
+        tick_count = [0]
+        max_ticks = 3
+
+        def fake_drain(outbox_dir, *, source, send_fn, log):
+            tick_count[0] += 1
+            if tick_count[0] >= max_ticks:
+                stop.set()
+
+        mock_observer = MagicMock()
+        mock_observer.is_alive.return_value = True
+
+        with patch.object(m, "drain_outbox", fake_drain):
+            m._scan_outbox_periodically(stop, mock_observer)
+
+        # is_alive should be called once per tick
+        assert mock_observer.is_alive.call_count >= max_ticks, (
+            f"Expected is_alive() called at least {max_ticks} times, "
+            f"got {mock_observer.is_alive.call_count}"
+        )


### PR DESCRIPTION
## Problem

The Slack router service silently stops sending outbox replies after running
for some time. The service stays active and continues receiving Slack messages,
but outbox files accumulate without being sent until the service is restarted.
This was observed twice on 2026-05-05 within a few hours.

The root cause is that the watchdog inotify Observer can silently stop
delivering `on_created` events in two scenarios:

1. **Kernel inotify queue overflow (`IN_Q_OVERFLOW`)**: when the kernel
   event queue is full, watchdog's emitter thread may miss events or die
   without logging anything visible.
2. **Observer thread death**: if an unhandled exception propagates out of
   `dispatch_events()`, the observer thread exits silently — the service
   remains alive but no further events are dispatched. The watchdog loop
   only catches `queue.Empty`; any other exception kills the thread.

In both cases `lobster-slack-router.service` shows as `active (running)`
because the Socket Mode handler and user-DM poll thread are still running.
Only the outbox watcher is dead.

## Fix

Adds a dedicated daemon thread (`outbox-scan-fallback`) that calls
`drain_outbox()` on every `OUTBOX_SCAN_INTERVAL`-second tick (default 30s).

```
Before (watchdog Observer only):
  inbox <- [Socket Mode] [user-DM poller]
  outbox -> [watchdog Observer]  <- can die silently

After (watchdog + fallback scanner):
  inbox <- [Socket Mode] [user-DM poller]
  outbox -> [watchdog Observer]           <- fast path (event-driven)
         -> [outbox-scan-fallback]  <- catches files missed by watchdog
```

Key properties:
- **Complementary, not replacement.** The watchdog Observer remains the
  primary delivery path; the fallback scanner is a safety net.
- **At most 30s delay** for files missed by inotify (configurable).
- **Observer health surfaced in logs.** The scan thread calls
  `observer.is_alive()` on every tick and logs a `WARNING` when the thread
  has died. Previously this was invisible until a restart.
- **Clean shutdown.** The scan thread's stop event is set in the `finally`
  block alongside the poll thread, and joined with a 5s timeout.
- **Configurable via `LOBSTER_SLACK_OUTBOX_SCAN_INTERVAL`** (documented in
  `config.env.example`).

No migration needed -- no new directories, cron entries, or service files.

## Functional patterns

Pure functions: `_scan_outbox_periodically` takes its stop event and
observer as arguments, closes over no mutable global state, and delegates
all side effects to `drain_outbox`. The main() wiring composes these
together declaratively.

## Tests run

- [x] `uv run pytest tests/unit/test_bot/test_slack_outbox_scan_fallback.py -v` -- 9 passed, 0 failed (new tests)
- [x] `uv run pytest tests/unit/ -v` -- 3272 passed, 31 skipped, 0 failed (full suite)
- [ ] Live Slack integration test -- not run. Requires production restart and a Slack session. This is safe to merge; the change is additive and the fallback scanner only calls `drain_outbox()` which is already exercised at startup.

## Manual test

N/A for this PR. The new thread calls `drain_outbox()` which is the same
idempotent function called at startup (`drain_outbox` deletes files on
success, so double-delivery cannot occur). Live end-to-end verification
requires waiting for the watcher to fail naturally.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [ ] Integration/manual test -- deferred; additive and idempotent
- [ ] User-visible outcome verified -- deferred pending live deployment
- [x] Side-effect audit: `drain_outbox` is idempotent; no floods, no unscoped writes
- [x] External service calls: mocked in tests

Closes #1935