### PR TITLE
Consolidate dispatcher-exclusion filter into one shared predicate

### DIFF
--- a/scripts/lib/agent_sessions.sh
+++ b/scripts/lib/agent_sessions.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#===============================================================================
+# Shared dispatcher-exclusion SQL fragment (Linear BIS-723)
+#
+# Single source of truth for the shell side of the dispatcher-exclusion check
+# against agent_sessions.db. Before this file existed, the fragment below was
+# copy-pasted directly into periodic-self-check.sh's sqlite3 query, alongside
+# four independent Python reimplementations of the same check
+# (session_store.py x2, inbox_server.py x2) — the whole family of duplicates
+# had to be fixed four separate times (issue #781, PR #2099, PR #2103).
+#
+# Cross-reference: this constant MUST match DISPATCHER_AGENT_TYPE /
+# DISPATCHER_EXCLUSION_SQL in src/utils/agent_types.py. Bash and Python cannot
+# literally share one function, so if you change the excluded agent_type
+# value here, change it in src/utils/agent_types.py too (and vice versa).
+#
+# Usage:
+#   source "$(dirname "$0")/lib/agent_sessions.sh"
+#   sqlite3 "$DB_PATH" \
+#     "SELECT COUNT(*) FROM agent_sessions WHERE status IN ('running','starting') AND $DISPATCHER_EXCLUSION_SQL"
+#===============================================================================
+
+# The agent_type value written when the dispatcher registers its own session.
+# Must match DISPATCHER_AGENT_TYPE in src/utils/agent_types.py.
+DISPATCHER_AGENT_TYPE="dispatcher"
+
+# SQL WHERE-clause fragment excluding dispatcher rows from a query over
+# agent_sessions. COALESCE guards against agent_type being NULL (legacy rows
+# predating the column, or subagents that never set it).
+# Must match DISPATCHER_EXCLUSION_SQL in src/utils/agent_types.py.
+DISPATCHER_EXCLUSION_SQL="COALESCE(agent_type, '') != '${DISPATCHER_AGENT_TYPE}'"

--- a/scripts/periodic-self-check.sh
+++ b/scripts/periodic-self-check.sh
@@ -103,12 +103,15 @@ else
     # Exclude agent_type='dispatcher' — the dispatcher's own session is always
     # registered as running/starting and would otherwise be counted as a
     # "pending agent" on every firing, producing a permanent false positive.
-    # Mirrors the fix applied in session_store.py's cleanup_stale_running_sessions()
-    # and get_unnotified_completed() (see #781 / PR #2099); this script queries
-    # the DB directly via sqlite3 rather than through session_store.py, so it
-    # was not covered by that PR and needs the same filter applied here.
+    # DISPATCHER_EXCLUSION_SQL is the shared single source of truth (BIS-723,
+    # scripts/lib/agent_sessions.sh) for this check — it must match
+    # DISPATCHER_EXCLUSION_SQL in src/utils/agent_types.py, used by the
+    # equivalent Python-side checks in session_store.py and inbox_server.py
+    # (see #781 / PR #2099 / PR #2103 for the history of this filter being
+    # fixed independently at each call site before consolidation).
+    source "${LOBSTER_INSTALL_DIR:-$HOME/lobster}/scripts/lib/agent_sessions.sh"
     PENDING_COUNT=$(sqlite3 "$MESSAGES_DIR/config/agent_sessions.db" \
-        "SELECT COUNT(*) FROM agent_sessions WHERE status IN ('running','starting') AND COALESCE(agent_type, '') != 'dispatcher'" \
+        "SELECT COUNT(*) FROM agent_sessions WHERE status IN ('running','starting') AND ${DISPATCHER_EXCLUSION_SQL}" \
         2>/dev/null || echo "0")
 
     # No completed tasks — only inject status check if subagents are still

--- a/src/agents/session_store.py
+++ b/src/agents/session_store.py
@@ -22,9 +22,19 @@ Design principles:
 import logging
 import os
 import sqlite3
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+# Ensure the parent src/ directory is on sys.path so the sibling `utils`
+# package is importable regardless of how this module is loaded (as part of
+# the `agents` package, or directly via sys.path manipulation in tests).
+_SRC_DIR = str(Path(__file__).resolve().parents[1])
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, _SRC_DIR)
+
+from utils.agent_types import DISPATCHER_EXCLUSION_SQL  # noqa: E402
 
 log = logging.getLogger(__name__)
 
@@ -518,11 +528,11 @@ def cleanup_stale_running_sessions(
     conn = _get_connection(resolved)
 
     cursor = conn.execute(
-        """
+        f"""
         SELECT id, output_file, spawned_at, timeout_minutes
         FROM agent_sessions
         WHERE status IN ('running', 'starting')
-          AND COALESCE(agent_type, '') != 'dispatcher'  -- #781: never reconcile the dispatcher (output_file is legitimately NULL) as a dead subagent
+          AND {DISPATCHER_EXCLUSION_SQL}  -- #781: never reconcile the dispatcher (output_file is legitimately NULL) as a dead subagent
         """
     )
     rows = cursor.fetchall()
@@ -704,12 +714,12 @@ def get_unnotified_completed(
     cutoff_str = cutoff_dt.isoformat()
 
     cursor = conn.execute(
-        """
+        f"""
         SELECT * FROM agent_sessions
         WHERE status IN ('completed', 'dead')
           AND notified_at IS NULL
           AND completed_at >= ?
-          AND COALESCE(agent_type, '') != 'dispatcher'  -- #781: belt-and-suspenders, never re-notify the dispatcher as a failed agent
+          AND {DISPATCHER_EXCLUSION_SQL}  -- #781: belt-and-suspenders, never re-notify the dispatcher as a failed agent
         ORDER BY completed_at ASC
         """,
         (cutoff_str,),

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -71,6 +71,9 @@ from utils.ifttt_rules import (
     find_rule as _ifttt_find_rule,
     get_enabled_rules as _ifttt_get_enabled_rules,
 )
+
+# Dispatcher-exclusion: shared single source of truth (BIS-723)
+from utils.agent_types import is_dispatcher_row
 import uuid as _uuid_mod
 
 # Reliability utilities (atomic writes, validation, audit logging)
@@ -9828,8 +9831,9 @@ async def _startup_sweep() -> None:
             agent_id = session.get("id", "")
             # #781 Fix 2 (extended): the dispatcher is never a dead subagent (its
             # output_file is legitimately NULL) — mirror reconcile_agent_sessions();
-            # never re-notify it as agent_failed.
-            if (session.get("agent_type") or "") == "dispatcher":
+            # never re-notify it as agent_failed. See utils/agent_types.py (BIS-723)
+            # for the shared single source of truth for this check.
+            if is_dispatcher_row(session):
                 continue
             if _inbox_already_has_agent(agent_id):
                 log.debug(
@@ -9911,8 +9915,10 @@ async def reconcile_agent_sessions() -> None:
                 # The SessionStart hook may register the dispatcher itself in
                 # agent_sessions.db with agent_type='dispatcher' (on crash-restart
                 # before the marker file is cleared).  The dispatcher is never a
-                # "dead agent" — never emit agent_failed for it.
-                if (session.get("agent_type") or "") == "dispatcher":
+                # "dead agent" — never emit agent_failed for it. See
+                # utils/agent_types.py (BIS-723) for the shared single source of
+                # truth for this check.
+                if is_dispatcher_row(session):
                     log.debug(
                         f"[reconciler] Skipping dispatcher session {agent_id!r} "
                         "(agent_type='dispatcher' — not a subagent)"

--- a/src/utils/agent_types.py
+++ b/src/utils/agent_types.py
@@ -1,0 +1,56 @@
+"""
+Dispatcher-exclusion: single source of truth (Linear BIS-723).
+
+The dispatcher's own row in agent_sessions.db must never be mistaken for a
+subagent that needs cleanup, dead-agent notification, or "pending agent"
+counting. Before this module existed, the check `agent_type != 'dispatcher'`
+was reimplemented independently at five call sites (session_store.py x2,
+inbox_server.py x2, periodic-self-check.sh) and had to be fixed four separate
+times (issue #781, PR #2099, PR #2103) because there was no shared definition
+to update. This module is that shared definition for all Python call sites.
+
+Cross-referenced with scripts/lib/agent_sessions.sh, which holds the
+equivalent SQL fragment for shell callers (periodic-self-check.sh) that query
+agent_sessions.db directly via `sqlite3` rather than importing this module.
+Python and bash cannot literally share one function, so the two files carry
+matching comments pointing at each other — if one changes, the other must
+change too.
+"""
+
+from __future__ import annotations
+
+# The agent_type value written when the dispatcher registers its own session
+# (see session_start(agent_type=...) in src/agents/session_store.py and the
+# SessionStart hook's crash-restart registration path). Must match
+# DISPATCHER_AGENT_TYPE in scripts/lib/agent_sessions.sh.
+DISPATCHER_AGENT_TYPE = "dispatcher"
+
+# SQL WHERE-clause fragment excluding dispatcher rows from a query over
+# agent_sessions. COALESCE guards against agent_type being NULL (legacy rows
+# predating the column, or subagents that never set it) — NULL != 'dispatcher'
+# is NULL (falsy) in SQL, so without COALESCE those rows would be silently
+# excluded from results that should include them.
+#
+# Must match DISPATCHER_EXCLUSION_SQL in scripts/lib/agent_sessions.sh.
+DISPATCHER_EXCLUSION_SQL = f"COALESCE(agent_type, '') != '{DISPATCHER_AGENT_TYPE}'"
+
+
+def is_dispatcher_agent_type(agent_type: str | None) -> bool:
+    """Return True if agent_type identifies the dispatcher's own session.
+
+    Exact, case-sensitive match against DISPATCHER_AGENT_TYPE. None and the
+    empty string are never the dispatcher — those represent ghost/legacy rows
+    with no agent_type recorded, which are handled by separate guards (see
+    tests/unit/test_mcp_server/test_ghost_session_fixes.py).
+    """
+    return (agent_type or "") == DISPATCHER_AGENT_TYPE
+
+
+def is_dispatcher_row(session: dict) -> bool:
+    """Return True if a session dict represents the dispatcher's own session.
+
+    Convenience wrapper around is_dispatcher_agent_type() for callers holding
+    a full session dict (e.g. from get_active_sessions() or a row returned by
+    get_unnotified_completed()) rather than a bare agent_type string.
+    """
+    return is_dispatcher_agent_type(session.get("agent_type"))

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -945,3 +945,70 @@ def test_cleanup_stale_marks_end_turn_as_completed_not_dead(isolated_db, tmp_pat
     assert result["status"] == "completed", (
         f"Expected 'completed' for end_turn agent but got {result['status']!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Test: dispatcher-exclusion (Linear BIS-723)
+#
+# The dispatcher's own row (agent_type='dispatcher') has output_file legitimately
+# NULL and no natural completion — it must never be swept up by the startup
+# cleanup or re-notified as a failed/completed agent. Regression coverage for
+# the shared predicate in src/utils/agent_types.py (issue #781 / PR #2099 /
+# PR #2103 — fixed independently at each call site before consolidation).
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_stale_running_excludes_dispatcher_row(isolated_db):
+    """cleanup_stale_running_sessions must never mark the dispatcher's own row dead.
+
+    A dispatcher row has no output_file and no natural completion signal, so
+    without the exclusion it would be treated like an orphaned subagent and
+    marked dead purely due to elapsed time.
+    """
+    db = isolated_db
+
+    old_spawned_at = (datetime.now(timezone.utc) - timedelta(minutes=200)).isoformat()
+    session_store._get_connection(db).execute(
+        """
+        INSERT INTO agent_sessions
+            (id, agent_type, description, chat_id, source, status, spawned_at)
+        VALUES ('dispatcher-main-loop', 'dispatcher', 'main dispatcher loop',
+                '0', 'telegram', 'running', ?)
+        """,
+        (old_spawned_at,),
+    )
+    session_store._get_connection(db).commit()
+
+    server_start = datetime.now(timezone.utc)
+    changed = session_store.cleanup_stale_running_sessions(server_start, path=db)
+
+    assert "dispatcher-main-loop" not in changed
+    result = session_store.find_session("dispatcher-main-loop", path=db)
+    assert result["status"] == "running"
+
+
+def test_get_unnotified_completed_excludes_dispatcher_row(isolated_db):
+    """get_unnotified_completed must never surface the dispatcher's own row.
+
+    Belt-and-suspenders guard: even if the dispatcher's row were ever marked
+    completed/dead with notified_at NULL, the startup sweep must not re-notify
+    it as a failed agent.
+    """
+    db = isolated_db
+
+    completed_at = datetime.now(timezone.utc).isoformat()
+    spawned_at = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+    session_store._get_connection(db).execute(
+        """
+        INSERT INTO agent_sessions
+            (id, agent_type, description, chat_id, source, status, spawned_at, completed_at)
+        VALUES ('dispatcher-main-loop', 'dispatcher', 'main dispatcher loop',
+                '0', 'telegram', 'dead', ?, ?)
+        """,
+        (spawned_at, completed_at),
+    )
+    session_store._get_connection(db).commit()
+
+    unnotified = session_store.get_unnotified_completed(since_hours=24, path=db)
+
+    assert all(row["id"] != "dispatcher-main-loop" for row in unnotified)

--- a/tests/unit/test_agent_types.py
+++ b/tests/unit/test_agent_types.py
@@ -1,0 +1,62 @@
+"""
+Tests for src/utils/agent_types.py — the shared dispatcher-exclusion predicate
+(Linear BIS-723).
+
+Before this module existed, `agent_type != 'dispatcher'` was reimplemented
+independently at five call sites and had to be fixed four separate times
+(issue #781, PR #2099, PR #2103). These tests pin down the one shared
+definition so a future accidental removal or inversion of the check is
+caught here first.
+"""
+
+from src.utils.agent_types import (
+    DISPATCHER_AGENT_TYPE,
+    DISPATCHER_EXCLUSION_SQL,
+    is_dispatcher_agent_type,
+    is_dispatcher_row,
+)
+
+
+def test_dispatcher_agent_type_is_excluded():
+    """The exact dispatcher agent_type value must be recognized as the dispatcher."""
+    assert is_dispatcher_agent_type(DISPATCHER_AGENT_TYPE) is True
+
+
+def test_real_subagent_type_is_not_excluded():
+    assert is_dispatcher_agent_type("subagent") is False
+    assert is_dispatcher_agent_type("functional-engineer") is False
+
+
+def test_none_agent_type_is_not_excluded():
+    """Ghost/legacy rows with no agent_type recorded are NOT the dispatcher.
+
+    These are handled by separate guards (see test_ghost_session_fixes.py) —
+    is_dispatcher_agent_type only matches the exact dispatcher marker.
+    """
+    assert is_dispatcher_agent_type(None) is False
+
+
+def test_empty_string_agent_type_is_not_excluded():
+    assert is_dispatcher_agent_type("") is False
+
+
+def test_match_is_case_sensitive():
+    assert is_dispatcher_agent_type("DISPATCHER") is False
+    assert is_dispatcher_agent_type("Dispatcher") is False
+
+
+def test_is_dispatcher_row_reads_agent_type_field():
+    assert is_dispatcher_row({"id": "abc", "agent_type": "dispatcher"}) is True
+    assert is_dispatcher_row({"id": "abc", "agent_type": "subagent"}) is False
+    assert is_dispatcher_row({"id": "abc"}) is False
+
+
+def test_dispatcher_exclusion_sql_matches_constant():
+    """The SQL fragment must reference the same value as DISPATCHER_AGENT_TYPE.
+
+    Guards against the SQL string constant and the Python predicate drifting
+    apart (e.g. someone editing one without the other).
+    """
+    assert f"'{DISPATCHER_AGENT_TYPE}'" in DISPATCHER_EXCLUSION_SQL
+    assert "COALESCE(agent_type, '')" in DISPATCHER_EXCLUSION_SQL
+    assert "!=" in DISPATCHER_EXCLUSION_SQL

--- a/tests/unit/test_mcp_server/test_ghost_session_fixes.py
+++ b/tests/unit/test_mcp_server/test_ghost_session_fixes.py
@@ -45,6 +45,8 @@ for _p in [str(_ROOT / "src" / "mcp"), str(_ROOT / "src" / "agents"),
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
+from utils.agent_types import is_dispatcher_row  # noqa: E402
+
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -167,18 +169,13 @@ class TestNoShouldDropFieldInMessages:
 # Bug 2 fix tests: reconciler skips dispatcher-type sessions
 # ---------------------------------------------------------------------------
 
-def _should_reconciler_skip(session: dict) -> bool:
-    """Pure function mirroring the skip guard added to reconcile_agent_sessions().
-
-    Sessions with agent_type='dispatcher' represent the Lobster dispatcher's
-    own process — they are never real subagents and should never be marked dead
-    or have agent_failed messages emitted for them.
-
-    This function is extracted here for unit testing in isolation. The same
-    check must appear at the top of the reconciler loop in inbox_server.py.
-    """
-    agent_type = session.get("agent_type") or ""
-    return agent_type == "dispatcher"
+# BIS-723: this used to be a locally-defined function mirroring the skip guard
+# in reconcile_agent_sessions() — a duplicate reimplementation for test
+# purposes, not a check of the real production code. It now delegates to the
+# shared predicate (src/utils/agent_types.py) that reconcile_agent_sessions()
+# itself calls, so this test exercises the actual implementation rather than a
+# hand-maintained copy of its logic.
+_should_reconciler_skip = is_dispatcher_row
 
 
 class TestReconcilerSkipsDispatcherSessions:


### PR DESCRIPTION
## Problem

The `agent_type='dispatcher'` exclusion check — used to make sure the dispatcher's own row in `agent_sessions.db` is never mistaken for a dead/failed subagent — was duplicated inline at five call sites: `src/agents/session_store.py` (`cleanup_stale_running_sessions`, `get_unnotified_completed`), `src/mcp/inbox_server.py` (`_startup_sweep`, `reconcile_agent_sessions`), and `scripts/periodic-self-check.sh`. Because there was no single definition, this exact filter had to be fixed independently four times (issue #781, PR #2099, PR #2103) as new call sites were added or the pattern was copy-pasted incorrectly. A sixth, test-only reimplementation had also crept into `test_ghost_session_fixes.py` — a hand-mirrored copy of the guard used to unit-test the concept, but not the actual production code.

Implements Linear BIS-723 (https://linear.app/fully-parsed/issue/BIS-723/slice-d-consolidate-the-dispatcher-exclusion-filter-into-one-shared): consolidate the dispatcher-exclusion filter into one shared function so a sixth reimplementation becomes structurally hard to add without noticing the existing shared definition.

## What changed

- **New `src/utils/agent_types.py`** — the Python single source of truth:
  - `DISPATCHER_AGENT_TYPE = "dispatcher"`
  - `DISPATCHER_EXCLUSION_SQL` — the `COALESCE(agent_type, '') != 'dispatcher'` SQL fragment, for callers building a raw SQL WHERE clause
  - `is_dispatcher_agent_type(agent_type)` — pure predicate over a bare string
  - `is_dispatcher_row(session)` — convenience wrapper over a session dict
- **New `scripts/lib/agent_sessions.sh`** — the shell counterpart (`DISPATCHER_AGENT_TYPE` / `DISPATCHER_EXCLUSION_SQL` shell variables), following the existing `scripts/lib/template.sh` sourced-library convention. Python and bash can't literally share one function, so the two files cross-reference each other by name in comments — if one changes, the other must change too.
- `session_store.py`'s two raw SQL queries now interpolate `DISPATCHER_EXCLUSION_SQL` instead of inlining the fragment.
- `inbox_server.py`'s two dict-based checks now call `is_dispatcher_row(session)` instead of `(session.get("agent_type") or "") == "dispatcher"`.
- `periodic-self-check.sh` sources the shared shell lib and interpolates `$DISPATCHER_EXCLUSION_SQL` into its `sqlite3` query.
- `test_ghost_session_fixes.py`'s locally-defined `_should_reconciler_skip()` mirror function is replaced with a direct reference to `is_dispatcher_row` — the test now exercises the real shared predicate instead of a hand-maintained copy of its logic.

This is a pure refactor: no behavior change. `grep` confirms no inline `!= 'dispatcher'` / `== "dispatcher"` reimplementation remains at any of the five original call sites — each now delegates to the shared definition. (Two unrelated uses of the literal `"dispatcher"` string remain in `inbox_server.py` — a session self-identification check in `session_start()`, and a `task_id` display-label default in two `_emit_event` calls. Both are semantically different from the exclusion filter and out of scope per the issue.)

## Functional patterns

`is_dispatcher_agent_type` / `is_dispatcher_row` are pure functions (no side effects, no I/O) — same input always produces the same output. `DISPATCHER_EXCLUSION_SQL` is a derived constant computed once from `DISPATCHER_AGENT_TYPE`, not duplicated data. No architectural changes to control flow — this is a "replace five equivalent expressions with five calls to one definition" refactor, not a new abstraction layer.

## No flow/state-machine changes

This PR does not alter any multi-step flow, notification sequence, retry logic, or state machine — the dispatcher-exclusion condition itself is byte-for-byte equivalent before and after (same SQL fragment, same boolean predicate). No diagram included per the PR guidance, since there's nothing to diagram.

## Tests run

- [x] `uv run pytest tests/test_agent_sessions.py tests/unit/test_mcp_server/test_ghost_session_fixes.py tests/unit/test_agent_types.py -q` — 97 passed (90 pre-existing + 7 new in `test_agent_types.py`)
- [x] `uv run pytest tests/unit/test_mcp_server/ -q` — 865 passed (confirms `inbox_server.py` still imports and behaves correctly with the new `utils.agent_types` import)
- [x] `uv run pytest tests/ -q` (full suite) — **before**: 4108 passed / 10 failed / 34 skipped. **after**: 4117 passed / 10 failed / 34 skipped — same 10 pre-existing failures both times (`test_message_volume`, `test_slack_router_config`, `test_context_monitor`, `test_on_compact_write_claude_session_id` — all unrelated to this change, none touch `agent_sessions.db` or the dispatcher-exclusion filter). +9 passed = the 7 new `test_agent_types.py` tests + 2 new dispatcher-exclusion regression tests added to `test_agent_sessions.py`.
- [x] Falsifiability check on `is_dispatcher_agent_type`: inverted `==` to `!=` in `src/utils/agent_types.py`, re-ran `test_agent_types.py` — 6 of 7 tests failed as expected, restored, re-ran — 7/7 passed.
- [x] Falsifiability check on `DISPATCHER_EXCLUSION_SQL`: temporarily replaced the constant with the SQL tautology `"1=1"`, re-ran the two new regression tests in `test_agent_sessions.py` plus the SQL-content test in `test_agent_types.py` — all 3 failed as expected (dispatcher row was no longer excluded), restored, re-ran — all passed.
- [x] `python3 -m py_compile` on all three changed/new Python modules — clean.

## Manual test

`scripts/periodic-self-check.sh` and the new `scripts/lib/agent_sessions.sh` are shell scripts invoked by cron in production, so I ran the real script end-to-end against an isolated fake `agent_sessions.db` (own `mktemp -d`, `AGENT_TASKS_DIR` pointed at an empty directory so the real production `/tmp/claude-*/tasks/*.output` files were never scanned, `LOBSTER_MESSAGES`/`LOBSTER_INSTALL_DIR` pointed at the temp tree):

- **Case A** — DB has only one `agent_type='dispatcher'` row, `status='running'`: script ran to completion, exit 0, **zero** files written to the fake inbox (dispatcher correctly excluded from the pending count, no false-positive self-check fired).
- **Case B** — added one real `agent_type='functional-engineer'` row, `status='running'`, re-ran: script wrote exactly one self-check message to the fake inbox with text `"status? (Self-check) [1 agents pending]"` — confirming the real subagent row is correctly counted while the dispatcher row is still excluded.

No production `agent_sessions.db`, inbox, or `/tmp/claude-*` data was read or written — every path was redirected into a throwaway temp directory, and I removed the worktree's `.state/last-self-check` / `.state/reported-tasks` test artifacts afterward (these live outside git per `.gitignore` regardless).

## Known gap

There were no existing tests exercising the dispatcher-exclusion behavior of `session_store.py`'s `cleanup_stale_running_sessions()` or `get_unnotified_completed()` before this PR (confirmed via `grep -rn dispatcher tests/test_agent_sessions.py` returning nothing pre-change) — only `inbox_server.py`'s reconciler had coverage, and even that was via the hand-mirrored function described above. This PR adds the first direct regression tests for both `session_store.py` functions.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — see Manual test section (isolated temp DB + temp dirs, no production paths touched)
- [x] User-visible outcome verified — not applicable; this is an internal refactor with no user-facing behavior change (dispatcher-exclusion outcome is provably identical before/after via the test suite)
- [x] Side-effect audit complete: no floods, no unscoped writes (manual test used `mktemp -d` + explicit env var overrides), no unintended volume
- [x] External service calls: N/A — no external services involved in this change