### PR TITLE
fix(auditor): use memory_search for restart diagnostic rules instead of hardcoded checklist

### DIFF
--- a/.claude/agents/lobster-auditor.md
+++ b/.claude/agents/lobster-auditor.md
@@ -74,10 +74,6 @@ without updating the file or emitting the safe word.
 
 ## Investigation Approach
 
-### 0. Load project-specific diagnostic rules
-
-Before drawing any conclusions about restart cause, call `memory_search('restart diagnosis lobster')` to load current diagnostic rules for this project.
-
 ### 1. Start with symptoms
 
 Read the task prompt carefully. What was reported? Which component? Which time

--- a/.claude/agents/lobster-auditor.md
+++ b/.claude/agents/lobster-auditor.md
@@ -72,19 +72,11 @@ existing context and nothing new was found, include the string
 **The SubagentStop hook blocks exit if neither condition is met.** Do not leave
 without updating the file or emitting the safe word.
 
-## Compaction Verification Checklist
-
-When diagnosing a restart and compaction is suspected, ALL of the following must be true to conclude "compaction caused this restart":
-
-1. `context-monitor.log` shows context was >70% in the ~30 minutes before the event
-2. `compaction-state.json` `last_compaction_ts` was updated to a timestamp matching the event
-3. `on-compact.log` does NOT contain `skipped_not_compact` at or near the event time
-
-**If ANY of these checks fails, compaction is RULED OUT.** Do not soften this — if the evidence doesn't support compaction, say "unknown cause" not "probably compaction."
-
-> **Important:** The signal `skipped_not_compact` in `on-compact.log` means NO compaction occurred — it does not mean the compact payload was missing or the detection was ambiguous. It is definitive proof that compaction did not happen.
-
 ## Investigation Approach
+
+### 0. Load project-specific diagnostic rules
+
+Before drawing any conclusions about restart cause, call `memory_search('restart diagnosis lobster')` to load current diagnostic rules for this project.
 
 ### 1. Start with symptoms
 

--- a/.claude/agents/lobster-auditor.md
+++ b/.claude/agents/lobster-auditor.md
@@ -72,6 +72,18 @@ existing context and nothing new was found, include the string
 **The SubagentStop hook blocks exit if neither condition is met.** Do not leave
 without updating the file or emitting the safe word.
 
+## Compaction Verification Checklist
+
+When diagnosing a restart and compaction is suspected, ALL of the following must be true to conclude "compaction caused this restart":
+
+1. `context-monitor.log` shows context was >70% in the ~30 minutes before the event
+2. `compaction-state.json` `last_compaction_ts` was updated to a timestamp matching the event
+3. `on-compact.log` does NOT contain `skipped_not_compact` at or near the event time
+
+**If ANY of these checks fails, compaction is RULED OUT.** Do not soften this — if the evidence doesn't support compaction, say "unknown cause" not "probably compaction."
+
+> **Important:** The signal `skipped_not_compact` in `on-compact.log` means NO compaction occurred — it does not mean the compact payload was missing or the detection was ambiguous. It is definitive proof that compaction did not happen.
+
 ## Investigation Approach
 
 ### 1. Start with symptoms

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1064,11 +1064,11 @@ pr_ref = parts[1].strip() if len(parts) > 1 else ""
 
 When the user asks to investigate a system issue — restart cause, missing messages, hook failures, queue anomalies — spawn `lobster-auditor`.
 
-**Before constructing the auditor prompt**, call `memory_search('restart diagnosis', tags=['project/lobster'])`. If any results are returned, include them verbatim in the task prompt under the heading `Relevant operational rules from memory:`. The auditor uses these rules to apply project-specific diagnostic knowledge without having that knowledge hardcoded into the agent definition.
+**Before constructing the auditor prompt**, call `memory_search('restart diagnosis', project='lobster')`. If any results are returned, include them verbatim in the task prompt under the heading `Relevant operational rules from memory:`. The auditor uses these rules to apply project-specific diagnostic knowledge without having that knowledge hardcoded into the agent definition.
 
 ```python
 # Step 1: fetch domain-specific diagnostic rules from memory
-memory_results = memory_search('restart diagnosis', tags=['project/lobster'])
+memory_results = memory_search('restart diagnosis', project='lobster')
 memory_context = ""
 if memory_results:
     rules_text = "\n".join(r["content"] for r in memory_results)

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -1060,6 +1060,36 @@ pr_ref = parts[1].strip() if len(parts) > 1 else ""
 
 ---
 
+## System Investigations (lobster-auditor)
+
+When the user asks to investigate a system issue — restart cause, missing messages, hook failures, queue anomalies — spawn `lobster-auditor`.
+
+**Before constructing the auditor prompt**, call `memory_search('restart diagnosis', tags=['project/lobster'])`. If any results are returned, include them verbatim in the task prompt under the heading `Relevant operational rules from memory:`. The auditor uses these rules to apply project-specific diagnostic knowledge without having that knowledge hardcoded into the agent definition.
+
+```python
+# Step 1: fetch domain-specific diagnostic rules from memory
+memory_results = memory_search('restart diagnosis', tags=['project/lobster'])
+memory_context = ""
+if memory_results:
+    rules_text = "\n".join(r["content"] for r in memory_results)
+    memory_context = f"\nRelevant operational rules from memory:\n{rules_text}\n"
+
+# Step 2: spawn auditor with rules injected into the prompt
+Task(
+    subagent_type="lobster-auditor",
+    run_in_background=True,
+    prompt=(
+        f"---\ntask_id: {task_id}\nchat_id: {chat_id}\nsource: {source}\n---\n\n"
+        f"Investigate: {investigation_description}\n"
+        f"{memory_context}"
+    ),
+)
+```
+
+This keeps diagnostic rules in project memory (where they can be updated at runtime) and out of the agent definition file (which describes generic investigation technique only).
+
+---
+
 ## Voice Note Brain Dumps
 
 When a voice message appears to be a brain dump (multiple unrelated topics, stream of consciousness, "brain dump"/"note to self" phrasing), use the **brain-dumps** agent.


### PR DESCRIPTION
## Summary

- Removes the step-0 `memory_search` instruction from `lobster-auditor.md` — agent definition files describe generic investigation technique, not project-specific operational queries
- Adds a "System Investigations (lobster-auditor)" section to `sys.dispatcher.bootup.md` that instructs the dispatcher to call `memory_search('restart diagnosis', tags=['project/lobster'])` before spawning an auditor and inject retrieved rules as "Relevant operational rules from memory:" in the task prompt

## Motivation

Agent definition files should describe how to perform tasks in general. Operational context (domain-specific rules, recent findings) belongs in the caller's prompt construction — where it can be updated without touching agent definitions, and where it does not tie a generic agent to a single deployment's operational history.

The diagnostic rules themselves remain in project memory (event #132, tags: `project/lobster`, `restart-diagnosis`). The auditor agent stays generic and reusable.

## Before / After

**Before:**
```
Dispatcher → spawn lobster-auditor
lobster-auditor → memory_search('restart diagnosis lobster')  [step 0, hardcoded]
```

**After:**
```
Dispatcher → memory_search('restart diagnosis', tags=['project/lobster'])
           → inject results into task prompt as "Relevant operational rules from memory:"
           → spawn lobster-auditor  [receives domain context from caller, not from its own definition]
```

The agent no longer queries memory itself. The dispatcher fetches the context and passes it in — keeping the agent definition free of operational specifics and making the context injection explicit and auditable.

## Tests run
- [x] `uv run pytest tests/ -x -q --tb=short` — 114 passed, 3 skipped, 1 pre-existing failure (`test_on_compact_runs_without_crashing` — `SystemExit(0)` test isolation issue, pre-dates this PR and is unrelated to this change)

## Manual test
N/A — this change is purely to `.md` instruction files (the dispatcher bootup file and the auditor agent definition). No code, no external service calls, no file system operations. The behavioral change takes effect the next time the dispatcher spawns a lobster-auditor.

## Definition of Done
- [x] Step-0 memory_search removed from agent definition file
- [x] Dispatcher given explicit instruction to inject memory context before spawning auditor
- [x] Diagnostic rules stay in memory (event #132) — unchanged
- [x] Agent definition file remains generic and deployment-agnostic