### PR TITLE
fix: graceful proactive restart at 7200s to avoid hard CC session limit

### DIFF
--- a/hooks/inject-bootup-context.py
+++ b/hooks/inject-bootup-context.py
@@ -76,6 +76,18 @@ STARTUP_CAUSE_FILE = Path(
 # compaction that was followed by an unrelated external restart.
 COMPACTION_CAUSE_WINDOW_SECONDS = 300  # 5 minutes
 
+# Dispatcher session start timestamp file (issue #2059).
+# Written by this hook on every dispatcher SessionStart as a plain Unix epoch
+# integer (seconds). Read by health-check-v3.sh to compute session age and
+# trigger a proactive restart before the hard 7440s CC session lifetime limit.
+# Override via env var for test isolation.
+DISPATCHER_SESSION_START_FILE = Path(
+    os.environ.get(
+        "LOBSTER_DISPATCHER_SESSION_START_FILE_OVERRIDE",
+        str(_LOBSTER_WORKSPACE / "data" / "dispatcher-session-start.ts"),
+    )
+)
+
 
 def _is_startup_flag_dispatcher() -> bool:
     """Return True if a live startup flag marks this as the dispatcher session.
@@ -118,6 +130,27 @@ def _consume_startup_flag() -> None:
     try:
         STARTUP_FLAG_FILE.unlink(missing_ok=True)
     except OSError:
+        pass
+
+
+def _write_dispatcher_session_start() -> None:
+    """Write the current Unix epoch to DISPATCHER_SESSION_START_FILE.
+
+    Called once per dispatcher SessionStart. The health check reads this file
+    to compute session age and trigger a proactive restart before the hard
+    7440s CC session lifetime limit (issue #2059).
+
+    Uses an atomic rename so the reader never sees a partial write.
+    Silent on any error — must never crash the hook.
+    """
+    try:
+        now_epoch = int(time.time())
+        path = DISPATCHER_SESSION_START_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_suffix(".tmp")
+        tmp_path.write_text(str(now_epoch) + "\n")
+        tmp_path.replace(path)  # atomic on Linux
+    except Exception:  # noqa: BLE001
         pass
 
 
@@ -272,6 +305,14 @@ def main() -> None:
         _consume_startup_flag()
         print(
             f"[{HOOK_NAME}] startup-flag detected live PID — injecting dispatcher bootup",
+            file=sys.stderr,
+        )
+        # Record session start time for health-check proactive restart (issue #2059).
+        # Plain Unix epoch written atomically; health-check-v3.sh reads it to detect
+        # sessions approaching the 7440s CC hard limit and send SIGTERM early.
+        _write_dispatcher_session_start()
+        print(
+            f"[{HOOK_NAME}] wrote dispatcher session start timestamp",
             file=sys.stderr,
         )
 

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -100,6 +100,14 @@ HEARTBEAT_FILE="$WORKSPACE_DIR/logs/claude-heartbeat"   # legacy WFM-touch signa
 DISPATCHER_HEARTBEAT_FILE="${LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE:-$WORKSPACE_DIR/logs/dispatcher-heartbeat}"
 DISPATCHER_HEARTBEAT_STALE_SECONDS=1200   # 20 min — covers compaction (~5m) + catchup (~12m) + margin
 
+# Session age limit: CC enforces a hard 7440s session lifetime (issue #2059).
+# At this limit, CC kills the process without firing the Stop hook — no tombstone,
+# no compaction alert. We trigger a graceful SIGTERM at SESSION_AGE_LIMIT_SECONDS
+# (7200s = 2 min before hard limit) so the Stop hook fires cleanly.
+# Written by inject-bootup-context.py as a plain Unix epoch integer.
+SESSION_AGE_LIMIT_SECONDS="${LOBSTER_SESSION_AGE_LIMIT_SECONDS:-7200}"
+DISPATCHER_SESSION_START_FILE="${LOBSTER_DISPATCHER_SESSION_START_FILE_OVERRIDE:-$WORKSPACE_DIR/data/dispatcher-session-start.ts}"
+
 # WFM-active signal (issue #1713 / #949): inbox_server.py writes this file with
 # a Unix epoch timestamp when wait_for_messages begins blocking and refreshes it
 # every WAIT_HEARTBEAT_INTERVAL (60s). When this file is fresh, the dispatcher is
@@ -1260,6 +1268,95 @@ except Exception as e:
 }
 
 #===============================================================================
+# Session Age Check — proactive restart before the 7440s CC hard limit
+# (issue #2059)
+#
+# CC enforces a hard 7440-second (124-minute) session lifetime. When this limit
+# is hit, CC exits without firing the Stop hook — no tombstone, no compact-
+# catchup. To avoid this, we send SIGTERM to the dispatcher process at
+# SESSION_AGE_LIMIT_SECONDS (7200s = 2 min before the limit), which fires the
+# Stop hook cleanly.
+#
+# Unlike do_restart() (which uses systemctl), this sends SIGTERM directly to the
+# claude process so the Stop hook fires. The claude-persistent.sh wrapper detects
+# the exit and restarts Claude automatically.
+#
+# Suppressed when:
+#   - DISPATCHER_SESSION_START_FILE is missing (old install, no session tracking)
+#   - Maintenance mode is active (flag is present — handled in main before this call)
+#   - Boot grace period is active (avoid killing a session that just started)
+#
+# Returns:
+#   0 — session age is within limit (or no data)
+#   1 — SIGTERM sent (graceful proactive restart initiated)
+#===============================================================================
+check_session_age() {
+    if [[ ! -f "$DISPATCHER_SESSION_START_FILE" ]]; then
+        log_info "Session age: no start timestamp file — skipping (old install or first run)"
+        return 0
+    fi
+
+    local session_start
+    session_start=$(< "$DISPATCHER_SESSION_START_FILE") 2>/dev/null || true
+    # Validate: must be a plain positive integer.
+    if [[ ! "$session_start" =~ ^[0-9]+$ ]]; then
+        log_warn "Session age: malformed start timestamp '${session_start}' — skipping"
+        return 0
+    fi
+
+    local now
+    now=$(date +%s)
+    local session_age=$(( now - session_start ))
+
+    log_info "Session age: ${session_age}s (limit: ${SESSION_AGE_LIMIT_SECONDS}s)"
+
+    if [[ $session_age -lt $SESSION_AGE_LIMIT_SECONDS ]]; then
+        return 0
+    fi
+
+    # Session is at or past the proactive restart threshold.
+    log_warn "SESSION AGE LIMIT: session is ${session_age}s old (>= ${SESSION_AGE_LIMIT_SECONDS}s) — sending SIGTERM for graceful restart"
+
+    # Read the dispatcher PID from the PID file (same source do_restart() uses).
+    local dispatcher_pid=""
+    if [[ -f "$DISPATCHER_PID_FILE" ]]; then
+        dispatcher_pid=$(< "$DISPATCHER_PID_FILE")
+        if [[ ! "$dispatcher_pid" =~ ^[0-9]+$ ]]; then
+            log_warn "Session age: dispatcher.pid contains non-numeric value '${dispatcher_pid}' — cannot send SIGTERM"
+            dispatcher_pid=""
+        fi
+    fi
+
+    if [[ -z "$dispatcher_pid" ]]; then
+        log_warn "Session age: no dispatcher.pid — cannot send SIGTERM (systemctl restart fallback not used for this path)"
+        return 0
+    fi
+
+    # Verify the PID is still alive before sending SIGTERM.
+    if ! kill -0 "$dispatcher_pid" 2>/dev/null; then
+        log_warn "Session age: dispatcher PID $dispatcher_pid is no longer alive — skipping SIGTERM"
+        return 0
+    fi
+
+    # Send SIGTERM. The Stop hook fires, writes the tombstone, and claude-persistent.sh
+    # restarts Claude. This is a graceful exit, not a crash.
+    if kill -TERM "$dispatcher_pid" 2>/dev/null; then
+        log_warn "Session age: SIGTERM sent to dispatcher PID $dispatcher_pid"
+        send_telegram_alert_deduped "proactive-session-restart" "Lobster: proactive restart at ${session_age}s (before the 7440s CC hard limit).
+
+Dispatcher PID $dispatcher_pid sent SIGTERM. Stop hook will fire, session will restart cleanly.
+Next session will start fresh — no context lost from hard limit."
+        # Delete the start timestamp so a subsequent health check run (within the
+        # next 4 minutes) does not send a second SIGTERM before the restart completes.
+        rm -f "$DISPATCHER_SESSION_START_FILE" 2>/dev/null || true
+        return 1
+    else
+        log_warn "Session age: SIGTERM to PID $dispatcher_pid failed (process may have exited already)"
+        return 0
+    fi
+}
+
+#===============================================================================
 # Recovery - always via systemd, never manual tmux
 #===============================================================================
 # DANGER: do_restart() must ONLY be called when the system is confirmed
@@ -1617,6 +1714,22 @@ main() {
     local boot_grace=false
     if is_boot_grace_period; then
         boot_grace=true
+    fi
+
+    # --- Session age check: proactive restart before 7440s CC hard limit ---
+    # Suppressed during boot grace: a session that just started cannot be near
+    # the limit, and a stale timestamp from a crashed previous session could
+    # cause a false SIGTERM during the new session's first minutes.
+    if [[ "$boot_grace" == "true" ]]; then
+        log_info "Session age check suppressed (boot grace period)"
+    else
+        check_session_age
+        # Return value 1 means SIGTERM was sent — exit now so we don't pile
+        # additional restart actions on top of the in-flight graceful exit.
+        if [[ $? -eq 1 ]]; then
+            log_info "=== Health check v3 complete (session age restart initiated) ==="
+            exit 0
+        fi
     fi
 
     # --- Always check systemd services (includes router/bot) ---

--- a/tests/test-health-check-session-age.sh
+++ b/tests/test-health-check-session-age.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+#===============================================================================
+# Test Suite: Health Check v3 - Session Age Check (issue #2059)
+#
+# Tests for check_session_age() — the proactive restart before the 7440s CC
+# hard session lifetime limit.
+#
+# CC kills the dispatcher at exactly 7440s with no Stop hook. check_session_age()
+# triggers a graceful SIGTERM at SESSION_AGE_LIMIT_SECONDS (7200s) so the
+# Stop hook fires cleanly before the hard limit hits.
+#
+# Tests:
+#   1. No start timestamp file → returns 0 (GREEN, no action)
+#   2. Young session (age < SESSION_AGE_LIMIT_SECONDS) → returns 0 (GREEN)
+#   3. Session at exact limit → sends SIGTERM, returns 1
+#   4. Session past limit (age > SESSION_AGE_LIMIT_SECONDS) → sends SIGTERM, returns 1
+#   5. SIGTERM sent to live dispatcher PID
+#   6. No dispatcher.pid file → returns 0 (cannot act, skip gracefully)
+#   7. Malformed start timestamp (non-integer) → returns 0 (graceful fallback)
+#   8. Empty start timestamp file → returns 0 (graceful fallback)
+#   9. Start file deleted after SIGTERM (prevents double-fire on next health check)
+#  10. Boot grace suppression: caller suppresses check during boot grace period
+#      (check_session_age itself does not implement boot grace — suppression is in main())
+#
+# Usage: bash tests/test-health-check-session-age.sh
+#===============================================================================
+
+set -u
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts"
+HEALTH_SCRIPT="$SCRIPT_DIR/health-check-v3.sh"
+
+TEST_TMPDIR=$(mktemp -d /tmp/lobster-session-age-test-XXXXXX)
+TEST_LOG_DIR="$TEST_TMPDIR/logs"
+TEST_DATA_DIR="$TEST_TMPDIR/data"
+TEST_MESSAGES_DIR="$TEST_TMPDIR/messages"
+TEST_CONFIG_DIR="$TEST_MESSAGES_DIR/config"
+
+cleanup() { rm -rf "$TEST_TMPDIR"; }
+trap cleanup EXIT
+
+mkdir -p "$TEST_LOG_DIR" "$TEST_DATA_DIR" "$TEST_CONFIG_DIR" "$TEST_TMPDIR/alert-dedup"
+
+begin_test() { TOTAL=$((TOTAL + 1)); test_name="$1"; }
+pass()  { PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC} $test_name"; }
+fail()  { FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC} $test_name: $1"; }
+
+assert_exit() {
+    local actual="$1" expected="$2"
+    if [[ "$actual" -eq "$expected" ]]; then pass; else fail "expected exit $expected, got $actual"; fi
+}
+
+#===============================================================================
+# Named constants (from the spec — never hardcode magic values in tests)
+#===============================================================================
+SESSION_AGE_LIMIT_SECONDS=7200        # from health-check-v3.sh default
+DISPATCHER_SESSION_START_FILENAME="dispatcher-session-start.ts"
+DISPATCHER_PID_FILENAME="dispatcher.pid"
+
+#===============================================================================
+# Stub the minimal environment for check_session_age() to run
+#===============================================================================
+
+LOG_FILE="$TEST_LOG_DIR/health-check.log"
+
+log()       { echo "[$(date -Iseconds)] [$1] $2" >> "$LOG_FILE" 2>/dev/null; }
+log_info()  { log INFO "$1"; }
+log_warn()  { log WARN "$1"; }
+log_error() { log ERROR "$1"; }
+
+# Stub send_telegram_alert_deduped: write to a file so we can assert it was called.
+TELEGRAM_ALERTS_FILE="$TEST_TMPDIR/telegram-alerts.txt"
+send_telegram_alert_deduped() {
+    echo "ALERT[$1]: $2" >> "$TELEGRAM_ALERTS_FILE"
+}
+
+# Override env vars that check_session_age() reads.
+DISPATCHER_SESSION_START_FILE="$TEST_DATA_DIR/$DISPATCHER_SESSION_START_FILENAME"
+DISPATCHER_PID_FILE="$TEST_CONFIG_DIR/$DISPATCHER_PID_FILENAME"
+ALERT_DEDUP_DIR="$TEST_TMPDIR/alert-dedup"
+
+# Load check_session_age() from the health check script.
+# We extract just the function to avoid sourcing the entire ~2000-line file.
+eval "$(sed -n '/^check_session_age()/,/^}/p' "$HEALTH_SCRIPT")" 2>/dev/null
+
+if ! declare -f check_session_age > /dev/null 2>&1; then
+    echo "FATAL: check_session_age() not found in $HEALTH_SCRIPT"
+    exit 1
+fi
+
+#===============================================================================
+# Helper: reset test state between tests
+#===============================================================================
+reset_state() {
+    rm -f "$DISPATCHER_SESSION_START_FILE" "$DISPATCHER_PID_FILE"
+    rm -f "$TELEGRAM_ALERTS_FILE"
+}
+
+#===============================================================================
+# Tests
+#===============================================================================
+
+echo ""
+echo "=== Health Check Session Age Tests ==="
+echo ""
+
+# 1. No start timestamp file → returns 0 (GREEN, no action)
+begin_test "no_start_file_returns_green"
+reset_state
+check_session_age
+assert_exit $? 0
+
+# 2. Young session (age = 0s) → returns 0 (GREEN)
+begin_test "young_session_returns_green"
+reset_state
+echo "$(date +%s)" > "$DISPATCHER_SESSION_START_FILE"
+check_session_age
+assert_exit $? 0
+
+# 3. Session just under the limit (SESSION_AGE_LIMIT_SECONDS - 1) → returns 0
+begin_test "session_just_under_limit_returns_green"
+reset_state
+early_start=$(( $(date +%s) - SESSION_AGE_LIMIT_SECONDS + 1 ))
+echo "$early_start" > "$DISPATCHER_SESSION_START_FILE"
+check_session_age
+assert_exit $? 0
+
+# 4. Session at exact limit → sends SIGTERM, returns 1
+# We use a dummy process to receive SIGTERM.
+begin_test "session_at_exact_limit_sends_sigterm"
+reset_state
+# Start a background sleep process to receive the SIGTERM.
+sleep 600 &
+target_pid=$!
+echo "$target_pid" > "$DISPATCHER_PID_FILE"
+at_limit_start=$(( $(date +%s) - SESSION_AGE_LIMIT_SECONDS ))
+echo "$at_limit_start" > "$DISPATCHER_SESSION_START_FILE"
+check_session_age
+rc=$?
+kill "$target_pid" 2>/dev/null || true  # clean up if SIGTERM didn't kill it
+assert_exit $rc 1
+
+# 5. Session past limit → sends SIGTERM, returns 1
+begin_test "session_past_limit_sends_sigterm"
+reset_state
+sleep 600 &
+target_pid=$!
+echo "$target_pid" > "$DISPATCHER_PID_FILE"
+past_limit_start=$(( $(date +%s) - SESSION_AGE_LIMIT_SECONDS - 60 ))
+echo "$past_limit_start" > "$DISPATCHER_SESSION_START_FILE"
+check_session_age
+rc=$?
+kill "$target_pid" 2>/dev/null || true
+assert_exit $rc 1
+
+# 6. No dispatcher.pid file → returns 0 (cannot send SIGTERM, skips gracefully)
+begin_test "no_pid_file_returns_green"
+reset_state
+past_start=$(( $(date +%s) - SESSION_AGE_LIMIT_SECONDS - 60 ))
+echo "$past_start" > "$DISPATCHER_SESSION_START_FILE"
+# No DISPATCHER_PID_FILE written
+check_session_age
+assert_exit $? 0
+
+# 7. Malformed start timestamp (non-integer) → returns 0 (graceful fallback)
+begin_test "malformed_start_timestamp_returns_green"
+reset_state
+echo "not-a-number" > "$DISPATCHER_SESSION_START_FILE"
+check_session_age
+assert_exit $? 0
+
+# 8. Empty start timestamp file → returns 0 (graceful fallback)
+begin_test "empty_start_file_returns_green"
+reset_state
+# shellcheck disable=SC2188
+> "$DISPATCHER_SESSION_START_FILE"  # empty file
+check_session_age
+assert_exit $? 0
+
+# 9. Start file deleted after SIGTERM (prevents double-fire on next health check run)
+begin_test "start_file_deleted_after_sigterm"
+reset_state
+sleep 600 &
+target_pid=$!
+echo "$target_pid" > "$DISPATCHER_PID_FILE"
+past_limit_start=$(( $(date +%s) - SESSION_AGE_LIMIT_SECONDS - 60 ))
+echo "$past_limit_start" > "$DISPATCHER_SESSION_START_FILE"
+check_session_age
+kill "$target_pid" 2>/dev/null || true
+if [[ ! -f "$DISPATCHER_SESSION_START_FILE" ]]; then
+    pass
+else
+    fail "start file still present after SIGTERM — double-fire risk on next health check"
+fi
+
+# 10. Dead PID in dispatcher.pid → returns 0 (cannot send SIGTERM to dead process)
+begin_test "dead_pid_returns_green"
+reset_state
+# Find a PID that is definitely not alive.
+dead_pid=999997
+while kill -0 "$dead_pid" 2>/dev/null; do
+    dead_pid=$((dead_pid - 1))
+done
+echo "$dead_pid" > "$DISPATCHER_PID_FILE"
+past_start=$(( $(date +%s) - SESSION_AGE_LIMIT_SECONDS - 60 ))
+echo "$past_start" > "$DISPATCHER_SESSION_START_FILE"
+check_session_age
+assert_exit $? 0
+
+# 11. Telegram alert is sent when SIGTERM fires
+begin_test "telegram_alert_sent_on_sigterm"
+reset_state
+sleep 600 &
+target_pid=$!
+echo "$target_pid" > "$DISPATCHER_PID_FILE"
+past_start=$(( $(date +%s) - SESSION_AGE_LIMIT_SECONDS - 60 ))
+echo "$past_start" > "$DISPATCHER_SESSION_START_FILE"
+check_session_age
+kill "$target_pid" 2>/dev/null || true
+if [[ -f "$TELEGRAM_ALERTS_FILE" ]] && grep -q "proactive-session-restart" "$TELEGRAM_ALERTS_FILE"; then
+    pass
+else
+    fail "no Telegram alert with key 'proactive-session-restart' found after SIGTERM"
+fi
+
+#===============================================================================
+# Summary
+#===============================================================================
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $TOTAL total"
+if [[ $FAIL -eq 0 ]]; then
+    echo -e "${GREEN}All session age tests passed.${NC}"
+    exit 0
+else
+    echo -e "${RED}$FAIL test(s) failed.${NC}"
+    exit 1
+fi

--- a/tests/unit/test_hooks/test_dispatcher_session_start.py
+++ b/tests/unit/test_hooks/test_dispatcher_session_start.py
@@ -1,0 +1,229 @@
+"""
+Unit tests for _write_dispatcher_session_start() in inject-bootup-context.py.
+
+Issue #2059: CC enforces a hard 7440s session lifetime. inject-bootup-context.py
+now writes a plain Unix epoch timestamp to dispatcher-session-start.ts on every
+dispatcher SessionStart so health-check-v3.sh can compute session age and send
+SIGTERM before the hard limit.
+
+Tests cover:
+- _write_dispatcher_session_start() writes a valid Unix epoch to the file
+- File is created atomically (written to .tmp then renamed)
+- Parent directory is created if it does not exist
+- LOBSTER_DISPATCHER_SESSION_START_FILE_OVERRIDE env var controls the output path
+- Silent on write failure (must not crash the SessionStart hook)
+- main() calls _write_dispatcher_session_start() for dispatcher sessions
+- main() does NOT call _write_dispatcher_session_start() for subagent sessions
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_INJECT_HOOK_PATH = _HOOKS_DIR / "inject-bootup-context.py"
+
+# Named constant matching the spec: the file that records session start time.
+DISPATCHER_SESSION_START_FILENAME = "dispatcher-session-start.ts"
+
+# Named constant matching the spec: env var that overrides the output path.
+SESSION_START_FILE_OVERRIDE_ENV = "LOBSTER_DISPATCHER_SESSION_START_FILE_OVERRIDE"
+
+# Named constant matching the spec: proactive restart threshold.
+SESSION_AGE_LIMIT_SECONDS = 7200
+
+
+class _PatchEnv:
+    """Context manager to temporarily set / restore environment variables."""
+
+    def __init__(self, env: dict):
+        self._env = env
+        self._saved: dict = {}
+
+    def __enter__(self):
+        for k, v in self._env.items():
+            self._saved[k] = os.environ.get(k)
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        return self
+
+    def __exit__(self, *_):
+        for k, saved_v in self._saved.items():
+            if saved_v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = saved_v
+
+
+def _load_inject_hook(*, workspace: Path, start_file_override: Path | None = None) -> object:
+    """Load inject-bootup-context.py with controlled env vars."""
+    import uuid
+
+    env = {"LOBSTER_WORKSPACE": str(workspace)}
+    if start_file_override is not None:
+        env[SESSION_START_FILE_OVERRIDE_ENV] = str(start_file_override)
+
+    unique_name = f"inject_bootup_session_start_{uuid.uuid4().hex}"
+    with _PatchEnv(env):
+        spec = importlib.util.spec_from_file_location(unique_name, _INJECT_HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Tests for _write_dispatcher_session_start()
+# ---------------------------------------------------------------------------
+
+
+class TestWriteDispatcherSessionStart:
+    """Unit tests for _write_dispatcher_session_start() in inject-bootup-context.py."""
+
+    def test_writes_unix_epoch_integer_to_file(self, tmp_path):
+        """Calling the function produces a file containing a valid Unix epoch integer."""
+        start_file = tmp_path / "data" / DISPATCHER_SESSION_START_FILENAME
+        mod = _load_inject_hook(workspace=tmp_path, start_file_override=start_file)
+
+        before = int(time.time())
+        mod._write_dispatcher_session_start()
+        after = int(time.time())
+
+        assert start_file.exists(), "session start file not written"
+        content = start_file.read_text().strip()
+        assert content.isdigit(), f"expected integer epoch, got: {content!r}"
+        epoch = int(content)
+        assert before <= epoch <= after, (
+            f"epoch {epoch} out of expected range [{before}, {after}]"
+        )
+
+    def test_env_var_overrides_output_path(self, tmp_path):
+        """LOBSTER_DISPATCHER_SESSION_START_FILE_OVERRIDE controls the output file."""
+        custom_path = tmp_path / "custom" / "session.ts"
+        mod = _load_inject_hook(workspace=tmp_path, start_file_override=custom_path)
+
+        mod._write_dispatcher_session_start()
+
+        assert custom_path.exists(), "custom path was not created"
+
+    def test_creates_parent_directory_if_missing(self, tmp_path):
+        """Parent directory of the start file is created automatically."""
+        start_file = tmp_path / "deep" / "nested" / DISPATCHER_SESSION_START_FILENAME
+        mod = _load_inject_hook(workspace=tmp_path, start_file_override=start_file)
+
+        mod._write_dispatcher_session_start()
+
+        assert start_file.exists(), "file not written when parent dir was missing"
+
+    def test_atomic_write_no_partial_file_left_on_success(self, tmp_path):
+        """After a successful write, no .tmp file remains."""
+        start_file = tmp_path / "data" / DISPATCHER_SESSION_START_FILENAME
+        mod = _load_inject_hook(workspace=tmp_path, start_file_override=start_file)
+
+        mod._write_dispatcher_session_start()
+
+        tmp_file = start_file.with_suffix(".tmp")
+        assert not tmp_file.exists(), ".tmp file left behind after successful write"
+
+    def test_silent_on_oserror(self, tmp_path):
+        """OSError during write must not propagate — hook must not crash."""
+        start_file = tmp_path / "data" / DISPATCHER_SESSION_START_FILENAME
+        mod = _load_inject_hook(workspace=tmp_path, start_file_override=start_file)
+
+        with patch("pathlib.Path.replace", side_effect=OSError("disk full")):
+            # Must not raise
+            mod._write_dispatcher_session_start()
+
+    def test_overwrites_stale_timestamp_on_restart(self, tmp_path):
+        """A new dispatcher session overwrites any stale timestamp from a prior session."""
+        start_file = tmp_path / "data" / DISPATCHER_SESSION_START_FILENAME
+        start_file.parent.mkdir(parents=True, exist_ok=True)
+        start_file.write_text("1000000000\n")  # very old epoch
+
+        mod = _load_inject_hook(workspace=tmp_path, start_file_override=start_file)
+        mod._write_dispatcher_session_start()
+
+        content = int(start_file.read_text().strip())
+        assert content > 1000000000, "stale timestamp was not overwritten"
+
+
+# ---------------------------------------------------------------------------
+# Integration: main() calls _write_dispatcher_session_start() for dispatcher
+# ---------------------------------------------------------------------------
+
+
+class TestMainCallsSessionStartWrite:
+    """Integration tests: main() calls _write_dispatcher_session_start() for dispatcher sessions."""
+
+    def _make_hook_input(self, session_id: str = "test-session-123") -> str:
+        return json.dumps({"session_id": session_id})
+
+    def _make_dispatcher_startup_flag(self, data_dir: Path) -> Path:
+        """Write a startup flag containing the current PID (live dispatcher detection)."""
+        data_dir.mkdir(parents=True, exist_ok=True)
+        flag = data_dir / "dispatcher-startup-flag"
+        flag.write_text(f"{os.getpid()}\n")
+        return flag
+
+    def test_session_start_written_for_dispatcher(self, tmp_path):
+        """main() writes the session start file when the startup flag marks a dispatcher."""
+        start_file = tmp_path / "data" / DISPATCHER_SESSION_START_FILENAME
+        self._make_dispatcher_startup_flag(tmp_path / "data")
+
+        # Also need the startup-cause file to exist.
+        cause_file = tmp_path / "data" / "last-startup-cause.json"
+        cause_file.parent.mkdir(parents=True, exist_ok=True)
+        cause_file.write_text(json.dumps({"cause": "restart", "ts": "2026-01-01T00:00:00Z"}))
+
+        mod = _load_inject_hook(workspace=tmp_path, start_file_override=start_file)
+
+        hook_input = self._make_hook_input()
+        before = int(time.time())
+        with (
+            patch.object(mod, "_read_file_safe", return_value="# dispatcher bootup"),
+            patch.object(mod, "_inject_if_exists", return_value=False),
+            patch.object(mod, "_append_injection_log"),
+            patch("builtins.print"),
+            patch("sys.exit"),
+            patch("sys.stdin", io.StringIO(hook_input)),
+        ):
+            mod.main()
+        after = int(time.time())
+
+        assert start_file.exists(), "session start file not written for dispatcher"
+        epoch = int(start_file.read_text().strip())
+        assert before <= epoch <= after
+
+    def test_session_start_NOT_written_for_subagent(self, tmp_path):
+        """main() does NOT write the session start file for subagent sessions."""
+        start_file = tmp_path / "data" / DISPATCHER_SESSION_START_FILENAME
+        # No startup flag → detected as subagent.
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+
+        cause_file = tmp_path / "data" / "last-startup-cause.json"
+        cause_file.write_text(json.dumps({"cause": "restart", "ts": "2026-01-01T00:00:00Z"}))
+
+        mod = _load_inject_hook(workspace=tmp_path, start_file_override=start_file)
+
+        hook_input = self._make_hook_input()
+        with (
+            patch.object(mod, "_read_file_safe", return_value="# subagent bootup"),
+            patch.object(mod, "_inject_if_exists", return_value=False),
+            patch.object(mod, "_append_injection_log"),
+            patch("builtins.print"),
+            patch("sys.exit"),
+            patch("sys.stdin", io.StringIO(hook_input)),
+        ):
+            mod.main()
+
+        assert not start_file.exists(), "session start file must NOT be written for subagent"


### PR DESCRIPTION
Closes #2059

## What problem does this solve?

Claude Code enforces a hard 7440-second (124-minute) session lifetime. When this limit hits, CC kills the dispatcher process **without firing the Stop hook** — no session tombstone, no compact-catchup, no user notification. Sahar sees "Lobster Starting" with no warning that anything happened.

Evidence from sessions 016 and 017: both died at exactly start+7433–7436s (within ±10s of 7440s). The pattern is deterministic.

## What this change does

Adds a two-part proactive restart mechanism that triggers a **graceful SIGTERM** at 7200s (2 min before the hard limit), so the Stop hook fires cleanly.

**Part 1 — `hooks/inject-bootup-context.py`:** On every dispatcher `SessionStart`, write the current Unix epoch to `data/dispatcher-session-start.ts` (atomic write via tmp+rename). This is the ground truth for "when did this session begin?"

**Part 2 — `scripts/health-check-v3.sh`:** Add `check_session_age()` which:
- Reads `dispatcher-session-start.ts`
- Computes `now - session_start`
- If `session_age >= SESSION_AGE_LIMIT_SECONDS` (7200s): sends SIGTERM to the PID in `dispatcher.pid`
- Deletes the start file after SIGTERM to prevent double-fire on the next 4-minute run
- Logs the action and sends a deduped Telegram alert (`proactive-session-restart`)
- Returns 1; `main()` exits early so no other checks pile on top of the in-flight restart

`main()` wraps the call: suppressed during boot grace (90s after a restart).

### Before / after flow

```
Before (hard CC limit):
  Session starts → 7440s → CC kills process (no Stop hook)
  systemd sees dead process → restarts
  User sees "Lobster Starting" with no context

After (proactive SIGTERM at 7200s):
  Session starts → 7200s → health check sends SIGTERM to dispatcher PID
  Stop hook fires → tombstone written → compact-catchup triggers
  claude-persistent.sh restarts Claude automatically
  User sees "Lobster Starting" after graceful handoff
```

## What this does NOT change

- `do_restart()` (systemctl-based) is not used for this path — SIGTERM directly to the PID is cleaner and fires the Stop hook
- No new cron entries — enhances the existing 4-minute health check
- All existing health check logic (stale inbox, heartbeat, outbox, auth) is unchanged

## Functional patterns used

Pure functions for timestamp reading (`int(time.time())`), named constants for all spec values (`SESSION_AGE_LIMIT_SECONDS=7200`), atomic file writes via `tmp+rename`, silent-on-error boundaries at both the hook level and health check level.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_dispatcher_session_start.py -v` — 8 passed, 0 failed
- [x] `uv run pytest tests/unit/test_hooks/ -v` — 437 passed, 7 skipped, 0 failed (no regressions in existing hook tests)
- [x] `bash tests/test-health-check-session-age.sh` — 11 passed, 0 failed (covers: no file, young session, at-limit, past-limit, SIGTERM sent, no PID file, malformed timestamp, empty file, start file deleted after SIGTERM, dead PID fallback, Telegram alert fires)

## Manual test

N/A — this change is not testable without a live 120-minute session. The SIGTERM path is exercised by the shell tests using real `sleep` background processes. The integration test for the full flow would require waiting for a real session to approach the 7440s limit, which is impractical in a PR test run.

The health check (`*/4 * * * *`) will pick up the change on the next deploy without any migration needed — no new cron entries, no new directories, no DB changes.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [ ] Integration/manual test run — not applicable (production-only observable; no live 120-min session available)
- [ ] User-visible outcome: Sahar will see a Telegram notification on proactive restart instead of silent "Lobster Starting" — not yet verified (requires production)
- [x] Side-effect audit: SIGTERM to one specific PID (from dispatcher.pid); start file deleted after SIGTERM; no floods, no mass writes, no unscoped operations
- [x] External service calls: none in automated tests; Telegram alert uses deduped send (at most once per 15 minutes)