### PR TITLE
fix(#1922): raise reconciler default dead-agent timeout from 30 to 90 minutes

### DIFF
--- a/scripts/agent-monitor.py
+++ b/scripts/agent-monitor.py
@@ -920,9 +920,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--threshold-minutes",
         type=float,
-        default=30.0,
+        default=90.0,
         metavar="N",
-        help="Age in minutes before a running agent is considered stale (default: 30)",
+        help="Age in minutes before a running agent is considered stale (default: 90)",
     )
     parser.add_argument(
         "--output-file-threshold-minutes",

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -2758,7 +2758,7 @@ async def list_tools() -> list[Tool]:
                         "type": "integer",
                         "description": (
                             "Expected maximum runtime in minutes. Agents older than this without "
-                            "recent output file activity can be presumed dead. Default: 30."
+                            "recent output file activity can be presumed dead. Default: 90."
                         ),
                     },
                     "idempotency": {
@@ -9743,7 +9743,7 @@ async def reconcile_agent_sessions() -> None:
       - Session in DB with status='running', scanner says 'done'
         → call session_end(..., status='completed'), enqueue Telegram notification
       - Session in DB with status='running', output file missing AND session
-        is older than its registered timeout_minutes (default 30 min) →
+        is older than its registered timeout_minutes (default 90 min) →
         call session_end(..., status='dead'), enqueue Telegram notification
       - Session in DB with status='running', file shows stop_reason=tool_use AND
         session is older than its registered timeout_minutes (default 120 min) →
@@ -9772,14 +9772,14 @@ async def reconcile_agent_sessions() -> None:
     """
     from agents.session_store import check_output_file_status, get_output_file_mtime
 
-    DEFAULT_DEAD_THRESHOLD_SECONDS = 30 * 60   # 30 minutes — fallback for missing output files
+    DEFAULT_DEAD_THRESHOLD_SECONDS = 90 * 60   # 90 minutes — fallback for missing output files (raised from 30 in issue #1922)
     DEFAULT_DEAD_THRESHOLD_RUNNING_SECONDS = 120 * 60  # 120 minutes — fallback for stuck tool_use files
     GRACE_PERIOD_SECONDS = 30          # Newly spawned agents get grace before DEAD
     # Mtime staleness gate (issue #868): if output file hasn't been written to in
     # this many seconds, treat the agent as interrupted rather than actively running.
     # An active agent updates its JSONL output continuously; an interrupted one stops
     # immediately. 15 minutes gives ample margin to avoid false positives during slow
-    # tool calls, while cutting the misclassification window from 120 min → 30 min.
+    # tool calls, while cutting the misclassification window from 120 min → 90 min.
     MTIME_STALE_THRESHOLD_SECONDS = 15 * 60    # 15 minutes
 
     # Startup sweep: re-send notifications for sessions that completed while down

--- a/tests/unit/test_mcp_server/test_reconciler_default_timeout.py
+++ b/tests/unit/test_mcp_server/test_reconciler_default_timeout.py
@@ -1,0 +1,191 @@
+"""
+Unit tests for reconciler default timeout change (issue #1922).
+
+The global default timeout for missing output files was raised from 30 minutes
+to 90 minutes. Long-running tasks such as Docker builds and complex
+multi-step implementations were being killed prematurely at the 30-minute mark.
+
+These tests verify the new defaults in isolation using pure functions that
+mirror the threshold-computation logic in reconcile_agent_sessions().
+
+Key behaviors tested:
+  - The "missing output file" default is now 90 minutes (was 30)
+  - The "running tool_use" default remains 120 minutes (unchanged)
+  - Per-session timeout_minutes overrides still work (medium-term feature)
+  - The floor for the missing-file branch is now 90 minutes (was 30)
+  - A long-running legitimate task at 45 minutes is no longer killed
+"""
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Constants — mirror reconcile_agent_sessions() in inbox_server.py
+# These must be kept in sync with the server-side constants.
+# ---------------------------------------------------------------------------
+
+# New defaults after issue #1922 fix
+DEFAULT_DEAD_THRESHOLD_SECONDS = 90 * 60          # 90 minutes (raised from 30)
+DEFAULT_DEAD_THRESHOLD_RUNNING_SECONDS = 120 * 60  # 120 minutes (unchanged)
+GRACE_PERIOD_SECONDS = 30
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — mirror the threshold logic in reconcile_agent_sessions()
+# ---------------------------------------------------------------------------
+
+
+def compute_thresholds(timeout_minutes: int | None) -> tuple[int, int]:
+    """Return (dead_threshold_running, dead_threshold_missing) for a session.
+
+    Pure function — no side effects.
+    """
+    if timeout_minutes is not None:
+        dead_threshold_running = timeout_minutes * 60
+        dead_threshold_missing = max(timeout_minutes * 60, DEFAULT_DEAD_THRESHOLD_SECONDS)
+    else:
+        dead_threshold_running = DEFAULT_DEAD_THRESHOLD_RUNNING_SECONDS
+        dead_threshold_missing = DEFAULT_DEAD_THRESHOLD_SECONDS
+    return dead_threshold_running, dead_threshold_missing
+
+
+def is_dead_running(elapsed: int, timeout_minutes: int | None) -> bool:
+    """True when a running (tool_use) session should be marked dead."""
+    running_threshold, _ = compute_thresholds(timeout_minutes)
+    return elapsed > running_threshold
+
+
+def is_dead_missing(elapsed: int, timeout_minutes: int | None) -> bool:
+    """True when a session with a missing output file should be marked dead."""
+    _, missing_threshold = compute_thresholds(timeout_minutes)
+    return elapsed >= GRACE_PERIOD_SECONDS and elapsed > missing_threshold
+
+
+# ---------------------------------------------------------------------------
+# Tests: the specific bug from issue #1922
+# ---------------------------------------------------------------------------
+
+
+class TestLongRunningTaskNotKilledPrematurely:
+    """Verify the concrete issue: a long-running task is not killed at 30 min."""
+
+    def test_docker_build_at_45_minutes_is_alive(self):
+        """docker-telegram-test-setup at 45 min must not be killed (was killed before fix)."""
+        assert not is_dead_missing(elapsed=45 * 60, timeout_minutes=None)
+
+    def test_docker_build_at_60_minutes_is_alive(self):
+        """Docker build at 60 minutes is within the new 90-minute default."""
+        assert not is_dead_missing(elapsed=60 * 60, timeout_minutes=None)
+
+    def test_task_at_89_minutes_is_alive(self):
+        """Task at 89 minutes is just below the 90-minute default."""
+        assert not is_dead_missing(elapsed=89 * 60, timeout_minutes=None)
+
+    def test_task_at_91_minutes_is_dead(self):
+        """Task at 91 minutes is past the 90-minute default — should be dead."""
+        assert is_dead_missing(elapsed=91 * 60, timeout_minutes=None)
+
+    def test_task_at_exactly_90_minutes_is_alive(self):
+        """Boundary: exactly at 90-minute threshold is NOT yet dead (strict >)."""
+        assert not is_dead_missing(elapsed=90 * 60, timeout_minutes=None)
+
+
+class TestOldDefaultNoLongerKills:
+    """Cases that were dead under the old 30-minute default are now alive."""
+
+    def test_31_minutes_elapsed_no_longer_dead(self):
+        """Under old default: 31 min → dead. Under new default: 31 min → alive."""
+        assert not is_dead_missing(elapsed=31 * 60, timeout_minutes=None)
+
+    def test_50_minutes_elapsed_no_longer_dead(self):
+        """Under old default: 50 min → dead. Under new default: 50 min → alive."""
+        assert not is_dead_missing(elapsed=50 * 60, timeout_minutes=None)
+
+    def test_89_minutes_elapsed_no_longer_dead(self):
+        """Under old default: 89 min → dead. Under new default: 89 min → alive."""
+        assert not is_dead_missing(elapsed=89 * 60, timeout_minutes=None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: new default values are correct
+# ---------------------------------------------------------------------------
+
+
+class TestNewDefaultValues:
+    """The new default thresholds have the expected numeric values."""
+
+    def test_default_missing_threshold_is_90_minutes(self):
+        _, missing_threshold = compute_thresholds(timeout_minutes=None)
+        assert missing_threshold == 90 * 60, (
+            f"Expected 90 * 60 = {90 * 60}, got {missing_threshold}. "
+            "The missing-file threshold was raised from 30 to 90 minutes in issue #1922."
+        )
+
+    def test_default_running_threshold_unchanged_at_120_minutes(self):
+        running_threshold, _ = compute_thresholds(timeout_minutes=None)
+        assert running_threshold == 120 * 60, (
+            f"Expected 120 * 60 = {120 * 60}, got {running_threshold}. "
+            "The running threshold should remain at 120 minutes."
+        )
+
+    def test_floor_for_missing_file_is_now_90_minutes(self):
+        """When timeout_minutes is set but very small, floor is now 90 min."""
+        _, missing_thresh = compute_thresholds(timeout_minutes=5)
+        assert missing_thresh == DEFAULT_DEAD_THRESHOLD_SECONDS  # 90 min floor
+
+
+# ---------------------------------------------------------------------------
+# Tests: per-session timeout_minutes override still works (medium-term feature)
+# ---------------------------------------------------------------------------
+
+
+class TestPerSessionTimeoutOverride:
+    """timeout_minutes registered at spawn time still overrides the default."""
+
+    def test_long_running_agent_respects_registered_timeout(self):
+        """Agent registered for 240 minutes at 180 minutes → alive."""
+        assert not is_dead_running(elapsed=180 * 60, timeout_minutes=240)
+
+    def test_long_running_agent_dead_after_registered_timeout(self):
+        """Agent registered for 240 minutes at 241 minutes → dead."""
+        assert is_dead_running(elapsed=241 * 60, timeout_minutes=240)
+
+    def test_short_registered_timeout_still_kills_running(self):
+        """Agent registered for 10 minutes at 11 minutes → dead."""
+        assert is_dead_running(elapsed=11 * 60, timeout_minutes=10)
+
+    def test_short_registered_timeout_floored_at_90_min_for_missing(self):
+        """Agent with 10-minute timeout: missing floor is now 90 min.
+        At 11 min: alive (below 90-minute floor).
+        """
+        assert not is_dead_missing(elapsed=11 * 60, timeout_minutes=10)
+
+    def test_large_registered_timeout_not_floored(self):
+        """Agent registered for 120 minutes: missing threshold uses registered value."""
+        _, missing_thresh = compute_thresholds(timeout_minutes=120)
+        assert missing_thresh == 120 * 60  # 120 min >= 90 min floor, no floor applied
+
+    def test_registered_timeout_below_90_floored(self):
+        """Agent registered for 60 minutes: missing threshold floored at 90 min."""
+        _, missing_thresh = compute_thresholds(timeout_minutes=60)
+        assert missing_thresh == DEFAULT_DEAD_THRESHOLD_SECONDS  # floor at 90 min
+
+    def test_registered_timeout_above_90_not_floored(self):
+        """Agent registered for 91 minutes: missing threshold is 91 min (no floor)."""
+        _, missing_thresh = compute_thresholds(timeout_minutes=91)
+        assert missing_thresh == 91 * 60
+
+
+# ---------------------------------------------------------------------------
+# Tests: grace period is unaffected
+# ---------------------------------------------------------------------------
+
+
+class TestGracePeriodUnchanged:
+    """The GRACE_PERIOD_SECONDS (30 seconds) is not changed by this fix."""
+
+    def test_within_grace_period_always_alive(self):
+        assert not is_dead_missing(elapsed=10, timeout_minutes=None)
+
+    def test_elapsed_zero_is_alive(self):
+        assert not is_dead_missing(elapsed=0, timeout_minutes=None)

--- a/tests/unit/test_mcp_server/test_reconciler_mtime_gate.py
+++ b/tests/unit/test_mcp_server/test_reconciler_mtime_gate.py
@@ -5,8 +5,8 @@ When a Claude Code agent is interrupted mid-turn, it writes no ``stop_reason``
 to its output JSONL file, so ``check_output_file_status()`` returns "running"
 — indistinguishable from a legitimately active agent.  The mtime gate closes
 this gap: if the output file has been idle for MTIME_STALE_THRESHOLD_SECONDS,
-the reconciler uses the shorter "missing file" threshold (30 min) instead of
-the generous "running" threshold (120 min).
+the reconciler uses the shorter "missing file" threshold (90 min, raised from
+30 in issue #1922) instead of the generous "running" threshold (120 min).
 
 Strategy: extract the pure threshold-selection logic into standalone functions
 and test all branching cases without instantiating the async reconciler or the
@@ -20,7 +20,7 @@ import pytest
 # Constants — mirror reconcile_agent_sessions() in inbox_server.py
 # ---------------------------------------------------------------------------
 
-DEFAULT_DEAD_THRESHOLD_SECONDS = 30 * 60          # 30 minutes
+DEFAULT_DEAD_THRESHOLD_SECONDS = 90 * 60          # 90 minutes (raised from 30 in issue #1922)
 DEFAULT_DEAD_THRESHOLD_RUNNING_SECONDS = 120 * 60  # 120 minutes
 MTIME_STALE_THRESHOLD_SECONDS = 15 * 60           # 15 minutes
 
@@ -119,21 +119,21 @@ class TestEffectiveRunningThreshold:
 
     def test_stale_file_uses_short_threshold_default(self):
         threshold = effective_running_threshold(file_is_stale=True, timeout_minutes=None)
-        assert threshold == DEFAULT_DEAD_THRESHOLD_SECONDS  # 30 min
+        assert threshold == DEFAULT_DEAD_THRESHOLD_SECONDS  # 90 min
 
     def test_fresh_file_uses_registered_timeout(self):
         threshold = effective_running_threshold(file_is_stale=False, timeout_minutes=240)
         assert threshold == 240 * 60
 
     def test_stale_file_with_registered_timeout_uses_missing_threshold(self):
-        # For a 240-minute agent, the "missing" threshold is max(240*60, 30*60) = 240*60
+        # For a 240-minute agent, the "missing" threshold is max(240*60, 90*60) = 240*60
         threshold = effective_running_threshold(file_is_stale=True, timeout_minutes=240)
         assert threshold == 240 * 60
 
-    def test_stale_file_with_short_timeout_floored_at_30_min(self):
-        # For a 5-minute agent, missing threshold is floored at 30 min
+    def test_stale_file_with_short_timeout_floored_at_90_min(self):
+        # For a 5-minute agent, missing threshold is floored at 90 min (raised from 30 in issue #1922)
         threshold = effective_running_threshold(file_is_stale=True, timeout_minutes=5)
-        assert threshold == DEFAULT_DEAD_THRESHOLD_SECONDS  # 30 min floor
+        assert threshold == DEFAULT_DEAD_THRESHOLD_SECONDS  # 90 min floor
 
 
 # ---------------------------------------------------------------------------
@@ -142,18 +142,31 @@ class TestEffectiveRunningThreshold:
 
 
 class TestMtimeGateBugFix:
-    """Verify the exact bug described in issue #868 is fixed."""
+    """Verify the exact bug described in issue #868 is fixed.
+
+    Note: the stale-file fallback threshold was raised from 30 to 90 minutes in
+    issue #1922. Tests updated to reflect the new boundary.
+    """
 
     NOW = 1_000_000.0
 
-    def test_interrupted_agent_at_35min_is_now_dead(self):
+    def test_interrupted_agent_at_91min_is_dead(self):
         """
-        Before the fix: interrupted agent at 35 min → alive (120-min threshold).
-        After the fix: stale mtime → use 30-min threshold → 35 min > 30 min → dead.
+        Before issue #1922: 30-min threshold. After: 90-min threshold.
+        Stale mtime → use 90-min threshold → 91 min > 90 min → dead.
+        """
+        elapsed = 91 * 60
+        stale_mtime = self.NOW - 20 * 60  # file idle 20 minutes
+        assert should_kill_running_session(elapsed, stale_mtime, self.NOW, None)
+
+    def test_interrupted_agent_at_35min_is_alive(self):
+        """
+        After issue #1922: stale-file threshold raised to 90 min.
+        Interrupted agent at 35 min with stale file → alive (35 < 90).
         """
         elapsed = 35 * 60
         stale_mtime = self.NOW - 20 * 60  # file idle 20 minutes
-        assert should_kill_running_session(elapsed, stale_mtime, self.NOW, None)
+        assert not should_kill_running_session(elapsed, stale_mtime, self.NOW, None)
 
     def test_live_agent_at_35min_is_still_alive(self):
         """
@@ -163,15 +176,15 @@ class TestMtimeGateBugFix:
         fresh_mtime = self.NOW - 2 * 60  # file updated 2 minutes ago
         assert not should_kill_running_session(elapsed, fresh_mtime, self.NOW, None)
 
-    def test_interrupted_agent_just_crossed_30min_is_dead(self):
-        """31 minutes elapsed, file idle 20 minutes → dead (just past short threshold)."""
-        elapsed = 31 * 60
+    def test_interrupted_agent_just_crossed_90min_is_dead(self):
+        """91 minutes elapsed, file idle 20 minutes → dead (just past new 90-min threshold)."""
+        elapsed = 91 * 60
         stale_mtime = self.NOW - 20 * 60
         assert should_kill_running_session(elapsed, stale_mtime, self.NOW, None)
 
-    def test_interrupted_agent_at_29min_is_still_alive(self):
-        """29 minutes elapsed, file idle 20 minutes → alive (below 30-min threshold)."""
-        elapsed = 29 * 60
+    def test_interrupted_agent_at_89min_is_still_alive(self):
+        """89 minutes elapsed, file idle 20 minutes → alive (below 90-min threshold)."""
+        elapsed = 89 * 60
         stale_mtime = self.NOW - 20 * 60
         assert not should_kill_running_session(elapsed, stale_mtime, self.NOW, None)
 
@@ -193,9 +206,9 @@ class TestMtimeGateBugFix:
     def test_interrupted_agent_with_registered_timeout_at_35min_dead(self):
         """
         Agent registered for 240-minute timeout, interrupted at 35 min.
-        Stale file collapses threshold to max(240*60, 30*60) = 240*60 … wait.
+        Stale file collapses threshold to max(240*60, 90*60) = 240*60.
 
-        For a 240-minute timeout, the "missing file" threshold = 240 min, not 30 min.
+        For a 240-minute timeout, the "missing file" threshold = 240 min.
         So 35 min is still alive — the floor only applies to *short* timeouts.
         (This is correct: a long-registered agent gets its full window even when stale.)
         """
@@ -204,13 +217,13 @@ class TestMtimeGateBugFix:
         # 240-minute agent: even stale, threshold is 240*60; 35 min < 240 min → alive
         assert not should_kill_running_session(elapsed, stale_mtime, self.NOW, 240)
 
-    def test_interrupted_agent_with_short_timeout_stale_uses_30min_floor(self):
+    def test_interrupted_agent_with_short_timeout_stale_uses_90min_floor(self):
         """
-        Agent registered for 5 minutes, interrupted at 35 min.
-        Stale file triggers missing threshold = max(5*60, 30*60) = 30 min.
-        35 min > 30 min → dead.
+        Agent registered for 5 minutes, interrupted at 95 min.
+        Stale file triggers missing threshold = max(5*60, 90*60) = 90 min.
+        95 min > 90 min → dead.
         """
-        elapsed = 35 * 60
+        elapsed = 95 * 60
         stale_mtime = self.NOW - 20 * 60
         assert should_kill_running_session(elapsed, stale_mtime, self.NOW, 5)
 

--- a/tests/unit/test_mcp_server/test_reconciler_timeout.py
+++ b/tests/unit/test_mcp_server/test_reconciler_timeout.py
@@ -15,6 +15,9 @@ The reconciler loop itself is an async function with side effects (DB writes,
 wire-server notifications); testing it end-to-end would require mocking the
 entire inbox_server module. These tests exercise the threshold logic in
 isolation, which is the changed code.
+
+Note: DEFAULT_DEAD_THRESHOLD_SECONDS was raised from 30 to 90 minutes in
+issue #1922 to prevent premature kills of long-running tasks (Docker builds, etc.).
 """
 
 import pytest
@@ -24,7 +27,7 @@ import pytest
 # Pure helper — mirrors the threshold computation in reconcile_agent_sessions()
 # ---------------------------------------------------------------------------
 
-DEFAULT_DEAD_THRESHOLD_SECONDS = 30 * 60        # 30 minutes
+DEFAULT_DEAD_THRESHOLD_SECONDS = 90 * 60        # 90 minutes (raised from 30 in issue #1922)
 DEFAULT_DEAD_THRESHOLD_RUNNING_SECONDS = 120 * 60  # 120 minutes
 GRACE_PERIOD_SECONDS = 30
 
@@ -78,12 +81,12 @@ class TestDefaultThresholds:
         assert not is_dead_running(elapsed=120 * 60, timeout_minutes=None)
 
     def test_missing_alive_under_default(self):
-        # 20 minutes elapsed — below 30-minute default, not dead
-        assert not is_dead_missing(elapsed=20 * 60, timeout_minutes=None)
+        # 60 minutes elapsed — below 90-minute default, not dead
+        assert not is_dead_missing(elapsed=60 * 60, timeout_minutes=None)
 
     def test_missing_dead_over_default(self):
-        # 31 minutes elapsed — above 30-minute default, dead
-        assert is_dead_missing(elapsed=31 * 60, timeout_minutes=None)
+        # 91 minutes elapsed — above 90-minute default, dead
+        assert is_dead_missing(elapsed=91 * 60, timeout_minutes=None)
 
     def test_missing_within_grace_period_is_alive(self):
         # 10 seconds elapsed — inside grace period, never dead
@@ -112,24 +115,24 @@ class TestRegisteredTimeoutRespected:
 
     def test_short_timeout_respected_for_missing(self):
         # Agent registered for 10 minutes; elapsed = 11 minutes, but floor
-        # means missing threshold = max(10*60, 30*60) = 30 minutes.
+        # means missing threshold = max(10*60, 90*60) = 90 minutes.
         # At 11 min: NOT dead (below floor).
         assert not is_dead_missing(elapsed=11 * 60, timeout_minutes=10)
 
     def test_floor_prevents_premature_kill_for_missing(self):
-        # timeout_minutes=5 is very short; missing threshold is floored at 30 min.
+        # timeout_minutes=5 is very short; missing threshold is floored at 90 min.
         # At 6 minutes elapsed: not dead.
         assert not is_dead_missing(elapsed=6 * 60, timeout_minutes=5)
 
     def test_missing_threshold_floored_at_default(self):
         running_thresh, missing_thresh = compute_thresholds(timeout_minutes=5)
         assert running_thresh == 5 * 60       # running uses raw timeout
-        assert missing_thresh == DEFAULT_DEAD_THRESHOLD_SECONDS  # floor kicks in
+        assert missing_thresh == DEFAULT_DEAD_THRESHOLD_SECONDS  # floor kicks in at 90 min
 
     def test_missing_threshold_not_floored_when_large(self):
-        running_thresh, missing_thresh = compute_thresholds(timeout_minutes=60)
-        assert running_thresh == 60 * 60
-        assert missing_thresh == 60 * 60  # 60 min >= 30 min floor, no floor needed
+        running_thresh, missing_thresh = compute_thresholds(timeout_minutes=120)
+        assert running_thresh == 120 * 60
+        assert missing_thresh == 120 * 60  # 120 min >= 90 min floor, no floor needed
 
     def test_old_hard_cap_no_longer_applies(self):
         # The old bug: 61 minutes would kill even a 240-minute agent.


### PR DESCRIPTION
🤖🦞 Lobster (engineer): Raise reconciler default timeout from 30 to 90 minutes.

## Why this change exists

Background agents with no registered `timeout_minutes` were being killed at the 30-minute mark regardless of whether they were actively making progress. The `docker-telegram-test-setup` task from the issue was mid-execution when the reconciler silently marked it dead and the dispatcher received a dead-agent notification. The caller had no way to signal that the task was expected to run longer.

The 30-minute default was set for responsiveness (detect truly stuck agents quickly), but the result was that any legitimately long-running work — Docker builds, multi-step implementations, complex setup scripts — was killed prematurely.

## What changed

**`src/mcp/inbox_server.py`** — reconciler's `reconcile_agent_sessions()`:
- `DEFAULT_DEAD_THRESHOLD_SECONDS` raised from `30 * 60` to `90 * 60`. This is the fallback for sessions where the output file is missing (no output file registered, or output file absent on disk).
- The floor for the per-session missing-file branch also raises accordingly: sessions registered with `timeout_minutes < 90` get at least 90 minutes before being marked dead for a missing output file.
- Docstring updated: "default 30 min" → "default 90 min".
- Comment on mtime gate updated: "120 min → 30 min" → "120 min → 90 min".

**`scripts/agent-monitor.py`** — standalone ghost detector:
- `--threshold-minutes` default raised from `30.0` to `90.0` to stay consistent with the reconciler.

**`src/mcp/inbox_server.py`** — `session_start` tool schema:
- `timeout_minutes` description: "Default: 30" → "Default: 90".

**What is not changed:**
- The running (tool_use) default of 120 minutes — unchanged.
- The grace period (30 seconds for newly spawned agents) — unchanged.
- The mtime stale threshold (15 minutes) — unchanged.
- Per-session `timeout_minutes` override logic — unchanged. The medium-term feature from the issue (callers declare expected runtime at spawn time) is already supported; this PR makes the default less aggressive for callers that don't declare one.

## Flow: how the threshold is applied

```
reconciler loop (every 5s):
  for each running session:
    if file_status == "missing":
      if elapsed < GRACE_PERIOD_SECONDS (30s):   → leave running
      elif elapsed > dead_threshold_missing:       → mark dead
        [dead_threshold_missing = timeout_minutes * 60 if set,
         else DEFAULT_DEAD_THRESHOLD_SECONDS (was 30min, now 90min)]
    elif file_status == "running":
      if file is stale (mtime idle > 15min):
        effective_threshold = dead_threshold_missing  ← same 90-min default
      else:
        effective_threshold = dead_threshold_running  ← 120-min default
      if elapsed > effective_threshold:            → mark dead
```

The only change is the fallback value of `DEFAULT_DEAD_THRESHOLD_SECONDS`: `30 * 60` → `90 * 60`.

## Functional patterns

Pure functions: threshold computation is a pure function of `(timeout_minutes) → (dead_threshold_running, dead_threshold_missing)`. Tests exercise this in isolation without instantiating the async reconciler. Immutable inputs — thresholds are computed from the session's registered value and system constants, never mutated.

## Tests run
- [x] `uv run pytest tests/unit/test_mcp_server/test_reconciler_timeout.py tests/unit/test_mcp_server/test_reconciler_mtime_gate.py tests/unit/test_mcp_server/test_reconciler_default_timeout.py -v` — 61 passed, 0 failed
- [x] `uv run pytest tests/ --ignore=tests/smoke/test_on_compact.py --ignore=tests/test_messages_db.py --ignore=tests/test_vps_integration.py --ignore=tests/test_whatsapp_bridge_adapter.py -q` — 3773 passed, 34 skipped, 0 failures caused by this change
- [ ] `tests/smoke/test_on_compact.py` — 6 pre-existing failures (SystemExit: 0 from missing pytest-timeout plugin in worktree venv). These pass on main: `uv run pytest tests/smoke/test_on_compact.py` → 7 passed.

## Manual test

N/A — this change is entirely internal to the reconciler loop constants. No external services, no Telegram output, no file I/O, no DB schema changes. The behavior difference is observable only when a session exceeds 30 minutes with a missing output file, at which point the reconciler will now leave it running rather than marking it dead.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A, internal constants change only
- [x] User-visible outcome verified — N/A (this prevents a bad outcome: premature kill)
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none

Closes #1922