### PR TITLE
fix(health-check): suppress proactive-restart Telegram alert unless LOBSTER_DEBUG=true

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -1342,10 +1342,14 @@ check_session_age() {
     # restarts Claude. This is a graceful exit, not a crash.
     if kill -TERM "$dispatcher_pid" 2>/dev/null; then
         log_warn "Session age: SIGTERM sent to dispatcher PID $dispatcher_pid"
-        send_telegram_alert_deduped "proactive-session-restart" "Lobster: proactive restart at ${session_age}s (before the 7440s CC hard limit).
+        if [[ "${LOBSTER_DEBUG:-false}" == "true" ]]; then
+            send_telegram_alert_deduped "proactive-session-restart" "Lobster: proactive restart at ${session_age}s (before the 7440s CC hard limit).
 
 Dispatcher PID $dispatcher_pid sent SIGTERM. Stop hook will fire, session will restart cleanly.
 Next session will start fresh — no context lost from hard limit."
+        else
+            log_info "Proactive-restart Telegram alert suppressed (LOBSTER_DEBUG not set)"
+        fi
         # Delete the start timestamp so a subsequent health check run (within the
         # next 4 minutes) does not send a second SIGTERM before the restart completes.
         rm -f "$DISPATCHER_SESSION_START_FILE" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- The health check sends SIGTERM every ~2 hours to gracefully restart the dispatcher before the 7440s Claude Code hard session limit
- The accompanying Telegram alert fired every ~2 hours with no actionable content, causing noise
- Wrap `send_telegram_alert_deduped("proactive-session-restart", ...)` in a `LOBSTER_DEBUG=true` guard — the restart itself is unchanged, only the notification is suppressed

## What changes

`scripts/health-check-v3.sh` — in `check_session_age()`, after sending SIGTERM:
- If `LOBSTER_DEBUG=true`: alert fires as before
- Otherwise: logs a line to health-check.log (`Proactive-restart Telegram alert suppressed`) and skips the Telegram call

## Test plan

- [ ] Confirm health-check.log shows the suppression line on next ~2h cycle (no Telegram ping received)
- [ ] Set `LOBSTER_DEBUG=true` in config.env and verify alert fires again
- [ ] Confirm the dispatcher still restarts cleanly (SIGTERM path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)