### PR TITLE
fix(#1996): combine two serial bootup Read calls into one

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -6,11 +6,8 @@ You are the **Lobster dispatcher**. You run in an infinite main loop, processing
 
 This file restores full context after a compaction or restart. Read it top-to-bottom.
 
-> **Two-pass read required.** This file exceeds the Read tool's single-call token limit (~10K tokens / ~150 lines). You MUST read it in two passes before taking any action:
-> - **Pass 1:** `Read(".claude/sys.dispatcher.bootup.md", limit=150)` — startup steps, main loop, 7-second rule, delegation pattern, in-flight tracking
-> - **Pass 2:** `Read(".claude/sys.dispatcher.bootup.md", offset=150, limit=200)` — message handlers (compact-reminder, subagent_result, etc.), source handling, session management, remaining behavioral rules
->
-> If you are reading this notice, Pass 1 is complete. Proceed to Pass 2 now before taking any startup action.
+> **Single-pass read.** Read this file in one call before taking any action:
+> `Read(".claude/sys.dispatcher.bootup.md", limit=350)` — startup steps, main loop, 7-second rule, delegation pattern, in-flight tracking, message handlers, source handling, session management, and core behavioral rules
 
 You are not a passive relay. You are a vigilant dispatcher. You take initiative based on what you observe — both from external signals and from the passage of time. When something seems off — whether because a signal says so or because time has passed and nothing has arrived — use your judgment to follow up. Spawning a brief investigation subagent takes <1 second and is almost always the right call when uncertain.
 

--- a/tests/unit/test_hooks/test_dispatcher_bootup_single_pass_read.py
+++ b/tests/unit/test_hooks/test_dispatcher_bootup_single_pass_read.py
@@ -1,0 +1,65 @@
+"""
+Regression test: sys.dispatcher.bootup.md uses a single-pass Read (issue #1996).
+
+Before issue #1996, the file contained a "Two-pass read required" notice that
+instructed the dispatcher to make two serial Read calls at startup (limit=150,
+then offset=150 limit=200). This caused unnecessary startup latency because the
+two calls were sequential and nothing else could proceed until both completed.
+
+The fix: replace with a single Read call using limit=350. This test ensures
+the two-pass instruction does not reappear as a regression.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Path to the actual dispatcher bootup file (relative to the repo root).
+_REPO_ROOT = Path(__file__).parents[3]
+_DISPATCHER_BOOTUP = _REPO_ROOT / ".claude" / "sys.dispatcher.bootup.md"
+
+
+def test_bootup_file_exists() -> None:
+    """Sanity check: the dispatcher bootup file must exist."""
+    assert _DISPATCHER_BOOTUP.exists(), (
+        f"sys.dispatcher.bootup.md not found at {_DISPATCHER_BOOTUP}"
+    )
+
+
+def test_no_two_pass_read_instruction() -> None:
+    """The two-pass read instruction must not be present (regression guard for #1996).
+
+    The old instruction read:
+      "Two-pass read required. ... limit=150 ... offset=150, limit=200"
+
+    This created two serial Read calls on the startup critical path. The fix
+    consolidated them into a single call (limit=350).
+    """
+    content = _DISPATCHER_BOOTUP.read_text()
+    assert "Two-pass read required" not in content, (
+        "sys.dispatcher.bootup.md still contains the old 'Two-pass read required' "
+        "instruction. Issue #1996 replaced this with a single-pass read (limit=350). "
+        "Remove the two-pass notice to fix this regression."
+    )
+    assert "Pass 1:" not in content, (
+        "sys.dispatcher.bootup.md still contains a 'Pass 1:' instruction from the "
+        "old two-pass read pattern (issue #1996). Replace with single-pass read."
+    )
+    assert "Pass 2:" not in content, (
+        "sys.dispatcher.bootup.md still contains a 'Pass 2:' instruction from the "
+        "old two-pass read pattern (issue #1996). Replace with single-pass read."
+    )
+
+
+def test_single_pass_read_instruction_present() -> None:
+    """The single-pass read instruction (limit=350) must be present (issue #1996).
+
+    Ensures the replacement instruction was actually added after removing the
+    two-pass notice.
+    """
+    content = _DISPATCHER_BOOTUP.read_text()
+    assert "limit=350" in content, (
+        "sys.dispatcher.bootup.md does not contain the single-pass read instruction "
+        "'limit=350'. Issue #1996 requires a single Read call with limit=350 to "
+        "replace the old two-pass pattern."
+    )


### PR DESCRIPTION
## Summary

- Replaces the two-pass Read instruction in `sys.dispatcher.bootup.md` with a single `Read(".claude/sys.dispatcher.bootup.md", limit=350)` call
- Eliminates one sequential round-trip from the startup critical path — previously the dispatcher had to wait for two Read calls to complete before proceeding
- Adds a regression test that fails if the old two-pass pattern is re-introduced

## Why

Startup made two sequential Read calls against `sys.dispatcher.bootup.md`:
- Pass 1: `limit=150`
- Pass 2: `offset=150, limit=200`

These calls were serial — nothing else could proceed until both completed. All other startup steps (inbox check, memory load, etc.) can run in parallel, but this serial pair sat on the critical path and was the startup bottleneck.

The fix is the one-line change described in issue #1996: replace with `limit=350` so startup requires one call instead of two.

## Test plan

- [x] New regression test `test_dispatcher_bootup_single_pass_read.py` verifies the two-pass pattern is absent and the single-pass instruction is present
- [x] All 430 hook unit tests pass
- [x] Full unit suite: 3256 passed (pre-existing failures in unrelated tests only)

Closes #1996
Part of #1993

🤖 Generated with [Claude Code](https://claude.com/claude-code)