### PR TITLE
feat(#1954): inject compact stub instead of full bootup on compaction starts

### DIFF
--- a/.claude/sys.compact-dispatcher.bootup.md
+++ b/.claude/sys.compact-dispatcher.bootup.md
@@ -1,0 +1,67 @@
+# Dispatcher Context (Post-Compaction Stub)
+
+<!-- startup-cause: compaction -->
+
+You are the **Lobster dispatcher**. You run in an infinite main loop, processing messages as they arrive. You are always-on — you never exit.
+
+**This is a post-compaction start.** You have lost recent situational awareness. The `compact-catchup` subagent will recover it. Follow the compact-reminder handler below — it is the only required action before entering `wait_for_messages()`.
+
+If you need full behavioral context (message handlers, rules, user config), read:
+- `~/.claude/sys.dispatcher.bootup.md` — full dispatcher context
+- `~/lobster-user-config/agents/user.base.bootup.md` — user preferences
+- `~/lobster-user-config/agents/user.dispatcher.bootup.md` — dispatcher overrides
+
+---
+
+## Minimal Startup Steps (post-compaction)
+
+0. Call `session_start(agent_type="dispatcher", agent_id="lobster-dispatcher", description="Lobster dispatcher main loop", chat_id=<ADMIN_CHAT_ID>)`.
+   - ADMIN_CHAT_ID is injected as `ADMIN_CHAT_ID=<value>` near the top of this context. Fallback: read `LOBSTER_ADMIN_CHAT_ID` from `~/lobster-config/config.env`.
+1. Call `session_start(agent_type='dispatcher', claude_session_id=hook_input["session_id"])`.
+2. Claim any pending user messages immediately to stop the health-check staleness clock:
+   - Call `check_inbox()` — for each non-system message, call `mark_processing(message_id)`.
+   - Do NOT process or reply to them yet.
+3. Call `wait_for_messages()` — the `compact-reminder` will be the first message. Handle it below.
+
+---
+
+## Compact-Reminder Handler
+
+When `wait_for_messages()` returns a message with `subtype: "compact-reminder"` (or filename `0_compact`):
+
+> **MANDATORY: Spawn compact-catchup before any other work. Never skip it.**
+
+```
+1. mark_processing(message_id)  <- compact-reminder ONLY
+2. Spawn session-note-polish subagent (run_in_background=True, subagent_type: "lobster-generalist"):
+   - See .claude/agents/session-note-polish.md for the agent definition
+   - Pass: task_id: "session-note-polish", chat_id: 0, source: "system"
+3. Spawn compact_catchup subagent (subagent_type: "compact-catchup", run_in_background=True):
+   - See .claude/agents/compact-catchup.md for the full prompt
+   - Pass task_id: "compact-catchup", chat_id: 0, source: "system"
+4. mark_processed(message_id)
+5. Resume wait_for_messages() — do NOT wait for either subagent result inline
+```
+
+> **CRITICAL — never batch the compact-reminder with other messages.** Handle it first, then return to `wait_for_messages()`.
+
+**When compact_catchup result arrives** (`task_id: "compact-catchup"`, `chat_id: 0`):
+- Read `msg["text"]` to restore situational awareness.
+- Do NOT send_reply — this is internal context.
+- `mark_processed`.
+
+---
+
+## Main Loop (abbreviated)
+
+```
+while True:
+    msg = wait_for_messages()
+    handle(msg)
+```
+
+For full message handler definitions (subagent_result, scheduled_reminder, user messages, etc.), read `~/.claude/sys.dispatcher.bootup.md` (offset=150) when needed.
+
+**7-second rule:** Any user-facing message (not a system message) must get an ack within 7 seconds. Send a brief "On it" or "Checking now" if processing will take more than a moment.
+
+**Never exit.** Never call sys.exit. Never call terminate. You are always-on.

--- a/.claude/sys.compact-dispatcher.bootup.md
+++ b/.claude/sys.compact-dispatcher.bootup.md
@@ -16,7 +16,7 @@ If you need full behavioral context (message handlers, rules, user config), read
 ## Minimal Startup Steps (post-compaction)
 
 0. Call `session_start(agent_type="dispatcher", agent_id="lobster-dispatcher", description="Lobster dispatcher main loop", chat_id=<ADMIN_CHAT_ID>)`.
-   - ADMIN_CHAT_ID is injected as `ADMIN_CHAT_ID=<value>` near the top of this context. Fallback: read `LOBSTER_ADMIN_CHAT_ID` from `~/lobster-config/config.env`.
+   - Read `ADMIN_CHAT_ID` from `LOBSTER_ADMIN_CHAT_ID` in `~/lobster-config/config.env`.
 1. Call `session_start(agent_type='dispatcher', claude_session_id=hook_input["session_id"])`.
 2. Call `list_rules(enabled_only=true)` to load IFTTT behavioral rules before handling any user messages.
 3. Claim any pending user messages immediately to stop the health-check staleness clock:

--- a/.claude/sys.compact-dispatcher.bootup.md
+++ b/.claude/sys.compact-dispatcher.bootup.md
@@ -7,7 +7,7 @@ You are the **Lobster dispatcher**. You run in an infinite main loop, processing
 **This is a post-compaction start.** You have lost recent situational awareness. The `compact-catchup` subagent will recover it. Follow the compact-reminder handler below — it is the only required action before entering `wait_for_messages()`.
 
 If you need full behavioral context (message handlers, rules, user config), read:
-- `~/.claude/sys.dispatcher.bootup.md` — full dispatcher context
+- `~/lobster/.claude/sys.dispatcher.bootup.md` — full dispatcher context
 - `~/lobster-user-config/agents/user.base.bootup.md` — user preferences
 - `~/lobster-user-config/agents/user.dispatcher.bootup.md` — dispatcher overrides
 
@@ -18,10 +18,13 @@ If you need full behavioral context (message handlers, rules, user config), read
 0. Call `session_start(agent_type="dispatcher", agent_id="lobster-dispatcher", description="Lobster dispatcher main loop", chat_id=<ADMIN_CHAT_ID>)`.
    - ADMIN_CHAT_ID is injected as `ADMIN_CHAT_ID=<value>` near the top of this context. Fallback: read `LOBSTER_ADMIN_CHAT_ID` from `~/lobster-config/config.env`.
 1. Call `session_start(agent_type='dispatcher', claude_session_id=hook_input["session_id"])`.
-2. Claim any pending user messages immediately to stop the health-check staleness clock:
+2. Call `list_rules(enabled_only=true)` to load IFTTT behavioral rules before handling any user messages.
+3. Claim any pending user messages immediately to stop the health-check staleness clock:
    - Call `check_inbox()` — for each non-system message, call `mark_processing(message_id)`.
    - Do NOT process or reply to them yet.
-3. Call `wait_for_messages()` — the `compact-reminder` will be the first message. Handle it below.
+4. Call `wait_for_messages()` — the `compact-reminder` will be the first message. Handle it below.
+
+> **Note:** `handoff.md` is unavailable at this point. Situational awareness (recent context, priorities, handoff notes) will be restored when the compact-catchup subagent result arrives.
 
 ---
 
@@ -60,7 +63,7 @@ while True:
     handle(msg)
 ```
 
-For full message handler definitions (subagent_result, scheduled_reminder, user messages, etc.), read `~/.claude/sys.dispatcher.bootup.md` (offset=150) when needed.
+For full message handler definitions (subagent_result, scheduled_reminder, user messages, etc.), read `~/lobster/.claude/sys.dispatcher.bootup.md` (offset=150) when needed.
 
 **7-second rule:** Any user-facing message (not a system message) must get an ack within 7 seconds. Send a brief "On it" or "Checking now" if processing will take more than a moment.
 

--- a/hooks/inject-bootup-context.py
+++ b/hooks/inject-bootup-context.py
@@ -44,6 +44,12 @@ USER_CONFIG_DIR = Path(os.path.expanduser("~/lobster-user-config/agents"))
 DISPATCHER_BOOTUP = CLAUDE_DIR / "sys.dispatcher.bootup.md"
 SUBAGENT_BOOTUP = CLAUDE_DIR / "sys.subagent.bootup.md"
 
+# Minimal bootup stub injected on compaction starts (issue #1954).
+# Saves ~25-35k tokens by skipping the full dispatcher bootup when the
+# compact-catchup subagent is about to restore context anyway.
+# Falls back to DISPATCHER_BOOTUP if this file is absent.
+COMPACT_DISPATCHER_BOOTUP = CLAUDE_DIR / "sys.compact-dispatcher.bootup.md"
+
 USER_BASE_BOOTUP = USER_CONFIG_DIR / "user.base.bootup.md"
 USER_DISPATCHER_BOOTUP = USER_CONFIG_DIR / "user.dispatcher.bootup.md"
 USER_SUBAGENT_BOOTUP = USER_CONFIG_DIR / "user.subagent.bootup.md"
@@ -290,12 +296,38 @@ def main() -> None:
     injected: list[str] = []
 
     # 1. Inject system bootup file based on role.
+    #
+    # For dispatcher + compaction start (issue #1954): use the compact stub instead
+    # of the full bootup to save ~25-35k tokens.  compact-catchup will restore full
+    # situational awareness, so the full bootup is redundant here.  Fall back to the
+    # full bootup if the compact stub file is absent (graceful degradation).
     if is_dispatcher:
-        content = _read_file_safe(DISPATCHER_BOOTUP, "sys.dispatcher.bootup.md")
-        system_file = DISPATCHER_BOOTUP
+        is_compact_start = startup_cause == "compaction"
+        if is_compact_start and COMPACT_DISPATCHER_BOOTUP.exists():
+            content = _read_file_safe(
+                COMPACT_DISPATCHER_BOOTUP, "sys.compact-dispatcher.bootup.md"
+            )
+            system_file = COMPACT_DISPATCHER_BOOTUP
+            print(
+                f"[{HOOK_NAME}] compact start detected — injecting compact stub"
+                f" ({COMPACT_DISPATCHER_BOOTUP.name})",
+                file=sys.stderr,
+            )
+        else:
+            if is_compact_start:
+                # Compact stub missing — log and fall back to full bootup.
+                print(
+                    f"[{HOOK_NAME}] compact start but stub absent"
+                    f" ({COMPACT_DISPATCHER_BOOTUP}) — falling back to full bootup",
+                    file=sys.stderr,
+                )
+            content = _read_file_safe(DISPATCHER_BOOTUP, "sys.dispatcher.bootup.md")
+            system_file = DISPATCHER_BOOTUP
+            is_compact_start = False  # treat as non-compact for user config injection
     else:
         content = _read_file_safe(SUBAGENT_BOOTUP, "sys.subagent.bootup.md")
         system_file = SUBAGENT_BOOTUP
+        is_compact_start = False
 
     if content is None:
         _append_injection_log(session_id, role, injected)
@@ -317,13 +349,18 @@ def main() -> None:
     injected.append(system_file.name)
 
     # 2. Inject user base bootup (both roles).
-    if _inject_if_exists(USER_BASE_BOOTUP, "user.base.bootup.md"):
-        injected.append(USER_BASE_BOOTUP.name)
+    # Skipped on compact starts — compact-catchup restores context; the full user
+    # config would add tokens without meaningful benefit at this point.
+    if not is_compact_start:
+        if _inject_if_exists(USER_BASE_BOOTUP, "user.base.bootup.md"):
+            injected.append(USER_BASE_BOOTUP.name)
 
     # 3. Inject role-specific user bootup.
+    # Also skipped on compact starts for the same reason.
     if is_dispatcher:
-        if _inject_if_exists(USER_DISPATCHER_BOOTUP, "user.dispatcher.bootup.md"):
-            injected.append(USER_DISPATCHER_BOOTUP.name)
+        if not is_compact_start:
+            if _inject_if_exists(USER_DISPATCHER_BOOTUP, "user.dispatcher.bootup.md"):
+                injected.append(USER_DISPATCHER_BOOTUP.name)
     else:
         if _inject_if_exists(USER_SUBAGENT_BOOTUP, "user.subagent.bootup.md"):
             injected.append(USER_SUBAGENT_BOOTUP.name)

--- a/tests/unit/test_hooks/test_compact_bootup_stub_injection.py
+++ b/tests/unit/test_hooks/test_compact_bootup_stub_injection.py
@@ -19,7 +19,6 @@ Behaviors tested:
   - On restart start: full dispatcher bootup is injected, compact stub is not
   - On restart start: user config files are injected as usual
   - When compact stub file is absent: falls back to full bootup (graceful degradation)
-  - Log entry records "compact-stub" or "compact" mode for compaction starts
 """
 
 from __future__ import annotations
@@ -76,12 +75,6 @@ class _PatchEnv:
                 os.environ[k] = saved_v
 
 
-def _fresh_compaction_ts() -> str:
-    """Return a UTC ISO timestamp 1 second old — well within the compaction window."""
-    ts = datetime.now(timezone.utc) - timedelta(seconds=1)
-    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
 def _make_bootup_files(claude_dir: Path) -> tuple[Path, Path, Path]:
     """Write dispatcher, subagent, and compact stub bootup files."""
     claude_dir.mkdir(parents=True, exist_ok=True)
@@ -110,6 +103,7 @@ def _load_and_run_hook(
     dispatcher_bootup: Path,
     compact_stub: Path | None,
     cause_file: Path,
+    subagent_bootup: Path | None = None,
     user_base_bootup: Path | None = None,
     user_dispatcher_bootup: Path | None = None,
     session_id: str = "test-session-uuid",
@@ -139,7 +133,7 @@ def _load_and_run_hook(
     # Override module-level paths.
     mod.STARTUP_FLAG_FILE = flag_path
     mod.DISPATCHER_BOOTUP = dispatcher_bootup
-    mod.SUBAGENT_BOOTUP = tmp_path / "no-subagent"  # not relevant for dispatcher tests
+    mod.SUBAGENT_BOOTUP = subagent_bootup if subagent_bootup is not None else tmp_path / "no-subagent"
     mod.STARTUP_CAUSE_FILE = cause_file
 
     if compact_stub is not None:
@@ -496,47 +490,17 @@ class TestSubagentPathUnchanged:
         cause_file = workspace / "data" / "last-startup-cause.json"
         _write_startup_cause(cause_file, "compaction", age_seconds=1)
 
-        import uuid as _uuid
-        env = {
-            "HOME": str(tmp_path),
-            "LOBSTER_WORKSPACE": str(workspace),
-            "LOBSTER_STARTUP_CAUSE_FILE_OVERRIDE": str(cause_file),
-        }
-        unique_name = f"inject_compact_sub_{_uuid.uuid4().hex}"
-        with _PatchEnv(env):
-            spec = importlib.util.spec_from_file_location(unique_name, _HOOK_PATH)
-            mod = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(mod)
+        stdout, _ = _load_and_run_hook(
+            tmp_path=tmp_path,
+            workspace=workspace,
+            startup_flag_pid=None,  # No startup flag → subagent session.
+            dispatcher_bootup=dispatcher_bootup,
+            compact_stub=compact_stub,
+            cause_file=cause_file,
+            subagent_bootup=subagent_bootup,
+            session_id="subagent-uuid",
+        )
 
-        # No startup flag (subagent session).
-        flag_path = workspace / "data" / "dispatcher-startup-flag"
-        flag_path.unlink(missing_ok=True)
-
-        mod.STARTUP_FLAG_FILE = flag_path
-        mod.DISPATCHER_BOOTUP = dispatcher_bootup
-        mod.SUBAGENT_BOOTUP = subagent_bootup
-        mod.COMPACT_DISPATCHER_BOOTUP = compact_stub
-        mod.STARTUP_CAUSE_FILE = cause_file
-        mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
-        mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
-        mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
-        mod.CONTEXT_INJECTION_LOG = workspace / "logs" / "context-injection.log"
-
-        hook_input = json.dumps({"session_id": "subagent-uuid"})
-        import io as _io
-        stdout_buf = _io.StringIO()
-        stderr_buf = _io.StringIO()
-
-        from unittest.mock import patch as _patch
-        with _patch("sys.stdin", _io.StringIO(hook_input)):
-            with _patch("sys.stdout", stdout_buf):
-                with _patch("sys.stderr", stderr_buf):
-                    try:
-                        mod.main()
-                    except SystemExit:
-                        pass
-
-        stdout = stdout_buf.getvalue()
         assert "SUBAGENT BOOTUP" in stdout, (
             "Subagent bootup must be injected for non-dispatcher sessions regardless of cause"
         )

--- a/tests/unit/test_hooks/test_compact_bootup_stub_injection.py
+++ b/tests/unit/test_hooks/test_compact_bootup_stub_injection.py
@@ -1,0 +1,544 @@
+"""
+Tests for compact-bootup-stub injection (issue #1954).
+
+When inject-bootup-context.py runs on a dispatcher SessionStart and detects
+startup_cause == "compaction", it should inject the minimal compact stub
+(sys.compact-dispatcher.bootup.md) instead of the full dispatcher bootup file.
+User config files are also skipped in this path.
+
+When startup_cause == "restart" (or any non-compaction value), the full
+dispatcher bootup and user config files are injected as before.
+
+Named constants (from spec):
+  COMPACT_DISPATCHER_BOOTUP_FILENAME = "sys.compact-dispatcher.bootup.md"
+    — the filename of the stub injected on compaction starts.
+
+Behaviors tested:
+  - On compaction start: compact stub is injected, full bootup is not
+  - On compaction start: user config files (base, dispatcher) are skipped
+  - On restart start: full dispatcher bootup is injected, compact stub is not
+  - On restart start: user config files are injected as usual
+  - When compact stub file is absent: falls back to full bootup (graceful degradation)
+  - Log entry records "compact-stub" or "compact" mode for compaction starts
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "inject-bootup-context.py"
+
+# The stub filename is a named constant shared between implementation and tests.
+COMPACT_DISPATCHER_BOOTUP_FILENAME = "sys.compact-dispatcher.bootup.md"
+
+# COMPACTION_CAUSE_WINDOW_SECONDS — max age for a "compaction" entry to be trusted.
+# Import from hook to avoid duplicating the constant here.
+def _get_window_seconds() -> int:
+    spec = importlib.util.spec_from_file_location("_inject_constants", _HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.COMPACTION_CAUSE_WINDOW_SECONDS
+
+COMPACTION_CAUSE_WINDOW_SECONDS = _get_window_seconds()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _PatchEnv:
+    """Context manager to temporarily set / restore environment variables."""
+
+    def __init__(self, env: dict):
+        self._env = env
+        self._saved: dict = {}
+
+    def __enter__(self):
+        for k, v in self._env.items():
+            self._saved[k] = os.environ.get(k)
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        return self
+
+    def __exit__(self, *_):
+        for k, saved_v in self._saved.items():
+            if saved_v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = saved_v
+
+
+def _fresh_compaction_ts() -> str:
+    """Return a UTC ISO timestamp 1 second old — well within the compaction window."""
+    ts = datetime.now(timezone.utc) - timedelta(seconds=1)
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _make_bootup_files(claude_dir: Path) -> tuple[Path, Path, Path]:
+    """Write dispatcher, subagent, and compact stub bootup files."""
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    dispatcher_bootup = claude_dir / "sys.dispatcher.bootup.md"
+    subagent_bootup = claude_dir / "sys.subagent.bootup.md"
+    compact_stub = claude_dir / COMPACT_DISPATCHER_BOOTUP_FILENAME
+    dispatcher_bootup.write_text("# DISPATCHER BOOTUP FULL\n")
+    subagent_bootup.write_text("# SUBAGENT BOOTUP\n")
+    compact_stub.write_text("# COMPACT DISPATCHER STUB\n")
+    return dispatcher_bootup, subagent_bootup, compact_stub
+
+
+def _write_startup_cause(cause_file: Path, cause: str, age_seconds: int = 1) -> None:
+    """Write a startup cause file with a timestamp of the given age."""
+    ts = datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+    cause_file.write_text(
+        json.dumps({"cause": cause, "ts": ts.strftime("%Y-%m-%dT%H:%M:%SZ")})
+    )
+
+
+def _load_and_run_hook(
+    *,
+    tmp_path: Path,
+    workspace: Path,
+    startup_flag_pid: int | None,  # None means no flag file
+    dispatcher_bootup: Path,
+    compact_stub: Path | None,
+    cause_file: Path,
+    user_base_bootup: Path | None = None,
+    user_dispatcher_bootup: Path | None = None,
+    session_id: str = "test-session-uuid",
+) -> tuple[str, str]:
+    """Load inject-bootup-context.py, override paths, run main(), return (stdout, stderr)."""
+    import uuid as _uuid
+
+    cause_file_str = str(cause_file)
+    env = {
+        "HOME": str(tmp_path),
+        "LOBSTER_WORKSPACE": str(workspace),
+        "LOBSTER_STARTUP_CAUSE_FILE_OVERRIDE": cause_file_str,
+    }
+    unique_name = f"inject_compact_{_uuid.uuid4().hex}"
+    with _PatchEnv(env):
+        spec = importlib.util.spec_from_file_location(unique_name, _HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+    # Set up the startup flag.
+    flag_path = workspace / "data" / "dispatcher-startup-flag"
+    if startup_flag_pid is not None:
+        flag_path.write_text(str(startup_flag_pid))
+    else:
+        flag_path.unlink(missing_ok=True)
+
+    # Override module-level paths.
+    mod.STARTUP_FLAG_FILE = flag_path
+    mod.DISPATCHER_BOOTUP = dispatcher_bootup
+    mod.SUBAGENT_BOOTUP = tmp_path / "no-subagent"  # not relevant for dispatcher tests
+    mod.STARTUP_CAUSE_FILE = cause_file
+
+    if compact_stub is not None:
+        mod.COMPACT_DISPATCHER_BOOTUP = compact_stub
+    else:
+        # Force the attribute to a non-existent path to test fallback behavior.
+        mod.COMPACT_DISPATCHER_BOOTUP = tmp_path / "no-compact-stub"
+
+    # User config paths.
+    if user_base_bootup is not None:
+        mod.USER_BASE_BOOTUP = user_base_bootup
+    else:
+        mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+
+    if user_dispatcher_bootup is not None:
+        mod.USER_DISPATCHER_BOOTUP = user_dispatcher_bootup
+    else:
+        mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+
+    mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+    mod.CONTEXT_INJECTION_LOG = workspace / "logs" / "context-injection.log"
+
+    hook_input = json.dumps({"session_id": session_id})
+    import io as _io
+    from unittest.mock import patch as _patch
+
+    stdout_buf = _io.StringIO()
+    stderr_buf = _io.StringIO()
+
+    with _patch("sys.stdin", _io.StringIO(hook_input)):
+        with _patch("sys.stdout", stdout_buf):
+            with _patch("sys.stderr", stderr_buf):
+                try:
+                    mod.main()
+                except SystemExit:
+                    pass
+
+    return stdout_buf.getvalue(), stderr_buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Tests: compact stub injected on compaction start
+# ---------------------------------------------------------------------------
+
+
+class TestCompactStubInjectedOnCompactionStart:
+    """On a compaction-caused dispatcher start, the compact stub replaces the full bootup."""
+
+    def test_compact_stub_injected_when_cause_is_compaction(self, tmp_path):
+        """Compact stub is injected instead of full dispatcher bootup on compaction start."""
+        workspace = tmp_path / "workspace"
+        (workspace / "data").mkdir(parents=True, exist_ok=True)
+        (workspace / "logs").mkdir(parents=True, exist_ok=True)
+
+        claude_dir = tmp_path / "lobster" / ".claude"
+        dispatcher_bootup, _, compact_stub = _make_bootup_files(claude_dir)
+
+        cause_file = workspace / "data" / "last-startup-cause.json"
+        _write_startup_cause(cause_file, "compaction", age_seconds=1)
+
+        stdout, _ = _load_and_run_hook(
+            tmp_path=tmp_path,
+            workspace=workspace,
+            startup_flag_pid=os.getpid(),
+            dispatcher_bootup=dispatcher_bootup,
+            compact_stub=compact_stub,
+            cause_file=cause_file,
+        )
+
+        assert "COMPACT DISPATCHER STUB" in stdout, (
+            "Compact stub must be injected when startup cause is 'compaction'"
+        )
+        assert "DISPATCHER BOOTUP FULL" not in stdout, (
+            "Full dispatcher bootup must NOT be injected on a compaction start"
+        )
+
+    def test_full_bootup_not_injected_on_compaction_start(self, tmp_path):
+        """Full bootup is absent from output on compaction start."""
+        workspace = tmp_path / "workspace"
+        (workspace / "data").mkdir(parents=True, exist_ok=True)
+        (workspace / "logs").mkdir(parents=True, exist_ok=True)
+
+        claude_dir = tmp_path / "lobster" / ".claude"
+        dispatcher_bootup, _, compact_stub = _make_bootup_files(claude_dir)
+
+        cause_file = workspace / "data" / "last-startup-cause.json"
+        _write_startup_cause(cause_file, "compaction", age_seconds=1)
+
+        stdout, _ = _load_and_run_hook(
+            tmp_path=tmp_path,
+            workspace=workspace,
+            startup_flag_pid=os.getpid(),
+            dispatcher_bootup=dispatcher_bootup,
+            compact_stub=compact_stub,
+            cause_file=cause_file,
+        )
+
+        assert "DISPATCHER BOOTUP FULL" not in stdout
+
+    def test_user_config_files_skipped_on_compaction_start(self, tmp_path):
+        """User base and dispatcher bootup files are NOT injected on compaction start."""
+        workspace = tmp_path / "workspace"
+        (workspace / "data").mkdir(parents=True, exist_ok=True)
+        (workspace / "logs").mkdir(parents=True, exist_ok=True)
+
+        claude_dir = tmp_path / "lobster" / ".claude"
+        dispatcher_bootup, _, compact_stub = _make_bootup_files(claude_dir)
+
+        # Create user config files with distinctive content.
+        user_base = tmp_path / "user.base.bootup.md"
+        user_base.write_text("# USER BASE BOOTUP\n")
+        user_dispatcher = tmp_path / "user.dispatcher.bootup.md"
+        user_dispatcher.write_text("# USER DISPATCHER BOOTUP\n")
+
+        cause_file = workspace / "data" / "last-startup-cause.json"
+        _write_startup_cause(cause_file, "compaction", age_seconds=1)
+
+        stdout, _ = _load_and_run_hook(
+            tmp_path=tmp_path,
+            workspace=workspace,
+            startup_flag_pid=os.getpid(),
+            dispatcher_bootup=dispatcher_bootup,
+            compact_stub=compact_stub,
+            cause_file=cause_file,
+            user_base_bootup=user_base,
+            user_dispatcher_bootup=user_dispatcher,
+        )
+
+        assert "USER BASE BOOTUP" not in stdout, (
+            "User base bootup must NOT be injected on a compaction start (saves tokens)"
+        )
+        assert "USER DISPATCHER BOOTUP" not in stdout, (
+            "User dispatcher bootup must NOT be injected on a compaction start"
+        )
+
+    def test_startup_cause_banner_still_present_in_compact_stub_path(self, tmp_path):
+        """The startup-cause banner is printed even when the compact stub is used."""
+        workspace = tmp_path / "workspace"
+        (workspace / "data").mkdir(parents=True, exist_ok=True)
+        (workspace / "logs").mkdir(parents=True, exist_ok=True)
+
+        claude_dir = tmp_path / "lobster" / ".claude"
+        dispatcher_bootup, _, compact_stub = _make_bootup_files(claude_dir)
+
+        cause_file = workspace / "data" / "last-startup-cause.json"
+        _write_startup_cause(cause_file, "compaction", age_seconds=1)
+
+        stdout, _ = _load_and_run_hook(
+            tmp_path=tmp_path,
+            workspace=workspace,
+            startup_flag_pid=os.getpid(),
+            dispatcher_bootup=dispatcher_bootup,
+            compact_stub=compact_stub,
+            cause_file=cause_file,
+        )
+
+        assert "startup-cause: compaction" in stdout, (
+            "The startup-cause banner must still appear in output even when compact stub is used"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: full bootup injected on restart start (unchanged behavior)
+# ---------------------------------------------------------------------------
+
+
+class TestFullBootupInjectedOnRestartStart:
+    """On a restart-caused dispatcher start, full bootup and user config are injected as before."""
+
+    def test_full_bootup_injected_on_restart(self, tmp_path):
+        """Full dispatcher bootup is injected when startup cause is 'restart'."""
+        workspace = tmp_path / "workspace"
+        (workspace / "data").mkdir(parents=True, exist_ok=True)
+        (workspace / "logs").mkdir(parents=True, exist_ok=True)
+
+        claude_dir = tmp_path / "lobster" / ".claude"
+        dispatcher_bootup, _, compact_stub = _make_bootup_files(claude_dir)
+
+        cause_file = workspace / "data" / "last-startup-cause.json"
+        _write_startup_cause(cause_file, "restart", age_seconds=1)
+
+        stdout, _ = _load_and_run_hook(
+            tmp_path=tmp_path,
+            workspace=workspace,
+            startup_flag_pid=os.getpid(),
+            dispatcher_bootup=dispatcher_bootup,
+            compact_stub=compact_stub,
+            cause_file=cause_file,
+        )
+
+        assert "DISPATCHER BOOTUP FULL" in stdout, (
+            "Full dispatcher bootup must be injected when startup cause is 'restart'"
+        )
+        assert "COMPACT DISPATCHER STUB" not in stdout, (
+            "Compact stub must NOT be injected on a restart start"
+        )
+
+    def test_user_config_injected_on_restart(self, tmp_path):
+        """User base and dispatcher bootup files ARE injected on restart start."""
+        workspace = tmp_path / "workspace"
+        (workspace / "data").mkdir(parents=True, exist_ok=True)
+        (workspace / "logs").mkdir(parents=True, exist_ok=True)
+
+        claude_dir = tmp_path / "lobster" / ".claude"
+        dispatcher_bootup, _, compact_stub = _make_bootup_files(claude_dir)
+
+        user_base = tmp_path / "user.base.bootup.md"
+        user_base.write_text("# USER BASE BOOTUP\n")
+        user_dispatcher = tmp_path / "user.dispatcher.bootup.md"
+        user_dispatcher.write_text("# USER DISPATCHER BOOTUP\n")
+
+        cause_file = workspace / "data" / "last-startup-cause.json"
+        _write_startup_cause(cause_file, "restart", age_seconds=1)
+
+        stdout, _ = _load_and_run_hook(
+            tmp_path=tmp_path,
+            workspace=workspace,
+            startup_flag_pid=os.getpid(),
+            dispatcher_bootup=dispatcher_bootup,
+            compact_stub=compact_stub,
+            cause_file=cause_file,
+            user_base_bootup=user_base,
+            user_dispatcher_bootup=user_dispatcher,
+        )
+
+        assert "USER BASE BOOTUP" in stdout, (
+            "User base bootup must be injected on restart start"
+        )
+        assert "USER DISPATCHER BOOTUP" in stdout, (
+            "User dispatcher bootup must be injected on restart start"
+        )
+
+    def test_no_startup_cause_file_treats_as_restart(self, tmp_path):
+        """When startup cause file is absent, defaults to restart (full bootup injected)."""
+        workspace = tmp_path / "workspace"
+        (workspace / "data").mkdir(parents=True, exist_ok=True)
+        (workspace / "logs").mkdir(parents=True, exist_ok=True)
+
+        claude_dir = tmp_path / "lobster" / ".claude"
+        dispatcher_bootup, _, compact_stub = _make_bootup_files(claude_dir)
+
+        # No cause file — should default to "restart".
+        cause_file = workspace / "data" / "last-startup-cause.json"
+        # File intentionally not created.
+
+        stdout, _ = _load_and_run_hook(
+            tmp_path=tmp_path,
+            workspace=workspace,
+            startup_flag_pid=os.getpid(),
+            dispatcher_bootup=dispatcher_bootup,
+            compact_stub=compact_stub,
+            cause_file=cause_file,
+        )
+
+        assert "DISPATCHER BOOTUP FULL" in stdout, (
+            "When startup cause file is absent, full bootup must be injected (default is restart)"
+        )
+        assert "COMPACT DISPATCHER STUB" not in stdout
+
+
+# ---------------------------------------------------------------------------
+# Tests: fallback when compact stub file is missing
+# ---------------------------------------------------------------------------
+
+
+class TestCompactStubFallbackWhenFileMissing:
+    """When the compact stub file does not exist, fall back to the full bootup."""
+
+    def test_falls_back_to_full_bootup_when_compact_stub_absent(self, tmp_path):
+        """When compact stub is absent, inject full bootup on compaction start (safe fallback)."""
+        workspace = tmp_path / "workspace"
+        (workspace / "data").mkdir(parents=True, exist_ok=True)
+        (workspace / "logs").mkdir(parents=True, exist_ok=True)
+
+        claude_dir = tmp_path / "lobster" / ".claude"
+        # Only create dispatcher and subagent bootup — NOT the compact stub.
+        dispatcher_bootup = claude_dir / "sys.dispatcher.bootup.md"
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        dispatcher_bootup.write_text("# DISPATCHER BOOTUP FULL\n")
+
+        cause_file = workspace / "data" / "last-startup-cause.json"
+        _write_startup_cause(cause_file, "compaction", age_seconds=1)
+
+        stdout, _ = _load_and_run_hook(
+            tmp_path=tmp_path,
+            workspace=workspace,
+            startup_flag_pid=os.getpid(),
+            dispatcher_bootup=dispatcher_bootup,
+            compact_stub=None,  # Signals to use a non-existent path.
+            cause_file=cause_file,
+        )
+
+        assert "DISPATCHER BOOTUP FULL" in stdout, (
+            "Full bootup must be injected when compact stub is absent (safe fallback)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: stale compaction cause treated as restart (existing behavior guard)
+# ---------------------------------------------------------------------------
+
+
+class TestStaleCompactionCauseTreatedAsRestart:
+    """A stale compaction cause (> COMPACTION_CAUSE_WINDOW_SECONDS) is treated as restart."""
+
+    def test_stale_compaction_cause_injects_full_bootup(self, tmp_path):
+        """Stale compaction entry (> 5 min) triggers full bootup injection, not compact stub."""
+        workspace = tmp_path / "workspace"
+        (workspace / "data").mkdir(parents=True, exist_ok=True)
+        (workspace / "logs").mkdir(parents=True, exist_ok=True)
+
+        claude_dir = tmp_path / "lobster" / ".claude"
+        dispatcher_bootup, _, compact_stub = _make_bootup_files(claude_dir)
+
+        cause_file = workspace / "data" / "last-startup-cause.json"
+        # Write a compaction cause that is 10 minutes old (outside the 5-min window).
+        _write_startup_cause(cause_file, "compaction", age_seconds=600)
+
+        stdout, _ = _load_and_run_hook(
+            tmp_path=tmp_path,
+            workspace=workspace,
+            startup_flag_pid=os.getpid(),
+            dispatcher_bootup=dispatcher_bootup,
+            compact_stub=compact_stub,
+            cause_file=cause_file,
+        )
+
+        assert "DISPATCHER BOOTUP FULL" in stdout, (
+            "Stale compaction entry must be treated as restart — full bootup must be injected"
+        )
+        assert "COMPACT DISPATCHER STUB" not in stdout, (
+            "Compact stub must NOT be injected for a stale compaction entry"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: subagent path is unaffected
+# ---------------------------------------------------------------------------
+
+
+class TestSubagentPathUnchanged:
+    """Subagent sessions (no startup flag) are never affected by this change."""
+
+    def test_subagent_gets_subagent_bootup_regardless_of_cause(self, tmp_path):
+        """When no startup flag, subagent bootup is injected regardless of startup cause."""
+        workspace = tmp_path / "workspace"
+        (workspace / "data").mkdir(parents=True, exist_ok=True)
+        (workspace / "logs").mkdir(parents=True, exist_ok=True)
+
+        claude_dir = tmp_path / "lobster" / ".claude"
+        dispatcher_bootup, subagent_bootup, compact_stub = _make_bootup_files(claude_dir)
+
+        # Write compaction cause — should have no effect on subagent injection.
+        cause_file = workspace / "data" / "last-startup-cause.json"
+        _write_startup_cause(cause_file, "compaction", age_seconds=1)
+
+        import uuid as _uuid
+        env = {
+            "HOME": str(tmp_path),
+            "LOBSTER_WORKSPACE": str(workspace),
+            "LOBSTER_STARTUP_CAUSE_FILE_OVERRIDE": str(cause_file),
+        }
+        unique_name = f"inject_compact_sub_{_uuid.uuid4().hex}"
+        with _PatchEnv(env):
+            spec = importlib.util.spec_from_file_location(unique_name, _HOOK_PATH)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+
+        # No startup flag (subagent session).
+        flag_path = workspace / "data" / "dispatcher-startup-flag"
+        flag_path.unlink(missing_ok=True)
+
+        mod.STARTUP_FLAG_FILE = flag_path
+        mod.DISPATCHER_BOOTUP = dispatcher_bootup
+        mod.SUBAGENT_BOOTUP = subagent_bootup
+        mod.COMPACT_DISPATCHER_BOOTUP = compact_stub
+        mod.STARTUP_CAUSE_FILE = cause_file
+        mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+        mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+        mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+        mod.CONTEXT_INJECTION_LOG = workspace / "logs" / "context-injection.log"
+
+        hook_input = json.dumps({"session_id": "subagent-uuid"})
+        import io as _io
+        stdout_buf = _io.StringIO()
+        stderr_buf = _io.StringIO()
+
+        from unittest.mock import patch as _patch
+        with _patch("sys.stdin", _io.StringIO(hook_input)):
+            with _patch("sys.stdout", stdout_buf):
+                with _patch("sys.stderr", stderr_buf):
+                    try:
+                        mod.main()
+                    except SystemExit:
+                        pass
+
+        stdout = stdout_buf.getvalue()
+        assert "SUBAGENT BOOTUP" in stdout, (
+            "Subagent bootup must be injected for non-dispatcher sessions regardless of cause"
+        )
+        assert "COMPACT DISPATCHER STUB" not in stdout
+        assert "DISPATCHER BOOTUP FULL" not in stdout


### PR DESCRIPTION
## What problem does this solve?

After a context compaction, the dispatcher restarts and immediately receives the full bootup injection (~25-35k tokens). This is followed by compact-catchup, which restores situational awareness — making the full bootup redundant in this path. The combined token cost can trigger a second compaction within minutes of the first.

## What changed

When `inject-bootup-context.py` detects `startup_cause == "compaction"` on a dispatcher SessionStart, it now injects a minimal stub (`sys.compact-dispatcher.bootup.md`) instead of the full `sys.dispatcher.bootup.md`. User config files (`user.base.bootup.md`, `user.dispatcher.bootup.md`) are also skipped in this path.

The stub contains only what's needed before compact-catchup restores full context:
- Identity: you are the dispatcher, keep running
- Abbreviated startup steps (session_start, claim pending messages, enter wait_for_messages)
- The compact-reminder handler (spawn session-note-polish + compact-catchup, mark processed)
- A pointer to the full bootup file for any handler not covered by the stub

**Fallback:** if `sys.compact-dispatcher.bootup.md` is absent, the hook falls back to the full bootup with a stderr warning. This ensures graceful degradation if the file is missing or misconfigured.

## Flow before and after

```
Before (every dispatcher start):
  SessionStart
    → inject sys.dispatcher.bootup.md (~1449 lines / ~25-35k tokens)
    → inject user.base.bootup.md + user.dispatcher.bootup.md
    → wait_for_messages()
    → compact-reminder → spawn compact-catchup (restores context)

After (compaction start):
  SessionStart (startup_cause == "compaction")
    → inject sys.compact-dispatcher.bootup.md (~70 lines / ~3-5k tokens)
    → skip user config files
    → wait_for_messages()
    → compact-reminder → spawn compact-catchup (restores context)

After (restart start, unchanged):
  SessionStart (startup_cause == "restart")
    → inject sys.dispatcher.bootup.md (unchanged)
    → inject user config files (unchanged)
    → ...
```

The startup-cause banner (injected by the hook before the bootup content) is preserved in both paths, so the dispatcher always knows which cause triggered the start.

## Functional patterns

Pure function `main()` branches on `startup_cause` value — deterministic, no mutation. Named constant `COMPACT_DISPATCHER_BOOTUP` is the single source of truth for the stub path.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_compact_bootup_stub_injection.py -v` — 10 passed, 0 failed (new tests, TDD)
- [x] `uv run pytest tests/unit/test_hooks/ -v` — 437 passed, 7 skipped, 0 failed (no regressions)
- [x] `uv run ruff check tests/unit/test_hooks/test_compact_bootup_stub_injection.py` — clean
- [ ] Live compaction test — blocked: requires a live compaction event in the running dispatcher; no safe way to trigger in test environment without affecting production. Behavioral correctness is covered by unit tests.

## Manual test

N/A — this change is entirely internal to the SessionStart hook (no Telegram output, no external service calls, no file system runtime state changes). The hook output is fully covered by unit tests that mock the startup cause file.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run (if applicable) — N/A, purely internal
- [x] User-visible outcome verified OR not applicable — not applicable (hook output affects context, not user-visible messages)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none

Closes #1954