### PR TITLE
fix(transcription): accept audio type in worker; sync inbox_server whisper flags

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -6779,7 +6779,11 @@ async def run_whisper_cpp(audio_path: Path) -> tuple[bool, str]:
         "-m", str(WHISPER_MODEL_PATH),
         "-f", str(audio_path),
         "-l", "en",      # English language
-        "-nt",           # No timestamps in output
+        # NOTE: do NOT pass -nt / --no-timestamps here.
+        # With that flag, whisper.cpp collapses all segments and only emits the
+        # last one, silently truncating long audio.  We let whisper output the
+        # default "[HH:MM:SS.mmm --> HH:MM:SS.mmm]  text" format and strip
+        # the timestamp brackets in post-processing (see worker.py PR #300).
         "--no-prints",   # Suppress progress output
     ]
 
@@ -6794,12 +6798,21 @@ async def run_whisper_cpp(audio_path: Path) -> tuple[bool, str]:
         error_msg = stderr.decode().strip() if stderr else "Unknown error"
         return False, f"whisper.cpp failed: {error_msg}"
 
-    # Parse output - whisper.cpp outputs the transcription to stdout
-    transcription = stdout.decode().strip()
-
-    # Remove any remaining timing info if present (lines starting with [)
-    lines = [line for line in transcription.split('\n') if not line.strip().startswith('[')]
-    transcription = ' '.join(lines).strip()
+    # Parse output: whisper-cli emits lines in the form:
+    #   [HH:MM:SS.mmm --> HH:MM:SS.mmm]   transcription text here
+    # The text lives on the same line as the timestamp bracket, so we must
+    # extract the text after "]" rather than discard the whole line.
+    raw = stdout.decode().strip()
+    _TIMESTAMP_RE = re.compile(r"^\[[\d:.,\s\-–>]+\]\s*")
+    lines = []
+    for ln in raw.split("\n"):
+        stripped = ln.strip()
+        if not stripped:
+            continue
+        text = _TIMESTAMP_RE.sub("", stripped).strip()
+        if text:
+            lines.append(text)
+    transcription = " ".join(lines).strip()
 
     return True, transcription
 

--- a/src/transcription/worker.py
+++ b/src/transcription/worker.py
@@ -353,8 +353,11 @@ async def transcribe_pending_file(pending_file: Path) -> None:
         log.error(f"Cannot read {pending_file}: {e}")
         return  # leave file in place — it may still be mid-write
 
-    # Validate it's a voice message ("audio" normalized to "voice" at ingest; issue #635)
-    if msg_data.get("type") != "voice":
+    # Accept both "voice" (in-app recording) and "audio" (file attachment).
+    # Earlier versions normalized "audio" to "voice" at ingest (issue #635) but
+    # that normalization was never implemented; the bot writes the real Telegram
+    # type so we must handle both here.
+    if msg_data.get("type") not in ("voice", "audio"):
         move_to_dead_letter(
             pending_file, msg_data,
             f"Unexpected type in pending-transcription: {msg_data.get('type')!r}"


### PR DESCRIPTION
## Summary

- **Primary fix**: `worker.py` rejected messages with `type="audio"` (Telegram file attachments) — dead-lettering them immediately with `Unexpected type in pending-transcription: 'audio'`. The bot correctly writes `type="audio"` for uploaded audio files and `type="voice"` for in-app recordings. Worker now accepts both.
- **Secondary fix**: Sync `inbox_server.py`'s `run_whisper_cpp` to the corrected worker.py implementation from PR #300: remove the `-nt` flag (which silently truncated long audio by only emitting the last whisper segment), and replace the `startswith('[')` line-filter with regex-based timestamp stripping that correctly extracts text from whisper's `[timestamp]   text` output format. Fixes #2091.

## Dead-lettered messages

Two audio messages (`1782777925082_3843`, `1782778750277_3848`) from Sahar are sitting in `~/messages/dead-letter/` with their audio files intact at `~/messages/audio/*.m4a`. After merging and deploying, move the JSON files back to `pending-transcription/` to retry them.

## Test plan

- [ ] Send a Telegram audio file attachment — should route to `pending-transcription/` and transcribe successfully
- [ ] Send a Telegram voice recording — should still work as before
- [ ] Manual `transcribe_audio` MCP call on a >30-second audio file — should return complete transcription without truncation
- [ ] Retry the two dead-lettered `.m4a` files by copying their JSON back to `pending-transcription/`

Closes #2091

🤖 Generated with [Claude Code](https://claude.com/claude-code)