### PR TITLE
fix(#2029): enumerate all known agent types in require-subagent-type hook error messages

### DIFF
--- a/hooks/require-subagent-type.py
+++ b/hooks/require-subagent-type.py
@@ -5,6 +5,20 @@ Encourages use of lobster-generalist or a named agent type instead.
 """
 import json, sys
 
+# All agent types defined in .claude/agents/. Keep in sync with that directory.
+KNOWN_AGENT_TYPES = (
+    "lobster-generalist",
+    "functional-engineer",
+    "review",
+    "lobster-ops",
+    "lobster-auditor",
+    "brain-dumps",
+    "compact-catchup",
+    "nightly-consolidation",
+    "session-note-appender",
+    "session-note-polish",
+)
+
 data = json.load(sys.stdin)
 tool = data.get("tool_name", "")
 inp = data.get("tool_input", {})
@@ -15,19 +29,21 @@ if tool != "Agent":
 subagent_type = inp.get("subagent_type")
 
 if not subagent_type:
+    types_list = ", ".join(KNOWN_AGENT_TYPES)
     print(
         "BLOCKED: Agent called without subagent_type. "
-        "Use subagent_type='lobster-generalist' for general background tasks, "
-        "or a named agent type (functional-engineer, lobster-ops, brain-dumps, etc.).",
+        f"Known types: {types_list}. "
+        "Use subagent_type='lobster-generalist' for general background tasks.",
         file=sys.stderr,
     )
     sys.exit(2)
 
 if subagent_type == "general-purpose":
+    types_list = ", ".join(KNOWN_AGENT_TYPES)
     print(
         "BLOCKED: subagent_type='general-purpose' is not used in Lobster. "
         "Use subagent_type='lobster-generalist' for open-ended background tasks instead. "
-        "For specialised work, use: functional-engineer, lobster-ops, or brain-dumps.",
+        f"For specialised work, choose from: {types_list}.",
         file=sys.stderr,
     )
     sys.exit(2)

--- a/tests/unit/test_hooks/test_require_subagent_type.py
+++ b/tests/unit/test_hooks/test_require_subagent_type.py
@@ -9,7 +9,7 @@ Tests cover:
 - Agent with subagent_type='general-purpose' is hard-blocked (exit 2)
 - Block messages go to stderr, not stdout
 - Error messages enumerate all known agent types including 'review'
-- KNOWN_AGENT_TYPES constant matches the agent files in .claude/agents/
+- KNOWN_AGENT_TYPES spot-checks key types and aligns with .claude/agents/ files
 """
 
 import json
@@ -22,6 +22,7 @@ import pytest
 
 HOOKS_DIR = Path(__file__).parents[3] / "hooks"
 HOOK_PATH = HOOKS_DIR / "require-subagent-type.py"
+AGENTS_DIR = Path(__file__).parents[3] / ".claude" / "agents"
 
 
 # ---------------------------------------------------------------------------
@@ -59,6 +60,29 @@ def _make_hook_input(tool_name: str, tool_input: dict) -> dict:
     }
 
 
+def _load_known_agent_types() -> tuple:
+    """Load KNOWN_AGENT_TYPES from the hook module at import time."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("_require_subagent_type_loader", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    fake_stdin = json.dumps({"tool_name": "Bash", "tool_input": {}})
+    with (
+        patch("sys.stdin", StringIO(fake_stdin)),
+        patch("sys.stdout", StringIO()),
+        patch("sys.stderr", StringIO()),
+    ):
+        try:
+            spec.loader.exec_module(mod)
+        except SystemExit:
+            pass
+    return mod.KNOWN_AGENT_TYPES
+
+
+# Single source of truth: import from the hook rather than duplicating the list.
+KNOWN_AGENT_TYPES = _load_known_agent_types()
+
+
 # ---------------------------------------------------------------------------
 # Non-Agent tool passthrough
 # ---------------------------------------------------------------------------
@@ -92,22 +116,8 @@ class TestNonAgentTool:
 # ---------------------------------------------------------------------------
 
 
-VALID_AGENT_TYPES = [
-    "lobster-generalist",
-    "functional-engineer",
-    "review",
-    "lobster-ops",
-    "lobster-auditor",
-    "brain-dumps",
-    "compact-catchup",
-    "nightly-consolidation",
-    "session-note-appender",
-    "session-note-polish",
-]
-
-
 class TestValidSubagentTypes:
-    @pytest.mark.parametrize("agent_type", VALID_AGENT_TYPES)
+    @pytest.mark.parametrize("agent_type", KNOWN_AGENT_TYPES)
     def test_known_agent_type_exits_0(self, agent_type):
         """Every known agent type must be allowed through (exit 0 or natural return)."""
         hook_input = _make_hook_input(
@@ -247,42 +257,28 @@ class TestGeneralPurposeBlocked:
 class TestKnownAgentTypesConstant:
     def test_review_is_in_known_types(self):
         """KNOWN_AGENT_TYPES must include 'review' since dispatcher uses subagent_type='review'."""
-        # Load the hook module to inspect KNOWN_AGENT_TYPES
-        import importlib.util
-
-        spec = importlib.util.spec_from_file_location("require_subagent_type", HOOK_PATH)
-        mod = importlib.util.module_from_spec(spec)
-        fake_stdin = json.dumps({"tool_name": "Bash", "tool_input": {}})
-        with (
-            patch("sys.stdin", StringIO(fake_stdin)),
-            patch("sys.stdout", StringIO()),
-            patch("sys.stderr", StringIO()),
-        ):
-            try:
-                spec.loader.exec_module(mod)
-            except SystemExit:
-                pass
-
-        assert "review" in mod.KNOWN_AGENT_TYPES, (
+        assert "review" in KNOWN_AGENT_TYPES, (
             "KNOWN_AGENT_TYPES must include 'review' — dispatcher uses subagent_type='review' "
             "for engineer→reviewer routing."
         )
 
     def test_functional_engineer_is_in_known_types(self):
         """KNOWN_AGENT_TYPES must include 'functional-engineer'."""
-        import importlib.util
+        assert "functional-engineer" in KNOWN_AGENT_TYPES
 
-        spec = importlib.util.spec_from_file_location("require_subagent_type_fe", HOOK_PATH)
-        mod = importlib.util.module_from_spec(spec)
-        fake_stdin = json.dumps({"tool_name": "Bash", "tool_input": {}})
-        with (
-            patch("sys.stdin", StringIO(fake_stdin)),
-            patch("sys.stdout", StringIO()),
-            patch("sys.stderr", StringIO()),
-        ):
-            try:
-                spec.loader.exec_module(mod)
-            except SystemExit:
-                pass
+    def test_known_types_matches_agents_directory(self):
+        """KNOWN_AGENT_TYPES must contain exactly the agent types defined in .claude/agents/.
 
-        assert "functional-engineer" in mod.KNOWN_AGENT_TYPES
+        Each .md file in .claude/agents/ defines one agent type (filename without extension).
+        This test catches a new agent file being added without updating KNOWN_AGENT_TYPES,
+        or a stale entry left after an agent file is removed.
+        """
+        files_on_disk = {p.stem for p in AGENTS_DIR.glob("*.md")}
+        constant_set = set(KNOWN_AGENT_TYPES)
+        missing_from_constant = files_on_disk - constant_set
+        extra_in_constant = constant_set - files_on_disk
+        assert not missing_from_constant and not extra_in_constant, (
+            f"KNOWN_AGENT_TYPES is out of sync with .claude/agents/. "
+            f"Missing from constant: {sorted(missing_from_constant)}. "
+            f"Extra in constant (no matching file): {sorted(extra_in_constant)}."
+        )

--- a/tests/unit/test_hooks/test_require_subagent_type.py
+++ b/tests/unit/test_hooks/test_require_subagent_type.py
@@ -1,0 +1,288 @@
+"""
+Unit tests for hooks/require-subagent-type.py
+
+Tests cover:
+- Non-Agent tool calls pass through (exit 0)
+- Agent with a valid subagent_type passes through (exit 0)
+- Agent with subagent_type='review' passes through (exit 0)
+- Agent without subagent_type is hard-blocked (exit 2)
+- Agent with subagent_type='general-purpose' is hard-blocked (exit 2)
+- Block messages go to stderr, not stdout
+- Error messages enumerate all known agent types including 'review'
+- KNOWN_AGENT_TYPES constant matches the agent files in .claude/agents/
+"""
+
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+HOOK_PATH = HOOKS_DIR / "require-subagent-type.py"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(hook_input: dict) -> tuple[int, str, str]:
+    """Run the hook script and return (exit_code, stdout, stderr)."""
+    stdout_capture = StringIO()
+    stderr_capture = StringIO()
+    stdin_data = json.dumps(hook_input)
+
+    exit_code = None
+    with (
+        patch("sys.stdin", StringIO(stdin_data)),
+        patch("sys.stdout", stdout_capture),
+        patch("sys.stderr", stderr_capture),
+    ):
+        try:
+            hook_globals = {"__name__": "__main__", "__file__": str(HOOK_PATH)}
+            exec(compile(HOOK_PATH.read_text(), str(HOOK_PATH), "exec"), hook_globals)
+        except SystemExit as e:
+            exit_code = e.code
+
+    return exit_code, stdout_capture.getvalue(), stderr_capture.getvalue()
+
+
+def _make_hook_input(tool_name: str, tool_input: dict) -> dict:
+    return {
+        "hook_event_name": "PreToolUse",
+        "session_id": "sess-001",
+        "tool_name": tool_name,
+        "tool_input": tool_input,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Non-Agent tool passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestNonAgentTool:
+    def test_bash_tool_exits_0(self):
+        """Non-Agent tools must pass through without modification."""
+        hook_input = _make_hook_input("Bash", {"command": "ls"})
+        exit_code, stdout, stderr = _run_hook(hook_input)
+        # The hook calls sys.exit(0) explicitly for non-Agent tools
+        assert exit_code == 0
+
+    def test_mcp_tool_exits_0(self):
+        """MCP tools are not the Agent tool and must pass through."""
+        hook_input = _make_hook_input(
+            "mcp__lobster-inbox__check_inbox", {"limit": 10}
+        )
+        exit_code, _, _ = _run_hook(hook_input)
+        assert exit_code == 0
+
+    def test_read_tool_exits_0(self):
+        """Read tool is not Agent and must pass through."""
+        hook_input = _make_hook_input("Read", {"file_path": "/tmp/foo"})
+        exit_code, _, _ = _run_hook(hook_input)
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Valid subagent_type values pass through
+# ---------------------------------------------------------------------------
+
+
+VALID_AGENT_TYPES = [
+    "lobster-generalist",
+    "functional-engineer",
+    "review",
+    "lobster-ops",
+    "lobster-auditor",
+    "brain-dumps",
+    "compact-catchup",
+    "nightly-consolidation",
+    "session-note-appender",
+    "session-note-polish",
+]
+
+
+class TestValidSubagentTypes:
+    @pytest.mark.parametrize("agent_type", VALID_AGENT_TYPES)
+    def test_known_agent_type_exits_0(self, agent_type):
+        """Every known agent type must be allowed through (exit 0 or natural return)."""
+        hook_input = _make_hook_input(
+            "Agent",
+            {"subagent_type": agent_type, "prompt": "do work"},
+        )
+        exit_code, _, stderr = _run_hook(hook_input)
+        # None means the hook returned normally without calling sys.exit — equivalent to exit 0
+        assert exit_code in (0, None), (
+            f"Known agent type '{agent_type}' should be allowed, "
+            f"got exit {exit_code}. stderr={stderr!r}"
+        )
+
+    def test_review_agent_type_passes_through(self):
+        """subagent_type='review' must pass through — dispatcher uses it for engineer→reviewer routing."""
+        hook_input = _make_hook_input(
+            "Agent",
+            {"subagent_type": "review", "prompt": "Review PR https://github.com/org/repo/pull/42"},
+        )
+        exit_code, _, stderr = _run_hook(hook_input)
+        # None means the hook returned normally without calling sys.exit — equivalent to exit 0
+        assert exit_code in (0, None), (
+            f"subagent_type='review' should be allowed (used by engineer→reviewer routing). "
+            f"Got exit {exit_code}. stderr={stderr!r}"
+        )
+
+    def test_unknown_custom_type_passes_through(self):
+        """An unknown but non-empty type must pass through — the hook only blocks missing and 'general-purpose'."""
+        hook_input = _make_hook_input(
+            "Agent",
+            {"subagent_type": "some-custom-agent", "prompt": "do work"},
+        )
+        exit_code, _, _ = _run_hook(hook_input)
+        # None means the hook returned normally without calling sys.exit — equivalent to exit 0
+        assert exit_code in (0, None)
+
+
+# ---------------------------------------------------------------------------
+# Missing subagent_type is hard-blocked
+# ---------------------------------------------------------------------------
+
+
+class TestMissingSubagentType:
+    def test_agent_without_subagent_type_exits_2(self):
+        """Agent called with no subagent_type is hard-blocked (exit 2)."""
+        hook_input = _make_hook_input("Agent", {"prompt": "do work"})
+        exit_code, _, _ = _run_hook(hook_input)
+        assert exit_code == 2
+
+    def test_block_message_goes_to_stderr(self):
+        """Block message for missing subagent_type must go to stderr."""
+        hook_input = _make_hook_input("Agent", {"prompt": "do work"})
+        exit_code, stdout, stderr = _run_hook(hook_input)
+        assert exit_code == 2
+        assert "BLOCKED" in stderr
+        assert "BLOCKED" not in stdout
+
+    def test_block_message_mentions_review(self):
+        """Missing subagent_type error message must list 'review' as a valid option."""
+        hook_input = _make_hook_input("Agent", {"prompt": "do work"})
+        _, _, stderr = _run_hook(hook_input)
+        assert "review" in stderr, (
+            f"Error message should mention 'review' as a valid agent type. stderr={stderr!r}"
+        )
+
+    def test_block_message_mentions_lobster_generalist(self):
+        """Missing subagent_type error message must recommend lobster-generalist."""
+        hook_input = _make_hook_input("Agent", {"prompt": "do work"})
+        _, _, stderr = _run_hook(hook_input)
+        assert "lobster-generalist" in stderr
+
+    def test_agent_with_empty_subagent_type_exits_2(self):
+        """Agent with empty string subagent_type is treated as missing (exit 2)."""
+        hook_input = _make_hook_input("Agent", {"subagent_type": "", "prompt": "do work"})
+        exit_code, _, _ = _run_hook(hook_input)
+        assert exit_code == 2
+
+    def test_agent_with_none_subagent_type_exits_2(self):
+        """Agent with null subagent_type is treated as missing (exit 2)."""
+        hook_input = _make_hook_input("Agent", {"subagent_type": None, "prompt": "do work"})
+        exit_code, _, _ = _run_hook(hook_input)
+        assert exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# general-purpose subagent_type is hard-blocked
+# ---------------------------------------------------------------------------
+
+
+class TestGeneralPurposeBlocked:
+    def test_general_purpose_exits_2(self):
+        """subagent_type='general-purpose' is not used in Lobster — must be hard-blocked."""
+        hook_input = _make_hook_input(
+            "Agent",
+            {"subagent_type": "general-purpose", "prompt": "do work"},
+        )
+        exit_code, _, _ = _run_hook(hook_input)
+        assert exit_code == 2
+
+    def test_general_purpose_block_message_goes_to_stderr(self):
+        """general-purpose block message must go to stderr, not stdout."""
+        hook_input = _make_hook_input(
+            "Agent",
+            {"subagent_type": "general-purpose", "prompt": "do work"},
+        )
+        exit_code, stdout, stderr = _run_hook(hook_input)
+        assert exit_code == 2
+        assert "BLOCKED" in stderr
+        assert "BLOCKED" not in stdout
+
+    def test_general_purpose_block_message_recommends_lobster_generalist(self):
+        """general-purpose block message must recommend lobster-generalist."""
+        hook_input = _make_hook_input(
+            "Agent",
+            {"subagent_type": "general-purpose", "prompt": "do work"},
+        )
+        _, _, stderr = _run_hook(hook_input)
+        assert "lobster-generalist" in stderr
+
+    def test_general_purpose_block_message_mentions_review(self):
+        """general-purpose block message must list 'review' as an alternative."""
+        hook_input = _make_hook_input(
+            "Agent",
+            {"subagent_type": "general-purpose", "prompt": "do work"},
+        )
+        _, _, stderr = _run_hook(hook_input)
+        assert "review" in stderr, (
+            f"general-purpose error message should list 'review' as an option. stderr={stderr!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# KNOWN_AGENT_TYPES constant alignment check
+# ---------------------------------------------------------------------------
+
+
+class TestKnownAgentTypesConstant:
+    def test_review_is_in_known_types(self):
+        """KNOWN_AGENT_TYPES must include 'review' since dispatcher uses subagent_type='review'."""
+        # Load the hook module to inspect KNOWN_AGENT_TYPES
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("require_subagent_type", HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        fake_stdin = json.dumps({"tool_name": "Bash", "tool_input": {}})
+        with (
+            patch("sys.stdin", StringIO(fake_stdin)),
+            patch("sys.stdout", StringIO()),
+            patch("sys.stderr", StringIO()),
+        ):
+            try:
+                spec.loader.exec_module(mod)
+            except SystemExit:
+                pass
+
+        assert "review" in mod.KNOWN_AGENT_TYPES, (
+            "KNOWN_AGENT_TYPES must include 'review' — dispatcher uses subagent_type='review' "
+            "for engineer→reviewer routing."
+        )
+
+    def test_functional_engineer_is_in_known_types(self):
+        """KNOWN_AGENT_TYPES must include 'functional-engineer'."""
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("require_subagent_type_fe", HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        fake_stdin = json.dumps({"tool_name": "Bash", "tool_input": {}})
+        with (
+            patch("sys.stdin", StringIO(fake_stdin)),
+            patch("sys.stdout", StringIO()),
+            patch("sys.stderr", StringIO()),
+        ):
+            try:
+                spec.loader.exec_module(mod)
+            except SystemExit:
+                pass
+
+        assert "functional-engineer" in mod.KNOWN_AGENT_TYPES


### PR DESCRIPTION
Fixes #2029.

## What problem this solves

When an Agent call is blocked for a missing or invalid \`subagent_type\`, the hook's error message lists only a partial set of agent types (\`functional-engineer\`, \`lobster-ops\`, \`brain-dumps\`). The \`review\` type — which the dispatcher actively uses for engineer→reviewer routing at \`subagent_type=\"review\"\` — was absent from both error messages, along with \`compact-catchup\`, \`nightly-consolidation\`, \`lobster-auditor\`, \`session-note-appender\`, and \`session-note-polish\`. A developer looking at the blocked error message would not know \`review\` is a valid choice.

Note: \`.claude/agents/review.md\` has existed since at least commit \`15a318c0\` (feat: design-review mode), and the dispatcher already uses \`subagent_type=\"review\"\` correctly. This fix is purely about keeping the hook's guidance text current.

## What changed

The hook now defines a \`KNOWN_AGENT_TYPES\` constant listing all agent types defined in \`.claude/agents/\`. Both error messages (missing type + \`general-purpose\` type) format this list into their output. The constant is the single source of truth for the list — no more divergence between message text and actual agent files.

**Follow-up (reviewer notes addressed):**
- Nit 1: Added \`test_known_types_matches_agents_directory\` — a filesystem-scan test that asserts \`KNOWN_AGENT_TYPES == {p.stem for p in AGENTS_DIR.glob("*.md")}\`. Catches new agent files added without updating the constant, and stale entries.
- Nit 2: Removed the duplicate \`VALID_AGENT_TYPES\` list from the test file. \`KNOWN_AGENT_TYPES\` is now imported from the hook via \`importlib\` at module load time and used directly as the \`@pytest.mark.parametrize\` source — single source of truth.

## Functional patterns

Pure data: \`KNOWN_AGENT_TYPES\` is a constant tuple; the error messages are derived from it declaratively via \`\", \".join(...)\`. No shared mutable state.

## Tests run
- [x] \`uv run pytest tests/unit/test_hooks/test_require_subagent_type.py -v\` — 28 passed, 0 failed (27 original + 1 new alignment test)
- [x] \`sudo docker compose -f tests/docker/docker-compose.test.yml up unit-tests\` — 3120 passed, 16 failed (pre-existing slack_bolt/slack_sdk import failures unrelated to this PR), 46 skipped

## Manual test
N/A — this change only affects error message text in a PreToolUse hook. No external services, no file system state, no systemd. The hook is tested exhaustively via the unit test suite above.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, error-message-only change
- [x] User-visible outcome verified — N/A, this is an internal developer-facing error message
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none