### PR TITLE
fix(#2004): jq --arg sweep for safe JSON in periodic-self-check, alert, check-agent-outputs, daily-update-check

### DIFF
--- a/scripts/alert.sh
+++ b/scripts/alert.sh
@@ -29,13 +29,19 @@ echo "[$timestamp] ALERT: $message" >> "$ALERT_LOG"
 # Try to send via Telegram if admin chat ID is configured
 if [[ -n "$ADMIN_CHAT_ID" ]]; then
     alert_file="$OUTBOX_DIR/alert_$(date +%s%N).json"
-    cat > "$alert_file" << EOF
-{
-    "chat_id": $ADMIN_CHAT_ID,
-    "text": "🚨 **Lobster Alert**\n\n$message\n\n_$(date)_",
-    "source": "telegram"
-}
-EOF
+    alert_text="🚨 **Lobster Alert**
+
+$message
+
+_$(date)_"
+    jq -n \
+        --argjson chat_id "$ADMIN_CHAT_ID" \
+        --arg text "$alert_text" \
+        '{
+            "chat_id": $chat_id,
+            "text": $text,
+            "source": "telegram"
+        }' > "$alert_file"
     echo "[$timestamp] Alert sent to Telegram chat $ADMIN_CHAT_ID" >> "$ALERT_LOG"
 fi
 

--- a/scripts/check-agent-outputs.sh
+++ b/scripts/check-agent-outputs.sh
@@ -115,19 +115,21 @@ while IFS= read -r agent_id; do
     # Safely escape agent_id for JSON (alphanumeric + hyphens only expected)
     SAFE_ID=$(echo "$agent_id" | tr -cd 'a-zA-Z0-9_-')
 
-    cat > "${INBOX_DIR}/${MSG_ID}.json" << EOF
-{
-  "id": "${MSG_ID}",
-  "source": "system",
-  "type": "health_check",
-  "chat_id": 0,
-  "user_id": 0,
-  "username": "lobster-system",
-  "user_name": "Agent Relay",
-  "text": "Agent relay check: ${SAFE_ID} output file appears complete. Check task-notifications and relay results to the user.",
-  "timestamp": "${TIMESTAMP}"
-}
-EOF
+    jq -n \
+        --arg id "${MSG_ID}" \
+        --arg text "Agent relay check: ${SAFE_ID} output file appears complete. Check task-notifications and relay results to the user." \
+        --arg timestamp "${TIMESTAMP}" \
+        '{
+            "id": $id,
+            "source": "system",
+            "type": "health_check",
+            "chat_id": 0,
+            "user_id": 0,
+            "username": "lobster-system",
+            "user_name": "Agent Relay",
+            "text": $text,
+            "timestamp": $timestamp
+        }' > "${INBOX_DIR}/${MSG_ID}.json"
 
     # Mark this agent as notified to prevent re-injection
     echo "$agent_id" >> "$NOTIFIED_FILE"

--- a/scripts/daily-update-check.sh
+++ b/scripts/daily-update-check.sh
@@ -28,16 +28,18 @@ if [ -d "$LOBSTER_DIR/.git" ]; then
     if [ "$LOCAL" != "$REMOTE" ]; then
         BEHIND=$(git rev-list --count "$LOCAL..$REMOTE")
         TIMESTAMP=$(date +%s%3N)
-        cat > "$INBOX/${TIMESTAMP}_update_available.json" << EOF
-{
-  "id": "${TIMESTAMP}_update_available",
-  "source": "system",
-  "chat_id": 0,
-  "type": "update_notification",
-  "text": "UPDATE AVAILABLE: Lobster is ${BEHIND} commits behind origin/main. Use check_updates for details.",
-  "timestamp": "$(date -Iseconds)"
-}
-EOF
+        jq -n \
+            --arg id "${TIMESTAMP}_update_available" \
+            --arg text "UPDATE AVAILABLE: Lobster is ${BEHIND} commits behind origin/main. Use check_updates for details." \
+            --arg timestamp "$(date -Iseconds)" \
+            '{
+                "id": $id,
+                "source": "system",
+                "chat_id": 0,
+                "type": "update_notification",
+                "text": $text,
+                "timestamp": $timestamp
+            }' > "$INBOX/${TIMESTAMP}_update_available.json"
     fi
 else
     # Tarball mode: check GitHub Releases API
@@ -47,15 +49,17 @@ else
 
     if [ -n "$LATEST_VERSION" ] && [ "$LATEST_VERSION" != "$CURRENT_VERSION" ]; then
         TIMESTAMP=$(date +%s%3N)
-        cat > "$INBOX/${TIMESTAMP}_update_available.json" << EOF
-{
-  "id": "${TIMESTAMP}_update_available",
-  "source": "system",
-  "chat_id": 0,
-  "type": "update_notification",
-  "text": "UPDATE AVAILABLE: Lobster v${CURRENT_VERSION} -> v${LATEST_VERSION}. Use check_updates for details.",
-  "timestamp": "$(date -Iseconds)"
-}
-EOF
+        jq -n \
+            --arg id "${TIMESTAMP}_update_available" \
+            --arg text "UPDATE AVAILABLE: Lobster v${CURRENT_VERSION} -> v${LATEST_VERSION}. Use check_updates for details." \
+            --arg timestamp "$(date -Iseconds)" \
+            '{
+                "id": $id,
+                "source": "system",
+                "chat_id": 0,
+                "type": "update_notification",
+                "text": $text,
+                "timestamp": $timestamp
+            }' > "$INBOX/${TIMESTAMP}_update_available.json"
     fi
 fi

--- a/scripts/periodic-self-check.sh
+++ b/scripts/periodic-self-check.sh
@@ -125,18 +125,20 @@ TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%S.%6N)
 EPOCH_MS=$(date +%s%3N)
 MSG_ID="${EPOCH_MS}_self"
 
-cat > "${INBOX_DIR}/${MSG_ID}.json" << EOF
-{
-  "id": "${MSG_ID}",
-  "source": "system",
-  "chat_id": 0,
-  "user_id": 0,
-  "username": "lobster-system",
-  "user_name": "Self-Check",
-  "text": "${SELF_CHECK_TEXT}",
-  "timestamp": "${TIMESTAMP}"
-}
-EOF
+jq -n \
+    --arg id "${MSG_ID}" \
+    --arg text "${SELF_CHECK_TEXT}" \
+    --arg timestamp "${TIMESTAMP}" \
+    '{
+        "id": $id,
+        "source": "system",
+        "chat_id": 0,
+        "user_id": 0,
+        "username": "lobster-system",
+        "user_name": "Self-Check",
+        "text": $text,
+        "timestamp": $timestamp
+    }' > "${INBOX_DIR}/${MSG_ID}.json"
 
 # Record timestamp
 date +%s > "$LAST_CHECK_FILE"


### PR DESCRIPTION
## Summary

- Replaces heredoc variable expansion with `jq -n --arg` for JSON construction in 4 scripts
- Fixes the root bug where multi-line variable values insert literal newlines into JSON strings, producing invalid JSON that triggers WFM tight-loops (same class as PR #1808)
- All existing tests pass; `test_script_inbox_sources.py` confirms source values are still valid

## The bug

When a shell heredoc expands a variable that contains newlines:

```bash
cat > file.json << EOF
{"text": "$MULTI_LINE_VAR"}
EOF
```

The literal newlines land inside the JSON string value, producing:

```
{"text": "line1
line2"}
```

This is invalid JSON. `json.load()` throws "Invalid control character", which causes `wait_for_messages` to tight-loop.

## Fix

Replace each heredoc block with:

```bash
jq -n --arg text "$MULTI_LINE_VAR" '{"text": $text}' > file.json
```

`jq` correctly escapes newlines as `\n` and handles all other special characters.

## Affected scripts

| Script | Risk | Variable at risk |
|---|---|---|
| `scripts/periodic-self-check.sh` | HIGH | `$SELF_CHECK_TEXT` — concatenates task descriptions and agent summaries |
| `scripts/alert.sh` | MEDIUM | `$message` — caller-supplied alert text |
| `scripts/check-agent-outputs.sh` | LOW | `$SAFE_ID` — sanitized but same pattern |
| `scripts/daily-update-check.sh` | LOW | Version strings — both git and tarball branches |

## Test plan

- [x] `tests/unit/test_script_inbox_sources.py` — all 3 source-guard tests pass (jq filter literals are still detected)
- [x] `tests/smoke/test_health_check.py` — 10 smoke tests pass
- [x] Manual: `jq -n --arg text "line1\nline2" '{"text": $text}'` produces valid JSON with `\n`-escaped newlines

Closes #2004

🤖 Generated with [Claude Code](https://claude.com/claude-code)
