### PR TITLE
fix(install.sh): stagger periodic cron offsets to avoid lcm-aligned CPU spikes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1739,8 +1739,9 @@ step "Setting up health monitoring..."
 chmod +x "$INSTALL_DIR/scripts/health-check-v3.sh" || true
 
 # Add health check to crontab (runs every 4 minutes)
+# Offset 1 (vs the */3 anchor) to avoid lcm-aligned overlap at :00.
 "$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-HEALTH" \
-    "*/4 * * * * $INSTALL_DIR/scripts/health-check-v3.sh # LOBSTER-HEALTH"
+    "1-59/4 * * * * $INSTALL_DIR/scripts/health-check-v3.sh # LOBSTER-HEALTH"
 
 success "Health monitoring configured (checks every 4 minutes)"
 
@@ -1791,8 +1792,9 @@ step "Setting up ghost detector cron..."
 # agent-monitor.py runs every 5 minutes, checks for stale/dead agent sessions,
 # sends a Telegram alert if GHOST_CONFIRMED or UNREGISTERED agents are found,
 # and marks ghost sessions as failed in agent_sessions.db. No LLM involved.
+# Offset 2 (vs the */3 anchor) to avoid lcm-aligned overlap at :00.
 "$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-GHOST-DETECTOR" \
-    "*/5 * * * * cd $HOME && uv run $INSTALL_DIR/scripts/agent-monitor.py --alert --mark-failed >> $HOME/lobster-workspace/logs/agent-monitor.log 2>&1 # LOBSTER-GHOST-DETECTOR"
+    "2-59/5 * * * * cd $HOME && uv run $INSTALL_DIR/scripts/agent-monitor.py --alert --mark-failed >> $HOME/lobster-workspace/logs/agent-monitor.log 2>&1 # LOBSTER-GHOST-DETECTOR"
 
 success "Ghost detector configured (runs every 5 minutes)"
 
@@ -1806,8 +1808,11 @@ step "Setting up OOM monitor cron..."
 # affecting Lobster/Claude processes, and writes an inbox message for the
 # dispatcher when new OOM kill events are detected. No LLM involved.
 # Only active when LOBSTER_DEBUG=true (the script is a no-op otherwise).
+# Offset 8 (vs the */3 anchor) to avoid lcm-aligned overlap at :00.
+# Even offset is deliberate: it makes the */4+*/10 offset parities disagree
+# on the gcd(4,10)=2 sub-lattice, so */3+*/4+*/10 never triple-fires.
 "$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-OOM-CHECK" \
-    "*/10 * * * * cd $HOME && uv run $INSTALL_DIR/scripts/oom-monitor.py --since-minutes 10 >> $HOME/lobster-workspace/logs/oom-monitor.log 2>&1 # LOBSTER-OOM-CHECK"
+    "8-59/10 * * * * cd $HOME && uv run $INSTALL_DIR/scripts/oom-monitor.py --since-minutes 10 >> $HOME/lobster-workspace/logs/oom-monitor.log 2>&1 # LOBSTER-OOM-CHECK"
 
 success "OOM monitor configured (runs every 10 minutes, active only when LOBSTER_DEBUG=true)"
 


### PR DESCRIPTION
## Observed

On two production Lobster VMs we see a small but visible CPU spike on the host at exactly `:00` every hour, plus smaller spikes at multiples of the various job periods. Visible in `/proc/stat` and the host's per-VM CPU graphs.

## Cause

`install.sh` writes four periodic user-cron entries with `*/N` schedules:

```
*/3  LOBSTER-INFLIGHT-REMINDERS
*/4  LOBSTER-HEALTH
*/5  LOBSTER-GHOST-DETECTOR
*/10 LOBSTER-OOM-CHECK
```

`*/N` is shorthand for `0-59/N`, so every job fires at minute 0. Since `lcm(3, 4, 5, 10) = 60`, all four schedules co-fire at minute 0 of every hour — and the jobs that matter (`agent-monitor.py`, `oom-monitor.py`, `check-inflight-reminders.py`) each run under `uv run`, which loads a Rust binary + a Python interpreter + the script. Four of those launching in the same second is enough to be visible on a small VM.

## Fix

Switch each schedule to cron's `OFFSET-59/N` form so the periods don't all share the minute-0 origin:

```
*/3  -> 0-59/3   (anchor -- INFLIGHT-REMINDERS)
*/4  -> 1-59/4   (HEALTH)
*/5  -> 2-59/5   (GHOST-DETECTOR)
*/10 -> 8-59/10  (OOM-CHECK)
```

The `/10` offset is `8` (even) on purpose. With `/4` offset `1` (odd) and `/10` offset `8` (even), the offsets disagree on the `gcd(4, 10) = 2` sub-lattice, which kills the `/3+/4+/10` triple. Likewise `/5` offset `2` and `/10` offset `8` disagree on `gcd(5, 10) = 5`, killing the `/3+/5+/10` and `/4+/5+/10` triples.

## Trade-off

`lcm(3, 4, 5) = 60`, so by CRT there is always exactly one minute per hour where `/3 + /4 + /5` co-fire — here that's `:57`. Eliminating that final triple would require moving to coprime / prime periods (e.g. `*/7`, `*/11`), which changes the contracted run cadence of each job, so it is out of scope for this PR.

What this PR achieves:

| | before | after |
|---|---|---|
| peak concurrent fires | **4** (at `:00`) | **3** (at `:57`) |
| minutes/hour with 3+ co-fires | 1 (`:00`, also 4-way) | 1 (`:57`) |
| every other minute | up to 2 | at most 2 |

The every-hour 4-way pile-up at `:00` is gone, and the residual 3-way collision is the mathematical minimum for these periods.

## Scope

- Touches only the four periodic entries in `install.sh` (`LOBSTER-HEALTH`, `LOBSTER-GHOST-DETECTOR`, `LOBSTER-OOM-CHECK`, `LOBSTER-INFLIGHT-REMINDERS`).
- Daily fixed-time entries (`0 3`, `0 4`, `0 6 * * *`) are left alone — they are not periodic and the spike does not apply.
- `LOBSTER-SELF-CHECK` is no longer installed (`install.sh` actively removes any lingering entry); not touched.
- `bash -n install.sh` passes.

## Diff stats

```
 install.sh | 11 ++++++++---
 1 file changed, 8 insertions(+), 3 deletions(-)
```
