### PR TITLE
Consolidate jq --arg JSON-escaping fix into one shared helper

### DIFF
--- a/scripts/alert.sh
+++ b/scripts/alert.sh
@@ -11,10 +11,15 @@
 
 MESSAGES_DIR="${LOBSTER_MESSAGES:-$HOME/messages}"
 WORKSPACE_DIR="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+LOBSTER_INSTALL_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
 
 ALERT_LOG="$WORKSPACE_DIR/logs/alerts.log"
 OUTBOX_DIR="$MESSAGES_DIR/outbox"
 ADMIN_CHAT_ID="${LOBSTER_ADMIN_CHAT_ID:-}"
+
+# Shared jq --arg JSON builder (BIS-724, scripts/lib/json_message.sh) — single
+# source of truth for jq-arg-safe JSON construction, see PR history for #2004.
+source "$LOBSTER_INSTALL_DIR/scripts/lib/json_message.sh"
 
 # Ensure directories exist
 mkdir -p "$(dirname "$ALERT_LOG")"
@@ -34,14 +39,11 @@ if [[ -n "$ADMIN_CHAT_ID" ]]; then
 $message
 
 _$(date)_"
-    jq -n \
+    _json_build_message \
         --argjson chat_id "$ADMIN_CHAT_ID" \
         --arg text "$alert_text" \
-        '{
-            "chat_id": $chat_id,
-            "text": $text,
-            "source": "telegram"
-        }' > "$alert_file"
+        --arg source "telegram" \
+        > "$alert_file"
     echo "[$timestamp] Alert sent to Telegram chat $ADMIN_CHAT_ID" >> "$ALERT_LOG"
 fi
 

--- a/scripts/check-agent-outputs.sh
+++ b/scripts/check-agent-outputs.sh
@@ -48,6 +48,10 @@ COMPLETION_THRESHOLD_SECONDS=120
 mkdir -p "$STATE_DIR" "$INBOX_DIR"
 touch "$NOTIFIED_FILE" 2>/dev/null || true
 
+# Shared jq --arg JSON builder (BIS-724, scripts/lib/json_message.sh) — single
+# source of truth for jq-arg-safe JSON construction, see PR history for #2004.
+source "${LOBSTER_INSTALL_DIR:-$HOME/lobster}/scripts/lib/json_message.sh"
+
 # Bail early if pending-agents.json doesn't exist or has no agents
 if [ ! -f "$PENDING_AGENTS_FILE" ]; then
     exit 0
@@ -115,21 +119,17 @@ while IFS= read -r agent_id; do
     # Safely escape agent_id for JSON (alphanumeric + hyphens only expected)
     SAFE_ID=$(echo "$agent_id" | tr -cd 'a-zA-Z0-9_-')
 
-    jq -n \
+    _json_build_message \
         --arg id "${MSG_ID}" \
+        --arg source "system" \
+        --arg type "health_check" \
+        --argjson chat_id 0 \
+        --argjson user_id 0 \
+        --arg username "lobster-system" \
+        --arg user_name "Agent Relay" \
         --arg text "Agent relay check: ${SAFE_ID} output file appears complete. Check task-notifications and relay results to the user." \
         --arg timestamp "${TIMESTAMP}" \
-        '{
-            "id": $id,
-            "source": "system",
-            "type": "health_check",
-            "chat_id": 0,
-            "user_id": 0,
-            "username": "lobster-system",
-            "user_name": "Agent Relay",
-            "text": $text,
-            "timestamp": $timestamp
-        }' > "${INBOX_DIR}/${MSG_ID}.json"
+        > "${INBOX_DIR}/${MSG_ID}.json"
 
     # Mark this agent as notified to prevent re-injection
     echo "$agent_id" >> "$NOTIFIED_FILE"

--- a/scripts/daily-update-check.sh
+++ b/scripts/daily-update-check.sh
@@ -16,6 +16,10 @@ unset _LOBSTER_CONFIG _DEV_MODE
 LOBSTER_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
 INBOX="${LOBSTER_MESSAGES:-$HOME/messages}/inbox"
 
+# Shared jq --arg JSON builder (BIS-724, scripts/lib/json_message.sh) — single
+# source of truth for jq-arg-safe JSON construction, see PR history for #2004.
+source "$LOBSTER_DIR/scripts/lib/json_message.sh"
+
 cd "$LOBSTER_DIR"
 
 # Support both git and tarball installs
@@ -28,18 +32,14 @@ if [ -d "$LOBSTER_DIR/.git" ]; then
     if [ "$LOCAL" != "$REMOTE" ]; then
         BEHIND=$(git rev-list --count "$LOCAL..$REMOTE")
         TIMESTAMP=$(date +%s%3N)
-        jq -n \
+        _json_build_message \
             --arg id "${TIMESTAMP}_update_available" \
+            --arg source "system" \
+            --argjson chat_id 0 \
+            --arg type "update_notification" \
             --arg text "UPDATE AVAILABLE: Lobster is ${BEHIND} commits behind origin/main. Use check_updates for details." \
             --arg timestamp "$(date -Iseconds)" \
-            '{
-                "id": $id,
-                "source": "system",
-                "chat_id": 0,
-                "type": "update_notification",
-                "text": $text,
-                "timestamp": $timestamp
-            }' > "$INBOX/${TIMESTAMP}_update_available.json"
+            > "$INBOX/${TIMESTAMP}_update_available.json"
     fi
 else
     # Tarball mode: check GitHub Releases API
@@ -49,17 +49,13 @@ else
 
     if [ -n "$LATEST_VERSION" ] && [ "$LATEST_VERSION" != "$CURRENT_VERSION" ]; then
         TIMESTAMP=$(date +%s%3N)
-        jq -n \
+        _json_build_message \
             --arg id "${TIMESTAMP}_update_available" \
+            --arg source "system" \
+            --argjson chat_id 0 \
+            --arg type "update_notification" \
             --arg text "UPDATE AVAILABLE: Lobster v${CURRENT_VERSION} -> v${LATEST_VERSION}. Use check_updates for details." \
             --arg timestamp "$(date -Iseconds)" \
-            '{
-                "id": $id,
-                "source": "system",
-                "chat_id": 0,
-                "type": "update_notification",
-                "text": $text,
-                "timestamp": $timestamp
-            }' > "$INBOX/${TIMESTAMP}_update_available.json"
+            > "$INBOX/${TIMESTAMP}_update_available.json"
     fi
 fi

--- a/scripts/lib/json_message.sh
+++ b/scripts/lib/json_message.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#===============================================================================
+# Shared jq-safe JSON object builder (Linear BIS-724)
+#
+# Canonical single implementation of _json_build_message(): builds a flat
+# JSON object from a list of jq argument flags, always routing values through
+# jq --arg/--argjson so quotes, newlines, backslashes, and unicode in the
+# values are escaped into valid JSON. Before this file existed, this exact
+# `jq -n --arg ... '{...}'` shape was reimplemented independently in 4
+# scripts (periodic-self-check.sh, alert.sh, check-agent-outputs.sh,
+# daily-update-check.sh x2) — issue #2004 / PR #2016 / PR #2031 fixed a
+# broken-escaping bug at each site separately before this consolidation.
+#
+# NOTE: This is the single source of truth for jq-arg-safe JSON message
+# construction. Do NOT reimplement the `jq -n --arg ... '{...}'` pattern
+# inline in a new script; source this file and call _json_build_message
+# instead.
+#
+# The 4 call sites build different message shapes (different field sets:
+# inbox messages, outbox messages, with/without a "type" field, etc.), so
+# this helper does not hardcode a fixed schema. Instead it is a thin,
+# documented wrapper around jq's `$ARGS.named` object — every --arg/--argjson
+# flag you pass becomes one key in the resulting flat JSON object, in
+# whatever shape the caller needs.
+#
+# Usage:
+#   source "$(dirname "$0")/lib/json_message.sh"
+#   _json_build_message \
+#       --arg id "$MSG_ID" \
+#       --arg source "system" \
+#       --argjson chat_id 0 \
+#       --arg text "$TEXT" \
+#       --arg timestamp "$TIMESTAMP" \
+#     > "$OUTPUT_FILE"
+#
+# Use --arg for string values (the common case — always safely escaped).
+# Use --argjson for values that are already valid JSON literals (numbers,
+# booleans, 0/1 chat_id placeholders, etc.) — never interpolate those
+# directly into a filter string.
+#===============================================================================
+
+# _json_build_message [--arg NAME VALUE | --argjson NAME VALUE] ...
+#
+# Prints a flat JSON object to stdout with one key per NAME passed, using
+# jq's $ARGS.named so the caller never has to hand-write an object literal
+# (and therefore can never forget to route a value through --arg/--argjson).
+_json_build_message() {
+    jq -n "$@" '$ARGS.named'
+}

--- a/scripts/periodic-self-check.sh
+++ b/scripts/periodic-self-check.sh
@@ -138,20 +138,19 @@ TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%S.%6N)
 EPOCH_MS=$(date +%s%3N)
 MSG_ID="${EPOCH_MS}_self"
 
-jq -n \
+# Shared jq --arg JSON builder (BIS-724, scripts/lib/json_message.sh) — single
+# source of truth for jq-arg-safe JSON construction, see PR history for #2004.
+source "${LOBSTER_INSTALL_DIR:-$HOME/lobster}/scripts/lib/json_message.sh"
+_json_build_message \
     --arg id "${MSG_ID}" \
+    --arg source "system" \
+    --argjson chat_id 0 \
+    --argjson user_id 0 \
+    --arg username "lobster-system" \
+    --arg user_name "Self-Check" \
     --arg text "${SELF_CHECK_TEXT}" \
     --arg timestamp "${TIMESTAMP}" \
-    '{
-        "id": $id,
-        "source": "system",
-        "chat_id": 0,
-        "user_id": 0,
-        "username": "lobster-system",
-        "user_name": "Self-Check",
-        "text": $text,
-        "timestamp": $timestamp
-    }' > "${INBOX_DIR}/${MSG_ID}.json"
+    > "${INBOX_DIR}/${MSG_ID}.json"
 
 # Record timestamp
 date +%s > "$LAST_CHECK_FILE"


### PR DESCRIPTION
Implements Linear BIS-724 (https://linear.app/fully-parsed/issue/BIS-724/slice-e-consolidate-the-jq-arg-json-escaping-fix-into-one-shared): consolidate the jq `--arg` JSON-escaping fix into one shared helper instead of 4 independent copies.

## Stacked branch — base will need retargeting

This PR is based on `refactor/bis-723-dispatcher-exclusion-consolidation` (#2109), not `main`, per the epic's branch stacking plan (BIS-719). The diff below only shows this slice's changes once #2109 merges and this PR's base is retargeted to `main` — I have not done that retargeting myself.

## Problem

`periodic-self-check.sh`, `alert.sh`, `check-agent-outputs.sh`, and `daily-update-check.sh` (which has two near-identical call sites) each independently built inbox/outbox message JSON with `jq -n --arg ... '{...}'`. Issue #2004 (PR #2016/#2031) found and fixed a JSON-escaping bug in this pattern — but because the pattern was copy-pasted 5 times across 4 files rather than shared, it had to be fixed at each site separately. This slice does not re-fix any escaping bug (the safe `--arg`/`--argjson` pattern is already on `main`); it removes the duplication so a future fix to the pattern only has to change one place.

This is the same shape of problem as BIS-723 (dispatcher-exclusion SQL fragment, #2109) — a correctness fix landed correctly, but landed 4-5 times instead of once — and follows that PR's precedent of extracting the duplicated logic into a small sourced `scripts/lib/*.sh` file.

## What changed

Added `scripts/lib/json_message.sh` with one function, `_json_build_message()`:

```bash
_json_build_message() {
    jq -n "$@" '$ARGS.named'
}
```

**Design decision:** the 4 call sites build different message shapes — different field sets (`id`/`source`/`chat_id`/`user_id`/`username`/`user_name`/`text`/`timestamp` vs. just `chat_id`/`text`/`source` vs. shapes with an added `type` field). A single hardcoded-schema function ("build an inbox message" vs "build an outbox message") wouldn't fit all 4 verbatim without either overloading it with optional-field plumbing or still leaving one call site half-duplicated. Instead, `_json_build_message` is a thin, documented wrapper around jq's `$ARGS.named` — every `--arg`/`--argjson` flag the caller passes becomes one key in the output object. This keeps the actual escaping logic (the part that's ever needed fixing) in exactly one place, while leaving each call site free to declare its own field set, e.g.:

```bash
_json_build_message \
    --arg id "${MSG_ID}" \
    --arg source "system" \
    --argjson chat_id 0 \
    --arg text "${SELF_CHECK_TEXT}" \
    --arg timestamp "${TIMESTAMP}" \
    > "${INBOX_DIR}/${MSG_ID}.json"
```

All 4 call sites (5 call sites counting `daily-update-check.sh`'s git-mode and tarball-mode blocks) were updated to call `_json_build_message` instead of reimplementing `jq -n --arg ... '{...}'`. Each site's exact field set and literal/arg values are unchanged — only the mechanism for constructing the JSON changed, from a hand-written filter literal to a list of `--arg`/`--argjson` flags.

This follows the sourced-lib convention already established in this repo: `scripts/lib/template.sh` (`_tmpl_generate_from_template()`) and, on this branch's base, `scripts/lib/agent_sessions.sh` (BIS-723) — both single-source-of-truth libraries with "do not reimplement, source this file instead" documentation, which `scripts/lib/json_message.sh` follows the same pattern for.

**Functional patterns used:** `_json_build_message` is a pure function (same inputs always produce the same JSON string, no side effects beyond stdout) — callers redirect stdout to a file, keeping the I/O effect at the call site rather than inside the shared helper. Using jq's `$ARGS.named` instead of a hand-written object literal means the helper is declarative (describe the desired key/value shape via flags) rather than imperative (build up a filter string), and composes with any field set without needing per-shape branches.

**Out of scope:** no other logic in these 4 scripts was touched — guards, staleness/completion detection, git-diff/version-check logic, and all field values/order are unchanged. This is not a state-machine or notification-sequencing change, so no before/after flow diagram is included.

## Tests run

- [x] `bash -n` on all 5 touched files (the new lib + 4 call sites) — all pass, no syntax errors
- [x] `grep -n "jq -n" scripts/periodic-self-check.sh scripts/alert.sh scripts/check-agent-outputs.sh scripts/daily-update-check.sh` — no matches; confirms no inline `jq -n --arg ... '{...}'` remains at any of the 4 original call sites
- [x] `grep -n "_json_build_message\|source.*json_message.sh"` on the same 4 files — confirms each site sources the lib and calls the shared helper

No existing automated test suite covers these shell scripts. Given this is bash glue code with no test harness in the repo, I used manual verification (below) rather than adding bats, matching the issue's own acceptance criteria (adversarial-input manual runs) and BIS-723/#2109's precedent.

## Manual test

All tests run in isolated `mktemp -d` directories with `LOBSTER_MESSAGES`/`LOBSTER_INSTALL_DIR`/`LOBSTER_WORKSPACE` overridden — production `~/messages/` and `~/lobster/.state` were never touched. Each of the 4 scripts was run through its **real code path** (not just the shared helper in isolation) with adversarial input (embedded double quotes, newlines, backslashes, tabs) and validated with both `jq empty` and `python3 -m json.tool`.

- **alert.sh** — ran with `bash scripts/alert.sh "$ADVERSARIAL_MSG"` where the message contained `"`, `\n`, `\`, and a tab. Output JSON: valid (`jq empty` and `python3 -m json.tool` both passed).
- **periodic-self-check.sh** — crafted a fake completed-task output file (`AGENT_TASKS_DIR` override) with a `"` character embedded in the task's basename, driving adversarial content through the real `scan_completed_tasks` → `SELF_CHECK_TEXT` → `_json_build_message` path. Output: `"text": "[Task Completed] Task agent\"with-quote completed (1 turns)"` — valid JSON.
- **check-agent-outputs.sh** — crafted `pending-agents.json` with an agent id containing a `"` character; ran the real script (with only the hardcoded `/tmp/claude-1000/...` `TASKS_DIR` constant patched to an isolated temp path for the test — that constant is pre-existing, out-of-scope behavior, not touched by this PR). Output JSON: valid.
- **daily-update-check.sh** — built a real local git repo + bare "origin" and forced local to be 1 commit behind, then ran the script's git-mode branch against it. Output JSON: valid, with the real `BEHIND` commit count interpolated.

**Falsifiability check:** temporarily replaced `_json_build_message` with a naive version that string-interpolates values into a JSON literal without jq escaping (reintroducing the pre-#2004 bug), reran the `alert.sh` adversarial test — `jq empty` failed with `parse error: Invalid string: control characters ... must be escaped`, confirming the test is falsifiable. Restored the real implementation and reran — valid JSON again.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits) — N/A (no existing unit test suite for these scripts); manual tests above ran entirely against isolated temp directories, never against production `~/messages`
- [x] Integration/manual test run — see `## Manual test` above; all 4 scripts exercised through their real code paths with adversarial input
- [x] User-visible outcome verified OR not applicable — N/A: this PR does not change any user-visible message content or delivery path, only how the JSON bytes for existing messages are constructed internally. The message shapes, field values, and delivery mechanisms (inbox/outbox file writes, consumed by other parts of the system) are byte-for-byte equivalent to before, which the manual tests confirm.
- [x] Side-effect audit complete: all manual tests used `mktemp -d` isolated directories with `LOBSTER_MESSAGES`/`LOBSTER_INSTALL_DIR` overridden; no writes to production `~/messages/` or `~/lobster/.state`; no floods (single message per test run); no shared-state writes outside the temp dirs
- [x] External service calls: N/A, no external service calls in this change