### PR TITLE
fix(health-check): suppress 'System recovered automatically' alert unless LOBSTER_DEBUG=true

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -1619,11 +1619,15 @@ Status: Restarted, but new stale messages detected post-restart"
         log_info "Restart successful"
         write_boot_timestamp
         if [[ "$suppress_alert" != "true" ]]; then
-            # "Recovered" alert: use raw send (important positive signal, not spammy)
-            send_telegram_alert "System recovered automatically.
+            if [[ "${LOBSTER_DEBUG:-false}" == "true" ]]; then
+                # "Recovered" alert: use raw send (important positive signal, not spammy)
+                send_telegram_alert "System recovered automatically.
 
 Reason: $reason
 Status: Restarted successfully"
+            else
+                log_info "Post-restart recovery Telegram alert suppressed (LOBSTER_DEBUG not set)"
+            fi
         else
             log_info "Post-restart Telegram alert suppressed (compaction window active)"
         fi


### PR DESCRIPTION
## Summary

- The `do_restart()` success path sent a `System recovered automatically` Telegram alert on every health-check-triggered restart
- This was the alert Sahar was receiving: `Reason: dispatcher heartbeat stale (>1200s) / Status: Restarted successfully`
- PR #2093 suppressed the `proactive-session-restart` alert; this PR suppresses the matching `System recovered automatically` recovery confirmation using the same LOBSTER_DEBUG guard pattern
- No change to restart behavior — only the Telegram notification is suppressed in production

## What's guarded now

After this PR, alerts that fire in production (LOBSTER_DEBUG=false):
- BLACK state (max restart attempts exceeded) — still fires, requires manual action
- Restart aborted (could not kill existing PID) — still fires, requires manual action  
- Restart failed (PID unchanged) — still fires, indicates a real problem
- Service/tmux not ready after restart — still fires, indicates initialization problem
- Auth expired — still fires, requires manual action
- Subagent guard (deferred restart) — still fires, informational
- Post-restart stale inbox — still fires, indicates persistent problem

Alerts suppressed behind LOBSTER_DEBUG=true:
- `proactive-session-restart` (PR #2093)
- `System recovered automatically` (this PR)

## Test plan

- [ ] Verify `send_telegram_alert` for "System recovered automatically" is wrapped in `LOBSTER_DEBUG == true` guard
- [ ] Confirm restart still fires and logs correctly when LOBSTER_DEBUG is unset
- [ ] Confirm alert still fires when LOBSTER_DEBUG=true

Closes #2094 (or as a follow-up to #2093)

🤖 Generated with [Claude Code](https://claude.com/claude-code)