### PR TITLE
fix(#1895): add wfm-lifecycle-logger.py + migration 92

### DIFF
--- a/hooks/wfm-lifecycle-logger.py
+++ b/hooks/wfm-lifecycle-logger.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+PreToolUse / PostToolUse hook: wait_for_messages lifecycle logger.
+
+Writes WFM_ENTER (PreToolUse) and WFM_EXIT (PostToolUse) events to the
+session lifecycle log so we can measure WFM blocking duration and identify
+the last WFM call before a crash.
+
+## Motivation
+
+On 2026-05-01 a CC dispatcher crash at ~13:40Z left no logged exit reason.
+Post-incident investigation could only infer a 3.5-minute WFM block from
+log gaps — there was no direct measurement. This hook provides that signal.
+
+## Events written
+
+PreToolUse (matcher: "mcp__lobster-inbox__wait_for_messages"):
+    {"ts": "...", "event": "WFM_ENTER", "session_id": "..."}
+
+PostToolUse (matcher: "mcp__lobster-inbox__wait_for_messages"):
+    {"ts": "...", "event": "WFM_EXIT", "session_id": "...", "duration_s": 213.4,
+     "messages": 2}
+
+## Design
+
+- Dispatcher-only: subagent sessions are skipped via session_role.
+- Module-level references to is_dispatcher and is_dispatcher_session allow
+  tests to monkeypatch them cleanly without importing session_role directly.
+- Append-only JSONL: one JSON object per line, never overwrites existing entries.
+- Atomic append: open with O_APPEND — writes <= PIPE_BUF (4096 bytes) are atomic
+  on Linux for single-writer use.
+- Silent failure: never blocks tool execution.
+
+## Usage
+
+This single script handles both PreToolUse and PostToolUse by reading
+WFM_HOOK_TYPE from environment: "pre" → WFM_ENTER, "post" → WFM_EXIT.
+
+The settings.json wiring uses two separate entries with different hook commands
+that set WFM_HOOK_TYPE before invoking this script.
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Path setup: add hooks dir to sys.path so session_role is importable.
+# Must happen before session_role import below.
+# ---------------------------------------------------------------------------
+_HOOKS_DIR = Path(__file__).parent
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+from session_role import is_dispatcher, is_dispatcher_session  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+WORKSPACE_DIR = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+LIFECYCLE_LOG = WORKSPACE_DIR / "logs" / "session-lifecycle.log"
+
+# Environment variable set by the settings.json hook wrapper to distinguish
+# PreToolUse ("pre") from PostToolUse ("post") invocations.
+HOOK_TYPE = os.environ.get("WFM_HOOK_TYPE", "")
+
+# State file: records WFM entry epoch so PostToolUse can compute duration.
+WFM_ENTER_TS_FILE = WORKSPACE_DIR / "logs" / "wfm-enter-ts"
+
+
+# ---------------------------------------------------------------------------
+# Core I/O primitives (pure functions for testability)
+# ---------------------------------------------------------------------------
+
+def _ts() -> str:
+    """Return current time as ISO 8601 UTC string."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _append_event(event: dict, lifecycle_log: Path = LIFECYCLE_LOG) -> None:
+    """Append a JSON event line to the lifecycle log.
+
+    Uses O_APPEND so each write is atomic at the filesystem level for writes
+    <= PIPE_BUF (4096 bytes on Linux), which all our events satisfy.
+    """
+    lifecycle_log.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(event, separators=(",", ":")) + "\n"
+    with open(lifecycle_log, "a", encoding="utf-8") as f:
+        f.write(line)
+
+
+def _write_enter_ts(ts_epoch: float, enter_ts_file: Path = WFM_ENTER_TS_FILE) -> None:
+    """Write WFM entry epoch atomically so PostToolUse can compute duration."""
+    enter_ts_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp = enter_ts_file.with_suffix(".tmp")
+    tmp.write_text(str(ts_epoch))
+    os.rename(str(tmp), str(enter_ts_file))
+
+
+def _read_enter_ts(enter_ts_file: Path = WFM_ENTER_TS_FILE) -> "float | None":
+    """Return the WFM entry epoch from state file, or None if absent/unreadable."""
+    try:
+        return float(enter_ts_file.read_text().strip())
+    except Exception:
+        return None
+
+
+def _parse_message_count(tool_response: "str | list | None") -> "int | None":
+    """Return message count from wait_for_messages tool response, or None."""
+    if tool_response is None:
+        return None
+    if isinstance(tool_response, list):
+        return len(tool_response)
+    if isinstance(tool_response, str):
+        try:
+            parsed = json.loads(tool_response)
+            if isinstance(parsed, list):
+                return len(parsed)
+            if isinstance(parsed, dict) and "messages" in parsed:
+                return len(parsed["messages"])
+        except Exception:
+            pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Hook handlers
+# ---------------------------------------------------------------------------
+
+def handle_pre_tool_use(hook_input: dict) -> None:
+    """Write WFM_ENTER event and record entry timestamp."""
+    if not is_dispatcher_session(hook_input):
+        return
+
+    now_epoch = time.time()
+    event = {
+        "ts": _ts(),
+        "event": "WFM_ENTER",
+        "session_id": hook_input.get("session_id", ""),
+    }
+    _append_event(event)
+    _write_enter_ts(now_epoch)
+
+
+def handle_post_tool_use(hook_input: dict) -> None:
+    """Write WFM_EXIT event with duration and message count."""
+    if not is_dispatcher(hook_input):
+        return
+
+    now_epoch = time.time()
+    enter_epoch = _read_enter_ts()
+    duration_s = round(now_epoch - enter_epoch, 1) if enter_epoch is not None else None
+    messages = _parse_message_count(hook_input.get("tool_response"))
+
+    event: dict = {
+        "ts": _ts(),
+        "event": "WFM_EXIT",
+        "session_id": hook_input.get("session_id", ""),
+    }
+    if duration_s is not None:
+        event["duration_s"] = duration_s
+    if messages is not None:
+        event["messages"] = messages
+
+    _append_event(event)
+
+    # Clean up enter timestamp — next WFM will write a fresh one.
+    try:
+        WFM_ENTER_TS_FILE.unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    try:
+        if HOOK_TYPE == "pre":
+            handle_pre_tool_use(hook_input)
+        elif HOOK_TYPE == "post":
+            handle_post_tool_use(hook_input)
+        # Unknown HOOK_TYPE: silently do nothing.
+    except Exception:
+        # Never block tool execution.
+        pass
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/install.sh
+++ b/install.sh
@@ -2118,6 +2118,51 @@ else
     info "Skipping pre-tool-heartbeat hook (settings.json not yet created)"
 fi
 
+# Set up Claude Code PreToolUse + PostToolUse hooks for WFM lifecycle logging (issue #1895).
+# Writes WFM_ENTER (PreToolUse) and WFM_EXIT (PostToolUse) events to
+# ~/lobster-workspace/logs/session-lifecycle.log, enabling post-crash investigation of
+# how long the dispatcher was blocked in wait_for_messages.
+# A single script handles both hooks; WFM_HOOK_TYPE env var ("pre"/"post") selects behavior.
+chmod +x "$INSTALL_DIR/hooks/wfm-lifecycle-logger.py" || true
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.PreToolUse[]?.hooks[]? | select((.command // "") | contains("wfm-lifecycle-logger"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1 || \
+       ! jq -e '.hooks.PostToolUse[]?.hooks[]? | select((.command // "") | contains("wfm-lifecycle-logger"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq --arg pre_cmd "WFM_HOOK_TYPE=pre python3 $INSTALL_DIR/hooks/wfm-lifecycle-logger.py" \
+           --arg post_cmd "WFM_HOOK_TYPE=post python3 $INSTALL_DIR/hooks/wfm-lifecycle-logger.py" '
+            .hooks.PreToolUse = (
+                (.hooks.PreToolUse // []) +
+                if ([(.hooks.PreToolUse // [])[]?.hooks[]? |
+                     select((.command // "") | contains("wfm-lifecycle-logger"))]
+                    | length) == 0
+                then [{
+                    "matcher": "mcp__lobster-inbox__wait_for_messages",
+                    "hooks": [{"type": "command", "command": $pre_cmd, "timeout": 5}]
+                }]
+                else []
+                end
+            ) |
+            .hooks.PostToolUse = (
+                (.hooks.PostToolUse // []) +
+                if ([(.hooks.PostToolUse // [])[]?.hooks[]? |
+                     select((.command // "") | contains("wfm-lifecycle-logger"))]
+                    | length) == 0
+                then [{
+                    "matcher": "mcp__lobster-inbox__wait_for_messages",
+                    "hooks": [{"type": "command", "command": $post_cmd, "timeout": 5}]
+                }]
+                else []
+                end
+            )
+        ' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "wfm-lifecycle-logger PreToolUse + PostToolUse hooks installed"
+    else
+        info "wfm-lifecycle-logger hooks already configured in Claude Code settings"
+    fi
+else
+    info "Skipping wfm-lifecycle-logger hooks (settings.json not yet created)"
+fi
+
 # Set up Claude Code PreToolUse hook to block tool use after compaction without context reload.
 # Uses a shell wrapper so Python is only spawned when the sentinel file exists (~1% of calls).
 # On the 99%+ of calls where the sentinel is absent, `test ! -f ...` exits in ~1ms with no

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -3091,6 +3091,88 @@ M88_PYEOF
         substep "Migration 90: settings.json or jq not found — skipping"
     fi
 
+    # Migration 92: Register WFM lifecycle logger hooks (PreToolUse + PostToolUse)
+    # in ~/.claude/settings.json (issue #1895).
+    #
+    # Adds two hook entries that write WFM_ENTER / WFM_EXIT events to
+    # ~/lobster-workspace/logs/session-lifecycle.log, enabling crash investigation
+    # by recording how long each wait_for_messages call blocked and whether the
+    # dispatcher was mid-WFM when it died.
+    #
+    # The hook reads WFM_HOOK_TYPE ("pre" or "post") from the environment to
+    # distinguish the two invocation modes from a single script file.
+    #
+    # Idempotent: skips if both entries already registered.
+    # Note: Migration 91 is reserved for PR #2027 (on-compact.py fix).
+    local _m92_hook="$LOBSTER_DIR/hooks/wfm-lifecycle-logger.py"
+    if [ -f "$CLAUDE_SETTINGS" ] && command -v jq &>/dev/null && [ -f "$_m92_hook" ]; then
+        local _m92_pre_present _m92_post_present
+        _m92_pre_present=$(jq -r '
+            [.hooks.PreToolUse[]?.hooks[]? |
+             select((.command // "") | contains("wfm-lifecycle-logger"))]
+            | length' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+        _m92_post_present=$(jq -r '
+            [.hooks.PostToolUse[]?.hooks[]? |
+             select((.command // "") | contains("wfm-lifecycle-logger"))]
+            | length' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+
+        if [[ "${_m92_pre_present:-0}" -gt 0 && "${_m92_post_present:-0}" -gt 0 ]]; then
+            substep "Migration 92: WFM lifecycle logger hooks already registered — skipping"
+        else
+            local _m92_tmp
+            _m92_tmp=$(mktemp)
+            local _m92_pre_cmd="WFM_HOOK_TYPE=pre python3 $_m92_hook"
+            local _m92_post_cmd="WFM_HOOK_TYPE=post python3 $_m92_hook"
+
+            if jq --arg pre_cmd "$_m92_pre_cmd" \
+                  --arg post_cmd "$_m92_post_cmd" '
+                # Add PreToolUse entry if not already present
+                .hooks.PreToolUse = (
+                    (.hooks.PreToolUse // []) +
+                    if ([(.hooks.PreToolUse // [])[]?.hooks[]? |
+                         select((.command // "") | contains("wfm-lifecycle-logger"))]
+                        | length) == 0
+                    then [{
+                        "matcher": "mcp__lobster-inbox__wait_for_messages",
+                        "hooks": [{
+                            "type": "command",
+                            "command": $pre_cmd,
+                            "timeout": 5
+                        }]
+                    }]
+                    else []
+                    end
+                ) |
+                # Add PostToolUse entry if not already present
+                .hooks.PostToolUse = (
+                    (.hooks.PostToolUse // []) +
+                    if ([(.hooks.PostToolUse // [])[]?.hooks[]? |
+                         select((.command // "") | contains("wfm-lifecycle-logger"))]
+                        | length) == 0
+                    then [{
+                        "matcher": "mcp__lobster-inbox__wait_for_messages",
+                        "hooks": [{
+                            "type": "command",
+                            "command": $post_cmd,
+                            "timeout": 5
+                        }]
+                    }]
+                    else []
+                    end
+                )
+            ' "$CLAUDE_SETTINGS" > "$_m92_tmp" \
+                && mv "$_m92_tmp" "$CLAUDE_SETTINGS" 2>/dev/null; then
+                substep "Migration 92: WFM lifecycle logger hooks registered in settings.json"
+                migrated=$((migrated + 1))
+            else
+                rm -f "$_m92_tmp" 2>/dev/null || true
+                warn "Migration 92: could not update settings.json — jq transform failed"
+            fi
+        fi
+    else
+        substep "Migration 92: settings.json, jq, or wfm-lifecycle-logger.py not found — skipping"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/tests/unit/test_hooks/test_wfm_lifecycle_logger.py
+++ b/tests/unit/test_hooks/test_wfm_lifecycle_logger.py
@@ -1,0 +1,329 @@
+"""
+Unit tests for hooks/wfm-lifecycle-logger.py
+
+The hook writes WFM_ENTER (PreToolUse) and WFM_EXIT (PostToolUse) events to
+session-lifecycle.log whenever wait_for_messages is called by the dispatcher.
+
+Tests cover:
+- WFM_ENTER is written on pre-tool-use for dispatcher sessions
+- WFM_ENTER is NOT written for subagent sessions (dispatcher guard)
+- WFM_EXIT is written with correct duration_s computation
+- WFM_EXIT is written even when enter-ts state file is absent (no crash)
+- WFM_EXIT includes message count when tool_response is a JSON list
+- WFM_EXIT omits message count when tool_response is unparseable
+- Log file is created if absent
+- Each event is a valid JSON object followed by newline
+- Unknown HOOK_TYPE produces no output and exits 0
+- Exceptions during write do not propagate
+- Enter-ts state file is cleaned up after WFM_EXIT
+
+Named constants from spec (issue #1895):
+  WFM_ENTER_EVENT = "WFM_ENTER"
+  WFM_EXIT_EVENT  = "WFM_EXIT"
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import time
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+HOOK_PATH = _HOOKS_DIR / "wfm-lifecycle-logger.py"
+
+# Named constants matching the spec
+WFM_ENTER_EVENT = "WFM_ENTER"
+WFM_EXIT_EVENT = "WFM_EXIT"
+SESSION_LIFECYCLE_LOG_NAME = "session-lifecycle.log"
+WFM_ENTER_TS_FILE_NAME = "wfm-enter-ts"
+
+
+# ---------------------------------------------------------------------------
+# Module loader helpers
+# ---------------------------------------------------------------------------
+
+def _load_module(monkeypatch, workspace: Path, hook_type: str):
+    """Load wfm-lifecycle-logger as a fresh module with workspace + hook type overrides."""
+    monkeypatch.setenv("LOBSTER_WORKSPACE", str(workspace))
+    monkeypatch.setenv("WFM_HOOK_TYPE", hook_type)
+    # Ensure hooks dir is on sys.path so session_role can be imported
+    if str(_HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(_HOOKS_DIR))
+    spec = importlib.util.spec_from_file_location("wfm_lifecycle_logger", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_hook_input(session_id: str = "test-session-123", agent_id: str | None = None,
+                     tool_response: str | None = None) -> dict:
+    d: dict = {"session_id": session_id}
+    if agent_id is not None:
+        d["agent_id"] = agent_id
+    if tool_response is not None:
+        d["tool_response"] = tool_response
+    return d
+
+
+def _run_hook(mod, hook_input: dict) -> int:
+    """Run mod.main() with hook_input on stdin. Returns exit code."""
+    with patch.object(sys, "stdin", StringIO(json.dumps(hook_input))):
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+    return exc_info.value.code
+
+
+def _read_log_events(log_file: Path) -> list[dict]:
+    """Read all JSONL events from the lifecycle log."""
+    events = []
+    for line in log_file.read_text().splitlines():
+        line = line.strip()
+        if line:
+            events.append(json.loads(line))
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def workspace(tmp_path):
+    """Provide a temp workspace dir with logs/ created."""
+    ws = tmp_path / "workspace"
+    ws.mkdir(exist_ok=True)
+    (ws / "logs").mkdir(exist_ok=True)
+    return ws
+
+
+# ---------------------------------------------------------------------------
+# WFM_ENTER tests (PreToolUse path)
+# ---------------------------------------------------------------------------
+
+class TestWfmEnter:
+    def test_wfm_enter_written_for_dispatcher(self, monkeypatch, workspace):
+        mod = _load_module(monkeypatch, workspace, "pre")
+        monkeypatch.setattr(mod, "is_dispatcher_session", lambda _: True)
+
+        exit_code = _run_hook(mod, _make_hook_input())
+        assert exit_code == 0
+
+        log_file = workspace / "logs" / SESSION_LIFECYCLE_LOG_NAME
+        assert log_file.exists(), "lifecycle log should be created"
+        events = _read_log_events(log_file)
+        assert len(events) == 1
+        event = events[0]
+        assert event["event"] == WFM_ENTER_EVENT
+        assert event["session_id"] == "test-session-123"
+        assert "ts" in event
+
+    def test_wfm_enter_not_written_for_subagent(self, monkeypatch, workspace):
+        mod = _load_module(monkeypatch, workspace, "pre")
+        monkeypatch.setattr(mod, "is_dispatcher_session", lambda _: False)
+
+        exit_code = _run_hook(mod, _make_hook_input(agent_id="some-agent-id"))
+        assert exit_code == 0
+
+        log_file = workspace / "logs" / SESSION_LIFECYCLE_LOG_NAME
+        assert not log_file.exists(), "log should not be written for subagents"
+
+    def test_wfm_enter_writes_enter_ts_file(self, monkeypatch, workspace):
+        mod = _load_module(monkeypatch, workspace, "pre")
+        monkeypatch.setattr(mod, "is_dispatcher_session", lambda _: True)
+
+        before = time.time()
+        _run_hook(mod, _make_hook_input())
+        after = time.time()
+
+        ts_file = workspace / "logs" / WFM_ENTER_TS_FILE_NAME
+        assert ts_file.exists(), "enter-ts state file should be written"
+        recorded = float(ts_file.read_text().strip())
+        assert before <= recorded <= after + 1
+
+    def test_wfm_enter_is_valid_json_line(self, monkeypatch, workspace):
+        mod = _load_module(monkeypatch, workspace, "pre")
+        monkeypatch.setattr(mod, "is_dispatcher_session", lambda _: True)
+
+        _run_hook(mod, _make_hook_input())
+
+        log_file = workspace / "logs" / SESSION_LIFECYCLE_LOG_NAME
+        raw = log_file.read_text()
+        assert raw.endswith("\n"), "each event line must end with newline"
+        json.loads(raw.strip())  # must be valid JSON
+
+    def test_wfm_enter_appends_to_existing_log(self, monkeypatch, workspace):
+        mod = _load_module(monkeypatch, workspace, "pre")
+        monkeypatch.setattr(mod, "is_dispatcher_session", lambda _: True)
+
+        log_file = workspace / "logs" / SESSION_LIFECYCLE_LOG_NAME
+        existing = json.dumps({"event": "CC_START", "ts": "2026-05-01T00:00:00Z"})
+        log_file.write_text(existing + "\n")
+
+        _run_hook(mod, _make_hook_input())
+
+        events = _read_log_events(log_file)
+        assert len(events) == 2
+        assert events[0]["event"] == "CC_START"
+        assert events[1]["event"] == WFM_ENTER_EVENT
+
+
+# ---------------------------------------------------------------------------
+# WFM_EXIT tests (PostToolUse path)
+# ---------------------------------------------------------------------------
+
+class TestWfmExit:
+    def _write_enter_ts(self, workspace: Path, epoch: float):
+        ts_file = workspace / "logs" / WFM_ENTER_TS_FILE_NAME
+        ts_file.write_text(str(epoch))
+
+    def test_wfm_exit_written_for_dispatcher(self, monkeypatch, workspace):
+        mod = _load_module(monkeypatch, workspace, "post")
+        monkeypatch.setattr(mod, "is_dispatcher", lambda _: True)
+
+        self._write_enter_ts(workspace, time.time() - 10.0)
+        exit_code = _run_hook(mod, _make_hook_input())
+        assert exit_code == 0
+
+        log_file = workspace / "logs" / SESSION_LIFECYCLE_LOG_NAME
+        events = _read_log_events(log_file)
+        assert len(events) == 1
+        event = events[0]
+        assert event["event"] == WFM_EXIT_EVENT
+        assert "ts" in event
+        assert "duration_s" in event
+
+    def test_wfm_exit_duration_is_accurate(self, monkeypatch, workspace):
+        mod = _load_module(monkeypatch, workspace, "post")
+        monkeypatch.setattr(mod, "is_dispatcher", lambda _: True)
+
+        # Simulate ~5 second WFM block
+        enter_time = time.time() - 5.0
+        self._write_enter_ts(workspace, enter_time)
+        _run_hook(mod, _make_hook_input())
+
+        log_file = workspace / "logs" / SESSION_LIFECYCLE_LOG_NAME
+        event = _read_log_events(log_file)[0]
+        # Duration should be approximately 5s — allow 1.5s slack for test execution
+        assert 3.5 <= event["duration_s"] <= 6.5
+
+    def test_wfm_exit_no_duration_when_enter_ts_absent(self, monkeypatch, workspace):
+        mod = _load_module(monkeypatch, workspace, "post")
+        monkeypatch.setattr(mod, "is_dispatcher", lambda _: True)
+
+        # No enter-ts file written — duration should be omitted, not crash
+        exit_code = _run_hook(mod, _make_hook_input())
+        assert exit_code == 0
+
+        log_file = workspace / "logs" / SESSION_LIFECYCLE_LOG_NAME
+        events = _read_log_events(log_file)
+        assert len(events) == 1
+        assert events[0]["event"] == WFM_EXIT_EVENT
+        assert "duration_s" not in events[0]
+
+    def test_wfm_exit_includes_message_count_from_json_list(self, monkeypatch, workspace):
+        mod = _load_module(monkeypatch, workspace, "post")
+        monkeypatch.setattr(mod, "is_dispatcher", lambda _: True)
+
+        self._write_enter_ts(workspace, time.time() - 1.0)
+        tool_response = json.dumps([{"id": "msg1"}, {"id": "msg2"}])
+        exit_code = _run_hook(mod, _make_hook_input(tool_response=tool_response))
+        assert exit_code == 0
+
+        event = _read_log_events(workspace / "logs" / SESSION_LIFECYCLE_LOG_NAME)[0]
+        assert event["messages"] == 2
+
+    def test_wfm_exit_omits_message_count_on_unparseable_response(self, monkeypatch, workspace):
+        mod = _load_module(monkeypatch, workspace, "post")
+        monkeypatch.setattr(mod, "is_dispatcher", lambda _: True)
+
+        self._write_enter_ts(workspace, time.time() - 1.0)
+        exit_code = _run_hook(mod, _make_hook_input(tool_response="not json at all"))
+        assert exit_code == 0
+
+        event = _read_log_events(workspace / "logs" / SESSION_LIFECYCLE_LOG_NAME)[0]
+        assert "messages" not in event
+
+    def test_wfm_exit_cleans_up_enter_ts_file(self, monkeypatch, workspace):
+        mod = _load_module(monkeypatch, workspace, "post")
+        monkeypatch.setattr(mod, "is_dispatcher", lambda _: True)
+
+        self._write_enter_ts(workspace, time.time() - 1.0)
+        _run_hook(mod, _make_hook_input())
+
+        ts_file = workspace / "logs" / WFM_ENTER_TS_FILE_NAME
+        assert not ts_file.exists(), "enter-ts file should be removed after WFM_EXIT"
+
+    def test_wfm_exit_not_written_for_subagent(self, monkeypatch, workspace):
+        mod = _load_module(monkeypatch, workspace, "post")
+        monkeypatch.setattr(mod, "is_dispatcher", lambda _: False)
+
+        self._write_enter_ts(workspace, time.time() - 1.0)
+        _run_hook(mod, _make_hook_input())
+
+        log_file = workspace / "logs" / SESSION_LIFECYCLE_LOG_NAME
+        assert not log_file.exists()
+
+    def test_wfm_exit_includes_session_id(self, monkeypatch, workspace):
+        mod = _load_module(monkeypatch, workspace, "post")
+        monkeypatch.setattr(mod, "is_dispatcher", lambda _: True)
+
+        self._write_enter_ts(workspace, time.time() - 1.0)
+        _run_hook(mod, _make_hook_input(session_id="abc-def-123"))
+
+        event = _read_log_events(workspace / "logs" / SESSION_LIFECYCLE_LOG_NAME)[0]
+        assert event["session_id"] == "abc-def-123"
+
+
+# ---------------------------------------------------------------------------
+# Unknown HOOK_TYPE
+# ---------------------------------------------------------------------------
+
+class TestUnknownHookType:
+    def test_unknown_hook_type_does_nothing(self, monkeypatch, workspace):
+        mod = _load_module(monkeypatch, workspace, "unknown_value")
+
+        exit_code = _run_hook(mod, _make_hook_input())
+        assert exit_code == 0
+
+        log_file = workspace / "logs" / SESSION_LIFECYCLE_LOG_NAME
+        assert not log_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# Resilience: exceptions must not propagate
+# ---------------------------------------------------------------------------
+
+class TestResilience:
+    def test_pre_hook_does_not_raise_on_write_error(self, monkeypatch, workspace):
+        mod = _load_module(monkeypatch, workspace, "pre")
+        monkeypatch.setattr(mod, "is_dispatcher_session", lambda _: True)
+
+        # Simulate a write failure by making the log file unwritable
+        log_file = workspace / "logs" / SESSION_LIFECYCLE_LOG_NAME
+        log_file.write_text("")  # create it
+        log_file.chmod(0o444)    # make read-only
+
+        try:
+            exit_code = _run_hook(mod, _make_hook_input())
+            assert exit_code == 0
+        finally:
+            log_file.chmod(0o644)  # restore for cleanup
+
+    def test_post_hook_does_not_raise_on_write_error(self, monkeypatch, workspace):
+        mod = _load_module(monkeypatch, workspace, "post")
+        monkeypatch.setattr(mod, "is_dispatcher", lambda _: True)
+
+        log_file = workspace / "logs" / SESSION_LIFECYCLE_LOG_NAME
+        log_file.write_text("")
+        log_file.chmod(0o444)
+
+        try:
+            exit_code = _run_hook(mod, _make_hook_input())
+            assert exit_code == 0
+        finally:
+            log_file.chmod(0o644)


### PR DESCRIPTION
## What this does

Adds `hooks/wfm-lifecycle-logger.py` to main and wires it into fresh installs and existing upgrades.

The hook writes `WFM_ENTER` (PreToolUse) and `WFM_EXIT` (PostToolUse) events to `~/lobster-workspace/logs/session-lifecycle.log` each time the dispatcher calls `wait_for_messages`. This lets us measure exactly how long the dispatcher was blocked in WFM and whether it was mid-WFM when it died — closing the observability gap exposed by the 2026-05-01 crash (issue #1895).

## Why it was missing

The hook was implemented in feature branch `feature/issue-1895-crash-logging` (commit `a908357a`) but that branch was never merged to main. The file was cherry-picked to local-dev and registered manually in `settings.json`, which is why it works on the live install today. This PR brings the hook into main so fresh installs get it automatically.

## Changes

- **`hooks/wfm-lifecycle-logger.py`** — new hook (extracted from `a908357a`). Handles both PreToolUse and PostToolUse via `WFM_HOOK_TYPE` env var. Dispatcher-only guard via `session_role`. Writes atomically, fails open.
- **`tests/unit/test_hooks/test_wfm_lifecycle_logger.py`** — 16 unit tests (all passing, extracted from same commit).
- **`install.sh`** — adds registration block after `pre-tool-heartbeat` section. Idempotent: checks both PreToolUse and PostToolUse before writing.
- **`scripts/upgrade.sh`** — adds **migration 92** (migration 91 is reserved for PR #2027). Idempotent: skips if both hook entries already present.

## Test results

```
443 passed, 7 skipped in 9.74s
```

All existing hook tests continue to pass.

## Migration note

Migration 92 registers:
- `PreToolUse` with `matcher="mcp__lobster-inbox__wait_for_messages"` → `WFM_HOOK_TYPE=pre python3 .../wfm-lifecycle-logger.py`
- `PostToolUse` with `matcher="mcp__lobster-inbox__wait_for_messages"` → `WFM_HOOK_TYPE=post python3 .../wfm-lifecycle-logger.py`

The live install already has these entries (registered manually from local-dev), so migration 92 will skip on the current machine.

Closes #1895

🤖 Generated with [Claude Code](https://claude.com/claude-code)