### PR TITLE
fix(#781): exclude dispatcher from periodic-self-check pending count

### DIFF
--- a/scripts/periodic-self-check.sh
+++ b/scripts/periodic-self-check.sh
@@ -100,13 +100,23 @@ if [ -n "$COMPLETED_TASKS" ]; then
 else
     # Query SQLite agent_sessions DB for pending (running/starting) agents.
     # pending-agents.json was migrated to SQLite and is no longer authoritative.
+    # Exclude agent_type='dispatcher' — the dispatcher's own session is always
+    # registered as running/starting and would otherwise be counted as a
+    # "pending agent" on every firing, producing a permanent false positive.
+    # Mirrors the fix applied in session_store.py's cleanup_stale_running_sessions()
+    # and get_unnotified_completed() (see #781 / PR #2099); this script queries
+    # the DB directly via sqlite3 rather than through session_store.py, so it
+    # was not covered by that PR and needs the same filter applied here.
     PENDING_COUNT=$(sqlite3 "$MESSAGES_DIR/config/agent_sessions.db" \
-        "SELECT COUNT(*) FROM agent_sessions WHERE status IN ('running','starting')" \
+        "SELECT COUNT(*) FROM agent_sessions WHERE status IN ('running','starting') AND COALESCE(agent_type, '') != 'dispatcher'" \
         2>/dev/null || echo "0")
 
     # No completed tasks — only inject status check if subagents are still
-    # running OR there are pending agents in the tracker.
-    if [ "$CLAUDE_COUNT" -le 1 ] && [ "$PENDING_COUNT" -eq 0 ] 2>/dev/null; then
+    # running. The DB session count is authoritative: if there are zero pending
+    # (non-dispatcher) sessions, do nothing. CLAUDE_COUNT is not reliable here
+    # because the dispatcher itself is always running (count >= 1 even with no
+    # subagents).
+    if [ "$PENDING_COUNT" -eq 0 ] 2>/dev/null; then
         exit 0
     fi
 


### PR DESCRIPTION
## Summary
- `periodic-self-check.sh` (cron, every 3 min) queries `agent_sessions.db` directly via `sqlite3` to count "pending" background agents, and injects a `status?` self-check into the inbox whenever the count is > 0.
- This direct SQL query never excluded `agent_type='dispatcher'`, so the dispatcher's own always-`running` session row was counted as a pending agent on every single firing — a permanent false positive with zero real subagents active.
- This is the same bug class fixed in PR #2099 / issue #781 for `session_store.py`'s `cleanup_stale_running_sessions()` and `get_unnotified_completed()` (both gained `AND COALESCE(agent_type, '') != 'dispatcher'`). This script bypasses `session_store.py` and queries the DB directly, so it was not covered by that PR.
- Fix: add the same `COALESCE(agent_type, '') != 'dispatcher'` filter to this script's `PENDING_COUNT` query, and simplify the now-redundant `CLAUDE_COUNT` guard (it was never reliable for this purpose since the dispatcher process itself always keeps the count >= 1).

## Root cause confirmation
Live production DB (`agent_sessions.db`) had exactly one `running` row: the dispatcher (`agent_type='dispatcher'`, `task_origin='user'`, `status='running'`, `spawned_at=2026-07-16T18:45:04Z`) — matching the reported symptom window (every 3-min firing from 18:45 UTC reporting `[1 agents pending]`).

```
-- old query (buggy)
SELECT COUNT(*) FROM agent_sessions WHERE status IN ('running','starting');
-- => 1  (the dispatcher row)

-- new query (fixed)
SELECT COUNT(*) FROM agent_sessions WHERE status IN ('running','starting')
  AND COALESCE(agent_type, '') != 'dispatcher';
-- => 0
```

## Test plan
- [x] `bash -n scripts/periodic-self-check.sh` — syntax OK
- [x] Ran old query vs. new query directly against the live `agent_sessions.db` — confirmed 1 → 0
- [x] Ran the patched script end-to-end against the real inbox/DB — exits 0, no `*_self.json` message injected (inbox file count unchanged before/after)
- [ ] Confirm the next few cron firings (every 3 min) stop reporting `[1 agents pending]` in production once merged and deployed