### PR TITLE
feat: remove wind-down mode and 70% context threshold

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -681,39 +681,9 @@ Rules:
 
 ---
 
-### context_warning (`type: "context_warning"`)
-
-Written by `hooks/context-monitor.py` when context window >= 70%.
-
-```
-1. mark_processing(message_id)
-2. Write a tombstone to the current session file (inline, no subagent needed — this is fast):
-   - Set Ended to current UTC ISO timestamp
-   - Set Messages processed to the count of messages handled this session (tracked in working context as MESSAGE_COUNT)
-   - Set End reason to "context_warning"
-   - Set Summary to "Graceful wind-down triggered at {context_pct}% context. [Brief list of what was in progress, if anything.]"
-   This ensures the session file is recoverable even if nothing else was written during this session.
-3. Enter wind-down mode:
-   - Set WIND_DOWN_MODE = True
-   - Do NOT spawn new non-trivial subagents
-   - For new user messages: ack, create_task to record, tell user "Compacting context shortly — will pick this up after."
-4. Drain in-flight agents: poll get_active_sessions() every 10s. Process arriving subagent results normally.
-5. Write ~/lobster-workspace/data/context-handoff.json:
-   {"triggered_at": "<iso8601>", "context_pct": <pct>, "pending_tasks": <list>, "last_user_message": "<text>", "note": "Graceful wind-down"}
-6. Send user (use admin chat_id from config): "Context at {pct}% — entering wind-down mode. Handing off cleanly."
-7. Do NOT call wait_for_messages() again. Do not attempt to self-terminate — the dispatcher cannot exit itself. Claude Code's context compaction will end the session externally when the context window fills.
-8. mark_processed(message_id)
-```
-
-Rules: `chat_id` is 0 — use admin chat_id for step 5. Never re-enter wind-down for a second warning. Do NOT call `lobster restart` — compaction is the recovery mechanism.
-
----
-
 ### session_note_reminder (`type: "session_note_reminder"`)
 
 Injected by the MCP server after every 20 real user messages. Spawn session-note-appender in the background; mark_processed silently (no reply).
-
-Do NOT spawn during wind-down mode (`WIND_DOWN_MODE = True`) — session-note-polish handles the final consolidation.
 
 ```
 1. mark_processing(message_id)
@@ -972,7 +942,7 @@ Do not modify Summary or Started/Ended. 3. Write back. 4. Call write_result.
 **Tombstone on session end (unconditional):** Whenever the session ends for any reason, write a tombstone update to the session file before stopping. This is done inline (not via subagent) and takes <1 second. Minimum content:
 - `Ended`: current UTC ISO timestamp
 - `Messages processed`: MESSAGE_COUNT (tracked in working context; increment on each `mark_processed` call)
-- `End reason`: one of `graceful wind-down`, `context_warning`, `short session`, `crash` (use `short session` if session ran < 5 minutes and no reason is known)
+- `End reason`: one of `compaction`, `short session`, `crash` (use `short session` if session ran < 5 minutes and no reason is known)
 - `Summary`: at minimum, "Session ended [reason]. [N] messages processed." — fill in more if context permits.
 
 This rule is unconditional — even if the session processed zero messages, the tombstone must be written. A stub file with only a start timestamp is nearly as bad as no file at all.
@@ -985,8 +955,6 @@ This rule is unconditional — even if the session processed zero messages, the 
 - All currently in-flight subagents (task_id, subagent type, brief description, and elapsed time since started_at) — these are the entries most at risk of being lost across compaction
 - Any pending user responses (messages that were mark_processing-d but not yet replied to)
 - The current MESSAGE_COUNT at time of compaction
-
-**On context_warning:** Write a tombstone inline as step 2 (see context_warning handler above) — this is faster and more reliable than spawning a subagent, and ensures the record survives even if wind-down is interrupted.
 
 ---
 

--- a/hooks/context-monitor.py
+++ b/hooks/context-monitor.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-PostToolUse hook: context window guard.
+PostToolUse hook: context window monitor.
 
 Reads actual token usage from the session's transcript JSONL file rather than
 relying on the `context_window` field in the PostToolUse payload — which Claude
@@ -15,51 +15,16 @@ Approach:
      + cache_read_input_tokens.
   4. Look up the model's max context window from a known table (200k for all
      current CC models; see MODEL_CONTEXT_SIZES for details).
-  5. Compute used_pct and trigger wind-down mode if at or above WARNING_THRESHOLD.
+  5. Log used_pct to context-monitor.log.
 
-Below the warning threshold (default 70%): logs usage to context-monitor.log.
-At or above the threshold: writes a context_warning message to ~/messages/inbox/
-so the dispatcher can enter wind-down mode and trigger a graceful restart.
-
-Dedup: once a warning is written, /tmp/lobster-context-warning-sent is touched
-so subsequent hook firings skip the write until the flag is cleared on restart.
+No threshold triggering, no wind-down mode, no inbox messages. CC compacts on
+its own terms; the on-compact.py hook handles recovery after each compaction.
+(issue #2056: wind-down mode removed)
 """
 import json
 import sys
-import uuid
 from pathlib import Path
 from datetime import datetime, timezone
-
-# Import state machine for WINDING_DOWN transition (issue #1918).
-# Imported lazily in _write_winding_down() so a missing/broken import never
-# blocks context monitoring. Silent on all errors.
-_STATE_MACHINE_LOADED = False
-_state_machine = None
-
-def _write_winding_down(session_id: str = "") -> None:
-    """Write WINDING_DOWN state to dispatcher-state.json (issue #1918).
-
-    Called once when the context_warning threshold is crossed. Silent on all
-    errors — must never interrupt context monitoring.
-    """
-    global _STATE_MACHINE_LOADED, _state_machine
-    try:
-        if not _STATE_MACHINE_LOADED:
-            import importlib.util
-            _hooks_dir = Path(__file__).parent
-            _src_dir = _hooks_dir.parent / "src"
-            if str(_src_dir) not in sys.path:
-                sys.path.insert(0, str(_src_dir))
-            import state_machine as _sm
-            _state_machine = _sm
-            _STATE_MACHINE_LOADED = True
-        if _state_machine is not None:
-            _state_machine.write_state(_state_machine.WINDING_DOWN, session_id=session_id)
-    except Exception:
-        pass
-
-WARNING_THRESHOLD = 70.0
-DEDUP_FLAG = Path("/tmp/lobster-context-warning-sent")
 
 # Known model context sizes. Matched by prefix so versioned IDs like
 # 'claude-haiku-4-5-20251001' resolve correctly.
@@ -90,10 +55,12 @@ def _model_max_context(model: str) -> int:
 
 def _read_transcript_usage(
     transcript_path: str | None,
-) -> "tuple[float, float, str] | None":
+) -> "tuple[float, float, str, int] | None":
     """Read the last assistant usage entry from the transcript JSONL.
 
-    Returns (used_pct, remaining_pct, model) or None if data is unavailable.
+    Returns (used_pct, remaining_pct, model, total_tokens) or None if data
+    is unavailable. total_tokens is the raw token count (input + cache), which
+    is always accurate regardless of the assumed max context window.
 
     Reads the file line-by-line, keeping only the last assistant entry with a
     usage block. This is O(n) in lines but O(1) in memory — suitable for large
@@ -157,7 +124,7 @@ def _read_transcript_usage(
     used_pct = (total_used / model_max) * 100.0
     remaining_pct = 100.0 - used_pct
 
-    return (used_pct, remaining_pct, last_model)
+    return (used_pct, remaining_pct, last_model, total_used)
 
 
 def _log_usage(log_dir: Path, entry: dict) -> None:
@@ -200,26 +167,6 @@ def _build_absent_context_entry(tool_name: str, reason: str = "") -> dict:
     }
 
 
-def _build_warning_message(used_pct: float) -> dict:
-    """Return the context_warning inbox message payload."""
-    return {
-        "id": str(uuid.uuid4()),
-        "type": "context_warning",
-        "source": "system",
-        "chat_id": 0,
-        "text": f"Context window at {used_pct:.1f}% — entering wind-down mode",
-        "used_percentage": used_pct,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-    }
-
-
-def _write_warning_to_inbox(inbox_dir: Path, message: dict) -> None:
-    """Write the warning message JSON to the inbox directory."""
-    inbox_dir.mkdir(parents=True, exist_ok=True)
-    filename = f"context-warning-{message['id']}.json"
-    (inbox_dir / filename).write_text(json.dumps(message, indent=2))
-
-
 def _handle_payload(
     data: dict,
     log_dir: Path | None = None,
@@ -229,16 +176,14 @@ def _handle_payload(
 
     Accepts log_dir and inbox_dir as injectable parameters so tests can verify
     behavior without touching the real filesystem. When not provided, defaults
-    to the standard runtime paths.
+    to the standard runtime paths. inbox_dir is accepted but unused — retained
+    for test compatibility (issue #2056: inbox warning removed with wind-down mode).
     """
     if log_dir is None:
         log_dir = Path.home() / "lobster-workspace" / "logs"
-    if inbox_dir is None:
-        inbox_dir = Path.home() / "messages" / "inbox"
 
     tool_name = data.get("tool_name", "unknown")
     transcript_path = data.get("transcript_path")
-    session_id = data.get("session_id", "")
 
     result = _read_transcript_usage(transcript_path)
 
@@ -255,25 +200,13 @@ def _handle_payload(
         _log_usage(log_dir, entry)
         return
 
-    used_pct, remaining_pct, model = result
+    used_pct, remaining_pct, model, _total_tokens = result
 
     entry = _build_log_entry(tool_name, used_pct, remaining_pct, model)
     _log_usage(log_dir, entry)
 
-    if used_pct < WARNING_THRESHOLD:
-        return
-
-    # At or above threshold — write a context_warning to inbox (once per session)
-    if DEDUP_FLAG.exists():
-        return
-
-    message = _build_warning_message(used_pct)
-    _write_warning_to_inbox(inbox_dir, message)
-    DEDUP_FLAG.touch()
-    # Transition dispatcher state to WINDING_DOWN (issue #1918).
-    # Written after the inbox message so the dispatcher sees the context_warning
-    # before the health check reads WINDING_DOWN and suppresses restarts.
-    _write_winding_down(session_id=session_id)
+    # No threshold check, no inbox message, no wind-down triggering.
+    # CC compacts on its own terms; on-compact.py handles post-compaction recovery.
 
 
 def main() -> None:

--- a/tests/unit/test_hooks/test_context_monitor.py
+++ b/tests/unit/test_hooks/test_context_monitor.py
@@ -1,29 +1,26 @@
 """
-Unit tests for hooks/context-monitor.py (issue #1790).
+Unit tests for hooks/context-monitor.py (issue #2056: remove wind-down mode).
 
-Root cause: The hook called data.get('context_window') on the PostToolUse payload,
-which Claude Code never populates for PostToolUse events. The hook was a no-op in
-every session.
-
-Fix: Read actual token usage from the transcript JSONL file (at transcript_path in
-the payload). The last assistant turn's usage block gives input + cache counts, which
-are divided by the model's known max context to produce used_pct.
+The context monitor reports token counts to a log. It does NOT trigger wind-down
+mode, does NOT write context_warning inbox messages, and does NOT call any state
+machine transitions. CC handles compaction on its own; no Lobster-side preparation
+is needed.
 
 Behaviors verified:
 1. Transcript present with usage → correct percentage computed from token counts.
 2. transcript_path absent → WARN logged, no crash.
 3. Last assistant turn is selected when multiple turns exist.
 4. Model lookup table: Sonnet 4.6 = 200k (CC default), Haiku 4.5 = 200k, unknown = 200k.
-5. At or above WARNING_THRESHOLD → context_warning written to inbox (once per session).
-6. Dedup flag suppresses second warning.
+5. Token usage is always logged (no threshold suppression).
+6. At ANY usage level, no context_warning is written to inbox.
 7. _handle_payload() accepts injectable log_dir and inbox_dir.
+8. Wind-down artifacts (WARNING_THRESHOLD, DEDUP_FLAG, _write_winding_down, etc.) are absent.
 """
 
 import importlib.util
 import json
 import sys
 from pathlib import Path
-from datetime import datetime, timezone
 
 import pytest
 
@@ -32,7 +29,6 @@ _HOOK_PATH = _HOOKS_DIR / "context-monitor.py"
 
 # Named constants matching the spec — these are protocol-level values.
 WARN_PREFIX_ABSENT_CONTEXT = "[WARN] transcript usage unavailable"
-WARNING_THRESHOLD = 70.0
 # claude-sonnet-4-6 supports up to 1M tokens but CC's default window is 200k.
 # Update when we can detect which mode is active.
 SONNET_4_6_MAX_CONTEXT = 200_000
@@ -99,10 +95,11 @@ class TestTranscriptUsageReading:
         ])
         result = mod._read_transcript_usage(str(transcript))
         assert result is not None, "Expected usage data from transcript"
-        used_pct, remaining_pct, model = result
+        used_pct, remaining_pct, model, total_tokens = result
         assert abs(used_pct - 50.0) < 0.01, f"Expected 50% used, got {used_pct}"
         assert abs(remaining_pct - 50.0) < 0.01
         assert model == "claude-sonnet-4-6"
+        assert total_tokens == 100_000, f"Expected 100_000 raw tokens, got {total_tokens}"
 
     def test_last_turn_wins_when_multiple_turns_exist(self, tmp_path):
         """When multiple assistant turns exist, the last one's usage is returned."""
@@ -127,10 +124,11 @@ class TestTranscriptUsageReading:
         ])
         result = mod._read_transcript_usage(str(transcript))
         assert result is not None
-        used_pct, _, _ = result
+        used_pct, _, _, total_tokens = result
         assert abs(used_pct - 80.0) < 0.01, (
             f"Expected 80% from last turn, got {used_pct}"
         )
+        assert total_tokens == 160_000, f"Expected 160_000 raw tokens from last turn, got {total_tokens}"
 
     def test_returns_none_when_transcript_path_is_none(self, tmp_path):
         """No transcript_path → returns None (caller logs WARN)."""
@@ -173,9 +171,10 @@ class TestTranscriptUsageReading:
         ])
         result = mod._read_transcript_usage(str(transcript))
         assert result is not None
-        used_pct, _, model = result
+        used_pct, _, model, total_tokens = result
         assert abs(used_pct - 100.0) < 0.01, f"Expected 100%, got {used_pct}"
         assert model == "claude-haiku-4-5"
+        assert total_tokens == 200_000, f"Expected 200_000 raw tokens, got {total_tokens}"
 
 
 class TestModelContextLookup:
@@ -212,11 +211,11 @@ class TestModelContextLookup:
         assert mod._model_max_context("") == DEFAULT_MAX_CONTEXT
 
 
-class TestHandlePayloadTranscriptPath:
-    """_handle_payload() uses transcript_path to read usage from the JSONL."""
+class TestHandlePayloadLogging:
+    """_handle_payload() logs token usage but never writes context_warning inbox messages."""
 
-    def test_logs_usage_from_transcript_below_threshold(self, tmp_path):
-        """Transcript present, below 70% → usage entry logged with source=transcript_jsonl."""
+    def test_logs_usage_from_transcript_at_any_level(self, tmp_path):
+        """Transcript present at 30% → usage entry logged with source=transcript_jsonl."""
         mod = _load_hook()
         log_dir = tmp_path / "lobster-workspace" / "logs"
         log_dir.mkdir(parents=True)
@@ -245,77 +244,72 @@ class TestHandlePayloadTranscriptPath:
         assert entry.get("source") == "transcript_jsonl"
         assert not entry.get("transcript_unavailable", False)
 
-    def test_writes_inbox_warning_at_threshold(self, tmp_path):
-        """Transcript usage at or above WARNING_THRESHOLD → inbox warning written."""
+    def test_logs_usage_above_former_threshold(self, tmp_path):
+        """Transcript usage above 70% (old threshold) → usage logged, NO inbox message."""
         mod = _load_hook()
         log_dir = tmp_path / "lobster-workspace" / "logs"
         log_dir.mkdir(parents=True, exist_ok=True)
         inbox_dir = tmp_path / "messages" / "inbox"
         inbox_dir.mkdir(parents=True, exist_ok=True)
-        dedup_flag = tmp_path / "lobster-context-warning-sent"
 
-        original_dedup = mod.DEDUP_FLAG
-        mod.DEDUP_FLAG = dedup_flag
-        try:
-            # 160k / 200k (CC default) = 80% → above 70% threshold
-            transcript = _make_transcript(tmp_path, [
-                {
-                    "model": "claude-sonnet-4-6",
-                    "usage": {
-                        "input_tokens": 160_000,
-                        "cache_creation_input_tokens": 0,
-                        "cache_read_input_tokens": 0,
-                    },
-                }
-            ])
-            payload = {
-                "tool_name": "mcp__lobster-inbox__wait_for_messages",
-                "transcript_path": str(transcript),
+        # 160k / 200k = 80% — formerly above the wind-down threshold
+        transcript = _make_transcript(tmp_path, [
+            {
+                "model": "claude-sonnet-4-6",
+                "usage": {
+                    "input_tokens": 160_000,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
             }
-            mod._handle_payload(payload, log_dir=log_dir, inbox_dir=inbox_dir)
-        finally:
-            mod.DEDUP_FLAG = original_dedup
+        ])
+        payload = {
+            "tool_name": "mcp__lobster-inbox__wait_for_messages",
+            "transcript_path": str(transcript),
+        }
+        mod._handle_payload(payload, log_dir=log_dir, inbox_dir=inbox_dir)
 
-        inbox_files = list(inbox_dir.glob("context-warning-*.json"))
-        assert len(inbox_files) == 1
-        msg = json.loads(inbox_files[0].read_text())
-        assert msg["type"] == "context_warning"
-        assert msg["used_percentage"] > WARNING_THRESHOLD
+        # Token usage must still be logged
+        entries = _read_log(log_dir)
+        assert len(entries) == 1, f"Expected 1 log entry, got {len(entries)}"
+        assert abs(entries[0]["used_percentage"] - 80.0) < 0.01
 
-    def test_dedup_suppresses_second_warning(self, tmp_path):
-        """Dedup flag present → second warning is not written."""
+        # Inbox must be completely empty — no context_warning ever
+        inbox_files = list(inbox_dir.glob("*.json"))
+        assert len(inbox_files) == 0, (
+            f"context_warning must never be written to inbox (wind-down mode removed), "
+            f"but found: {inbox_files}"
+        )
+
+    def test_no_inbox_message_at_full_context(self, tmp_path):
+        """Even at 100% context usage, no context_warning is written to inbox."""
         mod = _load_hook()
         log_dir = tmp_path / "lobster-workspace" / "logs"
         log_dir.mkdir(parents=True, exist_ok=True)
         inbox_dir = tmp_path / "messages" / "inbox"
         inbox_dir.mkdir(parents=True, exist_ok=True)
-        dedup_flag = tmp_path / "lobster-context-warning-sent"
-        dedup_flag.touch()  # Already flagged
 
-        original_dedup = mod.DEDUP_FLAG
-        mod.DEDUP_FLAG = dedup_flag
-        try:
-            # 180k / 200k (CC default) = 90% → above 70% threshold
-            transcript = _make_transcript(tmp_path, [
-                {
-                    "model": "claude-sonnet-4-6",
-                    "usage": {
-                        "input_tokens": 180_000,
-                        "cache_creation_input_tokens": 0,
-                        "cache_read_input_tokens": 0,
-                    },
-                }
-            ])
-            payload = {
-                "tool_name": "Bash",
-                "transcript_path": str(transcript),
+        # 200k / 200k = 100% — maximum possible context usage
+        transcript = _make_transcript(tmp_path, [
+            {
+                "model": "claude-sonnet-4-6",
+                "usage": {
+                    "input_tokens": 200_000,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
             }
-            mod._handle_payload(payload, log_dir=log_dir, inbox_dir=inbox_dir)
-        finally:
-            mod.DEDUP_FLAG = original_dedup
+        ])
+        payload = {
+            "tool_name": "Bash",
+            "transcript_path": str(transcript),
+        }
+        mod._handle_payload(payload, log_dir=log_dir, inbox_dir=inbox_dir)
 
-        inbox_files = list(inbox_dir.glob("context-warning-*.json"))
-        assert len(inbox_files) == 0, "Dedup flag should suppress second warning"
+        inbox_files = list(inbox_dir.glob("*.json"))
+        assert len(inbox_files) == 0, (
+            f"Inbox must remain empty regardless of context level, but found: {inbox_files}"
+        )
 
     def test_logs_warn_when_transcript_path_absent(self, tmp_path):
         """Payload with no transcript_path → WARN written to log, no crash."""
@@ -336,7 +330,7 @@ class TestHandlePayloadTranscriptPath:
         assert entry.get("tool") == "mcp__lobster-inbox__wait_for_messages"
 
     def test_no_inbox_message_when_transcript_absent(self, tmp_path):
-        """Missing transcript_path must never trigger a context_warning inbox message."""
+        """Missing transcript_path must never trigger any inbox message."""
         mod = _load_hook()
         inbox_dir = tmp_path / "messages" / "inbox"
         inbox_dir.mkdir(parents=True, exist_ok=True)
@@ -348,8 +342,51 @@ class TestHandlePayloadTranscriptPath:
 
         inbox_files = list(inbox_dir.glob("*.json"))
         assert len(inbox_files) == 0, (
-            f"No inbox message should be written when transcript absent, "
-            f"but found: {inbox_files}"
+            f"No inbox message should ever be written, but found: {inbox_files}"
+        )
+
+
+class TestWindDownRemoved:
+    """Wind-down mode artifacts are completely absent from the hook (issue #2056).
+
+    These tests verify that the hook no longer contains the wind-down triggering
+    mechanism: no WARNING_THRESHOLD, no DEDUP_FLAG, no _write_winding_down(),
+    no state machine imports.
+    """
+
+    def test_no_warning_threshold_constant(self):
+        """Hook must not export WARNING_THRESHOLD (removed with wind-down mode)."""
+        mod = _load_hook()
+        assert not hasattr(mod, "WARNING_THRESHOLD"), (
+            "WARNING_THRESHOLD constant must be removed — wind-down mode is gone"
+        )
+
+    def test_no_dedup_flag_constant(self):
+        """Hook must not export DEDUP_FLAG (removed with wind-down mode)."""
+        mod = _load_hook()
+        assert not hasattr(mod, "DEDUP_FLAG"), (
+            "DEDUP_FLAG must be removed — wind-down dedup logic is gone"
+        )
+
+    def test_no_write_winding_down_function(self):
+        """Hook must not export _write_winding_down() (removed with wind-down mode)."""
+        mod = _load_hook()
+        assert not hasattr(mod, "_write_winding_down"), (
+            "_write_winding_down() must be removed — state machine transition is gone"
+        )
+
+    def test_no_build_warning_message_function(self):
+        """Hook must not export _build_warning_message() (removed with wind-down mode)."""
+        mod = _load_hook()
+        assert not hasattr(mod, "_build_warning_message"), (
+            "_build_warning_message() must be removed — inbox warning is gone"
+        )
+
+    def test_no_write_warning_to_inbox_function(self):
+        """Hook must not export _write_warning_to_inbox() (removed with wind-down mode)."""
+        mod = _load_hook()
+        assert not hasattr(mod, "_write_warning_to_inbox"), (
+            "_write_warning_to_inbox() must be removed — inbox warning is gone"
         )
 
 
@@ -373,134 +410,6 @@ class TestHandlePayloadSignature:
         assert "inbox_dir" in sig.parameters, (
             "_handle_payload() must accept inbox_dir= for testability"
         )
-
-
-class TestWindingDownStateTransition:
-    """_write_winding_down() writes WINDING_DOWN to dispatcher-state.json (issue #1918)."""
-
-    def test_winding_down_calls_write_state_on_threshold(self, tmp_path):
-        """When context_warning is triggered, write_state(WINDING_DOWN) is called.
-
-        Uses a mock state machine so the test doesn't depend on the real
-        state_machine module being on sys.path (it may not be on older branches).
-        """
-        mod = _load_hook()
-        log_dir = tmp_path / "logs"
-        log_dir.mkdir(parents=True, exist_ok=True)
-        inbox_dir = tmp_path / "inbox"
-        inbox_dir.mkdir(parents=True, exist_ok=True)
-        dedup_flag = tmp_path / "context-warning-sent"
-
-        # Record calls to write_state via a mock state machine object
-        write_state_calls: list[dict] = []
-
-        class MockStateMachine:
-            WINDING_DOWN = "WINDING_DOWN"
-
-            @staticmethod
-            def write_state(state: str, session_id: str = "") -> None:
-                write_state_calls.append({"state": state, "session_id": session_id})
-
-        original_dedup = mod.DEDUP_FLAG
-        mod.DEDUP_FLAG = dedup_flag
-
-        # Inject mock directly — bypass the lazy import path
-        mod._STATE_MACHINE_LOADED = True
-        mod._state_machine = MockStateMachine
-
-        try:
-            # 160k / 200k (CC default) = 80% → triggers threshold
-            transcript = _make_transcript(tmp_path, [
-                {
-                    "model": "claude-sonnet-4-6",
-                    "usage": {
-                        "input_tokens": 160_000,
-                        "cache_creation_input_tokens": 0,
-                        "cache_read_input_tokens": 0,
-                    },
-                }
-            ])
-            payload = {
-                "tool_name": "Bash",
-                "transcript_path": str(transcript),
-                "session_id": "test-session-001",
-            }
-            mod._handle_payload(payload, log_dir=log_dir, inbox_dir=inbox_dir)
-        finally:
-            mod.DEDUP_FLAG = original_dedup
-            mod._STATE_MACHINE_LOADED = False
-            mod._state_machine = None
-
-        assert len(write_state_calls) == 1, (
-            f"Expected exactly one write_state call, got: {write_state_calls}"
-        )
-        assert write_state_calls[0]["state"] == "WINDING_DOWN", (
-            f"Expected WINDING_DOWN, got: {write_state_calls[0]['state']}"
-        )
-        assert write_state_calls[0]["session_id"] == "test-session-001"
-
-    def test_winding_down_not_called_below_threshold(self, tmp_path):
-        """write_state(WINDING_DOWN) must NOT be called when below threshold."""
-        mod = _load_hook()
-        log_dir = tmp_path / "logs"
-        log_dir.mkdir(parents=True, exist_ok=True)
-        inbox_dir = tmp_path / "inbox"
-        inbox_dir.mkdir(parents=True, exist_ok=True)
-
-        write_state_calls: list[dict] = []
-
-        class MockStateMachine:
-            WINDING_DOWN = "WINDING_DOWN"
-
-            @staticmethod
-            def write_state(state: str, session_id: str = "") -> None:
-                write_state_calls.append({"state": state, "session_id": session_id})
-
-        mod._STATE_MACHINE_LOADED = True
-        mod._state_machine = MockStateMachine
-
-        try:
-            # 60k / 200k (CC default) = 30% → below 70% threshold
-            transcript = _make_transcript(tmp_path, [
-                {
-                    "model": "claude-sonnet-4-6",
-                    "usage": {
-                        "input_tokens": 60_000,
-                        "cache_creation_input_tokens": 0,
-                        "cache_read_input_tokens": 0,
-                    },
-                }
-            ])
-            payload = {"tool_name": "Bash", "transcript_path": str(transcript)}
-            mod._handle_payload(payload, log_dir=log_dir, inbox_dir=inbox_dir)
-        finally:
-            mod._STATE_MACHINE_LOADED = False
-            mod._state_machine = None
-
-        assert len(write_state_calls) == 0, (
-            f"write_state must not be called below threshold, got: {write_state_calls}"
-        )
-
-    def test_winding_down_silent_on_import_error(self, tmp_path):
-        """_write_winding_down() must never raise — it is a best-effort write."""
-        mod = _load_hook()
-        # Ensure lazy-load state is reset so the import path is exercised
-        mod._STATE_MACHINE_LOADED = False
-        mod._state_machine = None
-
-        # Restrict sys.path to a location with no state_machine module
-        import sys
-        original_path = sys.path[:]
-        sys.path = [str(tmp_path)]  # empty dir, no state_machine
-        try:
-            # Must not raise
-            mod._write_winding_down(session_id="test")
-        except Exception as exc:
-            pytest.fail(f"_write_winding_down() must be silent on error, but raised: {exc}")
-        finally:
-            sys.path = original_path
-            mod._STATE_MACHINE_LOADED = False
-            mod._state_machine = None
 
 
 # Named constants for the matcher pattern (issue #1985).


### PR DESCRIPTION
Closes #2056

## Why this exists

The 70% context threshold in `context-monitor.py` raced with CC's own compaction threshold (also ~70%), causing 11+ compactions on May 8 alone. Wind-down mode also created an indistinguishable silence state — from outside the process, there was no way to tell whether Lobster was intentionally winding down or crashed.

The core design assumption behind wind-down was wrong: the dispatcher does not need to prepare for compaction. `on-compact.py` already fires after each compaction and handles recovery (notification, compact-catchup). The 70% hook and the dispatcher's preparation for it were redundant defensive code that introduced more problems than they solved.

## What changed

**`hooks/context-monitor.py`** — Removed the threshold check entirely. Removed `WARNING_THRESHOLD`, `DEDUP_FLAG`, `_write_winding_down()`, `_build_warning_message()`, and `_write_warning_to_inbox()`. The hook now logs token usage on every tool call and returns immediately — no inbox messages, no state machine transitions. The 4-tuple return from `_read_transcript_usage()` (with `total_tokens`, from PR #2013) is preserved.

**`.claude/sys.dispatcher.bootup.md`** — Removed the `context_warning` message handler (26 lines), all `WIND_DOWN_MODE` references, and the "On context_warning" tombstone instruction. Updated the tombstone `End reason` list to replace `graceful wind-down`/`context_warning` with `compaction`. The `session_note_reminder` handler no longer has a `WIND_DOWN_MODE` guard.

**`tests/unit/test_hooks/test_context_monitor.py`** — Replaced wind-down-specific tests (`TestWindingDownStateTransition`, `TestTokenCountDisplay`, threshold-triggered inbox write tests) with:
- `TestHandlePayloadLogging`: verifies usage is logged at any level, inbox stays empty at 80% and 100%, warn on absent transcript
- `TestWindDownRemoved`: structural tests asserting that `WARNING_THRESHOLD`, `DEDUP_FLAG`, `_write_winding_down`, `_build_warning_message`, and `_write_warning_to_inbox` are absent from the module

## What was not touched

- `on-compact.py` SessionStart hook
- Compact-catchup agent
- Health-check grace periods after compaction
- Post-compact gate
- `session_note_reminder` handler logic (only removed the `WIND_DOWN_MODE` guard line)
- `session.end` event in `events.jsonl` (startup recovery check at step 2c still reads this — the only emitter was the context_warning handler, so this check will produce "no recent session.end" after this change, which is correct behavior)

## State transition: before vs after

```
Before:
  Token usage checked after every tool call
  |
  >= 70% threshold?
    Yes -> write context_warning to inbox -> dispatcher enters WIND_DOWN_MODE
             -> stops spawning, drains agents, writes tombstone
             -> waits for CC compaction (which also triggers at ~70%)
             -> RACE: both CC and dispatcher acting on same context overflow

After:
  Token usage logged after every tool call (no threshold, no action taken)
  |
  CC compacts when it decides to
  |
  on-compact.py fires -> sends notification -> spawns compact-catchup
```

## Functional patterns used

Pure functions throughout (`_read_transcript_usage`, `_build_log_entry`, `_build_absent_context_entry` — all return immutable dicts from inputs, no side effects). Side effects isolated to `_log_usage` and `_handle_payload`. Injectable parameters (`log_dir`, `inbox_dir`) preserved for testability.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_context_monitor.py -v` — 29 passed, 0 failed (red phase: 5 failures before implementation; green phase: all 29 pass after)
- [x] `uv run pytest tests/unit/ -q` — 3264 passed, 1 pre-existing failure in `test_bisque/test_relay_server.py::TestWSAuth::test_auth_success` (test isolation issue when run in full suite; passes in isolation on both main and this branch — unrelated to this change)

## Manual test

N/A — this change is entirely internal. The hook still fires on every tool call and logs to `context-monitor.log`; the only behavioral change is that it no longer writes inbox messages or transitions dispatcher state. No external service calls, no Telegram output, no DB schema changes.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run (N/A — internal change only)
- [x] User-visible outcome verified (N/A — removal of a silent internal state)
- [x] Side-effect audit complete: no floods, no unscoped writes — change removes writes, does not add them
- [x] External service calls: none