### PR TITLE
fix(#1991): upgrade.sh and daily-update-check.sh track origin/local-dev

### DIFF
--- a/scripts/daily-update-check.sh
+++ b/scripts/daily-update-check.sh
@@ -20,10 +20,10 @@ cd "$LOBSTER_DIR"
 
 # Support both git and tarball installs
 if [ -d "$LOBSTER_DIR/.git" ]; then
-    git fetch origin main --quiet
+    git fetch origin local-dev --quiet
 
     LOCAL=$(git rev-parse HEAD)
-    REMOTE=$(git rev-parse origin/main)
+    REMOTE=$(git rev-parse origin/local-dev)
 
     if [ "$LOCAL" != "$REMOTE" ]; then
         BEHIND=$(git rev-list --count "$LOCAL..$REMOTE")
@@ -34,7 +34,7 @@ if [ -d "$LOBSTER_DIR/.git" ]; then
   "source": "system",
   "chat_id": 0,
   "type": "update_notification",
-  "text": "UPDATE AVAILABLE: Lobster is ${BEHIND} commits behind origin/main. Use check_updates for details.",
+  "text": "UPDATE AVAILABLE: Lobster is ${BEHIND} commits behind origin/local-dev. Use check_updates for details.",
   "timestamp": "$(date -Iseconds)"
 }
 EOF

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -107,7 +107,7 @@ Options:
 
 What it does:
   1. Backs up config, env files, tasks, and scheduled jobs
-  2. Pulls latest code from main branch
+  2. Pulls latest code from local-dev branch
   3. Updates Python dependencies in the venv
   4. Creates any new directories the updated code expects
   5. Optionally installs Syncthing for LobsterDrop file sharing
@@ -307,7 +307,7 @@ git_pull() {
         return $?
     fi
 
-    step "Pulling latest code from main"
+    step "Pulling latest code from local-dev"
 
     cd "$LOBSTER_DIR"
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -322,45 +322,45 @@ git_pull() {
         fi
     fi
 
-    # Ensure we're on main before pulling.
+    # Ensure we're on local-dev before pulling.
     # If ~/lobster/ is on a feature branch or detached HEAD (e.g. after local
-    # testing), git merge --ff-only would fail. Switch to main first so the
+    # testing), git merge --ff-only would fail. Switch to local-dev first so the
     # update always lands correctly.
     local current_branch
     current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "DETACHED")
-    if [ "$current_branch" != "main" ]; then
+    if [ "$current_branch" != "local-dev" ]; then
         if $DRY_RUN; then
-            info "[dry-run] Not on main branch (currently: $current_branch). Would switch to main before updating."
+            info "[dry-run] Not on local-dev branch (currently: $current_branch). Would switch to local-dev before updating."
         else
-            warn "Not on main branch (currently: $current_branch). Switching to main before updating..."
-            git checkout main --quiet || die "Could not checkout main. Resolve manually and re-run." 3
-            success "Switched to main"
+            warn "Not on local-dev branch (currently: $current_branch). Switching to local-dev before updating..."
+            git checkout local-dev --quiet || die "Could not checkout local-dev. Resolve manually and re-run." 3
+            success "Switched to local-dev"
         fi
     fi
 
     # Fetch
     info "Fetching from origin..."
     if $DRY_RUN; then
-        git fetch origin main --quiet 2>/dev/null || die "Failed to fetch from origin" 3
+        git fetch origin local-dev --quiet 2>/dev/null || die "Failed to fetch from origin" 3
         local behind
-        behind=$(git rev-list HEAD..origin/main --count 2>/dev/null || echo "0")
+        behind=$(git rev-list HEAD..origin/local-dev --count 2>/dev/null || echo "0")
         info "[dry-run] $behind commit(s) available"
-        CURRENT_COMMIT=$(git rev-parse --short origin/main)
+        CURRENT_COMMIT=$(git rev-parse --short origin/local-dev)
         info "[dry-run] Would update to: $CURRENT_COMMIT"
         return 0
     fi
 
-    git fetch origin main --quiet 2>/dev/null || die "Failed to fetch from origin" 3
+    git fetch origin local-dev --quiet 2>/dev/null || die "Failed to fetch from origin" 3
 
     local behind
-    behind=$(git rev-list HEAD..origin/main --count 2>/dev/null || echo "0")
+    behind=$(git rev-list HEAD..origin/local-dev --count 2>/dev/null || echo "0")
 
     if [ "$behind" = "0" ]; then
         success "Already up to date"
         CURRENT_COMMIT="$PREVIOUS_COMMIT"
     else
         info "$behind commit(s) to pull"
-        if git merge origin/main --ff-only --quiet 2>/dev/null; then
+        if git merge origin/local-dev --ff-only --quiet 2>/dev/null; then
             CURRENT_COMMIT=$(git rev-parse --short HEAD)
             success "Updated: $PREVIOUS_COMMIT -> $CURRENT_COMMIT"
 
@@ -371,7 +371,7 @@ git_pull() {
             done
         else
             warn "Fast-forward merge failed. Attempting rebase..."
-            if git rebase origin/main --quiet 2>/dev/null; then
+            if git rebase origin/local-dev --quiet 2>/dev/null; then
                 CURRENT_COMMIT=$(git rev-parse --short HEAD)
                 success "Rebased to: $CURRENT_COMMIT"
             else
@@ -3120,11 +3120,11 @@ health_check() {
     if [ "$INSTALL_MODE" = "git" ]; then
         local branch
         branch=$(git branch --show-current 2>/dev/null || echo "unknown")
-        if [ "$branch" = "main" ]; then
-            success "On branch: main"
+        if [ "$branch" = "local-dev" ]; then
+            success "On branch: local-dev"
             checks_passed=$((checks_passed + 1))
         else
-            warn "Not on main branch (on: $branch)"
+            warn "Warning: lobster is running from '${branch}' branch, not local-dev"
             checks_failed=$((checks_failed + 1))
         fi
     else


### PR DESCRIPTION
## Summary

Lobster now runs from the `local-dev` branch as the canonical production baseline (see issue #1991). However, `upgrade.sh` and `daily-update-check.sh` still fetched/merged from `origin/main`, meaning the running instance would never pick up commits that landed on `local-dev` but hadn't yet been merged to `main`.

This PR updates both scripts to target `origin/local-dev`.

## Changes

### `scripts/upgrade.sh`
- `git fetch origin main` → `git fetch origin local-dev`
- `git rev-list HEAD..origin/main` → `git rev-list HEAD..origin/local-dev`
- `git rev-parse --short origin/main` → `git rev-parse --short origin/local-dev`
- `git merge origin/main --ff-only` → `git merge origin/local-dev --ff-only`
- `git rebase origin/main` → `git rebase origin/local-dev`
- Branch pre-check: switches to `local-dev` (not `main`) before pulling
- Health check: passes when on `local-dev`; warns with `"Warning: lobster is running from '<branch>' branch, not local-dev"` otherwise

### `scripts/daily-update-check.sh`
- `git fetch origin main` → `git fetch origin local-dev`
- `git rev-parse origin/main` → `git rev-parse origin/local-dev`
- Update notification message now says `"behind origin/local-dev"` instead of `"behind origin/main"`

### `install.sh`
No changes — `install.sh` does not exist in this repository.

## Why `local-dev` is the production branch

Reviewed PRs land on `local-dev` first. Running from `local-dev` means fixes go live as soon as they pass review, without requiring a separate merge-to-main step. `main` only advances when `local-dev` is explicitly merged — an extra manual gate with no added safety benefit.

## Test plan
- [ ] All 30 existing upgrade safety tests pass (`uv run pytest tests/integration/test_upgrade_safety.py`)
- [ ] `upgrade.sh --dry-run` on a `local-dev` checkout shows fetch from `origin/local-dev`
- [ ] `upgrade.sh` health check passes on `local-dev`, warns on any other branch
- [ ] `daily-update-check.sh` detects commits on `origin/local-dev`

Closes #1991

🤖 Generated with [Claude Code](https://claude.com/claude-code)