### PR TITLE
feat(#1989): persist full Agent prompt for killed-subagent recovery

### DIFF
--- a/.claude/agents/compact-catchup.md
+++ b/.claude/agents/compact-catchup.md
@@ -58,6 +58,8 @@ You are the **compact_catchup** subagent. Your job is to:
    - Notable system events: `update_notification`, `consolidation`
    - Exclude: `self_check`, `compact-reminder`, `compact_catchup`, `subagent_notification`, test messages
 5. **Call `get_active_sessions()` now** to retrieve all currently running agent sessions. Filter to `status: "running"` sessions, excluding dispatcher sessions. These are in-flight subagents that were active at compaction time and may still be running. If `get_active_sessions()` errors, note the failure and continue. Also read `~/lobster-workspace/data/inflight-work.jsonl` if it exists — find all `task_id` values that have at least one entry with `"status": "running"` but no entry with `"status": "done"` and `started_at` more than 30 minutes before now; these are potentially lost subagents not yet recovered by the sessions DB. (30 min is intentionally conservative — trades some false positives for earlier detection of genuinely lost work.)
+
+   **Prompt recovery:** For each potentially-lost subagent entry, check whether its inflight-work.jsonl entry has a `prompt_file` field. If `prompt_file` exists and the file at that path is readable, include a note in the "Possibly lost subagents" section: "prompt available at <path>" — this enables future auto-restart. If `prompt_file` is absent (entries written before issue #1989), note "prompt not available (pre-1989 entry)". Do NOT read or include the full prompt in write_result output — only note its availability.
 6. Read session notes in tiers (see "Session notes reading" below).
 7. **Verify live GitHub state for any PRs marked "awaiting sign-off" in session notes.**
    Extract all PR numbers mentioned in session notes alongside phrases like "awaiting sign-off", "awaiting owner sign-off", "PASS review, awaiting", "pending review", or "awaiting merge". For each PR number found:
@@ -263,8 +265,8 @@ Structure your `write_result` text as follows:
 (or "None." if no subagent_result messages found in inbox scan)
 
 ## Possibly lost subagents (from inflight-work.jsonl)
-(only if any entries qualify — task_id, description, started_at ET, chat_id)
-- task_id=<id>  description=<desc>  started=<HH:MM ET>  chat_id=<id>
+(only if any entries qualify — task_id, description, started_at ET, chat_id, prompt availability)
+- task_id=<id>  description=<desc>  started=<HH:MM ET>  chat_id=<id>  prompt=<"available at <path>" | "not available (pre-#1989)">
 - ...
 (omit this section entirely if there are no qualifying entries)
 

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -214,21 +214,36 @@ Use `get_active_sessions` to answer "what agents are running?" at any time — a
 
 ## In-Flight Work Tracking
 
-Before calling the Agent tool to spawn any background subagent, append a JSON line to `~/lobster-workspace/data/inflight-work.jsonl` (create the file if it doesn't exist):
+Before calling the Agent tool to spawn any background subagent, persist the entry **and the full prompt** by piping JSON to the helper script:
 
-```json
-{"task_id": "<task_id>", "type": "<task type>", "description": "<brief description>", "started_at": "<ISO UTC timestamp>", "chat_id": <chat_id>, "status": "running"}
+```python
+Bash(
+    'echo \'' + json.dumps({
+        "task_id": task_id,
+        "type": "<task type>",
+        "description": "<brief description>",
+        "started_at": datetime.utcnow().isoformat() + "Z",
+        "chat_id": chat_id,
+        "subagent_type": subagent_type,  # the value passed to the Agent tool
+        "status": "running",
+        "prompt": prompt,  # full prompt text — will be written to a separate file
+    }).replace("'", "'\\''") + '\' | uv run ~/lobster/scripts/save-inflight-prompt.py'
+)
 ```
 
-This is a **synchronous write on the main thread** — it must complete before the Agent call. Use a Bash append: `echo '<json>' >> ~/lobster-workspace/data/inflight-work.jsonl`. Do not spawn a subagent for this write.
+**Why a script instead of `echo '...' >> file`:** Prompts contain newlines and special characters that make shell escaping unreliable. `save-inflight-prompt.py` writes the prompt to `~/lobster-workspace/data/inflight-prompts/<task_id>.txt` and appends a JSONL entry to `inflight-work.jsonl` with a `prompt_file` path — never inline. The raw prompt must NOT appear in the JSONL file.
 
-**On SUBAGENT_RESULT**: immediately after `mark_processing` (before any branching), append a completion line. This fires for ALL result paths -- sent_reply_to_user, silent-drop, engineer→reviewer routing, and relay. "done" means the result arrived at the dispatcher -- not that the user has received the relay:
+This is a **synchronous write on the main thread** — it must complete before the Agent call. Do not spawn a subagent for this write.
 
-```json
-{"task_id": "<task_id>", "completed_at": "<ISO UTC timestamp>", "status": "done"}
+**Idempotency requirement:** Prompts passed to the Agent tool must be written to be stateless and idempotent. If the same prompt is launched 10 hours later, it should produce similar or better results — not worse. Prompts must not assume any ambient state (open editor windows, in-progress filesystem writes, specific partial outputs) that may have changed. This is the prerequisite for reliable auto-restart after session death.
+
+**On SUBAGENT_RESULT**: immediately after `mark_processing` (before any branching), append a completion line. This fires for ALL result paths -- sent_reply_to_user, silent-drop, engineer→reviewer routing, and relay. "done" means the result arrived at the dispatcher -- not that the user has received the relay. Use a Bash append for "done" entries (no prompt involved):
+
+```python
+Bash(f'echo \'{{"task_id": "{task_id}", "completed_at": "{completed_at}", "status": "done"}}\' >> ~/lobster-workspace/data/inflight-work.jsonl')
 ```
 
-The log is append-only. A task is "done" if any entry with the same `task_id` has `"status": "done"`. Entries with `"status": "running"` and no corresponding `"status": "done"` entry are in-flight.
+The log is append-only. A task is "done" if any entry with the same `task_id` has `"status": "done"`. Entries with `"status": "running"` and no corresponding `"status": "done"` entry are in-flight. The full prompt for any in-flight entry is readable from its `prompt_file` path.
 
 ---
 

--- a/scripts/save-inflight-prompt.py
+++ b/scripts/save-inflight-prompt.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""save-inflight-prompt.py — persist full Agent prompt for killed-subagent recovery.
+
+Part of issue #1989 — Automatic subagent restart after dispatcher session death.
+
+## Purpose
+
+When the dispatcher spawns a background subagent via the Agent tool, it must
+persist the full prompt so that if the dispatcher session dies (health-check
+kill, OOM, crash), the new dispatcher can recover and relaunch the killed
+subagent automatically.
+
+## Why not store the prompt inline in inflight-work.jsonl?
+
+The existing inflight-work.jsonl is written via Bash `echo '...' >> file`.
+Prompts are multi-line strings containing quotes, braces, and special
+characters that make shell escaping unreliable and fragile. Instead:
+- The prompt text is written to a separate file:
+    ~/lobster-workspace/data/inflight-prompts/<task_id>.txt
+- The JSONL entry adds `prompt_file` (path) and `subagent_type` fields.
+  The raw prompt text is NEVER stored inline in the JSONL.
+
+## Usage
+
+```bash
+echo '{"task_id": "fix-pr-42", "type": "engineer", "description": "...",
+       "started_at": "2026-05-09T12:00:00Z", "chat_id": 12345,
+       "subagent_type": "lobster-engineer", "status": "running",
+       "prompt": "---\\ntask_id: fix-pr-42\\n..."}' | uv run scripts/save-inflight-prompt.py
+```
+
+## Input (JSON on stdin)
+
+Required fields:
+  task_id   — unique identifier for this subagent task
+  status    — "running" (this script is only called on spawn; "done" entries are
+              written by the dispatcher inline as before)
+
+Optional fields:
+  type          — task type label (e.g. "engineer", "reviewer")
+  description   — brief human-readable description
+  started_at    — ISO UTC timestamp (e.g. "2026-05-09T12:00:00Z")
+  chat_id       — originating chat ID (0 for system tasks)
+  subagent_type — the subagent type passed to the Agent tool
+  prompt        — full prompt text (may be multi-line, any encoding)
+
+## Output
+
+Exit 0 on success. Non-zero on fatal error (missing required fields, invalid
+JSON). Always silent on all non-fatal errors (e.g. prompt file write failure)
+— those are logged to stderr but do not affect the JSONL append.
+
+## Environment overrides (for tests)
+
+  LOBSTER_INFLIGHT_WORK_FILE_OVERRIDE   — override the inflight-work.jsonl path
+  LOBSTER_INFLIGHT_PROMPTS_DIR_OVERRIDE — override the inflight-prompts/ dir path
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Named constants (spec-derived, not magic literals)
+# ---------------------------------------------------------------------------
+
+# Required fields that must be present in the input payload.
+REQUIRED_FIELDS: tuple[str, ...] = ("task_id", "status")
+
+# Default paths (can be overridden by env vars for testability).
+_WORKSPACE = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+
+INFLIGHT_WORK_FILE: Path = Path(
+    os.environ.get(
+        "LOBSTER_INFLIGHT_WORK_FILE_OVERRIDE",
+        str(_WORKSPACE / "data" / "inflight-work.jsonl"),
+    )
+)
+
+INFLIGHT_PROMPTS_DIR: Path = Path(
+    os.environ.get(
+        "LOBSTER_INFLIGHT_PROMPTS_DIR_OVERRIDE",
+        str(_WORKSPACE / "data" / "inflight-prompts"),
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure functions
+# ---------------------------------------------------------------------------
+
+
+def validate_payload(payload: dict) -> list[str]:
+    """Return a list of validation error messages for the input payload.
+
+    Returns an empty list if the payload is valid. Pure function — no I/O.
+    """
+    errors: list[str] = []
+    for field in REQUIRED_FIELDS:
+        if field not in payload:
+            errors.append(f"missing required field: {field!r}")
+    return errors
+
+
+def build_jsonl_entry(payload: dict, prompt_file_path: Path) -> dict:
+    """Return the JSONL entry dict for inflight-work.jsonl.
+
+    The raw prompt is NOT included — only the path to the prompt file.
+    All metadata fields from the payload are carried through.
+
+    Pure function — no I/O.
+    """
+    entry: dict = {}
+
+    # Copy all payload fields except 'prompt' (stored in a separate file).
+    for key, value in payload.items():
+        if key != "prompt":
+            entry[key] = value
+
+    # Add prompt_file field pointing to the written file.
+    entry["prompt_file"] = str(prompt_file_path)
+
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# I/O functions (isolated side effects)
+# ---------------------------------------------------------------------------
+
+
+def write_prompt_file(prompts_dir: Path, task_id: str, prompt: str) -> Path:
+    """Write the prompt text to prompts_dir/<task_id>.txt atomically.
+
+    Creates prompts_dir if it does not exist.
+    Overwrites any existing file with the same task_id (idempotent).
+    Returns the absolute path of the written file.
+
+    Raises OSError on write failure.
+    """
+    prompts_dir.mkdir(parents=True, exist_ok=True)
+    prompt_file = prompts_dir / f"{task_id}.txt"
+
+    # Atomic write: temp file in same dir + rename.
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(prompts_dir),
+        prefix=f".{task_id}-",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(prompt)
+        os.replace(tmp_path, str(prompt_file))
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+    return prompt_file.resolve()
+
+
+def append_jsonl_entry(work_file: Path, entry: dict) -> None:
+    """Append a JSON line to inflight-work.jsonl.
+
+    Creates parent directories if they do not exist.
+    Uses O_APPEND semantics — atomic for payloads < PIPE_BUF (4096 bytes).
+    Single JSONL entries are well under that limit.
+
+    Raises OSError on write failure.
+    """
+    work_file.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(entry, ensure_ascii=False) + "\n"
+    with open(work_file, "a", encoding="utf-8") as f:
+        f.write(line)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Parse stdin, write prompt file, append JSONL entry.
+
+    Returns 0 on success, 1 on invalid input, 2 on unexpected error.
+    """
+    # 1. Parse stdin as JSON.
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"[save-inflight-prompt] fatal: invalid JSON on stdin: {exc}", file=sys.stderr)
+        return 1
+
+    if not isinstance(payload, dict):
+        print(
+            f"[save-inflight-prompt] fatal: expected JSON object, got {type(payload).__name__}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # 2. Validate required fields.
+    errors = validate_payload(payload)
+    if errors:
+        for err in errors:
+            print(f"[save-inflight-prompt] fatal: {err}", file=sys.stderr)
+        return 1
+
+    task_id: str = payload["task_id"]
+    prompt: str = payload.get("prompt", "")
+
+    # 3. Write the prompt to a dedicated file (best-effort — JSONL still appended on failure).
+    prompt_file_path = INFLIGHT_PROMPTS_DIR / f"{task_id}.txt"
+    try:
+        prompt_file_path = write_prompt_file(INFLIGHT_PROMPTS_DIR, task_id, prompt)
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[save-inflight-prompt] warning: failed to write prompt file for {task_id!r}: {exc}",
+            file=sys.stderr,
+        )
+        # Continue — JSONL entry still appended with the intended path.
+        prompt_file_path = (INFLIGHT_PROMPTS_DIR / f"{task_id}.txt").resolve()
+
+    # 4. Build and append the JSONL entry.
+    entry = build_jsonl_entry(payload, prompt_file_path)
+    try:
+        append_jsonl_entry(INFLIGHT_WORK_FILE, entry)
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[save-inflight-prompt] fatal: failed to append JSONL entry for {task_id!r}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/save-inflight-prompt.py
+++ b/scripts/save-inflight-prompt.py
@@ -141,6 +141,8 @@ def write_prompt_file(prompts_dir: Path, task_id: str, prompt: str) -> Path:
 
     Raises OSError on write failure.
     """
+    if "/" in task_id or task_id.startswith("."):
+        raise ValueError(f"task_id contains path traversal characters: {task_id!r}")
     prompts_dir.mkdir(parents=True, exist_ok=True)
     prompt_file = prompts_dir / f"{task_id}.txt"
 
@@ -214,9 +216,16 @@ def main() -> int:
     prompt: str = payload.get("prompt", "")
 
     # 3. Write the prompt to a dedicated file (best-effort — JSONL still appended on failure).
+    #    ValueError (e.g. path traversal) is fatal and causes immediate exit.
     prompt_file_path = INFLIGHT_PROMPTS_DIR / f"{task_id}.txt"
     try:
         prompt_file_path = write_prompt_file(INFLIGHT_PROMPTS_DIR, task_id, prompt)
+    except ValueError as exc:
+        print(
+            f"[save-inflight-prompt] fatal: {exc}",
+            file=sys.stderr,
+        )
+        return 1
     except Exception as exc:  # noqa: BLE001
         print(
             f"[save-inflight-prompt] warning: failed to write prompt file for {task_id!r}: {exc}",

--- a/tests/unit/test_save_inflight_prompt.py
+++ b/tests/unit/test_save_inflight_prompt.py
@@ -1,0 +1,448 @@
+"""
+Unit tests for scripts/save-inflight-prompt.py (issue #1989 — Component 1).
+
+## What this file tests
+
+The save-inflight-prompt script must:
+- Accept a JSON payload on stdin: {task_id, type, description, started_at,
+  chat_id, subagent_type, status, prompt}
+- Write the prompt text to ~/lobster-workspace/data/inflight-prompts/<task_id>.txt
+- Append a JSONL entry to inflight-work.jsonl with all fields except prompt
+  replaced by a prompt_file path pointing to the written file
+- Handle the case where the inflight-prompts/ directory does not exist (create it)
+- Handle missing or blank prompt gracefully (write empty file, still append JSONL)
+- Be idempotent: if the same task_id is submitted again, overwrite the prompt
+  file and append a new JSONL entry (append-only log semantics)
+- Exit 0 on success, non-zero on fatal error (missing required fields)
+- Never crash if the prompt file write fails — still append JSONL entry with
+  prompt_file pointing to the intended path (best-effort)
+
+## Named constants (spec-derived, not magic literals)
+
+INFLIGHT_PROMPTS_DIR_NAME = "inflight-prompts"
+INFLIGHT_WORK_FILENAME = "inflight-work.jsonl"
+REQUIRED_FIELDS = ["task_id", "status"]
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Named constants matching those in the implementation
+# ---------------------------------------------------------------------------
+
+INFLIGHT_PROMPTS_DIR_NAME = "inflight-prompts"
+INFLIGHT_WORK_FILENAME = "inflight-work.jsonl"
+REQUIRED_FIELDS = ["task_id", "status"]
+
+# ---------------------------------------------------------------------------
+# Path to the script under test
+# ---------------------------------------------------------------------------
+
+_SCRIPT_PATH = Path(__file__).parents[2] / "scripts" / "save-inflight-prompt.py"
+
+
+def _run_script(payload: dict, inflight_work: Path, inflight_prompts_dir: Path) -> subprocess.CompletedProcess:
+    """Run the script with controlled file paths via env vars, payload via stdin."""
+    env = {
+        **os.environ,
+        "LOBSTER_INFLIGHT_WORK_FILE_OVERRIDE": str(inflight_work),
+        "LOBSTER_INFLIGHT_PROMPTS_DIR_OVERRIDE": str(inflight_prompts_dir),
+    }
+    return subprocess.run(
+        ["uv", "run", str(_SCRIPT_PATH)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    """Read all entries from a JSONL file, skipping blank lines."""
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tests: happy path
+# ---------------------------------------------------------------------------
+
+
+class TestSaveInflightPromptHappyPath:
+    """Tests for the normal save-inflight-prompt.py operation."""
+
+    def test_writes_prompt_to_file(self, tmp_path: Path) -> None:
+        """Prompt text is written to inflight-prompts/<task_id>.txt."""
+        work_file = tmp_path / INFLIGHT_WORK_FILENAME
+        prompts_dir = tmp_path / INFLIGHT_PROMPTS_DIR_NAME
+        payload = {
+            "task_id": "fix-pr-42",
+            "type": "engineer",
+            "description": "Fix PR #42 review comments",
+            "started_at": "2026-05-09T12:00:00Z",
+            "chat_id": 12345,
+            "subagent_type": "lobster-engineer",
+            "status": "running",
+            "prompt": "---\ntask_id: fix-pr-42\nchat_id: 12345\n---\n\nFix the bug.",
+        }
+        result = _run_script(payload, work_file, prompts_dir)
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        prompt_file = prompts_dir / "fix-pr-42.txt"
+        assert prompt_file.exists(), "Prompt file must be created"
+        assert prompt_file.read_text() == payload["prompt"], (
+            "Prompt file content must match the input prompt"
+        )
+
+    def test_appends_jsonl_entry_with_prompt_file_field(self, tmp_path: Path) -> None:
+        """The JSONL entry includes prompt_file and subagent_type, not the prompt inline."""
+        work_file = tmp_path / INFLIGHT_WORK_FILENAME
+        prompts_dir = tmp_path / INFLIGHT_PROMPTS_DIR_NAME
+        payload = {
+            "task_id": "fix-pr-42",
+            "type": "engineer",
+            "description": "Fix PR #42",
+            "started_at": "2026-05-09T12:00:00Z",
+            "chat_id": 12345,
+            "subagent_type": "lobster-engineer",
+            "status": "running",
+            "prompt": "Do the task.",
+        }
+        result = _run_script(payload, work_file, prompts_dir)
+        assert result.returncode == 0
+
+        entries = _read_jsonl(work_file)
+        assert len(entries) == 1, "Exactly one JSONL entry must be appended"
+
+        entry = entries[0]
+        assert entry["task_id"] == "fix-pr-42"
+        assert entry["status"] == "running"
+        assert entry["subagent_type"] == "lobster-engineer"
+        assert "prompt_file" in entry, "Entry must contain prompt_file field"
+        assert "fix-pr-42.txt" in entry["prompt_file"], (
+            "prompt_file must point to the task-specific file"
+        )
+        assert "prompt" not in entry, "Raw prompt must NOT be stored inline in the JSONL entry"
+
+    def test_does_not_store_prompt_inline_in_jsonl(self, tmp_path: Path) -> None:
+        """The raw prompt must not appear in the JSONL entry — only prompt_file."""
+        work_file = tmp_path / INFLIGHT_WORK_FILENAME
+        prompts_dir = tmp_path / INFLIGHT_PROMPTS_DIR_NAME
+        payload = {
+            "task_id": "check-task",
+            "type": "research",
+            "description": "Check something",
+            "started_at": "2026-05-09T12:00:00Z",
+            "chat_id": 0,
+            "subagent_type": "lobster-generalist",
+            "status": "running",
+            "prompt": "SECRET_CONTENT_12345",
+        }
+        result = _run_script(payload, work_file, prompts_dir)
+        assert result.returncode == 0
+
+        raw_content = work_file.read_text()
+        assert "SECRET_CONTENT_12345" not in raw_content, (
+            "Prompt text must not appear verbatim in inflight-work.jsonl"
+        )
+
+    def test_creates_inflight_prompts_dir_if_absent(self, tmp_path: Path) -> None:
+        """inflight-prompts/ directory is created if it does not exist."""
+        work_file = tmp_path / INFLIGHT_WORK_FILENAME
+        prompts_dir = tmp_path / "nonexistent-dir" / INFLIGHT_PROMPTS_DIR_NAME
+        payload = {
+            "task_id": "new-task",
+            "type": "engineer",
+            "description": "A task",
+            "started_at": "2026-05-09T12:00:00Z",
+            "chat_id": 0,
+            "subagent_type": "lobster-engineer",
+            "status": "running",
+            "prompt": "Do the thing.",
+        }
+        result = _run_script(payload, work_file, prompts_dir)
+        assert result.returncode == 0
+        assert prompts_dir.exists(), "Directory must be created if absent"
+        assert (prompts_dir / "new-task.txt").exists()
+
+    def test_creates_inflight_work_jsonl_if_absent(self, tmp_path: Path) -> None:
+        """inflight-work.jsonl is created (appended to) even if it does not exist."""
+        work_file = tmp_path / INFLIGHT_WORK_FILENAME
+        prompts_dir = tmp_path / INFLIGHT_PROMPTS_DIR_NAME
+        assert not work_file.exists()
+
+        payload = {
+            "task_id": "first-task",
+            "type": "engineer",
+            "description": "First",
+            "started_at": "2026-05-09T12:00:00Z",
+            "chat_id": 99,
+            "subagent_type": "lobster-engineer",
+            "status": "running",
+            "prompt": "Hello.",
+        }
+        result = _run_script(payload, work_file, prompts_dir)
+        assert result.returncode == 0
+        assert work_file.exists(), "inflight-work.jsonl must be created on first write"
+        entries = _read_jsonl(work_file)
+        assert len(entries) == 1
+
+    def test_preserves_all_metadata_fields_in_jsonl(self, tmp_path: Path) -> None:
+        """task_id, type, description, started_at, chat_id, status are all in the JSONL entry."""
+        work_file = tmp_path / INFLIGHT_WORK_FILENAME
+        prompts_dir = tmp_path / INFLIGHT_PROMPTS_DIR_NAME
+        payload = {
+            "task_id": "full-task",
+            "type": "reviewer",
+            "description": "Review the PR",
+            "started_at": "2026-05-09T14:30:00Z",
+            "chat_id": 8305714125,
+            "subagent_type": "review",
+            "status": "running",
+            "prompt": "Review PR #55.",
+        }
+        result = _run_script(payload, work_file, prompts_dir)
+        assert result.returncode == 0
+
+        entry = _read_jsonl(work_file)[0]
+        assert entry["task_id"] == "full-task"
+        assert entry["type"] == "reviewer"
+        assert entry["description"] == "Review the PR"
+        assert entry["started_at"] == "2026-05-09T14:30:00Z"
+        assert entry["chat_id"] == 8305714125
+        assert entry["subagent_type"] == "review"
+        assert entry["status"] == "running"
+
+    def test_multiline_prompt_written_correctly(self, tmp_path: Path) -> None:
+        """Multiline prompts (with newlines, quotes, special chars) are preserved exactly."""
+        work_file = tmp_path / INFLIGHT_WORK_FILENAME
+        prompts_dir = tmp_path / INFLIGHT_PROMPTS_DIR_NAME
+        multiline = (
+            "---\ntask_id: ml-task\nchat_id: 0\nsource: system\nbackground: true\n---\n\n"
+            'Fix the "bug" with special chars: {\'key\': \'value\'} and newlines\n'
+            "Line 2 of prompt.\n"
+            "Line 3 with unicode: — é 中文\n"
+        )
+        payload = {
+            "task_id": "ml-task",
+            "type": "engineer",
+            "description": "Multiline test",
+            "started_at": "2026-05-09T12:00:00Z",
+            "chat_id": 0,
+            "subagent_type": "lobster-engineer",
+            "status": "running",
+            "prompt": multiline,
+        }
+        result = _run_script(payload, work_file, prompts_dir)
+        assert result.returncode == 0
+
+        prompt_file = prompts_dir / "ml-task.txt"
+        assert prompt_file.read_text(encoding="utf-8") == multiline, (
+            "Multiline prompt must be written verbatim"
+        )
+
+    def test_appends_multiple_entries_to_existing_file(self, tmp_path: Path) -> None:
+        """Multiple calls append to the existing JSONL file rather than overwriting it."""
+        work_file = tmp_path / INFLIGHT_WORK_FILENAME
+        prompts_dir = tmp_path / INFLIGHT_PROMPTS_DIR_NAME
+
+        for i in range(3):
+            payload = {
+                "task_id": f"task-{i}",
+                "type": "engineer",
+                "description": f"Task {i}",
+                "started_at": "2026-05-09T12:00:00Z",
+                "chat_id": i,
+                "subagent_type": "lobster-engineer",
+                "status": "running",
+                "prompt": f"Prompt for task {i}.",
+            }
+            result = _run_script(payload, work_file, prompts_dir)
+            assert result.returncode == 0, f"Call {i} failed: {result.stderr}"
+
+        entries = _read_jsonl(work_file)
+        assert len(entries) == 3, "Three sequential calls must produce three JSONL entries"
+        task_ids = {e["task_id"] for e in entries}
+        assert task_ids == {"task-0", "task-1", "task-2"}
+
+
+# ---------------------------------------------------------------------------
+# Tests: edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestSaveInflightPromptEdgeCases:
+    """Edge case and resilience tests."""
+
+    def test_blank_prompt_writes_empty_file(self, tmp_path: Path) -> None:
+        """A blank or missing prompt writes an empty prompt file; JSONL entry still appended."""
+        work_file = tmp_path / INFLIGHT_WORK_FILENAME
+        prompts_dir = tmp_path / INFLIGHT_PROMPTS_DIR_NAME
+        payload = {
+            "task_id": "no-prompt-task",
+            "type": "engineer",
+            "description": "No prompt",
+            "started_at": "2026-05-09T12:00:00Z",
+            "chat_id": 0,
+            "subagent_type": "lobster-engineer",
+            "status": "running",
+            # prompt field absent
+        }
+        result = _run_script(payload, work_file, prompts_dir)
+        assert result.returncode == 0
+
+        entries = _read_jsonl(work_file)
+        assert len(entries) == 1, "JSONL entry must be appended even with no prompt"
+        assert entries[0]["task_id"] == "no-prompt-task"
+
+        prompt_file = prompts_dir / "no-prompt-task.txt"
+        assert prompt_file.exists(), "Prompt file must be created even for empty prompt"
+        assert prompt_file.read_text() == "", "Empty prompt writes an empty file"
+
+    def test_exits_nonzero_on_missing_task_id(self, tmp_path: Path) -> None:
+        """Missing task_id causes non-zero exit (task_id is required to name the prompt file)."""
+        work_file = tmp_path / INFLIGHT_WORK_FILENAME
+        prompts_dir = tmp_path / INFLIGHT_PROMPTS_DIR_NAME
+        payload = {
+            "type": "engineer",
+            "description": "No task_id",
+            "status": "running",
+            "prompt": "Oops.",
+        }
+        result = _run_script(payload, work_file, prompts_dir)
+        assert result.returncode != 0, "Must exit non-zero when task_id is missing"
+
+    def test_exits_nonzero_on_missing_status(self, tmp_path: Path) -> None:
+        """Missing status causes non-zero exit (status is required for JSONL semantics)."""
+        work_file = tmp_path / INFLIGHT_WORK_FILENAME
+        prompts_dir = tmp_path / INFLIGHT_PROMPTS_DIR_NAME
+        payload = {
+            "task_id": "no-status-task",
+            "type": "engineer",
+            "description": "No status",
+            "prompt": "Oops.",
+        }
+        result = _run_script(payload, work_file, prompts_dir)
+        assert result.returncode != 0, "Must exit non-zero when status is missing"
+
+    def test_overwrites_prompt_file_on_same_task_id(self, tmp_path: Path) -> None:
+        """Re-submitting the same task_id overwrites the prompt file (idempotent)."""
+        work_file = tmp_path / INFLIGHT_WORK_FILENAME
+        prompts_dir = tmp_path / INFLIGHT_PROMPTS_DIR_NAME
+
+        base_payload = {
+            "task_id": "idempotent-task",
+            "type": "engineer",
+            "description": "Idempotent task",
+            "started_at": "2026-05-09T12:00:00Z",
+            "chat_id": 0,
+            "subagent_type": "lobster-engineer",
+            "status": "running",
+        }
+
+        # First run
+        result1 = _run_script({**base_payload, "prompt": "First prompt."}, work_file, prompts_dir)
+        assert result1.returncode == 0
+
+        # Second run with same task_id
+        result2 = _run_script({**base_payload, "prompt": "Second prompt."}, work_file, prompts_dir)
+        assert result2.returncode == 0
+
+        # Prompt file has the second prompt
+        prompt_file = prompts_dir / "idempotent-task.txt"
+        assert prompt_file.read_text() == "Second prompt.", (
+            "Prompt file must be overwritten on re-submission of same task_id"
+        )
+
+        # JSONL has two entries (append-only)
+        entries = _read_jsonl(work_file)
+        assert len(entries) == 2, "Two JSONL entries are appended (append-only semantics)"
+
+    def test_exits_nonzero_on_invalid_json_stdin(self, tmp_path: Path) -> None:
+        """Invalid JSON on stdin causes non-zero exit."""
+        work_file = tmp_path / INFLIGHT_WORK_FILENAME
+        prompts_dir = tmp_path / INFLIGHT_PROMPTS_DIR_NAME
+        env = {
+            **os.environ,
+            "LOBSTER_INFLIGHT_WORK_FILE_OVERRIDE": str(work_file),
+            "LOBSTER_INFLIGHT_PROMPTS_DIR_OVERRIDE": str(prompts_dir),
+        }
+        result = subprocess.run(
+            ["uv", "run", str(_SCRIPT_PATH)],
+            input="NOT VALID JSON",
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode != 0, "Must exit non-zero on invalid JSON stdin"
+
+
+# ---------------------------------------------------------------------------
+# Tests: prompt_file path format
+# ---------------------------------------------------------------------------
+
+
+class TestPromptFilePath:
+    """Tests for the prompt_file path stored in the JSONL entry."""
+
+    def test_prompt_file_path_is_absolute(self, tmp_path: Path) -> None:
+        """prompt_file in JSONL entry must be an absolute path."""
+        work_file = tmp_path / INFLIGHT_WORK_FILENAME
+        prompts_dir = tmp_path / INFLIGHT_PROMPTS_DIR_NAME
+        payload = {
+            "task_id": "abs-path-task",
+            "type": "engineer",
+            "description": "Test",
+            "started_at": "2026-05-09T12:00:00Z",
+            "chat_id": 0,
+            "subagent_type": "lobster-engineer",
+            "status": "running",
+            "prompt": "Hello.",
+        }
+        result = _run_script(payload, work_file, prompts_dir)
+        assert result.returncode == 0
+
+        entry = _read_jsonl(work_file)[0]
+        assert Path(entry["prompt_file"]).is_absolute(), (
+            "prompt_file must be an absolute path"
+        )
+
+    def test_prompt_file_path_matches_actual_file(self, tmp_path: Path) -> None:
+        """The prompt_file path in JSONL entry must point to the actual file written."""
+        work_file = tmp_path / INFLIGHT_WORK_FILENAME
+        prompts_dir = tmp_path / INFLIGHT_PROMPTS_DIR_NAME
+        payload = {
+            "task_id": "path-check-task",
+            "type": "engineer",
+            "description": "Path check",
+            "started_at": "2026-05-09T12:00:00Z",
+            "chat_id": 0,
+            "subagent_type": "lobster-engineer",
+            "status": "running",
+            "prompt": "Prompt content.",
+        }
+        result = _run_script(payload, work_file, prompts_dir)
+        assert result.returncode == 0
+
+        entry = _read_jsonl(work_file)[0]
+        prompt_path = Path(entry["prompt_file"])
+        assert prompt_path.exists(), "prompt_file path must point to an existing file"
+        assert prompt_path.read_text() == "Prompt content.", (
+            "File at prompt_file path must contain the original prompt"
+        )

--- a/tests/unit/test_save_inflight_prompt.py
+++ b/tests/unit/test_save_inflight_prompt.py
@@ -374,6 +374,29 @@ class TestSaveInflightPromptEdgeCases:
         entries = _read_jsonl(work_file)
         assert len(entries) == 2, "Two JSONL entries are appended (append-only semantics)"
 
+    def test_path_traversal_task_id_raises(self, tmp_path: Path) -> None:
+        """A task_id containing path traversal characters must raise ValueError (non-zero exit)."""
+        work_file = tmp_path / INFLIGHT_WORK_FILENAME
+        prompts_dir = tmp_path / INFLIGHT_PROMPTS_DIR_NAME
+        payload = {
+            "task_id": "../evil",
+            "type": "engineer",
+            "description": "Traversal attempt",
+            "started_at": "2026-05-09T12:00:00Z",
+            "chat_id": 0,
+            "subagent_type": "lobster-engineer",
+            "status": "running",
+            "prompt": "evil content",
+        }
+        result = _run_script(payload, work_file, prompts_dir)
+        assert result.returncode != 0, (
+            "Must exit non-zero when task_id contains path traversal characters"
+        )
+        # No files should have been written outside the prompts_dir
+        assert not (tmp_path / "evil.txt").exists(), (
+            "Path traversal must not write outside the prompts directory"
+        )
+
     def test_exits_nonzero_on_invalid_json_stdin(self, tmp_path: Path) -> None:
         """Invalid JSON on stdin causes non-zero exit."""
         work_file = tmp_path / INFLIGHT_WORK_FILENAME


### PR DESCRIPTION
## Problem

When the dispatcher session dies, all in-flight subagents die with it. The new dispatcher has to manually figure out what was running and restart things — there is no automatic recovery. This PR implements Component 1 of issue #1989, the prerequisite for all other components.

## What was missing

The inflight-work.jsonl log tracked task metadata but not the full prompt. Without the prompt, a killed subagent cannot be relaunched — you don't know what to tell it. Shell-escaping prompts in `echo '...' >> file` commands is also unreliable for multi-line prompts with quotes, braces, and unicode.

## What this adds

**`scripts/save-inflight-prompt.py`** — a helper the dispatcher calls before each Agent spawn. It:
1. Writes the full prompt to `~/lobster-workspace/data/inflight-prompts/<task_id>.txt` (atomic write via tmp + rename)
2. Appends a JSONL entry to `inflight-work.jsonl` with `prompt_file` and `subagent_type` fields — the raw prompt is never stored inline

**`sys.dispatcher.bootup.md`** — replaces the `echo '...'` inflight write with a pipe to the script, adds the `subagent_type` field to entries, and documents the idempotency requirement: prompts must be stateless and produce similar results if relaunched 10 hours later.

**`compact-catchup.md`** — updated to surface prompt availability in the "Possibly lost subagents" section, so the dispatcher can see at a glance whether a lost subagent is recoverable.

## What this does NOT do

- No auto-restart (Component 3) — that requires this prompt persistence to be in place first
- No smart deduplication (Component 4) — explicitly deferred in the issue
- No changes to the "done" completion entries — those stay as simple echo appends

## Functional patterns used

- **Pure functions**: `validate_payload()`, `build_jsonl_entry()` — no side effects, easily testable
- **Isolated I/O**: `write_prompt_file()`, `append_jsonl_entry()` — all filesystem writes in one boundary
- **Atomic writes**: temp file + `os.replace()` for the prompt file to prevent partial writes

## Before/After

```
Before:
  echo '{"task_id": "fix-pr-42", "status": "running", ...}' >> inflight-work.jsonl
  Agent(prompt="Do the thing.", subagent_type="lobster-engineer")
  On restart: task_id known, but prompt is gone — cannot relaunch

After:
  echo '{"task_id": "fix-pr-42", ..., "prompt": "Do the thing."}' | save-inflight-prompt.py
  Writes: data/inflight-prompts/fix-pr-42.txt (full prompt)
  Appends: {"task_id": "fix-pr-42", ..., "prompt_file": "/.../fix-pr-42.txt", "subagent_type": "lobster-engineer"}
  Agent(prompt="Do the thing.", subagent_type="lobster-engineer")
  On restart: compact-catchup reads prompt_file, reports "prompt available at <path>"
```

## Tests run

- [x] `uv run pytest tests/unit/test_save_inflight_prompt.py -v` — 15 passed, 0 failed
- [x] `uv run pytest tests/unit/ -q --tb=no` — 3278 passed, 31 skipped

## Manual test

N/A — no external service calls, no systemd/cron changes, no file-system operations affecting runtime state beyond the new data/inflight-prompts/ directory (created lazily on first use).

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run (if applicable) — N/A for this change
- [x] User-visible outcome verified OR not applicable (internal data store, no user-visible output)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume (append-only JSONL + one file per task_id)
- [x] External service calls: none

Closes #1989 (Component 1 only — Components 2-4 are follow-up issues)