### PR TITLE
docs: wire functional-engineer.md to read engineering-lessons-learned.md

### DIFF
--- a/.claude/agents/functional-engineer.md
+++ b/.claude/agents/functional-engineer.md
@@ -42,6 +42,7 @@ When assigned to work on a GitHub issue, you follow this structured workflow. **
 
 ### 1. Issue Acceptance & Planning
 - Read and understand the issue thoroughly using `gh issue view <number> --repo <owner/repo>`
+- **MANDATORY: Read `docs/engineering-lessons-learned.md` in full before writing any implementation plan or code.** This is a required pre-read, not an optional reference — give it the same weight as branch setup and Docker setup below. It catalogs recurring bug patterns from past reviews (PID reuse races, missing flags, shell quoting bugs, etc.); skipping it risks reintroducing a mistake this repo has already paid to learn from. Do this before drafting the implementation plan so any relevant lesson can shape the approach, not just get caught in review.
 - **Assign yourself** to the issue using `gh issue edit <number> --repo <owner/repo> --add-assignee @me`
 - **Set "Main Board" project status to "In Progress"** (see Project Status Management below)
 - Create a clear implementation plan with checkable items

--- a/docs/engineering-lessons-learned.md
+++ b/docs/engineering-lessons-learned.md
@@ -174,3 +174,39 @@ The correct two-step sequence is unavoidable:
 **Fix:** Preserve the two-step model. Use `is_dispatcher()` for SessionStart hooks (reads the startup flag only — the startup flag is still present at SessionStart time). Use `is_dispatcher_session()` for Stop and PreToolUse hooks (reads session-id-marker, with process-tree fallback for the early-boot window before any file is written).
 
 **History:** Startup-flag model introduced in PR #1914 to replace fragile process-tree walking. Session-id-marker-at-Stop bug fixed in PR #1960 — DEAD state was never written because the startup flag was already consumed when Stop fired.
+
+---
+
+## Dispatcher-Exclusion Bug: The Dispatcher's Own Session Row Miscounted as a Dead/Pending Subagent
+
+**Pattern:** The dispatcher registers itself as a row in `agent_sessions.db` (`agent_type='dispatcher'`) so hooks and reconciliation logic can identify the live dispatcher process. Unlike a real subagent, this row legitimately has `output_file=NULL`, no real task, and stays `status='running'` for the entire lifetime of the dispatcher process. Any code that scans `agent_sessions` — directly via SQL or indirectly via a `session_store.py` helper — to find dead, stale, completed, or pending *subagents* must explicitly exclude `agent_type='dispatcher'` rows. If it doesn't, the dispatcher's own row gets misclassified as a hung/dead/pending subagent.
+
+**Why it matters:** This exact bug has been found and fixed **four separate times**, by different people, in different files, because nothing documented it as one recurring pattern:
+
+1. **Issue #781** — first discovered: the dispatcher's `SessionStart` hook could mis-register it as a subagent, and the periodic reconciler loop would later mark it dead and enqueue a false `agent_failed` message. Fix applied only to the periodic loop (`reconcile_agent_sessions()` in `inbox_server.py`).
+2. **PR #2099** — found the *same* missing exclusion in two more code paths that run at **restart time**, before the periodic loop's skip ever gets a chance to apply: `cleanup_stale_running_sessions()` (marks the dispatcher's always-`running`/`output_file=NULL` row dead on every proactive restart) and `get_unnotified_completed()` / `_startup_sweep()` (re-notifies unnotified dead/completed sessions, re-surfacing the dispatcher as a false `agent_failed: lobster-dispatcher` on every restart, roughly every 2 hours).
+3. **PR #2103** — found a **fourth** occurrence: `scripts/periodic-self-check.sh` (cron, every 3 minutes) queries `agent_sessions.db` directly via raw `sqlite3`, bypassing `session_store.py` — and therefore bypassing every fix above. It counted `status IN ('running','starting')` rows as "pending agents" with no dispatcher exclusion, producing a permanent false-positive `[1 agents pending]` self-check firing every 3 minutes with zero real subagents active.
+
+Each fix independently rediscovered the same root cause because there was no single place documenting "any code that lists/counts/reconciles agent-session rows needs this filter" — so nobody searching before writing new reconciliation code would have found it.
+
+**What to look for:** Any new or modified code that:
+- Queries `agent_sessions` (via `session_store.py` or a raw `sqlite3`/SQL call) with `WHERE status IN (...)` intended to find live, dead, completed, or stale *subagents*
+- Iterates over `get_active_sessions()` / `get_unnotified_completed()` / any similar session list and reasons about "is this agent dead / stuck / pending"
+- Counts or reconciles session rows for a health check, self-check, or notification path
+
+...without filtering out `agent_type='dispatcher'` rows.
+
+**Fix pattern:** Add the exclusion at the query or iteration boundary itself — not in some downstream consumer that might not be the only caller:
+- SQL: `AND COALESCE(agent_type, '') != 'dispatcher'`
+- Python iteration: `if (session.get("agent_type") or "") == "dispatcher": continue`
+
+**All known affected call sites (as of this writing):**
+1. `src/agents/session_store.py` — `cleanup_stale_running_sessions()` (SQL filter)
+2. `src/agents/session_store.py` — `get_unnotified_completed()` (SQL filter)
+3. `src/mcp/inbox_server.py` — `reconcile_agent_sessions()` periodic loop (Python skip)
+4. `src/mcp/inbox_server.py` — `_startup_sweep()` (Python skip, mirrors #3)
+5. `scripts/periodic-self-check.sh` — the `PENDING_COUNT` raw `sqlite3` query (bypasses `session_store.py` entirely — SQL filter)
+
+**Forward pointer:** A structural fix is planned so this cannot recur a fifth time: `docs/INVARIANTS.md` will record "the dispatcher session is never a subagent" as a named system invariant, and a shared, consolidated helper (single source of truth for the exclusion, usable from both Python and shell call sites) is planned to replace the five hand-copied filters above. Until those land, any new agent-session query must apply the filter/skip pattern manually and should reference this entry.
+
+**History:** Issue #781 (initial partial fix — periodic loop only) → PR #2099 (extended to `cleanup_stale_running_sessions()`, `get_unnotified_completed()`, and `_startup_sweep()`) → PR #2103 (extended to `periodic-self-check.sh`'s raw SQL query, which bypasses `session_store.py` entirely).


### PR DESCRIPTION
Implements Linear BIS-721 (https://linear.app/fully-parsed/issue/BIS-721/slice-b-wire-functional-engineermd-to-read-engineering-lessons): adds a mandatory pre-read of `docs/engineering-lessons-learned.md` to `.claude/agents/functional-engineer.md` before implementation begins.

## Stacked PR notice
This branch (`docs/bis-721-wire-lessons-learned-read`) is based on `docs/bis-720-dispatcher-exclusion-lesson` (PR #2104, not yet merged), not `main`. The base of **this** PR is intentionally set to that branch. Once #2104 merges, this PR's base will need to be retargeted to `main` — I have not done that retargeting myself; flagging it for whoever merges #2104.

## Problem
Even when `docs/engineering-lessons-learned.md` is correctly updated with a new lesson, `functional-engineer.md` — the agent that implements GitHub issues — never reads it before writing code. The only existing references were in `review.md` (post-hoc, at review time) and `docs/DEVELOPMENT.md` (a pointer in a "related documentation" list). Lessons had no path into the implementation loop itself; they were only ever caught after the fact in review.

## Change
Added a new required bullet to Phase 1 ("Issue Acceptance & Planning") of the Workflow Protocol in `.claude/agents/functional-engineer.md`, immediately after "read the issue" and before "assign yourself":

> **MANDATORY: Read `docs/engineering-lessons-learned.md` in full before writing any implementation plan or code.** This is a required pre-read, not an optional reference — give it the same weight as branch setup and Docker setup below. It catalogs recurring bug patterns from past reviews (PID reuse races, missing flags, shell quoting bugs, etc.); skipping it risks reintroducing a mistake this repo has already paid to learn from. Do this before drafting the implementation plan so any relevant lesson can shape the approach, not just get caught in review.

Placed in Phase 1 rather than immediately before Phase 4 (Implementation) because the goal is for lessons to inform the *plan* (branch/approach decisions), not just be consulted right as code-writing starts — by Phase 4 the plan is already fixed. The phrasing ("MANDATORY", bolded, framed as equal weight to the existing CRITICAL branch-isolation requirement in Phase 3) matches this repo's established convention for hard requirements rather than soft suggestions.

This is a docs-only change to an agent definition file — no application code, no config, no other files touched.

## Fact-check on the issue's stated claim
The issue states review.md and docs/DEVELOPMENT.md are "currently" the only two files referencing `docs/engineering-lessons-learned.md`. Verified via:

```
$ grep -rn "engineering-lessons-learned" --include="*" . 2>/dev/null | grep -v "^\./docs/engineering-lessons-learned.md"
.claude/agents/review.md:113:4. `docs/engineering-lessons-learned.md` in the repo — known recurring patterns to check against
docs/DEVELOPMENT.md:132:- `docs/engineering-lessons-learned.md` — recurring patterns to check during PR review
```

Confirmed still accurate as of this branch (based on BIS-720's branch, which only edited the lessons-learned file's content, not any references to it). No other files reference it.

## Proof of work (docs-only slice)
Grep confirming `functional-engineer.md` now references the file:

```
$ grep -n "engineering-lessons-learned" .claude/agents/functional-engineer.md
45:- **MANDATORY: Read `docs/engineering-lessons-learned.md` in full before writing any implementation plan or code.** This is a required pre-read, not an optional reference — give it the same weight as branch setup and Docker setup below. It catalogs recurring bug patterns from past reviews (PID reuse races, missing flags, shell quoting bugs, etc.); skipping it risks reintroducing a mistake this repo has already paid to learn from. Do this before drafting the implementation plan so any relevant lesson can shape the approach, not just get caught in review.
```

The bolded "MANDATORY" lead-in, the explicit "not an optional reference" framing, and the direct comparison to the existing "same weight as branch setup and Docker setup" (both of which are established hard requirements elsewhere in this same document) are intended to make it unambiguous to a human reviewer that this is a required step, not a suggestion.

## Out of scope
- No changes to `review.md` or `docs/DEVELOPMENT.md` (already correct per the grep above)
- No changes to `docs/engineering-lessons-learned.md` itself (that's BIS-720/Slice A's concern)
- No application code changed — this PR only edits agent-definition markdown

## Tests run
This is a docs-only change with no runtime code path; there is no automated test to write or run. Verification is the grep output above plus manual review of the diff for tone/placement, per the issue's own "Independently testable via" criteria.

## Manual test
N/A — no systemd, cron, external service, file I/O, or DB schema changes.

## Definition of Done
- [x] Change is verifiable via grep (shown above)
- [x] Surrounding text reads as mandatory, not optional (bolded "MANDATORY" + "not an optional reference" + explicit equal-weight comparison to existing CRITICAL requirements)
- [x] No other files needed to change for this to be reviewable in isolation (confirmed by fact-check grep above)
- [N/A] External service / Telegram output — none in this change