### PR TITLE
fix(#1983): move compaction recovery notification into compact-catchup agent

### DIFF
--- a/.claude/agents/compact-catchup.md
+++ b/.claude/agents/compact-catchup.md
@@ -221,7 +221,7 @@ After Phase 4, if `LOBSTER_DEBUG=true`, send a recovery status notification dire
 22. Check `os.environ.get("LOBSTER_DEBUG", "false").lower() == "true"`. If False, skip this entire phase.
 
 23. Determine ADMIN_CHAT_ID. Check in order:
-    a. `os.environ.get("LOBSTER_ADMIN_CHAT_ID")` — set by the dispatcher launcher.
+    a. `os.environ.get("LOBSTER_ADMIN_CHAT_ID")` — available via config.env loaded by the systemd service's EnvironmentFile directive.
     b. Parse `~/lobster-config/config.env` for `TELEGRAM_ALLOWED_USERS` — take the first user ID (same approach as `on-compact.py`).
     If neither source yields a usable chat_id, skip the notification silently (do not crash).
 
@@ -245,6 +245,8 @@ mcp__lobster-inbox__send_reply(
 ```
 
     Silent on any failure — this notification must never crash the catchup or prevent `write_result` from being called.
+
+27. After the `send_reply` call succeeds, call `write_result` with `sent_reply_to_user=True` so the dispatcher's relay path does not forward this internal message to the user. Pass this flag only when the Phase 5 send succeeded — if `send_reply` raised an exception, omit the flag (defaults to False) so the dispatcher is not misled.
 
 ## Session notes reading
 
@@ -353,6 +355,7 @@ mcp__lobster-inbox__write_result(
     text=<structured summary above>,
     source="system",
     status="success",
-    # sent_reply_to_user omitted (defaults to False) -- dispatcher reads this inline
+    # sent_reply_to_user: set to True if Phase 5 send_reply succeeded (LOBSTER_DEBUG=true path)
+    # omit (defaults to False) if Phase 5 was skipped or send_reply raised an exception
 )
 ```

--- a/.claude/agents/compact-catchup.md
+++ b/.claude/agents/compact-catchup.md
@@ -4,7 +4,7 @@ description: "Post-compaction catch-up agent. Recovers situational awareness for
 model: sonnet
 ---
 
-> **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `write_result` (NOT `send_reply`) when your task is complete -- the dispatcher reads your result as structured context, not a user message.
+> **Subagent note:** You are a background subagent. Do NOT call `wait_for_messages`. Call `write_result` when your task is complete -- the dispatcher reads your result as structured context, not a user message. Exception: when `LOBSTER_DEBUG=true`, call `send_reply` at the end of Phase 5 to send the "Back online" notification directly to the owner (see Phase 5 below).
 
 You are the **compact_catchup** subagent. Your job is to:
 1. Scan recent message history and session notes, then produce a structured summary for the dispatcher to restore situational awareness.
@@ -214,6 +214,38 @@ After Phase 3, verify that open commitments in the session notes are also captur
     ```
     If `rolling-summary.md` could not be read or written during Phase 4, note the failure but do not abort catchup.
 
+### Phase 5: Debug notification (LOBSTER_DEBUG=true only)
+
+After Phase 4, if `LOBSTER_DEBUG=true`, send a recovery status notification directly to the owner. This is the deterministic path — the notification fires here, inside the agent, so it cannot be skipped by dispatcher behavior.
+
+22. Check `os.environ.get("LOBSTER_DEBUG", "false").lower() == "true"`. If False, skip this entire phase.
+
+23. Determine ADMIN_CHAT_ID. Check in order:
+    a. `os.environ.get("LOBSTER_ADMIN_CHAT_ID")` — set by the dispatcher launcher.
+    b. Parse `~/lobster-config/config.env` for `TELEGRAM_ALLOWED_USERS` — take the first user ID (same approach as `on-compact.py`).
+    If neither source yields a usable chat_id, skip the notification silently (do not crash).
+
+24. Extract the catch-up window from the structured summary you already computed:
+    - `window_start`: the ISO UTC timestamp used as the start of the inbox scan (step 3 above).
+    - `now`: current UTC time.
+    Convert both to Eastern Time before including them in the message. Rule: EDT (UTC-4) from mid-March through early November; EST (UTC-5) otherwise. Format: "5:29 AM ET". Never send raw UTC ISO strings to the user.
+
+25. Count from your inbox scan results:
+    - `N`: total user messages found in the window (user messages count only, not system events).
+    - `M`: number of in-flight subagents at compaction time (from `get_active_sessions()` result in step 5).
+
+26. Send the notification:
+
+```python
+mcp__lobster-inbox__send_reply(
+    chat_id=<ADMIN_CHAT_ID>,
+    text=f"🔄 Back online. Context recovered from {window_start_et} to {now_et}. {N} messages processed, {M} subagents were running.",
+    source="telegram",
+)
+```
+
+    Silent on any failure — this notification must never crash the catchup or prevent `write_result` from being called.
+
 ## Session notes reading
 
 Read session notes from `~/lobster-user-config/memory/canonical/sessions/` in tiers:
@@ -299,7 +331,7 @@ Keep each line to one sentence. The dispatcher is on mobile -- brevity matters.
 
 ## Rules
 
-- Do NOT call `send_reply` -- this is internal context recovery, not a user message.
+- Do NOT call `send_reply` to relay catch-up content to the user, except for the debug notification in Phase 5 (`LOBSTER_DEBUG=true` only). This is internal context recovery — the structured summary goes to the dispatcher, not the user.
 - Do NOT relay catch-up content to the user unless an event is urgent (e.g. a failed subagent that the user has not been notified about).
 - If `check_inbox` returns no messages in the window, that is valid -- report "Nothing to report" in the inbox section but still populate the session file.
 - If `compaction-state.json` is missing or corrupt, default to scanning the last 6 hours.

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -287,11 +287,7 @@ After a context compaction you lose situational awareness of the last ~30 minute
 
 **When the compact_catchup result arrives** (`task_id: "compact-catchup"`, `chat_id: 0`):
 - Read `msg["text"]` to restore situational awareness
-- Do NOT send_reply — this is internal context, except:
-  - If `LOBSTER_DEBUG=true`: send a brief status to ADMIN_CHAT_ID:
-    `"🔄 Back online. Context recovered from [window_start] to [now]. [N messages] processed, [M subagents] were running."`
-    (Fill in N and M from `msg["text"]`. ADMIN_CHAT_ID from `lobster.conf` or the compact-reminder context.)
-    **Before composing this message, convert `[window_start]` and `[now]` from UTC ISO timestamps to ET (e.g. "5:29 AM ET"). Rule: EDT (UTC-4) mid-March through early November, EST (UTC-5) otherwise. Never send raw UTC ISO strings to the user.**
+- Do NOT send_reply — this is internal context. The compact-catchup agent sends the "🔄 Back online" notification directly when `LOBSTER_DEBUG=true` (Phase 5 of compact-catchup.md). No dispatcher action needed.
 - `mark_processed`
 
 ---


### PR DESCRIPTION
🤖🦞 Lobster (engineer):

## What was broken

The \"🔄 Back online. Context recovered from [window_start] to [now]...\" notification was sent manually by the dispatcher after receiving the `compact-catchup` result when `LOBSTER_DEBUG=true`. This made it contingent on dispatcher behavior:

- If the dispatcher processed the result correctly → notification fires
- If the dispatcher skipped the step, crashed, or handled the result poorly → silence

A signal that fires \"most of the time\" is worse than no signal at all. It creates false confidence when it fires, and ambiguous silence when it doesn't. Issue #1983 classifies this as epistemic rot.

## What changed

**`compact-catchup.md`** — new Phase 5:
After completing Phases 1–4, if `LOBSTER_DEBUG=true`, the agent sends the recovery notification directly to ADMIN_CHAT_ID before calling `write_result`. The notification fires inside the agent and cannot be skipped by dispatcher behavior.

The agent determines ADMIN_CHAT_ID from `LOBSTER_ADMIN_CHAT_ID` env var (primary) or `config.env` TELEGRAM_ALLOWED_USERS (fallback) — the same two-tier pattern used by `on-compact.py`. ET timezone conversion is applied before sending. The phase is entirely silent on failure — it never prevents `write_result` from being called.

The \"Do NOT call `send_reply`\" rule is updated to document the Phase 5 exception.

**`sys.dispatcher.bootup.md`** — compact-catchup result handling:
The manual notification instruction (6 lines of dispatcher logic) is replaced with a one-line note: the agent handles it, no dispatcher action needed.

## Before / after

```
Before:
  compact-catchup agent -> write_result(chat_id=0)
  -> dispatcher receives result
  -> dispatcher reads msg["text"]
  -> IF LOBSTER_DEBUG: dispatcher sends "Back online" (may be skipped)
  -> dispatcher mark_processed

After:
  compact-catchup agent
  -> Phase 5: send_reply("Back online") to ADMIN_CHAT_ID if LOBSTER_DEBUG (always fires)
  -> write_result(chat_id=0)
  -> dispatcher receives result
  -> dispatcher reads msg["text"]
  -> dispatcher mark_processed (no send needed -- agent already sent it)
```

## Functional patterns

Pure composition: Phase 5 is self-contained with no side effects on the other phases. Silent failure pattern (exception caught, never propagates) keeps the notification non-blocking. ADMIN_CHAT_ID lookup uses the same two-tier strategy as `on-compact.py` — no new config surface.

## Tests run

- [x] `uv run pytest tests/unit/ -q` — 3225 passed, 31 skipped (same baseline count as before changes)
- [ ] Live compaction test — cannot trigger a real compaction in test scope. Phase 5 is LLM-instruction logic (not Python code), so unit tests cannot directly exercise it. The change is verified by diff inspection.
- [ ] Telegram notification verified — requires live `LOBSTER_DEBUG=true` compaction in production. Will be confirmed on next observed compaction.

Blocked items needing attention before merge: none (the live verification is observational, not a blocker).

## Manual test

The notification path is inside `compact-catchup.md` (LLM agent instructions), not executable Python code. No Python test can exercise it. The dispatcher-side change (removing the manual send instruction) is verified by diff — 6 lines of manual dispatch instructions are gone; 1 line notes the agent handles it.

User-visible outcome: the "🔄 Back online" message now fires when compact-catchup completes (not when the dispatcher processes the result). Difference is subtle timing — a few seconds earlier. Will be confirmed on next production compaction.

## Definition of Done

- [x] Unit tests pass (3225 passed, 0 failures introduced)
- [ ] Integration/manual test — requires live compaction (see above)
- [ ] User-visible outcome — will be confirmed on next production compaction
- [x] Side-effect audit: no new file writes, no new external calls, no volume risk. Phase 5 sends exactly one Telegram message per compaction when LOBSTER_DEBUG=true — same rate as before, just from a different location.
- [x] External service calls: send_reply is an existing MCP tool, already tested in unit suite

Closes #1983