### PR TITLE
fix(#1998): write reflection prompts to sidecar file instead of inbox

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -57,6 +57,8 @@ When you first start (or after reading this file), follow these steps:
     - Skip if step 2c already sent a restart notification (context-handoff.json was recent).
     - **Do not use `compaction-state.json` or `last_catchup_ts` alone to determine cause** — those fields are updated by catchup subagents and will give false positives for restarts.
 
+2e. **Read reflection prompt sidecar (LOBSTER_DEBUG=true only):** If `~/messages/bootup-prompt.md` exists, read it now and delete it. Reflect on its contents -- were there friction points, gaps, or improvements in the bootup/compaction flow worth capturing? If there are substantive observations, file or update GitHub issues in SiderealPress/lobster, or open PRs for straightforward fixes. If nothing worth capturing: do nothing -- silence is correct. This is a one-Read, zero-claim operation (no `mark_processing`/`mark_processed`). If `LOBSTER_DEBUG` is not `true`, skip this step entirely.
+
 3. **Claim any pending user messages immediately** to stop the health-check staleness clock:
     - Call `check_inbox()` to get any messages currently waiting in the inbox
     - For each message that is NOT a system message (i.e. `chat_id != 0` and `source != "system"`): call `mark_processing(message_id)`
@@ -366,23 +368,15 @@ Rules: never `send_reply` (chat_id: 0).
 
 ---
 
-### reflection_prompt (`type: "reflection_prompt"`)
+### reflection_prompt (sidecar file, not inbox)
 
-Debug-mode prompts written by `on-compact.py` and `on-fresh-start.py` when `LOBSTER_DEBUG=true`. They arrive after a compaction or fresh bootup and ask the dispatcher to reflect on the experience while it is fresh.
+Debug-mode prompts written by `on-compact.py` and `on-fresh-start.py` when `LOBSTER_DEBUG=true`. **These are no longer inbox messages.** They are written to `~/messages/bootup-prompt.md` (a sidecar file) and read at startup in step 2e above -- no `mark_processing`/`mark_processed` required.
+
+If a `reflection_prompt` inbox message somehow arrives (e.g. written by an older hook version), drop it silently:
 
 ```
-1. mark_processing(message_id)
-2. Read msg["text"] — the reflection question
-3. Reflect genuinely: were there friction points, gaps, or improvements in the
-   bootup/compaction flow worth capturing?
-4. If there are substantive observations:
-   - File or update GitHub issues in SiderealPress/lobster
-   - Open PRs for straightforward fixes (no need to wait for instruction)
-   - If nothing worth capturing: do nothing — silence is the correct response
-5. mark_processed(message_id)
+1. mark_processed(message_id)   # drop without processing -- legacy path
 ```
-
-Rules: never `send_reply` (chat_id: 0). Reflection is optional — only act if there are real observations.
 
 ---
 

--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -120,6 +120,16 @@ SENTINEL_FILE = Path(os.path.expanduser("~/messages/config/compact-pending"))
 
 COMPACTION_TELEGRAM_MESSAGE = "\u267b\ufe0f Context compacted. Re-orienting..."
 
+# Sidecar file for debug reflection prompts (Fix B, issue #1998).
+# Written here instead of the inbox to avoid mark_processing/mark_processed overhead.
+# The dispatcher reads this file at startup when LOBSTER_DEBUG=true.
+BOOTUP_PROMPT_FILE = Path(
+    os.environ.get(
+        "LOBSTER_BOOTUP_PROMPT_FILE_OVERRIDE",
+        os.path.expanduser("~/messages/bootup-prompt.md"),
+    )
+)
+
 
 def already_pending() -> bool:
     """Return True if a compact-reminder message is already in inbox/ or processing/.
@@ -473,55 +483,39 @@ def _is_dispatcher_compact(data: dict) -> bool:
 
 
 def _schedule_reflection_prompt(trigger: str) -> None:
-    """In debug mode, write a reflection-prompt message to the inbox.
+    """In debug mode, write a reflection prompt to the bootup-prompt sidecar file.
 
-    When LOBSTER_DEBUG=true, drops a message asking the dispatcher to reflect
-    on the bootup/compaction experience and file GitHub issues with observations.
-    Written immediately — the dispatcher processes inbox messages in order so it
-    will reach this after handling the compact-reminder and catching up.
+    When LOBSTER_DEBUG=true, writes a prompt asking the dispatcher to reflect on
+    the bootup/compaction experience and file GitHub issues with observations.
 
-    Silent on any failure — must never crash the hook.
+    Writes to BOOTUP_PROMPT_FILE (~/messages/bootup-prompt.md) instead of the
+    inbox (Fix B, issue #1998).  The dispatcher reads this file at startup
+    when LOBSTER_DEBUG=true -- one Read call, no mark_processing/mark_processed
+    round-trips.  The file is overwritten on the next restart, so it never
+    accumulates stale entries.
+
+    Silent on any failure -- must never crash the hook.
     """
     if os.environ.get("LOBSTER_DEBUG", "false").lower() != "true":
         return
 
     try:
-        INBOX_DIR.mkdir(parents=True, exist_ok=True)
-
-        ts = time.time()
-        msg_id = f"reflection_{trigger}_{int(ts)}"
-        timestamp = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + ".000000"
+        BOOTUP_PROMPT_FILE.parent.mkdir(parents=True, exist_ok=True)
 
         content = (
             f"[Debug] {trigger.capitalize()} reflection prompt:\n\n"
             "How was the experience? Were there friction points, gaps, or improvements "
             "worth capturing?\n\n"
             "If you have observations: file or update GitHub issues in SiderealPress/lobster, "
-            "or open PRs for straightforward fixes. Capture it while it's fresh."
+            "or open PRs for straightforward fixes. Capture it while it's fresh.\n\n"
+            f"trigger: {trigger}\n"
         )
 
-        msg = {
-            "id": msg_id,
-            "source": "system",
-            "chat_id": 0,
-            "user_id": 0,
-            "username": "lobster-system",
-            "user_name": "System",
-            "type": "reflection_prompt",
-            "trigger": trigger,
-            "text": content,
-            "timestamp": timestamp,
-        }
-
-        # Use current epoch_ms so this sorts after the compact-reminder (ts_ms=0)
-        # and after any queued user messages, but before future messages.
-        ts_ms = int(ts * 1000)
-        msg_path = INBOX_DIR / f"{ts_ms}_reflection_{trigger}.json"
-        tmp_path = msg_path.with_suffix(".tmp")
-        tmp_path.write_text(json.dumps(msg, indent=2) + "\n")
-        tmp_path.rename(msg_path)
+        tmp_path = BOOTUP_PROMPT_FILE.with_suffix(".tmp")
+        tmp_path.write_text(content)
+        tmp_path.rename(BOOTUP_PROMPT_FILE)
         print(
-            f"[on-compact] debug: wrote reflection prompt to {msg_path}",
+            f"[on-compact] debug: wrote reflection prompt to {BOOTUP_PROMPT_FILE}",
             file=sys.stderr,
         )
     except Exception as exc:  # noqa: BLE001
@@ -529,7 +523,6 @@ def _schedule_reflection_prompt(trigger: str) -> None:
             f"[on-compact] debug: failed to write reflection prompt: {exc}",
             file=sys.stderr,
         )
-
 
 def main() -> None:
     try:

--- a/hooks/on-fresh-start.py
+++ b/hooks/on-fresh-start.py
@@ -107,6 +107,16 @@ COMPACTION_STATE_FILE = Path(
 INBOX_DIR = Path(os.path.expanduser("~/messages/inbox"))
 PROCESSING_DIR = Path(os.path.expanduser("~/messages/processing"))
 
+# Sidecar file for debug reflection prompts (Fix B, issue #1998).
+# Written here instead of the inbox to avoid mark_processing/mark_processed overhead.
+# The dispatcher reads this file at startup when LOBSTER_DEBUG=true.
+BOOTUP_PROMPT_FILE = Path(
+    os.environ.get(
+        "LOBSTER_BOOTUP_PROMPT_FILE_OVERRIDE",
+        os.path.expanduser("~/messages/bootup-prompt.md"),
+    )
+)
+
 # Pointer to the current session file (written by compact-catchup / session management).
 # If this file exists and was modified recently, there is a prior session worth catching up.
 CURRENT_SESSION_FILE_POINTER = Path(
@@ -367,55 +377,39 @@ def _inject_compact_reminder() -> None:
 
 
 def _schedule_reflection_prompt(trigger: str) -> None:
-    """In debug mode, write a reflection-prompt message to the inbox.
+    """In debug mode, write a reflection prompt to the bootup-prompt sidecar file.
 
-    When LOBSTER_DEBUG=true, drops a message asking the dispatcher to reflect
-    on the bootup/compaction experience and file GitHub issues with observations.
-    Written immediately — the dispatcher processes inbox messages in order so it
-    will reach this after the compact-reminder and catchup handling.
+    When LOBSTER_DEBUG=true, writes a prompt asking the dispatcher to reflect on
+    the bootup/compaction experience and file GitHub issues with observations.
 
-    Silent on any failure — must never crash the hook.
+    Writes to BOOTUP_PROMPT_FILE (~/messages/bootup-prompt.md) instead of the
+    inbox (Fix B, issue #1998).  The dispatcher reads this file at startup
+    when LOBSTER_DEBUG=true -- one Read call, no mark_processing/mark_processed
+    round-trips.  The file is overwritten on the next restart, so it never
+    accumulates stale entries.
+
+    Silent on any failure -- must never crash the hook.
     """
     if os.environ.get("LOBSTER_DEBUG", "false").lower() != "true":
         return
 
     try:
-        INBOX_DIR.mkdir(parents=True, exist_ok=True)
-
-        ts = time.time()
-        msg_id = f"reflection_{trigger}_{int(ts)}"
-        timestamp = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + ".000000"
+        BOOTUP_PROMPT_FILE.parent.mkdir(parents=True, exist_ok=True)
 
         content = (
             f"[Debug] {trigger.capitalize()} reflection prompt:\n\n"
             "How was the experience? Were there friction points, gaps, or improvements "
             "worth capturing?\n\n"
             "If you have observations: file or update GitHub issues in SiderealPress/lobster, "
-            "or open PRs for straightforward fixes. Capture it while it's fresh."
+            "or open PRs for straightforward fixes. Capture it while it's fresh.\n\n"
+            f"trigger: {trigger}\n"
         )
 
-        msg = {
-            "id": msg_id,
-            "source": "system",
-            "chat_id": 0,
-            "user_id": 0,
-            "username": "lobster-system",
-            "user_name": "System",
-            "type": "reflection_prompt",
-            "trigger": trigger,
-            "text": content,
-            "timestamp": timestamp,
-        }
-
-        # Use current epoch_ms so this sorts after the startup compact-reminder
-        # (ts_ms=0/1) and after any queued user messages.
-        ts_ms = int(ts * 1000)
-        msg_path = INBOX_DIR / f"{ts_ms}_reflection_{trigger}.json"
-        tmp_path = msg_path.with_suffix(".tmp")
-        tmp_path.write_text(json.dumps(msg, indent=2) + "\n")
-        tmp_path.rename(msg_path)
+        tmp_path = BOOTUP_PROMPT_FILE.with_suffix(".tmp")
+        tmp_path.write_text(content)
+        tmp_path.rename(BOOTUP_PROMPT_FILE)
         print(
-            f"[on-fresh-start] debug: wrote reflection prompt to {msg_path}",
+            f"[on-fresh-start] debug: wrote reflection prompt to {BOOTUP_PROMPT_FILE}",
             file=sys.stderr,
         )
     except Exception as exc:  # noqa: BLE001
@@ -423,7 +417,6 @@ def _schedule_reflection_prompt(trigger: str) -> None:
             f"[on-fresh-start] debug: failed to write reflection prompt: {exc}",
             file=sys.stderr,
         )
-
 
 def _mark_all_running_failed() -> None:
     """Run agent-monitor.py --mark-failed via uv.

--- a/tests/unit/test_hooks/test_reflection_prompt.py
+++ b/tests/unit/test_hooks/test_reflection_prompt.py
@@ -1,16 +1,17 @@
 """
 Unit tests for _schedule_reflection_prompt() in on-compact.py and on-fresh-start.py.
 
-Verifies:
-- In debug mode, writes a well-formed reflection_prompt message to the inbox
-- In non-debug mode, writes nothing
-- Written message has expected fields and content
-- Atomic write (no .tmp file left behind)
-- Silent on filesystem errors (never crashes the hook)
+Verifies (Fix B, issue #1998):
+- In debug mode, writes a well-formed reflection prompt to the sidecar file
+  (~/messages/bootup-prompt.md) -- NOT to the inbox.
+- In non-debug mode, writes nothing.
+- Written content contains expected key phrases and the trigger name.
+- Atomic write (no .tmp file left behind).
+- Silent on filesystem errors (never crashes the hook).
+- Second call overwrites the sidecar file (not appends / accumulates).
 """
 
 import importlib.util
-import json
 import os
 import sys
 import types
@@ -55,41 +56,72 @@ def _make_session_role_stub(is_dispatcher: bool = True):
     return stub
 
 
-def _load_on_compact(inbox_dir: str = None, compaction_state_override: str = None):
+def _load_on_compact(
+    bootup_prompt_file: str = None,
+    compaction_state_override: str = None,
+):
     """Load hooks/on-compact.py as a module, with isolated file paths."""
     env_patch = {}
     if compaction_state_override:
         env_patch["LOBSTER_COMPACTION_STATE_FILE_OVERRIDE"] = compaction_state_override
+    if bootup_prompt_file:
+        env_patch["LOBSTER_BOOTUP_PROMPT_FILE_OVERRIDE"] = bootup_prompt_file
 
     hook_path = _HOOKS_DIR / "on-compact.py"
-    with _PatchEnv(env_patch):
-        spec = importlib.util.spec_from_file_location("on_compact", hook_path)
-        mod = importlib.util.module_from_spec(spec)
-        sys.modules.setdefault("session_role", _make_session_role_stub())
-        spec.loader.exec_module(mod)
+    # Save and restore session_role to avoid polluting other tests that rely on the
+    # real session_role module.
+    saved_session_role = sys.modules.get("session_role")
+    try:
+        with _PatchEnv(env_patch):
+            spec = importlib.util.spec_from_file_location(
+                f"on_compact_{os.getpid()}_{id(bootup_prompt_file)}", hook_path
+            )
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules["session_role"] = _make_session_role_stub()
+            spec.loader.exec_module(mod)
+    finally:
+        # Restore the previous session_role (or remove if it was not there)
+        if saved_session_role is None:
+            sys.modules.pop("session_role", None)
+        else:
+            sys.modules["session_role"] = saved_session_role
 
-    if inbox_dir:
-        mod.INBOX_DIR = Path(inbox_dir)
+    if bootup_prompt_file:
+        mod.BOOTUP_PROMPT_FILE = Path(bootup_prompt_file)
     if compaction_state_override:
         mod.COMPACTION_STATE_FILE = Path(compaction_state_override)
     return mod
 
 
-def _load_on_fresh_start(inbox_dir: str = None, compaction_state_override: str = None):
+def _load_on_fresh_start(
+    bootup_prompt_file: str = None,
+    compaction_state_override: str = None,
+):
     """Load hooks/on-fresh-start.py as a module, with isolated file paths."""
     env_patch = {}
     if compaction_state_override:
         env_patch["LOBSTER_COMPACTION_STATE_FILE_OVERRIDE"] = compaction_state_override
+    if bootup_prompt_file:
+        env_patch["LOBSTER_BOOTUP_PROMPT_FILE_OVERRIDE"] = bootup_prompt_file
 
     hook_path = _HOOKS_DIR / "on-fresh-start.py"
-    with _PatchEnv(env_patch):
-        spec = importlib.util.spec_from_file_location("on_fresh_start", hook_path)
-        mod = importlib.util.module_from_spec(spec)
-        sys.modules.setdefault("session_role", _make_session_role_stub())
-        spec.loader.exec_module(mod)
+    saved_session_role = sys.modules.get("session_role")
+    try:
+        with _PatchEnv(env_patch):
+            spec = importlib.util.spec_from_file_location(
+                f"on_fresh_start_{os.getpid()}_{id(bootup_prompt_file)}", hook_path
+            )
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules["session_role"] = _make_session_role_stub()
+            spec.loader.exec_module(mod)
+    finally:
+        if saved_session_role is None:
+            sys.modules.pop("session_role", None)
+        else:
+            sys.modules["session_role"] = saved_session_role
 
-    if inbox_dir:
-        mod.INBOX_DIR = Path(inbox_dir)
+    if bootup_prompt_file:
+        mod.BOOTUP_PROMPT_FILE = Path(bootup_prompt_file)
     if compaction_state_override:
         mod.COMPACTION_STATE_FILE = Path(compaction_state_override)
     return mod
@@ -100,96 +132,98 @@ def _load_on_fresh_start(inbox_dir: str = None, compaction_state_override: str =
 # ---------------------------------------------------------------------------
 
 class TestScheduleReflectionPromptCompact:
-    """Tests for _schedule_reflection_prompt() in on-compact.py."""
+    """Tests for _schedule_reflection_prompt() in on-compact.py (sidecar, Fix B)."""
 
-    def test_writes_inbox_file_in_debug_mode(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        mod = _load_on_compact(inbox_dir=str(inbox))
+    def test_writes_sidecar_file_in_debug_mode(self, tmp_path):
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_compact(bootup_prompt_file=str(sidecar))
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             mod._schedule_reflection_prompt("compaction")
 
-        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-        assert len(files) == 1, f"expected 1 file, got {[f.name for f in files]}"
+        assert sidecar.exists(), "sidecar file was not written in debug mode"
 
-    def test_does_not_write_in_non_debug_mode(self, tmp_path):
+    def test_does_not_write_to_inbox(self, tmp_path):
+        """No inbox file should be written -- sidecar only."""
         inbox = tmp_path / "inbox"
         inbox.mkdir()
-        mod = _load_on_compact(inbox_dir=str(inbox))
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_compact(bootup_prompt_file=str(sidecar))
+        mod.INBOX_DIR = inbox
+
+        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
+            mod._schedule_reflection_prompt("compaction")
+
+        inbox_files = list(inbox.iterdir())
+        assert len(inbox_files) == 0, f"unexpected inbox files: {[f.name for f in inbox_files]}"
+
+    def test_does_not_write_in_non_debug_mode(self, tmp_path):
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_compact(bootup_prompt_file=str(sidecar))
 
         with _PatchEnv({"LOBSTER_DEBUG": "false"}):
             mod._schedule_reflection_prompt("compaction")
 
-        files = list(inbox.iterdir())
-        assert len(files) == 0
+        assert not sidecar.exists()
 
     def test_does_not_write_when_debug_env_absent(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        mod = _load_on_compact(inbox_dir=str(inbox))
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_compact(bootup_prompt_file=str(sidecar))
 
-        env_without_debug = {k: v for k, v in os.environ.items() if k != "LOBSTER_DEBUG"}
         with _PatchEnv({"LOBSTER_DEBUG": ""}):
             mod._schedule_reflection_prompt("compaction")
 
-        files = list(inbox.iterdir())
-        assert len(files) == 0
+        assert not sidecar.exists()
 
-    def test_written_message_has_correct_type_and_trigger(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        mod = _load_on_compact(inbox_dir=str(inbox))
+    def test_written_content_contains_trigger_and_key_phrases(self, tmp_path):
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_compact(bootup_prompt_file=str(sidecar))
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             mod._schedule_reflection_prompt("compaction")
 
-        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-        data = json.loads(files[0].read_text())
-        assert data["type"] == "reflection_prompt"
-        assert data["trigger"] == "compaction"
-        assert data["source"] == "system"
-        assert data["chat_id"] == 0
-
-    def test_written_message_content_contains_key_phrases(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        mod = _load_on_compact(inbox_dir=str(inbox))
-
-        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
-            mod._schedule_reflection_prompt("compaction")
-
-        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-        data = json.loads(files[0].read_text())
-        text = data["text"]
+        text = sidecar.read_text()
+        assert "compaction" in text.lower()
         assert "friction" in text.lower() or "observations" in text.lower()
         assert "SiderealPress/lobster" in text
 
     def test_no_tmp_file_left_behind(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        mod = _load_on_compact(inbox_dir=str(inbox))
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_compact(bootup_prompt_file=str(sidecar))
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             mod._schedule_reflection_prompt("compaction")
 
-        tmp_files = [f for f in inbox.iterdir() if f.suffix == ".tmp"]
+        tmp_files = list(tmp_path.glob("*.tmp"))
         assert len(tmp_files) == 0, f"tmp files left behind: {tmp_files}"
 
-    def test_creates_inbox_dir_if_absent(self, tmp_path):
-        inbox = tmp_path / "inbox_not_created_yet"
-        mod = _load_on_compact(inbox_dir=str(inbox))
+    def test_creates_parent_dir_if_absent(self, tmp_path):
+        sidecar = tmp_path / "subdir_not_created_yet" / "bootup-prompt.md"
+        mod = _load_on_compact(bootup_prompt_file=str(sidecar))
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             mod._schedule_reflection_prompt("compaction")
 
-        assert inbox.exists()
-        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-        assert len(files) == 1
+        assert sidecar.exists()
 
-    def test_silent_on_write_failure(self, tmp_path):
-        """Must not raise when the inbox path is not writable."""
-        mod = _load_on_compact(inbox_dir="/proc/lobster_test_nonexistent/inbox")
+    def test_overwrites_on_second_call(self, tmp_path):
+        """Second call must overwrite, not append."""
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_compact(bootup_prompt_file=str(sidecar))
+
+        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
+            mod._schedule_reflection_prompt("compaction")
+            first_content = sidecar.read_text()
+            mod._schedule_reflection_prompt("compaction")
+            second_content = sidecar.read_text()
+
+        assert second_content == first_content  # same content, not doubled
+
+    def test_silent_on_write_failure(self):
+        """Must not raise when the sidecar path is not writable."""
+        mod = _load_on_compact(
+            bootup_prompt_file="/proc/lobster_test_nonexistent/bootup-prompt.md"
+        )
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             # Must not raise
@@ -201,60 +235,79 @@ class TestScheduleReflectionPromptCompact:
 # ---------------------------------------------------------------------------
 
 class TestScheduleReflectionPromptFreshStart:
-    """Tests for _schedule_reflection_prompt() in on-fresh-start.py."""
+    """Tests for _schedule_reflection_prompt() in on-fresh-start.py (sidecar, Fix B)."""
 
-    def test_writes_inbox_file_in_debug_mode(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
+    def test_writes_sidecar_file_in_debug_mode(self, tmp_path):
+        sidecar = tmp_path / "bootup-prompt.md"
         state_file = tmp_path / "compaction-state.json"
         mod = _load_on_fresh_start(
-            inbox_dir=str(inbox),
+            bootup_prompt_file=str(sidecar),
             compaction_state_override=str(state_file),
         )
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             mod._schedule_reflection_prompt("bootup")
 
-        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-        assert len(files) == 1
+        assert sidecar.exists(), "sidecar file was not written in debug mode"
 
-    def test_does_not_write_in_non_debug_mode(self, tmp_path):
+    def test_does_not_write_to_inbox(self, tmp_path):
+        """No inbox file should be written -- sidecar only."""
         inbox = tmp_path / "inbox"
         inbox.mkdir()
-        mod = _load_on_fresh_start(inbox_dir=str(inbox))
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_fresh_start(bootup_prompt_file=str(sidecar))
+        mod.INBOX_DIR = inbox
+
+        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
+            mod._schedule_reflection_prompt("bootup")
+
+        inbox_files = list(inbox.iterdir())
+        assert len(inbox_files) == 0, f"unexpected inbox files: {[f.name for f in inbox_files]}"
+
+    def test_does_not_write_in_non_debug_mode(self, tmp_path):
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_fresh_start(bootup_prompt_file=str(sidecar))
 
         with _PatchEnv({"LOBSTER_DEBUG": "false"}):
             mod._schedule_reflection_prompt("bootup")
 
-        files = list(inbox.iterdir())
-        assert len(files) == 0
+        assert not sidecar.exists()
 
-    def test_bootup_trigger_in_message(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        mod = _load_on_fresh_start(inbox_dir=str(inbox))
+    def test_bootup_trigger_appears_in_content(self, tmp_path):
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_fresh_start(bootup_prompt_file=str(sidecar))
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             mod._schedule_reflection_prompt("bootup")
 
-        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-        data = json.loads(files[0].read_text())
-        assert data["trigger"] == "bootup"
-        assert data["type"] == "reflection_prompt"
+        text = sidecar.read_text()
+        assert "bootup" in text.lower()
+
+    def test_written_content_contains_key_phrases(self, tmp_path):
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_fresh_start(bootup_prompt_file=str(sidecar))
+
+        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
+            mod._schedule_reflection_prompt("bootup")
+
+        text = sidecar.read_text()
+        assert "friction" in text.lower() or "observations" in text.lower()
+        assert "SiderealPress/lobster" in text
 
     def test_no_tmp_file_left_behind(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        mod = _load_on_fresh_start(inbox_dir=str(inbox))
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_fresh_start(bootup_prompt_file=str(sidecar))
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             mod._schedule_reflection_prompt("bootup")
 
-        tmp_files = [f for f in inbox.iterdir() if f.suffix == ".tmp"]
+        tmp_files = list(tmp_path.glob("*.tmp"))
         assert len(tmp_files) == 0
 
     def test_silent_on_write_failure(self):
-        mod = _load_on_fresh_start(inbox_dir="/proc/lobster_test_nonexistent/inbox")
+        mod = _load_on_fresh_start(
+            bootup_prompt_file="/proc/lobster_test_nonexistent/bootup-prompt.md"
+        )
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             # Must not raise


### PR DESCRIPTION
## Summary

- Eliminates 2 MCP round-trips per restart (`mark_processing` + `mark_processed`) caused by reflection prompt messages flowing through the inbox
- Both `on-compact.py` and `on-fresh-start.py` now write to `~/messages/bootup-prompt.md` (sidecar file) via atomic `.tmp` → rename, only when `LOBSTER_DEBUG=true`
- Dispatcher reads and deletes the sidecar at startup in new step 2e — one `Read` call, zero claim/process overhead
- Updated `.claude/sys.dispatcher.bootup.md` to document step 2e and clarify the old inbox path is legacy (drop silently if encountered)
- Rewrote `tests/unit/test_hooks/test_reflection_prompt.py` for the sidecar approach (16 tests covering debug/non-debug mode, atomic write, no tmp left, parent dir creation, overwrite behavior, silent failure, and no inbox writes)

Closes #1998

## Test plan
- [x] `uv run pytest tests/unit/ -q` — 3265 passed, 31 skipped, 1 pre-existing flaky timing test (`test_exactly_at_window_boundary_blocks`) that passes when run in isolation
- [x] All 16 reflection prompt tests pass (9 for on-compact.py, 7 for on-fresh-start.py)
- [x] `LOBSTER_BOOTUP_PROMPT_FILE_OVERRIDE` env var used for test isolation (no writes to real `~/messages/`)
- [x] `sys.modules["session_role"]` save/restore pattern prevents cross-test pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)