### PR TITLE
fix(health-check): bound WFM-active suppression by heartbeat-stale age (issue #2074)

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -37,6 +37,15 @@
 #   suppression logic. The dispatcher no longer needs to call
 #   record-catchup-state.sh to suppress false alarms. See issue #1483.
 #
+#   WFM-active suppression: while the dispatcher blocks in wait_for_messages on
+#   an idle inbox, the WFM daemon thread refreshes DISPATCHER_WFM_ACTIVE_FILE
+#   every 60s. A fresh WFM-active file (< 180s) suppresses the heartbeat-stale RED.
+#   CRITICAL (issue #2074): suppression is time-bounded at WFM_SUPPRESSION_MAX_SECONDS
+#   (2700s). A frozen dispatcher's daemon thread keeps refreshing WFM-active
+#   independently of the asyncio loop — unbounded suppression recreates the
+#   false-negative that caused the May 2026 2-day outage. After 2700s of heartbeat
+#   staleness, RED fires regardless of WFM-active freshness.
+#
 # Boot grace period:
 #   After any restart (health-check-initiated or manual), the new Claude session
 #   needs ~60-90s to initialize and begin draining the inbox. During this window
@@ -116,6 +125,22 @@ DISPATCHER_SESSION_START_FILE="${LOBSTER_DISPATCHER_SESSION_START_FILE_OVERRIDE:
 # File is deleted by the MCP server when WFM returns (message arrived or timeout).
 DISPATCHER_WFM_ACTIVE_FILE="${LOBSTER_WFM_ACTIVE_OVERRIDE:-$WORKSPACE_DIR/logs/dispatcher-wfm-active}"
 WFM_ACTIVE_STALE_SECONDS=180   # 3x WAIT_HEARTBEAT_INTERVAL (60s) — absorbs one missed tick
+#
+# CRITICAL TIME CAP (issue #2074): A frozen dispatcher's WFM daemon thread
+# continues to refresh DISPATCHER_WFM_ACTIVE_FILE every 60s independently of the
+# main asyncio event loop — so WFM-active freshness alone is NOT sufficient proof
+# of liveness. The suppression is therefore time-bounded:
+#
+#   If the dispatcher heartbeat has been stale for > WFM_SUPPRESSION_MAX_SECONDS,
+#   the WFM-active freshness check is ignored and RED fires regardless.
+#
+# Rationale: the heartbeat goes stale when the dispatcher enters WFM (the last
+# PostToolUse fires just before wait_for_messages is called). So heartbeat stale
+# age ≈ time spent in WFM. After WFM_SUPPRESSION_MAX_SECONDS the system has been
+# idle long enough that (a) the watchdog has already fired if WFM was frozen, and
+# (b) the session age limit (SESSION_AGE_LIMIT_SECONDS = 7200s) will soon force a
+# graceful restart. This constant must be less than SESSION_AGE_LIMIT_SECONDS.
+WFM_SUPPRESSION_MAX_SECONDS=2700   # 45 min: stop suppressing beyond this heartbeat-stale age
 
 OUTBOX_DIR="$MESSAGES_DIR/outbox"
 OUTBOX_STALE_THRESHOLD_SECONDS=900   # 15 min = RED
@@ -1011,7 +1036,18 @@ check_dispatcher_heartbeat() {
         if [[ -n "$wfm_active_ts" ]] && [[ "$wfm_active_ts" =~ ^[0-9]+$ ]]; then
             local wfm_age=$(( now - wfm_active_ts ))
             if [[ $wfm_age -le $WFM_ACTIVE_STALE_SECONDS ]]; then
-                log_info "Dispatcher heartbeat stale (${age}s) but WFM-active is fresh (${wfm_age}s) — dispatcher alive in wait_for_messages, skipping RED"
+                # WFM-active is fresh: the daemon thread is alive and updating.
+                # Normally this means the dispatcher is idle in WFM — suppress RED.
+                # BUT: check the time-cap first (issue #2074). A frozen dispatcher's
+                # daemon thread continues refreshing WFM-active independently of the
+                # asyncio loop. If the heartbeat has been stale for longer than
+                # WFM_SUPPRESSION_MAX_SECONDS, the system has been unresponsive long
+                # enough that we must escalate regardless of daemon thread activity.
+                if [[ $age -ge $WFM_SUPPRESSION_MAX_SECONDS ]]; then
+                    log_error "RED: dispatcher heartbeat stale (${age}s >= ${WFM_SUPPRESSION_MAX_SECONDS}s cap) — WFM-active is fresh (daemon thread alive) but suppression window expired; frozen dispatcher suspected (issue #2074)"
+                    return 2
+                fi
+                log_info "Dispatcher heartbeat stale (${age}s) but WFM-active is fresh (${wfm_age}s) and within suppression window (${WFM_SUPPRESSION_MAX_SECONDS}s) — dispatcher alive in wait_for_messages, skipping RED"
                 return 0
             else
                 log_error "RED: dispatcher heartbeat stale (${age}s) and WFM-active also stale (${wfm_age}s, threshold: ${WFM_ACTIVE_STALE_SECONDS}s) — dispatcher appears frozen"

--- a/tests/test-health-check-dispatcher-heartbeat.sh
+++ b/tests/test-health-check-dispatcher-heartbeat.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 #===============================================================================
-# Test Suite: Health Check v3 - Dispatcher Heartbeat Sentinel (issue #1483)
+# Test Suite: Health Check v3 - Dispatcher Heartbeat Sentinel (issues #1483, #2074)
 #
 # Tests for check_dispatcher_heartbeat() — the simplified single-file liveness check.
 #
-# Tests:
+# Basic heartbeat tests (issue #1483):
 #   1. Heartbeat file absent → GREEN (skipped, no false alarm on fresh install)
 #   2. Heartbeat file recent (< DISPATCHER_HEARTBEAT_STALE_SECONDS) → GREEN
 #   3. Heartbeat file stale (> DISPATCHER_HEARTBEAT_STALE_SECONDS) → RED (exit 2)
@@ -14,10 +14,20 @@
 #   7. Stale by 1 second past threshold → RED (boundary condition)
 #   8. Fresh by 1 second before threshold → GREEN (boundary condition)
 #
-# Key behavioral assertion: the check uses a single dispatcher-heartbeat file with
-# a single epoch timestamp. No lobster-state.json reads. The WFM-active file is
-# also consulted by check_dispatcher_heartbeat() but is bypassed safely here via
-# DISPATCHER_WFM_ACTIVE_FILE pointing to an absent file (defaulting to GREEN).
+# WFM-active suppression tests (issue #2074):
+#   9.  Stale heartbeat + WFM-active fresh + heartbeat age inside cap → GREEN (suppressed)
+#   10. Stale heartbeat + WFM-active fresh + heartbeat age AT cap → RED (cap expired, not suppressed)
+#   11. Stale heartbeat + WFM-active fresh + heartbeat age beyond cap → RED (frozen dispatcher suspected)
+#   12. Stale heartbeat + WFM-active stale → RED (daemon thread also stale)
+#   13. Stale heartbeat + WFM-active absent → RED (no suppression)
+#   14. Stale heartbeat + WFM-active tombstone ("exited") → RED (WFM returned normally)
+#   15. Stale heartbeat + WFM-active fresh + heartbeat well inside cap → GREEN
+#
+# Key behavioral assertion (issue #2074): WFM-active suppression is time-bounded.
+# A frozen dispatcher's WFM daemon thread continues refreshing the WFM-active file
+# every 60s independently of the main asyncio loop. File freshness alone does NOT
+# prove the dispatcher is responsive. After WFM_SUPPRESSION_MAX_SECONDS (2700s)
+# of heartbeat staleness, RED fires regardless of WFM-active freshness.
 #
 # Usage: bash tests/test-health-check-dispatcher-heartbeat.sh
 #===============================================================================
@@ -56,10 +66,12 @@ assert_exit() {
 # Source check_dispatcher_heartbeat() from the health check script once.
 LOG_FILE="$TEST_LOG_DIR/health-check.log"
 DISPATCHER_HEARTBEAT_STALE_SECONDS=1200
-# WFM-active variables (issue #1713): must match the values in health-check-v3.sh.
-# Default to an absent file so existing heartbeat tests are unaffected.
+# WFM-active variables (issues #1713, #2074): must match the values in health-check-v3.sh.
+# Default to an absent file so existing basic heartbeat tests (1-8) are unaffected.
+# Tests 9-15 override WFM_ACTIVE_FILE_FOR_TEST to exercise the suppression logic.
 DISPATCHER_WFM_ACTIVE_FILE="$TEST_LOG_DIR/dispatcher-wfm-active-ABSENT"
 WFM_ACTIVE_STALE_SECONDS=180
+WFM_SUPPRESSION_MAX_SECONDS=2700
 
 log()       { echo "[$1] $2" >> "$LOG_FILE" 2>/dev/null; }
 log_info()  { log INFO "$1"; }
@@ -144,6 +156,118 @@ assert_exit "$rc" 2
 begin_test "1s before threshold (1199s ago) → GREEN"
 echo "$(( $(date +%s) - 1199 ))" > "$DISPATCHER_HEARTBEAT_FILE"
 run_heartbeat_check "$DISPATCHER_HEARTBEAT_FILE" && rc=$? || rc=$?
+assert_exit "$rc" 0
+
+# ===================================================================
+# WFM-active suppression + time-cap tests (issue #2074)
+#
+# These tests verify that the time-bounded suppression correctly handles
+# the frozen-dispatcher false-negative from the May 2026 outage.
+#
+# Setup: use a separate WFM-active file; override DISPATCHER_WFM_ACTIVE_FILE.
+# ===================================================================
+
+echo ""
+echo "--- WFM-active suppression + time-cap tests (issue #2074) ---"
+WFM_ACTIVE_TEST_FILE="$TEST_LOG_DIR/dispatcher-wfm-active"
+
+# Helper: write a fresh WFM-active file (timestamp = now - $1 seconds ago)
+write_wfm_active() {
+    local age_seconds="$1"
+    echo "$(( $(date +%s) - age_seconds ))" > "$WFM_ACTIVE_TEST_FILE"
+}
+
+remove_wfm_active() {
+    rm -f "$WFM_ACTIVE_TEST_FILE"
+}
+
+# Run with WFM-active file active and a heartbeat stale for $1 seconds.
+# DISPATCHER_WFM_ACTIVE_FILE is set to WFM_ACTIVE_TEST_FILE.
+run_check_with_wfm() {
+    local hb_stale_age="$1"
+    echo "$(( $(date +%s) - hb_stale_age ))" > "$DISPATCHER_HEARTBEAT_FILE"
+    DISPATCHER_WFM_ACTIVE_FILE="$WFM_ACTIVE_TEST_FILE"
+    check_dispatcher_heartbeat
+    local rc=$?
+    DISPATCHER_WFM_ACTIVE_FILE="$TEST_LOG_DIR/dispatcher-wfm-active-ABSENT"
+    return $rc
+}
+
+# -------------------------------------------------------------------
+# Test 9: Stale heartbeat + WFM-active fresh + heartbeat inside cap → GREEN
+# Healthy idle dispatcher: WFM is fresh, heartbeat has been stale for 1500s
+# (well within the 2700s suppression cap). Should be GREEN.
+# -------------------------------------------------------------------
+begin_test "Stale hb (1500s) + WFM-active fresh (5s) + inside cap → GREEN"
+write_wfm_active 5
+run_check_with_wfm 1500 && rc=$? || rc=$?
+remove_wfm_active
+assert_exit "$rc" 0
+
+# -------------------------------------------------------------------
+# Test 10: Stale heartbeat + WFM-active fresh + heartbeat AT cap → RED
+# Heartbeat stale for exactly WFM_SUPPRESSION_MAX_SECONDS: cap is hit.
+# Even though WFM-active is fresh, suppression must not apply.
+# -------------------------------------------------------------------
+begin_test "Stale hb (at cap=${WFM_SUPPRESSION_MAX_SECONDS}s) + WFM-active fresh → RED"
+write_wfm_active 5
+run_check_with_wfm "$WFM_SUPPRESSION_MAX_SECONDS" && rc=$? || rc=$?
+remove_wfm_active
+assert_exit "$rc" 2
+
+# -------------------------------------------------------------------
+# Test 11: Stale heartbeat + WFM-active fresh + heartbeat beyond cap → RED
+# This is the May 2026 frozen-dispatcher scenario: the daemon thread keeps
+# WFM-active fresh, but the dispatcher has been unresponsive for 3600s.
+# The suppression cap (2700s) has expired → RED must fire.
+# -------------------------------------------------------------------
+begin_test "Stale hb (3600s, beyond cap) + WFM-active fresh → RED (frozen dispatcher)"
+write_wfm_active 5
+run_check_with_wfm 3600 && rc=$? || rc=$?
+remove_wfm_active
+assert_exit "$rc" 2
+
+# -------------------------------------------------------------------
+# Test 12: Stale heartbeat + WFM-active also stale → RED
+# Both heartbeat and WFM-active are stale: the daemon thread stopped
+# updating, which means either the process died or WFM exited abnormally.
+# -------------------------------------------------------------------
+begin_test "Stale hb (1500s) + WFM-active stale (200s > 180s threshold) → RED"
+write_wfm_active 200   # > WFM_ACTIVE_STALE_SECONDS (180s)
+run_check_with_wfm 1500 && rc=$? || rc=$?
+remove_wfm_active
+assert_exit "$rc" 2
+
+# -------------------------------------------------------------------
+# Test 13: Stale heartbeat + WFM-active absent → RED
+# No WFM-active file: WFM is not running (or returned normally).
+# A stale heartbeat in this state is a genuine problem.
+# -------------------------------------------------------------------
+begin_test "Stale hb (1500s) + WFM-active absent → RED"
+remove_wfm_active
+run_check_with_wfm 1500 && rc=$? || rc=$?
+assert_exit "$rc" 2
+
+# -------------------------------------------------------------------
+# Test 14: Stale heartbeat + WFM-active tombstone ("exited") → RED
+# The tombstone is written when WFM returns normally (issue #1730).
+# The integer guard rejects it, so the check falls through to RED.
+# -------------------------------------------------------------------
+begin_test "Stale hb (1500s) + WFM-active tombstone ('exited') → RED"
+echo "exited" > "$WFM_ACTIVE_TEST_FILE"
+run_check_with_wfm 1500 && rc=$? || rc=$?
+remove_wfm_active
+assert_exit "$rc" 2
+
+# -------------------------------------------------------------------
+# Test 15: Stale heartbeat + WFM-active fresh + heartbeat well inside cap → GREEN
+# Additional positive case: heartbeat stale for 2500s (60s below the 2700s cap
+# with 60s margin to avoid timing flakiness). Should be GREEN.
+# -------------------------------------------------------------------
+begin_test "Stale hb (2500s) + WFM-active fresh + well inside cap → GREEN"
+write_wfm_active 5
+run_check_with_wfm $(( WFM_SUPPRESSION_MAX_SECONDS - 200 )) && rc=$? || rc=$?
+remove_wfm_active
 assert_exit "$rc" 0
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
## What this fixes

A frozen dispatcher session silently passed health checks for 6+ hours during the May 2026 outage. The root cause: the WFM daemon thread continues refreshing `dispatcher-wfm-active` every 60 seconds independently of the main asyncio event loop. With unbounded suppression, a stale main heartbeat combined with a fresh WFM-active file always produced GREEN — the exact false-negative described in #2074.

## The fix

Adds `WFM_SUPPRESSION_MAX_SECONDS = 2700` and a guard inside `check_dispatcher_heartbeat()`: when the dispatcher heartbeat has been stale for **≥ 2700 seconds**, the WFM-active freshness check is **bypassed** and RED fires regardless of daemon thread activity.

### Why heartbeat stale age is a reliable proxy for WFM session duration

The last `PostToolUse` hook fires just before `wait_for_messages` is called — meaning the heartbeat stale age closely approximates how long WFM has been running. After 2700s (45 min), the system has been idle long enough that:
- The watchdog would have already fired (at 2100s, now removed) to attempt recovery
- Any session that isn't making progress within this window is considered suspicious

The 2700s cap is deliberately below `SESSION_AGE_LIMIT_SECONDS` (7200s), which provides a second recovery layer by forcing a graceful session restart.

## State machine change

```
Before (unbounded suppression):
  hb stale > 1200s AND wfm-active fresh → GREEN (regardless of how long stale)
                                           ^^^^^ frozen daemon thread fools this check

After (time-bounded suppression):
  hb stale > 1200s AND wfm-active fresh AND stale age < 2700s → GREEN (legitimately idle)
  hb stale > 1200s AND wfm-active fresh AND stale age >= 2700s → RED  (frozen dispatcher)
  hb stale > 1200s AND wfm-active stale → RED (daemon thread stopped)
  hb stale > 1200s AND wfm-active absent/tombstone → RED (WFM not running)
```

## Functional patterns

Pure function: `check_dispatcher_heartbeat()` reads files and returns exit codes deterministically. The new guard is an early-return condition with no side effects.

## What is NOT changed

- The `WFM_ACTIVE_STALE_SECONDS = 180` threshold (process-crashed detection) is unchanged
- The daemon thread write interval is unchanged
- The tombstone/TOCTOU fix (#1730) is unchanged
- `SESSION_AGE_LIMIT_SECONDS` behavior is unchanged
- No MCP server changes — this is a pure health-check fix

## Tests run

- [x] `bash tests/test-health-check-dispatcher-heartbeat.sh` — 15/15 passed (added 7 new tests covering the time-cap boundary, the May 2026 frozen-daemon scenario, and all WFM-active edge cases)

## Manual test

N/A — this change is internal to the health check script. No external services are touched. The behavior change only manifests after 2700s of heartbeat staleness, which cannot be triggered in a short manual test without mocking time. The unit tests exercise the boundary directly.

## Definition of Done
- [x] Unit tests pass (15/15, no production hits in automated tests)
- [x] Integration/manual test — N/A (pure health check logic, no external service calls)
- [x] User-visible outcome — not directly visible; prevents future 2-day outages by triggering restart when frozen
- [x] Side-effect audit: read-only signal files, no writes, no flooding risk
- [x] External service calls: none (cat/stat on local files only)

Closes #2074