### PR TITLE
test(hooks): fix smoke tests broken by source-field compact detection

### DIFF
--- a/tests/smoke/test_on_compact.py
+++ b/tests/smoke/test_on_compact.py
@@ -109,8 +109,10 @@ def _load_hook(
 
     # Patch sys.stdin so main()'s json.load(sys.stdin) gets a valid compact event
     # rather than hitting pytest's captured stdin which raises OSError.
+    # Use source="compact" (CC-documented primary field) so _is_compact_event()
+    # returns True and main() processes the event rather than exiting early.
     hook_input = json.dumps(
-        {"session_id": session_id, "hook_event_name": "SessionStart", "is_compact": True}
+        {"session_id": session_id, "hook_event_name": "SessionStart", "source": "compact"}
     )
     mod._test_stdin_data = hook_input  # store for reference
 


### PR DESCRIPTION
## Summary

After commit `c0c534ad` (issue #1949) switched `_is_compact_event()` to check `data["source"] == "compact"` as the primary detection field, the smoke test helper in `tests/smoke/test_on_compact.py` was left using the old `"is_compact": True` field that the function no longer reads.

This caused tests A1–A6 to exit early via `sys.exit(0)` rather than processing the compact event, silently invalidating all six core behavior tests. Only A7 (the new outbox-write test) still passed, since it calls `send_compaction_notify()` directly without going through `main()`.

The fix is a one-line change in the test helper: use `source="compact"` (the CC-documented primary field) instead of the defunct `is_compact: True` flag.

## What changed

- `_load_hook()` in `tests/smoke/test_on_compact.py`: hook input uses `source="compact"` so `_is_compact_event()` returns True and `main()` enters the compact-event code path.

## Before / after

Before: A1–A6 exit at `sys.exit(0)` (self-gate returns False), writing nothing. Tests appear to pass vacuously but exercise no actual behavior.

After: All 7 smoke tests (A1–A7) exercise the correct code paths.

## Functional patterns

Pure-function testing approach: the fix uses the documented CC payload field (`source`) rather than an internal flag, keeping test inputs aligned with the real contract. No behavior changes; test-only fix.

## Tests run

- [x] `uv run pytest tests/smoke/test_on_compact.py -v` — 7 passed, 0 failed
- [x] `uv run pytest tests/unit/test_hooks/ -v` — 427 passed, 7 skipped, 0 failed

## Manual test

N/A — this is a test-only change with no behavior change to production code.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (test-only fix)
- [x] User-visible outcome verified — not applicable (no user-visible behavior change)
- [x] Side-effect audit: no production code changed, no outbound messages, no shared state writes
- [x] External service calls: none (test-only fix)

Relates to #1949