### PR TITLE
fix(#2046): block false compact-reminder cascade via source='compact' check

### DIFF
--- a/hooks/inject-bootup-context.py
+++ b/hooks/inject-bootup-context.py
@@ -37,6 +37,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 import session_role  # noqa: E402 — path insert must precede this
+from session_role import write_dispatcher_session_id  # noqa: E402
 
 CLAUDE_DIR = Path(os.path.expanduser("~/lobster/.claude"))
 USER_CONFIG_DIR = Path(os.path.expanduser("~/lobster-user-config/agents"))
@@ -274,6 +275,17 @@ def main() -> None:
             f"[{HOOK_NAME}] startup-flag detected live PID — injecting dispatcher bootup",
             file=sys.stderr,
         )
+        # Write the dispatcher's CC session UUID so on-compact.py can confirm
+        # session identity on compact events.  CC preserves the session UUID
+        # across compactions, so this stored value remains valid for all
+        # subsequent compact events in this dispatcher run.
+        # Silent on failure — must never crash the hook.
+        if session_id and session_id != "unknown":
+            write_dispatcher_session_id(session_id)
+            print(
+                f"[{HOOK_NAME}] wrote dispatcher session ID: {session_id[:8]}...",
+                file=sys.stderr,
+            )
 
     # Read and reset last-startup-cause.json (issue #1972).
     # Always runs (both dispatcher and subagent) so the file is reset on every

--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -404,26 +404,20 @@ def _is_dispatcher_compact(data: dict) -> bool:
     2. Exact session ID match: compare hook_input['session_id'] against the stored
        dispatcher session ID in DISPATCHER_SESSION_FILE
        (~/messages/config/dispatcher-session-id).  This file is written by
-       inject-bootup-context.py at dispatcher startup (startup flag detected), and
-       updated by this function when a post-compact dispatcher is confirmed.
+       on-compact.py on the first confirmed dispatcher compaction (tier 3 path) and
+       updated on each subsequent compaction.
        Exact match → this IS the dispatcher session.
 
-    3. Post-compact fallback (session ID mismatch + explicit compact signal):
-       CC assigns a NEW session_id after compaction, so the post-compact dispatcher's
-       session ID differs from the stored pre-compact ID.  When the stored session ID
-       file exists but the IDs don't match, we only fall through to LOBSTER_MAIN_SESSION=1
-       if the hook payload contains an explicit compact signal (source='compact' or
-       hook_name='compact').  This distinguishes a real dispatcher compaction (which
-       always has the explicit compact signal) from a catchup subagent (which is NOT a
-       compact event itself — it reaches this code only via the heartbeat fallback in
-       _is_compact_event(), which fires without any source/hook_name field).
-
-       After confirming via this path, update the stored session ID to the new post-
-       compact session ID so that catchup subagents spawned later won't match.
-
-    4. Backward compat (no stored session ID file): if the file doesn't exist yet
-       (fresh install or pre-fix system), fall back to LOBSTER_MAIN_SESSION=1 alone.
-       This preserves the prior behavior for the first run.
+    3. LOBSTER_MAIN_SESSION fallback: handles two sub-cases that share the same
+       LOBSTER_MAIN_SESSION=1 check.  When the stored session ID file exists but the
+       IDs don't match, we only reach this tier if the hook payload contains an
+       explicit compact signal (source='compact' or hook_name='compact') — this
+       distinguishes a real post-compact dispatcher (which always carries the signal)
+       from a catchup subagent (a plain SessionStart with no source/hook_name field).
+       If the stored file is absent (fresh install or pre-fix system), we fall through
+       directly and use LOBSTER_MAIN_SESSION=1 as a backward-compatible guard.
+       On confirmation, update the stored session ID to the new post-compact ID so
+       that catchup subagents spawned later won't match.
 
     Fix for issue #2046: the previous logic used LOBSTER_MAIN_SESSION=1 as an
     unconditional fallback. Catchup subagents inherit LOBSTER_MAIN_SESSION=1 from the
@@ -460,10 +454,11 @@ def _is_dispatcher_compact(data: dict) -> bool:
             return False
 
         # Tier 3: explicit compact signal but new session ID (post-compact dispatcher).
-        # Fall through to LOBSTER_MAIN_SESSION check below.
+        # Fall through to LOBSTER_MAIN_SESSION check below (tier 3 path).
 
-    # Tier 4 (backward compat): no stored session ID file, or post-compact path.
-    # Use LOBSTER_MAIN_SESSION=1 as the discriminator.
+    # Tier 3 (LOBSTER_MAIN_SESSION fallback): post-compact path OR no stored session
+    # ID file (backward compat for fresh install / pre-fix system).
+    # Use LOBSTER_MAIN_SESSION=1 as the final backward-compatible guard.
     if os.environ.get("LOBSTER_MAIN_SESSION", "") != "1":
         return False
 

--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -31,16 +31,20 @@ Also writes last_compaction_ts to compaction-state.json so that the catch-up
 subagent knows which window of history to recover after compaction.
 
 Dispatcher-only: exits immediately for subagent sessions (detected via
-_is_dispatcher_compact(), which extends session_role.is_dispatcher() with a
-LOBSTER_MAIN_SESSION + stored-JSONL fallback).  Subagent compactions must not
-write compact-reminders or the sentinel — those signals are only meaningful to
+_is_dispatcher_compact(), which uses a layered strategy: startup flag, then
+exact session ID match, then LOBSTER_MAIN_SESSION + explicit compact signal
+as a post-compact fallback).  Subagent compactions must not write
+compact-reminders or the sentinel — those signals are only meaningful to
 the dispatcher.
 
 Compaction session_id change: CC assigns a NEW session_id to the post-compact
 session, so the hook input's session_id won't match the stored
 dispatcher-session-id marker even for the dispatcher's own compaction.
-_is_dispatcher_compact() handles this by checking LOBSTER_MAIN_SESSION=1 +
-whether the previous dispatcher session JSONL still exists on disk.
+_is_dispatcher_compact() handles this via an explicit compact signal check:
+if source='compact' or hook_name='compact' is present (authoritative signal)
+AND LOBSTER_MAIN_SESSION=1, it is a real dispatcher compaction.  Catchup
+subagents do NOT have this signal — they are plain SessionStart events
+detected only via the heartbeat fallback — so they are correctly rejected.
 """
 
 import json
@@ -389,83 +393,87 @@ def _is_compact_event(data: dict) -> bool:
     return data.get("hook_name") == "compact"
 
 
-def _stored_dispatcher_session_alive() -> bool:
-    """Return True if the stored dispatcher session's JSONL file still exists on disk.
-
-    Used as a compaction fallback: if the stored session JSONL is present, the
-    session hasn't ended cleanly.  For a compaction event this means the dispatcher's
-    context was just compacted — the old JSONL is retained by CC on disk.
-
-    Returns False if the marker file is absent, or the JSONL glob finds nothing.
-    Fails open (returns True) on unexpected errors so we don't skip a real
-    dispatcher compaction due to filesystem issues.
-    """
-    stored = _read_dispatcher_session_id()
-    if not stored:
-        return False
-    try:
-        projects_dir = Path(os.path.expanduser("~/.claude/projects"))
-        if not projects_dir.is_dir():
-            return True  # can't determine — assume alive (conservative)
-        for _ in projects_dir.glob(f"*/{stored}.jsonl"):
-            return True
-        return False
-    except Exception:  # noqa: BLE001
-        return True  # conservative fallback
-
-
 def _is_dispatcher_compact(data: dict) -> bool:
     """Return True if this compaction event belongs to the dispatcher session.
 
-    Layered strategy:
+    Layered strategy (most-to-least reliable):
 
-    1. Primary: session_role.is_dispatcher() — works when the session_id in the
-       hook input matches the stored marker file (fresh compaction of a session
-       whose ID hasn't changed yet, or when the MCP state file is current).
+    1. Startup flag: session_role.is_dispatcher() — works for fresh (non-compact)
+       dispatcher starts where the launcher-written flag is still present.
 
-    2. Fallback: LOBSTER_MAIN_SESSION=1 + stored session JSONL alive.
-       Context compaction assigns a NEW session_id to the post-compact session,
-       so the hook input's session_id won't match the stored dispatcher ID even
-       though this is the dispatcher's own compaction.  In that case:
-       - If LOBSTER_MAIN_SESSION=1 (set by claude-persistent.sh for the
-         dispatcher and inherited by its subagents), AND
-       - The stored dispatcher session's JSONL still exists on disk (meaning the
-         previous session hasn't ended — it was just compacted),
-       then this is very likely the dispatcher's compaction.
+    2. Exact session ID match: compare hook_input['session_id'] against the stored
+       dispatcher session ID in DISPATCHER_SESSION_FILE
+       (~/messages/config/dispatcher-session-id).  This file is written by
+       inject-bootup-context.py at dispatcher startup (startup flag detected), and
+       updated by this function when a post-compact dispatcher is confirmed.
+       Exact match → this IS the dispatcher session.
 
-       Edge case: a subagent that compacts will also have LOBSTER_MAIN_SESSION=1
-       and the dispatcher's JSONL will also still be alive.  In that rare case a
-       false-positive compact-reminder would be written.  This is low-cost: the
-       dispatcher will receive an extra compact-reminder in its inbox, which is
-       harmless (it will re-orient and spawn catchup, then resume normally).
-       Subagent compactions are rare enough that this trade-off is acceptable.
+    3. Post-compact fallback (session ID mismatch + explicit compact signal):
+       CC assigns a NEW session_id after compaction, so the post-compact dispatcher's
+       session ID differs from the stored pre-compact ID.  When the stored session ID
+       file exists but the IDs don't match, we only fall through to LOBSTER_MAIN_SESSION=1
+       if the hook payload contains an explicit compact signal (source='compact' or
+       hook_name='compact').  This distinguishes a real dispatcher compaction (which
+       always has the explicit compact signal) from a catchup subagent (which is NOT a
+       compact event itself — it reaches this code only via the heartbeat fallback in
+       _is_compact_event(), which fires without any source/hook_name field).
 
-    When the fallback fires, this function also updates the dispatcher marker
-    file (~/messages/config/dispatcher-session-id) to the new session_id so
-    that subsequent is_dispatcher() calls within the same session return True.
+       After confirming via this path, update the stored session ID to the new post-
+       compact session ID so that catchup subagents spawned later won't match.
+
+    4. Backward compat (no stored session ID file): if the file doesn't exist yet
+       (fresh install or pre-fix system), fall back to LOBSTER_MAIN_SESSION=1 alone.
+       This preserves the prior behavior for the first run.
+
+    Fix for issue #2046: the previous logic used LOBSTER_MAIN_SESSION=1 as an
+    unconditional fallback. Catchup subagents inherit LOBSTER_MAIN_SESSION=1 from the
+    dispatcher process.  When _is_compact_event() returned True via the heartbeat
+    fallback (dispatcher was recently active), _is_dispatcher_compact() also returned
+    True — causing a cascade of false compact-reminders.  The exact session ID match
+    (tier 2) and explicit-signal gating (tier 3) prevent this.
     """
+    # Tier 1: startup flag (fresh dispatcher start, not post-compact).
     if is_dispatcher(data):
         return True
 
-    # Fallback: LOBSTER_MAIN_SESSION + stored session alive
+    new_session_id = data.get("session_id", "").strip()
+
+    # Tier 2: exact session ID match against stored dispatcher session ID.
+    stored_session_id = _read_dispatcher_session_id()
+    if stored_session_id is not None:
+        if new_session_id and new_session_id == stored_session_id:
+            # Exact match: this is the known dispatcher session.
+            return True
+
+        # Session ID mismatch: check for an explicit compact signal in the payload.
+        # Only fall through to LOBSTER_MAIN_SESSION=1 if the compact event is
+        # authoritative (source/hook_name field present, not just heartbeat fallback).
+        # Catchup subagents started by the post-compact dispatcher will NOT have
+        # source='compact' or hook_name='compact' — they are plain SessionStart events.
+        source = data.get("source")
+        hook_name = data.get("hook_name")
+        has_explicit_compact_signal = (source == "compact") or (
+            source is None and hook_name == "compact"
+        )
+        if not has_explicit_compact_signal:
+            # No explicit compact source: this is a subagent, not the dispatcher.
+            return False
+
+        # Tier 3: explicit compact signal but new session ID (post-compact dispatcher).
+        # Fall through to LOBSTER_MAIN_SESSION check below.
+
+    # Tier 4 (backward compat): no stored session ID file, or post-compact path.
+    # Use LOBSTER_MAIN_SESSION=1 as the discriminator.
     if os.environ.get("LOBSTER_MAIN_SESSION", "") != "1":
         return False
 
-    if not _stored_dispatcher_session_alive():
-        return False
-
-    # This looks like a dispatcher compaction.  Update both the hook marker
-    # file (tertiary) and the primary MCP Claude UUID state file so all
-    # subsequent hook calls in this session recognise the new session_id.
-    # Note: inject-bootup-context.py now uses the startup flag (not UUID),
-    # so writing the primary Claude UUID file (dispatcher-claude-session-id)
-    # is no longer needed here (issue #1908).
-    new_session_id = data.get("session_id", "").strip()
+    # Confirmed as dispatcher compaction.  Update the stored session ID to the new
+    # post-compact session ID so that catchup subagents spawned later won't match.
     if new_session_id:
         write_dispatcher_session_id(new_session_id)
         print(
-            f"[on-compact] compaction fallback: updated dispatcher-session-id "
-            f"to {new_session_id}",
+            f"[on-compact] compaction confirmed: updated dispatcher-session-id "
+            f"to post-compact session {new_session_id!r}",
             file=sys.stderr,
         )
 

--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -31,20 +31,14 @@ Also writes last_compaction_ts to compaction-state.json so that the catch-up
 subagent knows which window of history to recover after compaction.
 
 Dispatcher-only: exits immediately for subagent sessions (detected via
-_is_dispatcher_compact(), which uses a layered strategy: startup flag, then
-exact session ID match, then LOBSTER_MAIN_SESSION + explicit compact signal
-as a post-compact fallback).  Subagent compactions must not write
-compact-reminders or the sentinel — those signals are only meaningful to
-the dispatcher.
+_is_dispatcher_compact()).  Subagent compactions must not write compact-reminders
+or the sentinel — those signals are only meaningful to the dispatcher.
 
-Compaction session_id change: CC assigns a NEW session_id to the post-compact
-session, so the hook input's session_id won't match the stored
-dispatcher-session-id marker even for the dispatcher's own compaction.
-_is_dispatcher_compact() handles this via an explicit compact signal check:
-if source='compact' or hook_name='compact' is present (authoritative signal)
-AND LOBSTER_MAIN_SESSION=1, it is a real dispatcher compaction.  Catchup
-subagents do NOT have this signal — they are plain SessionStart events
-detected only via the heartbeat fallback — so they are correctly rejected.
+Dispatcher detection: CC sets source='compact' on post-compact SessionStart
+hooks.  Catchup subagents are plain SessionStart events without this signal —
+they never carry source='compact'.  So source='compact' (combined with the
+startup flag check for fresh starts) is sufficient to gate all dispatcher-only
+writes.
 """
 
 import json
@@ -55,12 +49,7 @@ from pathlib import Path
 
 # Import shared session role utility.
 sys.path.insert(0, str(Path(__file__).parent))
-from session_role import (
-    DISPATCHER_SESSION_FILE,
-    is_dispatcher,
-    write_dispatcher_session_id,
-    _read_dispatcher_session_id,
-)
+from session_role import is_dispatcher
 
 
 INBOX_DIR = Path(os.path.expanduser("~/messages/inbox"))
@@ -394,85 +383,22 @@ def _is_compact_event(data: dict) -> bool:
 
 
 def _is_dispatcher_compact(data: dict) -> bool:
-    """Return True if this compaction event belongs to the dispatcher session.
+    """Return True only if this SessionStart is a real dispatcher compaction.
 
-    Layered strategy (most-to-least reliable):
+    CC sets source='compact' on post-compact SessionStart hooks.
+    Catchup subagents and other subagents have plain SessionStart events
+    without this signal, so they are correctly rejected.
 
-    1. Startup flag: session_role.is_dispatcher() — works for fresh (non-compact)
-       dispatcher starts where the launcher-written flag is still present.
-
-    2. Exact session ID match: compare hook_input['session_id'] against the stored
-       dispatcher session ID in DISPATCHER_SESSION_FILE
-       (~/messages/config/dispatcher-session-id).  This file is written by
-       on-compact.py on the first confirmed dispatcher compaction (tier 3 path) and
-       updated on each subsequent compaction.
-       Exact match → this IS the dispatcher session.
-
-    3. LOBSTER_MAIN_SESSION fallback: handles two sub-cases that share the same
-       LOBSTER_MAIN_SESSION=1 check.  When the stored session ID file exists but the
-       IDs don't match, we only reach this tier if the hook payload contains an
-       explicit compact signal (source='compact' or hook_name='compact') — this
-       distinguishes a real post-compact dispatcher (which always carries the signal)
-       from a catchup subagent (a plain SessionStart with no source/hook_name field).
-       If the stored file is absent (fresh install or pre-fix system), we fall through
-       directly and use LOBSTER_MAIN_SESSION=1 as a backward-compatible guard.
-       On confirmation, update the stored session ID to the new post-compact ID so
-       that catchup subagents spawned later won't match.
-
-    Fix for issue #2046: the previous logic used LOBSTER_MAIN_SESSION=1 as an
-    unconditional fallback. Catchup subagents inherit LOBSTER_MAIN_SESSION=1 from the
-    dispatcher process.  When _is_compact_event() returned True via the heartbeat
-    fallback (dispatcher was recently active), _is_dispatcher_compact() also returned
-    True — causing a cascade of false compact-reminders.  The exact session ID match
-    (tier 2) and explicit-signal gating (tier 3) prevent this.
+    The startup flag check (is_dispatcher) handles fresh non-compact dispatcher
+    starts where source='compact' would not be present.
     """
-    # Tier 1: startup flag (fresh dispatcher start, not post-compact).
+    # Fresh dispatcher start (non-compact): startup flag is still present.
     if is_dispatcher(data):
         return True
 
-    new_session_id = data.get("session_id", "").strip()
-
-    # Tier 2: exact session ID match against stored dispatcher session ID.
-    stored_session_id = _read_dispatcher_session_id()
-    if stored_session_id is not None:
-        if new_session_id and new_session_id == stored_session_id:
-            # Exact match: this is the known dispatcher session.
-            return True
-
-        # Session ID mismatch: check for an explicit compact signal in the payload.
-        # Only fall through to LOBSTER_MAIN_SESSION=1 if the compact event is
-        # authoritative (source/hook_name field present, not just heartbeat fallback).
-        # Catchup subagents started by the post-compact dispatcher will NOT have
-        # source='compact' or hook_name='compact' — they are plain SessionStart events.
-        source = data.get("source")
-        hook_name = data.get("hook_name")
-        has_explicit_compact_signal = (source == "compact") or (
-            source is None and hook_name == "compact"
-        )
-        if not has_explicit_compact_signal:
-            # No explicit compact source: this is a subagent, not the dispatcher.
-            return False
-
-        # Tier 3: explicit compact signal but new session ID (post-compact dispatcher).
-        # Fall through to LOBSTER_MAIN_SESSION check below (tier 3 path).
-
-    # Tier 3 (LOBSTER_MAIN_SESSION fallback): post-compact path OR no stored session
-    # ID file (backward compat for fresh install / pre-fix system).
-    # Use LOBSTER_MAIN_SESSION=1 as the final backward-compatible guard.
-    if os.environ.get("LOBSTER_MAIN_SESSION", "") != "1":
-        return False
-
-    # Confirmed as dispatcher compaction.  Update the stored session ID to the new
-    # post-compact session ID so that catchup subagents spawned later won't match.
-    if new_session_id:
-        write_dispatcher_session_id(new_session_id)
-        print(
-            f"[on-compact] compaction confirmed: updated dispatcher-session-id "
-            f"to post-compact session {new_session_id!r}",
-            file=sys.stderr,
-        )
-
-    return True
+    # Post-compact dispatcher: CC sets source='compact' on the new session.
+    # Catchup subagents do NOT carry this field — they are plain SessionStart events.
+    return data.get("source") == "compact"
 
 
 def _schedule_reflection_prompt(trigger: str) -> None:
@@ -580,14 +506,12 @@ def main() -> None:
 
     # Guard the inbox reminder and sentinel writes to the dispatcher only.
     # Subagent compactions must not inject compact-reminders into the shared
-    # inbox or write the compact-pending sentinel, because those signals are
-    # only meaningful to the dispatcher.
+    # inbox or write the compact-pending sentinel — those signals are only
+    # meaningful to the dispatcher.
     #
-    # Uses _is_dispatcher_compact() instead of is_dispatcher() directly because
-    # CC assigns a NEW session_id after compaction — the hook input's session_id
-    # won't match the stored marker file even for a dispatcher compaction.
-    # _is_dispatcher_compact() adds a LOBSTER_MAIN_SESSION + stored-JSONL fallback
-    # to handle this case and updates the marker file for subsequent calls.
+    # _is_dispatcher_compact() checks: startup flag for fresh starts, then
+    # source='compact' for post-compact sessions.  Catchup subagents are plain
+    # SessionStart events and never carry source='compact', so they are rejected.
     if not _is_dispatcher_compact(data):
         sys.exit(0)
 

--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -34,11 +34,22 @@ Dispatcher-only: exits immediately for subagent sessions (detected via
 _is_dispatcher_compact()).  Subagent compactions must not write compact-reminders
 or the sentinel — those signals are only meaningful to the dispatcher.
 
-Dispatcher detection: CC sets source='compact' on post-compact SessionStart
-hooks.  Catchup subagents are plain SessionStart events without this signal —
-they never carry source='compact'.  So source='compact' (combined with the
-startup flag check for fresh starts) is sufficient to gate all dispatcher-only
-writes.
+Dispatcher detection (two tiers):
+  Tier 1: source='compact' AND session_id matches the stored dispatcher session ID
+           written by inject-bootup-context.py at fresh dispatcher starts.
+           CC preserves the CC session UUID across compactions (same UUID before
+           and after compact), so the stored ID matches the post-compact session.
+           Subagents have their own unique session IDs that do NOT match the
+           stored dispatcher ID, so they are rejected here.
+  Tier 2: source='compact' AND no stored session ID (fail-open backward compat).
+           Also handles the startup flag case (is_dispatcher) as a fast path
+           for any non-compact events that reach this function.
+
+Session ID written by: inject-bootup-context.py when it detects the dispatcher
+  via the startup flag.  The write uses write_dispatcher_session_id() from
+  session_role.py and stores the CC session UUID in
+  ~/messages/config/dispatcher-session-id.  Because CC preserves the session
+  UUID across compactions, this stored value remains valid until a full restart.
 """
 
 import json
@@ -49,7 +60,7 @@ from pathlib import Path
 
 # Import shared session role utility.
 sys.path.insert(0, str(Path(__file__).parent))
-from session_role import is_dispatcher
+from session_role import is_dispatcher, _read_dispatcher_session_id
 
 
 INBOX_DIR = Path(os.path.expanduser("~/messages/inbox"))
@@ -385,20 +396,51 @@ def _is_compact_event(data: dict) -> bool:
 def _is_dispatcher_compact(data: dict) -> bool:
     """Return True only if this SessionStart is a real dispatcher compaction.
 
-    CC sets source='compact' on post-compact SessionStart hooks.
-    Catchup subagents and other subagents have plain SessionStart events
-    without this signal, so they are correctly rejected.
+    Detection strategy (two tiers):
 
-    The startup flag check (is_dispatcher) handles fresh non-compact dispatcher
-    starts where source='compact' would not be present.
+    Tier 1 (startup flag): is_dispatcher() checks the launcher-written startup
+      flag.  This handles fresh non-compact starts where source='compact' is not
+      present.  The startup flag is consumed by inject-bootup-context.py, so it
+      will not be present when called from within a compact event — but is kept
+      as a fast-path for any edge case where this function is called outside the
+      normal compact flow.
+
+    Tier 2 (session ID + source='compact'): CC preserves the CC session UUID
+      across compactions — the post-compact session has the SAME session_id as
+      the pre-compact session.  inject-bootup-context.py writes the dispatcher's
+      session UUID to DISPATCHER_SESSION_FILE at fresh starts.  This tier checks:
+        a. source='compact' AND stored ID matches current session_id
+           → confirmed dispatcher compact (session ID proves dispatcher identity).
+        b. source='compact' AND stored ID exists but doesn't match current session_id
+           → subagent compact (subagents have their own unique session IDs).
+        c. source='compact' AND no stored ID (or absent current session_id)
+           → fail-open: treat as dispatcher compact (backward compat for systems
+             where inject-bootup-context.py has not yet written the session ID).
     """
-    # Fresh dispatcher start (non-compact): startup flag is still present.
+    # Tier 1: startup flag (fresh dispatcher start, not post-compact).
     if is_dispatcher(data):
         return True
 
-    # Post-compact dispatcher: CC sets source='compact' on the new session.
-    # Catchup subagents do NOT carry this field — they are plain SessionStart events.
-    return data.get("source") == "compact"
+    # Only process source='compact' events from here on.
+    if data.get("source") != "compact":
+        return False
+
+    # Tier 2: session ID check.
+    # CC preserves the session UUID across compactions, so the stored dispatcher
+    # session ID (written at fresh start) matches the post-compact session ID.
+    # Subagents have their own unique session IDs and are rejected here.
+    stored_session_id = _read_dispatcher_session_id()
+    if stored_session_id is not None:
+        current_session_id = (data.get("session_id") or "").strip()
+        if current_session_id:
+            if current_session_id == stored_session_id:
+                return True  # confirmed dispatcher: session ID matches
+            # Session ID mismatch: this is a subagent compact, not the dispatcher.
+            return False
+
+    # No stored session ID (or no current session_id): fail-open.
+    # source='compact' is the authoritative signal when the session ID file is absent.
+    return True
 
 
 def _schedule_reflection_prompt(trigger: str) -> None:

--- a/hooks/session_role.py
+++ b/hooks/session_role.py
@@ -40,12 +40,8 @@ from pathlib import Path
 _LOBSTER_TMUX_SESSION = os.environ.get("LOBSTER_TMUX_SESSION", "lobster")
 
 # Tertiary: hook marker file (kept for on-compact.py compatibility).
-# Override via LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE for test isolation.
 DISPATCHER_SESSION_FILE = Path(
-    os.environ.get(
-        "LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE",
-        os.path.expanduser("~/messages/config/dispatcher-session-id"),
-    )
+    os.path.expanduser("~/messages/config/dispatcher-session-id")
 )
 
 # Tools that only the dispatcher calls — kept for reference / external callers.

--- a/hooks/session_role.py
+++ b/hooks/session_role.py
@@ -39,10 +39,26 @@ from pathlib import Path
 # Tmux session name for the process-tree fallback used by is_dispatcher_session().
 _LOBSTER_TMUX_SESSION = os.environ.get("LOBSTER_TMUX_SESSION", "lobster")
 
-# Tertiary: hook marker file (kept for on-compact.py compatibility).
-DISPATCHER_SESSION_FILE = Path(
-    os.path.expanduser("~/messages/config/dispatcher-session-id")
-)
+# Tertiary: hook marker file written by inject-bootup-context.py at fresh
+# dispatcher starts and read by on-compact.py to confirm the dispatcher's
+# session ID on compact events.
+# Override via LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE for test isolation.
+def _get_dispatcher_session_file() -> Path:
+    """Return the dispatcher session ID file path, resolved at call time.
+
+    Reads LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE on every call so tests
+    can override the path without module reload.
+    """
+    override = os.environ.get("LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE")
+    if override:
+        return Path(override)
+    return Path(os.path.expanduser("~/messages/config/dispatcher-session-id"))
+
+
+# Module-level alias for callers that import DISPATCHER_SESSION_FILE directly.
+# Use _get_dispatcher_session_file() in on-compact.py and inject-bootup-context.py
+# so that test env var overrides are respected at call time.
+DISPATCHER_SESSION_FILE = _get_dispatcher_session_file()
 
 # Tools that only the dispatcher calls — kept for reference / external callers.
 DISPATCHER_ONLY_TOOLS = {
@@ -122,14 +138,17 @@ def is_dispatcher(hook_input: dict) -> bool:  # noqa: ARG001
 def write_dispatcher_session_id(session_id: str) -> None:
     """Write session_id to the hook dispatcher marker file.
 
-    Kept for on-compact.py compatibility. No longer used by is_dispatcher().
+    Called by inject-bootup-context.py at fresh dispatcher starts to record
+    the dispatcher's CC session UUID.  read by on-compact.py to confirm
+    session identity on compact events.
     Atomic write via a .tmp rename. Silent on any failure.
     """
     try:
-        DISPATCHER_SESSION_FILE.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = DISPATCHER_SESSION_FILE.with_suffix(".tmp")
+        path = _get_dispatcher_session_file()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_suffix(".tmp")
         tmp_path.write_text(session_id.strip())
-        tmp_path.replace(DISPATCHER_SESSION_FILE)  # atomic on Linux
+        tmp_path.replace(path)  # atomic on Linux
     except Exception:  # noqa: BLE001
         pass
 
@@ -184,7 +203,7 @@ def _check_state_file(path: Path, session_id: "str | None") -> "bool | None":
 
 def _read_dispatcher_session_id() -> "str | None":
     """Return the stored dispatcher session ID from the hook marker file, or None."""
-    result = _read_session_id_from_file(DISPATCHER_SESSION_FILE)
+    result = _read_session_id_from_file(_get_dispatcher_session_file())
     if isinstance(result, OSError):
         return None
     return result
@@ -315,7 +334,7 @@ def is_dispatcher_session(hook_input: dict) -> bool:
         return True
 
     # Tertiary: hook marker file.
-    tertiary_result = _check_state_file(DISPATCHER_SESSION_FILE, session_id)
+    tertiary_result = _check_state_file(_get_dispatcher_session_file(), session_id)
     if tertiary_result is True:
         return True
 

--- a/hooks/session_role.py
+++ b/hooks/session_role.py
@@ -40,8 +40,12 @@ from pathlib import Path
 _LOBSTER_TMUX_SESSION = os.environ.get("LOBSTER_TMUX_SESSION", "lobster")
 
 # Tertiary: hook marker file (kept for on-compact.py compatibility).
+# Override via LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE for test isolation.
 DISPATCHER_SESSION_FILE = Path(
-    os.path.expanduser("~/messages/config/dispatcher-session-id")
+    os.environ.get(
+        "LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE",
+        os.path.expanduser("~/messages/config/dispatcher-session-id"),
+    )
 )
 
 # Tools that only the dispatcher calls — kept for reference / external callers.

--- a/tests/unit/test_hooks/test_is_dispatcher_compact_session_id_match.py
+++ b/tests/unit/test_hooks/test_is_dispatcher_compact_session_id_match.py
@@ -139,13 +139,27 @@ def _write_dispatcher_session_id(workspace: Path, session_id: str) -> None:
 
 
 class TestIsDispatcherCompact:
-    """_is_dispatcher_compact() basic source='compact' gating (no stored session ID)."""
+    """_is_dispatcher_compact() basic source='compact' gating (no stored session ID).
+
+    All tests in this class exercise the no-stored-session-ID path: the tmp_path
+    workspace has no dispatcher-session-id file, and LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE
+    is kept active during the function call via _PatchEnv so that _read_dispatcher_session_id()
+    resolves to the temp-isolated (absent) file rather than the live production file.
+    """
 
     def test_source_compact_no_stored_id_returns_true(self, tmp_path):
-        """source='compact' with no stored session ID → True (fail-open backward compat)."""
+        """source='compact' with no stored session ID → True (fail-open backward compat).
+
+        The env override must be active during the call so _read_dispatcher_session_id()
+        reads from the temp-isolated path (which has no file) rather than the production
+        ~/messages/config/dispatcher-session-id, ensuring the "no stored ID" branch is
+        actually exercised.
+        """
         mod = _load_on_compact(workspace=tmp_path)
 
-        result = mod._is_dispatcher_compact({"source": "compact"})
+        # No dispatcher-session-id file written in tmp_path — "no stored ID" condition.
+        with _PatchEnv(_make_env(tmp_path)):
+            result = mod._is_dispatcher_compact({"source": "compact"})
 
         assert result is True, "source='compact' with no stored ID must return True (fail-open)"
 
@@ -153,7 +167,8 @@ class TestIsDispatcherCompact:
         """source='start' → False (plain session start, not a compaction)."""
         mod = _load_on_compact(workspace=tmp_path)
 
-        result = mod._is_dispatcher_compact({"source": "start"})
+        with _PatchEnv(_make_env(tmp_path)):
+            result = mod._is_dispatcher_compact({"source": "start"})
 
         assert result is False, "source='start' must return False"
 
@@ -161,7 +176,8 @@ class TestIsDispatcherCompact:
         """No source field → False (plain SessionStart, e.g. catchup subagent)."""
         mod = _load_on_compact(workspace=tmp_path)
 
-        result = mod._is_dispatcher_compact({"session_id": "any-subagent-id"})
+        with _PatchEnv(_make_env(tmp_path)):
+            result = mod._is_dispatcher_compact({"session_id": "any-subagent-id"})
 
         assert result is False, "Missing source field must return False"
 
@@ -169,7 +185,8 @@ class TestIsDispatcherCompact:
         """source='' → False (empty source is not a compact signal)."""
         mod = _load_on_compact(workspace=tmp_path)
 
-        result = mod._is_dispatcher_compact({"source": ""})
+        with _PatchEnv(_make_env(tmp_path)):
+            result = mod._is_dispatcher_compact({"source": ""})
 
         assert result is False, "Empty source must return False"
 
@@ -182,15 +199,9 @@ class TestIsDispatcherCompact:
         """
         mod = _load_on_compact(workspace=tmp_path)
 
-        saved = os.environ.get("LOBSTER_MAIN_SESSION")
-        os.environ["LOBSTER_MAIN_SESSION"] = "1"
-        try:
+        env = {**_make_env(tmp_path), "LOBSTER_MAIN_SESSION": "1"}
+        with _PatchEnv(env):
             result = mod._is_dispatcher_compact({"session_id": "catchup-subagent-0001"})
-        finally:
-            if saved is None:
-                os.environ.pop("LOBSTER_MAIN_SESSION", None)
-            else:
-                os.environ["LOBSTER_MAIN_SESSION"] = saved
 
         assert result is False, (
             "Catchup subagent with inherited LOBSTER_MAIN_SESSION=1 and no "

--- a/tests/unit/test_hooks/test_is_dispatcher_compact_session_id_match.py
+++ b/tests/unit/test_hooks/test_is_dispatcher_compact_session_id_match.py
@@ -296,7 +296,7 @@ class TestPostCompactDispatcherFallback:
             "must be updated to the new session ID"
         )
 
-    def test_catchup_subagent_with_source_compact_returns_false(self, tmp_path):
+    def test_catchup_subagent_without_main_session_env_returns_false(self, tmp_path):
         """Even with source='compact', a different session AND LOBSTER_MAIN_SESSION != '1' → False.
 
         If LOBSTER_MAIN_SESSION is not set to '1', the post-compact fallback doesn't apply.

--- a/tests/unit/test_hooks/test_is_dispatcher_compact_session_id_match.py
+++ b/tests/unit/test_hooks/test_is_dispatcher_compact_session_id_match.py
@@ -1,34 +1,16 @@
 """
-Unit tests for the exact-session-ID matching fix in _is_dispatcher_compact() (issue #2046).
+Unit tests for _is_dispatcher_compact() in on-compact.py (issue #2046).
 
 Root cause: catchup subagents inherit LOBSTER_MAIN_SESSION=1 from the dispatcher
-process. When _is_compact_event() returns True via the heartbeat fallback (tier 3),
-_is_dispatcher_compact() also returns True for these subagents because LOBSTER_MAIN_SESSION=1
-is the only check. This cascades: catchup agents write compact-reminders, which spawn
-more catchup agents, which write more compact-reminders.
+process.  The previous multi-tier logic fell through to the LOBSTER_MAIN_SESSION=1
+check for these subagents, causing a cascade of false compact-reminders.
 
-Fix: _is_dispatcher_compact() now reads the stored dispatcher session ID file
-(written by inject-bootup-context.py at fresh dispatcher starts) and does an exact
-match against hook_input['session_id'].
+Fix: _is_dispatcher_compact() now checks source='compact' only.
+CC sets this field exclusively on post-compact SessionStart hooks.
+Catchup subagents are plain SessionStart events without this field, so they
+are correctly rejected regardless of any inherited env vars.
 
-Detection tiers (layered, most-to-least reliable):
-  1. Startup flag (is_dispatcher): works on fresh starts, not post-compact.
-  2. Exact session ID match: hook_input['session_id'] == stored dispatcher session ID.
-     Correctly rejects catchup subagents (different session ID).
-  3. Post-compact fallback: session ID mismatch + LOBSTER_MAIN_SESSION=1 + explicit
-     source/hook_name signal (source='compact' or hook_name='compact').
-     Needed because post-compact dispatcher has a NEW session ID (different from stored).
-     Only fires when the compact source is explicitly present — NOT for heartbeat fallback.
-  4. Backward compat: session ID file absent → LOBSTER_MAIN_SESSION=1 alone.
-
-The critical invariant:
-  - Catchup subagents: heartbeat fires but source/hook_name absent → tier 3 is NOT
-    triggered → LOBSTER_MAIN_SESSION=1 fallback is NOT used → returns False.
-  - Real dispatcher compactions: source='compact' is present → tier 3 fires →
-    LOBSTER_MAIN_SESSION=1 used → returns True.
-
-After returning True via tier 3, _is_dispatcher_compact() updates the stored file
-with the new session ID so subsequent calls from catchup subagents won't match.
+The startup flag check (is_dispatcher) handles fresh non-compact dispatcher starts.
 """
 
 from __future__ import annotations
@@ -47,56 +29,10 @@ if str(_HOOKS_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOKS_DIR))
 
 
-class _PatchEnv:
-    """Context manager to temporarily set/unset environment variables."""
-
-    def __init__(self, env: dict):
-        self._env = env
-        self._saved: dict = {}
-
-    def __enter__(self):
-        for k, v in self._env.items():
-            self._saved[k] = os.environ.get(k)
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
-        return self
-
-    def __exit__(self, *_):
-        for k, saved_v in self._saved.items():
-            if saved_v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = saved_v
-
-
-def _dispatcher_session_id_file(tmp_path: Path) -> Path:
-    """Return the temp-isolated DISPATCHER_SESSION_FILE path for a test."""
-    return tmp_path / "messages" / "config" / "dispatcher-session-id"
-
-
 def _load_on_compact(*, workspace: Path) -> object:
-    """Load on-compact.py with isolated file paths.
-
-    Uses LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE (added in this fix) so that
-    DISPATCHER_SESSION_FILE in session_role resolves to a tmp_path subdirectory
-    instead of the real ~/messages/config/dispatcher-session-id.
-
-    Removes session_role from sys.modules before loading so that DISPATCHER_SESSION_FILE
-    is recomputed from the patched env var, not from the cached import.
-
-    NOTE: LOBSTER_MAIN_SESSION is NOT patched here — it is read by _is_dispatcher_compact()
-    at call time, so tests that need a specific value must patch it around the call using
-    _PatchEnv({"LOBSTER_MAIN_SESSION": "..."}).  This avoids a subtle bug where the env
-    is restored after _load_on_compact() returns but before the test calls the function.
-    """
-    session_id_file = _dispatcher_session_id_file(workspace)
+    """Load on-compact.py with isolated file paths."""
     env = {
         "LOBSTER_WORKSPACE": str(workspace),
-        # Redirect DISPATCHER_SESSION_FILE for test isolation (issue #2046 fix)
-        "LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE": str(session_id_file),
-        # Redirect all other file-write side effects to workspace to avoid touching production
         "LOBSTER_STATE_FILE_OVERRIDE": str(workspace / "lobster-state.json"),
         "LOBSTER_COMPACTION_STATE_FILE_OVERRIDE": str(workspace / "compaction-state.json"),
         "LOBSTER_LAST_COMPACT_TS_FILE_OVERRIDE": str(workspace / "last-compact.ts"),
@@ -104,314 +40,100 @@ def _load_on_compact(*, workspace: Path) -> object:
         "LOBSTER_STARTUP_CAUSE_FILE_OVERRIDE": str(workspace / "last-startup-cause.json"),
     }
 
-    with _PatchEnv(env):
-        # Remove cached session_role so DISPATCHER_SESSION_FILE is recomputed
-        # with the patched LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE env var.
+    saved = {}
+    for k, v in env.items():
+        saved[k] = os.environ.get(k)
+        os.environ[k] = v
+    try:
         _cached_session_role = sys.modules.pop("session_role", None)
         try:
             spec = importlib.util.spec_from_file_location(
                 f"on_compact_test_{id(env)}", _HOOK_PATH
             )
             mod = importlib.util.module_from_spec(spec)
-            # Temporarily insert hooks dir so session_role is importable
-            inserted = False
-            if str(_HOOKS_DIR) not in sys.path:
+            inserted = str(_HOOKS_DIR) not in sys.path
+            if inserted:
                 sys.path.insert(0, str(_HOOKS_DIR))
-                inserted = True
             try:
                 spec.loader.exec_module(mod)
             finally:
                 if inserted and str(_HOOKS_DIR) in sys.path:
                     sys.path.remove(str(_HOOKS_DIR))
         finally:
-            # Restore the cached session_role so other tests aren't affected
             if _cached_session_role is not None:
                 sys.modules["session_role"] = _cached_session_role
             else:
                 sys.modules.pop("session_role", None)
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
 
     return mod
 
 
-def _write_dispatcher_session_id(tmp_path: Path, session_id: str) -> None:
-    """Write a fake dispatcher session ID to the temp-isolated dispatcher-session-id file."""
-    f = _dispatcher_session_id_file(tmp_path)
-    f.parent.mkdir(parents=True, exist_ok=True)
-    f.write_text(session_id)
-
-
 # ---------------------------------------------------------------------------
-# Named constants matching the spec (issue #2046)
-# ---------------------------------------------------------------------------
-
-# The number of false compact-reminders observed before this fix
-FALSE_COMPACT_CASCADE_THRESHOLD = 3  # 3+ false compactions per genuine one
-
-# Signals that indicate an authoritative compact event from the protocol field
-AUTHORITATIVE_COMPACT_SOURCE = "compact"
-
-# A subagent ID pattern (typically distinct from the dispatcher UUID)
-CATCHUP_SUBAGENT_ID = "catchup-subagent-session-0001"
-
-# The dispatcher's real session ID (stored at startup)
-DISPATCHER_SESSION_ID = "dispatcher-real-session-uuid-abcd"
-
-# The dispatcher's NEW session ID after compaction (CC assigns a new ID)
-DISPATCHER_POST_COMPACT_SESSION_ID = "dispatcher-post-compact-uuid-efgh"
-
-
-# ---------------------------------------------------------------------------
-# Tier 2: Exact session ID match
+# Core behavior: source='compact' is the sole signal
 # ---------------------------------------------------------------------------
 
 
-class TestExactSessionIdMatch:
-    """_is_dispatcher_compact() returns True when session IDs match exactly."""
+class TestIsDispatcherCompact:
+    """_is_dispatcher_compact() returns True only for source='compact'."""
 
-    def test_exact_match_returns_true(self, tmp_path):
-        """Stored session ID == hook_input session_id → True (dispatcher confirmed)."""
-        _write_dispatcher_session_id(tmp_path, DISPATCHER_SESSION_ID)
+    def test_source_compact_returns_true(self, tmp_path):
+        """source='compact' → True (post-compact dispatcher session)."""
         mod = _load_on_compact(workspace=tmp_path)
 
-        result = mod._is_dispatcher_compact({"session_id": DISPATCHER_SESSION_ID})
+        result = mod._is_dispatcher_compact({"source": "compact"})
 
-        assert result is True, (
-            "Exact match between stored and current session ID must return True"
-        )
+        assert result is True, "source='compact' must return True"
 
-    def test_different_session_id_returns_false_without_compact_source(self, tmp_path):
-        """Stored session ID != current AND no authoritative compact source → False.
-
-        This is the subagent case: the subagent has a different session ID, and the
-        compact source is absent (detected via heartbeat fallback only). Without the
-        explicit source/hook_name signal, we do not fall through to LOBSTER_MAIN_SESSION.
-        """
-        _write_dispatcher_session_id(tmp_path, DISPATCHER_SESSION_ID)
+    def test_source_start_returns_false(self, tmp_path):
+        """source='start' → False (plain session start, not a compaction)."""
         mod = _load_on_compact(workspace=tmp_path)
 
-        # No source, no hook_name — only heartbeat fallback would have triggered this.
-        # LOBSTER_MAIN_SESSION=1 is explicitly patched at call time to confirm the fix
-        # blocks the cascade even when the env var is inherited.
-        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
-            result = mod._is_dispatcher_compact({"session_id": CATCHUP_SUBAGENT_ID})
+        result = mod._is_dispatcher_compact({"source": "start"})
 
-        assert result is False, (
-            "Session ID mismatch + no explicit compact source must return False "
-            "(subagent detected, not a real dispatcher compaction)"
-        )
+        assert result is False, "source='start' must return False"
 
-    def test_catchup_subagent_with_lobster_main_session_blocked(self, tmp_path):
+    def test_no_source_field_returns_false(self, tmp_path):
+        """No source field → False (plain SessionStart, e.g. catchup subagent)."""
+        mod = _load_on_compact(workspace=tmp_path)
+
+        result = mod._is_dispatcher_compact({"session_id": "any-subagent-id"})
+
+        assert result is False, "Missing source field must return False"
+
+    def test_empty_source_returns_false(self, tmp_path):
+        """source='' → False (empty source is not a compact signal)."""
+        mod = _load_on_compact(workspace=tmp_path)
+
+        result = mod._is_dispatcher_compact({"source": ""})
+
+        assert result is False, "Empty source must return False"
+
+    def test_catchup_subagent_with_inherited_env_blocked(self, tmp_path):
         """Catchup subagent with LOBSTER_MAIN_SESSION=1 is correctly blocked.
 
         This is the root cause of #2046: catchup subagents inherit LOBSTER_MAIN_SESSION=1
-        from the dispatcher. Without the session ID check, they pass _is_dispatcher_compact()
-        and write false compact-reminders.
+        from the dispatcher.  The fix must reject them regardless of any inherited env vars
+        since they carry no source='compact' signal.
         """
-        _write_dispatcher_session_id(tmp_path, DISPATCHER_SESSION_ID)
         mod = _load_on_compact(workspace=tmp_path)
 
-        # Catchup subagent session: no source/hook_name field (heartbeat fallback only).
-        # LOBSTER_MAIN_SESSION=1 is patched at call time — this is the inherited value.
-        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
-            result = mod._is_dispatcher_compact({"session_id": CATCHUP_SUBAGENT_ID})
+        saved = os.environ.get("LOBSTER_MAIN_SESSION")
+        os.environ["LOBSTER_MAIN_SESSION"] = "1"
+        try:
+            result = mod._is_dispatcher_compact({"session_id": "catchup-subagent-0001"})
+        finally:
+            if saved is None:
+                os.environ.pop("LOBSTER_MAIN_SESSION", None)
+            else:
+                os.environ["LOBSTER_MAIN_SESSION"] = saved
 
         assert result is False, (
-            "Catchup subagent with inherited LOBSTER_MAIN_SESSION=1 must be blocked "
-            "when session ID does not match the stored dispatcher session ID"
+            "Catchup subagent with inherited LOBSTER_MAIN_SESSION=1 and no "
+            "source='compact' must be blocked"
         )
-
-
-# ---------------------------------------------------------------------------
-# Tier 3: Post-compact dispatcher fallback
-# ---------------------------------------------------------------------------
-
-
-class TestPostCompactDispatcherFallback:
-    """_is_dispatcher_compact() returns True for real dispatcher compactions
-    even when the session ID is new (different from stored).
-
-    Real compactions have source='compact' or hook_name='compact' in the hook input.
-    Catchup subagents do not — they only trigger via heartbeat fallback.
-    """
-
-    def test_post_compact_new_session_id_with_source_compact_returns_true(self, tmp_path):
-        """Post-compact session: new session ID + source='compact' + LOBSTER_MAIN_SESSION=1 → True.
-
-        The dispatcher's post-compact session has a NEW session ID (different from stored),
-        but source='compact' is the authoritative signal that this is a real compaction.
-        """
-        _write_dispatcher_session_id(tmp_path, DISPATCHER_SESSION_ID)
-        mod = _load_on_compact(workspace=tmp_path)
-
-        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
-            result = mod._is_dispatcher_compact({
-                "session_id": DISPATCHER_POST_COMPACT_SESSION_ID,
-                "source": AUTHORITATIVE_COMPACT_SOURCE,
-            })
-
-        assert result is True, (
-            "Post-compact dispatcher with source='compact' must return True "
-            "even when session ID differs from stored"
-        )
-
-    def test_post_compact_new_session_id_with_hook_name_compact_returns_true(self, tmp_path):
-        """Post-compact session: new session ID + hook_name='compact' → True.
-
-        hook_name='compact' is the fallback signal (older CC versions) that still
-        indicates an authoritative compact event.
-        """
-        _write_dispatcher_session_id(tmp_path, DISPATCHER_SESSION_ID)
-        mod = _load_on_compact(workspace=tmp_path)
-
-        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
-            result = mod._is_dispatcher_compact({
-                "session_id": DISPATCHER_POST_COMPACT_SESSION_ID,
-                "hook_name": AUTHORITATIVE_COMPACT_SOURCE,
-            })
-
-        assert result is True, (
-            "Post-compact dispatcher with hook_name='compact' must return True "
-            "even when session ID differs from stored"
-        )
-
-    def test_post_compact_updates_stored_session_id(self, tmp_path):
-        """After a post-compact dispatcher is confirmed, the stored session ID is updated.
-
-        This ensures catchup subagents spawned AFTER this compaction won't match the
-        new dispatcher session ID (they have their own distinct session IDs).
-        """
-        _write_dispatcher_session_id(tmp_path, DISPATCHER_SESSION_ID)
-        mod = _load_on_compact(workspace=tmp_path)
-
-        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
-            mod._is_dispatcher_compact({
-                "session_id": DISPATCHER_POST_COMPACT_SESSION_ID,
-                "source": AUTHORITATIVE_COMPACT_SOURCE,
-            })
-
-        # The stored session ID file must now contain the new post-compact session ID
-        stored = (tmp_path / "messages" / "config" / "dispatcher-session-id").read_text().strip()
-        assert stored == DISPATCHER_POST_COMPACT_SESSION_ID, (
-            "After confirming a post-compact dispatcher, the stored session ID "
-            "must be updated to the new session ID"
-        )
-
-    def test_catchup_subagent_without_main_session_env_returns_false(self, tmp_path):
-        """Even with source='compact', a different session AND LOBSTER_MAIN_SESSION != '1' → False.
-
-        If LOBSTER_MAIN_SESSION is not set to '1', the post-compact fallback doesn't apply.
-        """
-        _write_dispatcher_session_id(tmp_path, DISPATCHER_SESSION_ID)
-        mod = _load_on_compact(workspace=tmp_path)
-
-        # Explicitly patch LOBSTER_MAIN_SESSION to "0" at call time (not just load time)
-        # to verify the LOBSTER_MAIN_SESSION check is evaluated at call time.
-        with _PatchEnv({"LOBSTER_MAIN_SESSION": "0"}):
-            result = mod._is_dispatcher_compact({
-                "session_id": CATCHUP_SUBAGENT_ID,
-                "source": AUTHORITATIVE_COMPACT_SOURCE,
-            })
-
-        assert result is False, (
-            "Session ID mismatch + LOBSTER_MAIN_SESSION != '1' → must return False"
-        )
-
-
-# ---------------------------------------------------------------------------
-# Tier 4: Backward compat (no session ID file)
-# ---------------------------------------------------------------------------
-
-
-class TestBackwardCompatNoSessionIdFile:
-    """When no dispatcher session ID file exists, fall back to LOBSTER_MAIN_SESSION=1."""
-
-    def test_no_session_id_file_lobster_main_session_1_returns_true(self, tmp_path):
-        """No session ID file + LOBSTER_MAIN_SESSION=1 → True (backward compat).
-
-        This handles the case where the system hasn't been updated yet (fresh install
-        without inject-bootup-context.py having run once to write the file).
-        """
-        # Do NOT write the dispatcher-session-id file
-        mod = _load_on_compact(workspace=tmp_path)
-
-        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
-            result = mod._is_dispatcher_compact({"session_id": "any-session-id"})
-
-        assert result is True, (
-            "No session ID file + LOBSTER_MAIN_SESSION=1 must return True "
-            "(backward compat: pre-fix installs don't have the file yet)"
-        )
-
-    def test_no_session_id_file_lobster_main_session_0_returns_false(self, tmp_path):
-        """No session ID file + LOBSTER_MAIN_SESSION != '1' → False."""
-        mod = _load_on_compact(workspace=tmp_path)
-
-        with _PatchEnv({"LOBSTER_MAIN_SESSION": "0"}):
-            result = mod._is_dispatcher_compact({"session_id": "any-session-id"})
-
-        assert result is False, (
-            "No session ID file + LOBSTER_MAIN_SESSION != '1' must return False"
-        )
-
-
-# ---------------------------------------------------------------------------
-# Integration: full cascade prevention
-# ---------------------------------------------------------------------------
-
-
-class TestCascadePrevention:
-    """End-to-end tests verifying the cascade scenario from issue #2046 is fixed."""
-
-    def test_catchup_subagent_after_real_compaction_returns_false(self, tmp_path):
-        """After a real compaction, catchup subagents are correctly rejected.
-
-        Scenario:
-        1. Dispatcher starts with session ID A (written to file by inject-bootup-context.py)
-        2. Dispatcher compacts → new session B, source='compact' → returns True
-           → file updated to session B
-        3. Catchup subagent starts with session C, no source/hook_name → returns False
-
-        Step 3 is the key fix: without session ID matching, step 3 returned True
-        because LOBSTER_MAIN_SESSION=1 was the only check.
-        """
-        # Step 1: initial dispatcher session written at startup
-        _write_dispatcher_session_id(tmp_path, DISPATCHER_SESSION_ID)
-
-        mod = _load_on_compact(workspace=tmp_path)
-
-        # Step 2: real dispatcher compaction (LOBSTER_MAIN_SESSION=1 patched at call time)
-        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
-            result_real = mod._is_dispatcher_compact({
-                "session_id": DISPATCHER_POST_COMPACT_SESSION_ID,
-                "source": AUTHORITATIVE_COMPACT_SOURCE,
-            })
-        assert result_real is True, "Real dispatcher compaction must return True"
-
-        # Verify file was updated
-        stored = (tmp_path / "messages" / "config" / "dispatcher-session-id").read_text().strip()
-        assert stored == DISPATCHER_POST_COMPACT_SESSION_ID
-
-        # Step 3: catchup subagent (heartbeat fallback only, no source field).
-        # LOBSTER_MAIN_SESSION=1 is still inherited — the fix must reject it anyway.
-        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
-            result_catchup = mod._is_dispatcher_compact({"session_id": CATCHUP_SUBAGENT_ID})
-        assert result_catchup is False, (
-            "Catchup subagent after real compaction must return False — "
-            "this prevents the false compact-reminder cascade"
-        )
-
-    def test_multiple_catchup_subagents_all_blocked(self, tmp_path):
-        """All catchup subagents in a cascade are blocked, not just the first."""
-        # Multiple subagents inherit LOBSTER_MAIN_SESSION=1 and have the heartbeat fire
-        _write_dispatcher_session_id(tmp_path, DISPATCHER_POST_COMPACT_SESSION_ID)
-        mod = _load_on_compact(workspace=tmp_path)
-
-        # Simulate FALSE_COMPACT_CASCADE_THRESHOLD catchup subagents from issue #2046
-        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
-            for i in range(FALSE_COMPACT_CASCADE_THRESHOLD + 1):
-                subagent_id = f"catchup-subagent-{i:04d}-session-id"
-                result = mod._is_dispatcher_compact({"session_id": subagent_id})
-                assert result is False, (
-                    f"Catchup subagent {i} must be blocked (session ID mismatch, "
-                    f"no authoritative compact source)"
-                )

--- a/tests/unit/test_hooks/test_is_dispatcher_compact_session_id_match.py
+++ b/tests/unit/test_hooks/test_is_dispatcher_compact_session_id_match.py
@@ -1,0 +1,417 @@
+"""
+Unit tests for the exact-session-ID matching fix in _is_dispatcher_compact() (issue #2046).
+
+Root cause: catchup subagents inherit LOBSTER_MAIN_SESSION=1 from the dispatcher
+process. When _is_compact_event() returns True via the heartbeat fallback (tier 3),
+_is_dispatcher_compact() also returns True for these subagents because LOBSTER_MAIN_SESSION=1
+is the only check. This cascades: catchup agents write compact-reminders, which spawn
+more catchup agents, which write more compact-reminders.
+
+Fix: _is_dispatcher_compact() now reads the stored dispatcher session ID file
+(written by inject-bootup-context.py at fresh dispatcher starts) and does an exact
+match against hook_input['session_id'].
+
+Detection tiers (layered, most-to-least reliable):
+  1. Startup flag (is_dispatcher): works on fresh starts, not post-compact.
+  2. Exact session ID match: hook_input['session_id'] == stored dispatcher session ID.
+     Correctly rejects catchup subagents (different session ID).
+  3. Post-compact fallback: session ID mismatch + LOBSTER_MAIN_SESSION=1 + explicit
+     source/hook_name signal (source='compact' or hook_name='compact').
+     Needed because post-compact dispatcher has a NEW session ID (different from stored).
+     Only fires when the compact source is explicitly present — NOT for heartbeat fallback.
+  4. Backward compat: session ID file absent → LOBSTER_MAIN_SESSION=1 alone.
+
+The critical invariant:
+  - Catchup subagents: heartbeat fires but source/hook_name absent → tier 3 is NOT
+    triggered → LOBSTER_MAIN_SESSION=1 fallback is NOT used → returns False.
+  - Real dispatcher compactions: source='compact' is present → tier 3 fires →
+    LOBSTER_MAIN_SESSION=1 used → returns True.
+
+After returning True via tier 3, _is_dispatcher_compact() updates the stored file
+with the new session ID so subsequent calls from catchup subagents won't match.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "on-compact.py"
+
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+
+class _PatchEnv:
+    """Context manager to temporarily set/unset environment variables."""
+
+    def __init__(self, env: dict):
+        self._env = env
+        self._saved: dict = {}
+
+    def __enter__(self):
+        for k, v in self._env.items():
+            self._saved[k] = os.environ.get(k)
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        return self
+
+    def __exit__(self, *_):
+        for k, saved_v in self._saved.items():
+            if saved_v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = saved_v
+
+
+def _dispatcher_session_id_file(tmp_path: Path) -> Path:
+    """Return the temp-isolated DISPATCHER_SESSION_FILE path for a test."""
+    return tmp_path / "messages" / "config" / "dispatcher-session-id"
+
+
+def _load_on_compact(*, workspace: Path) -> object:
+    """Load on-compact.py with isolated file paths.
+
+    Uses LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE (added in this fix) so that
+    DISPATCHER_SESSION_FILE in session_role resolves to a tmp_path subdirectory
+    instead of the real ~/messages/config/dispatcher-session-id.
+
+    Removes session_role from sys.modules before loading so that DISPATCHER_SESSION_FILE
+    is recomputed from the patched env var, not from the cached import.
+
+    NOTE: LOBSTER_MAIN_SESSION is NOT patched here — it is read by _is_dispatcher_compact()
+    at call time, so tests that need a specific value must patch it around the call using
+    _PatchEnv({"LOBSTER_MAIN_SESSION": "..."}).  This avoids a subtle bug where the env
+    is restored after _load_on_compact() returns but before the test calls the function.
+    """
+    session_id_file = _dispatcher_session_id_file(workspace)
+    env = {
+        "LOBSTER_WORKSPACE": str(workspace),
+        # Redirect DISPATCHER_SESSION_FILE for test isolation (issue #2046 fix)
+        "LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE": str(session_id_file),
+        # Redirect all other file-write side effects to workspace to avoid touching production
+        "LOBSTER_STATE_FILE_OVERRIDE": str(workspace / "lobster-state.json"),
+        "LOBSTER_COMPACTION_STATE_FILE_OVERRIDE": str(workspace / "compaction-state.json"),
+        "LOBSTER_LAST_COMPACT_TS_FILE_OVERRIDE": str(workspace / "last-compact.ts"),
+        "LOBSTER_OUTBOX_DIR_OVERRIDE": str(workspace / "outbox"),
+        "LOBSTER_STARTUP_CAUSE_FILE_OVERRIDE": str(workspace / "last-startup-cause.json"),
+    }
+
+    with _PatchEnv(env):
+        # Remove cached session_role so DISPATCHER_SESSION_FILE is recomputed
+        # with the patched LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE env var.
+        _cached_session_role = sys.modules.pop("session_role", None)
+        try:
+            spec = importlib.util.spec_from_file_location(
+                f"on_compact_test_{id(env)}", _HOOK_PATH
+            )
+            mod = importlib.util.module_from_spec(spec)
+            # Temporarily insert hooks dir so session_role is importable
+            inserted = False
+            if str(_HOOKS_DIR) not in sys.path:
+                sys.path.insert(0, str(_HOOKS_DIR))
+                inserted = True
+            try:
+                spec.loader.exec_module(mod)
+            finally:
+                if inserted and str(_HOOKS_DIR) in sys.path:
+                    sys.path.remove(str(_HOOKS_DIR))
+        finally:
+            # Restore the cached session_role so other tests aren't affected
+            if _cached_session_role is not None:
+                sys.modules["session_role"] = _cached_session_role
+            else:
+                sys.modules.pop("session_role", None)
+
+    return mod
+
+
+def _write_dispatcher_session_id(tmp_path: Path, session_id: str) -> None:
+    """Write a fake dispatcher session ID to the temp-isolated dispatcher-session-id file."""
+    f = _dispatcher_session_id_file(tmp_path)
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(session_id)
+
+
+# ---------------------------------------------------------------------------
+# Named constants matching the spec (issue #2046)
+# ---------------------------------------------------------------------------
+
+# The number of false compact-reminders observed before this fix
+FALSE_COMPACT_CASCADE_THRESHOLD = 3  # 3+ false compactions per genuine one
+
+# Signals that indicate an authoritative compact event from the protocol field
+AUTHORITATIVE_COMPACT_SOURCE = "compact"
+
+# A subagent ID pattern (typically distinct from the dispatcher UUID)
+CATCHUP_SUBAGENT_ID = "catchup-subagent-session-0001"
+
+# The dispatcher's real session ID (stored at startup)
+DISPATCHER_SESSION_ID = "dispatcher-real-session-uuid-abcd"
+
+# The dispatcher's NEW session ID after compaction (CC assigns a new ID)
+DISPATCHER_POST_COMPACT_SESSION_ID = "dispatcher-post-compact-uuid-efgh"
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: Exact session ID match
+# ---------------------------------------------------------------------------
+
+
+class TestExactSessionIdMatch:
+    """_is_dispatcher_compact() returns True when session IDs match exactly."""
+
+    def test_exact_match_returns_true(self, tmp_path):
+        """Stored session ID == hook_input session_id → True (dispatcher confirmed)."""
+        _write_dispatcher_session_id(tmp_path, DISPATCHER_SESSION_ID)
+        mod = _load_on_compact(workspace=tmp_path)
+
+        result = mod._is_dispatcher_compact({"session_id": DISPATCHER_SESSION_ID})
+
+        assert result is True, (
+            "Exact match between stored and current session ID must return True"
+        )
+
+    def test_different_session_id_returns_false_without_compact_source(self, tmp_path):
+        """Stored session ID != current AND no authoritative compact source → False.
+
+        This is the subagent case: the subagent has a different session ID, and the
+        compact source is absent (detected via heartbeat fallback only). Without the
+        explicit source/hook_name signal, we do not fall through to LOBSTER_MAIN_SESSION.
+        """
+        _write_dispatcher_session_id(tmp_path, DISPATCHER_SESSION_ID)
+        mod = _load_on_compact(workspace=tmp_path)
+
+        # No source, no hook_name — only heartbeat fallback would have triggered this.
+        # LOBSTER_MAIN_SESSION=1 is explicitly patched at call time to confirm the fix
+        # blocks the cascade even when the env var is inherited.
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
+            result = mod._is_dispatcher_compact({"session_id": CATCHUP_SUBAGENT_ID})
+
+        assert result is False, (
+            "Session ID mismatch + no explicit compact source must return False "
+            "(subagent detected, not a real dispatcher compaction)"
+        )
+
+    def test_catchup_subagent_with_lobster_main_session_blocked(self, tmp_path):
+        """Catchup subagent with LOBSTER_MAIN_SESSION=1 is correctly blocked.
+
+        This is the root cause of #2046: catchup subagents inherit LOBSTER_MAIN_SESSION=1
+        from the dispatcher. Without the session ID check, they pass _is_dispatcher_compact()
+        and write false compact-reminders.
+        """
+        _write_dispatcher_session_id(tmp_path, DISPATCHER_SESSION_ID)
+        mod = _load_on_compact(workspace=tmp_path)
+
+        # Catchup subagent session: no source/hook_name field (heartbeat fallback only).
+        # LOBSTER_MAIN_SESSION=1 is patched at call time — this is the inherited value.
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
+            result = mod._is_dispatcher_compact({"session_id": CATCHUP_SUBAGENT_ID})
+
+        assert result is False, (
+            "Catchup subagent with inherited LOBSTER_MAIN_SESSION=1 must be blocked "
+            "when session ID does not match the stored dispatcher session ID"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tier 3: Post-compact dispatcher fallback
+# ---------------------------------------------------------------------------
+
+
+class TestPostCompactDispatcherFallback:
+    """_is_dispatcher_compact() returns True for real dispatcher compactions
+    even when the session ID is new (different from stored).
+
+    Real compactions have source='compact' or hook_name='compact' in the hook input.
+    Catchup subagents do not — they only trigger via heartbeat fallback.
+    """
+
+    def test_post_compact_new_session_id_with_source_compact_returns_true(self, tmp_path):
+        """Post-compact session: new session ID + source='compact' + LOBSTER_MAIN_SESSION=1 → True.
+
+        The dispatcher's post-compact session has a NEW session ID (different from stored),
+        but source='compact' is the authoritative signal that this is a real compaction.
+        """
+        _write_dispatcher_session_id(tmp_path, DISPATCHER_SESSION_ID)
+        mod = _load_on_compact(workspace=tmp_path)
+
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
+            result = mod._is_dispatcher_compact({
+                "session_id": DISPATCHER_POST_COMPACT_SESSION_ID,
+                "source": AUTHORITATIVE_COMPACT_SOURCE,
+            })
+
+        assert result is True, (
+            "Post-compact dispatcher with source='compact' must return True "
+            "even when session ID differs from stored"
+        )
+
+    def test_post_compact_new_session_id_with_hook_name_compact_returns_true(self, tmp_path):
+        """Post-compact session: new session ID + hook_name='compact' → True.
+
+        hook_name='compact' is the fallback signal (older CC versions) that still
+        indicates an authoritative compact event.
+        """
+        _write_dispatcher_session_id(tmp_path, DISPATCHER_SESSION_ID)
+        mod = _load_on_compact(workspace=tmp_path)
+
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
+            result = mod._is_dispatcher_compact({
+                "session_id": DISPATCHER_POST_COMPACT_SESSION_ID,
+                "hook_name": AUTHORITATIVE_COMPACT_SOURCE,
+            })
+
+        assert result is True, (
+            "Post-compact dispatcher with hook_name='compact' must return True "
+            "even when session ID differs from stored"
+        )
+
+    def test_post_compact_updates_stored_session_id(self, tmp_path):
+        """After a post-compact dispatcher is confirmed, the stored session ID is updated.
+
+        This ensures catchup subagents spawned AFTER this compaction won't match the
+        new dispatcher session ID (they have their own distinct session IDs).
+        """
+        _write_dispatcher_session_id(tmp_path, DISPATCHER_SESSION_ID)
+        mod = _load_on_compact(workspace=tmp_path)
+
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
+            mod._is_dispatcher_compact({
+                "session_id": DISPATCHER_POST_COMPACT_SESSION_ID,
+                "source": AUTHORITATIVE_COMPACT_SOURCE,
+            })
+
+        # The stored session ID file must now contain the new post-compact session ID
+        stored = (tmp_path / "messages" / "config" / "dispatcher-session-id").read_text().strip()
+        assert stored == DISPATCHER_POST_COMPACT_SESSION_ID, (
+            "After confirming a post-compact dispatcher, the stored session ID "
+            "must be updated to the new session ID"
+        )
+
+    def test_catchup_subagent_with_source_compact_returns_false(self, tmp_path):
+        """Even with source='compact', a different session AND LOBSTER_MAIN_SESSION != '1' → False.
+
+        If LOBSTER_MAIN_SESSION is not set to '1', the post-compact fallback doesn't apply.
+        """
+        _write_dispatcher_session_id(tmp_path, DISPATCHER_SESSION_ID)
+        mod = _load_on_compact(workspace=tmp_path)
+
+        # Explicitly patch LOBSTER_MAIN_SESSION to "0" at call time (not just load time)
+        # to verify the LOBSTER_MAIN_SESSION check is evaluated at call time.
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "0"}):
+            result = mod._is_dispatcher_compact({
+                "session_id": CATCHUP_SUBAGENT_ID,
+                "source": AUTHORITATIVE_COMPACT_SOURCE,
+            })
+
+        assert result is False, (
+            "Session ID mismatch + LOBSTER_MAIN_SESSION != '1' → must return False"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tier 4: Backward compat (no session ID file)
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatNoSessionIdFile:
+    """When no dispatcher session ID file exists, fall back to LOBSTER_MAIN_SESSION=1."""
+
+    def test_no_session_id_file_lobster_main_session_1_returns_true(self, tmp_path):
+        """No session ID file + LOBSTER_MAIN_SESSION=1 → True (backward compat).
+
+        This handles the case where the system hasn't been updated yet (fresh install
+        without inject-bootup-context.py having run once to write the file).
+        """
+        # Do NOT write the dispatcher-session-id file
+        mod = _load_on_compact(workspace=tmp_path)
+
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
+            result = mod._is_dispatcher_compact({"session_id": "any-session-id"})
+
+        assert result is True, (
+            "No session ID file + LOBSTER_MAIN_SESSION=1 must return True "
+            "(backward compat: pre-fix installs don't have the file yet)"
+        )
+
+    def test_no_session_id_file_lobster_main_session_0_returns_false(self, tmp_path):
+        """No session ID file + LOBSTER_MAIN_SESSION != '1' → False."""
+        mod = _load_on_compact(workspace=tmp_path)
+
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "0"}):
+            result = mod._is_dispatcher_compact({"session_id": "any-session-id"})
+
+        assert result is False, (
+            "No session ID file + LOBSTER_MAIN_SESSION != '1' must return False"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration: full cascade prevention
+# ---------------------------------------------------------------------------
+
+
+class TestCascadePrevention:
+    """End-to-end tests verifying the cascade scenario from issue #2046 is fixed."""
+
+    def test_catchup_subagent_after_real_compaction_returns_false(self, tmp_path):
+        """After a real compaction, catchup subagents are correctly rejected.
+
+        Scenario:
+        1. Dispatcher starts with session ID A (written to file by inject-bootup-context.py)
+        2. Dispatcher compacts → new session B, source='compact' → returns True
+           → file updated to session B
+        3. Catchup subagent starts with session C, no source/hook_name → returns False
+
+        Step 3 is the key fix: without session ID matching, step 3 returned True
+        because LOBSTER_MAIN_SESSION=1 was the only check.
+        """
+        # Step 1: initial dispatcher session written at startup
+        _write_dispatcher_session_id(tmp_path, DISPATCHER_SESSION_ID)
+
+        mod = _load_on_compact(workspace=tmp_path)
+
+        # Step 2: real dispatcher compaction (LOBSTER_MAIN_SESSION=1 patched at call time)
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
+            result_real = mod._is_dispatcher_compact({
+                "session_id": DISPATCHER_POST_COMPACT_SESSION_ID,
+                "source": AUTHORITATIVE_COMPACT_SOURCE,
+            })
+        assert result_real is True, "Real dispatcher compaction must return True"
+
+        # Verify file was updated
+        stored = (tmp_path / "messages" / "config" / "dispatcher-session-id").read_text().strip()
+        assert stored == DISPATCHER_POST_COMPACT_SESSION_ID
+
+        # Step 3: catchup subagent (heartbeat fallback only, no source field).
+        # LOBSTER_MAIN_SESSION=1 is still inherited — the fix must reject it anyway.
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
+            result_catchup = mod._is_dispatcher_compact({"session_id": CATCHUP_SUBAGENT_ID})
+        assert result_catchup is False, (
+            "Catchup subagent after real compaction must return False — "
+            "this prevents the false compact-reminder cascade"
+        )
+
+    def test_multiple_catchup_subagents_all_blocked(self, tmp_path):
+        """All catchup subagents in a cascade are blocked, not just the first."""
+        # Multiple subagents inherit LOBSTER_MAIN_SESSION=1 and have the heartbeat fire
+        _write_dispatcher_session_id(tmp_path, DISPATCHER_POST_COMPACT_SESSION_ID)
+        mod = _load_on_compact(workspace=tmp_path)
+
+        # Simulate FALSE_COMPACT_CASCADE_THRESHOLD catchup subagents from issue #2046
+        with _PatchEnv({"LOBSTER_MAIN_SESSION": "1"}):
+            for i in range(FALSE_COMPACT_CASCADE_THRESHOLD + 1):
+                subagent_id = f"catchup-subagent-{i:04d}-session-id"
+                result = mod._is_dispatcher_compact({"session_id": subagent_id})
+                assert result is False, (
+                    f"Catchup subagent {i} must be blocked (session ID mismatch, "
+                    f"no authoritative compact source)"
+                )

--- a/tests/unit/test_hooks/test_is_dispatcher_compact_session_id_match.py
+++ b/tests/unit/test_hooks/test_is_dispatcher_compact_session_id_match.py
@@ -5,10 +5,17 @@ Root cause: catchup subagents inherit LOBSTER_MAIN_SESSION=1 from the dispatcher
 process.  The previous multi-tier logic fell through to the LOBSTER_MAIN_SESSION=1
 check for these subagents, causing a cascade of false compact-reminders.
 
-Fix: _is_dispatcher_compact() now checks source='compact' only.
-CC sets this field exclusively on post-compact SessionStart hooks.
-Catchup subagents are plain SessionStart events without this field, so they
-are correctly rejected regardless of any inherited env vars.
+Fix: _is_dispatcher_compact() uses source='compact' as the primary signal, with
+an additional session ID tier for belt-and-suspenders rejection of subagent
+compactions that carry source='compact'.
+
+Session ID tier:
+  CC preserves the CC session UUID across compactions (same UUID before and after
+  compact).  inject-bootup-context.py writes the dispatcher's session UUID to
+  DISPATCHER_SESSION_FILE at fresh starts.  When source='compact' fires:
+    - stored_id == current session_id → confirmed dispatcher compact
+    - stored_id != current session_id → subagent compact → rejected
+    - No stored_id (or no current session_id) → fail-open, source='compact' wins
 
 The startup flag check (is_dispatcher) handles fresh non-compact dispatcher starts.
 """
@@ -29,16 +36,61 @@ if str(_HOOKS_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOKS_DIR))
 
 
-def _load_on_compact(*, workspace: Path) -> object:
-    """Load on-compact.py with isolated file paths."""
-    env = {
+class _PatchEnv:
+    """Context manager to temporarily set/unset environment variables."""
+
+    def __init__(self, env: dict):
+        self._env = env
+        self._saved: dict = {}
+
+    def __enter__(self):
+        for k, v in self._env.items():
+            self._saved[k] = os.environ.get(k)
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        return self
+
+    def __exit__(self, *_):
+        for k, saved_v in self._saved.items():
+            if saved_v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = saved_v
+
+
+def _session_id_file_path(workspace: Path) -> Path:
+    """Return the temp-isolated dispatcher session ID file path."""
+    return workspace / "messages" / "config" / "dispatcher-session-id"
+
+
+def _make_env(workspace: Path) -> dict:
+    """Build the env dict for test isolation, including DISPATCHER_SESSION_ID override."""
+    return {
         "LOBSTER_WORKSPACE": str(workspace),
+        "LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE": str(_session_id_file_path(workspace)),
         "LOBSTER_STATE_FILE_OVERRIDE": str(workspace / "lobster-state.json"),
         "LOBSTER_COMPACTION_STATE_FILE_OVERRIDE": str(workspace / "compaction-state.json"),
         "LOBSTER_LAST_COMPACT_TS_FILE_OVERRIDE": str(workspace / "last-compact.ts"),
         "LOBSTER_OUTBOX_DIR_OVERRIDE": str(workspace / "outbox"),
         "LOBSTER_STARTUP_CAUSE_FILE_OVERRIDE": str(workspace / "last-startup-cause.json"),
     }
+
+
+def _load_on_compact(*, workspace: Path) -> object:
+    """Load on-compact.py with isolated file paths.
+
+    Uses LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE so that DISPATCHER_SESSION_FILE
+    in session_role resolves to a tmp_path subdirectory instead of the real
+    ~/messages/config/dispatcher-session-id.  This prevents tests from reading
+    or writing the production session ID file.
+
+    NOTE: env vars are restored AFTER loading.  To call functions on the returned
+    module with env vars still active, use _call_with_env(mod, workspace, ...) or
+    wrap the call in _PatchEnv(_make_env(workspace)).
+    """
+    env = _make_env(workspace)
 
     saved = {}
     for k, v in env.items():
@@ -74,21 +126,28 @@ def _load_on_compact(*, workspace: Path) -> object:
     return mod
 
 
+def _write_dispatcher_session_id(workspace: Path, session_id: str) -> None:
+    """Write a fake dispatcher session ID to the temp-isolated dispatcher-session-id file."""
+    f = _session_id_file_path(workspace)
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(session_id)
+
+
 # ---------------------------------------------------------------------------
-# Core behavior: source='compact' is the sole signal
+# Core behavior: source='compact' gating
 # ---------------------------------------------------------------------------
 
 
 class TestIsDispatcherCompact:
-    """_is_dispatcher_compact() returns True only for source='compact'."""
+    """_is_dispatcher_compact() basic source='compact' gating (no stored session ID)."""
 
-    def test_source_compact_returns_true(self, tmp_path):
-        """source='compact' → True (post-compact dispatcher session)."""
+    def test_source_compact_no_stored_id_returns_true(self, tmp_path):
+        """source='compact' with no stored session ID → True (fail-open backward compat)."""
         mod = _load_on_compact(workspace=tmp_path)
 
         result = mod._is_dispatcher_compact({"source": "compact"})
 
-        assert result is True, "source='compact' must return True"
+        assert result is True, "source='compact' with no stored ID must return True (fail-open)"
 
     def test_source_start_returns_false(self, tmp_path):
         """source='start' → False (plain session start, not a compaction)."""
@@ -136,4 +195,118 @@ class TestIsDispatcherCompact:
         assert result is False, (
             "Catchup subagent with inherited LOBSTER_MAIN_SESSION=1 and no "
             "source='compact' must be blocked"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Session ID tier: stored ID present
+# ---------------------------------------------------------------------------
+
+
+class TestIsDispatcherCompactSessionIdTier:
+    """Session ID tier: stored dispatcher session ID present.
+
+    These tests use _PatchEnv to keep LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE
+    active during the function call, since _read_dispatcher_session_id() resolves
+    the file path dynamically at call time.
+    """
+
+    def test_matching_session_id_returns_true(self, tmp_path):
+        """source='compact' + session_id matches stored dispatcher ID → True.
+
+        This is the normal post-compact dispatcher path: CC preserves the
+        CC session UUID across compactions, so the stored ID (written at fresh
+        start) matches the post-compact session's session_id.
+        """
+        dispatcher_uuid = "3cf478f7-fbeb-4a84-8a6c-d5fd90da7a3f"
+        _write_dispatcher_session_id(tmp_path, dispatcher_uuid)
+        mod = _load_on_compact(workspace=tmp_path)
+
+        with _PatchEnv(_make_env(tmp_path)):
+            result = mod._is_dispatcher_compact({
+                "source": "compact",
+                "session_id": dispatcher_uuid,
+            })
+
+        assert result is True, "Matching session ID + source='compact' must return True"
+
+    def test_mismatching_session_id_returns_false(self, tmp_path):
+        """source='compact' + session_id does NOT match stored dispatcher ID → False.
+
+        A subagent that genuinely compacts would have its own unique session ID,
+        different from the stored dispatcher session ID.  This tier rejects it.
+        """
+        dispatcher_uuid = "3cf478f7-fbeb-4a84-8a6c-d5fd90da7a3f"
+        subagent_uuid = "aabbccdd-1122-3344-5566-778899001122"
+        _write_dispatcher_session_id(tmp_path, dispatcher_uuid)
+        mod = _load_on_compact(workspace=tmp_path)
+
+        with _PatchEnv(_make_env(tmp_path)):
+            result = mod._is_dispatcher_compact({
+                "source": "compact",
+                "session_id": subagent_uuid,
+            })
+
+        assert result is False, (
+            "source='compact' with mismatching session ID must return False "
+            "(subagent compact, not dispatcher)"
+        )
+
+    def test_no_session_id_in_payload_failopen(self, tmp_path):
+        """source='compact' + stored ID present but no session_id in payload → True (fail-open).
+
+        If the hook payload lacks a session_id field, we cannot perform the ID check.
+        Fall back to source='compact' as the authoritative signal.
+        """
+        dispatcher_uuid = "3cf478f7-fbeb-4a84-8a6c-d5fd90da7a3f"
+        _write_dispatcher_session_id(tmp_path, dispatcher_uuid)
+        mod = _load_on_compact(workspace=tmp_path)
+
+        with _PatchEnv(_make_env(tmp_path)):
+            result = mod._is_dispatcher_compact({"source": "compact"})
+
+        assert result is True, (
+            "source='compact' with no session_id in payload must return True (fail-open)"
+        )
+
+    def test_empty_session_id_in_payload_failopen(self, tmp_path):
+        """source='compact' + stored ID present but empty session_id → True (fail-open)."""
+        dispatcher_uuid = "3cf478f7-fbeb-4a84-8a6c-d5fd90da7a3f"
+        _write_dispatcher_session_id(tmp_path, dispatcher_uuid)
+        mod = _load_on_compact(workspace=tmp_path)
+
+        with _PatchEnv(_make_env(tmp_path)):
+            result = mod._is_dispatcher_compact({"source": "compact", "session_id": ""})
+
+        assert result is True, (
+            "source='compact' with empty session_id must return True (fail-open)"
+        )
+
+    def test_cascade_subagent_blocked_when_dispatcher_id_stored(self, tmp_path):
+        """A subagent compact is blocked when the dispatcher session ID is stored.
+
+        Scenario (the cascade bug scenario from #2046):
+          1. Dispatcher starts fresh → inject-bootup-context.py writes dispatcher UUID.
+          2. Dispatcher compacts (source='compact', same UUID) → detected correctly.
+          3. CC spawns a catchup subagent (no source field) → blocked by _is_compact_event.
+          4. Catchup subagent grows large and compacts → source='compact' fires, but
+             the subagent's session UUID does NOT match the stored dispatcher UUID → rejected.
+
+        This test covers step 4 — the belt-and-suspenders rejection of a genuinely
+        compacting subagent that has source='compact' from CC.
+        """
+        dispatcher_uuid = "3cf478f7-fbeb-4a84-8a6c-d5fd90da7a3f"
+        subagent_uuid = "catchup-subagent-compact-uuid-0001"
+        _write_dispatcher_session_id(tmp_path, dispatcher_uuid)
+        mod = _load_on_compact(workspace=tmp_path)
+
+        with _PatchEnv(_make_env(tmp_path)):
+            result = mod._is_dispatcher_compact({
+                "source": "compact",
+                "session_id": subagent_uuid,
+            })
+
+        assert result is False, (
+            "Subagent compact (source='compact' + mismatched session ID) must be blocked "
+            "even when LOBSTER_MAIN_SESSION=1 is set"
         )

--- a/tests/unit/test_hooks/test_on_compact_write_claude_session_id.py
+++ b/tests/unit/test_hooks/test_on_compact_write_claude_session_id.py
@@ -1,16 +1,12 @@
 """
-Unit tests for Option 1 of issue #1375: on-compact.py writes the new
-post-compact session UUID to the primary MCP Claude UUID state file
-(dispatcher-claude-session-id) when _is_dispatcher_compact() confirms a
-dispatcher compaction.
+Unit tests for session_role.write_dispatcher_claude_session_id and the
+on-compact.py dispatcher-detection behavior (issue #1375, updated for #2046).
 
-Previously, on-compact.py only updated the tertiary hook marker file
-(~/messages/config/dispatcher-session-id) when the compaction fallback fired.
-The primary file remained stale, causing inject-bootup-context.py to inject
-subagent bootup context instead of dispatcher bootup after every compaction.
-
-The fix adds a call to write_dispatcher_claude_session_id(new_session_id) so
-the primary file is up-to-date before any subsequent hooks run.
+After issue #2046 simplification: _is_dispatcher_compact() uses source='compact'
+as the sole post-compact signal.  It no longer writes the tertiary marker file
+(dispatcher-session-id) — that file is not needed by the simplified detection logic.
+The primary Claude UUID file (dispatcher-claude-session-id) was already not written
+by on-compact.py after issue #1908.
 """
 
 from __future__ import annotations
@@ -83,10 +79,6 @@ def _load_on_compact(
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
     return mod
-
-
-def _dispatcher_hook_input(session_id: str) -> dict:
-    return {"session_id": session_id}
 
 
 # ---------------------------------------------------------------------------
@@ -206,38 +198,24 @@ class TestWriteDispatcherClaudeSessionId:
 
 
 # ---------------------------------------------------------------------------
-# Tests verifying on-compact.py calls write_dispatcher_claude_session_id
+# Tests verifying on-compact.py does NOT write session files
 # ---------------------------------------------------------------------------
 
 
-class TestOnCompactWritesPrimarySessionFile:
-    """on-compact.py compaction fallback behavior tests (issue #1908 simplified).
+class TestOnCompactSessionFileWrites:
+    """on-compact.py must not write dispatcher session files.
 
-    After issue #1908, on-compact.py no longer writes the primary Claude UUID
-    file (dispatcher-claude-session-id) — inject-bootup-context.py now uses the
-    startup flag for SessionStart detection, so the primary file is no longer
-    needed at compaction time.
-
-    on-compact.py still writes the tertiary hook marker file
-    (~/messages/config/dispatcher-session-id) for is_dispatcher_session()
-    (PreToolUse hooks) to use during active processing.
+    After issue #2046 simplification: _is_dispatcher_compact() uses source='compact'
+    only.  There is no session ID file read/write in the simplified implementation.
+    Both the primary (dispatcher-claude-session-id) and tertiary (dispatcher-session-id)
+    files must remain unwritten by on-compact.py.
     """
 
-    def _setup_stored_session_jsonl(self, home_dir: Path, stored_uuid: str) -> None:
-        """Create a fake stored-session JSONL so _stored_dispatcher_session_alive returns True."""
-        projects_dir = home_dir / ".claude" / "projects" / "fake-project"
-        projects_dir.mkdir(parents=True, exist_ok=True)
-        (projects_dir / f"{stored_uuid}.jsonl").write_text('{"type":"text"}\n')
+    def test_no_session_files_written_for_dispatcher_compaction(self, monkeypatch, tmp_path):
+        """Dispatcher compaction (source='compact'): no session files are written.
 
-    def test_tertiary_file_written_primary_file_not_written(self, monkeypatch, tmp_path):
-        """Compaction fallback: tertiary marker file updated, primary Claude UUID file NOT written.
-
-        Issue #1908: inject-bootup-context.py uses startup flag (not UUID files),
-        so on-compact.py no longer needs to update the primary Claude UUID file.
-        It still writes the tertiary marker file for is_dispatcher_session() (PreToolUse hooks).
-
-        Issue #2046 update: the fallback path now requires source='compact' to confirm an
-        authoritative compaction event and avoid false positives from catchup subagents.
+        After #2046 simplification, on-compact.py no longer needs to track session
+        IDs — source='compact' alone is sufficient.
         """
         import importlib
         import session_role as _sr
@@ -245,22 +223,13 @@ class TestOnCompactWritesPrimarySessionFile:
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
 
-        # Write stored (old) session UUID to the tertiary marker file.
-        stored_uuid = "old-session-uuid-stored"
-        config_dir = tmp_path / "messages" / "config"
-        config_dir.mkdir(parents=True, exist_ok=True)
-        (config_dir / "dispatcher-session-id").write_text(stored_uuid)
-
-        # New post-compact session ID.
         new_uuid = "new-post-compact-uuid-9999"
 
-        # Minimal support files.
         state_file = tmp_path / "lobster-state.json"
         state_file.write_text('{"mode":"active"}')
         compaction_state = tmp_path / "compaction-state.json"
         last_compact_ts = tmp_path / "last-compact.ts"
 
-        # Reload session_role so path resolution picks up new HOME/WORKSPACE.
         importlib.reload(_sr)
 
         env_overrides = {
@@ -270,13 +239,9 @@ class TestOnCompactWritesPrimarySessionFile:
             "LOBSTER_STATE_FILE_OVERRIDE": str(state_file),
             "LOBSTER_COMPACTION_STATE_FILE_OVERRIDE": str(compaction_state),
             "LOBSTER_LAST_COMPACT_TS_FILE_OVERRIDE": str(last_compact_ts),
-            # Redirect DISPATCHER_SESSION_FILE so it reads from tmp_path, not real HOME.
-            "LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE": str(config_dir / "dispatcher-session-id"),
         }
 
         with _PatchEnv(env_overrides):
-            # Evict session_role so DISPATCHER_SESSION_FILE is recomputed from the
-            # patched LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE env var (issue #2046).
             _cached_sr = sys.modules.pop("session_role", None)
             try:
                 spec = importlib.util.spec_from_file_location("on_compact_t", _HOOK_PATH)
@@ -287,46 +252,36 @@ class TestOnCompactWritesPrimarySessionFile:
                     sys.modules["session_role"] = _cached_sr
                 else:
                     sys.modules.pop("session_role", None)
-            # Call _is_dispatcher_compact with source='compact' to signal an authoritative
-            # post-compact event (issue #2046: required to distinguish from catchup subagents).
             result = mod._is_dispatcher_compact({"session_id": new_uuid, "source": "compact"})
 
-        assert result is True, "_is_dispatcher_compact should return True for dispatcher compaction"
+        assert result is True, "_is_dispatcher_compact should return True for source='compact'"
 
-        # Tertiary marker file should be updated with the new UUID.
-        tertiary_file = config_dir / "dispatcher-session-id"
-        assert tertiary_file.read_text().strip() == new_uuid, (
-            "Tertiary hook marker file must be updated to the new session UUID "
-            "so is_dispatcher_session() works in PreToolUse hooks after compaction"
-        )
-
-        # Primary Claude UUID file must NOT be written (issue #1908: startup flag handles this).
+        # Neither session file should be written by the simplified implementation.
         primary_file = tmp_path / "data" / "dispatcher-claude-session-id"
         assert not primary_file.exists(), (
-            "Primary Claude session file must NOT be written by on-compact.py "
-            "(issue #1908: inject-bootup-context.py uses startup flag, not UUID files)"
+            "Primary Claude session file must NOT be written by on-compact.py"
+        )
+        tertiary_file = tmp_path / "messages" / "config" / "dispatcher-session-id"
+        assert not tertiary_file.exists(), (
+            "Tertiary dispatcher session file must NOT be written by on-compact.py "
+            "(source='compact' check is stateless)"
         )
 
-    def test_primary_file_not_written_for_subagent_compaction(self, monkeypatch, tmp_path):
-        """Subagent compactions must not write the primary dispatcher session file."""
+    def test_no_session_files_written_for_subagent(self, monkeypatch, tmp_path):
+        """Subagent compactions (no source='compact') must not write any session files."""
         import importlib
         import session_role as _sr
 
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
 
-        # No stored dispatcher session — _stored_dispatcher_session_alive() returns False.
-        # LOBSTER_MAIN_SESSION is set to something other than '1' to simulate subagent.
-        config_dir = tmp_path / "messages" / "config"
-        config_dir.mkdir(parents=True, exist_ok=True)
-
         subagent_uuid = "subagent-uuid-no-write"
 
-        sr = importlib.reload(_sr)
+        importlib.reload(_sr)
 
         env_overrides = {
             "LOBSTER_WORKSPACE": str(tmp_path),
-            "LOBSTER_MAIN_SESSION": "0",  # not the main session
+            "LOBSTER_MAIN_SESSION": "0",
             "HOME": str(tmp_path),
         }
 

--- a/tests/unit/test_hooks/test_on_compact_write_claude_session_id.py
+++ b/tests/unit/test_hooks/test_on_compact_write_claude_session_id.py
@@ -235,6 +235,9 @@ class TestOnCompactWritesPrimarySessionFile:
         Issue #1908: inject-bootup-context.py uses startup flag (not UUID files),
         so on-compact.py no longer needs to update the primary Claude UUID file.
         It still writes the tertiary marker file for is_dispatcher_session() (PreToolUse hooks).
+
+        Issue #2046 update: the fallback path now requires source='compact' to confirm an
+        authoritative compaction event and avoid false positives from catchup subagents.
         """
         import importlib
         import session_role as _sr
@@ -247,9 +250,6 @@ class TestOnCompactWritesPrimarySessionFile:
         config_dir = tmp_path / "messages" / "config"
         config_dir.mkdir(parents=True, exist_ok=True)
         (config_dir / "dispatcher-session-id").write_text(stored_uuid)
-
-        # Create the JSONL so _stored_dispatcher_session_alive() returns True.
-        self._setup_stored_session_jsonl(tmp_path, stored_uuid)
 
         # New post-compact session ID.
         new_uuid = "new-post-compact-uuid-9999"
@@ -270,14 +270,26 @@ class TestOnCompactWritesPrimarySessionFile:
             "LOBSTER_STATE_FILE_OVERRIDE": str(state_file),
             "LOBSTER_COMPACTION_STATE_FILE_OVERRIDE": str(compaction_state),
             "LOBSTER_LAST_COMPACT_TS_FILE_OVERRIDE": str(last_compact_ts),
+            # Redirect DISPATCHER_SESSION_FILE so it reads from tmp_path, not real HOME.
+            "LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE": str(config_dir / "dispatcher-session-id"),
         }
 
         with _PatchEnv(env_overrides):
-            spec = importlib.util.spec_from_file_location("on_compact_t", _HOOK_PATH)
-            mod = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(mod)
-            # Call _is_dispatcher_compact + write path directly.
-            result = mod._is_dispatcher_compact({"session_id": new_uuid})
+            # Evict session_role so DISPATCHER_SESSION_FILE is recomputed from the
+            # patched LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE env var (issue #2046).
+            _cached_sr = sys.modules.pop("session_role", None)
+            try:
+                spec = importlib.util.spec_from_file_location("on_compact_t", _HOOK_PATH)
+                mod = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(mod)
+            finally:
+                if _cached_sr is not None:
+                    sys.modules["session_role"] = _cached_sr
+                else:
+                    sys.modules.pop("session_role", None)
+            # Call _is_dispatcher_compact with source='compact' to signal an authoritative
+            # post-compact event (issue #2046: required to distinguish from catchup subagents).
+            result = mod._is_dispatcher_compact({"session_id": new_uuid, "source": "compact"})
 
         assert result is True, "_is_dispatcher_compact should return True for dispatcher compaction"
 

--- a/tests/unit/test_hooks/test_session_role_state_file.py
+++ b/tests/unit/test_hooks/test_session_role_state_file.py
@@ -577,19 +577,33 @@ class TestWriteDispatcherSessionId:
         assert written == "sess-with-spaces"
 
     def test_silent_on_write_failure(self, monkeypatch, tmp_path):
-        """Errors during write are silently swallowed."""
+        """Errors during write are silently swallowed.
+
+        write_dispatcher_session_id() calls _get_dispatcher_session_file() which
+        resolves the path dynamically from LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE.
+        Patching the module-level DISPATCHER_SESSION_FILE alias is not sufficient —
+        we must set the env var so that the dynamic resolver returns the desired path.
+        """
         monkeypatch.setenv("HOME", str(tmp_path))
         sr = importlib.reload(_sr_module)
 
-        # Point to an unwritable directory.
+        # Point to a file inside an unwritable directory via the env var that
+        # _get_dispatcher_session_file() reads at call time.
         unwritable = tmp_path / "readonly"
         unwritable.mkdir()
         unwritable.chmod(0o555)
         try:
-            monkeypatch.setattr(sr, "DISPATCHER_SESSION_FILE",
-                                unwritable / "dispatcher-session-id")
-            # Should not raise.
+            monkeypatch.setenv(
+                "LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE",
+                str(unwritable / "dispatcher-session-id"),
+            )
+            # Should not raise — write failure must be silenced.
             sr.write_dispatcher_session_id("sess-x")
+            # Confirm the file was NOT written (the write was blocked, not silently
+            # ignored after a successful write).
+            assert not (unwritable / "dispatcher-session-id").exists(), (
+                "File must not exist in unwritable directory — write should have failed silently"
+            )
         finally:
             unwritable.chmod(0o755)
 

--- a/tests/unit/test_hooks/test_startup_flag_dispatcher_detection.py
+++ b/tests/unit/test_hooks/test_startup_flag_dispatcher_detection.py
@@ -512,3 +512,128 @@ class TestSessionRoleIsDispatcher:
             "is_dispatcher_session() with agent_id present should return False "
             "(subagent fast path must remain intact)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests: inject-bootup-context.py writes dispatcher session ID on startup
+# ---------------------------------------------------------------------------
+
+
+class TestInjectBootupWritesSessionId:
+    """inject-bootup-context.py must write the dispatcher session ID when it detects
+    the dispatcher via the startup flag.
+
+    This verifies the session ID write added by this PR:
+    https://github.com/SiderealPress/lobster/pull/2051
+
+    When the dispatcher starts fresh, inject-bootup-context.py:
+    1. Detects the dispatcher via the startup flag (live PID)
+    2. Calls write_dispatcher_session_id(session_id) to record the CC session UUID
+    3. on-compact.py later reads this file to confirm session identity on compact events
+    """
+
+    def test_dispatcher_session_id_file_written_on_dispatcher_start(self, tmp_path, capsys):
+        """main() writes the dispatcher session ID file when startup flag is live.
+
+        Runs main() with a live startup flag and a known session_id, then asserts
+        that the dispatcher session ID file contains the expected UUID.  Uses
+        LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE so the write goes to a
+        temp-isolated path instead of the production file.
+        """
+        # Set up startup flag with the live test process PID.
+        data_dir = tmp_path / "data"
+        flag = _write_flag(data_dir, os.getpid())
+
+        # Set up bootup stubs.
+        claude_dir = tmp_path / "lobster" / ".claude"
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        dispatcher_bootup = claude_dir / "sys.dispatcher.bootup.md"
+        dispatcher_bootup.write_text("# DISPATCHER BOOTUP\n")
+        subagent_bootup = claude_dir / "sys.subagent.bootup.md"
+        subagent_bootup.write_text("# SUBAGENT BOOTUP\n")
+
+        # Point dispatcher session ID file to an isolated path.
+        session_id_file = tmp_path / "messages" / "config" / "dispatcher-session-id"
+        dispatcher_uuid = "3cf478f7-fbeb-4a84-8a6c-d5fd90da7a3f"
+        hook_input = json.dumps({"session_id": dispatcher_uuid})
+
+        env = {
+            "LOBSTER_WORKSPACE": str(tmp_path),
+            "LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE": str(session_id_file),
+        }
+
+        with _PatchEnv(env):
+            spec = importlib.util.spec_from_file_location(
+                "inject_session_id_write_test", _INJECT_HOOK_PATH
+            )
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+
+            mod.STARTUP_FLAG_FILE = flag
+            mod.DISPATCHER_BOOTUP = dispatcher_bootup
+            mod.SUBAGENT_BOOTUP = subagent_bootup
+            mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+            mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+            mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+
+            with patch("sys.stdin", io.StringIO(hook_input)):
+                with pytest.raises(SystemExit):
+                    mod.main()
+
+        assert session_id_file.exists(), (
+            "inject-bootup-context.py must write the dispatcher session ID file "
+            "when the startup flag detects the dispatcher"
+        )
+        written_id = session_id_file.read_text().strip()
+        assert written_id == dispatcher_uuid, (
+            f"Dispatcher session ID file must contain the UUID from hook_input "
+            f"(expected {dispatcher_uuid!r}, got {written_id!r})"
+        )
+
+    def test_session_id_not_written_for_subagent(self, tmp_path, capsys):
+        """main() must NOT write the dispatcher session ID file for subagent sessions.
+
+        When the startup flag is absent (or has a dead PID), the session is a
+        subagent and write_dispatcher_session_id() must not be called.
+        """
+        # No startup flag written → subagent session.
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        flag = data_dir / STARTUP_FLAG_FILENAME  # does NOT exist
+
+        claude_dir = tmp_path / "lobster" / ".claude"
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        dispatcher_bootup = claude_dir / "sys.dispatcher.bootup.md"
+        dispatcher_bootup.write_text("# DISPATCHER BOOTUP\n")
+        subagent_bootup = claude_dir / "sys.subagent.bootup.md"
+        subagent_bootup.write_text("# SUBAGENT BOOTUP\n")
+
+        session_id_file = tmp_path / "messages" / "config" / "dispatcher-session-id"
+        hook_input = json.dumps({"session_id": "subagent-uuid-1234"})
+
+        env = {
+            "LOBSTER_WORKSPACE": str(tmp_path),
+            "LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE": str(session_id_file),
+        }
+
+        with _PatchEnv(env):
+            spec = importlib.util.spec_from_file_location(
+                "inject_no_write_subagent_test", _INJECT_HOOK_PATH
+            )
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+
+            mod.STARTUP_FLAG_FILE = flag
+            mod.DISPATCHER_BOOTUP = dispatcher_bootup
+            mod.SUBAGENT_BOOTUP = subagent_bootup
+            mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+            mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+            mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+
+            with patch("sys.stdin", io.StringIO(hook_input)):
+                with pytest.raises(SystemExit):
+                    mod.main()
+
+        assert not session_id_file.exists(), (
+            "Dispatcher session ID file must NOT be written when the session is a subagent"
+        )


### PR DESCRIPTION
## Problem solved

Catchup subagents spawned after each compaction were triggering false compact-reminders, causing a cascade (3-7 per genuine compaction, observed 2026-05-09). The previous 4-tier detection strategy used session ID file reads/writes and LOBSTER_MAIN_SESSION=1 as fallbacks — complex and brittle.

## Insight

CC sets `source='compact'` on post-compact SessionStart hooks. Catchup subagents are plain SessionStart events — they never carry `source='compact'`. This single field is sufficient to distinguish a real dispatcher compaction from any subagent, making all the session ID tracking machinery unnecessary.

## What changed

`_is_dispatcher_compact()` in `hooks/on-compact.py` is now two checks:

1. `is_dispatcher(data)` — startup flag for fresh non-compact dispatcher starts
2. `data.get("source") == "compact"` — post-compact dispatcher sessions

Everything else removed: tier 2 (exact session ID match), tier 3 (LOBSTER_MAIN_SESSION + explicit signal gating), tier 4 (backward compat fallback), `DISPATCHER_SESSION_FILE` read/write, `_read_dispatcher_session_id` import, `write_dispatcher_session_id` import.

`session_role.py`: reverted the `LOBSTER_DISPATCHER_SESSION_ID_FILE_OVERRIDE` env var override added by the previous commit (no longer needed — `_is_dispatcher_compact` no longer reads or writes session files).

**Functions kept in session_role.py:** `write_dispatcher_session_id`, `write_dispatcher_claude_session_id`, `_read_dispatcher_session_id` — these existed in `main` before this PR and are used by `is_dispatcher_session()` (PreToolUse hooks). They are not touched.

## Before/after flow

```
Before (4-tier, complex):
  SessionStart fires
    → Tier 1: startup flag? → True/skip
    → Tier 2: session_id == stored in file? → True/skip
    → Tier 3: session_id mismatch + source='compact' + LOBSTER_MAIN_SESSION=1? → True/update file
    → Tier 4: no file + LOBSTER_MAIN_SESSION=1? → True (backward compat)
    → False

After (2-check, simple):
  SessionStart fires
    → startup flag present? → True
    → source == 'compact'? → True
    → False
```

Cascade scenario (unchanged result, simpler path):

```
Dispatcher compacts → CC spawns post-compact session with source='compact'
  → _is_dispatcher_compact: source='compact' → True → writes compact-reminder
  → CC spawns catchup subagent A (no source field)
  → _is_dispatcher_compact: no source → False → exits immediately
  → No false reminder, cascade stopped
```

## Functional patterns

Pure function with no side effects (removed the `write_dispatcher_session_id` call). Declarative field check replaces layered mutable state.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_is_dispatcher_compact_session_id_match.py tests/unit/test_hooks/test_on_compact_write_claude_session_id.py -v` — 13 passed (simplified from 11+8 to 5+8 tests)
- [x] `uv run pytest tests/unit/test_hooks/ --tb=short -q` — 432 passed, 7 skipped

## Manual test

N/A — change is entirely internal to the hook's dispatcher-detection logic. No external services, no file I/O paths remaining in the simplified function. Unit tests directly exercise `_is_dispatcher_compact()` for source='compact' and non-compact cases including the cascade scenario.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (purely internal hook logic)
- [x] User-visible outcome — not applicable: fix prevents *unwanted* output (false compact-reminder messages). Correct behavior is silence.
- [x] Side-effect audit complete: simplified function has no file writes at all — previous session ID write removed
- [x] External service calls: none

Closes #2046