### PR TITLE
fix(#1950): whitelist Read through post-compact gate to break circular dependency

### DIFF
--- a/hooks/post-compact-gate.py
+++ b/hooks/post-compact-gate.py
@@ -9,7 +9,14 @@ on-compact.py when a compaction occurs. This hook passes when:
   1. No sentinel file exists (normal operation), OR
   2. Not the dispatcher session (see session_role.is_dispatcher()), OR
   3. The sentinel is older than SENTINEL_TTL_SECONDS (stale / post-hibernation), OR
-  4. The tool being called IS wait_for_messages (let it through, delete sentinel).
+  4. The tool being called IS wait_for_messages (let it through, delete sentinel), OR
+  5. The tool being called IS ToolSearch (read-only schema fetch, needed to load
+     deferred MCP tool schemas — the dispatcher must be able to call ToolSearch to
+     fetch the wait_for_messages schema before it can call wait_for_messages), OR
+  6. The tool being called IS Read (read-only file access — non-destructive and
+     needed to break the circular dependency in issue #1950: Read is required to
+     learn the confirmation token from the bootup file, but the gate was blocking
+     Read before the token was known).
 
 The TTL (10 minutes) eliminates the stuck-sentinel failure mode: if the
 dispatcher hibernates or crashes while the sentinel is active, the next boot
@@ -90,18 +97,28 @@ WAIT_FOR_MESSAGES_TOOL = "mcp__lobster-inbox__wait_for_messages"
 # ToolSearch first.  See issue #1914 staging infinite-compaction-loop bug.
 TOOL_SEARCH_TOOL = "ToolSearch"
 
+# Read is a read-only file access tool.  It is always allowed through the gate
+# because reads are non-destructive: they cannot send messages, spawn agents, or
+# mutate state.  The gate's purpose is to prevent state mutation before
+# re-orientation, not to block information access.  Blocking Read created a
+# circular dependency (issue #1950): the gate blocked reads, but the dispatcher
+# needed to read the bootup file to learn the confirmation token.  Whitelisting
+# Read eliminates this deadlock — the token lives only in sys.dispatcher.bootup.md,
+# which is now readable through the gate without a two-step WFM dance.
+READ_TOOL = "Read"
+
 CONFIRMATION_TOKEN = "LOBSTER_COMPACTED_REORIENTED"  # noqa: S105 — not a secret, intentional safe word
 
 DENY_REASON_NEEDS_TOKEN = (
     "GATE BLOCKED: Context compaction was just detected. "
-    "If you need the wait_for_messages schema, call ToolSearch first (it is allowed). "
+    "You may Read files or call ToolSearch (both are allowed). "
     "Then call `mcp__lobster-inbox__wait_for_messages(confirmation='LOBSTER_COMPACTED_REORIENTED')` directly. "
     "Confirmation token: LOBSTER_COMPACTED_REORIENTED"
 )
 
 DENY_REASON = (
     "GATE BLOCKED: Context compaction was just detected. Your only permitted "
-    "actions right now are: (1) ToolSearch to load the wait_for_messages schema if needed, "
+    "actions right now are: (1) Read files or call ToolSearch as needed, "
     "then (2) call `mcp__lobster-inbox__wait_for_messages(confirmation='LOBSTER_COMPACTED_REORIENTED')` directly. "
     "When it returns, you will receive a compact-reminder system message — read it to re-orient "
     "as the Lobster dispatcher, then resume your main loop normally. "
@@ -159,6 +176,16 @@ def main() -> None:
     # effects and no risk of bypassing the intent of the gate.
     if tool_name == TOOL_SEARCH_TOOL:
         log_gate_event(tool_name, "allowed-schema-fetch")
+        sys.exit(0)
+
+    # Read is always allowed through even when the sentinel is active.
+    # Reads are non-destructive — they cannot send messages, spawn agents, or
+    # mutate state.  The gate's purpose is to prevent state mutation before
+    # re-orientation, not to block information access.  Blocking Read created
+    # a circular dependency (issue #1950): the dispatcher needed to read the
+    # bootup file to learn the confirmation token, but the gate blocked reads.
+    if tool_name == READ_TOOL:
+        log_gate_event(tool_name, "allowed-read")
         sys.exit(0)
 
     # If the tool IS wait_for_messages, handle based on sentinel state.

--- a/tests/unit/test_hooks/test_post_compact_gate_read.py
+++ b/tests/unit/test_hooks/test_post_compact_gate_read.py
@@ -1,0 +1,233 @@
+"""
+Unit tests for the Read always-allow path in hooks/post-compact-gate.py.
+
+When a Read tool call is detected, the gate must return exit 0 and allow
+the call through — even if the compact-pending sentinel is fresh and the gate
+would otherwise block.
+
+This path is critical to avoid a circular dependency (issue #1950):
+the gate blocked Read, but the dispatcher needed to read the bootup file
+(sys.dispatcher.bootup.md) to learn the confirmation token. Blocking Read
+before the token was known forced a two-step dance: fail WFM once to get the
+token in the error message, then call WFM again with the token. Whitelisting
+Read breaks this cycle — the token can now live only in the bootup file,
+which is readable through the gate on the first attempt.
+"""
+
+import importlib.util
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "post-compact-gate.py"
+
+# Relative path (from HOME) where the hook looks for the sentinel.
+SENTINEL_REL = Path("messages") / "config" / "compact-pending"
+
+READ_TOOL = "Read"
+
+
+def _make_sentinel(home: Path) -> Path:
+    """Create a fresh sentinel file at the expected location under home."""
+    sentinel = home / SENTINEL_REL
+    sentinel.parent.mkdir(parents=True, exist_ok=True)
+    sentinel.touch()
+    return sentinel
+
+
+def _load_hook(monkeypatch, tmp_path: Path):
+    """Load post-compact-gate.py with HOME and LOBSTER_MAIN_SESSION overridden."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+
+    spec = importlib.util.spec_from_file_location("post_compact_gate", _HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    if str(_HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(_HOOKS_DIR))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_hook_input(
+    tool_name: str,
+    tool_input: dict | None = None,
+    agent_id: str | None = None,
+) -> dict:
+    payload = {"tool_name": tool_name, "tool_input": tool_input or {}}
+    if agent_id is not None:
+        payload["agent_id"] = agent_id
+    return payload
+
+
+def _run_hook(mod, hook_input: dict) -> tuple[int, str, str]:
+    """Run mod.main() with hook_input as stdin. Returns (exit_code, stdout, stderr)."""
+    stdout_cap = StringIO()
+    stderr_cap = StringIO()
+    stdin_data = json.dumps(hook_input)
+    exit_code = None
+
+    with (
+        patch("sys.stdin", StringIO(stdin_data)),
+        patch("sys.stdout", stdout_cap),
+        patch("sys.stderr", stderr_cap),
+    ):
+        try:
+            mod.main()
+        except SystemExit as e:
+            exit_code = e.code
+
+    return exit_code, stdout_cap.getvalue(), stderr_cap.getvalue()
+
+
+def _make_dispatcher_session_file(tmp_path: Path, session_id: str) -> Path:
+    """Write the hook marker file so is_dispatcher_session returns True."""
+    config_dir = tmp_path / "messages" / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    marker = config_dir / "dispatcher-session-id"
+    marker.write_text(session_id)
+    return marker
+
+
+# ---------------------------------------------------------------------------
+# Read always-allow path (issue #1950)
+# ---------------------------------------------------------------------------
+
+
+class TestReadAlwaysAllow:
+    """Read is allowed through the gate even when sentinel is fresh.
+
+    Failure mode: if this path is missing, the dispatcher is caught in a
+    circular dependency after compaction — the gate blocks reads, but the
+    dispatcher needs to read the bootup file to discover the confirmation token.
+    Whitelisting Read breaks this cycle.
+    """
+
+    def test_read_allowed_when_sentinel_fresh(self, monkeypatch, tmp_path):
+        """Read exits 0 with no deny output even if compact-pending is fresh.
+
+        This is the core regression test for issue #1950. A fresh sentinel
+        causes the gate to block any other tool, but Read must pass through
+        unconditionally because it is non-destructive.
+        """
+        _make_sentinel(tmp_path)
+        _make_dispatcher_session_file(tmp_path, "sess-disp-read")
+
+        mod = _load_hook(monkeypatch, tmp_path)
+        mod.SENTINEL_FILE = tmp_path / SENTINEL_REL
+
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+
+        hook_input = _make_hook_input(
+            tool_name=READ_TOOL,
+            tool_input={"file_path": "/home/lobster/lobster-workspace/.claude/sys.dispatcher.bootup.md"},
+        )
+        exit_code, stdout, stderr = _run_hook(mod, hook_input)
+
+        assert exit_code == 0, (
+            f"Read should exit 0 even with fresh sentinel, got {exit_code}. "
+            f"stderr: {stderr!r}"
+        )
+        assert stdout.strip() == "", (
+            f"Read should produce no deny output (empty stdout), got: {stdout!r}"
+        )
+
+    def test_read_allowed_and_sentinel_remains(self, monkeypatch, tmp_path):
+        """Read does not delete the sentinel — it only passes through.
+
+        After Read is allowed, the sentinel must still be present so that
+        subsequent non-Read / non-ToolSearch / non-wait_for_messages calls
+        are still blocked.
+        """
+        sentinel = _make_sentinel(tmp_path)
+        _make_dispatcher_session_file(tmp_path, "sess-disp-read-nodel")
+
+        mod = _load_hook(monkeypatch, tmp_path)
+        mod.SENTINEL_FILE = tmp_path / SENTINEL_REL
+
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+
+        hook_input = _make_hook_input(
+            tool_name=READ_TOOL,
+            tool_input={"file_path": "/home/lobster/lobster-workspace/.claude/sys.dispatcher.bootup.md"},
+        )
+        _run_hook(mod, hook_input)
+
+        assert sentinel.exists(), (
+            "Sentinel must NOT be deleted by a Read call — only wait_for_messages "
+            "with the confirmation token clears the sentinel."
+        )
+
+    def test_read_allowed_any_file_path(self, monkeypatch, tmp_path):
+        """Read is allowed for any file path, not just specific bootup files.
+
+        The whitelist is unconditional: all Read calls pass through regardless
+        of the file being read. Reads are inherently non-destructive.
+        """
+        _make_sentinel(tmp_path)
+        _make_dispatcher_session_file(tmp_path, "sess-disp-read-anypath")
+
+        mod = _load_hook(monkeypatch, tmp_path)
+        mod.SENTINEL_FILE = tmp_path / SENTINEL_REL
+
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+
+        for file_path in [
+            "/etc/hostname",
+            "/home/lobster/lobster-workspace/CLAUDE.md",
+            "/tmp/some-random-file.txt",
+        ]:
+            hook_input = _make_hook_input(
+                tool_name=READ_TOOL,
+                tool_input={"file_path": file_path},
+            )
+            exit_code, stdout, _ = _run_hook(mod, hook_input)
+            assert exit_code == 0, f"Read({file_path!r}) should exit 0 with fresh sentinel"
+            assert stdout.strip() == "", f"Read({file_path!r}) should produce no deny output"
+
+    def test_write_still_blocked_when_sentinel_fresh(self, monkeypatch, tmp_path):
+        """Confirm that Write (a state-mutating tool) is still blocked with a fresh sentinel.
+
+        This is a sanity check that the Read allow-path does not accidentally
+        disable the gate for all file-related tools. Write can modify state,
+        so it must remain blocked until WFM clears the sentinel.
+        """
+        _make_sentinel(tmp_path)
+        _make_dispatcher_session_file(tmp_path, "sess-disp-read-sanity")
+
+        mod = _load_hook(monkeypatch, tmp_path)
+        mod.SENTINEL_FILE = tmp_path / SENTINEL_REL
+
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+
+        hook_input = _make_hook_input(tool_name="Write")
+        exit_code, stdout, stderr = _run_hook(mod, hook_input)
+
+        assert exit_code == 0, f"Hook exited non-zero: {stderr}"
+        assert stdout.strip() != "", (
+            "Write tool should produce a deny decision when sentinel is fresh, "
+            f"got empty stdout. stderr: {stderr!r}"
+        )
+        output = json.loads(stdout)
+        decision = output.get("hookSpecificOutput", {}).get("permissionDecision", "")
+        assert decision == "deny", (
+            f"Expected permissionDecision=deny for Write tool, got: {decision!r}"
+        )


### PR DESCRIPTION
## Problem

After context compaction, the post-compact gate blocks all tool calls until the dispatcher calls `wait_for_messages(confirmation='LOBSTER_COMPACTED_REORIENTED')`. But the confirmation token lives only in `sys.dispatcher.bootup.md` — a file the dispatcher could not read because Read was blocked. This created a circular dependency:

```
Compaction occurs
    → gate blocks Read
    → dispatcher calls WFM (no token)
    → gate blocks WFM: "call WFM with token LOBSTER_COMPACTED_REORIENTED"
    → dispatcher learns token from error message
    → dispatcher calls WFM with token
    → gate clears
```

The dispatcher had to fail WFM once before discovering the token. Worse, the error message was the only path to the token — the bootup file (the canonical home of the token) was unreachable.

## Fix

Whitelist Read unconditionally alongside ToolSearch. The gate's purpose is to prevent **state mutation** before re-orientation, not to block information access. Reads are non-destructive — they cannot send messages, spawn agents, or mutate state.

With Read whitelisted, the flow becomes:

```
Compaction occurs
    → dispatcher reads sys.dispatcher.bootup.md (now allowed through gate)
    → dispatcher calls WFM(confirmation='LOBSTER_COMPACTED_REORIENTED')
    → gate clears
```

One fewer forced failure. The token can now live exclusively in the bootup file rather than also being embedded in gate error messages as a workaround.

The gate still blocks all state-mutating tools (Bash, Write, Edit, all MCP tools except wait_for_messages) until the sentinel is cleared.

## Changes

- `hooks/post-compact-gate.py`: Add `READ_TOOL = "Read"` constant and a passthrough check before the sentinel enforcement block, mirroring the existing ToolSearch passthrough. Update `DENY_REASON` and `DENY_REASON_NEEDS_TOKEN` to accurately state that Read and ToolSearch are permitted.
- `tests/unit/test_hooks/test_post_compact_gate_read.py`: New test file with 4 unit tests covering the Read always-allow path (pass through with fresh sentinel, sentinel not deleted, any file path passes, Write still blocked).

**Functional patterns used:** named constants (`READ_TOOL`, `TOOL_SEARCH_TOOL`, `CONFIRMATION_TOKEN`), early-exit guard clauses, pure functions (`sentinel_is_fresh`, `log_gate_event`).

## Before / after gate flow

```
Before                               After
──────────────────────────────────   ──────────────────────────────────
PreToolUse: ToolSearch → ALLOW       PreToolUse: ToolSearch → ALLOW
PreToolUse: Read       → DENY  ✗     PreToolUse: Read       → ALLOW  ✓
PreToolUse: WFM(none)  → DENY        PreToolUse: WFM(none)  → DENY
PreToolUse: WFM(token) → ALLOW, clear PreToolUse: WFM(token) → ALLOW, clear
```

## Tests run
- [x] `uv run pytest tests/unit/test_hooks/test_post_compact_gate_read.py -v` — 4 passed, 0 failed
- [x] `uv run pytest tests/unit/test_hooks/test_post_compact_gate_toolsearch.py -v` — 3 passed (no regression)
- [x] `uv run pytest tests/smoke/test_post_compact_gate.py -v` — 5 passed (no regression)
- [x] `uv run pytest tests/unit/ -q` — 3267 passed, 31 skipped, 0 failed

## Manual test
N/A — this change is entirely a hook logic fix. The hook runs in-process via `importlib` in tests, with sentinel files isolated to `tmp_path`. No external services, systemd, cron, or DB schema are touched.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — not applicable (hook logic, no external services)
- [x] User-visible outcome — not applicable (gate is invisible to the user; effect is fewer WFM failures in dispatcher logs post-compaction)
- [x] Side-effect audit: no floods, no unscoped writes, no unintended volume — the only behavior change is that Read passes through the gate; no messages are sent
- [x] External service calls: none

Closes #1950