### PR TITLE
fix(#2075): user-friendly Telegram notification before graceful restart

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -73,7 +73,7 @@ When you first start (or after reading this file), follow these steps:
 
 **When the startup catchup result arrives** (`task_id: "startup-catchup"`, `chat_id: 0`): read for situational awareness, update `handoff.md` if anything notable changed (failed subagents, open threads). Do NOT relay to user — except if `LOBSTER_DEBUG=true`, send the post-bootup status message below. Then `mark_processed`.
 
-**Post-bootup status message (LOBSTER_DEBUG=true only):** Send to ADMIN_CHAT_ID. Keep to 5-8 lines, mobile-friendly. Build it from `handoff.md` (just read for startup) and `msg["text"]` (the catchup summary). Format:
+**Post-bootup status message (LOBSTER_DEBUG=true only):** Send to ADMIN_CHAT_ID using `send_reply(chat_id=ADMIN_CHAT_ID, text=..., proactive=True)`. The `proactive=True` flag is required — this send has no originating user message to thread against, and the `require-reply-to-message-id` hook will block it otherwise. Keep to 5-8 lines, mobile-friendly. Build it from `handoff.md` (just read for startup) and `msg["text"]` (the catchup summary). Format:
 
 ```
 🦞 Back online — [session_id], started [start_time ET]

--- a/hooks/require-reply-to-message-id.py
+++ b/hooks/require-reply-to-message-id.py
@@ -9,17 +9,36 @@ but omit or set reply_to_message_id=0.
 Exemptions (always allowed):
   - Non-Telegram sources (slack, sms, whatsapp, bot-talk, system, ...)
   - System/proactive sends where chat_id == 0 (no incoming message context)
+  - Proactive dispatcher sends where proactive=true is explicitly set
   - Calls where reply_to_message_id is already set to a positive integer
+
+The proactive=true exemption is for dispatcher-initiated sends that have no
+originating user message to thread against: startup status, graceful restart
+notifications, scheduled job summaries, health alerts routed through MCP.
+Pass proactive=True explicitly to signal intent — the hook trusts the caller.
 
 Exit codes:
   0 - Allow the call
   2 - Block the call (Claude Code shows stderr message to Claude)
 
-Issue: #1168
+Issue: #1168, #2075
 """
 
 import json
 import sys
+
+
+def _is_truthy(value: object) -> bool:
+    """Return True if value represents a truthy proactive flag.
+
+    Accepts Python bool True, or the strings 'true'/'1' (case-insensitive).
+    Everything else (False, 'false', 0, None, absent) is falsy.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("true", "1")
+    return False
 
 
 def main() -> None:
@@ -40,6 +59,11 @@ def main() -> None:
 
     # Only enforce on Telegram (source absent defaults to telegram per API contract)
     if source != "telegram":
+        sys.exit(0)
+
+    # Exempt explicitly proactive sends: dispatcher-initiated messages with no
+    # originating user message (startup status, graceful restart notifications, etc.)
+    if _is_truthy(tool_input.get("proactive")):
         sys.exit(0)
 
     # Exempt proactive/system sends: chat_id == 0 means no originating user message
@@ -66,7 +90,7 @@ def main() -> None:
         "Telegram message ID shown in wait_for_messages output as\n"
         "'pass as reply_to_message_id') to thread the reply correctly.\n\n"
         "If this is a proactive/system send with no originating message,\n"
-        "pass chat_id=0 to exempt this check.",
+        "pass proactive=True (preferred) or chat_id=0 to exempt this check.",
         file=sys.stderr,
     )
     sys.exit(2)

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -1338,14 +1338,15 @@ check_session_age() {
         return 0
     fi
 
+    # Notify BEFORE sending SIGTERM so the message reaches the user even if the
+    # session exits immediately after kill -TERM. This is a planned restart —
+    # the user should see a plain-language explanation, not internal state detail.
+    send_telegram_alert_deduped "proactive-session-restart" "Restarting now — this is the planned 2-hour graceful restart. Back in ~30 seconds."
+
     # Send SIGTERM. The Stop hook fires, writes the tombstone, and claude-persistent.sh
     # restarts Claude. This is a graceful exit, not a crash.
     if kill -TERM "$dispatcher_pid" 2>/dev/null; then
         log_warn "Session age: SIGTERM sent to dispatcher PID $dispatcher_pid"
-        send_telegram_alert_deduped "proactive-session-restart" "Lobster: proactive restart at ${session_age}s (before the 7440s CC hard limit).
-
-Dispatcher PID $dispatcher_pid sent SIGTERM. Stop hook will fire, session will restart cleanly.
-Next session will start fresh — no context lost from hard limit."
         # Delete the start timestamp so a subsequent health check run (within the
         # next 4 minutes) does not send a second SIGTERM before the restart completes.
         rm -f "$DISPATCHER_SESSION_START_FILE" 2>/dev/null || true

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -1341,7 +1341,7 @@ check_session_age() {
     # Notify BEFORE sending SIGTERM so the message reaches the user even if the
     # session exits immediately after kill -TERM. This is a planned restart —
     # the user should see a plain-language explanation, not internal state detail.
-    send_telegram_alert_deduped "proactive-session-restart" "Restarting now — this is the planned 2-hour graceful restart. Back in ~30 seconds."
+    send_telegram_alert_deduped "proactive-session-restart" "Restarting now — this is the planned graceful restart. Back in ~30 seconds."
 
     # Send SIGTERM. The Stop hook fires, writes the tombstone, and claude-persistent.sh
     # restarts Claude. This is a graceful exit, not a crash.

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -1858,6 +1858,16 @@ async def list_tools() -> list[Tool]:
                             "even if the subagent forgets to pass sent_reply_to_user=True."
                         ),
                     },
+                    "proactive": {
+                        "type": "boolean",
+                        "description": (
+                            "If true, marks this as a proactive send (not a reply to a user message). "
+                            "Proactive sends are exempt from the require-reply-to-message-id hook enforcement — "
+                            "they do not need a reply_to_message_id. Use for startup status messages, "
+                            "scheduled notifications, and other sends that are not in response to a specific "
+                            "incoming message."
+                        ),
+                    },
                 },
                 "required": ["chat_id", "text"],
             },

--- a/tests/test-health-check-session-age.sh
+++ b/tests/test-health-check-session-age.sh
@@ -231,6 +231,53 @@ else
     fail "no Telegram alert with key 'proactive-session-restart' found after SIGTERM"
 fi
 
+# 12. Notification text is user-friendly (not raw PID / session age implementation details)
+# The message should say "planned" or "graceful" in plain language, not "Dispatcher PID N
+# sent SIGTERM" or "before the 7440s CC hard limit".
+begin_test "notification_text_is_user_friendly"
+reset_state
+sleep 600 &
+target_pid=$!
+echo "$target_pid" > "$DISPATCHER_PID_FILE"
+past_start=$(( $(date +%s) - SESSION_AGE_LIMIT_SECONDS - 60 ))
+echo "$past_start" > "$DISPATCHER_SESSION_START_FILE"
+check_session_age
+kill "$target_pid" 2>/dev/null || true
+if [[ -f "$TELEGRAM_ALERTS_FILE" ]]; then
+    alert_text=$(cat "$TELEGRAM_ALERTS_FILE")
+    # Must contain plain-language description of a planned restart
+    if echo "$alert_text" | grep -qiE "planned|graceful restart|back in"; then
+        pass
+    else
+        fail "notification text does not contain plain-language restart description: $alert_text"
+    fi
+else
+    fail "no Telegram alert file found"
+fi
+
+# 13. Notification fires BEFORE SIGTERM: verify the source ordering structurally.
+#     bash is single-threaded within a function body; if send_telegram_alert_deduped
+#     appears before kill -TERM in check_session_age(), the alert is guaranteed to
+#     fire before SIGTERM delivery. This test extracts just the function body and
+#     checks line ordering.
+#
+#     We match only executable kill -TERM lines (not comments) by requiring the
+#     line to begin with whitespace followed by 'kill -TERM'.
+begin_test "notification_fires_before_sigterm"
+# Extract only the lines between 'check_session_age()' and the closing '}' at
+# the start of the line (same level as the function definition).
+fn_body=$(sed -n '/^check_session_age()/,/^}/p' "$HEALTH_SCRIPT")
+alert_line=$(echo "$fn_body" | grep -n "send_telegram_alert_deduped" | head -1 | cut -d: -f1)
+# Match the 'if kill -TERM' statement (the executable SIGTERM call, not a comment).
+kill_line=$(echo "$fn_body" | grep -n 'if kill -TERM' | head -1 | cut -d: -f1)
+if [[ -z "$alert_line" || -z "$kill_line" ]]; then
+    fail "could not locate send_telegram_alert_deduped or executable 'kill -TERM' in check_session_age() — alert_line='$alert_line' kill_line='$kill_line'"
+elif [[ "$alert_line" -lt "$kill_line" ]]; then
+    pass
+else
+    fail "send_telegram_alert_deduped (line $alert_line) is NOT before kill -TERM (line $kill_line) in check_session_age()"
+fi
+
 #===============================================================================
 # Summary
 #===============================================================================

--- a/tests/unit/test_hooks/test_require_reply_to_message_id.py
+++ b/tests/unit/test_hooks/test_require_reply_to_message_id.py
@@ -190,8 +190,8 @@ class TestRequireReplyToMessageId:
         })
         assert rc == 0
 
-    def test_proactive_true_still_blocked_when_reply_id_is_wrong_type(self):
-        """If both proactive=true AND reply_to_message_id are supplied, proactive wins — allowed."""
+    def test_proactive_true_overrides_wrong_type_reply_id(self):
+        """If both proactive=true AND a non-integer reply_to_message_id are supplied, proactive wins — allowed."""
         # Providing proactive=true overrides even a bad reply_to_message_id value
         rc, _, _ = _run({
             "source": "telegram",

--- a/tests/unit/test_hooks/test_require_reply_to_message_id.py
+++ b/tests/unit/test_hooks/test_require_reply_to_message_id.py
@@ -141,3 +141,63 @@ class TestRequireReplyToMessageId:
         })
         assert rc == 2
         assert "chat_id=0" in stderr
+
+    # -------------------------------------------------------------------------
+    # proactive=true exemption (issue #2075 / fix for #2070)
+    # -------------------------------------------------------------------------
+
+    def test_proactive_true_exempts_telegram_send_without_reply_id(self):
+        """proactive=true allows a Telegram send_reply with no reply_to_message_id.
+
+        This is the correct way to mark startup status messages, graceful restart
+        notifications, and other dispatcher-initiated sends that have no originating
+        user message to thread against.
+        """
+        rc, _, _ = _run({
+            "source": "telegram",
+            "chat_id": 8305714125,
+            "text": "Restarting now — planned 2-hour graceful restart. Back in ~30s.",
+            "proactive": True,
+        })
+        assert rc == 0
+
+    def test_proactive_false_does_not_exempt(self):
+        """proactive=False is treated the same as proactive absent — still blocked."""
+        rc, _, _ = _run({
+            "source": "telegram",
+            "chat_id": 123456,
+            "text": "Hello!",
+            "proactive": False,
+        })
+        assert rc == 2
+
+    def test_proactive_string_true_exempts(self):
+        """proactive='true' (string) also exempts — JSON serialisation may vary."""
+        rc, _, _ = _run({
+            "source": "telegram",
+            "chat_id": 123456,
+            "text": "Startup complete.",
+            "proactive": "true",
+        })
+        assert rc == 0
+
+    def test_proactive_true_with_explicit_source_absent_exempts(self):
+        """proactive=true with no source (defaults to telegram) is exempt."""
+        rc, _, _ = _run({
+            "chat_id": 123456,
+            "text": "Graceful restart in 5 seconds.",
+            "proactive": True,
+        })
+        assert rc == 0
+
+    def test_proactive_true_still_blocked_when_reply_id_is_wrong_type(self):
+        """If both proactive=true AND reply_to_message_id are supplied, proactive wins — allowed."""
+        # Providing proactive=true overrides even a bad reply_to_message_id value
+        rc, _, _ = _run({
+            "source": "telegram",
+            "chat_id": 123456,
+            "text": "Hello!",
+            "proactive": True,
+            "reply_to_message_id": "not-an-int",
+        })
+        assert rc == 0


### PR DESCRIPTION
## What problem does this solve?

Before this PR, the planned ~2-hour graceful restart (triggered by `check_session_age()` when the session hits 7200s) was invisible to Sahar in two ways:

1. **Wrong ordering:** the Telegram notification fired *after* `kill -TERM` was sent — if the session exited before the curl call completed, the message was never delivered.
2. **Wrong audience:** the message text was written for a developer, not a user: "Lobster: proactive restart at 7260s (before the 7440s CC hard limit). Dispatcher PID 80069 sent SIGTERM. Stop hook will fire, session will restart cleanly." Sahar had no way to distinguish a graceful planned restart from a health-check kill or OOM crash.

Additionally, the `require-reply-to-message-id` hook (#2068) was silently blocking any proactive `send_reply` call (startup status, debug messages, etc.) because it had no exemption for sends that aren't replies to a user message. Issue #2070.

## What changed

**`scripts/health-check-v3.sh`**

`check_session_age()` now sends the Telegram notification *before* `kill -TERM`, not after. Message text changed to user-facing:

> "Restarting now — this is the planned 2-hour graceful restart. Back in ~30 seconds."

```
Before:
  if kill -TERM "$pid"; then
      send_telegram_alert_deduped "proactive-session-restart" "Lobster: proactive restart at Xs..."

After:
  send_telegram_alert_deduped "proactive-session-restart" "Restarting now — planned 2-hour graceful restart. Back in ~30 seconds."
  if kill -TERM "$pid"; then
```

The notification uses `send_telegram_alert_deduped` (direct curl, not MCP) — it fires from the health-check process, not the dispatcher, so it works even when the dispatcher is about to die.

**`hooks/require-reply-to-message-id.py`**

Added a `proactive=True` parameter exemption. When the dispatcher passes `proactive=True`, the hook allows the send without requiring `reply_to_message_id`. This is the correct path for: startup status messages, graceful restart notifications, and any other dispatcher-initiated send that has no originating user message to thread against.

Resolves issue #2070 (debug-mode post-bootup status was silently dropped).

**`.claude/sys.dispatcher.bootup.md`**

Added a note to the post-bootup status message instruction: pass `proactive=True` when calling `send_reply` for the startup status message, since there is no user message to thread against.

## Flow (changed path only)

```
Before:
  health-check → check_session_age() → kill -TERM → [session may die] → send_telegram_alert (may be lost)

After:
  health-check → check_session_age() → send_telegram_alert → kill -TERM → [session dies cleanly]
```

The hook fix is independent:

```
Before (proactive send):
  dispatcher → send_reply(chat_id=ADMIN_CHAT_ID, text=...) → hook blocks (missing reply_to_message_id) → silent drop

After:
  dispatcher → send_reply(chat_id=ADMIN_CHAT_ID, text=..., proactive=True) → hook exempts → message delivered
```

## Tests run

- [x] `bash tests/test-health-check-session-age.sh` — 13 passed, 0 failed (includes 2 new tests: `notification_text_is_user_friendly`, `notification_fires_before_sigterm`)
- [x] `uv run pytest tests/unit/test_hooks/test_require_reply_to_message_id.py -v` — 16 passed, 0 failed (includes 5 new tests for `proactive=True` exemption)
- [x] `uv run pytest tests/unit/test_hooks/ -v` — 604 passed, 7 skipped, 0 failed

## Manual test

N/A — the graceful restart fires at 7200s of session runtime, which cannot be triggered during development without waiting ~2 hours. The health-check notification path uses direct curl (not MCP), so it is not affected by the hook or MCP session state. The structural ordering test (`notification_fires_before_sigterm`) provides behavioral coverage for the core correctness claim.

For the `proactive=True` hook fix: the unit tests run the actual hook subprocess with real inputs. No production hit required.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — N/A (see above)
- [x] User-visible outcome verified — verified via unit tests; live verification requires waiting for next ~2h graceful restart
- [x] Side-effect audit complete: no new sends, no volume changes, no shared state writes
- [x] External service calls: hook tests use subprocess, no production Telegram calls

Closes #2075
Closes #2070