### PR TITLE
redesign(hooks): replace context-handoff singleton JSON with session.end EventBus append-log (#2002)

### DIFF
--- a/.claude/sys.debug.dispatcher.bootup.md
+++ b/.claude/sys.debug.dispatcher.bootup.md
@@ -55,7 +55,7 @@ Full startup sequence in debug mode (extends the base startup in
 `sys.dispatcher.bootup.md`):
 
 1. (Base) Read `handoff.md`, `_context.md`, create session file
-2. (Base) Check context-handoff.json, send warming-up notification if stale
+2. (Base) Check `events.jsonl` for the last `session.end` event (step 2c), send warming-up notification if recent
 3. **(Debug-only)** Spawn branch-check subagent (parallel with step 4)
 4. (Base) Spawn `compact-catchup` in background
 5. (Base) Call `wait_for_messages()` — enter the main loop

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -49,7 +49,9 @@ When you first start (or after reading this file), follow these steps:
 2a. Create a new session file inline (see Session File Management). Store its path as `current_session_file`. Immediately after copying the template, write the session's start timestamp and set `Messages processed: 0` and `End reason: active` — this makes the file recoverable even if the session ends before any subagent writes to it.
 2b. Call `list_rules(enabled_only=true)` to load IFTTT behavioral rules into working context.
 2c. Check `~/lobster-workspace/logs/events.jsonl` for the last `session.end` event:
-    - Read the file from the end (tail backwards) and find the last line where `event_type == "session.end"`. If no such line exists or the file is absent, treat as "no prior context".
+    - Run: `tail -n 200 ~/lobster-workspace/logs/events.jsonl | grep '"event_type": "session.end"' | tail -1`
+      Do NOT load the whole file into context — it may be very large. Use this command to extract just the last matching line.
+    - If the command returns nothing or the file is absent, treat as "no prior context".
     - Extract `payload.context_pct` and `timestamp` from the matching event. (`payload.in_flight_agents` is recorded for audit purposes but not used during restart recovery — re-queuing is handled by scanning `~/messages/processing/` directly.)
     - If **recent** (< 10 min, based on `timestamp`): read `payload.context_pct`. Notify user: "Restarted — context was at {context_pct}%. Resuming from where we left off." Re-queue any stuck messages from `~/messages/processing/`.
     - If **stale** (>= 10 min) or absent/empty: ignore.
@@ -701,7 +703,8 @@ Written by `hooks/context-monitor.py` when context window >= 70%.
    - For new user messages: ack, create_task to record, tell user "Compacting context shortly — will pick this up after."
 4. Drain in-flight agents: poll get_active_sessions() every 10s. Process arriving subagent results normally.
 5. Emit a `session.end` event to the EventBus (call `emit_event` MCP tool):
-   {"event_type": "session.end", "severity": "info", "source": "dispatcher-graceful-winddown", "payload": {"context_pct": <pct>, "in_flight_agents": <list>, "note": "Graceful wind-down"}}
+   {"event_type": "session.end", "severity": "info", "payload": {"context_pct": <pct>, "in_flight_agents": <list>, "note": "Graceful wind-down"}}
+   Note: `source` is set to `"mcp-tool"` automatically by the server for all MCP-emitted events — do not pass it in the call.
 6. Send user (use admin chat_id from config): "Context at {pct}% — entering wind-down mode. Handing off cleanly."
 7. Do NOT call wait_for_messages() again. Do not attempt to self-terminate — the dispatcher cannot exit itself. Claude Code's context compaction will end the session externally when the context window fills.
 8. mark_processed(message_id)

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -28,7 +28,7 @@ When you first start (or after reading this file), follow these steps:
 > **Note on stale agent sessions:** The `on-fresh-start.py` SessionStart hook runs automatically before your first turn and calls `agent-monitor.py --mark-failed` to clear any sessions left in "running" state. You do not need to do this manually.
 
 0. Call `session_start(agent_type="dispatcher", agent_id="lobster-dispatcher", description="Lobster dispatcher main loop", chat_id=<ADMIN_CHAT_ID>)` to register this session as the dispatcher. This clears any stale `_dispatcher_session_id` from a previous dispatcher instance and ensures all guarded MCP tools (`send_reply`, `check_inbox`, etc.) work immediately. Without this, a new dispatcher session may be blocked by a stale session ID from the previous instance.
-   - Get ADMIN_CHAT_ID from `lobster.conf` (`grep ADMIN_CHAT_ID ~/lobster-config/lobster.conf` or equivalent), or use the `chat_id` from `context-handoff.json` if available.
+   - Get ADMIN_CHAT_ID from `lobster.conf` (`grep ADMIN_CHAT_ID ~/lobster-config/lobster.conf` or equivalent).
    - This is the FIRST action before any guarded tools — must fire before step 2d.
 
 0b. **ToolSearch pre-load** — ALL MCP tools are deferred by default in Claude Code. Without schema pre-loading, the CC client's Zod validator stringifies numeric/boolean args, causing `InputValidationError: '10' is not of type 'integer'`. Call ToolSearch immediately after step 0:
@@ -48,13 +48,15 @@ When you first start (or after reading this file), follow these steps:
 2. Read `~/lobster-workspace/user-model/_context.md` if it exists — pre-computed summary of user values, preferences, and active projects. Skip if absent.
 2a. Create a new session file inline (see Session File Management). Store its path as `current_session_file`. Immediately after copying the template, write the session's start timestamp and set `Messages processed: 0` and `End reason: active` — this makes the file recoverable even if the session ends before any subagent writes to it.
 2b. Call `list_rules(enabled_only=true)` to load IFTTT behavioral rules into working context.
-2c. Check `~/lobster-workspace/data/context-handoff.json`:
-    - If **recent** (< 10 min, based on `triggered_at`): read `context_pct`, `pending_tasks`, `last_user_message`. Notify user: "Restarted — context was at {context_pct}%. Resuming from where we left off." Re-queue any stuck messages from `~/messages/processing/`. Delete the file.
-    - If **stale** (>= 10 min) or absent: ignore.
+2c. Check `~/lobster-workspace/logs/events.jsonl` for the last `session.end` event:
+    - Read the file from the end (tail backwards) and find the last line where `event_type == "session.end"`. If no such line exists or the file is absent, treat as "no prior context".
+    - Extract `payload.context_pct` and `timestamp` from the matching event. (`payload.in_flight_agents` is recorded for audit purposes but not used during restart recovery — re-queuing is handled by scanning `~/messages/processing/` directly.)
+    - If **recent** (< 10 min, based on `timestamp`): read `payload.context_pct`. Notify user: "Restarted — context was at {context_pct}%. Resuming from where we left off." Re-queue any stuck messages from `~/messages/processing/`.
+    - If **stale** (>= 10 min) or absent/empty: ignore.
 2d. **Determine startup cause** — read it from the `<!-- startup-cause: ... -->` banner injected at the top of this file by `inject-bootup-context.py`. Do not read `last-startup-cause.json` yourself; the hook already read and reset it.
     - `startup-cause: compaction` → this was a context compaction. Expect the `compact-reminder` message in the inbox. Spawn `compact-catchup` at step 4 as usual.
     - `startup-cause: restart` → this was a plain restart (systemd, external kill, or health-check). No compact-reminder will be in the inbox. Spawn `startup-catchup` at step 4 for a normal restart window.
-    - Skip if step 2c already sent a restart notification (context-handoff.json was recent).
+    - Skip if step 2c already sent a restart notification (events.jsonl had a recent session.end event).
     - **Do not use `compaction-state.json` or `last_catchup_ts` alone to determine cause** — those fields are updated by catchup subagents and will give false positives for restarts.
 
 3. **Claim any pending user messages immediately** to stop the health-check staleness clock:
@@ -698,8 +700,8 @@ Written by `hooks/context-monitor.py` when context window >= 70%.
    - Do NOT spawn new non-trivial subagents
    - For new user messages: ack, create_task to record, tell user "Compacting context shortly — will pick this up after."
 4. Drain in-flight agents: poll get_active_sessions() every 10s. Process arriving subagent results normally.
-5. Write ~/lobster-workspace/data/context-handoff.json:
-   {"triggered_at": "<iso8601>", "context_pct": <pct>, "pending_tasks": <list>, "last_user_message": "<text>", "note": "Graceful wind-down"}
+5. Emit a `session.end` event to the EventBus (call `emit_event` MCP tool):
+   {"event_type": "session.end", "severity": "info", "source": "dispatcher-graceful-winddown", "payload": {"context_pct": <pct>, "in_flight_agents": <list>, "note": "Graceful wind-down"}}
 6. Send user (use admin chat_id from config): "Context at {pct}% — entering wind-down mode. Handing off cleanly."
 7. Do NOT call wait_for_messages() again. Do not attempt to self-terminate — the dispatcher cannot exit itself. Claude Code's context compaction will end the session externally when the context window fills.
 8. mark_processed(message_id)

--- a/hooks/dispatcher-state-stop.py
+++ b/hooks/dispatcher-state-stop.py
@@ -61,8 +61,7 @@ subagent SessionStop payloads. The dispatcher session never carries agent_id.
   - agent_id present and non-empty → subagent → exit 0 immediately (no I/O).
   - agent_id absent or empty → dispatcher → proceed.
 
-This is the same approach used by thinking-heartbeat.py (PR #2007 / issue #1897).
-It eliminates the previous is_dispatcher_session() call, which added ~10ms of
+This eliminates the previous is_dispatcher_session() call, which added ~10ms of
 subprocess calls (process-tree walk) on every session stop.
 
 Why NOT is_dispatcher() or is_dispatcher_session:

--- a/hooks/dispatcher-state-stop.py
+++ b/hooks/dispatcher-state-stop.py
@@ -1,32 +1,317 @@
 #!/usr/bin/env python3
 """
-SessionStop hook: write DEAD state for dispatcher.
+SessionStop hook: write DEAD state for dispatcher and emit session.end to events.jsonl.
 
-Prototype for issue #1918 (5-state liveness machine).
+Responsibilities:
+1. Write DEAD state to dispatcher-state.json (issue #1918 — 5-state liveness machine)
+   so the health check can immediately restart.
+2. Emit a session.end LobsterEvent to ~/lobster-workspace/logs/events.jsonl when the
+   dispatcher session ends (issue #1977, redesigned in issues #2002 and v2 design).
 
-Writes DEAD state when the dispatcher session ends so the health check can
-immediately restart (rather than waiting for the heartbeat to go stale).
+## session.end event emit (issues #1977, #2002, v2 redesign)
 
-Dispatcher detection: uses is_dispatcher() from session_role.py (not
-is_dispatcher_session()) — correct for SessionStop hooks per the existing
-convention (see thinking-heartbeat.py docstring for the is_dispatcher vs
-is_dispatcher_session distinction).
+All events in the Lobster system go through the central EventBus, which writes to
+~/lobster-workspace/logs/events.jsonl. This hook emits a session.end LobsterEvent
+directly to that file rather than maintaining a separate context-handoff.jsonl.
 
-Silent on all errors.
+The graceful wind-down path (context_warning handler in sys.dispatcher.bootup.md,
+step 5) also writes to events.jsonl. The startup reader finds the last session.end
+event by scanning backwards through events.jsonl.
+
+Each session.end event payload contains:
+  - context_pct: last known context % from the session transcript (None if unavailable)
+  - in_flight_agents: list of running tasks from inflight-work.jsonl without completion
+  - note: "Stop hook session end"
+
+## LobsterEvent format (matched to event_bus.LobsterEvent.to_dict())
+
+The emitted JSON line matches the exact format produced by LobsterEvent.to_dict():
+
+  {
+    "event_type": "session.end",
+    "severity": "info",
+    "source": "dispatcher-state-stop",
+    "payload": { ... },
+    "timestamp": "<ISO 8601 UTC with timezone offset>",
+    "task_id": null,
+    "chat_id": null
+  }
+
+## Locking concern
+
+GzipRotatingFileHandler (in src/mcp/log_utils.py) uses handler.acquire() /
+handler.release() — the standard logging.Handler threading.RLock — around the stream
+write in JsonlFileListener.deliver(). This hook does NOT use the handler; it writes
+directly to the file with open(path, "a").
+
+Linux O_APPEND writes are atomic for payloads smaller than PIPE_BUF (4096 bytes on
+Linux). A single session.end JSON line is well under that limit (~200–400 bytes
+typically), so the direct append is safe and consistent with the atomicity guarantee
+Linux provides for O_APPEND writes below PIPE_BUF.
+
+There is no shared in-process handler to acquire. Each MCP server process that uses
+the handler holds its own lock, which is irrelevant to this out-of-process hook. The
+append atomicity guarantee is sufficient.
+
+## Dispatcher detection (agent_id guard)
+
+Uses the agent_id fast path from hook_input: Claude Code injects agent_id only into
+subagent SessionStop payloads. The dispatcher session never carries agent_id.
+
+  - agent_id present and non-empty → subagent → exit 0 immediately (no I/O).
+  - agent_id absent or empty → dispatcher → proceed.
+
+This is the same approach used by thinking-heartbeat.py (PR #2007 / issue #1897).
+It eliminates the previous is_dispatcher_session() call, which added ~10ms of
+subprocess calls (process-tree walk) on every session stop.
+
+Why NOT is_dispatcher() or is_dispatcher_session:
+- is_dispatcher() reads the startup-flag file, which is deleted at SessionStart by
+  inject-bootup-context.py — so it always returns False during SessionStop (issue #1958).
+- is_dispatcher_session() falls back to a process-tree walk (tmux + /proc reads), adding
+  latency and external-process dependencies that are unnecessary when agent_id is available.
+
+Fail-open behavior: if stdin is unparseable, hook_input defaults to {} — agent_id is
+absent, so the hook proceeds as if it were the dispatcher. The dispatcher cannot set
+agent_id, so an unparseable payload cannot be a subagent. This preserves the liveness
+signal during edge cases (very short sessions, abnormal stdin).
+
+Silent on all errors — must never block session stop.
 """
 
 import json
+import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 _HOOKS_DIR = Path(__file__).parent
-sys.path.insert(0, str(_HOOKS_DIR))
-
-import session_role  # noqa: E402
-
 _LOBSTER_DIR = _HOOKS_DIR.parent
 sys.path.insert(0, str(_LOBSTER_DIR / "src"))
 import state_machine  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Named constant (spec-derived, not magic literal)
+# ---------------------------------------------------------------------------
+
+# The hook_input field injected by Claude Code into subagent payloads only.
+# Absent in dispatcher payloads — used as a fast O(1) guard with no file I/O.
+AGENT_ID_FIELD = "agent_id"
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_SESSION_END_NOTE = "Stop hook session end"
+_EVENT_TYPE = "session.end"
+_EVENT_SEVERITY = "info"
+_EVENT_SOURCE = "dispatcher-state-stop"
+
+# Known model context window sizes (same table as context-monitor.py).
+# Matched by prefix so versioned IDs resolve correctly.
+_MODEL_CONTEXT_SIZES: list[tuple[str, int]] = [
+    ("claude-sonnet-4-6", 200_000),
+    ("claude-opus-4-6", 200_000),
+    ("claude-haiku-4-5", 200_000),
+]
+_DEFAULT_CONTEXT_SIZE = 200_000
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def is_subagent(hook_input: dict) -> bool:
+    """Return True if hook_input belongs to a subagent session.
+
+    Claude Code injects agent_id only into subagent SessionStop payloads.
+    The dispatcher session never carries this field.
+
+    Pure function — no file I/O, no subprocess calls, no imports.
+    """
+    return bool(hook_input.get(AGENT_ID_FIELD))
+
+
+def _model_max_context(model: str) -> int:
+    """Return the max context window size for a known model ID.
+
+    Matches by prefix to handle versioned IDs. Falls back to
+    _DEFAULT_CONTEXT_SIZE for unknown models.
+    """
+    for prefix, size in _MODEL_CONTEXT_SIZES:
+        if model.startswith(prefix):
+            return size
+    return _DEFAULT_CONTEXT_SIZE
+
+
+def _read_context_pct_from_transcript(transcript_path: str | None) -> float | None:
+    """Return the last known context usage percentage from the session transcript.
+
+    Reads the transcript JSONL file line-by-line and returns the usage % from
+    the last assistant turn that contains a usage block. Returns None if the
+    transcript is unavailable or contains no usage data.
+
+    This reuses the same logic as context-monitor.py's _read_transcript_usage
+    but is a pure standalone function to avoid coupling.
+    """
+    if not transcript_path:
+        return None
+
+    path = Path(transcript_path)
+    if not path.exists():
+        return None
+
+    last_usage: dict | None = None
+    last_model: str = "unknown"
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for raw_line in f:
+                raw_line = raw_line.strip()
+                if not raw_line:
+                    continue
+                try:
+                    obj = json.loads(raw_line)
+                except json.JSONDecodeError:
+                    continue
+
+                if obj.get("type") == "assistant":
+                    msg = obj.get("message", {})
+                    if msg.get("role") == "assistant" and "usage" in msg:
+                        last_usage = msg["usage"]
+                        last_model = msg.get("model", "unknown")
+    except OSError:
+        return None
+
+    if last_usage is None:
+        return None
+
+    input_tokens = last_usage.get("input_tokens", 0) or 0
+    cache_create = last_usage.get("cache_creation_input_tokens", 0) or 0
+    cache_read = last_usage.get("cache_read_input_tokens", 0) or 0
+    total_used = input_tokens + cache_create + cache_read
+
+    model_max = _model_max_context(last_model)
+    return (total_used / model_max) * 100.0
+
+
+def _read_in_flight_agents(inflight_path: Path) -> list[dict]:
+    """Return a list of in-flight agents from inflight-work.jsonl.
+
+    An agent is in-flight if its last status entry is "running" (not "done").
+    The log is append-only, so entries are processed in order:
+    - "running" entry: marks the task as in-flight (removes from done_ids to
+      handle retries — a new "running" after a "done" means the task was retried
+      with the same task_id and the retry is in-flight).
+    - "done" entry: marks the task as completed (removes from running dict).
+
+    The final state is determined by whichever of "running" or "done" appeared
+    last for each task_id.
+
+    Returns an empty list if the file is absent, unreadable, or has no in-flight
+    entries. Silent on all errors.
+    """
+    if not inflight_path.exists():
+        return []
+
+    try:
+        running: dict[str, dict] = {}
+        done_ids: set[str] = set()
+
+        with open(inflight_path, "r", encoding="utf-8") as f:
+            for raw_line in f:
+                raw_line = raw_line.strip()
+                if not raw_line:
+                    continue
+                try:
+                    entry = json.loads(raw_line)
+                except json.JSONDecodeError:
+                    continue
+
+                task_id = entry.get("task_id")
+                if not task_id:
+                    continue
+
+                status = entry.get("status", "")
+                if status == "done":
+                    done_ids.add(task_id)
+                    running.pop(task_id, None)
+                elif status == "running":
+                    # Remove from done_ids: a new "running" entry after a "done"
+                    # means the task was retried with the same task_id. The retry
+                    # is in-flight until its own "done" entry appears.
+                    done_ids.discard(task_id)
+                    running[task_id] = entry
+
+        # Return only tasks still in running state (not completed).
+        return list(running.values())
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _resolve_inflight_path() -> Path:
+    """Return the inflight-work.jsonl path, resolved from LOBSTER_WORKSPACE."""
+    workspace = Path(
+        os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace")
+    )
+    return workspace / "data" / "inflight-work.jsonl"
+
+
+def _resolve_events_path() -> Path:
+    """Return the events.jsonl path, resolved from LOBSTER_WORKSPACE."""
+    workspace = Path(
+        os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace")
+    )
+    return workspace / "logs" / "events.jsonl"
+
+
+def _build_session_end_event(context_pct: float | None, in_flight_agents: list[dict]) -> dict:
+    """Return a LobsterEvent dict for session.end, matching LobsterEvent.to_dict() format.
+
+    The format matches the exact field names and structure produced by
+    LobsterEvent.to_dict() in src/mcp/event_bus.py, so the startup reader can
+    parse it with the same keys.
+    """
+    return {
+        "event_type": _EVENT_TYPE,
+        "severity": _EVENT_SEVERITY,
+        "source": _EVENT_SOURCE,
+        "payload": {
+            "context_pct": context_pct,
+            "in_flight_agents": in_flight_agents,
+            "note": _SESSION_END_NOTE,
+        },
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "task_id": None,
+        "chat_id": None,
+    }
+
+
+def _emit_session_end_event(events_path: Path, event: dict) -> None:
+    """Append a session.end JSON line to events.jsonl.
+
+    Always appends — every dispatcher session end writes one record. The startup
+    reader scans backwards to find the last session.end event.
+
+    Write safety: Linux O_APPEND writes are atomic for payloads smaller than
+    PIPE_BUF (4096 bytes). A single JSON line for session.end is ~200–400 bytes,
+    well within that limit. No additional locking is needed.
+
+    Silent on all errors.
+    """
+    try:
+        events_path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(event) + "\n"
+        with open(events_path, "a", encoding="utf-8") as f:
+            f.write(line)
+    except Exception:  # noqa: BLE001
+        pass  # Never interrupt session stop
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
 
 
 def main() -> None:
@@ -35,16 +320,28 @@ def main() -> None:
     except (json.JSONDecodeError, ValueError, EOFError):
         hook_input = {}
 
-    # For SessionStop, use is_dispatcher() which checks the startup flag file.
-    # Note: by SessionStop, the flag may already have been consumed by SessionStart.
-    # Fall back to is_dispatcher_session() as a secondary check.
-    is_disp = session_role.is_dispatcher(hook_input) or session_role.is_dispatcher_session(hook_input)
-    if not is_disp:
+    # Guard: agent_id is present only in subagent SessionStop payloads.
+    # The dispatcher session never has agent_id — exit immediately for subagents.
+    # Fail-open: if stdin is unparseable, hook_input is {} — agent_id is absent,
+    # so we proceed as dispatcher. An unparseable payload cannot be a subagent.
+    if is_subagent(hook_input):
         sys.exit(0)
 
+    session_id = hook_input.get("session_id", "")
+
+    # --- 1. Write DEAD state (existing behaviour, issue #1918) ---
     try:
-        session_id = hook_input.get("session_id", "")
         state_machine.write_state(state_machine.DEAD, session_id=session_id)
+    except Exception:
+        pass
+
+    # --- 2. Emit session.end event to events.jsonl (issues #1977, #2002, v2 redesign) ---
+    try:
+        transcript_path = hook_input.get("transcript_path")
+        context_pct = _read_context_pct_from_transcript(transcript_path)
+        in_flight_agents = _read_in_flight_agents(_resolve_inflight_path())
+        event = _build_session_end_event(context_pct, in_flight_agents)
+        _emit_session_end_event(_resolve_events_path(), event)
     except Exception:
         pass
 

--- a/tests/unit/test_hooks/test_dispatcher_state_stop_handoff.py
+++ b/tests/unit/test_hooks/test_dispatcher_state_stop_handoff.py
@@ -1,0 +1,775 @@
+"""
+Unit tests for the session.end event emission added to dispatcher-state-stop.py
+(issue #1977, redesigned in issue #2002 to use events.jsonl via EventBus).
+
+The Stop hook fires whenever a dispatcher session ends — including hard context
+limits and crashes that bypass the graceful wind-down LLM path. Emitting a
+session.end LobsterEvent to events.jsonl ensures the next session always has at
+least minimal state to restart from, routed through the central EventBus.
+
+Behaviors verified:
+1. Non-dispatcher sessions (agent_id present): no entry written to events.jsonl.
+2. Dispatcher session: Stop hook always emits a session.end event to events.jsonl.
+3. Multiple dispatcher sessions: events accumulate in events.jsonl (log never truncated).
+4. context_pct populated from transcript JSONL when available.
+5. context_pct is None when transcript is unavailable or has no usage data.
+6. Required fields present: event_type, severity, source, payload, timestamp, task_id, chat_id.
+   Payload must contain: context_pct, in_flight_agents, note="Stop hook session end".
+7. event_type must be "session.end".
+8. Hook is silent on all errors (never crashes the stop sequence).
+9. Retried agents (same task_id: done then running again) appear in in_flight_agents.
+
+Named constants (spec-derived, not reverse-engineered from implementation):
+  EXPECTED_NOTE = "Stop hook session end"      # payload note field
+  EXPECTED_EVENT_TYPE = "session.end"          # LobsterEvent event_type
+  EXPECTED_SOURCE = "dispatcher-state-stop"    # LobsterEvent source
+  EVENTS_FILENAME = "events.jsonl"             # relative to logs/ in workspace
+  AGENT_ID_FIELD = "agent_id"                  # field that identifies subagent payloads
+"""
+
+import importlib.util
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Spec-derived named constants
+# ---------------------------------------------------------------------------
+
+EXPECTED_NOTE = "Stop hook session end"
+EXPECTED_EVENT_TYPE = "session.end"
+EXPECTED_SOURCE = "dispatcher-state-stop"
+EVENTS_FILENAME = "events.jsonl"
+
+# The hook_input field that Claude Code injects only into subagent payloads.
+# A non-empty value means subagent; absent or empty means dispatcher.
+AGENT_ID_FIELD = "agent_id"
+SUBAGENT_AGENT_ID = "subagent-abc-123"
+
+# Matching the context-monitor.py constants (same spec source).
+SONNET_4_6_MAX_CONTEXT = 200_000
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "dispatcher-state-stop.py"
+
+
+def _load_hook():
+    """Load dispatcher-state-stop.py as a fresh module.
+
+    Inserts src/ into sys.path so state_machine imports work.
+    """
+    src_dir = _HOOKS_DIR.parent / "src"
+    if str(src_dir) not in sys.path:
+        sys.path.insert(0, str(src_dir))
+
+    spec = importlib.util.spec_from_file_location("dispatcher_state_stop", _HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_transcript(tmp_path: Path, turns: list[dict]) -> Path:
+    """Write a transcript JSONL file for the given assistant turns."""
+    path = tmp_path / "transcript.jsonl"
+    with open(path, "w") as f:
+        for turn in turns:
+            obj = {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "model": turn.get("model", "claude-sonnet-4-6"),
+                    "usage": turn.get("usage", {}),
+                },
+            }
+            f.write(json.dumps(obj) + "\n")
+    return path
+
+
+def _make_hook_input(
+    session_id: str = "test-session",
+    transcript_path: str = "",
+    agent_id: str = "",
+) -> str:
+    """Return JSON string representing hook stdin.
+
+    Pass a non-empty agent_id to simulate a subagent SessionStop payload.
+    Leave agent_id empty (or omit) to simulate a dispatcher SessionStop payload.
+    """
+    data: dict = {"session_id": session_id}
+    if transcript_path:
+        data["transcript_path"] = transcript_path
+    if agent_id:
+        data[AGENT_ID_FIELD] = agent_id
+    return json.dumps(data)
+
+
+def _run_main(mod, monkeypatch, hook_input_json: str, workspace: Path) -> int:
+    """Call mod.main() with patched stdin and events file path.
+
+    Returns the exit code captured from sys.exit() calls.
+    The events path is injected via LOBSTER_WORKSPACE env var pointing to
+    a tmp workspace so we can inspect the written file.
+    """
+    # Patch stdin
+    monkeypatch.setattr(sys, "stdin", StringIO(hook_input_json))
+    # Point LOBSTER_WORKSPACE at a temp directory
+    monkeypatch.setenv("LOBSTER_WORKSPACE", str(workspace))
+    # Make logs/ and data/ subdirs
+    (workspace / "logs").mkdir(parents=True, exist_ok=True)
+    (workspace / "data").mkdir(parents=True, exist_ok=True)
+
+    # Patch state_machine to avoid touching real state file
+    import state_machine as sm
+    monkeypatch.setattr(sm, "write_state", lambda *a, **kw: None)
+
+    exit_code = 0
+    try:
+        mod.main()
+    except SystemExit as e:
+        exit_code = e.code or 0
+    return exit_code
+
+
+def _events_path(workspace: Path) -> Path:
+    """Return the events.jsonl path for a given workspace."""
+    return workspace / "logs" / EVENTS_FILENAME
+
+
+def _read_session_end_events(events_path: Path) -> list[dict]:
+    """Read all session.end events from events.jsonl."""
+    if not events_path.exists():
+        return []
+    lines = [l.strip() for l in events_path.read_text().splitlines() if l.strip()]
+    events = [json.loads(line) for line in lines]
+    return [e for e in events if e.get("event_type") == EXPECTED_EVENT_TYPE]
+
+
+def _read_last_session_end(events_path: Path) -> dict:
+    """Read the last session.end event from events.jsonl."""
+    events = _read_session_end_events(events_path)
+    assert events, f"Expected at least one session.end event in {events_path}"
+    return events[-1]
+
+
+def _read_all_events(events_path: Path) -> list[dict]:
+    """Read all JSON lines from events.jsonl."""
+    if not events_path.exists():
+        return []
+    lines = [l.strip() for l in events_path.read_text().splitlines() if l.strip()]
+    return [json.loads(line) for line in lines]
+
+
+# ---------------------------------------------------------------------------
+# Tests: is_subagent() pure function
+# ---------------------------------------------------------------------------
+
+
+class TestIsSubagent:
+    """is_subagent() must correctly classify dispatcher vs subagent hook inputs."""
+
+    def test_subagent_when_agent_id_present(self):
+        """Non-empty agent_id → subagent."""
+        mod = _load_hook()
+        assert mod.is_subagent({AGENT_ID_FIELD: SUBAGENT_AGENT_ID}) is True
+
+    def test_dispatcher_when_agent_id_absent(self):
+        """Missing agent_id key → dispatcher (fail-open)."""
+        mod = _load_hook()
+        assert mod.is_subagent({}) is False
+
+    def test_dispatcher_when_agent_id_empty_string(self):
+        """Empty string agent_id → treated as dispatcher (fail-open)."""
+        mod = _load_hook()
+        assert mod.is_subagent({AGENT_ID_FIELD: ""}) is False
+
+    def test_dispatcher_when_agent_id_none(self):
+        """None agent_id → treated as dispatcher (fail-open)."""
+        mod = _load_hook()
+        assert mod.is_subagent({AGENT_ID_FIELD: None}) is False
+
+    def test_agent_id_field_constant_matches_spec(self):
+        """AGENT_ID_FIELD constant must equal 'agent_id' (prevents silent rename drift)."""
+        mod = _load_hook()
+        assert mod.AGENT_ID_FIELD == "agent_id", (
+            f"AGENT_ID_FIELD must be 'agent_id', got {mod.AGENT_ID_FIELD!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: event NOT written for non-dispatcher sessions
+# ---------------------------------------------------------------------------
+
+
+class TestEventNotWrittenForNonDispatcher:
+    """Non-dispatcher sessions (agent_id present) must not write to events.jsonl."""
+
+    def test_subagent_session_writes_no_event(self, monkeypatch, tmp_path):
+        """Stop hook for a subagent session must not write a session.end event to events.jsonl."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        mod = _load_hook()
+
+        # Subagent session: agent_id is present and non-empty.
+        hook_input = _make_hook_input(agent_id=SUBAGENT_AGENT_ID)
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        session_end_events = _read_session_end_events(events_file)
+        assert len(session_end_events) == 0, (
+            "session.end must NOT be written to events.jsonl for subagent sessions"
+        )
+
+    def test_subagent_exits_zero(self, monkeypatch, tmp_path):
+        """Stop hook must exit 0 for subagent sessions without any I/O."""
+        mod = _load_hook()
+        hook_input = _make_hook_input(agent_id=SUBAGENT_AGENT_ID)
+        exit_code = _run_main(mod, monkeypatch, hook_input, tmp_path)
+        assert exit_code == 0, "Hook must exit 0 for subagent sessions"
+
+
+# ---------------------------------------------------------------------------
+# Tests: session.end always emitted for dispatcher sessions
+# ---------------------------------------------------------------------------
+
+
+class TestSessionEndEventAlwaysEmittedForDispatcher:
+    """Dispatcher sessions must always emit a session.end event to events.jsonl."""
+
+    def test_emits_event_on_dispatcher_stop(self, monkeypatch, tmp_path):
+        """Stop hook emits a session.end event to events.jsonl for dispatcher sessions."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        mod = _load_hook()
+
+        # Dispatcher session: no agent_id field.
+        hook_input = _make_hook_input(session_id="disp-001")
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        assert events_file.exists(), "events.jsonl must be created on dispatcher stop"
+        session_end_events = _read_session_end_events(events_file)
+        assert len(session_end_events) == 1, "Exactly one session.end event must be emitted on first stop"
+
+    def test_event_has_correct_event_type(self, monkeypatch, tmp_path):
+        """Emitted event must have event_type == 'session.end'."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        mod = _load_hook()
+        hook_input = _make_hook_input()
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        assert event["event_type"] == EXPECTED_EVENT_TYPE, (
+            f"event_type must be '{EXPECTED_EVENT_TYPE}', got {event['event_type']!r}"
+        )
+
+    def test_event_has_lobster_event_fields(self, monkeypatch, tmp_path):
+        """Emitted event must contain all LobsterEvent.to_dict() fields."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        mod = _load_hook()
+        hook_input = _make_hook_input()
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        # Top-level LobsterEvent fields (as produced by LobsterEvent.to_dict())
+        for field in ("event_type", "severity", "source", "payload", "timestamp", "task_id", "chat_id"):
+            assert field in event, f"LobsterEvent field '{field}' must be present in emitted event"
+
+    def test_payload_contains_required_fields(self, monkeypatch, tmp_path):
+        """Payload must contain context_pct, in_flight_agents, and note."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        mod = _load_hook()
+        hook_input = _make_hook_input()
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        payload = event["payload"]
+        assert "context_pct" in payload, "payload.context_pct field must be present"
+        assert "in_flight_agents" in payload, "payload.in_flight_agents field must be present"
+        assert "note" in payload, "payload.note field must be present"
+
+    def test_payload_note_is_stop_hook_session_end(self, monkeypatch, tmp_path):
+        """The payload.note field must equal 'Stop hook session end' exactly."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        mod = _load_hook()
+        hook_input = _make_hook_input()
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        assert event["payload"]["note"] == EXPECTED_NOTE, (
+            f"payload.note must be '{EXPECTED_NOTE}', got {event['payload']['note']!r}"
+        )
+
+    def test_event_source_is_dispatcher_state_stop(self, monkeypatch, tmp_path):
+        """The source field must be 'dispatcher-state-stop'."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        mod = _load_hook()
+        hook_input = _make_hook_input()
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        assert event["source"] == EXPECTED_SOURCE, (
+            f"source must be '{EXPECTED_SOURCE}', got {event['source']!r}"
+        )
+
+    def test_timestamp_is_valid_iso8601(self, monkeypatch, tmp_path):
+        """timestamp must be a parseable ISO 8601 UTC timestamp."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        mod = _load_hook()
+        hook_input = _make_hook_input()
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        ts = event["timestamp"]
+        # Should parse as ISO 8601. fromisoformat handles the +00:00 suffix.
+        parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        assert parsed.year >= 2024, f"timestamp year is implausibly old: {ts}"
+
+    def test_task_id_and_chat_id_are_null(self, monkeypatch, tmp_path):
+        """task_id and chat_id must be null in the emitted event."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        mod = _load_hook()
+        hook_input = _make_hook_input()
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        assert event["task_id"] is None, f"task_id must be null, got {event['task_id']!r}"
+        assert event["chat_id"] is None, f"chat_id must be null, got {event['chat_id']!r}"
+
+    def test_fail_open_empty_agent_id_treated_as_dispatcher(self, monkeypatch, tmp_path):
+        """agent_id='' (empty string) is treated as dispatcher — fail-open."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        mod = _load_hook()
+        # Pass empty string agent_id — must be treated as dispatcher.
+        hook_input = json.dumps({AGENT_ID_FIELD: "", "session_id": "disp-session"})
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        session_end_events = _read_session_end_events(events_file)
+        assert len(session_end_events) == 1, (
+            "Empty agent_id must be treated as dispatcher — session.end must be emitted"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: multiple entries accumulate (no truncation)
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleEntriesAccumulate:
+    """Multiple session ends must accumulate events in events.jsonl (no truncation)."""
+
+    def test_three_stops_produce_three_session_end_events(self, monkeypatch, tmp_path):
+        """Calling the hook three times appends three session.end events; log not truncated."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        for session_id in ["disp-001", "disp-002", "disp-003"]:
+            mod = _load_hook()
+            hook_input = _make_hook_input(session_id=session_id)
+            _run_main(mod, monkeypatch, hook_input, workspace)
+
+        session_end_events = _read_session_end_events(events_file)
+        assert len(session_end_events) == 3, (
+            f"Three session stops must produce three session.end events; got {len(session_end_events)}"
+        )
+
+    def test_last_event_is_most_recent(self, monkeypatch, tmp_path):
+        """The last session.end event reflects the most recently ended session."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        # Ensure logs/ dir exists before seeding events.jsonl.
+        events_file.parent.mkdir(parents=True, exist_ok=True)
+
+        # Pre-seed events.jsonl with an older session.end event.
+        old_event = {
+            "event_type": "session.end",
+            "severity": "info",
+            "source": "dispatcher-state-stop",
+            "payload": {"context_pct": 50.0, "in_flight_agents": [], "note": EXPECTED_NOTE},
+            "timestamp": "2026-05-07T10:00:00+00:00",
+            "task_id": None,
+            "chat_id": None,
+        }
+        with open(events_file, "a") as f:
+            f.write(json.dumps(old_event) + "\n")
+
+        mod = _load_hook()
+        hook_input = _make_hook_input(session_id="disp-new")
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        session_end_events = _read_session_end_events(events_file)
+        assert len(session_end_events) == 2, "Must have two session.end events: seeded + new"
+        # The most recent event must not be the pre-seeded one.
+        assert session_end_events[-1]["timestamp"] != old_event["timestamp"], (
+            "Last session.end event must be the most recently appended one"
+        )
+        # The old event must still be intact.
+        assert session_end_events[0]["timestamp"] == old_event["timestamp"], (
+            "Pre-seeded event must not be removed"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: context_pct from transcript
+# ---------------------------------------------------------------------------
+
+
+class TestContextPctFromTranscript:
+    """context_pct must be populated from transcript JSONL when available."""
+
+    def test_context_pct_populated_when_transcript_available(self, monkeypatch, tmp_path):
+        """context_pct is computed from the last assistant turn's token usage."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        # Build a transcript: 100k tokens out of 200k = 50%
+        transcript = _make_transcript(tmp_path, [
+            {
+                "model": "claude-sonnet-4-6",
+                "usage": {
+                    "input_tokens": 80_000,
+                    "cache_creation_input_tokens": 10_000,
+                    "cache_read_input_tokens": 10_000,
+                },
+            }
+        ])
+
+        mod = _load_hook()
+        hook_input = _make_hook_input(transcript_path=str(transcript))
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        # 100k / 200k = 50.0%
+        assert event["payload"]["context_pct"] == pytest.approx(50.0, abs=0.1), (
+            f"context_pct should be ~50.0 for 100k/200k tokens, got {event['payload']['context_pct']}"
+        )
+
+    def test_context_pct_uses_last_turn(self, monkeypatch, tmp_path):
+        """When multiple turns exist, context_pct is from the LAST assistant turn."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        # First turn: 40k / 200k = 20%. Second turn: 160k / 200k = 80%.
+        transcript = _make_transcript(tmp_path, [
+            {
+                "model": "claude-sonnet-4-6",
+                "usage": {"input_tokens": 40_000, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0},
+            },
+            {
+                "model": "claude-sonnet-4-6",
+                "usage": {"input_tokens": 160_000, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0},
+            },
+        ])
+
+        mod = _load_hook()
+        hook_input = _make_hook_input(transcript_path=str(transcript))
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        assert event["payload"]["context_pct"] == pytest.approx(80.0, abs=0.1), (
+            "context_pct must reflect the last turn, not an earlier one"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: context_pct is None when unavailable
+# ---------------------------------------------------------------------------
+
+
+class TestContextPctNullWhenUnavailable:
+    """context_pct must be None when transcript is absent or has no usage data."""
+
+    def test_context_pct_null_when_no_transcript(self, monkeypatch, tmp_path):
+        """context_pct is None when no transcript_path is provided."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        mod = _load_hook()
+        hook_input = _make_hook_input()  # no transcript_path
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        assert event["payload"]["context_pct"] is None, (
+            "context_pct must be None when transcript is unavailable"
+        )
+
+    def test_context_pct_null_when_transcript_missing_file(self, monkeypatch, tmp_path):
+        """context_pct is None when transcript_path points to a non-existent file."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        mod = _load_hook()
+        hook_input = _make_hook_input(transcript_path="/nonexistent/path/transcript.jsonl")
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        assert event["payload"]["context_pct"] is None, (
+            "context_pct must be None when transcript file does not exist"
+        )
+
+    def test_context_pct_null_when_transcript_has_no_usage(self, monkeypatch, tmp_path):
+        """context_pct is None when transcript exists but has no assistant usage blocks."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        # Write a transcript with only user turns (no assistant usage).
+        transcript_path = tmp_path / "empty_transcript.jsonl"
+        transcript_path.write_text(
+            json.dumps({"type": "user", "message": {"role": "user", "content": "hello"}}) + "\n"
+        )
+
+        mod = _load_hook()
+        hook_input = _make_hook_input(transcript_path=str(transcript_path))
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        assert event["payload"]["context_pct"] is None, (
+            "context_pct must be None when no assistant usage data is in the transcript"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers for inflight tests
+# ---------------------------------------------------------------------------
+
+
+def _make_inflight_jsonl(data_dir: Path, entries: list[dict]) -> Path:
+    """Write an inflight-work.jsonl file with the given entries."""
+    path = data_dir / "inflight-work.jsonl"
+    with open(path, "w") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Tests: in_flight_agents from inflight-work.jsonl
+# ---------------------------------------------------------------------------
+
+
+class TestInFlightAgents:
+    """in_flight_agents must be populated from inflight-work.jsonl."""
+
+    def test_in_flight_agents_empty_when_no_inflight_file(self, monkeypatch, tmp_path):
+        """in_flight_agents is an empty list when inflight-work.jsonl does not exist."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        mod = _load_hook()
+        hook_input = _make_hook_input()
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        assert event["payload"]["in_flight_agents"] == [], (
+            "in_flight_agents must be empty when inflight-work.jsonl does not exist"
+        )
+
+    def test_in_flight_agents_contains_running_without_done(self, monkeypatch, tmp_path):
+        """Running tasks without a done entry appear in in_flight_agents."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        # Write inflight-work.jsonl to the workspace/data/ dir.
+        data_dir = workspace / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        _make_inflight_jsonl(data_dir, [
+            {"task_id": "task-alpha", "type": "engineering", "status": "running",
+             "description": "Fix the thing", "started_at": "2026-05-07T23:00:00Z"},
+        ])
+
+        mod = _load_hook()
+        hook_input = _make_hook_input()
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        assert len(event["payload"]["in_flight_agents"]) == 1, (
+            "One running-without-done task must appear in in_flight_agents"
+        )
+        assert event["payload"]["in_flight_agents"][0]["task_id"] == "task-alpha"
+
+    def test_in_flight_agents_excludes_completed_tasks(self, monkeypatch, tmp_path):
+        """Tasks with a done entry are excluded from in_flight_agents."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        # task-a: running then done (completed — should be excluded)
+        # task-b: only running (in-flight — should be included)
+        data_dir = workspace / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        _make_inflight_jsonl(data_dir, [
+            {"task_id": "task-a", "type": "research", "status": "running",
+             "description": "Investigate X", "started_at": "2026-05-07T22:00:00Z"},
+            {"task_id": "task-b", "type": "engineering", "status": "running",
+             "description": "Fix Y", "started_at": "2026-05-07T23:00:00Z"},
+            {"task_id": "task-a", "completed_at": "2026-05-07T22:30:00Z", "status": "done"},
+        ])
+
+        mod = _load_hook()
+        hook_input = _make_hook_input()
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        task_ids = [a["task_id"] for a in event["payload"]["in_flight_agents"]]
+        assert "task-b" in task_ids, "task-b (running, no done) must be in in_flight_agents"
+        assert "task-a" not in task_ids, "task-a (completed) must NOT be in in_flight_agents"
+
+    def test_in_flight_agents_all_done_gives_empty_list(self, monkeypatch, tmp_path):
+        """When all tasks are completed, in_flight_agents is an empty list."""
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        data_dir = workspace / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        _make_inflight_jsonl(data_dir, [
+            {"task_id": "task-done", "type": "research", "status": "running",
+             "description": "All done", "started_at": "2026-05-07T22:00:00Z"},
+            {"task_id": "task-done", "completed_at": "2026-05-07T22:30:00Z", "status": "done"},
+        ])
+
+        mod = _load_hook()
+        hook_input = _make_hook_input()
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        assert event["payload"]["in_flight_agents"] == [], (
+            "in_flight_agents must be empty when all tasks are done"
+        )
+
+    def test_retried_agent_appears_in_flight_after_done_then_running(self, monkeypatch, tmp_path):
+        """A task that completed and was retried with the same task_id is tracked as in-flight.
+
+        Log sequence: running -> done -> running (retry). The retry is still running when
+        the session ends, so it must appear in in_flight_agents. The first done entry must
+        not permanently suppress the subsequent running entry.
+        """
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        # task-retry: first run completes, then retried with same task_id and still running.
+        data_dir = workspace / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        _make_inflight_jsonl(data_dir, [
+            {"task_id": "task-retry", "type": "engineering", "status": "running",
+             "description": "First attempt", "started_at": "2026-05-07T20:00:00Z"},
+            {"task_id": "task-retry", "completed_at": "2026-05-07T20:30:00Z", "status": "done"},
+            {"task_id": "task-retry", "type": "engineering", "status": "running",
+             "description": "Retry attempt", "started_at": "2026-05-07T21:00:00Z"},
+        ])
+
+        mod = _load_hook()
+        hook_input = _make_hook_input()
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        task_ids = [a["task_id"] for a in event["payload"]["in_flight_agents"]]
+        assert "task-retry" in task_ids, (
+            "task-retry must appear in in_flight_agents: its retry is still running"
+        )
+
+    def test_retried_agent_excluded_when_retry_also_completes(self, monkeypatch, tmp_path):
+        """A retried task that also completes is excluded from in_flight_agents.
+
+        Log sequence: running -> done -> running (retry) -> done. Both runs completed,
+        so the task must not appear in in_flight_agents.
+        """
+        workspace = tmp_path
+        events_file = _events_path(workspace)
+
+        data_dir = workspace / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        _make_inflight_jsonl(data_dir, [
+            {"task_id": "task-retry-done", "type": "engineering", "status": "running",
+             "description": "First attempt", "started_at": "2026-05-07T20:00:00Z"},
+            {"task_id": "task-retry-done", "completed_at": "2026-05-07T20:30:00Z", "status": "done"},
+            {"task_id": "task-retry-done", "type": "engineering", "status": "running",
+             "description": "Retry attempt", "started_at": "2026-05-07T21:00:00Z"},
+            {"task_id": "task-retry-done", "completed_at": "2026-05-07T21:30:00Z", "status": "done"},
+        ])
+
+        mod = _load_hook()
+        hook_input = _make_hook_input()
+        _run_main(mod, monkeypatch, hook_input, workspace)
+
+        event = _read_last_session_end(events_file)
+        task_ids = [a["task_id"] for a in event["payload"]["in_flight_agents"]]
+        assert "task-retry-done" not in task_ids, (
+            "task-retry-done must NOT appear in in_flight_agents: retry also completed"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: hook is silent on all errors
+# ---------------------------------------------------------------------------
+
+
+class TestSilentOnAllErrors:
+    """Hook must be silent on errors and never crash the stop sequence."""
+
+    def test_exits_zero_when_write_fails(self, monkeypatch, tmp_path):
+        """Hook exits 0 even if the events.jsonl write fails (read-only dir)."""
+        workspace = tmp_path
+        logs_dir = workspace / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        (workspace / "data").mkdir(parents=True, exist_ok=True)
+
+        # Make logs/ directory read-only to force write failure.
+        os.chmod(str(logs_dir), 0o555)
+
+        try:
+            mod = _load_hook()
+            hook_input = _make_hook_input()
+            exit_code = _run_main(mod, monkeypatch, hook_input, workspace)
+
+            assert exit_code == 0, "Hook must exit 0 even when events.jsonl write fails"
+        finally:
+            # Restore permissions so pytest can clean up tmp_path.
+            os.chmod(str(logs_dir), 0o755)
+
+    def test_exits_zero_with_malformed_stdin(self, monkeypatch, tmp_path):
+        """Hook exits 0 gracefully when given malformed JSON on stdin — treated as dispatcher (fail-open)."""
+        workspace = tmp_path
+
+        mod = _load_hook()
+
+        monkeypatch.setattr(sys, "stdin", StringIO("not valid json {{{"))
+        monkeypatch.setenv("LOBSTER_WORKSPACE", str(workspace))
+        (workspace / "logs").mkdir(parents=True, exist_ok=True)
+        (workspace / "data").mkdir(parents=True, exist_ok=True)
+
+        import state_machine as sm
+        monkeypatch.setattr(sm, "write_state", lambda *a, **kw: None)
+
+        exit_code = 0
+        try:
+            mod.main()
+        except SystemExit as e:
+            exit_code = e.code or 0
+
+        assert exit_code == 0, "Hook must exit 0 with malformed stdin"


### PR DESCRIPTION
🤖🦞 Lobster (engineer): redesign(hooks): replace context-handoff singleton JSON with session.end EventBus append-log

## Problem

The Stop hook wrote `context-handoff.json` using a write-if-absent singleton pattern: skip if the file exists (to preserve the graceful wind-down version). Two problems:

1. The existence check adds unnecessary branching. Since the graceful wind-down writes the file before the Stop hook fires, the check is guarding against a race that never happens in practice.
2. A singleton file loses history — each restart erases the previous record.

## What changed

**Replaced the singleton write with a log-append pattern routed through the central EventBus.** Each dispatcher session end now appends one `session.end` LobsterEvent to `~/lobster-workspace/logs/events.jsonl`. The startup reader scans backwards through `events.jsonl` to find the last `session.end` event and extracts `payload.context_pct` and `timestamp`. No separate `context-handoff.json` or `context-handoff.jsonl` file.

**Dispatcher detection** is now the `agent_id` guard: Claude Code injects `agent_id` only into subagent SessionStop payloads — a single dict lookup replaces the previous `is_dispatcher_session()` process-tree walk (~10ms, subprocess-based). The `session_role` import is removed entirely.

### Before / After

```
Before:
  Session ends → write context-handoff.json (skip if already exists)
  Startup → read context-handoff.json; delete after reading
  Dispatcher detection → is_dispatcher() or is_dispatcher_session() (process-tree walk)

After:
  Session ends → append session.end LobsterEvent to logs/events.jsonl (always)
  Startup → tail events.jsonl backwards for last event_type=="session.end"
  Dispatcher detection → hook_input.get("agent_id") — absent = dispatcher, present = subagent
```

## Changes

**`hooks/dispatcher-state-stop.py`**
- New: `is_subagent(hook_input)` pure function — O(1) dict lookup, no I/O, no imports
- New: `AGENT_ID_FIELD = "agent_id"` named constant (prevents silent rename drift)
- `_write_handoff_if_absent` → `_emit_session_end_event`: always appends to `logs/events.jsonl`
- `_build_handoff_payload` → `_build_session_end_event`: LobsterEvent format matching `LobsterEvent.to_dict()` exactly (`event_type`, `severity`, `source`, `payload`, `timestamp`, `task_id`, `chat_id`)
- `_resolve_handoff_path` → `_resolve_events_path`: points to `logs/events.jsonl`
- Removed: `session_role` import and `is_dispatcher` / `is_dispatcher_session` calls

**`.claude/sys.dispatcher.bootup.md`**
- Step 0: removed stale `context-handoff.json` fallback for ADMIN_CHAT_ID
- Step 2c: now reads `logs/events.jsonl`, scans backwards for `event_type == "session.end"`, extracts `payload.context_pct` and `timestamp`
- Step 2d: updated skip condition reference
- Context-warning handler step 5: calls `emit_event` MCP tool instead of writing a separate file

**`tests/unit/test_hooks/test_dispatcher_state_stop_handoff.py`** (new file, 31 tests)
- `TestIsSubagent`: pure function contract for `is_subagent()`
- `TestEventNotWrittenForNonDispatcher`: subagent sessions (agent_id present) produce no events
- `TestSessionEndEventAlwaysEmittedForDispatcher`: event format, all LobsterEvent fields, fail-open cases
- `TestMultipleEntriesAccumulate`: three stops → three session.end events; log never truncated
- `TestContextPctFromTranscript`: computed from last assistant turn's token usage
- `TestContextPctNullWhenUnavailable`: None when transcript absent/empty/no usage data
- `TestInFlightAgents`: running/done state tracking, retry logic (done → running again)
- `TestSilentOnAllErrors`: exit 0 on write failure, exit 0 on malformed stdin

## Functional patterns

Pure functions (`is_subagent`, `_build_session_end_event`, `_read_context_pct_from_transcript`, `_read_in_flight_agents`) with no side effects. Side effects isolated to `_emit_session_end_event`. Immutable event dict built before writing. Composition: build event → write. Named constants for all spec-derived values.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_dispatcher_state_stop_handoff.py -q` — 31 passed, 0 failed
- [x] `uv run pytest tests/unit/ -q --ignore=tests/unit/test_bisque` — 3294 passed, 31 skipped, 0 failed

## Manual test

N/A — this change is entirely within Python logic and JSONL file I/O covered by unit tests. No systemd units, cron entries, Telegram API calls, or external service calls are affected.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (pure Python + file I/O, no external services)
- [x] User-visible outcome — N/A (this is a hook internal to session lifecycle; no Telegram output)
- [x] Side-effect audit: appends one line per session end to events.jsonl; no floods, no unintended shared-state conflicts
- [x] External service calls: none

Closes #2002