### PR TITLE
test(#1976): comprehensive TDD tests for ADMIN_CHAT_ID injection

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -28,7 +28,7 @@ When you first start (or after reading this file), follow these steps:
 > **Note on stale agent sessions:** The `on-fresh-start.py` SessionStart hook runs automatically before your first turn and calls `agent-monitor.py --mark-failed` to clear any sessions left in "running" state. You do not need to do this manually.
 
 0. Call `session_start(agent_type="dispatcher", agent_id="lobster-dispatcher", description="Lobster dispatcher main loop", chat_id=<ADMIN_CHAT_ID>)` to register this session as the dispatcher. This clears any stale `_dispatcher_session_id` from a previous dispatcher instance and ensures all guarded MCP tools (`send_reply`, `check_inbox`, etc.) work immediately. Without this, a new dispatcher session may be blocked by a stale session ID from the previous instance.
-   - Get ADMIN_CHAT_ID from `lobster.conf` (`grep ADMIN_CHAT_ID ~/lobster-config/lobster.conf` or equivalent), or use the `chat_id` from `context-handoff.json` if available.
+   - **ADMIN_CHAT_ID is injected directly into this context by `inject-bootup-context.py` at session start** as the line `ADMIN_CHAT_ID=<value>` near the top of this injected content. Read it from there — no grep or file read needed. Fallback if absent: read `LOBSTER_ADMIN_CHAT_ID` from `~/lobster-config/config.env`.
    - This is the FIRST action before any guarded tools — must fire before step 2d.
 
 0b. **ToolSearch pre-load** — ALL MCP tools are deferred by default in Claude Code. Without schema pre-loading, the CC client's Zod validator stringifies numeric/boolean args, causing `InputValidationError: '10' is not of type 'integer'`. Call ToolSearch immediately after step 0:
@@ -290,7 +290,7 @@ After a context compaction you lose situational awareness of the last ~30 minute
 - Do NOT send_reply — this is internal context, except:
   - If `LOBSTER_DEBUG=true`: send a brief status to ADMIN_CHAT_ID:
     `"🔄 Back online. Context recovered from [window_start] to [now]. [N messages] processed, [M subagents] were running."`
-    (Fill in N and M from `msg["text"]`. ADMIN_CHAT_ID from `lobster.conf` or the compact-reminder context.)
+    (Fill in N and M from `msg["text"]`. ADMIN_CHAT_ID is injected at startup — read it from the top of your context.)
     **Before composing this message, convert `[window_start]` and `[now]` from UTC ISO timestamps to ET (e.g. "5:29 AM ET"). Rule: EDT (UTC-4) mid-March through early November, EST (UTC-5) otherwise. Never send raw UTC ISO strings to the user.**
 - `mark_processed`
 

--- a/hooks/inject-bootup-context.py
+++ b/hooks/inject-bootup-context.py
@@ -8,11 +8,16 @@ and user-specific bootup files, printing their contents to stdout.
 Claude Code SessionStart hooks inject stdout as a system message at the start
 of the session, making this content available before the first turn.
 
-File injection order:
-1. sys.dispatcher.bootup.md OR sys.subagent.bootup.md (based on role)
+File injection order (dispatcher):
+0. ADMIN_CHAT_ID preamble line (from ~/lobster-config/config.env, if present)
+1. sys.dispatcher.bootup.md
 2. ~/lobster-user-config/agents/user.base.bootup.md (if exists)
-3. ~/lobster-user-config/agents/user.dispatcher.bootup.md (dispatcher only, if exists)
-   OR ~/lobster-user-config/agents/user.subagent.bootup.md (subagent only, if exists)
+3. ~/lobster-user-config/agents/user.dispatcher.bootup.md (if exists)
+
+File injection order (subagent):
+1. sys.subagent.bootup.md
+2. ~/lobster-user-config/agents/user.base.bootup.md (if exists)
+3. ~/lobster-user-config/agents/user.subagent.bootup.md (if exists)
 
 Dispatcher detection (simplified, issue #1908):
 The launcher (claude-persistent.sh) writes the subshell PID to
@@ -24,6 +29,14 @@ claude. This hook reads that flag:
 This eliminates the chicken-and-egg problem of UUID-based detection: the flag
 is written *before* CC starts, not after session_start() is called. Stale
 flags (dead PID) are safe because the check is purely process-existence-based.
+
+ADMIN_CHAT_ID injection (issue #1976):
+For dispatcher sessions, this hook reads LOBSTER_ADMIN_CHAT_ID from
+~/lobster-config/config.env and injects a one-line preamble:
+  ADMIN_CHAT_ID=<value>
+This eliminates the failed grep at every startup (the old doc referenced
+~/lobster-config/lobster.conf which does not exist). If config.env is absent
+or the key is missing, injection is silently skipped — bootup still proceeds.
 """
 
 import json
@@ -50,6 +63,10 @@ USER_SUBAGENT_BOOTUP = USER_CONFIG_DIR / "user.subagent.bootup.md"
 
 HOOK_NAME = "inject-bootup-context"
 
+# Key name used in ~/lobster-config/config.env for the admin chat ID.
+# Named constant so tests and implementation agree on the same string.
+_ADMIN_CHAT_ID_KEY = "LOBSTER_ADMIN_CHAT_ID"
+
 # Append-only log of context injections — one line per hook run.
 # Populated at import time so tests can override by setting mod.CONTEXT_INJECTION_LOG.
 _LOBSTER_WORKSPACE = Path(
@@ -60,6 +77,13 @@ CONTEXT_INJECTION_LOG = _LOBSTER_WORKSPACE / "logs" / "context-injection.log"
 # Startup flag written by claude-persistent.sh before exec-ing claude.
 # Contains the launcher subshell PID. Deleted after the dispatcher is detected.
 STARTUP_FLAG_FILE = _LOBSTER_WORKSPACE / "data" / "dispatcher-startup-flag"
+
+# Config file that contains LOBSTER_ADMIN_CHAT_ID (issue #1976).
+# The old dispatcher bootup doc referenced ~/lobster-config/lobster.conf which
+# does not exist — the real location is config.env. We read it here so the
+# dispatcher receives ADMIN_CHAT_ID injected into context at session start
+# and never needs to grep for it.
+CONFIG_ENV_PATH = Path(os.path.expanduser("~/lobster-config/config.env"))
 
 # Single source of truth for startup cause classification (issue #1972).
 # on-compact.py writes {"cause": "compaction", "ts": "<iso_utc>"} before exiting.
@@ -75,6 +99,38 @@ STARTUP_CAUSE_FILE = Path(
 # Beyond this window we fall back to "restart" to avoid misclassifying a
 # compaction that was followed by an unrelated external restart.
 COMPACTION_CAUSE_WINDOW_SECONDS = 300  # 5 minutes
+
+
+def _parse_admin_chat_id(config_env_path: Path) -> str | None:
+    """Parse LOBSTER_ADMIN_CHAT_ID from a config.env file.
+
+    Returns the stripped string value if the key is present and non-empty.
+    Returns None if:
+      - The file does not exist
+      - The key is absent from the file
+      - The value is empty or blank after stripping
+      - Any OSError occurs while reading
+
+    This is a pure function — it reads the file and returns a value without
+    any side effects. Never raises.
+    """
+    try:
+        if not config_env_path.exists():
+            return None
+        text = config_env_path.read_text()
+    except OSError:
+        return None
+
+    prefix = f"{_ADMIN_CHAT_ID_KEY}="
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if stripped.startswith(prefix):
+            value = stripped[len(prefix):].strip()
+            return value if value else None
+
+    return None
 
 
 def _is_startup_flag_dispatcher() -> bool:
@@ -300,6 +356,18 @@ def main() -> None:
     if content is None:
         _append_injection_log(session_id, role, injected)
         sys.exit(0)
+
+    # For the dispatcher: inject ADMIN_CHAT_ID preamble from config.env so the
+    # dispatcher has the value available in context without any grep at startup.
+    # Silent when config.env is absent or the key is missing (graceful degradation).
+    if is_dispatcher:
+        admin_chat_id = _parse_admin_chat_id(CONFIG_ENV_PATH)
+        if admin_chat_id is not None:
+            print(f"ADMIN_CHAT_ID={admin_chat_id}")
+            print(
+                "(Injected by inject-bootup-context.py from ~/lobster-config/config.env"
+                " — no grep needed at startup)\n"
+            )
 
     # For the dispatcher: prepend a single line announcing the startup cause
     # so step 2d of the startup sequence can use it without reading any files.

--- a/tests/unit/test_hooks/test_inject_admin_chat_id.py
+++ b/tests/unit/test_hooks/test_inject_admin_chat_id.py
@@ -30,8 +30,9 @@ import importlib.util
 import io
 import json
 import os
+from contextlib import redirect_stdout
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -144,10 +145,8 @@ def _run_hook(
         if is_dispatcher:
             mod._consume_startup_flag = lambda: None
 
-        import io as _io
-        out_buf = _io.StringIO()
+        out_buf = io.StringIO()
         with patch("sys.stdin", io.StringIO(hook_input)):
-            from contextlib import redirect_stdout
             with redirect_stdout(out_buf):
                 with pytest.raises(SystemExit):
                     mod.main()
@@ -222,7 +221,6 @@ class TestParseAdminChatId:
 
     def test_returns_none_on_oserror(self, tmp_path):
         """Returns None on OSError reading the file (safe default)."""
-        from unittest.mock import MagicMock
         mock_path = MagicMock(spec=Path)
         mock_path.exists.return_value = True
         mock_path.read_text.side_effect = OSError("permission denied")

--- a/tests/unit/test_hooks/test_inject_admin_chat_id.py
+++ b/tests/unit/test_hooks/test_inject_admin_chat_id.py
@@ -1,0 +1,353 @@
+"""
+Unit tests for ADMIN_CHAT_ID injection in inject-bootup-context.py (issue #1976).
+
+Problem: sys.dispatcher.bootup.md tells the dispatcher to find ADMIN_CHAT_ID via
+  grep ADMIN_CHAT_ID ~/lobster-config/lobster.conf
+But ~/lobster-config/lobster.conf does not exist. The value lives in
+~/lobster-config/config.env as LOBSTER_ADMIN_CHAT_ID.
+
+Fix: inject-bootup-context.py parses config.env at session start and prepends
+a preamble line  ``ADMIN_CHAT_ID=<value>``  to the dispatcher's injected content.
+The dispatcher can then read the value directly from its context without any
+grep/file-read at startup.
+
+Test coverage:
+- _parse_admin_chat_id() returns the value when config.env contains LOBSTER_ADMIN_CHAT_ID
+- _parse_admin_chat_id() returns None when config.env is absent
+- _parse_admin_chat_id() returns None when LOBSTER_ADMIN_CHAT_ID is not in the file
+- _parse_admin_chat_id() returns None when the value is empty/blank
+- _parse_admin_chat_id() strips surrounding whitespace from the value
+- _parse_admin_chat_id() handles OSError gracefully (returns None)
+- Integration: dispatcher sessions get ADMIN_CHAT_ID preamble injected before bootup content
+- Integration: subagent sessions do NOT get the preamble
+- Integration: missing config.env does not break injection (graceful degradation)
+- Integration: injected preamble appears before (not after) the dispatcher bootup content
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "inject-bootup-context.py"
+
+# Named constant matching the variable name in config.env
+LOBSTER_ADMIN_CHAT_ID_VAR = "LOBSTER_ADMIN_CHAT_ID"
+SAMPLE_CHAT_ID = "8305714125"
+PREAMBLE_PREFIX = "ADMIN_CHAT_ID="
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _PatchEnv:
+    """Context manager to temporarily set / restore environment variables."""
+
+    def __init__(self, env: dict):
+        self._env = env
+        self._saved: dict = {}
+
+    def __enter__(self):
+        for k, v in self._env.items():
+            self._saved[k] = os.environ.get(k)
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        return self
+
+    def __exit__(self, *_):
+        for k, saved_v in self._saved.items():
+            if saved_v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = saved_v
+
+
+def _load_hook(*, workspace: Path) -> object:
+    """Load inject-bootup-context.py with a controlled LOBSTER_WORKSPACE."""
+    import uuid
+
+    unique_name = f"inject_bootup_{uuid.uuid4().hex}"
+    with _PatchEnv({"LOBSTER_WORKSPACE": str(workspace)}):
+        spec = importlib.util.spec_from_file_location(unique_name, _HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_config_env(config_dir: Path, content: str) -> Path:
+    """Write a config.env file with the given content."""
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_file = config_dir / "config.env"
+    config_file.write_text(content)
+    return config_file
+
+
+def _setup_bootup_files(tmp_path: Path) -> tuple[Path, Path]:
+    """Write minimal dispatcher and subagent bootup stubs."""
+    claude_dir = tmp_path / "lobster" / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    dispatcher_bootup = claude_dir / "sys.dispatcher.bootup.md"
+    subagent_bootup = claude_dir / "sys.subagent.bootup.md"
+    dispatcher_bootup.write_text("# DISPATCHER BOOTUP\n")
+    subagent_bootup.write_text("# SUBAGENT BOOTUP\n")
+    return dispatcher_bootup, subagent_bootup
+
+
+def _run_hook(
+    *,
+    tmp_path: Path,
+    config_env_path: Path | None,
+    is_dispatcher: bool,
+    session_id: str = "test-session-uuid",
+) -> str:
+    """Run main() and return stdout output as a string."""
+    dispatcher_bootup, subagent_bootup = _setup_bootup_files(tmp_path)
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    hook_input = json.dumps({"session_id": session_id})
+
+    with _PatchEnv({"LOBSTER_WORKSPACE": str(tmp_path)}):
+        spec = importlib.util.spec_from_file_location(
+            f"inject_admin_chat_id_{session_id[:8]}", _HOOK_PATH
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        # Override file paths to use tmp_path
+        mod.DISPATCHER_BOOTUP = dispatcher_bootup
+        mod.SUBAGENT_BOOTUP = subagent_bootup
+        mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+        mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+        mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+
+        if config_env_path is not None:
+            mod.CONFIG_ENV_PATH = config_env_path
+        else:
+            # Point to a non-existent path
+            mod.CONFIG_ENV_PATH = tmp_path / "nonexistent" / "config.env"
+
+        # Control dispatcher detection directly
+        mod._is_startup_flag_dispatcher = lambda: is_dispatcher
+        if is_dispatcher:
+            mod._consume_startup_flag = lambda: None
+
+        import io as _io
+        out_buf = _io.StringIO()
+        with patch("sys.stdin", io.StringIO(hook_input)):
+            from contextlib import redirect_stdout
+            with redirect_stdout(out_buf):
+                with pytest.raises(SystemExit):
+                    mod.main()
+
+    return out_buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _parse_admin_chat_id()
+# ---------------------------------------------------------------------------
+
+
+class TestParseAdminChatId:
+    """Unit tests for the _parse_admin_chat_id() helper."""
+
+    def test_returns_value_when_key_present(self, tmp_path):
+        """Returns the value when LOBSTER_ADMIN_CHAT_ID is present in config.env."""
+        config_file = _write_config_env(
+            tmp_path / "lobster-config",
+            f"TELEGRAM_BOT_TOKEN=fake-token\n{LOBSTER_ADMIN_CHAT_ID_VAR}={SAMPLE_CHAT_ID}\n",
+        )
+        mod = _load_hook(workspace=tmp_path)
+        result = mod._parse_admin_chat_id(config_file)
+        assert result == SAMPLE_CHAT_ID
+
+    def test_returns_none_when_file_absent(self, tmp_path):
+        """Returns None when config.env does not exist."""
+        absent_path = tmp_path / "no-config" / "config.env"
+        mod = _load_hook(workspace=tmp_path)
+        result = mod._parse_admin_chat_id(absent_path)
+        assert result is None
+
+    def test_returns_none_when_key_absent(self, tmp_path):
+        """Returns None when LOBSTER_ADMIN_CHAT_ID is not in the file."""
+        config_file = _write_config_env(
+            tmp_path / "lobster-config",
+            "TELEGRAM_BOT_TOKEN=fake-token\nSOME_OTHER_KEY=value\n",
+        )
+        mod = _load_hook(workspace=tmp_path)
+        result = mod._parse_admin_chat_id(config_file)
+        assert result is None
+
+    def test_returns_none_when_value_is_empty(self, tmp_path):
+        """Returns None when LOBSTER_ADMIN_CHAT_ID= has an empty value."""
+        config_file = _write_config_env(
+            tmp_path / "lobster-config",
+            f"{LOBSTER_ADMIN_CHAT_ID_VAR}=\n",
+        )
+        mod = _load_hook(workspace=tmp_path)
+        result = mod._parse_admin_chat_id(config_file)
+        assert result is None
+
+    def test_returns_none_when_value_is_blank(self, tmp_path):
+        """Returns None when LOBSTER_ADMIN_CHAT_ID= has only whitespace."""
+        config_file = _write_config_env(
+            tmp_path / "lobster-config",
+            f"{LOBSTER_ADMIN_CHAT_ID_VAR}=   \n",
+        )
+        mod = _load_hook(workspace=tmp_path)
+        result = mod._parse_admin_chat_id(config_file)
+        assert result is None
+
+    def test_strips_whitespace_from_value(self, tmp_path):
+        """Strips surrounding whitespace from the parsed value."""
+        config_file = _write_config_env(
+            tmp_path / "lobster-config",
+            f"{LOBSTER_ADMIN_CHAT_ID_VAR}=  {SAMPLE_CHAT_ID}  \n",
+        )
+        mod = _load_hook(workspace=tmp_path)
+        result = mod._parse_admin_chat_id(config_file)
+        assert result == SAMPLE_CHAT_ID
+
+    def test_returns_none_on_oserror(self, tmp_path):
+        """Returns None on OSError reading the file (safe default)."""
+        from unittest.mock import MagicMock
+        mock_path = MagicMock(spec=Path)
+        mock_path.exists.return_value = True
+        mock_path.read_text.side_effect = OSError("permission denied")
+
+        mod = _load_hook(workspace=tmp_path)
+        result = mod._parse_admin_chat_id(mock_path)
+        assert result is None
+
+    def test_handles_comment_lines(self, tmp_path):
+        """Skips comment lines (lines starting with #) and finds the value."""
+        config_file = _write_config_env(
+            tmp_path / "lobster-config",
+            f"# This is a comment\n{LOBSTER_ADMIN_CHAT_ID_VAR}={SAMPLE_CHAT_ID}\n",
+        )
+        mod = _load_hook(workspace=tmp_path)
+        result = mod._parse_admin_chat_id(config_file)
+        assert result == SAMPLE_CHAT_ID
+
+    def test_handles_file_without_trailing_newline(self, tmp_path):
+        """Parses the value correctly even without a trailing newline."""
+        config_file = _write_config_env(
+            tmp_path / "lobster-config",
+            f"{LOBSTER_ADMIN_CHAT_ID_VAR}={SAMPLE_CHAT_ID}",  # no trailing newline
+        )
+        mod = _load_hook(workspace=tmp_path)
+        result = mod._parse_admin_chat_id(config_file)
+        assert result == SAMPLE_CHAT_ID
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: preamble injection in main()
+# ---------------------------------------------------------------------------
+
+
+class TestAdminChatIdInjectionInMain:
+    """main() injects ADMIN_CHAT_ID preamble for dispatcher sessions only."""
+
+    def test_dispatcher_gets_preamble_before_bootup_content(self, tmp_path):
+        """Dispatcher session: preamble line appears before bootup content."""
+        config_file = _write_config_env(
+            tmp_path / "lobster-config",
+            f"{LOBSTER_ADMIN_CHAT_ID_VAR}={SAMPLE_CHAT_ID}\n",
+        )
+        output = _run_hook(
+            tmp_path=tmp_path,
+            config_env_path=config_file,
+            is_dispatcher=True,
+        )
+
+        preamble_line = f"{PREAMBLE_PREFIX}{SAMPLE_CHAT_ID}"
+        assert preamble_line in output, (
+            f"Dispatcher output must contain '{preamble_line}'"
+        )
+        assert "DISPATCHER BOOTUP" in output, "Dispatcher bootup content must still be injected"
+
+        # Preamble must appear before the bootup content
+        preamble_pos = output.index(preamble_line)
+        bootup_pos = output.index("DISPATCHER BOOTUP")
+        assert preamble_pos < bootup_pos, (
+            "ADMIN_CHAT_ID preamble must appear before the dispatcher bootup content"
+        )
+
+    def test_subagent_does_not_get_preamble(self, tmp_path):
+        """Subagent session: preamble is NOT injected."""
+        config_file = _write_config_env(
+            tmp_path / "lobster-config",
+            f"{LOBSTER_ADMIN_CHAT_ID_VAR}={SAMPLE_CHAT_ID}\n",
+        )
+        output = _run_hook(
+            tmp_path=tmp_path,
+            config_env_path=config_file,
+            is_dispatcher=False,
+        )
+
+        assert PREAMBLE_PREFIX not in output, (
+            "Subagent sessions must NOT receive the ADMIN_CHAT_ID preamble"
+        )
+        assert "SUBAGENT BOOTUP" in output, "Subagent bootup content must still be injected"
+
+    def test_dispatcher_without_config_env_still_injects_bootup(self, tmp_path):
+        """Missing config.env: graceful degradation — bootup still injected, no preamble."""
+        output = _run_hook(
+            tmp_path=tmp_path,
+            config_env_path=None,  # config.env absent
+            is_dispatcher=True,
+        )
+
+        assert "DISPATCHER BOOTUP" in output, (
+            "Dispatcher bootup must still be injected even when config.env is absent"
+        )
+        assert PREAMBLE_PREFIX not in output, (
+            "No ADMIN_CHAT_ID preamble when config.env is absent"
+        )
+
+    def test_dispatcher_without_key_in_config_env_still_injects_bootup(self, tmp_path):
+        """config.env exists but lacks LOBSTER_ADMIN_CHAT_ID: no preamble, bootup still runs."""
+        config_file = _write_config_env(
+            tmp_path / "lobster-config",
+            "TELEGRAM_BOT_TOKEN=fake-token\n",  # no LOBSTER_ADMIN_CHAT_ID
+        )
+        output = _run_hook(
+            tmp_path=tmp_path,
+            config_env_path=config_file,
+            is_dispatcher=True,
+        )
+
+        assert "DISPATCHER BOOTUP" in output
+        assert PREAMBLE_PREFIX not in output, (
+            "No preamble when LOBSTER_ADMIN_CHAT_ID is absent from config.env"
+        )
+
+    def test_preamble_contains_exact_chat_id(self, tmp_path):
+        """Preamble line contains the exact numeric value from config.env."""
+        config_file = _write_config_env(
+            tmp_path / "lobster-config",
+            f"{LOBSTER_ADMIN_CHAT_ID_VAR}={SAMPLE_CHAT_ID}\n",
+        )
+        output = _run_hook(
+            tmp_path=tmp_path,
+            config_env_path=config_file,
+            is_dispatcher=True,
+        )
+
+        expected_line = f"{PREAMBLE_PREFIX}{SAMPLE_CHAT_ID}"
+        assert expected_line in output, (
+            f"Expected preamble '{expected_line}' in output"
+        )

--- a/tests/unit/test_hooks/test_inject_admin_chat_id.py
+++ b/tests/unit/test_hooks/test_inject_admin_chat_id.py
@@ -30,7 +30,6 @@ import importlib.util
 import io
 import json
 import os
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -252,6 +251,22 @@ class TestParseAdminChatId:
         result = mod._parse_admin_chat_id(config_file)
         assert result == SAMPLE_CHAT_ID
 
+    def test_does_not_match_key_with_longer_prefix(self, tmp_path):
+        """Does not falsely match a key that starts with LOBSTER_ADMIN_CHAT_ID but has a suffix.
+
+        e.g. LOBSTER_ADMIN_CHAT_ID_BACKUP=999 must not be returned when
+        LOBSTER_ADMIN_CHAT_ID itself is absent.
+        """
+        config_file = _write_config_env(
+            tmp_path / "lobster-config",
+            f"{LOBSTER_ADMIN_CHAT_ID_VAR}_BACKUP=999\n",  # similar but different key
+        )
+        mod = _load_hook(workspace=tmp_path)
+        result = mod._parse_admin_chat_id(config_file)
+        assert result is None, (
+            "Should not match LOBSTER_ADMIN_CHAT_ID_BACKUP when LOBSTER_ADMIN_CHAT_ID is absent"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Integration tests: preamble injection in main()
@@ -350,4 +365,27 @@ class TestAdminChatIdInjectionInMain:
         expected_line = f"{PREAMBLE_PREFIX}{SAMPLE_CHAT_ID}"
         assert expected_line in output, (
             f"Expected preamble '{expected_line}' in output"
+        )
+
+    def test_preamble_annotation_appears_in_dispatcher_output(self, tmp_path):
+        """Dispatcher output includes the annotation comment explaining the injection source.
+
+        The annotation tells the dispatcher that ADMIN_CHAT_ID was injected from
+        config.env so it knows not to grep for it at startup.
+        """
+        config_file = _write_config_env(
+            tmp_path / "lobster-config",
+            f"{LOBSTER_ADMIN_CHAT_ID_VAR}={SAMPLE_CHAT_ID}\n",
+        )
+        output = _run_hook(
+            tmp_path=tmp_path,
+            config_env_path=config_file,
+            is_dispatcher=True,
+        )
+
+        assert "config.env" in output, (
+            "Annotation must mention config.env as the injection source"
+        )
+        assert "no grep needed" in output.lower(), (
+            "Annotation must confirm no grep is needed at startup"
         )


### PR DESCRIPTION
## What problem does this solve?

Issue #1976 requires TDD coverage for the ADMIN_CHAT_ID injection feature. The feature itself ships in PR #1978 (which extends `inject-bootup-context.py` to read `LOBSTER_ADMIN_CHAT_ID` from `config.env` and inject it into the dispatcher context). This PR carries the test file, starting from that branch's state with two improvements: a lint fix and two additional tests for coverage gaps.

## What changed

**`tests/unit/test_hooks/test_inject_admin_chat_id.py`** — 16 tests covering:

**Unit tests for `_parse_admin_chat_id()`:**
- Returns the value when `LOBSTER_ADMIN_CHAT_ID` is present
- Returns `None` when `config.env` is absent
- Returns `None` when the key is absent from the file
- Returns `None` when the value is empty or blank
- Strips surrounding whitespace from the parsed value
- Returns `None` on `OSError` (safe default, never raises)
- Skips comment lines starting with `#`
- Handles files without a trailing newline
- Does NOT falsely match `LOBSTER_ADMIN_CHAT_ID_BACKUP=...` (prefix-collision prevention)

**Integration tests for `main()`:**
- Dispatcher session: preamble line `ADMIN_CHAT_ID=<value>` appears before bootup content
- Subagent session: preamble is NOT injected
- Missing `config.env`: graceful degradation — bootup still runs, no preamble
- `config.env` exists but lacks the key: no preamble, bootup still runs
- Preamble contains the exact numeric value from `config.env`
- Preamble annotation includes "config.env" and "no grep needed" (confirms the lookup elimination intent)

**Improvements over the original 14 tests in PR #1978:**
- Removed unused `sys` import (ruff F401)
- Added `test_does_not_match_key_with_longer_prefix` — verifies prefix-collision safety
- Added `test_preamble_annotation_appears_in_dispatcher_output` — verifies the annotation text that tells the dispatcher it has ADMIN_CHAT_ID injected without greping

**Functional patterns:** Pure function under test (`_parse_admin_chat_id`) has no side effects. Tests use `tmp_path` fixtures and direct function calls — no mocking of the function under test, only of filesystem side effects (`OSError`) and hook routing (`_is_startup_flag_dispatcher`, `_consume_startup_flag`).

## What is NOT changed

- `inject-bootup-context.py`: unchanged (implementation is in PR #1978)
- `.claude/sys.dispatcher.bootup.md`: unchanged
- All other hook tests: 408 tests unaffected

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_inject_admin_chat_id.py -v` — 16 passed, 0 failed
- [x] `uv run pytest tests/unit/test_hooks/ -q` — 424 passed, 7 skipped, 0 failed (full hook suite, no regressions)
- [x] `uv run --with ruff ruff check tests/unit/test_hooks/test_inject_admin_chat_id.py` — all checks passed

## Manual test

N/A — this PR adds only test code. The tested behavior is internal to the hook injection pipeline and has no user-visible output.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, test-only PR
- [x] User-visible outcome verified — N/A, internal plumbing
- [x] Side-effect audit complete: test file only, no floods or writes
- [x] External service calls: none

Relates to #1976