### PR TITLE
fix(post-compact-gate): bail out after 3 consecutive blocked-needs-token failures (#2061)

### DIFF
--- a/hooks/post-compact-gate.py
+++ b/hooks/post-compact-gate.py
@@ -9,11 +9,14 @@ on-compact.py when a compaction occurs. This hook passes when:
   1. No sentinel file exists (normal operation), OR
   2. Not the dispatcher session (see session_role.is_dispatcher()), OR
   3. The sentinel is older than SENTINEL_TTL_SECONDS (stale / post-hibernation), OR
-  4. The tool being called IS wait_for_messages (let it through, delete sentinel), OR
-  5. The tool being called IS ToolSearch (read-only schema fetch, needed to load
+  4. The tool being called IS wait_for_messages with the correct confirmation token
+     (let it through, delete sentinel and failure counter), OR
+  5. The tool being called IS wait_for_messages WITHOUT the token but consecutive
+     failures have reached MAX_FAILED_ATTEMPTS (bail-out path — see below), OR
+  6. The tool being called IS ToolSearch (read-only schema fetch, needed to load
      deferred MCP tool schemas — the dispatcher must be able to call ToolSearch to
      fetch the wait_for_messages schema before it can call wait_for_messages), OR
-  6. The tool being called IS Read (read-only file access — non-destructive and
+  7. The tool being called IS Read (read-only file access — non-destructive and
      needed to break the circular dependency in issue #1950: Read is required to
      learn the confirmation token from the bootup file, but the gate was blocking
      Read before the token was known).
@@ -21,6 +24,19 @@ on-compact.py when a compaction occurs. This hook passes when:
 The TTL (10 minutes) eliminates the stuck-sentinel failure mode: if the
 dispatcher hibernates or crashes while the sentinel is active, the next boot
 finds a stale sentinel and the gate passes immediately. No deadlock.
+
+## Consecutive-failure bail-out (issue #2061)
+
+After MAX_FAILED_ATTEMPTS consecutive blocked-needs-token WFM calls within the
+same sentinel window, the gate deletes the sentinel and its companion counter
+file (~/messages/config/compact-pending-failures) and allows WFM through without
+the token. This prevents the model from going silent after exhausting viable
+actions in its context window — the failure mode observed in session 018 where
+the dispatcher froze 49 seconds after compaction and never processed the queued
+user message.
+
+The counter is reset whenever the sentinel is cleared (correct token, TTL expiry,
+or bail-out), so it does not accumulate across sentinel windows.
 
 ## Dispatcher vs subagent detection
 
@@ -86,6 +102,20 @@ SENTINEL_FILE = Path(os.path.expanduser("~/messages/config/compact-pending"))
 SENTINEL_TTL_SECONDS = 600  # 10 minutes — treats stale sentinel as harmless
 LOG_FILE = Path(os.path.expanduser("~/lobster-workspace/logs/compact-gate.log"))
 
+# Consecutive-failure bail-out (issue #2061).
+#
+# After MAX_FAILED_ATTEMPTS consecutive blocked-needs-token WFM calls within
+# the same sentinel window, the gate deletes the sentinel (and this counter
+# file) and allows through rather than continuing to block.  This prevents the
+# model from going silent after exhausting viable actions in its context window.
+#
+# The counter file records the number of consecutive blocked-needs-token events
+# since the current sentinel was written.  It lives in the same directory as
+# the sentinel and is always removed together with it (correct token, TTL
+# expiry, or bail-out).
+FAILURE_COUNTER_FILE = Path(os.path.expanduser("~/messages/config/compact-pending-failures"))
+MAX_FAILED_ATTEMPTS = 3  # Bail out after this many consecutive blocked-needs-token failures
+
 WAIT_FOR_MESSAGES_TOOL = "mcp__lobster-inbox__wait_for_messages"
 
 # ToolSearch is a read-only schema fetch.  It is always allowed through the gate
@@ -134,6 +164,54 @@ def log_gate_event(tool_name: str, action: str) -> None:
         with LOG_FILE.open("a") as f:
             f.write(line)
     except Exception:  # noqa: BLE001
+        pass
+
+
+def _read_failure_count() -> int:
+    """Return the current consecutive-failure count from FAILURE_COUNTER_FILE.
+
+    Returns 0 if the file is absent or cannot be parsed — conservative: we
+    prefer to give the dispatcher one more chance rather than bail out early.
+    Pure read — no side effects.
+    """
+    try:
+        raw = FAILURE_COUNTER_FILE.read_text().strip()
+        return int(raw) if raw.isdigit() else 0
+    except OSError:
+        return 0
+
+
+def _increment_failure_count() -> int:
+    """Increment the consecutive-failure counter and return the new value.
+
+    Creates the counter file if it does not exist.  Uses an atomic rename so
+    the file is never half-written.  Silent on any failure — returns the
+    pre-increment value on error (conservative: avoids premature bail-out due
+    to a filesystem hiccup).
+    """
+    try:
+        current = _read_failure_count()
+        new_count = current + 1
+        FAILURE_COUNTER_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = FAILURE_COUNTER_FILE.with_suffix(".tmp")
+        tmp.write_text(str(new_count))
+        tmp.replace(FAILURE_COUNTER_FILE)
+        return new_count
+    except Exception:  # noqa: BLE001
+        return _read_failure_count()
+
+
+def _reset_failure_count() -> None:
+    """Delete the failure counter file.
+
+    Called when the sentinel is cleared (correct token, TTL expiry, or
+    bail-out).  Silent on any failure — a leftover counter file is harmless
+    because the sentinel gate checks for an *active* sentinel before reading
+    the counter.
+    """
+    try:
+        FAILURE_COUNTER_FILE.unlink(missing_ok=True)
+    except OSError:
         pass
 
 
@@ -194,24 +272,45 @@ def main() -> None:
             # Sentinel is active — require the confirmation token.
             confirmation = tool_input.get("confirmation", "")
             if confirmation == CONFIRMATION_TOKEN:
-                # Correct token: clear the sentinel and allow through.
+                # Correct token: clear the sentinel + failure counter and allow through.
                 try:
                     SENTINEL_FILE.unlink(missing_ok=True)
                 except OSError:
                     pass
+                _reset_failure_count()
                 log_gate_event(tool_name, "cleared")
                 sys.exit(0)
             else:
-                # No or wrong token: deny with instructions.
-                log_gate_event(tool_name, "blocked-needs-token")
-                print(json.dumps({
-                    "hookSpecificOutput": {
-                        "hookEventName": "PreToolUse",
-                        "permissionDecision": "deny",
-                        "permissionDecisionReason": DENY_REASON_NEEDS_TOKEN,
-                    }
-                }))
-                sys.exit(0)
+                # No or wrong token: increment the consecutive-failure counter.
+                # If the counter reaches MAX_FAILED_ATTEMPTS, bail out by clearing the
+                # sentinel rather than blocking indefinitely.  This prevents the model
+                # from going silent after exhausting viable actions in its context window
+                # (issue #2061: post-compaction WFM freeze after repeated denied calls).
+                new_count = _increment_failure_count()
+                if new_count >= MAX_FAILED_ATTEMPTS:
+                    # Bail-out: delete sentinel and counter, allow through.
+                    # The gate has been blocking long enough that the model is at risk
+                    # of freezing.  Clearing the sentinel lets the dispatcher resume
+                    # its main loop even without the correct token.  This is a
+                    # last-resort safety valve — normal operation uses the token path.
+                    try:
+                        SENTINEL_FILE.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+                    _reset_failure_count()
+                    log_gate_event(tool_name, f"bail-out-after-{new_count}-failures")
+                    sys.exit(0)
+                else:
+                    # Below threshold: deny with instructions.
+                    log_gate_event(tool_name, "blocked-needs-token")
+                    print(json.dumps({
+                        "hookSpecificOutput": {
+                            "hookEventName": "PreToolUse",
+                            "permissionDecision": "deny",
+                            "permissionDecisionReason": DENY_REASON_NEEDS_TOKEN,
+                        }
+                    }))
+                    sys.exit(0)
         else:
             # No active sentinel: wait_for_messages passes through normally
             # regardless of confirmation param.
@@ -219,7 +318,7 @@ def main() -> None:
             sys.exit(0)
 
     # If sentinel is absent or stale, allow everything through.
-    # Delete a stale sentinel so it doesn't linger as an orphan file.
+    # Delete a stale sentinel (and its failure counter) so they don't linger.
     if not sentinel_is_fresh():
         if SENTINEL_FILE.exists():
             try:
@@ -227,6 +326,7 @@ def main() -> None:
                 log_gate_event(tool_name, "stale-sentinel-deleted")
             except OSError:
                 pass
+            _reset_failure_count()
         sys.exit(0)
 
     # Sentinel is fresh and tool is not wait_for_messages — deny.

--- a/tests/unit/test_hooks/test_post_compact_gate_bailout.py
+++ b/tests/unit/test_hooks/test_post_compact_gate_bailout.py
@@ -1,0 +1,391 @@
+"""
+Unit tests for the consecutive-failure bail-out in hooks/post-compact-gate.py.
+
+Root cause addressed: after N repeated blocked-needs-token denials, the model
+exhausts viable actions in its context window and goes silent (issue #2061).
+The gate had no escape mechanism — it blocked indefinitely until the 10-minute
+TTL expired or the health check killed the session.
+
+Fix: after MAX_FAILED_ATTEMPTS consecutive blocked-needs-token failures within
+the same sentinel window, the gate deletes the sentinel (and its associated
+failure counter) and logs a bail-out warning. This prevents the model from
+reaching the freeze state by clearing the gate before the context window is
+exhausted.
+
+Behaviors verified:
+  F1. First N-1 failures increment the counter and still block.
+  F2. The Nth failure triggers bail-out: sentinel + counter deleted, no deny output.
+  F3. Correct token clears sentinel + resets counter on success.
+  F4. Counter file is deleted when sentinel expires (stale TTL path).
+  F5. Counter file is absent after clean sentinel deletion.
+"""
+
+import importlib.util
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "post-compact-gate.py"
+
+SENTINEL_REL = Path("messages") / "config" / "compact-pending"
+COUNTER_REL = Path("messages") / "config" / "compact-pending-failures"
+
+# The confirmation token that clears the sentinel on a successful WFM call.
+# Derived from the hook source so we don't hardcode a value that the security
+# scanner might flag as a credential.
+def _read_confirmation_token() -> str:
+    text = _HOOK_PATH.read_text()
+    for line in text.splitlines():
+        if line.startswith("CONFIRMATION_TOKEN") and "=" in line:
+            import re
+            value_part = line.split("=", 1)[1].strip()
+            m = re.search(r'["\']([^"\']+)["\']', value_part)
+            if m:
+                return m.group(1)
+    raise RuntimeError(f"CONFIRMATION_TOKEN not found in {_HOOK_PATH}")
+
+CONFIRMATION_TOKEN = _read_confirmation_token()
+
+
+def _make_sentinel(home: Path) -> Path:
+    sentinel = home / SENTINEL_REL
+    sentinel.parent.mkdir(parents=True, exist_ok=True)
+    sentinel.touch()
+    return sentinel
+
+
+def _make_dispatcher_session_file(tmp_path: Path, session_id: str) -> Path:
+    config_dir = tmp_path / "messages" / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    marker = config_dir / "dispatcher-session-id"
+    marker.write_text(session_id)
+    return marker
+
+
+def _load_hook(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOBSTER_MAIN_SESSION", "1")
+
+    spec = importlib.util.spec_from_file_location("post_compact_gate", _HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    if str(_HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(_HOOKS_DIR))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_hook_input(
+    tool_name: str,
+    tool_input: dict | None = None,
+    agent_id: str | None = None,
+) -> dict:
+    payload = {"tool_name": tool_name, "tool_input": tool_input or {}}
+    if agent_id is not None:
+        payload["agent_id"] = agent_id
+    return payload
+
+
+def _run_hook(mod, hook_input: dict) -> tuple[int, str, str]:
+    stdout_cap = StringIO()
+    stderr_cap = StringIO()
+    stdin_data = json.dumps(hook_input)
+    exit_code = None
+
+    with (
+        patch("sys.stdin", StringIO(stdin_data)),
+        patch("sys.stdout", stdout_cap),
+        patch("sys.stderr", stderr_cap),
+    ):
+        try:
+            mod.main()
+        except SystemExit as e:
+            exit_code = e.code
+
+    return exit_code, stdout_cap.getvalue(), stderr_cap.getvalue()
+
+
+def _wfm_input_no_token() -> dict:
+    return _make_hook_input(
+        tool_name="mcp__lobster-inbox__wait_for_messages",
+        tool_input={},
+    )
+
+
+def _wfm_input_wrong_token() -> dict:
+    return _make_hook_input(
+        tool_name="mcp__lobster-inbox__wait_for_messages",
+        tool_input={"confirmation": "wrong-token"},
+    )
+
+
+def _wfm_input_correct_token() -> dict:
+    return _make_hook_input(
+        tool_name="mcp__lobster-inbox__wait_for_messages",
+        tool_input={"confirmation": CONFIRMATION_TOKEN},
+    )
+
+
+def _setup(monkeypatch, tmp_path: Path):
+    """Create sentinel + dispatcher marker, load hook module with redirected paths."""
+    _make_sentinel(tmp_path)
+    _make_dispatcher_session_file(tmp_path, "sess-disp-bailout")
+    mod = _load_hook(monkeypatch, tmp_path)
+    mod.SENTINEL_FILE = tmp_path / SENTINEL_REL
+    mod.FAILURE_COUNTER_FILE = tmp_path / COUNTER_REL
+
+    import session_role
+    monkeypatch.setattr(
+        session_role, "DISPATCHER_SESSION_FILE",
+        tmp_path / "messages" / "config" / "dispatcher-session-id",
+    )
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# F1: failures before the threshold still block
+# ---------------------------------------------------------------------------
+
+
+class TestFailuresBeforeThreshold:
+    """Each failure below MAX_FAILED_ATTEMPTS increments the counter but keeps blocking."""
+
+    def test_first_failure_still_blocks(self, monkeypatch, tmp_path):
+        """F1a: a single failed WFM call (no token) still produces a deny decision."""
+        mod = _setup(monkeypatch, tmp_path)
+        sentinel = tmp_path / SENTINEL_REL
+
+        exit_code, stdout, stderr = _run_hook(mod, _wfm_input_no_token())
+
+        assert exit_code == 0, f"Hook should exit 0, got {exit_code}. stderr: {stderr!r}"
+        assert stdout.strip(), "Expected deny decision on stdout"
+        output = json.loads(stdout)
+        decision = output.get("hookSpecificOutput", {}).get("permissionDecision", "")
+        assert decision == "deny", f"Expected deny, got {decision!r}"
+        assert sentinel.exists(), "Sentinel must remain after first failure — threshold not reached"
+
+    def test_failure_increments_counter(self, monkeypatch, tmp_path):
+        """F1b: each blocked-needs-token event increments the failure counter file."""
+        mod = _setup(monkeypatch, tmp_path)
+        counter_file = tmp_path / COUNTER_REL
+
+        assert not counter_file.exists(), "Counter should not exist before any failures"
+
+        _run_hook(mod, _wfm_input_no_token())
+        assert counter_file.exists(), "Counter file must be created after first failure"
+        count_after_1 = int(counter_file.read_text().strip())
+        assert count_after_1 == 1, f"Expected count=1 after 1 failure, got {count_after_1}"
+
+        _run_hook(mod, _wfm_input_wrong_token())
+        count_after_2 = int(counter_file.read_text().strip())
+        assert count_after_2 == 2, f"Expected count=2 after 2 failures, got {count_after_2}"
+
+    def test_second_failure_still_blocks(self, monkeypatch, tmp_path):
+        """F1c: a second failed WFM call (below threshold) still blocks."""
+        mod = _setup(monkeypatch, tmp_path)
+        sentinel = tmp_path / SENTINEL_REL
+
+        _run_hook(mod, _wfm_input_no_token())
+        exit_code, stdout, stderr = _run_hook(mod, _wfm_input_no_token())
+
+        assert exit_code == 0
+        output = json.loads(stdout)
+        decision = output.get("hookSpecificOutput", {}).get("permissionDecision", "")
+        assert decision == "deny", f"Expected deny on 2nd failure, got {decision!r}"
+        assert sentinel.exists(), "Sentinel must remain after 2nd failure — threshold not reached"
+
+
+# ---------------------------------------------------------------------------
+# F2: Nth failure triggers bail-out
+# ---------------------------------------------------------------------------
+
+
+class TestBailoutOnThreshold:
+    """After MAX_FAILED_ATTEMPTS consecutive failures, gate clears sentinel and allows through."""
+
+    def _exhaust_failures(self, mod, count: int) -> None:
+        """Run count failures against the gate without checking results."""
+        for _ in range(count):
+            _run_hook(mod, _wfm_input_no_token())
+
+    def test_nth_failure_clears_sentinel(self, monkeypatch, tmp_path):
+        """F2a: after MAX_FAILED_ATTEMPTS failures, the sentinel file is deleted."""
+        mod = _setup(monkeypatch, tmp_path)
+        sentinel = tmp_path / SENTINEL_REL
+        threshold = mod.MAX_FAILED_ATTEMPTS
+
+        # Exhaust all failures up to the threshold.
+        for _ in range(threshold):
+            _run_hook(mod, _wfm_input_no_token())
+
+        assert not sentinel.exists(), (
+            f"Sentinel must be deleted after {threshold} consecutive failures. "
+            "The gate must bail out to prevent model freeze."
+        )
+
+    def test_nth_failure_clears_counter(self, monkeypatch, tmp_path):
+        """F2b: after bail-out, the failure counter file is also deleted."""
+        mod = _setup(monkeypatch, tmp_path)
+        counter_file = tmp_path / COUNTER_REL
+        threshold = mod.MAX_FAILED_ATTEMPTS
+
+        for _ in range(threshold):
+            _run_hook(mod, _wfm_input_no_token())
+
+        assert not counter_file.exists(), (
+            "Counter file must be deleted after bail-out."
+        )
+
+    def test_nth_failure_allows_tool_through(self, monkeypatch, tmp_path):
+        """F2c: the Nth failure produces no deny output (gate allows through after bail-out)."""
+        mod = _setup(monkeypatch, tmp_path)
+        threshold = mod.MAX_FAILED_ATTEMPTS
+
+        # Run threshold-1 failures first.
+        for _ in range(threshold - 1):
+            _run_hook(mod, _wfm_input_no_token())
+
+        # The final (Nth) failure should bail out and allow through.
+        exit_code, stdout, stderr = _run_hook(mod, _wfm_input_no_token())
+
+        assert exit_code == 0, f"Hook should exit 0 on bail-out, got {exit_code}"
+        assert stdout.strip() == "", (
+            f"Bail-out call should produce no deny output (empty stdout), got: {stdout!r}"
+        )
+
+    def test_post_bailout_tool_calls_allowed(self, monkeypatch, tmp_path):
+        """F2d: after bail-out, subsequent tool calls pass through normally (sentinel gone)."""
+        mod = _setup(monkeypatch, tmp_path)
+        threshold = mod.MAX_FAILED_ATTEMPTS
+
+        for _ in range(threshold):
+            _run_hook(mod, _wfm_input_no_token())
+
+        # Sentinel is now gone — any tool should pass.
+        hook_input = _make_hook_input(tool_name="mcp__lobster-inbox__check_inbox")
+        exit_code, stdout, _ = _run_hook(mod, hook_input)
+
+        assert exit_code == 0
+        assert stdout.strip() == "", (
+            "After bail-out, non-WFM tools should pass through (sentinel deleted)."
+        )
+
+    def test_threshold_is_named_constant(self, monkeypatch, tmp_path):
+        """F2e: MAX_FAILED_ATTEMPTS is a named constant exposed on the module (not a magic literal)."""
+        mod = _setup(monkeypatch, tmp_path)
+        assert hasattr(mod, "MAX_FAILED_ATTEMPTS"), (
+            "MAX_FAILED_ATTEMPTS must be a named constant on the module for testability."
+        )
+        assert isinstance(mod.MAX_FAILED_ATTEMPTS, int), "MAX_FAILED_ATTEMPTS must be an int"
+        assert mod.MAX_FAILED_ATTEMPTS >= 2, "Threshold must be at least 2 (1 would bail on first failure)"
+
+
+# ---------------------------------------------------------------------------
+# F3: correct token clears sentinel + resets counter
+# ---------------------------------------------------------------------------
+
+
+class TestCorrectTokenClearsCounter:
+    """A correct token clears both sentinel and counter in a single call."""
+
+    def test_correct_token_after_failures_clears_counter(self, monkeypatch, tmp_path):
+        """F3a: counter is reset when the correct token is supplied (even after prior failures)."""
+        mod = _setup(monkeypatch, tmp_path)
+        counter_file = tmp_path / COUNTER_REL
+        threshold = mod.MAX_FAILED_ATTEMPTS
+
+        # Accumulate some failures (below threshold).
+        for _ in range(threshold - 1):
+            _run_hook(mod, _wfm_input_no_token())
+
+        assert counter_file.exists(), "Counter should exist after failures"
+
+        # Supply the correct token.
+        _run_hook(mod, _wfm_input_correct_token())
+
+        assert not counter_file.exists(), (
+            "Counter file must be deleted when the correct token clears the sentinel."
+        )
+
+    def test_correct_token_allows_through(self, monkeypatch, tmp_path):
+        """F3b: correct token allows WFM through (basic correctness, regression guard)."""
+        mod = _setup(monkeypatch, tmp_path)
+
+        exit_code, stdout, stderr = _run_hook(mod, _wfm_input_correct_token())
+
+        assert exit_code == 0, f"Correct token should exit 0, got {exit_code}. stderr: {stderr!r}"
+        assert stdout.strip() == "", (
+            f"Correct token should produce no deny output, got: {stdout!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# F4: stale sentinel clears counter
+# ---------------------------------------------------------------------------
+
+
+class TestStaleSentinelClearsCounter:
+    """A stale sentinel (TTL expired) causes the gate to pass and cleans up the counter file."""
+
+    def test_stale_sentinel_deletes_counter(self, monkeypatch, tmp_path):
+        """F4a: when the sentinel is stale, the failure counter is also deleted."""
+        import os
+        import time
+
+        mod = _setup(monkeypatch, tmp_path)
+        sentinel = tmp_path / SENTINEL_REL
+        counter_file = tmp_path / COUNTER_REL
+
+        # Write a failure count manually (simulating prior failures).
+        counter_file.parent.mkdir(parents=True, exist_ok=True)
+        counter_file.write_text("2")
+
+        # Back-date the sentinel beyond the TTL.
+        stale_mtime = time.time() - (mod.SENTINEL_TTL_SECONDS + 60)
+        os.utime(sentinel, (stale_mtime, stale_mtime))
+
+        # Any tool call should pass (stale sentinel) and clean up counter.
+        hook_input = _make_hook_input(tool_name="mcp__lobster-inbox__check_inbox")
+        exit_code, stdout, _ = _run_hook(mod, hook_input)
+
+        assert exit_code == 0
+        assert stdout.strip() == "", "Stale sentinel should allow through"
+        assert not counter_file.exists(), (
+            "Counter file must be deleted when a stale sentinel is cleaned up."
+        )
+
+
+# ---------------------------------------------------------------------------
+# F5: no sentinel means no counter accumulation
+# ---------------------------------------------------------------------------
+
+
+class TestNoSentinelNoCounter:
+    """Without a sentinel, the counter is never created (normal operation)."""
+
+    def test_no_counter_without_sentinel(self, monkeypatch, tmp_path):
+        """F5a: calling WFM without a sentinel does not create a failure counter."""
+        # No sentinel — normal operation.
+        _make_dispatcher_session_file(tmp_path, "sess-no-sentinel")
+        mod = _load_hook(monkeypatch, tmp_path)
+        mod.SENTINEL_FILE = tmp_path / SENTINEL_REL
+        mod.FAILURE_COUNTER_FILE = tmp_path / COUNTER_REL
+
+        import session_role
+        monkeypatch.setattr(
+            session_role, "DISPATCHER_SESSION_FILE",
+            tmp_path / "messages" / "config" / "dispatcher-session-id",
+        )
+
+        counter_file = tmp_path / COUNTER_REL
+
+        # Call WFM (no sentinel) — should pass, no counter created.
+        _run_hook(mod, _wfm_input_no_token())
+
+        assert not counter_file.exists(), (
+            "Failure counter must not be created when there is no active sentinel."
+        )


### PR DESCRIPTION
## Summary

After a context compaction, the dispatcher is required to call `wait_for_messages` with a confirmation token before resuming normal operation. If the token is wrong or absent, the gate blocks the call. The bug: there was no escape — the gate would block indefinitely until the 10-minute TTL expired, and after enough denials the model exhausted its viable context-window actions and went silent. Session 018 demonstrated this: the dispatcher froze 49 seconds post-compaction with a user message already queued in the inbox.

This PR adds a consecutive-failure bail-out: after `MAX_FAILED_ATTEMPTS` (3) consecutive `blocked-needs-token` WFM calls within the same sentinel window, the gate clears the sentinel and allows the call through rather than continuing to block.

The bail-out is a last-resort safety valve — normal operation uses the token path. The counter is scoped to a single sentinel window: it is reset whenever the sentinel is cleared (correct token, TTL expiry, or bail-out), so it never accumulates across compaction events.

## What changed

**`hooks/post-compact-gate.py`**

- Added `FAILURE_COUNTER_FILE` (`~/messages/config/compact-pending-failures`) and `MAX_FAILED_ATTEMPTS = 3` as named module-level constants.
- Added three pure helper functions:
  - `_read_failure_count()` — reads the counter file, returns 0 on absence/error (conservative)
  - `_increment_failure_count()` — atomic write via `.tmp` rename; returns new count; silent on error
  - `_reset_failure_count()` — deletes the counter file; silent on error
- In the `blocked-needs-token` branch: increments counter; if `>= MAX_FAILED_ATTEMPTS`, deletes sentinel + counter and exits 0 (bail-out); otherwise emits deny as before.
- Clears counter on correct-token path, stale-TTL path, and bail-out path — counter never leaks across sentinel windows.
- Updated docstring to document the new pass condition (case 5) and the bail-out section.

**Functional patterns used:** pure helper functions (`_read_failure_count`, `_increment_failure_count`, `_reset_failure_count`) that compose into the gate's main logic; side effects (file writes) isolated to the increment/reset functions; named constants for all spec values (`MAX_FAILED_ATTEMPTS = 3`).

## Before/after flow

```
Before:
  WFM call (no token) → deny → [repeat 1..N times] → model goes silent → health check kills session

After:
  WFM call (no token) → deny (count=1)
  WFM call (no token) → deny (count=2)
  WFM call (no token) → BAIL-OUT: sentinel deleted, allowed through (count=3)
  [dispatcher resumes main loop without health-check intervention]
```

## Out of scope

- The 8 pre-existing test failures in `test_on_compact_write_claude_session_id.py` and `test_context_monitor.py` exist on `main` before this branch and are unrelated to this change.
- Root cause 1 from the issue (7440-second session limit) is a separate infrastructure problem not addressed here.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_post_compact_gate_bailout.py -v` — 12 passed, 0 failed
- [x] `uv run pytest tests/smoke/test_post_compact_gate.py tests/smoke/test_on_compact.py -v` — 12 passed, 0 failed
- [x] `uv run pytest tests/unit/test_hooks/test_post_compact_gate_toolsearch.py tests/unit/test_hooks/test_post_compact_gate_read.py -v` — 7 passed, 0 failed
- [x] `uv run pytest tests/unit/test_hooks/ -v` — 611 passed, 8 pre-existing failures (unrelated), 7 skipped

## Manual test

N/A — this change is entirely within a PreToolUse hook (deterministic file I/O, no external services, no runtime state touched while the live dispatcher is running). Fully covered by unit and smoke tests. The bail-out path produces a `compact-gate.log` entry with action `bail-out-after-N-failures` observable in production after a compaction if the model fails to supply the token.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test — N/A (hook is deterministic file I/O, covered by unit tests)
- [x] User-visible outcome: dispatcher resumes processing user messages after compaction instead of freezing
- [x] Side-effect audit: counter file is max a few bytes, scoped to ~/messages/config/, always cleaned up with sentinel — no volume risk
- [x] External service calls: none

Closes #2061