### PR TITLE
docs: add CONTRIBUTING.md with For AI agents pre-read section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to Lobster
+
+Thanks for contributing. This document covers what to read before you touch the codebase, and the conventions expected of any change — whether you're a human or an AI agent.
+
+## For AI agents
+
+Before making any change to this repository, read the following documents **in this order**:
+
+1. [`docs/engineering-lessons-learned.md`](docs/engineering-lessons-learned.md) — recurring bug patterns and subtle system behaviors that have bitten past reviews (PID reuse races, tmux `-a` flag, dispatcher-exclusion bugs, etc.). Check new code against these patterns before proposing it.
+2. [`docs/INVARIANTS.md`](docs/INVARIANTS.md) — named system invariants (e.g. "the dispatcher session is never a subagent") that must never be violated, regardless of which file or code path you're touching.
+3. [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) — the worktree workflow and the hard constraints around it: `~/lobster/` must always stay on `main`, the cp-then-test pattern for hooks/agent definitions, and the register-after-merge rule for new hooks.
+
+Other documents worth reading depending on what you're changing:
+
+- [`README.md`](README.md) — system architecture overview and the 7-second dispatcher rule
+- `.claude/agents/review.md` — if you are (or are spawning) a review agent, this defines what "done" review looks like, including the scope check and the lessons-learned cross-reference
+- `.claude/agents/functional-engineer.md` — if you are implementing a GitHub issue end-to-end, this defines the full issue → branch → TDD → PR workflow
+
+### Enforcement note
+
+`.claude/agents/functional-engineer.md` is wired to **programmatically enforce** step 1 above (reading `docs/engineering-lessons-learned.md`) before it starts implementation work — this is not optional for that agent.
+
+No equivalent enforcement exists for any other agent definition, or for humans. Every other agent (`review.md`, `general-purpose`, custom subagents, etc.) and every human contributor is expected to follow the same numbered order **manually**. If you're writing a new agent definition or onboarding a new contributor, point them at this section rather than re-deriving the reading list.
+
+## General contributing guidelines
+
+### Development environment
+
+All feature and fix work happens in a git worktree, never directly on `main` in `~/lobster/`. See `docs/DEVELOPMENT.md` for the full worktree workflow, including how to test hooks and agent definitions locally before they're merged (the cp-then-test pattern).
+
+### Running tests
+
+The dev environment runs in Docker via `docker-compose.dev.yml`:
+
+```bash
+make test            # full test suite
+make test-unit        # tests/unit/ only
+make test-integration  # tests/integration/ only
+make test-file FILE=tests/unit/test_skill_manager.py   # a single file
+make shell            # interactive shell in the dev container
+```
+
+### Commit and PR conventions
+
+- Write atomic, well-documented commits with clear messages.
+- Reference the issue or ticket being addressed in the PR description (`Closes #N` for GitHub issues; for Linear-tracked work, state `Implements LINEAR-KEY (url): <summary>` since Linear issues have no auto-close syntax).
+- Tests must be written before the implementation they cover, and must be shown to fail without that implementation (see `docs/engineering-lessons-learned.md` and the functional-engineer workflow for the falsifiability check).
+- Prefer functional style where the language supports it: pure functions, immutability, composition over inheritance, higher-order functions over imperative loops.
+
+### Migrations
+
+Changes that affect existing installs (new cron entries, new directories, config renames, new service files) need a numbered migration in `scripts/upgrade.sh`, not just `install.sh`. See `.claude/agents/lobster-ops.md` for the migration format.

--- a/docs/engineering-lessons-learned.md
+++ b/docs/engineering-lessons-learned.md
@@ -174,3 +174,39 @@ The correct two-step sequence is unavoidable:
 **Fix:** Preserve the two-step model. Use `is_dispatcher()` for SessionStart hooks (reads the startup flag only — the startup flag is still present at SessionStart time). Use `is_dispatcher_session()` for Stop and PreToolUse hooks (reads session-id-marker, with process-tree fallback for the early-boot window before any file is written).
 
 **History:** Startup-flag model introduced in PR #1914 to replace fragile process-tree walking. Session-id-marker-at-Stop bug fixed in PR #1960 — DEAD state was never written because the startup flag was already consumed when Stop fired.
+
+---
+
+## Dispatcher-Exclusion Bug: The Dispatcher's Own Session Row Miscounted as a Dead/Pending Subagent
+
+**Pattern:** The dispatcher registers itself as a row in `agent_sessions.db` (`agent_type='dispatcher'`) so hooks and reconciliation logic can identify the live dispatcher process. Unlike a real subagent, this row legitimately has `output_file=NULL`, no real task, and stays `status='running'` for the entire lifetime of the dispatcher process. Any code that scans `agent_sessions` — directly via SQL or indirectly via a `session_store.py` helper — to find dead, stale, completed, or pending *subagents* must explicitly exclude `agent_type='dispatcher'` rows. If it doesn't, the dispatcher's own row gets misclassified as a hung/dead/pending subagent.
+
+**Why it matters:** This exact bug has been found and fixed **four separate times**, by different people, in different files, because nothing documented it as one recurring pattern:
+
+1. **Issue #781** — first discovered: the dispatcher's `SessionStart` hook could mis-register it as a subagent, and the periodic reconciler loop would later mark it dead and enqueue a false `agent_failed` message. Fix applied only to the periodic loop (`reconcile_agent_sessions()` in `inbox_server.py`).
+2. **PR #2099** — found the *same* missing exclusion in two more code paths that run at **restart time**, before the periodic loop's skip ever gets a chance to apply: `cleanup_stale_running_sessions()` (marks the dispatcher's always-`running`/`output_file=NULL` row dead on every proactive restart) and `get_unnotified_completed()` / `_startup_sweep()` (re-notifies unnotified dead/completed sessions, re-surfacing the dispatcher as a false `agent_failed: lobster-dispatcher` on every restart, roughly every 2 hours).
+3. **PR #2103** — found a **fourth** occurrence: `scripts/periodic-self-check.sh` (cron, every 3 minutes) queries `agent_sessions.db` directly via raw `sqlite3`, bypassing `session_store.py` — and therefore bypassing every fix above. It counted `status IN ('running','starting')` rows as "pending agents" with no dispatcher exclusion, producing a permanent false-positive `[1 agents pending]` self-check firing every 3 minutes with zero real subagents active.
+
+Each fix independently rediscovered the same root cause because there was no single place documenting "any code that lists/counts/reconciles agent-session rows needs this filter" — so nobody searching before writing new reconciliation code would have found it.
+
+**What to look for:** Any new or modified code that:
+- Queries `agent_sessions` (via `session_store.py` or a raw `sqlite3`/SQL call) with `WHERE status IN (...)` intended to find live, dead, completed, or stale *subagents*
+- Iterates over `get_active_sessions()` / `get_unnotified_completed()` / any similar session list and reasons about "is this agent dead / stuck / pending"
+- Counts or reconciles session rows for a health check, self-check, or notification path
+
+...without filtering out `agent_type='dispatcher'` rows.
+
+**Fix pattern:** Add the exclusion at the query or iteration boundary itself — not in some downstream consumer that might not be the only caller:
+- SQL: `AND COALESCE(agent_type, '') != 'dispatcher'`
+- Python iteration: `if (session.get("agent_type") or "") == "dispatcher": continue`
+
+**All known affected call sites (as of this writing):**
+1. `src/agents/session_store.py` — `cleanup_stale_running_sessions()` (SQL filter)
+2. `src/agents/session_store.py` — `get_unnotified_completed()` (SQL filter)
+3. `src/mcp/inbox_server.py` — `reconcile_agent_sessions()` periodic loop (Python skip)
+4. `src/mcp/inbox_server.py` — `_startup_sweep()` (Python skip, mirrors #3)
+5. `scripts/periodic-self-check.sh` — the `PENDING_COUNT` raw `sqlite3` query (bypasses `session_store.py` entirely — SQL filter)
+
+**Forward pointer:** A structural fix is planned so this cannot recur a fifth time: `docs/INVARIANTS.md` will record "the dispatcher session is never a subagent" as a named system invariant, and a shared, consolidated helper (single source of truth for the exclusion, usable from both Python and shell call sites) is planned to replace the five hand-copied filters above. Until those land, any new agent-session query must apply the filter/skip pattern manually and should reference this entry.
+
+**History:** Issue #781 (initial partial fix — periodic loop only) → PR #2099 (extended to `cleanup_stale_running_sessions()`, `get_unnotified_completed()`, and `_startup_sweep()`) → PR #2103 (extended to `periodic-self-check.sh`'s raw SQL query, which bypasses `session_store.py` entirely).


### PR DESCRIPTION
## Problem

There was no single onboarding document telling a new contributor — human or AI agent — what to read before touching this codebase, or in what order. Agents and reviewers each had to independently discover `docs/engineering-lessons-learned.md`, the worktree constraints in `docs/DEVELOPMENT.md`, etc.

## What changed

Adds `CONTRIBUTING.md` at the repo root with:

- A **"For AI agents"** section listing mandatory pre-reads in order:
  1. `docs/engineering-lessons-learned.md`
  2. `docs/INVARIANTS.md`
  3. `docs/DEVELOPMENT.md`

  Plus pointers to `README.md`, `.claude/agents/review.md`, and `.claude/agents/functional-engineer.md` for role-specific context, and an explicit note that `.claude/agents/functional-engineer.md` programmatically enforces step 1 (per Slice B / BIS-721) while every other agent definition and every human contributor follows the same order manually.
- A general (non-AI-specific) contributing section covering the worktree development workflow, how to run tests (`make test`, `make test-unit`, etc. via `docker-compose.dev.yml`), commit/PR conventions (including the falsifiability check), and the migration requirement for install-affecting changes (`scripts/upgrade.sh`).

The ordered pre-read list was built by grepping this repo's own agent definitions for existing "read this first" references, not just the three items given as an example in the Linear issue:
- `docs/DEVELOPMENT.md`'s own "Related documentation" section already points to `docs/engineering-lessons-learned.md`
- `.claude/agents/review.md` already lists `docs/engineering-lessons-learned.md` as required reading before forming a review opinion
- `docs/engineering-lessons-learned.md`'s own "Forward pointer" note (in the dispatcher-exclusion-bug entry, landed via #2104) describes `docs/INVARIANTS.md` as the planned home for named system invariants

## Stacked PR — base branch note

This branch is stacked on `docs/bis-720-dispatcher-exclusion-lesson` (#2104, dispatcher-exclusion lesson, already landed on that branch) rather than `main`, per the sibling-slice sequencing for this docs-coherence epic (BIS-720/721/722/725 all touch overlapping doc content). **The base will need to be retargeted to `main` once #2104 merges** — I have not done this myself, flagging it for whoever merges this stack.

`docs/INVARIANTS.md` (BIS-722) and the `functional-engineer.md` enforcement wiring (BIS-721) do not exist yet as of this PR. Per the Linear issue's own independence note, this file is written to reference both by path regardless — it is reviewable/mergeable independent of whether those sibling slices have landed.

## Proof of work

This is a docs-only slice; the "test" is the issue's stated acceptance criteria, verified directly:

- `CONTRIBUTING.md` exists at the repo root:
  ```
  $ ls CONTRIBUTING.md
  CONTRIBUTING.md
  ```
- It contains a "For AI agents" section with a numbered/ordered pre-read list (not prose):
  ```markdown
  ## For AI agents

  Before making any change to this repository, read the following documents **in this order**:

  1. [`docs/engineering-lessons-learned.md`](docs/engineering-lessons-learned.md) — recurring bug patterns and subtle system behaviors that have bitten past reviews (PID reuse races, tmux `-a` flag, dispatcher-exclusion bugs, etc.). Check new code against these patterns before proposing it.
  2. [`docs/INVARIANTS.md`](docs/INVARIANTS.md) — named system invariants (e.g. "the dispatcher session is never a subagent") that must never be violated, regardless of which file or code path you're touching.
  3. [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) — the worktree workflow and the hard constraints around it: `~/lobster/` must always stay on `main`, the cp-then-test pattern for hooks/agent definitions, and the register-after-merge rule for new hooks.
  ```

Implements Linear BIS-725 (https://linear.app/fully-parsed/issue/BIS-725/slice-f-add-contributingmd-with-a-for-ai-agents-pre-read-section): adds a root-level CONTRIBUTING.md with an ordered "For AI agents" pre-read list.

## Tests run

Not applicable — docs-only change, no code paths affected. Verified file existence and content structure directly (see Proof of work above).

## Manual test

N/A — no systemd, cron, external service, file I/O (runtime), or DB schema changes. This adds a static markdown file only.