### PR TITLE
docs: add INVARIANTS.md registry for cross-cutting invariants

### DIFF
--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -1,0 +1,40 @@
+# Invariants Registry
+
+This file maps each **cross-cutting invariant** — a rule that must be kept true across multiple files — to the full list of files that encode it. Unlike `docs/engineering-lessons-learned.md` (which describes bug patterns after the fact), this registry is forward-looking: it lets an agent editing one call site discover every other call site it must keep in sync, *before* introducing a new bug.
+
+If you add a new call site for an existing invariant, or discover a new cross-cutting invariant, update this file in the same PR.
+
+---
+
+## Dispatcher-Exclusion Invariant
+
+**Invariant:** A session row with `agent_type='dispatcher'` must never be treated as a subagent by any code that lists, counts, or reconciles `agent_sessions` rows for dead/stale/completed/pending status.
+
+**Files that must stay in sync (5):**
+
+1. `src/agents/session_store.py` — `cleanup_stale_running_sessions()` (SQL filter: `AND COALESCE(agent_type, '') != 'dispatcher'`)
+2. `src/agents/session_store.py` — `get_unnotified_completed()` (SQL filter, same pattern)
+3. `src/mcp/inbox_server.py` — `reconcile_agent_sessions()` periodic loop (Python skip: `if (session.get("agent_type") or "") == "dispatcher": continue`)
+4. `src/mcp/inbox_server.py` — `_startup_sweep()` (Python skip, mirrors #3)
+5. `scripts/periodic-self-check.sh` — the `PENDING_COUNT` raw `sqlite3` query (bypasses `session_store.py` entirely, so it needs its own SQL filter)
+
+**Related lessons-learned entry:** [`Dispatcher-Exclusion Bug: The Dispatcher's Own Session Row Miscounted as a Dead/Pending Subagent`](engineering-lessons-learned.md#dispatcher-exclusion-bug-the-dispatchers-own-session-row-miscounted-as-a-deadpending-subagent) — documents that this exact bug was independently found and fixed four times (Issue #781, PR #2099 x2, PR #2103) because nothing recorded all affected call sites in one place.
+
+**Note:** A consolidation refactor to replace these five hand-copied filters with a single shared helper is tracked separately (Slice D / BIS-723) and has not landed as of this writing. Until it does, any new agent-session query must apply the filter/skip pattern manually at all five sites above.
+
+---
+
+## jq `--arg` JSON-Escaping Invariant
+
+**Invariant:** Any shell script that constructs a JSON inbox message from a variable that may contain newlines or special characters must build it via `jq -n --arg`/`--argjson`, never via heredoc variable expansion — otherwise the result can be invalid JSON that tight-loops `wait_for_messages`.
+
+**Files that must stay in sync (4):**
+
+1. `scripts/periodic-self-check.sh` — `jq -n` JSON construction (around line 138); highest risk, since `$SELF_CHECK_TEXT` concatenates agent summaries and scan output that can contain newlines
+2. `scripts/alert.sh` — `jq -n` JSON construction (around line 37); `$message` is caller-supplied and can contain anything
+3. `scripts/check-agent-outputs.sh` — `jq -n` JSON construction (around line 118); `$SAFE_ID` is pre-sanitized but kept consistent with the pattern
+4. `scripts/daily-update-check.sh` — two `jq -n` JSON construction sites (around lines 31 and 52), for the git-behind-count and version-check messages respectively
+
+**Related lessons-learned entry:** none exists yet. `docs/engineering-lessons-learned.md` currently documents the dispatcher-exclusion bug and several other patterns, but has no dedicated entry for the heredoc-vs-`jq --arg` JSON-escaping bug, despite it being fixed twice at the same four call sites (PR #2016, then re-fixed/re-landed in PR #2031 — both merged, both referencing issue #2004). If this bug recurs, add an entry there and link it from here.
+
+**History:** Both PR #2016 (merged 2026-05-08) and PR #2031 (merged 2026-05-10) replaced heredoc-based JSON construction with `jq -n --arg`/`--argjson` across these same four scripts, citing the 2026-04-24/25 WFM tight-loop restart storm (originally fixed for `daily-health-check.sh` in PR #1808) as the root-cause precedent.

--- a/docs/engineering-lessons-learned.md
+++ b/docs/engineering-lessons-learned.md
@@ -174,3 +174,39 @@ The correct two-step sequence is unavoidable:
 **Fix:** Preserve the two-step model. Use `is_dispatcher()` for SessionStart hooks (reads the startup flag only — the startup flag is still present at SessionStart time). Use `is_dispatcher_session()` for Stop and PreToolUse hooks (reads session-id-marker, with process-tree fallback for the early-boot window before any file is written).
 
 **History:** Startup-flag model introduced in PR #1914 to replace fragile process-tree walking. Session-id-marker-at-Stop bug fixed in PR #1960 — DEAD state was never written because the startup flag was already consumed when Stop fired.
+
+---
+
+## Dispatcher-Exclusion Bug: The Dispatcher's Own Session Row Miscounted as a Dead/Pending Subagent
+
+**Pattern:** The dispatcher registers itself as a row in `agent_sessions.db` (`agent_type='dispatcher'`) so hooks and reconciliation logic can identify the live dispatcher process. Unlike a real subagent, this row legitimately has `output_file=NULL`, no real task, and stays `status='running'` for the entire lifetime of the dispatcher process. Any code that scans `agent_sessions` — directly via SQL or indirectly via a `session_store.py` helper — to find dead, stale, completed, or pending *subagents* must explicitly exclude `agent_type='dispatcher'` rows. If it doesn't, the dispatcher's own row gets misclassified as a hung/dead/pending subagent.
+
+**Why it matters:** This exact bug has been found and fixed **four separate times**, by different people, in different files, because nothing documented it as one recurring pattern:
+
+1. **Issue #781** — first discovered: the dispatcher's `SessionStart` hook could mis-register it as a subagent, and the periodic reconciler loop would later mark it dead and enqueue a false `agent_failed` message. Fix applied only to the periodic loop (`reconcile_agent_sessions()` in `inbox_server.py`).
+2. **PR #2099** — found the *same* missing exclusion in two more code paths that run at **restart time**, before the periodic loop's skip ever gets a chance to apply: `cleanup_stale_running_sessions()` (marks the dispatcher's always-`running`/`output_file=NULL` row dead on every proactive restart) and `get_unnotified_completed()` / `_startup_sweep()` (re-notifies unnotified dead/completed sessions, re-surfacing the dispatcher as a false `agent_failed: lobster-dispatcher` on every restart, roughly every 2 hours).
+3. **PR #2103** — found a **fourth** occurrence: `scripts/periodic-self-check.sh` (cron, every 3 minutes) queries `agent_sessions.db` directly via raw `sqlite3`, bypassing `session_store.py` — and therefore bypassing every fix above. It counted `status IN ('running','starting')` rows as "pending agents" with no dispatcher exclusion, producing a permanent false-positive `[1 agents pending]` self-check firing every 3 minutes with zero real subagents active.
+
+Each fix independently rediscovered the same root cause because there was no single place documenting "any code that lists/counts/reconciles agent-session rows needs this filter" — so nobody searching before writing new reconciliation code would have found it.
+
+**What to look for:** Any new or modified code that:
+- Queries `agent_sessions` (via `session_store.py` or a raw `sqlite3`/SQL call) with `WHERE status IN (...)` intended to find live, dead, completed, or stale *subagents*
+- Iterates over `get_active_sessions()` / `get_unnotified_completed()` / any similar session list and reasons about "is this agent dead / stuck / pending"
+- Counts or reconciles session rows for a health check, self-check, or notification path
+
+...without filtering out `agent_type='dispatcher'` rows.
+
+**Fix pattern:** Add the exclusion at the query or iteration boundary itself — not in some downstream consumer that might not be the only caller:
+- SQL: `AND COALESCE(agent_type, '') != 'dispatcher'`
+- Python iteration: `if (session.get("agent_type") or "") == "dispatcher": continue`
+
+**All known affected call sites (as of this writing):**
+1. `src/agents/session_store.py` — `cleanup_stale_running_sessions()` (SQL filter)
+2. `src/agents/session_store.py` — `get_unnotified_completed()` (SQL filter)
+3. `src/mcp/inbox_server.py` — `reconcile_agent_sessions()` periodic loop (Python skip)
+4. `src/mcp/inbox_server.py` — `_startup_sweep()` (Python skip, mirrors #3)
+5. `scripts/periodic-self-check.sh` — the `PENDING_COUNT` raw `sqlite3` query (bypasses `session_store.py` entirely — SQL filter)
+
+**Forward pointer:** A structural fix is planned so this cannot recur a fifth time: `docs/INVARIANTS.md` will record "the dispatcher session is never a subagent" as a named system invariant, and a shared, consolidated helper (single source of truth for the exclusion, usable from both Python and shell call sites) is planned to replace the five hand-copied filters above. Until those land, any new agent-session query must apply the filter/skip pattern manually and should reference this entry.
+
+**History:** Issue #781 (initial partial fix — periodic loop only) → PR #2099 (extended to `cleanup_stale_running_sessions()`, `get_unnotified_completed()`, and `_startup_sweep()`) → PR #2103 (extended to `periodic-self-check.sh`'s raw SQL query, which bypasses `session_store.py` entirely).


### PR DESCRIPTION
## Problem

There is no single place that maps a cross-cutting invariant (a rule that must be kept true across multiple files) to the full list of files that encode it. Without this, an agent editing one call site of the dispatcher-exclusion filter (for example) has no way to discover the other 4 call sites — which is exactly how that bug was independently rediscovered and fixed four separate times (see `docs/engineering-lessons-learned.md`).

This PR adds `docs/INVARIANTS.md`, a registry with one entry per cross-cutting invariant, seeded with the two invariants the epic identified as most urgent.

**Implements Linear BIS-722** (https://linear.app/fully-parsed/issue/BIS-722/slice-c-add-docsinvariantsmd-invariant-registry): add docs/INVARIANTS.md invariant registry, seeded with the dispatcher-exclusion and jq-escaping invariants.

## Stacked PR — base branch note

This PR is **stacked on #2104** (`docs/bis-720-dispatcher-exclusion-lesson`, BIS-720), which is reviewed/approved-in-content but not yet merged. The base is set to that branch, not `main`, because this entry quotes and links the "Dispatcher-Exclusion Bug" lessons-learned entry that BIS-720 adds. **The base will need to be retargeted to `main` once #2104 merges — I have not done that and am flagging it here rather than attempting it.**

A third sibling slice, BIS-723 (consolidating the dispatcher-exclusion filter into a shared helper), is running in parallel on a separate branch off `main`. This PR does not touch any code — it is docs-only (one new file).

## What's in docs/INVARIANTS.md

### 1. Dispatcher-Exclusion Invariant

> A session row with `agent_type='dispatcher'` must never be treated as a subagent by any code that lists, counts, or reconciles `agent_sessions` rows for dead/stale/completed/pending status.

Files (5, verified against the current tree on this branch):
1. `src/agents/session_store.py` — `cleanup_stale_running_sessions()` (SQL filter, line ~525)
2. `src/agents/session_store.py` — `get_unnotified_completed()` (SQL filter, line ~712)
3. `src/mcp/inbox_server.py` — `reconcile_agent_sessions()` periodic loop (Python skip, line ~9915)
4. `src/mcp/inbox_server.py` — `_startup_sweep()` (Python skip, line ~9829)
5. `scripts/periodic-self-check.sh` — the `PENDING_COUNT` raw `sqlite3` query (line ~110-111)

Linked to the "Dispatcher-Exclusion Bug" entry in `docs/engineering-lessons-learned.md` (added by BIS-720, present on this branch).

### 2. jq `--arg` JSON-Escaping Invariant

> Any shell script that constructs a JSON inbox message from a variable that may contain newlines or special characters must build it via `jq -n --arg`/`--argjson`, never via heredoc variable expansion, or the result can be invalid JSON that tight-loops `wait_for_messages`.

Files (4, verified via `grep -n "jq -n" <script>` against the current tree, and cross-checked against the merged PR history):
1. `scripts/periodic-self-check.sh` (line ~138)
2. `scripts/alert.sh` (line ~37)
3. `scripts/check-agent-outputs.sh` (line ~118)
4. `scripts/daily-update-check.sh` (lines ~31 and ~52)

**Known gap, flagged rather than fabricated:** I checked `docs/engineering-lessons-learned.md` for an existing entry to link for this invariant and found none — the file currently documents 8 other patterns (PID reuse, tmux `-a` flag, execute-bit drift, PR description mismatches, `RemainAfterExit`+tmux, socket unlinking, `$`-mangling, dispatcher detection files, and the dispatcher-exclusion bug) but nothing specific to jq-vs-heredoc JSON escaping. The INVARIANTS.md entry says so explicitly rather than linking a nonexistent anchor. I confirmed via `gh pr view 2016` and `gh pr view 2031` (both merged, both closing issue #2004, both touching these same 4 scripts with the same `jq -n --arg` fix) that the file list and fix pattern are accurate as of today.

## Functional patterns

Pure documentation change — no code, no behavior. The registry itself is a flat, declarative data structure (one entry per invariant, each an immutable list of file references) rather than prose that has to be re-derived by re-reading five files every time.

## Proof of work

This is a docs-only slice; the issue's own acceptance criteria are the test:
- [x] `docs/INVARIANTS.md` exists (this PR adds it)
- [x] It lists at least the dispatcher-exclusion and jq-escaping invariants, each with its associated file list (both included above, verbatim from the file)
- [x] Reviewable/mergeable without slices D, E, F, G existing — it documents current file locations only, no consolidation refactor required

## Tests run

- [x] `grep -n "jq -n" scripts/{periodic-self-check.sh,alert.sh,check-agent-outputs.sh,daily-update-check.sh}` — confirmed all 4 scripts currently use the `jq -n` pattern at the line numbers cited
- [x] `grep -n "dispatcher" src/agents/session_store.py src/mcp/inbox_server.py scripts/periodic-self-check.sh` — confirmed all 5 dispatcher-exclusion call sites currently contain the exclusion filter/skip
- [x] `gh pr view 2016 --repo SiderealPress/lobster` / `gh pr view 2031 --repo SiderealPress/lobster` — confirmed both merged, both reference issue #2004, both touch the same 4 scripts
- [x] `grep -n "jq\|JSON-escap" docs/engineering-lessons-learned.md` — confirmed no existing entry for the jq-escaping pattern (only the intro line mentioning the file itself)
- No automated tests apply — this PR adds no code, only a markdown file.

## Manual test

N/A — docs-only change, no systemd/cron/external-service/file-I/O/DB-schema surface.

## Definition of Done

Not applicable — this PR touches no external services, no Telegram output, no user-visible runtime behavior.