### PR TITLE
fix(#2071): add UUID-based dispatcher detection as secondary signal

### DIFF
--- a/hooks/inject-bootup-context.py
+++ b/hooks/inject-bootup-context.py
@@ -19,16 +19,31 @@ File injection order (subagent):
 2. ~/lobster-user-config/agents/user.base.bootup.md (if exists)
 3. ~/lobster-user-config/agents/user.subagent.bootup.md (if exists)
 
-Dispatcher detection (simplified, issue #1908):
+Dispatcher detection — two-signal approach (issues #1908, #2071):
+
+Signal 1 — PID startup flag (issue #1908):
 The launcher (claude-persistent.sh) writes the subshell PID to
 ~/lobster-workspace/data/dispatcher-startup-flag immediately before exec-ing
 claude. This hook reads that flag:
   - Flag present AND PID alive (kill -0) → dispatcher session. Delete the flag.
-  - Flag absent OR PID dead → subagent session.
+  - Flag absent OR PID dead → not detected by this signal.
 
-This eliminates the chicken-and-egg problem of UUID-based detection: the flag
-is written *before* CC starts, not after session_start() is called. Stale
-flags (dead PID) are safe because the check is purely process-existence-based.
+Signal 2 — UUID file match (issue #2071):
+session_start(agent_type='dispatcher', claude_session_id=<uuid>) writes the
+dispatcher's Claude session UUID to
+~/lobster-workspace/data/dispatcher-claude-session-id. On each SessionStart,
+this hook compares hook_input["session_id"] to the UUID in that file:
+  - Match → dispatcher session (post-compact or resumed session).
+  - No match / file absent → not detected by this signal.
+
+Either signal firing → inject dispatcher bootup. Safe default (neither fires)
+→ subagent path. The UUID file is NOT deleted after detection — it is written
+once by session_start() and must persist across turns.
+
+This two-signal approach handles:
+  - Fresh starts (PID flag only, UUID file not yet written)
+  - Post-compact sessions (PID flag consumed on first start, UUID file exists)
+  - Both signals active simultaneously (no double-injection)
 
 ADMIN_CHAT_ID injection (issue #1976):
 For dispatcher sessions, this hook reads LOBSTER_ADMIN_CHAT_ID from
@@ -83,6 +98,18 @@ CONTEXT_INJECTION_LOG = _LOBSTER_WORKSPACE / "logs" / "context-injection.log"
 # Startup flag written by claude-persistent.sh before exec-ing claude.
 # Contains the launcher subshell PID. Deleted after the dispatcher is detected.
 STARTUP_FLAG_FILE = _LOBSTER_WORKSPACE / "data" / "dispatcher-startup-flag"
+
+# Dispatcher Claude session UUID file (issue #2071).
+# Written atomically by session_start(agent_type='dispatcher', claude_session_id=<uuid>)
+# in inbox_server.py. This hook compares hook_input["session_id"] to the UUID in this
+# file to detect post-compact dispatcher sessions where the PID flag is already consumed.
+# Unlike STARTUP_FLAG_FILE, this file is NOT deleted after detection — it persists across
+# turns and is only overwritten when a new dispatcher session calls session_start().
+DISPATCHER_CLAUDE_SESSION_FILE = _LOBSTER_WORKSPACE / "data" / "dispatcher-claude-session-id"
+
+# Sentinel value used when hook_input["session_id"] is missing. Must never match
+# a real UUID — prevents false-positive dispatcher detection on malformed input.
+_UNKNOWN_SESSION_ID = "unknown"
 
 # Config file that contains LOBSTER_ADMIN_CHAT_ID (issue #1976).
 # The old dispatcher bootup doc referenced ~/lobster-config/lobster.conf which
@@ -193,6 +220,37 @@ def _consume_startup_flag() -> None:
         STARTUP_FLAG_FILE.unlink(missing_ok=True)
     except OSError:
         pass
+
+
+def _is_uuid_match_dispatcher(session_id: str, uuid_file: Path) -> bool:
+    """Return True if session_id matches the UUID in the dispatcher session file.
+
+    This is the secondary dispatcher detection signal (issue #2071), used when
+    the PID startup flag is absent (e.g. post-compact sessions where the flag
+    was consumed on the first start).
+
+    Returns True only when:
+      - session_id is non-empty and not the _UNKNOWN_SESSION_ID sentinel
+      - uuid_file exists and contains a non-empty UUID
+      - session_id matches the file's UUID (after stripping whitespace)
+
+    Returns False on any error (OSError, empty values, mismatches) — conservative
+    default. Does NOT delete the UUID file — it must persist across turns.
+
+    This is a pure function: reads one file, returns a bool, no side effects.
+    """
+    # Guard: empty or sentinel session_id can never be a real dispatcher UUID.
+    if not session_id or session_id == _UNKNOWN_SESSION_ID:
+        return False
+    try:
+        if not uuid_file.exists():
+            return False
+        stored = uuid_file.read_text().strip()
+        if not stored:
+            return False
+        return session_id == stored
+    except OSError:
+        return False
 
 
 def _write_dispatcher_session_start() -> None:
@@ -358,12 +416,22 @@ def main() -> None:
 
     session_id = hook_input.get("session_id", "unknown")
 
-    # Simplified dispatcher detection (issue #1908):
-    # Check the launcher-written startup flag file. Live PID = dispatcher.
-    is_dispatcher = _is_startup_flag_dispatcher()
+    # Two-signal dispatcher detection (issues #1908, #2071):
+    #
+    # Signal 1 — PID startup flag: written by the launcher before exec-ing claude.
+    # Fires for fresh dispatcher starts. Consumed (deleted) after detection so
+    # subsequent sessions (subagents) do not see it.
+    pid_flag_dispatcher = _is_startup_flag_dispatcher()
 
-    if is_dispatcher:
-        # Consume the flag so subsequent sessions (subagents) do not see it.
+    # Signal 2 — UUID file match: written by session_start(agent_type='dispatcher').
+    # Fires for post-compact sessions where Signal 1 was already consumed.
+    # NOT consumed after detection — the file must persist for subsequent turns.
+    uuid_dispatcher = _is_uuid_match_dispatcher(session_id, DISPATCHER_CLAUDE_SESSION_FILE)
+
+    is_dispatcher = pid_flag_dispatcher or uuid_dispatcher
+
+    if pid_flag_dispatcher:
+        # Consume the PID flag so subsequent sessions (subagents) do not see it.
         _consume_startup_flag()
         print(
             f"[{HOOK_NAME}] startup-flag detected live PID — injecting dispatcher bootup",
@@ -375,6 +443,12 @@ def main() -> None:
         _write_dispatcher_session_start()
         print(
             f"[{HOOK_NAME}] wrote dispatcher session start timestamp",
+            file=sys.stderr,
+        )
+    elif uuid_dispatcher:
+        print(
+            f"[{HOOK_NAME}] UUID match detected — injecting dispatcher bootup"
+            f" (post-compact session, PID flag already consumed)",
             file=sys.stderr,
         )
 

--- a/tests/unit/test_hooks/test_uuid_dispatcher_detection.py
+++ b/tests/unit/test_hooks/test_uuid_dispatcher_detection.py
@@ -1,0 +1,445 @@
+"""
+Tests for UUID-based dispatcher detection (issue #2071).
+
+When the PID startup flag is absent (e.g. post-compact sessions where the flag
+was already consumed on the first start), the hook falls back to comparing
+hook_input["session_id"] with the UUID written to
+~/lobster-workspace/data/dispatcher-claude-session-id by session_start().
+
+Named constant for the file path:
+  DISPATCHER_CLAUDE_SESSION_FILENAME = "dispatcher-claude-session-id"
+
+Behavioral requirements (spec from issue #2071):
+  - _is_uuid_match_dispatcher(session_id, uuid_file) returns True when
+    session_id matches the UUID in the file (exact match, strip whitespace)
+  - _is_uuid_match_dispatcher returns False when file is absent
+  - _is_uuid_match_dispatcher returns False when UUIDs don't match
+  - _is_uuid_match_dispatcher returns False on OSError
+  - _is_uuid_match_dispatcher returns False when session_id is empty string
+  - _is_uuid_match_dispatcher returns False when file is empty
+  - Integration: main() injects sys.dispatcher.bootup.md when UUID matches
+    (no PID flag present)
+  - Integration: main() injects sys.subagent.bootup.md when UUID does not match
+    (no PID flag present)
+  - Integration: main() injects sys.dispatcher.bootup.md when PID flag is live
+    (UUID file absent — original path unchanged)
+  - Integration: main() injects sys.dispatcher.bootup.md when BOTH PID flag
+    and UUID match — no double-injection
+  - Integration: UUID detection does NOT consume the dispatcher UUID file
+    (it is written once by session_start and should persist across turns)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "inject-bootup-context.py"
+
+# Named constant matching the spec — file written by session_start().
+DISPATCHER_CLAUDE_SESSION_FILENAME = "dispatcher-claude-session-id"
+
+# Marker strings for verifying which bootup was injected.
+DISPATCHER_BOOTUP_MARKER = "DISPATCHER BOOTUP CONTENT"
+SUBAGENT_BOOTUP_MARKER = "SUBAGENT BOOTUP CONTENT"
+
+# A realistic-looking UUID for tests.
+DISPATCHER_UUID = "aabbccdd-1234-5678-abcd-000000000001"
+OTHER_UUID = "11111111-0000-0000-0000-000000000002"
+
+
+class _PatchEnv:
+    """Context manager to temporarily set / restore environment variables."""
+
+    def __init__(self, env: dict):
+        self._env = env
+        self._saved: dict = {}
+
+    def __enter__(self):
+        for k, v in self._env.items():
+            self._saved[k] = os.environ.get(k)
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        return self
+
+    def __exit__(self, *_):
+        for k, saved_v in self._saved.items():
+            if saved_v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = saved_v
+
+
+def _load_hook(workspace: Path) -> object:
+    """Load inject-bootup-context.py module with an isolated LOBSTER_WORKSPACE."""
+    import uuid
+
+    unique_name = f"inject_uuid_test_{uuid.uuid4().hex}"
+    with _PatchEnv({"LOBSTER_WORKSPACE": str(workspace)}):
+        spec = importlib.util.spec_from_file_location(unique_name, _HOOK_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_bootup_files(tmp_path: Path) -> tuple[Path, Path]:
+    """Write minimal bootup stubs with distinct markers into a fake .claude dir."""
+    claude_dir = tmp_path / "lobster" / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    dispatcher_bootup = claude_dir / "sys.dispatcher.bootup.md"
+    subagent_bootup = claude_dir / "sys.subagent.bootup.md"
+    dispatcher_bootup.write_text(f"# {DISPATCHER_BOOTUP_MARKER}\n")
+    subagent_bootup.write_text(f"# {SUBAGENT_BOOTUP_MARKER}\n")
+    return dispatcher_bootup, subagent_bootup
+
+
+def _write_uuid_file(data_dir: Path, uuid_value: str) -> Path:
+    """Write a dispatcher-claude-session-id file."""
+    data_dir.mkdir(parents=True, exist_ok=True)
+    uuid_file = data_dir / DISPATCHER_CLAUDE_SESSION_FILENAME
+    uuid_file.write_text(uuid_value)
+    return uuid_file
+
+
+def _run_hook_no_pid_flag(
+    tmp_path: Path,
+    session_id: str,
+    uuid_file_content: str | None = None,
+) -> tuple[str, str]:
+    """Run the hook with no PID startup flag present.
+
+    Optionally writes a UUID file with the given content.
+    Returns (stdout, stderr) strings.
+    """
+    workspace = tmp_path / "workspace"
+    data_dir = workspace / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (workspace / "logs").mkdir(parents=True, exist_ok=True)
+
+    uuid_file = data_dir / DISPATCHER_CLAUDE_SESSION_FILENAME
+    if uuid_file_content is not None:
+        uuid_file.write_text(uuid_file_content)
+
+    dispatcher_bootup, subagent_bootup = _make_bootup_files(tmp_path)
+
+    # PID flag is absent — no file created at startup_flag path.
+    absent_flag = data_dir / "dispatcher-startup-flag"
+    # Make sure it really does not exist.
+    assert not absent_flag.exists()
+
+    hook_input = json.dumps({"session_id": session_id})
+
+    with _PatchEnv({"LOBSTER_WORKSPACE": str(workspace)}):
+        mod = _load_hook(workspace)
+
+        mod.STARTUP_FLAG_FILE = absent_flag  # absent
+        mod.DISPATCHER_BOOTUP = dispatcher_bootup
+        mod.SUBAGENT_BOOTUP = subagent_bootup
+        mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+        mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+        mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+        mod.CONTEXT_INJECTION_LOG = workspace / "logs" / "context-injection.log"
+        mod.DISPATCHER_CLAUDE_SESSION_FILE = uuid_file
+
+        stdout_buf = io.StringIO()
+        stderr_buf = io.StringIO()
+
+        with patch("sys.stdin", io.StringIO(hook_input)):
+            with patch("sys.stdout", stdout_buf):
+                with patch("sys.stderr", stderr_buf):
+                    try:
+                        mod.main()
+                    except SystemExit:
+                        pass
+
+    return stdout_buf.getvalue(), stderr_buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _is_uuid_match_dispatcher()
+# ---------------------------------------------------------------------------
+
+
+class TestIsUuidMatchDispatcher:
+    """Pure function tests for _is_uuid_match_dispatcher(session_id, uuid_file)."""
+
+    def test_returns_true_when_uuid_matches(self, tmp_path):
+        """Exact UUID match → True."""
+        data_dir = tmp_path / "data"
+        uuid_file = _write_uuid_file(data_dir, DISPATCHER_UUID)
+
+        mod = _load_hook(tmp_path)
+        result = mod._is_uuid_match_dispatcher(DISPATCHER_UUID, uuid_file)
+
+        assert result is True
+
+    def test_returns_true_when_uuid_matches_with_trailing_newline(self, tmp_path):
+        """UUID file with trailing newline → still matches after strip."""
+        data_dir = tmp_path / "data"
+        uuid_file = _write_uuid_file(data_dir, DISPATCHER_UUID + "\n")
+
+        mod = _load_hook(tmp_path)
+        result = mod._is_uuid_match_dispatcher(DISPATCHER_UUID, uuid_file)
+
+        assert result is True
+
+    def test_returns_false_when_uuid_file_absent(self, tmp_path):
+        """UUID file absent → False (safe default)."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        absent_file = data_dir / DISPATCHER_CLAUDE_SESSION_FILENAME
+
+        mod = _load_hook(tmp_path)
+        result = mod._is_uuid_match_dispatcher(DISPATCHER_UUID, absent_file)
+
+        assert result is False
+
+    def test_returns_false_when_uuid_does_not_match(self, tmp_path):
+        """Different UUID in file → False."""
+        data_dir = tmp_path / "data"
+        uuid_file = _write_uuid_file(data_dir, OTHER_UUID)
+
+        mod = _load_hook(tmp_path)
+        result = mod._is_uuid_match_dispatcher(DISPATCHER_UUID, uuid_file)
+
+        assert result is False
+
+    def test_returns_false_when_session_id_empty(self, tmp_path):
+        """Empty session_id → False (cannot match anything meaningfully)."""
+        data_dir = tmp_path / "data"
+        uuid_file = _write_uuid_file(data_dir, DISPATCHER_UUID)
+
+        mod = _load_hook(tmp_path)
+        result = mod._is_uuid_match_dispatcher("", uuid_file)
+
+        assert result is False
+
+    def test_returns_false_when_file_is_empty(self, tmp_path):
+        """UUID file exists but is empty → False."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        uuid_file = data_dir / DISPATCHER_CLAUDE_SESSION_FILENAME
+        uuid_file.write_text("")
+
+        mod = _load_hook(tmp_path)
+        result = mod._is_uuid_match_dispatcher(DISPATCHER_UUID, uuid_file)
+
+        assert result is False
+
+    def test_returns_false_on_oserror(self, tmp_path):
+        """OSError reading file → False (conservative default)."""
+        mod = _load_hook(tmp_path)
+
+        mock_file = MagicMock(spec=Path)
+        mock_file.exists.return_value = True
+        mock_file.read_text.side_effect = OSError("permission denied")
+
+        result = mod._is_uuid_match_dispatcher(DISPATCHER_UUID, mock_file)
+
+        assert result is False
+
+    def test_returns_false_when_session_id_is_unknown(self, tmp_path):
+        """session_id='unknown' (fallback value when stdin fails) → False."""
+        data_dir = tmp_path / "data"
+        # Even if the file contains "unknown", it must not match
+        uuid_file = _write_uuid_file(data_dir, "unknown")
+
+        mod = _load_hook(tmp_path)
+        result = mod._is_uuid_match_dispatcher("unknown", uuid_file)
+
+        # "unknown" is the fallback sentinel — must never be treated as a real UUID
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: main() routing via UUID when PID flag is absent
+# ---------------------------------------------------------------------------
+
+
+class TestUuidDetectionIntegration:
+    """main() injects dispatcher bootup when UUID matches, subagent when it doesn't."""
+
+    def test_dispatcher_bootup_injected_when_uuid_matches(self, tmp_path):
+        """UUID match → sys.dispatcher.bootup.md injected (no PID flag)."""
+        stdout, _stderr = _run_hook_no_pid_flag(
+            tmp_path,
+            session_id=DISPATCHER_UUID,
+            uuid_file_content=DISPATCHER_UUID,
+        )
+
+        assert DISPATCHER_BOOTUP_MARKER in stdout, (
+            f"sys.dispatcher.bootup.md must be injected when UUID matches. "
+            f"Got stdout:\n{stdout[:500]}"
+        )
+        assert SUBAGENT_BOOTUP_MARKER not in stdout, (
+            "sys.subagent.bootup.md must NOT appear when UUID matches dispatcher"
+        )
+
+    def test_subagent_bootup_injected_when_uuid_absent(self, tmp_path):
+        """UUID file absent → subagent path (no PID flag, no UUID file)."""
+        stdout, _stderr = _run_hook_no_pid_flag(
+            tmp_path,
+            session_id=DISPATCHER_UUID,
+            uuid_file_content=None,  # file not created
+        )
+
+        assert SUBAGENT_BOOTUP_MARKER in stdout, (
+            "sys.subagent.bootup.md must be injected when UUID file is absent"
+        )
+        assert DISPATCHER_BOOTUP_MARKER not in stdout
+
+    def test_subagent_bootup_injected_when_uuid_mismatches(self, tmp_path):
+        """UUID file present but doesn't match session_id → subagent path."""
+        stdout, _stderr = _run_hook_no_pid_flag(
+            tmp_path,
+            session_id=OTHER_UUID,
+            uuid_file_content=DISPATCHER_UUID,  # different UUID in file
+        )
+
+        assert SUBAGENT_BOOTUP_MARKER in stdout, (
+            "sys.subagent.bootup.md must be injected when UUID does not match"
+        )
+        assert DISPATCHER_BOOTUP_MARKER not in stdout
+
+    def test_uuid_file_not_deleted_after_detection(self, tmp_path):
+        """UUID file must persist after detection — session_start wrote it once."""
+        workspace = tmp_path / "workspace"
+        data_dir = workspace / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (workspace / "logs").mkdir(parents=True, exist_ok=True)
+
+        uuid_file = _write_uuid_file(data_dir, DISPATCHER_UUID)
+        assert uuid_file.exists()
+
+        dispatcher_bootup, subagent_bootup = _make_bootup_files(tmp_path)
+        absent_flag = data_dir / "dispatcher-startup-flag"
+        hook_input = json.dumps({"session_id": DISPATCHER_UUID})
+
+        with _PatchEnv({"LOBSTER_WORKSPACE": str(workspace)}):
+            mod = _load_hook(workspace)
+            mod.STARTUP_FLAG_FILE = absent_flag
+            mod.DISPATCHER_BOOTUP = dispatcher_bootup
+            mod.SUBAGENT_BOOTUP = subagent_bootup
+            mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+            mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+            mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+            mod.CONTEXT_INJECTION_LOG = workspace / "logs" / "context-injection.log"
+            mod.DISPATCHER_CLAUDE_SESSION_FILE = uuid_file
+
+            with patch("sys.stdin", io.StringIO(hook_input)):
+                with patch("sys.stdout", io.StringIO()):
+                    with patch("sys.stderr", io.StringIO()):
+                        try:
+                            mod.main()
+                        except SystemExit:
+                            pass
+
+        # UUID file must still exist — it is not consumed by detection.
+        assert uuid_file.exists(), (
+            "dispatcher-claude-session-id must NOT be deleted after UUID-based detection"
+        )
+        assert uuid_file.read_text().strip() == DISPATCHER_UUID
+
+
+class TestPidFlagStillWorks:
+    """PID-based detection path is unchanged by the UUID addition."""
+
+    def test_pid_flag_still_triggers_dispatcher_bootup(self, tmp_path):
+        """Live PID flag → dispatcher bootup injected (UUID file absent)."""
+        workspace = tmp_path / "workspace"
+        data_dir = workspace / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (workspace / "logs").mkdir(parents=True, exist_ok=True)
+
+        # Write live PID to startup flag.
+        flag = data_dir / "dispatcher-startup-flag"
+        flag.write_text(str(os.getpid()))
+
+        # No UUID file.
+        uuid_file = data_dir / DISPATCHER_CLAUDE_SESSION_FILENAME
+        assert not uuid_file.exists()
+
+        dispatcher_bootup, subagent_bootup = _make_bootup_files(tmp_path)
+        hook_input = json.dumps({"session_id": "any-session-uuid"})
+
+        with _PatchEnv({"LOBSTER_WORKSPACE": str(workspace)}):
+            mod = _load_hook(workspace)
+            mod.STARTUP_FLAG_FILE = flag
+            mod.DISPATCHER_BOOTUP = dispatcher_bootup
+            mod.SUBAGENT_BOOTUP = subagent_bootup
+            mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+            mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+            mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+            mod.CONTEXT_INJECTION_LOG = workspace / "logs" / "context-injection.log"
+            mod.DISPATCHER_CLAUDE_SESSION_FILE = uuid_file  # absent
+
+            stdout_buf = io.StringIO()
+            with patch("sys.stdin", io.StringIO(hook_input)):
+                with patch("sys.stdout", stdout_buf):
+                    with patch("sys.stderr", io.StringIO()):
+                        try:
+                            mod.main()
+                        except SystemExit:
+                            pass
+
+        stdout = stdout_buf.getvalue()
+        assert DISPATCHER_BOOTUP_MARKER in stdout, (
+            "PID flag path must still inject sys.dispatcher.bootup.md"
+        )
+        assert SUBAGENT_BOOTUP_MARKER not in stdout
+
+    def test_both_pid_and_uuid_match_injects_dispatcher_bootup_once(self, tmp_path):
+        """PID flag live AND UUID matches → dispatcher bootup injected exactly once."""
+        workspace = tmp_path / "workspace"
+        data_dir = workspace / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (workspace / "logs").mkdir(parents=True, exist_ok=True)
+
+        # Write live PID to startup flag.
+        flag = data_dir / "dispatcher-startup-flag"
+        flag.write_text(str(os.getpid()))
+
+        # Also write matching UUID file.
+        uuid_file = _write_uuid_file(data_dir, DISPATCHER_UUID)
+
+        dispatcher_bootup, subagent_bootup = _make_bootup_files(tmp_path)
+        hook_input = json.dumps({"session_id": DISPATCHER_UUID})
+
+        with _PatchEnv({"LOBSTER_WORKSPACE": str(workspace)}):
+            mod = _load_hook(workspace)
+            mod.STARTUP_FLAG_FILE = flag
+            mod.DISPATCHER_BOOTUP = dispatcher_bootup
+            mod.SUBAGENT_BOOTUP = subagent_bootup
+            mod.USER_BASE_BOOTUP = tmp_path / "no-user-base"
+            mod.USER_DISPATCHER_BOOTUP = tmp_path / "no-user-dispatcher"
+            mod.USER_SUBAGENT_BOOTUP = tmp_path / "no-user-subagent"
+            mod.CONTEXT_INJECTION_LOG = workspace / "logs" / "context-injection.log"
+            mod.DISPATCHER_CLAUDE_SESSION_FILE = uuid_file
+
+            stdout_buf = io.StringIO()
+            with patch("sys.stdin", io.StringIO(hook_input)):
+                with patch("sys.stdout", stdout_buf):
+                    with patch("sys.stderr", io.StringIO()):
+                        try:
+                            mod.main()
+                        except SystemExit:
+                            pass
+
+        stdout = stdout_buf.getvalue()
+        assert DISPATCHER_BOOTUP_MARKER in stdout
+        assert SUBAGENT_BOOTUP_MARKER not in stdout
+        # Verify no double-injection — marker appears exactly once.
+        assert stdout.count(DISPATCHER_BOOTUP_MARKER) == 1, (
+            f"Dispatcher bootup must be injected exactly once. "
+            f"Found {stdout.count(DISPATCHER_BOOTUP_MARKER)} occurrences."
+        )


### PR DESCRIPTION
## Problem

`inject-bootup-context.py` used only the PID startup flag to identify dispatcher sessions. The flag is deleted after detection, so post-compact sessions — where the dispatcher resumes after compaction — had no signal and fell through to the subagent path. This lost dispatcher bootup injection for post-compact starts.

Sahar's decision (2026-05-10 8:53 PM ET): the dispatcher bootup file must be injected for dispatchers and only for dispatchers — not removed (which is what PR #2044, now closed, did instead).

## What changed

Adds `_is_uuid_match_dispatcher(session_id, uuid_file)` as a secondary dispatcher detection signal alongside the existing PID startup flag.

**Detection flow (two-signal OR):**
1. **PID flag** (`dispatcher-startup-flag`): fires for fresh starts, consumed after detection. Behavior unchanged.
2. **UUID match** (`dispatcher-claude-session-id`): fires for post-compact sessions. Compares `hook_input["session_id"]` to the UUID written by `session_start(agent_type='dispatcher', claude_session_id=<uuid>)`. NOT consumed — persists across turns.

Either signal → inject `sys.dispatcher.bootup.md`. Neither signal → subagent path. Both active simultaneously → dispatcher bootup injected exactly once.

### Before / after

```
Before (post-compact start, PID flag already consumed):
  Signal 1 (PID flag): absent -> no detection
  Signal 2 (UUID match): not checked -> no detection
  Result: SUBAGENT PATH -- dispatcher bootup lost

After (post-compact start, PID flag already consumed):
  Signal 1 (PID flag): absent -> no detection
  Signal 2 (UUID match): session_id matches file -> DISPATCHER detected
  Result: DISPATCHER PATH -- sys.dispatcher.bootup.md injected
```

### What is out of scope

- No changes to `session_start()` or how `dispatcher-claude-session-id` is written (already implemented in `inbox_server.py`)
- No changes to subagent bootup injection
- No changes to compact stub logic (issue #1954)
- No changes to the health-check timestamp write (issue #2059)

## Functional patterns used

Pure function (`_is_uuid_match_dispatcher`): reads one file, returns bool, no side effects. Returns False on any error — conservative default. Two-signal detection composed in `main()` with `or`, keeping each signal isolated and independently testable.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_uuid_dispatcher_detection.py -v` — 14 passed, 0 failed
- [x] `uv run pytest tests/unit/test_hooks/ -q` — 561 passed, 7 skipped, 0 failed
- [x] `uv run pytest tests/unit/ -q` — 3465 passed, 31 skipped, 0 failed, 0 new failures

## Manual test

N/A — this change is entirely internal (hook output to Claude's context window). No external services, no DB, no systemd. Behavioral effect observable only at dispatcher startup. Deployed to `local-dev-fresh` for soak testing.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] User-visible outcome: N/A — startup efficiency and role detection fix, not a user-visible feature
- [x] Side-effect audit: no floods, no shared state writes, no external calls; UUID file explicitly NOT deleted (read-only detection)
- [x] External service calls: none in this change

Closes #2071