### PR TITLE
fix(#2029): update require-subagent-type hook to list all valid agent types

### DIFF
--- a/hooks/require-subagent-type.py
+++ b/hooks/require-subagent-type.py
@@ -18,7 +18,9 @@ if not subagent_type:
     print(
         "BLOCKED: Agent called without subagent_type. "
         "Use subagent_type='lobster-generalist' for general background tasks, "
-        "or a named agent type (functional-engineer, lobster-ops, brain-dumps, etc.).",
+        "or a named agent type (brain-dumps, compact-catchup, functional-engineer, "
+        "lobster-auditor, lobster-ops, nightly-consolidation, review, "
+        "session-note-appender, session-note-polish).",
         file=sys.stderr,
     )
     sys.exit(2)
@@ -27,7 +29,9 @@ if subagent_type == "general-purpose":
     print(
         "BLOCKED: subagent_type='general-purpose' is not used in Lobster. "
         "Use subagent_type='lobster-generalist' for open-ended background tasks instead. "
-        "For specialised work, use: functional-engineer, lobster-ops, or brain-dumps.",
+        "For specialised work, use: brain-dumps, compact-catchup, functional-engineer, "
+        "lobster-auditor, lobster-ops, nightly-consolidation, review, "
+        "session-note-appender, or session-note-polish.",
         file=sys.stderr,
     )
     sys.exit(2)


### PR DESCRIPTION
## Problem

`hooks/require-subagent-type.py` blocks Agent calls with missing or invalid `subagent_type`. Its error messages only listed `functional-engineer`, `lobster-ops`, and `brain-dumps` as valid named types, but omitted seven other agent types that have `.claude/agents/*.md` definitions and are actively used.

Most critically, the dispatcher's engineer→reviewer routing path explicitly uses `subagent_type="review"` (lines ~524 and ~890 of `sys.dispatcher.bootup.md`), but `review` was not mentioned anywhere in the blocked error output. A developer seeing the error had no way to know that `review` is a valid and expected value.

## Fix

Updated both error messages in `hooks/require-subagent-type.py` to enumerate all current named agent types:

- `brain-dumps`
- `compact-catchup`
- `functional-engineer`
- `lobster-auditor`
- `lobster-ops`
- `nightly-consolidation`
- `review`
- `session-note-appender`
- `session-note-polish`

No logic changes — only the guidance text in the two `print()` calls was updated.

## Why

The hook's error messages serve as discovery documentation: they tell callers what values are valid. Omitting `review` (and six others) from these messages meant the guidance was misleading and incomplete. This fix makes the error output accurately reflect the full set of `.claude/agents/*.md` agent definitions.

Closes #2029

🤖 Generated with [Claude Code](https://claude.com/claude-code)