### PR TITLE
fix(#781): never reconcile the dispatcher session as a dead agent (cleanup + startup-sweep)

### DIFF
--- a/src/agents/session_store.py
+++ b/src/agents/session_store.py
@@ -522,6 +522,7 @@ def cleanup_stale_running_sessions(
         SELECT id, output_file, spawned_at, timeout_minutes
         FROM agent_sessions
         WHERE status IN ('running', 'starting')
+          AND COALESCE(agent_type, '') != 'dispatcher'  -- #781: never reconcile the dispatcher (output_file is legitimately NULL) as a dead subagent
         """
     )
     rows = cursor.fetchall()
@@ -708,6 +709,7 @@ def get_unnotified_completed(
         WHERE status IN ('completed', 'dead')
           AND notified_at IS NULL
           AND completed_at >= ?
+          AND COALESCE(agent_type, '') != 'dispatcher'  -- #781: belt-and-suspenders, never re-notify the dispatcher as a failed agent
         ORDER BY completed_at ASC
         """,
         (cutoff_str,),

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -9826,6 +9826,11 @@ async def _startup_sweep() -> None:
             )
         for session in unnotified:
             agent_id = session.get("id", "")
+            # #781 Fix 2 (extended): the dispatcher is never a dead subagent (its
+            # output_file is legitimately NULL) — mirror reconcile_agent_sessions();
+            # never re-notify it as agent_failed.
+            if (session.get("agent_type") or "") == "dispatcher":
+                continue
             if _inbox_already_has_agent(agent_id):
                 log.debug(
                     "[reconciler] Startup sweep: inbox file already exists for "


### PR DESCRIPTION
## Summary

A self-registered dispatcher session (`id='lobster-dispatcher'`, `agent_type='dispatcher'`, `output_file=NULL`) is marked `dead` and a false **`agent_failed: lobster-dispatcher`** is emitted on every proactive restart (~every 7200s, #2059). #781 added a dispatcher-skip to `reconcile_agent_sessions()` but **not** to the two other paths that run at restart, so the regression persists on `main` (`1119fb5`).

## Root cause

The `agent_failed` alarm comes from the agent-session reconciler, which has **three** dead-marking / notify paths. The #781 `agent_type=='dispatcher'` skip was applied to only one of them:

| Path | Skips dispatcher? |
|------|-------------------|
| `reconcile_agent_sessions()` — periodic loop (`inbox_server.py`) | ✅ yes (`# Issue #781 Fix 2`) |
| `session_store.cleanup_stale_running_sessions()` — called from `main()` at restart | ❌ no |
| `_startup_sweep()` → `get_unnotified_completed()` | ❌ no |

On each proactive restart, `cleanup_stale_running_sessions()` marks the no-`output_file` dispatcher row `dead` (no skip), then `_startup_sweep()` re-notifies it as `agent_failed` (no skip). The periodic loop's skip never fires for this row, because the kill + notify both happen during restart — before/outside the loop, which only ever evaluates `status='running'` rows.

The dispatcher **legitimately** has `output_file=NULL` — it is not a subagent and must never be reconciled as a dead agent.

### Live evidence

`agent_sessions.db` row on an affected install:
```
id=lobster-dispatcher  agent_type=dispatcher  status=running  output_file=NULL  notified_at=NULL
```
Every other `dead` row is `agent_type=subagent` with `notified_at` set — the dispatcher row is the lone anomaly. The dispatcher PID file (`~/messages/config/dispatcher.pid`) holds a **live** PID, i.e. the dispatcher is not actually dead; this is a pure false positive.

## Fix

Extend the `agent_type=='dispatcher'` skip to both restart-time paths:

- **`cleanup_stale_running_sessions()`** — exclude dispatcher rows from the stale-session SELECT (`AND COALESCE(agent_type, '') != 'dispatcher'`), so the dispatcher is never marked dead.
- **`get_unnotified_completed()`** — same filter (defense in depth), so a dispatcher row can never be returned for notification.
- **`_startup_sweep()`** — mirror the periodic-loop skip (`if (session.get("agent_type") or "") == "dispatcher": continue`).

## Validation

Applied to a live install and restarted the MCP server (the exact ~2h trigger). Before: every restart logged `cleanup ... marked dead` + `Enqueued ... agent_failed: lobster-dispatcher`. After: those lines no longer appear, the service comes up healthy (`active`, no SQL errors), and there is no pending dispatcher notification in the inbox.

## Follow-ups (not in this draft)

- **Tests:** assert `cleanup_stale_running_sessions()` leaves an `agent_type='dispatcher'` row untouched, and `get_unnotified_completed()` / `_startup_sweep()` skip it; a regression test for the full proactive-restart cycle on a seeded dispatcher row.
- **(Optional robustness):** gate any future dispatcher dead-marking behind a real liveness signal (`_is_dispatcher_alive()` PID check and/or a fresh `dispatcher-heartbeat`) rather than the mere absence of a subagent `output_file`.

Closes #781 (completes the partial fix).
