### PR TITLE
fix(slack): inject fallback text for file-only messages with no caption

### DIFF
--- a/src/bot/slack_router.py
+++ b/src/bot/slack_router.py
@@ -524,6 +524,13 @@ def handle_message_events(body, say, logger):
                 except Exception as e:
                     log.error(f"Error downloading file: {e}")
 
+    # File-only messages have no caption text, which leaves msg_data["text"]
+    # empty.  An empty text field confuses the dispatcher, so inject a
+    # human-readable fallback so there is always something meaningful to route.
+    if not msg_data.get("text") and msg_data.get("files"):
+        first_file = msg_data["files"][0]
+        msg_data["text"] = f"[File: {first_file.get('name', 'unknown')}]"
+
     # Post "..." typing indicator immediately so the user sees a response
     # appear right away, before Lobster has had a chance to process the message.
     # Store placeholder_ts in msg_data so the outbox watcher can update it
@@ -1200,6 +1207,12 @@ def _poll_channel_conversations(stop_event: Event) -> None:
                                 download_slack_file(f, msg_id, msg_data)
                             except Exception as e:
                                 log.error(f"Channel poll: error downloading file: {e}")
+
+                # File-only messages have no caption text — inject a fallback
+                # so the dispatcher always sees meaningful text to route.
+                if not msg_data.get("text") and msg_data.get("files"):
+                    first_file = msg_data["files"][0]
+                    msg_data["text"] = f"[File: {first_file.get('name', 'unknown')}]"
 
                 # Post "..." typing indicator immediately (same as Socket Mode path)
                 placeholder_ts = _post_typing_placeholder(channel_id, thread_ts, ts)


### PR DESCRIPTION
## Summary

Fixes #2079 — Slice 3 of 3 in the Slack file-receiving fix series.

File-only Slack messages (no caption text) produce `cleaned_text = ""`, leaving `msg_data["text"] = ""`. The dispatcher sees a blank message and gives a confused or unhelpful reply.

- After the file-extraction block in **both** the Socket Mode handler and the channel-conversation poll path, check: if `text` is empty AND `files` is non-empty, inject `[File: <filename>]` as the fallback text
- Messages with a caption are unaffected — the fallback only triggers when text would otherwise be empty
- Applied consistently in both paths for uniform dispatcher behaviour

## Test plan

- [ ] Send a file with no caption; verify `msg_data["text"]` = `"[File: filename.ext]"`
- [ ] Send a file with a caption; verify caption text is preserved unchanged
- [ ] Verify both Socket Mode path and channel-poll path behave identically
- [ ] Confirm plain text messages are unaffected

## Depends on

#2077 (Slice 1) and #2078 (Slice 2) — already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)