### PR TITLE
feat: Fireflies.ai transcript integration (fetch, vault sync, multi-account)

### DIFF
--- a/scheduled-tasks/fireflies-sync.sh
+++ b/scheduled-tasks/fireflies-sync.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# fireflies-sync.sh — Scheduled Fireflies → Obsidian sync job
+#
+# Runs the Python sync script and writes output to the Lobster task output system.
+# Intended to be called by a systemd timer every 30 minutes (mirrors granola-sync.sh).
+#
+# Logs: ~/lobster-workspace/scheduled-jobs/logs/fireflies-sync-*.log
+
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
+
+# --- Load env ---
+CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+for _env_file in "$CONFIG_DIR/config.env" "$CONFIG_DIR/global.env"; do
+    if [ -f "$_env_file" ]; then
+        set -a
+        # shellcheck source=/dev/null
+        source "$_env_file"
+        set +a
+    fi
+done
+unset _env_file
+
+WORKSPACE="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+LOBSTER_DIR="${LOBSTER_DIR:-$HOME/lobster}"
+LOG_DIR="$WORKSPACE/scheduled-jobs/logs"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+LOG_FILE="$LOG_DIR/fireflies-sync-${TIMESTAMP}.log"
+
+mkdir -p "$LOG_DIR"
+
+if [ -z "${FIREFLIES_API_KEY:-}" ]; then
+    echo "[$(date -Iseconds)] fireflies-sync: FIREFLIES_API_KEY not set — skipping run" | tee "$LOG_FILE"
+    exit 0
+fi
+
+echo "[$(date -Iseconds)] fireflies-sync starting" | tee "$LOG_FILE"
+
+# Run the sync script
+cd "$LOBSTER_DIR"
+set +e
+OUTPUT=$(uv run python -m integrations.fireflies.sync 2>&1)
+EXIT_CODE=$?
+set -e
+
+echo "$OUTPUT" | tee -a "$LOG_FILE"
+echo "[$(date -Iseconds)] fireflies-sync exit code: $EXIT_CODE" | tee -a "$LOG_FILE"
+
+exit $EXIT_CODE

--- a/scheduled-tasks/tasks/fireflies-sync.md
+++ b/scheduled-tasks/tasks/fireflies-sync.md
@@ -1,0 +1,110 @@
+# Fireflies → Obsidian Sync
+
+**Job**: fireflies-sync
+**Schedule**: `*/30 * * * *` (every 30 minutes) — proposed, mirrors granola-sync
+**Status**: NOT YET ACTIVATED — see "Activation" below
+
+## Context
+
+You are a scheduled sync agent. Your job is to pull all new Fireflies call
+transcripts (across every configured team member's Fireflies account) into
+the Obsidian vault at `~/lobster-workspace/obsidian-vault/` and git-commit
+the results.
+
+This is a raw ingest job — no LLM summarisation, no token spend beyond this
+invocation. Fireflies' own AI summary (including `action_items`) is captured
+verbatim; the Python sync script handles all API calls and file I/O.
+
+## Task
+
+Run the Fireflies sync script:
+
+```bash
+cd ~/lobster
+source ~/lobster-config/config.env
+
+# Run the sync (Python module)
+uv run python -m integrations.fireflies.sync
+```
+
+The script will:
+1. Read the last-sync timestamp from `~/lobster-workspace/data/fireflies-sync-state.json`
+2. Fetch all transcripts created since last sync, for every configured account
+   (`FIREFLIES_API_KEY` plus any `FIREFLIES_API_KEY_<NAME>`), full sync on first run
+3. Write each transcript as `fireflies/YYYY/MM/YYYY-MM-DD-{slug}.md` in the vault,
+   with a dedicated "Action Items" section up top
+4. Git-commit the vault with message: `fireflies: sync {N} transcripts [{timestamp}]`
+5. Update the state file
+6. Print a JSON result summary to stdout
+
+## Expected output
+
+Example success output:
+```json
+{
+  "status": "success",
+  "transcripts_fetched": 3,
+  "transcripts_written": 3,
+  "transcripts_skipped": 0,
+  "transcripts_errored": 0,
+  "committed": true,
+  "last_sync_at": "2026-06-01T15:00:00.000Z",
+  "vault_path": "/home/lobster/lobster-workspace/obsidian-vault",
+  "accounts_polled": ["primary", "jake", "ben", "priya"],
+  "message": "Synced 3 new/updated transcripts, skipped 0 unchanged"
+}
+```
+
+If `FIREFLIES_API_KEY` is not set, the wrapper script exits 0 without error
+(no key configured yet is an expected, not exceptional, state) — see
+`scheduled-tasks/fireflies-sync.sh`.
+
+## Error handling
+
+- If the script exits with code 1, the sync failed. Log the output and mark the job as failed.
+- Auth errors (FIREFLIES_API_KEY missing/invalid for any configured account) will appear in stderr.
+- On failure, call `write_task_output` with `status="failed"`.
+
+## Reporting
+
+After running:
+
+1. Call `write_task_output` with:
+   - `job_name`: `fireflies-sync`
+   - `output`: The JSON output from the script (or error message)
+   - `status`: `"success"` or `"failed"`
+
+2. If `transcripts_written > 0`, send a Telegram notification to the admin
+   (chat_id from `LOBSTER_ADMIN_CHAT_ID` env var):
+   - Message: `Fireflies sync: {transcripts_written} new call transcripts added to vault. [{timestamp}]`
+   - Keep it brief — only send if there are actually new transcripts.
+
+3. If status is `"failed"`, always notify the admin with the error.
+
+4. Call `write_result` with a concise summary.
+
+## Dry run (for testing)
+
+```bash
+uv run python -m integrations.fireflies.sync --dry-run
+```
+
+This fetches transcripts but does not write to disk or update state.
+
+## Activation
+
+This job definition (script + task doc) is committed and ready, but no live
+systemd timer has been created for it yet — deliberately, since
+`FIREFLIES_API_KEY` is not currently set in `~/lobster-config/config.env`.
+Installing the timer before a key exists would mean it fails silently every
+30 minutes for no operational benefit. Once the account owner adds the key(s), activate
+with the `create_scheduled_job` MCP tool (or the systemd-timer equivalent
+used for `granola-sync`):
+
+```
+create_scheduled_job(
+    name="fireflies-sync",
+    schedule="*/30 * * * *",
+    context=<this file's content>,
+)
+```

--- a/src/integrations/fireflies/__init__.py
+++ b/src/integrations/fireflies/__init__.py
@@ -1,0 +1,1 @@
+"""Fireflies.ai integration package."""

--- a/src/integrations/fireflies/client.py
+++ b/src/integrations/fireflies/client.py
@@ -1,0 +1,604 @@
+"""
+Fireflies.ai GraphQL API client.
+
+Provides a clean, typed Python layer over the Fireflies.ai public GraphQL
+API so Lobster can list and retrieve call transcripts — mirrors the design
+of ``integrations.granola.client`` (same HTTP/retry conventions, same
+multi-account shape) but adapted to Fireflies' GraphQL query surface.
+
+All HTTP calls go through ``_call_api``, the single point of contact with
+the network. Rate limits (429) are retried with exponential backoff. Auth
+failures (401/403, or a GraphQL ``errors`` array whose message looks
+auth-related) raise ``FirefliesAuthError``.
+
+Design principles (consistent with other integrations):
+- Immutable value objects (frozen dataclasses)
+- Pure parsing helpers isolated from I/O
+- Side effects (network calls) kept at the boundaries
+- No credentials ever appear in logs or exception messages
+- Timezone-aware datetimes throughout (UTC)
+
+Fireflies public API docs:
+    https://docs.fireflies.ai/
+
+Environment variables:
+    FIREFLIES_API_KEY            — primary account's API key (required)
+    FIREFLIES_API_KEY_<NAME>     — additional team members' keys, e.g.
+                                    FIREFLIES_API_KEY_JAKE, FIREFLIES_API_KEY_BEN.
+                                    Any suffix is picked up automatically —
+                                    no code change needed to add a new
+                                    teammate's account. See
+                                    build_account_configs_from_env().
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import requests
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Fireflies GraphQL API constants
+# ---------------------------------------------------------------------------
+
+_FIREFLIES_ENDPOINT: str = "https://api.fireflies.ai/graphql"
+_HTTP_TIMEOUT: int = 20
+
+# Fireflies caps `limit` at 50 transcripts per page (per API docs).
+_MAX_PAGE_SIZE: int = 50
+
+# Rate limiting backoff (mirrors integrations.granola.client).
+_RATE_LIMIT_BACKOFF_BASE: float = 1.0
+_RATE_LIMIT_MAX_RETRIES: int = 4
+
+
+# ---------------------------------------------------------------------------
+# Domain types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FirefliesAttendee:
+    """Immutable meeting attendee record."""
+
+    name: str
+    email: str
+
+
+@dataclass(frozen=True)
+class FirefliesSentence:
+    """A single transcript utterance."""
+
+    index: int
+    speaker_name: str
+    speaker_id: str
+    text: str
+    start_time: Optional[float]
+    end_time: Optional[float]
+
+
+@dataclass(frozen=True)
+class FirefliesSummary:
+    """
+    AI-generated summary attached to a transcript.
+
+    ``action_items`` is the field the sales-CRM use case cares about most —
+    Fireflies returns it as a Markdown-formatted bullet list of next steps.
+    """
+
+    overview: str = ""
+    action_items: str = ""
+    keywords: list[str] = field(default_factory=list)
+    outline: str = ""
+    shorthand_bullet: str = ""
+    bullet_gist: str = ""
+    gist: str = ""
+    short_summary: str = ""
+
+
+# Account name constant for the primary (required) API key.
+ACCOUNT_PRIMARY: str = "primary"
+
+
+@dataclass(frozen=True)
+class FirefliesTranscript:
+    """
+    Immutable representation of a single Fireflies call transcript.
+
+    The ``fireflies_account`` field identifies which configured Fireflies
+    account this transcript came from ('primary', or a teammate's account
+    name such as 'jake'). Defaults to 'primary'.
+    """
+
+    id: str
+    title: str
+    date: Optional[datetime] = None
+    duration: Optional[float] = None
+    transcript_url: str = ""
+    meeting_link: str = ""
+    host_email: str = ""
+    organizer_email: str = ""
+    participants: list[str] = field(default_factory=list)
+    meeting_attendees: list[FirefliesAttendee] = field(default_factory=list)
+    summary: FirefliesSummary = field(default_factory=FirefliesSummary)
+    sentences: list[FirefliesSentence] = field(default_factory=list)
+    fireflies_account: str = ACCOUNT_PRIMARY
+
+
+@dataclass(frozen=True)
+class TranscriptListPage:
+    """A single page of results from list_transcripts()."""
+
+    transcripts: list[FirefliesTranscript]
+    has_more: bool
+    skip: int = 0
+    limit: int = _MAX_PAGE_SIZE
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class FirefliesAPIError(RuntimeError):
+    """Non-auth error from the Fireflies API (HTTP-level or GraphQL `errors`)."""
+
+    def __init__(self, status_code: int, summary: str = "") -> None:
+        self.status_code = status_code
+        msg = f"Fireflies API error {status_code}" if status_code else "Fireflies API error"
+        if summary:
+            msg += f": {summary}"
+        super().__init__(msg)
+
+
+class FirefliesAuthError(FirefliesAPIError):
+    """Authentication / authorisation failure (401/403, or an auth-shaped GraphQL error)."""
+
+    def __init__(self) -> None:
+        super().__init__(401, "authentication failed — check FIREFLIES_API_KEY")
+
+
+class FirefliesNotFoundError(FirefliesAPIError):
+    """Transcript not found (the `transcript` query returned null)."""
+
+    def __init__(self, transcript_id: str) -> None:
+        self.transcript_id = transcript_id
+        super().__init__(404, f"transcript {transcript_id!r} not found")
+
+
+class FirefliesUnknownAccountError(KeyError):
+    """
+    Raised when a transcript's fireflies_account name has no registered API key.
+
+    Mirrors GranolaUnknownAccountError: signals a configuration gap (a new
+    account name appeared without a matching key in config.env) rather than
+    silently falling back to the primary account's key.
+    """
+
+    def __init__(self, account_name: str) -> None:
+        self.account_name = account_name
+        super().__init__(
+            f"No API key registered for Fireflies account {account_name!r}. "
+            f"Add FIREFLIES_API_KEY_{account_name.upper()} to ~/lobster-config/config.env."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_api_key() -> str:
+    """Load FIREFLIES_API_KEY from environment. Raises ValueError if missing."""
+    key = os.environ.get("FIREFLIES_API_KEY", "").strip()
+    if not key:
+        raise ValueError(
+            "FIREFLIES_API_KEY environment variable is not set. "
+            "Set it in ~/lobster-config/config.env."
+        )
+    return key
+
+
+def _parse_dt(value: Optional[Any]) -> Optional[datetime]:
+    """
+    Parse a Fireflies date value → UTC datetime, or None if blank/None.
+
+    Fireflies returns ISO 8601 strings for `date` in transcript responses,
+    but some deprecated fields use epoch milliseconds (float). Handle both.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(value / 1000.0, tz=timezone.utc)
+        except (ValueError, OverflowError, OSError):
+            return None
+    try:
+        s = str(value).replace("Z", "+00:00")
+        return datetime.fromisoformat(s).astimezone(timezone.utc)
+    except (ValueError, TypeError):
+        log.debug("Could not parse Fireflies datetime: %r", value)
+        return None
+
+
+def _parse_attendee(raw: dict[str, Any]) -> FirefliesAttendee:
+    return FirefliesAttendee(
+        name=raw.get("name") or "",
+        email=raw.get("email") or "",
+    )
+
+
+def _parse_sentence(raw: dict[str, Any]) -> FirefliesSentence:
+    return FirefliesSentence(
+        index=raw.get("index") or 0,
+        speaker_name=raw.get("speaker_name") or "",
+        speaker_id=str(raw.get("speaker_id") or ""),
+        text=raw.get("text") or "",
+        start_time=raw.get("start_time"),
+        end_time=raw.get("end_time"),
+    )
+
+
+def _parse_summary(raw: Optional[dict[str, Any]]) -> FirefliesSummary:
+    if not raw:
+        return FirefliesSummary()
+    return FirefliesSummary(
+        overview=raw.get("overview") or "",
+        action_items=raw.get("action_items") or "",
+        keywords=list(raw.get("keywords") or []),
+        outline=raw.get("outline") or "",
+        shorthand_bullet=raw.get("shorthand_bullet") or "",
+        bullet_gist=raw.get("bullet_gist") or "",
+        gist=raw.get("gist") or "",
+        short_summary=raw.get("short_summary") or "",
+    )
+
+
+def _parse_transcript(
+    raw: dict[str, Any], fireflies_account: str = ACCOUNT_PRIMARY
+) -> FirefliesTranscript:
+    """Convert a raw API transcript dict → FirefliesTranscript dataclass."""
+    return FirefliesTranscript(
+        id=raw["id"],
+        title=raw.get("title") or "Untitled",
+        date=_parse_dt(raw.get("date")),
+        duration=raw.get("duration"),
+        transcript_url=raw.get("transcript_url") or "",
+        meeting_link=raw.get("meeting_link") or "",
+        host_email=raw.get("host_email") or "",
+        organizer_email=raw.get("organizer_email") or "",
+        participants=list(raw.get("participants") or []),
+        meeting_attendees=[_parse_attendee(a) for a in raw.get("meeting_attendees") or []],
+        summary=_parse_summary(raw.get("summary")),
+        sentences=[_parse_sentence(s) for s in raw.get("sentences") or []],
+        fireflies_account=fireflies_account,
+    )
+
+
+def _looks_like_auth_error(message: str) -> bool:
+    """Heuristic: does a GraphQL error message describe an auth failure?"""
+    lowered = message.lower()
+    return any(token in lowered for token in ("unauthor", "auth", "api key", "api_key"))
+
+
+# ---------------------------------------------------------------------------
+# GraphQL queries
+# ---------------------------------------------------------------------------
+
+_LIST_TRANSCRIPTS_QUERY = """
+query Transcripts($limit: Int, $skip: Int, $fromDate: DateTime) {
+  transcripts(limit: $limit, skip: $skip, fromDate: $fromDate) {
+    id
+    title
+    date
+  }
+}
+"""
+
+_GET_TRANSCRIPT_QUERY = """
+query Transcript($transcriptId: String!) {
+  transcript(id: $transcriptId) {
+    id
+    title
+    date
+    duration
+    transcript_url
+    meeting_link
+    host_email
+    organizer_email
+    participants
+    meeting_attendees {
+      name
+      email
+    }
+    summary {
+      overview
+      action_items
+      keywords
+      outline
+      shorthand_bullet
+      bullet_gist
+      gist
+      short_summary
+    }
+    sentences {
+      index
+      speaker_name
+      speaker_id
+      text
+      start_time
+      end_time
+    }
+  }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# HTTP transport
+# ---------------------------------------------------------------------------
+
+
+def _call_api(
+    query: str,
+    variables: dict[str, Any],
+    api_key: Optional[str] = None,
+) -> dict[str, Any]:
+    """
+    Make one authenticated GraphQL request to the Fireflies API.
+
+    Handles 429 rate-limit with exponential backoff (up to
+    _RATE_LIMIT_MAX_RETRIES). Raises FirefliesAuthError on 401/403 (or a
+    GraphQL `errors` array that looks auth-related), FirefliesAPIError on
+    other non-2xx or GraphQL error responses.
+
+    Returns the `data` object from the GraphQL response.
+    """
+    if api_key is None:
+        api_key = _get_api_key()
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {"query": query, "variables": variables}
+
+    for attempt in range(_RATE_LIMIT_MAX_RETRIES + 1):
+        try:
+            resp = requests.request(
+                "POST",
+                _FIREFLIES_ENDPOINT,
+                headers=headers,
+                json=payload,
+                timeout=_HTTP_TIMEOUT,
+            )
+        except requests.RequestException as exc:
+            log.warning("Fireflies API request failed (network): %s", exc)
+            raise FirefliesAPIError(0, "network error") from exc
+
+        if resp.status_code == 429:
+            if attempt < _RATE_LIMIT_MAX_RETRIES:
+                wait = _RATE_LIMIT_BACKOFF_BASE * (2 ** attempt)
+                log.warning("Fireflies rate limit hit, waiting %.1fs (attempt %d)", wait, attempt + 1)
+                time.sleep(wait)
+                continue
+            raise FirefliesAPIError(429, "rate limit exceeded after retries")
+
+        if resp.status_code in (401, 403):
+            raise FirefliesAuthError()
+
+        if not resp.ok:
+            raise FirefliesAPIError(resp.status_code, resp.text[:200])
+
+        body = resp.json()
+        errors = body.get("errors")
+        if errors:
+            message = "; ".join(str(e.get("message", "")) for e in errors)
+            if _looks_like_auth_error(message):
+                raise FirefliesAuthError()
+            raise FirefliesAPIError(0, message[:200])
+
+        return body.get("data") or {}
+
+    # Should never reach here
+    raise FirefliesAPIError(0, "unexpected retry exhaustion")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def list_transcripts(
+    since: Optional[datetime] = None,
+    skip: int = 0,
+    limit: int = _MAX_PAGE_SIZE,
+    api_key: Optional[str] = None,
+    fireflies_account: str = ACCOUNT_PRIMARY,
+) -> TranscriptListPage:
+    """
+    List call transcripts, newest-first (summary fields only — id/title/date).
+
+    Args:
+        since:             If provided, only return transcripts on/after this
+                            datetime (Fireflies `fromDate` filter).
+        skip:               Pagination offset.
+        limit:              Max transcripts per page. Clamped to Fireflies'
+                             documented maximum of 50.
+        api_key:            Override FIREFLIES_API_KEY env var.
+        fireflies_account:  Account identifier to embed in returned transcripts.
+
+    Returns:
+        TranscriptListPage with transcripts, has_more flag, skip and limit used.
+        has_more is a heuristic: True iff the page returned exactly `limit`
+        items (Fireflies does not return a total count or cursor).
+    """
+    effective_limit = min(limit, _MAX_PAGE_SIZE)
+    variables: dict[str, Any] = {"limit": effective_limit, "skip": skip}
+    if since is not None:
+        variables["fromDate"] = since.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+    data = _call_api(_LIST_TRANSCRIPTS_QUERY, variables, api_key=api_key)
+    raw_list = data.get("transcripts") or []
+    transcripts = [_parse_transcript(t, fireflies_account=fireflies_account) for t in raw_list]
+
+    has_more = effective_limit > 0 and len(raw_list) == effective_limit
+
+    return TranscriptListPage(
+        transcripts=transcripts,
+        has_more=has_more,
+        skip=skip,
+        limit=effective_limit,
+    )
+
+
+def get_transcript(
+    transcript_id: str,
+    api_key: Optional[str] = None,
+    fireflies_account: str = ACCOUNT_PRIMARY,
+) -> FirefliesTranscript:
+    """
+    Retrieve a single transcript by ID, including summary and sentences.
+
+    Args:
+        transcript_id:      The transcript's `id` field.
+        api_key:            Override FIREFLIES_API_KEY env var.
+        fireflies_account:  Account identifier to embed in returned transcript.
+
+    Raises:
+        FirefliesNotFoundError: if the transcript does not exist.
+    """
+    data = _call_api(_GET_TRANSCRIPT_QUERY, {"transcriptId": transcript_id}, api_key=api_key)
+    raw = data.get("transcript")
+    if raw is None:
+        raise FirefliesNotFoundError(transcript_id)
+    return _parse_transcript(raw, fireflies_account=fireflies_account)
+
+
+def iter_all_transcripts(
+    since: Optional[datetime] = None,
+    api_key: Optional[str] = None,
+    fireflies_account: str = ACCOUNT_PRIMARY,
+    limit: int = _MAX_PAGE_SIZE,
+) -> list[FirefliesTranscript]:
+    """
+    Fetch ALL transcript summaries (following pagination via skip/limit).
+
+    Returns a flat list of FirefliesTranscript objects (summary fields only —
+    callers needing full detail should call get_transcript() per ID).
+    """
+    all_transcripts: list[FirefliesTranscript] = []
+    skip = 0
+
+    while True:
+        page = list_transcripts(
+            since=since, skip=skip, limit=limit, api_key=api_key, fireflies_account=fireflies_account
+        )
+        all_transcripts.extend(page.transcripts)
+        log.debug("Fetched page: %d transcripts, has_more=%s", len(page.transcripts), page.has_more)
+
+        if not page.has_more:
+            break
+        skip += page.limit
+
+    log.info("iter_all_transcripts: fetched %d total transcripts", len(all_transcripts))
+    return all_transcripts
+
+
+# ---------------------------------------------------------------------------
+# Multi-account support
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FirefliesAccountConfig:
+    """
+    Immutable descriptor for a single Fireflies account used in multi-account polling.
+
+    Attributes:
+        name:    Account identifier ('primary', or a teammate's name e.g. 'jake').
+        api_key: Bearer token for this account.
+    """
+
+    name: str
+    api_key: str
+
+
+# Matches FIREFLIES_API_KEY_<NAME> but not the bare FIREFLIES_API_KEY itself.
+_NAMED_ACCOUNT_KEY_RE = re.compile(r"^FIREFLIES_API_KEY_(.+)$")
+
+
+def build_account_configs_from_env(env: Optional[dict[str, str]] = None) -> list[FirefliesAccountConfig]:
+    """
+    Discover configured Fireflies accounts from environment variables.
+
+    Rules:
+    - FIREFLIES_API_KEY is required (primary account). Returns empty list if absent.
+    - Any FIREFLIES_API_KEY_<NAME> variable is treated as an additional account,
+      named after the lowercased suffix (e.g. FIREFLIES_API_KEY_JAKE → 'jake').
+      This is discovered dynamically by scanning env — unlike Granola's
+      build_account_configs_from_env(), which only recognises a single
+      hardcoded '_2' suffix and silently ignores any other named key. Adding a
+      new teammate's Fireflies account here requires no code change, only a
+      new env var in config.env.
+    - Primary account is always first in the returned list; named accounts
+      follow in alphabetical order (deterministic, independent of dict
+      iteration order).
+
+    Args:
+        env: Dict of environment variables. Defaults to os.environ.
+
+    Returns:
+        List of FirefliesAccountConfig, primary account first.
+    """
+    if env is None:
+        env = dict(os.environ)
+
+    primary_key = env.get("FIREFLIES_API_KEY", "").strip()
+    if not primary_key:
+        return []
+
+    configs: list[FirefliesAccountConfig] = [
+        FirefliesAccountConfig(name=ACCOUNT_PRIMARY, api_key=primary_key),
+    ]
+
+    named: list[tuple[str, str]] = []
+    for key, value in env.items():
+        match = _NAMED_ACCOUNT_KEY_RE.match(key)
+        if not match:
+            continue
+        stripped_value = (value or "").strip()
+        if not stripped_value:
+            continue
+        named.append((match.group(1).lower(), stripped_value))
+
+    for name, api_key in sorted(named, key=lambda pair: pair[0]):
+        configs.append(FirefliesAccountConfig(name=name, api_key=api_key))
+
+    return configs
+
+
+def iter_all_transcripts_for_account(
+    account: FirefliesAccountConfig,
+    since: Optional[datetime] = None,
+) -> list[FirefliesTranscript]:
+    """
+    Fetch ALL transcript summaries for a specific account, with account attribution.
+
+    Identical to iter_all_transcripts() but takes a FirefliesAccountConfig so
+    the api_key and account name are bundled together.
+    """
+    log.info("Fetching transcripts for Fireflies account '%s'", account.name)
+    return iter_all_transcripts(
+        since=since,
+        api_key=account.api_key,
+        fireflies_account=account.name,
+    )

--- a/src/integrations/fireflies/serializer.py
+++ b/src/integrations/fireflies/serializer.py
@@ -1,0 +1,222 @@
+"""
+Fireflies transcript serializer.
+
+Pure functions that convert FirefliesTranscript dataclass objects into clean
+Markdown files with YAML frontmatter — mirrors integrations.granola.serializer
+but leads with an "Action Items" section, since the driving use case (per the
+Eloso team's request) is turning sales call transcripts into a CRM with next
+actions. Burying action items inside a generic summary blob would defeat that
+purpose, so they get their own labelled, easy-to-find section.
+
+No I/O, no network calls — independently testable.
+
+Output format per transcript:
+    ---
+    id: abc123
+    title: "Sales call with Acme"
+    date: 2026-06-01
+    ...
+    source: fireflies
+    fireflies_account: primary
+    ---
+
+    # Sales call with Acme
+
+    ## Action Items
+
+    - Follow up with Acme on pricing
+    - Send proposal by Friday
+
+    ## Overview
+
+    <overview text>
+
+    ## Transcript
+
+    **Alex** (00:00 → 00:02)
+    Thanks for joining today.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Optional
+
+from integrations.fireflies.client import FirefliesSentence, FirefliesTranscript
+
+
+# ---------------------------------------------------------------------------
+# Filename generation
+# ---------------------------------------------------------------------------
+
+
+def _slugify(text: str, max_len: int = 60) -> str:
+    """
+    Convert a title to a URL-safe slug for use in filenames.
+
+    Examples:
+        "Sales call with Acme" → "sales-call-with-acme"
+        "Q3 Renewal: Acme Corp" → "q3-renewal-acme-corp"
+    """
+    s = text.lower()
+    s = re.sub(r"[^\w\s-]", "", s)
+    s = re.sub(r"[\s_]+", "-", s)
+    s = s.strip("-")
+    if len(s) > max_len:
+        truncated = s[:max_len].rsplit("-", 1)[0]
+        s = truncated if truncated else s[:max_len]
+    return s or "untitled"
+
+
+def transcript_filename(transcript: FirefliesTranscript) -> str:
+    """
+    Generate the filename (without directory path) for a transcript.
+
+    Format: ``YYYY-MM-DD-{slug}.md``, using the transcript's `date` field.
+    Falls back to today's date if `date` is missing.
+    """
+    dt = transcript.date or datetime.now(timezone.utc)
+    date_str = dt.astimezone(timezone.utc).strftime("%Y-%m-%d")
+    slug = _slugify(transcript.title)
+    return f"{date_str}-{slug}.md"
+
+
+def transcript_vault_path(transcript: FirefliesTranscript) -> str:
+    """
+    Return the relative vault path (from vault root) for a transcript.
+
+    Format: ``fireflies/YYYY/MM/{filename}`` — mirrors granola/YYYY/MM/....
+    """
+    dt = transcript.date or datetime.now(timezone.utc)
+    year = dt.astimezone(timezone.utc).strftime("%Y")
+    month = dt.astimezone(timezone.utc).strftime("%m")
+    filename = transcript_filename(transcript)
+    return f"fireflies/{year}/{month}/{filename}"
+
+
+# ---------------------------------------------------------------------------
+# YAML frontmatter helpers
+# ---------------------------------------------------------------------------
+
+
+def _yaml_str(value: str) -> str:
+    """Wrap a string in double quotes, escaping any existing double quotes."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _format_dt(dt: Optional[datetime]) -> str:
+    """Format a datetime for YAML frontmatter."""
+    if dt is None:
+        return '""'
+    return _yaml_str(dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+
+def _format_hms(seconds: Optional[float]) -> str:
+    """Format a float seconds offset as MM:SS for transcript speaker labels."""
+    if seconds is None:
+        return "00:00"
+    total = max(0, int(seconds))
+    return f"{total // 60:02d}:{total % 60:02d}"
+
+
+# ---------------------------------------------------------------------------
+# Transcript body formatting
+# ---------------------------------------------------------------------------
+
+
+def _format_sentences(sentences: list[FirefliesSentence]) -> str:
+    """Format transcript sentences into readable Markdown, grouped by speaker."""
+    if not sentences:
+        return "_No transcript available._\n"
+
+    lines: list[str] = []
+    current_speaker: Optional[str] = None
+
+    for sent in sentences:
+        speaker = sent.speaker_name or "Unknown"
+        if speaker != current_speaker:
+            if lines:
+                lines.append("")
+            lines.append(f"**{speaker}** ({_format_hms(sent.start_time)} → {_format_hms(sent.end_time)})")
+            current_speaker = speaker
+        text = sent.text.strip()
+        if text:
+            lines.append(text)
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Main serializer
+# ---------------------------------------------------------------------------
+
+
+def transcript_to_markdown(transcript: FirefliesTranscript) -> str:
+    """
+    Convert a FirefliesTranscript → clean Markdown string with YAML frontmatter.
+
+    Args:
+        transcript: A fully populated FirefliesTranscript (from get_transcript()).
+
+    Returns:
+        A UTF-8 Markdown string ready to write to disk.
+    """
+    # --- Attendees YAML block ---
+    attendees_yaml_lines: list[str] = []
+    for attendee in transcript.meeting_attendees:
+        name_q = _yaml_str(attendee.name) if attendee.name else '""'
+        email_q = _yaml_str(attendee.email) if attendee.email else '""'
+        attendees_yaml_lines.append(f"  - name: {name_q}")
+        attendees_yaml_lines.append(f"    email: {email_q}")
+    attendees_yaml = "\n".join(attendees_yaml_lines) if attendees_yaml_lines else "  []"
+
+    duration_str = str(int(transcript.duration)) if transcript.duration is not None else "null"
+
+    date_str = (
+        transcript.date.astimezone(timezone.utc).strftime("%Y-%m-%d")
+        if transcript.date
+        else ""
+    )
+
+    frontmatter = f"""---
+id: {transcript.id}
+title: {_yaml_str(transcript.title)}
+date: {date_str}
+date_iso: {_format_dt(transcript.date)}
+duration_seconds: {duration_str}
+host_email: {_yaml_str(transcript.host_email)}
+organizer_email: {_yaml_str(transcript.organizer_email)}
+transcript_url: {_yaml_str(transcript.transcript_url)}
+meeting_link: {_yaml_str(transcript.meeting_link)}
+attendees:
+{attendees_yaml}
+keywords: {transcript.summary.keywords!r}
+source: fireflies
+fireflies_account: {transcript.fireflies_account}
+---"""
+
+    title_line = f"# {transcript.title}"
+
+    # Action items — leads the body (see module docstring for rationale).
+    action_items = transcript.summary.action_items.strip()
+    if action_items:
+        action_items_section = f"## Action Items\n\n{action_items}"
+    else:
+        action_items_section = "## Action Items\n\n_No action items were generated for this call._"
+
+    # Overview
+    if transcript.summary.overview:
+        overview_section = f"## Overview\n\n{transcript.summary.overview.strip()}"
+    else:
+        overview_section = "## Overview\n\n_No overview available._"
+
+    # Transcript
+    transcript_body = _format_sentences(transcript.sentences)
+    transcript_section = f"## Transcript\n\n{transcript_body}"
+
+    body_parts = [title_line, "", action_items_section, "", overview_section, "", transcript_section]
+    body = "\n".join(body_parts)
+
+    return frontmatter + "\n\n" + body + "\n"

--- a/src/integrations/fireflies/sync.py
+++ b/src/integrations/fireflies/sync.py
@@ -1,0 +1,413 @@
+"""
+Fireflies → Obsidian incremental sync.
+
+Entry point for the scheduled job. Reads the last-sync timestamp from a
+state file, fetches only transcripts created since then (or all transcripts
+on first run) for every configured Fireflies account, writes to the Obsidian
+vault, git-commits, and updates state. Mirrors integrations.granola.sync.
+
+Unlike Granola's sync (which merges a hardcoded 'primary'/'secondary' pair),
+this module merges an arbitrary, dynamically-discovered set of accounts —
+see build_account_configs_from_env() in client.py. Adding a new teammate's
+FIREFLIES_API_KEY_<NAME> env var is picked up automatically by both account
+discovery and this merge step, with no code change required.
+
+State file: ~/lobster-workspace/data/fireflies-sync-state.json
+Vault path: ~/lobster-workspace/obsidian-vault/
+
+Usage (standalone):
+    cd ~/lobster
+    uv run python -m integrations.fireflies.sync
+
+Usage (as scheduled job, called by Lobster cron system):
+    The scheduled task markdown file instructs the agent to run this script.
+
+Output:
+    Writes a structured result dict to stdout (JSON).
+    Also calls write_task_output via the lobster-inbox HTTP API if
+    LOBSTER_INBOX_URL env var is set.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+_SRC_DIR = Path(__file__).parent.parent.parent
+if str(_SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(_SRC_DIR))
+
+from integrations.fireflies.client import (
+    FirefliesAccountConfig,
+    FirefliesAPIError,
+    FirefliesAuthError,
+    FirefliesTranscript,
+    FirefliesUnknownAccountError,
+    build_account_configs_from_env,
+    get_transcript,
+    iter_all_transcripts_for_account,
+)
+from integrations.fireflies.vault_writer import WriteResult, write_transcripts_batch
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_WORKSPACE = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+_STATE_FILE = _WORKSPACE / "data" / "fireflies-sync-state.json"
+_VAULT_PATH = Path(os.environ.get("FIREFLIES_VAULT_PATH", _WORKSPACE / "obsidian-vault"))
+_JOB_NAME = "fireflies-sync"
+
+
+# ---------------------------------------------------------------------------
+# State management
+# ---------------------------------------------------------------------------
+
+
+def _load_sync_state() -> dict[str, Any]:
+    """Load sync state from JSON file, returning defaults if missing."""
+    if _STATE_FILE.exists():
+        try:
+            with _STATE_FILE.open() as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError) as exc:
+            log.warning("Could not read state file %s: %s — starting fresh", _STATE_FILE, exc)
+    return {"last_sync_at": None, "total_synced": 0, "last_run_at": None}
+
+
+def _save_sync_state(state: dict[str, Any]) -> None:
+    """Persist sync state to disk."""
+    _STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with _STATE_FILE.open("w") as f:
+        json.dump(state, f, indent=2)
+    log.debug("Saved sync state to %s", _STATE_FILE)
+
+
+# ---------------------------------------------------------------------------
+# write_task_output via lobster-inbox HTTP API
+# ---------------------------------------------------------------------------
+
+
+def _write_task_output(output: str, status: str = "success") -> None:
+    """
+    Write task output to Lobster's task output system.
+
+    Tries the lobster-inbox MCP API endpoint directly. Silently skips
+    if LOBSTER_INBOX_URL is not set or the call fails (non-critical).
+    """
+    base_url = os.environ.get("LOBSTER_INBOX_URL", "http://localhost:9922")
+    url = f"{base_url}/task-output"
+    payload = json.dumps({
+        "job_name": _JOB_NAME,
+        "output": output,
+        "status": status,
+    }).encode("utf-8")
+
+    try:
+        req = urllib.request.Request(
+            url,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            if resp.status == 200:
+                log.debug("write_task_output: success")
+            else:
+                log.debug("write_task_output: HTTP %d", resp.status)
+    except (urllib.error.URLError, OSError) as exc:
+        log.debug("write_task_output skipped (not available): %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Fireflies → transcript detail fetching
+# ---------------------------------------------------------------------------
+
+
+def _fetch_transcripts_with_detail(
+    transcripts_summary: list[FirefliesTranscript],
+    account_configs: list[FirefliesAccountConfig],
+) -> list[FirefliesTranscript]:
+    """
+    For each transcript from iter_all_transcripts_for_account() (summary
+    fields only), fetch full detail (summary/action_items/sentences) via
+    get_transcript() using the correct per-account API key.
+
+    The fireflies_account field from the summary transcript is used to look
+    up the matching FirefliesAccountConfig, so the correct api_key is passed
+    to get_transcript(). Using dict access (not .get()) means an unknown
+    account name raises FirefliesUnknownAccountError immediately rather than
+    silently falling back to the primary API key — this is the same
+    regression class the Granola integration guards against.
+    """
+    api_key_by_account: dict[str, str] = {cfg.name: cfg.api_key for cfg in account_configs}
+
+    full_transcripts: list[FirefliesTranscript] = []
+    for transcript in transcripts_summary:
+        if transcript.fireflies_account not in api_key_by_account:
+            raise FirefliesUnknownAccountError(transcript.fireflies_account)
+        try:
+            api_key = api_key_by_account[transcript.fireflies_account]
+            full = get_transcript(
+                transcript.id,
+                api_key=api_key,
+                fireflies_account=transcript.fireflies_account,
+            )
+            full_transcripts.append(full)
+            log.debug(
+                "Fetched detail for transcript %s (account=%s)",
+                transcript.id, transcript.fireflies_account,
+            )
+        except FirefliesAPIError as exc:
+            log.warning("Could not fetch detail for transcript %s: %s", transcript.id, exc)
+            full_transcripts.append(transcript)
+    return full_transcripts
+
+
+# ---------------------------------------------------------------------------
+# Main sync
+# ---------------------------------------------------------------------------
+
+
+def _merge_transcripts_deduplicated(
+    transcripts_by_account: dict[str, list[FirefliesTranscript]],
+) -> list[FirefliesTranscript]:
+    """
+    Merge transcripts from an arbitrary set of accounts, deduplicating by ID.
+
+    Unlike Granola's merge (hardcoded to exactly 'primary' and 'secondary'),
+    this handles however many named accounts build_account_configs_from_env()
+    discovered. The primary account is authoritative: if the same transcript
+    ID appears under multiple accounts, the primary version wins; among
+    non-primary accounts, dict iteration order determines which is kept
+    (a transcript genuinely shared across two teammates' non-primary
+    accounts is a rare edge case, not the common path this optimises for).
+
+    This is a pure function — no I/O, no mutation of inputs.
+    """
+    seen_ids: set[str] = set()
+    merged: list[FirefliesTranscript] = []
+
+    # Primary first (authoritative), then every other account in whatever
+    # order the caller provided (dict iteration order).
+    ordered_names = [name for name in transcripts_by_account if name == "primary"]
+    ordered_names += [name for name in transcripts_by_account if name != "primary"]
+
+    for name in ordered_names:
+        for transcript in transcripts_by_account[name]:
+            if transcript.id in seen_ids:
+                continue
+            seen_ids.add(transcript.id)
+            merged.append(transcript)
+
+    return merged
+
+
+def run_sync(dry_run: bool = False) -> dict[str, Any]:
+    """
+    Run a full incremental sync cycle across all configured Fireflies accounts.
+
+    1. Load last-sync timestamp from state file.
+    2. Discover configured accounts (primary + any FIREFLIES_API_KEY_<NAME>).
+    3. Fetch all transcripts since last sync per account (or all on first run).
+    4. Merge and deduplicate by transcript ID (primary wins on conflict).
+    5. For each merged transcript, fetch full detail (summary + sentences).
+    6. Write to Obsidian vault (idempotent, annotated with fireflies_account).
+    7. Git-commit the vault.
+    8. Update state file with new timestamp.
+    9. Return result summary dict.
+
+    Args:
+        dry_run: If True, fetch and serialise but do not write to disk
+                 or update state. Useful for testing.
+    """
+    run_start = datetime.now(timezone.utc)
+    state = _load_sync_state()
+
+    last_sync_str: Optional[str] = state.get("last_sync_at")
+    since: Optional[datetime] = None
+    if last_sync_str:
+        try:
+            since = datetime.fromisoformat(last_sync_str.replace("Z", "+00:00"))
+            log.info("Incremental sync since: %s", since.isoformat())
+        except ValueError:
+            log.warning("Could not parse last_sync_at %r — doing full sync", last_sync_str)
+    else:
+        log.info("No prior sync state — running full sync (all transcripts)")
+
+    accounts = build_account_configs_from_env()
+    if not accounts:
+        msg = "FIREFLIES_API_KEY not set — check config.env"
+        log.error(msg)
+        _write_task_output(msg, status="failed")
+        return {"status": "failed", "message": msg}
+
+    account_names = [a.name for a in accounts]
+    log.info("Polling %d Fireflies account(s): %s", len(accounts), ", ".join(account_names))
+
+    transcripts_by_account: dict[str, list[FirefliesTranscript]] = {}
+    for account in accounts:
+        try:
+            account_transcripts = iter_all_transcripts_for_account(account, since=since)
+            transcripts_by_account[account.name] = account_transcripts
+            log.info("Account '%s': %d transcripts fetched", account.name, len(account_transcripts))
+        except FirefliesAuthError:
+            msg = f"Fireflies authentication failed for account '{account.name}' — check API key in config.env"
+            log.error(msg)
+            _write_task_output(msg, status="failed")
+            return {"status": "failed", "message": msg}
+        except FirefliesAPIError as exc:
+            msg = f"Fireflies API error for account '{account.name}': {exc}"
+            log.error(msg)
+            _write_task_output(msg, status="failed")
+            return {"status": "failed", "message": msg}
+
+    transcripts_summary = _merge_transcripts_deduplicated(transcripts_by_account)
+    n_fetched = len(transcripts_summary)
+    log.info(
+        "Merged: %s → %d total after dedup",
+        ", ".join(f"{acc}={len(transcripts_by_account.get(acc, []))}" for acc in account_names),
+        n_fetched,
+    )
+
+    if n_fetched == 0:
+        msg = "No new transcripts since last sync."
+        log.info(msg)
+        state["last_run_at"] = run_start.isoformat()
+        if not dry_run:
+            _save_sync_state(state)
+        result = {
+            "status": "success",
+            "transcripts_fetched": 0,
+            "transcripts_written": 0,
+            "transcripts_skipped": 0,
+            "transcripts_errored": 0,
+            "committed": False,
+            "last_sync_at": last_sync_str,
+            "vault_path": str(_VAULT_PATH),
+            "accounts_polled": account_names,
+            "message": msg,
+        }
+        _write_task_output(json.dumps(result), status="success")
+        return result
+
+    log.info("Fetching full detail for %d transcripts...", n_fetched)
+    transcripts_full = _fetch_transcripts_with_detail(transcripts_summary, accounts)
+
+    if dry_run:
+        log.info("DRY RUN — not writing to vault")
+        return {
+            "status": "dry_run",
+            "transcripts_fetched": n_fetched,
+            "transcripts_written": 0,
+            "transcripts_skipped": 0,
+            "transcripts_errored": 0,
+            "committed": False,
+            "vault_path": str(_VAULT_PATH),
+            "accounts_polled": account_names,
+            "message": f"Dry run: would write {n_fetched} transcripts",
+        }
+
+    write_result: WriteResult = write_transcripts_batch(
+        transcripts=transcripts_full,
+        vault_path=_VAULT_PATH,
+        commit=True,
+    )
+
+    if transcripts_full:
+        dated = [t.date for t in transcripts_full if t.date is not None]
+        if dated:
+            latest_dt = max(dated)
+            state["last_sync_at"] = latest_dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+    state["last_run_at"] = run_start.isoformat()
+    state["total_synced"] = state.get("total_synced", 0) + write_result.n_written
+    _save_sync_state(state)
+
+    status = "failed" if write_result.n_errors > 0 and write_result.n_written == 0 else "success"
+    message = (
+        f"Synced {write_result.n_written} new/updated transcripts, "
+        f"skipped {write_result.n_skipped} unchanged"
+    )
+    if write_result.n_errors:
+        message += f", {write_result.n_errors} errors"
+
+    result = {
+        "status": status,
+        "transcripts_fetched": n_fetched,
+        "transcripts_written": write_result.n_written,
+        "transcripts_skipped": write_result.n_skipped,
+        "transcripts_errored": write_result.n_errors,
+        "committed": write_result.committed,
+        "last_sync_at": state.get("last_sync_at"),
+        "vault_path": str(_VAULT_PATH),
+        "accounts_polled": account_names,
+        "message": message,
+    }
+
+    if write_result.errors:
+        result["errors"] = [{"id": eid, "error": emsg} for eid, emsg in write_result.errors]
+
+    output_str = json.dumps(result, indent=2)
+    log.info("Sync complete: %s", message)
+    _write_task_output(output_str, status=status)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Run sync and print JSON result to stdout."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        stream=sys.stderr,
+    )
+
+    _load_lobster_env()
+
+    dry_run = "--dry-run" in sys.argv
+    if dry_run:
+        log.info("Running in dry-run mode")
+
+    result = run_sync(dry_run=dry_run)
+    print(json.dumps(result, indent=2))
+
+    if result.get("status") == "failed":
+        sys.exit(1)
+
+
+def _load_lobster_env() -> None:
+    """Load Lobster config env files if running as a standalone script."""
+    config_dir = Path(os.environ.get("LOBSTER_CONFIG_DIR", Path.home() / "lobster-config"))
+    for env_file in [config_dir / "config.env", config_dir / "global.env"]:
+        if env_file.exists():
+            try:
+                with env_file.open() as f:
+                    for line in f:
+                        line = line.strip()
+                        if line and not line.startswith("#") and "=" in line:
+                            key, _, val = line.partition("=")
+                            key = key.strip()
+                            val = val.strip()
+                            if key and key not in os.environ:
+                                os.environ[key] = val
+            except OSError as exc:
+                log.warning("Could not load %s: %s", env_file, exc)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/integrations/fireflies/vault_writer.py
+++ b/src/integrations/fireflies/vault_writer.py
@@ -1,0 +1,229 @@
+"""
+Fireflies vault writer.
+
+Idempotent writer that stores serialised FirefliesTranscript Markdown files
+into the Obsidian vault at the correct path, skipping unchanged transcripts
+(by comparing SHA-256 content hashes), and git-committing after each sync
+run. Mirrors integrations.granola.vault_writer exactly, aside from the
+"fireflies" vault subdirectory and commit message prefix.
+
+Vault structure:
+    ~/lobster-workspace/obsidian-vault/fireflies/YYYY/MM/{date}-{slug}.md
+
+Git commit message format:
+    fireflies: sync {N} transcripts [{ISO timestamp}]
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from integrations.fireflies.client import FirefliesTranscript
+from integrations.fireflies.serializer import transcript_to_markdown, transcript_vault_path
+
+log = logging.getLogger(__name__)
+
+# Default vault location (can be overridden via FIREFLIES_VAULT_PATH env var or argument)
+_DEFAULT_VAULT = Path.home() / "lobster-workspace" / "obsidian-vault"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sha256(content: str) -> str:
+    """Return the hex SHA-256 of a UTF-8 string."""
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _ensure_git_repo(vault_path: Path) -> None:
+    """
+    Initialise vault as a git repo if it isn't one already.
+    No-op if .git/ already exists.
+    """
+    git_dir = vault_path / ".git"
+    if git_dir.exists():
+        return
+
+    log.info("Initialising git repo in vault: %s", vault_path)
+    subprocess.run(
+        ["git", "init"],
+        cwd=str(vault_path),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "lobster@localhost"],
+        cwd=str(vault_path), check=True, capture_output=True, text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Lobster"],
+        cwd=str(vault_path), check=True, capture_output=True, text=True,
+    )
+    log.info("Git repo initialised in vault.")
+
+
+def _git_commit(vault_path: Path, n_written: int, timestamp: str) -> bool:
+    """
+    Stage all changes and create a git commit.
+
+    Returns True if a commit was made, False if there was nothing to commit.
+    """
+    add_result = subprocess.run(
+        ["git", "add", "-A"],
+        cwd=str(vault_path),
+        capture_output=True,
+        text=True,
+    )
+    if add_result.returncode != 0:
+        log.warning("git add failed: %s", add_result.stderr)
+        return False
+
+    status_result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=str(vault_path),
+        capture_output=True,
+        text=True,
+    )
+    if not status_result.stdout.strip():
+        log.debug("Nothing to commit in vault.")
+        return False
+
+    msg = f"fireflies: sync {n_written} transcripts [{timestamp}]"
+    commit_result = subprocess.run(
+        ["git", "commit", "-m", msg],
+        cwd=str(vault_path),
+        capture_output=True,
+        text=True,
+    )
+    if commit_result.returncode != 0:
+        log.warning("git commit failed: %s", commit_result.stderr)
+        return False
+
+    log.info("Git commit: %s", msg)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# WriteResult
+# ---------------------------------------------------------------------------
+
+
+class WriteResult:
+    """Summary of what the vault writer did during a sync run."""
+
+    def __init__(self) -> None:
+        self.written: list[str] = []
+        self.skipped: list[str] = []
+        self.errors: list[tuple[str, str]] = []
+        self.committed: bool = False
+
+    @property
+    def n_written(self) -> int:
+        return len(self.written)
+
+    @property
+    def n_skipped(self) -> int:
+        return len(self.skipped)
+
+    @property
+    def n_errors(self) -> int:
+        return len(self.errors)
+
+    def __repr__(self) -> str:
+        return (
+            f"WriteResult(written={self.n_written}, skipped={self.n_skipped}, "
+            f"errors={self.n_errors}, committed={self.committed})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main write function
+# ---------------------------------------------------------------------------
+
+
+def write_transcript(
+    transcript: FirefliesTranscript,
+    vault_path: Optional[Path] = None,
+) -> tuple[bool, str]:
+    """
+    Write a single transcript to the vault.
+
+    Idempotent: if the file already exists with identical content
+    (same SHA-256), the write is skipped.
+
+    Returns:
+        (was_written, message) — was_written is True if file was created/updated.
+    """
+    if vault_path is None:
+        vault_env = os.environ.get("FIREFLIES_VAULT_PATH", "").strip()
+        vault_path = Path(vault_env) if vault_env else _DEFAULT_VAULT
+
+    rel_path = transcript_vault_path(transcript)
+    abs_path = vault_path / rel_path
+
+    abs_path.parent.mkdir(parents=True, exist_ok=True)
+
+    content = transcript_to_markdown(transcript)
+    new_hash = _sha256(content)
+
+    if abs_path.exists():
+        existing_content = abs_path.read_text(encoding="utf-8")
+        existing_hash = _sha256(existing_content)
+        if existing_hash == new_hash:
+            log.debug("Transcript %s unchanged — skipping write", transcript.id)
+            return False, "unchanged"
+
+    abs_path.write_text(content, encoding="utf-8")
+    log.info("Wrote transcript %s → %s", transcript.id, rel_path)
+    return True, rel_path
+
+
+def write_transcripts_batch(
+    transcripts: list[FirefliesTranscript],
+    vault_path: Optional[Path] = None,
+    commit: bool = True,
+) -> WriteResult:
+    """
+    Write a batch of transcripts to the vault, then optionally git-commit.
+
+    Returns:
+        WriteResult summarising what happened.
+    """
+    if vault_path is None:
+        vault_env = os.environ.get("FIREFLIES_VAULT_PATH", "").strip()
+        vault_path = Path(vault_env) if vault_env else _DEFAULT_VAULT
+
+    vault_path.mkdir(parents=True, exist_ok=True)
+    _ensure_git_repo(vault_path)
+
+    result = WriteResult()
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    for transcript in transcripts:
+        try:
+            was_written, detail = write_transcript(transcript, vault_path=vault_path)
+            if was_written:
+                result.written.append(transcript.id)
+            else:
+                result.skipped.append(transcript.id)
+        except Exception as exc:
+            log.error("Failed to write transcript %s: %s", transcript.id, exc)
+            result.errors.append((transcript.id, str(exc)))
+
+    if commit and (result.written or result.errors):
+        result.committed = _git_commit(vault_path, result.n_written, timestamp)
+
+    log.info(
+        "write_transcripts_batch: written=%d skipped=%d errors=%d committed=%s",
+        result.n_written, result.n_skipped, result.n_errors, result.committed,
+    )
+    return result

--- a/tests/unit/test_fireflies_client.py
+++ b/tests/unit/test_fireflies_client.py
@@ -1,0 +1,449 @@
+"""
+Tests for src/integrations/fireflies/client.py
+
+Written before the implementation exists (TDD). These exercise the GraphQL
+client against a mocked `requests` layer — no real network calls, mirroring
+the approach used in tests/unit/test_granola_client.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_SRC_DIR = Path(__file__).parent.parent.parent / "src"
+sys.path.insert(0, str(_SRC_DIR))
+
+from integrations.fireflies.client import (  # noqa: E402
+    ACCOUNT_PRIMARY,
+    FirefliesAccountConfig,
+    FirefliesAPIError,
+    FirefliesAuthError,
+    FirefliesNotFoundError,
+    FirefliesTranscript,
+    FirefliesUnknownAccountError,
+    TranscriptListPage,
+    build_account_configs_from_env,
+    get_transcript,
+    iter_all_transcripts,
+    iter_all_transcripts_for_account,
+    list_transcripts,
+)
+
+_ENDPOINT = "https://api.fireflies.ai/graphql"
+
+
+def _mock_http_response(json_body: dict, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    resp.json.return_value = json_body
+    resp.text = str(json_body)
+    return resp
+
+
+def _transcript_payload(
+    tid: str = "abc123",
+    title: str = "Sales call with Acme",
+    action_items: str = "- Follow up with Acme on pricing\n- Send proposal by Friday",
+) -> dict:
+    return {
+        "id": tid,
+        "title": title,
+        "date": "2026-06-01T15:00:00.000Z",
+        "duration": 1800,
+        "transcript_url": "https://app.fireflies.ai/view/abc123",
+        "meeting_link": "https://meet.google.com/xyz",
+        "host_email": "alex@example.com",
+        "organizer_email": "alex@example.com",
+        "participants": ["alex@example.com", "prospect@acme.com"],
+        "meeting_attendees": [
+            {"name": "Alex", "email": "alex@example.com"},
+            {"name": "Prospect Person", "email": "prospect@acme.com"},
+        ],
+        "summary": {
+            "overview": "Discovery call about Acme's CRM needs.",
+            "action_items": action_items,
+            "keywords": ["CRM", "pricing"],
+            "outline": "1. Intro\n2. Needs\n3. Next steps",
+            "shorthand_bullet": "- Needs CRM\n- Wants pricing",
+            "bullet_gist": "Acme wants a CRM.",
+            "gist": "Acme CRM discovery call.",
+            "short_summary": "Acme discovery call.",
+        },
+        "sentences": [
+            {
+                "index": 0,
+                "speaker_name": "Alex",
+                "speaker_id": "1",
+                "text": "Thanks for joining today.",
+                "start_time": 0.0,
+                "end_time": 2.5,
+            },
+            {
+                "index": 1,
+                "speaker_name": "Prospect Person",
+                "speaker_id": "2",
+                "text": "Happy to be here.",
+                "start_time": 2.5,
+                "end_time": 4.0,
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# list_transcripts
+# ---------------------------------------------------------------------------
+
+
+class TestListTranscripts:
+    def test_returns_empty_page(self):
+        resp = _mock_http_response({"data": {"transcripts": []}})
+        with patch("integrations.fireflies.client.requests.request", return_value=resp):
+            page = list_transcripts(api_key="ff_test_key")
+        assert isinstance(page, TranscriptListPage)
+        assert page.transcripts == []
+        assert page.has_more is False
+
+    def test_returns_transcripts_summary_only(self):
+        payload = {"data": {"transcripts": [
+            {"id": "t1", "title": "Call 1", "date": "2026-06-01T10:00:00.000Z"},
+            {"id": "t2", "title": "Call 2", "date": "2026-06-02T10:00:00.000Z"},
+        ]}}
+        resp = _mock_http_response(payload)
+        with patch("integrations.fireflies.client.requests.request", return_value=resp):
+            page = list_transcripts(api_key="ff_test_key")
+        assert len(page.transcripts) == 2
+        assert page.transcripts[0].id == "t1"
+        assert page.transcripts[1].title == "Call 2"
+
+    def test_has_more_true_when_page_full(self):
+        payload = {"data": {"transcripts": [
+            {"id": f"t{i}", "title": f"Call {i}", "date": "2026-06-01T10:00:00.000Z"}
+            for i in range(3)
+        ]}}
+        resp = _mock_http_response(payload)
+        with patch("integrations.fireflies.client.requests.request", return_value=resp):
+            page = list_transcripts(api_key="ff_test_key", limit=3)
+        assert page.has_more is True
+
+    def test_has_more_false_when_page_partial(self):
+        payload = {"data": {"transcripts": [
+            {"id": "t1", "title": "Call 1", "date": "2026-06-01T10:00:00.000Z"},
+        ]}}
+        resp = _mock_http_response(payload)
+        with patch("integrations.fireflies.client.requests.request", return_value=resp):
+            page = list_transcripts(api_key="ff_test_key", limit=50)
+        assert page.has_more is False
+
+    def test_from_date_passed_as_graphql_variable(self):
+        resp = _mock_http_response({"data": {"transcripts": []}})
+        captured = {}
+
+        def fake_request(method, url, headers=None, json=None, timeout=None, **kw):
+            captured["json"] = json
+            return resp
+
+        with patch("integrations.fireflies.client.requests.request", side_effect=fake_request):
+            since = datetime(2026, 6, 1, tzinfo=timezone.utc)
+            list_transcripts(api_key="ff_test_key", since=since)
+
+        assert captured["json"]["variables"]["fromDate"].startswith("2026-06-01")
+
+    def test_skip_passed_as_graphql_variable(self):
+        resp = _mock_http_response({"data": {"transcripts": []}})
+        captured = {}
+
+        def fake_request(method, url, headers=None, json=None, timeout=None, **kw):
+            captured["json"] = json
+            return resp
+
+        with patch("integrations.fireflies.client.requests.request", side_effect=fake_request):
+            list_transcripts(api_key="ff_test_key", skip=50)
+
+        assert captured["json"]["variables"]["skip"] == 50
+
+    def test_limit_capped_at_fifty(self):
+        """Fireflies caps `limit` at 50 per page — requesting more must be clamped."""
+        resp = _mock_http_response({"data": {"transcripts": []}})
+        captured = {}
+
+        def fake_request(method, url, headers=None, json=None, timeout=None, **kw):
+            captured["json"] = json
+            return resp
+
+        with patch("integrations.fireflies.client.requests.request", side_effect=fake_request):
+            list_transcripts(api_key="ff_test_key", limit=500)
+
+        assert captured["json"]["variables"]["limit"] == 50
+
+    def test_bearer_header_sent(self):
+        resp = _mock_http_response({"data": {"transcripts": []}})
+        captured = {}
+
+        def fake_request(method, url, headers=None, json=None, timeout=None, **kw):
+            captured["headers"] = headers
+            return resp
+
+        with patch("integrations.fireflies.client.requests.request", side_effect=fake_request):
+            list_transcripts(api_key="ff_super_secret")
+
+        assert captured["headers"]["Authorization"] == "Bearer ff_super_secret"
+
+
+# ---------------------------------------------------------------------------
+# get_transcript
+# ---------------------------------------------------------------------------
+
+
+class TestGetTranscript:
+    def test_returns_full_transcript(self):
+        payload = {"data": {"transcript": _transcript_payload()}}
+        resp = _mock_http_response(payload)
+        with patch("integrations.fireflies.client.requests.request", return_value=resp):
+            t = get_transcript("abc123", api_key="ff_test_key")
+        assert isinstance(t, FirefliesTranscript)
+        assert t.id == "abc123"
+        assert t.title == "Sales call with Acme"
+        assert t.summary.action_items.startswith("- Follow up")
+        assert len(t.sentences) == 2
+        assert t.sentences[0].speaker_name == "Alex"
+        assert len(t.meeting_attendees) == 2
+        assert t.meeting_attendees[0].email == "alex@example.com"
+
+    def test_account_attribution_defaults_to_primary(self):
+        payload = {"data": {"transcript": _transcript_payload()}}
+        resp = _mock_http_response(payload)
+        with patch("integrations.fireflies.client.requests.request", return_value=resp):
+            t = get_transcript("abc123", api_key="ff_test_key")
+        assert t.fireflies_account == ACCOUNT_PRIMARY
+
+    def test_account_attribution_explicit(self):
+        payload = {"data": {"transcript": _transcript_payload()}}
+        resp = _mock_http_response(payload)
+        with patch("integrations.fireflies.client.requests.request", return_value=resp):
+            t = get_transcript("abc123", api_key="ff_test_key", fireflies_account="jake")
+        assert t.fireflies_account == "jake"
+
+    def test_missing_transcript_raises_not_found(self):
+        payload = {"data": {"transcript": None}}
+        resp = _mock_http_response(payload)
+        with patch("integrations.fireflies.client.requests.request", return_value=resp):
+            with pytest.raises(FirefliesNotFoundError):
+                get_transcript("ghost", api_key="ff_test_key")
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    def test_401_raises_auth_error(self):
+        resp = _mock_http_response({}, status_code=401)
+        with patch("integrations.fireflies.client.requests.request", return_value=resp):
+            with pytest.raises(FirefliesAuthError):
+                list_transcripts(api_key="bad_key")
+
+    def test_403_raises_auth_error(self):
+        resp = _mock_http_response({}, status_code=403)
+        with patch("integrations.fireflies.client.requests.request", return_value=resp):
+            with pytest.raises(FirefliesAuthError):
+                list_transcripts(api_key="bad_key")
+
+    def test_graphql_error_array_raises_api_error(self):
+        """Fireflies (like most GraphQL APIs) can return HTTP 200 with an `errors` array."""
+        resp = _mock_http_response({"errors": [{"message": "Something went wrong"}]})
+        with patch("integrations.fireflies.client.requests.request", return_value=resp):
+            with pytest.raises(FirefliesAPIError):
+                list_transcripts(api_key="ff_test_key")
+
+    def test_graphql_auth_error_message_raises_auth_error(self):
+        resp = _mock_http_response({"errors": [{"message": "Unauthorized: invalid api key"}]})
+        with patch("integrations.fireflies.client.requests.request", return_value=resp):
+            with pytest.raises(FirefliesAuthError):
+                list_transcripts(api_key="bad_key")
+
+    def test_5xx_raises_api_error(self):
+        resp = _mock_http_response({}, status_code=500)
+        with patch("integrations.fireflies.client.requests.request", return_value=resp):
+            with pytest.raises(FirefliesAPIError) as exc_info:
+                list_transcripts(api_key="ff_test_key")
+        assert exc_info.value.status_code == 500
+
+    def test_retries_on_429_then_succeeds(self):
+        ok_resp = _mock_http_response({"data": {"transcripts": []}})
+        rate_limited_resp = _mock_http_response({}, status_code=429)
+        call_count = {"n": 0}
+
+        def fake_request(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] < 3:
+                return rate_limited_resp
+            return ok_resp
+
+        with patch("integrations.fireflies.client.requests.request", side_effect=fake_request), \
+             patch("integrations.fireflies.client.time.sleep"):
+            page = list_transcripts(api_key="ff_test_key")
+
+        assert call_count["n"] == 3
+        assert page.transcripts == []
+
+    def test_raises_rate_limit_after_max_retries(self):
+        resp = _mock_http_response({}, status_code=429)
+        with patch("integrations.fireflies.client.requests.request", return_value=resp), \
+             patch("integrations.fireflies.client.time.sleep"):
+            with pytest.raises(FirefliesAPIError):
+                list_transcripts(api_key="ff_test_key")
+
+    def test_missing_api_key_raises_value_error(self):
+        import os
+        original = os.environ.pop("FIREFLIES_API_KEY", None)
+        try:
+            with pytest.raises(ValueError, match="FIREFLIES_API_KEY"):
+                list_transcripts()
+        finally:
+            if original is not None:
+                os.environ["FIREFLIES_API_KEY"] = original
+
+
+# ---------------------------------------------------------------------------
+# iter_all_transcripts — pagination
+# ---------------------------------------------------------------------------
+
+
+class TestIterAllTranscripts:
+    def test_follows_pagination_until_partial_page(self):
+        page1 = {"data": {"transcripts": [
+            {"id": f"t{i}", "title": "x", "date": "2026-06-01T00:00:00.000Z"} for i in range(2)
+        ]}}
+        page2 = {"data": {"transcripts": [
+            {"id": "t2", "title": "x", "date": "2026-06-01T00:00:00.000Z"},
+        ]}}
+        responses = [_mock_http_response(page1), _mock_http_response(page2)]
+
+        def fake_request(*args, **kwargs):
+            return responses.pop(0)
+
+        with patch("integrations.fireflies.client.requests.request", side_effect=fake_request):
+            transcripts = iter_all_transcripts(api_key="ff_test_key", limit=2)
+
+        assert [t.id for t in transcripts] == ["t0", "t1", "t2"]
+
+
+# ---------------------------------------------------------------------------
+# Multi-account support — dynamic FIREFLIES_API_KEY_<NAME> discovery
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAccountConfigsFromEnv:
+    def test_empty_env_returns_empty(self):
+        assert build_account_configs_from_env({}) == []
+
+    def test_missing_primary_key_returns_empty_even_with_named_keys(self):
+        env = {"FIREFLIES_API_KEY_JAKE": "ff_jake"}
+        assert build_account_configs_from_env(env) == []
+
+    def test_primary_only(self):
+        env = {"FIREFLIES_API_KEY": "ff_primary"}
+        configs = build_account_configs_from_env(env)
+        assert len(configs) == 1
+        assert configs[0] == FirefliesAccountConfig(name=ACCOUNT_PRIMARY, api_key="ff_primary")
+
+    def test_discovers_named_accounts_dynamically(self):
+        """
+        Regression test for the Granola bug: build_account_configs_from_env()
+        must NOT hardcode a fixed set of suffixes (e.g. only '_2'). Any
+        FIREFLIES_API_KEY_<NAME> env var must be picked up automatically.
+        """
+        env = {
+            "FIREFLIES_API_KEY": "ff_primary",
+            "FIREFLIES_API_KEY_JAKE": "ff_jake",
+            "FIREFLIES_API_KEY_BEN": "ff_ben",
+            "FIREFLIES_API_KEY_PRIYA": "ff_priya",
+        }
+        configs = build_account_configs_from_env(env)
+        names = {c.name for c in configs}
+        assert names == {ACCOUNT_PRIMARY, "jake", "ben", "priya"}
+
+    def test_named_account_keys_correctly_attributed(self):
+        env = {
+            "FIREFLIES_API_KEY": "ff_primary",
+            "FIREFLIES_API_KEY_JAKE": "ff_jake_key",
+        }
+        configs = build_account_configs_from_env(env)
+        by_name = {c.name: c.api_key for c in configs}
+        assert by_name["jake"] == "ff_jake_key"
+        assert by_name[ACCOUNT_PRIMARY] == "ff_primary"
+
+    def test_primary_account_always_first(self):
+        env = {
+            "FIREFLIES_API_KEY": "ff_primary",
+            "FIREFLIES_API_KEY_ZEBRA": "ff_zebra",
+            "FIREFLIES_API_KEY_AARDVARK": "ff_aardvark",
+        }
+        configs = build_account_configs_from_env(env)
+        assert configs[0].name == ACCOUNT_PRIMARY
+
+    def test_named_accounts_deterministically_ordered(self):
+        env = {
+            "FIREFLIES_API_KEY": "ff_primary",
+            "FIREFLIES_API_KEY_ZEBRA": "ff_zebra",
+            "FIREFLIES_API_KEY_AARDVARK": "ff_aardvark",
+        }
+        configs = build_account_configs_from_env(env)
+        names = [c.name for c in configs]
+        assert names == [ACCOUNT_PRIMARY, "aardvark", "zebra"]
+
+    def test_blank_named_key_is_ignored(self):
+        env = {
+            "FIREFLIES_API_KEY": "ff_primary",
+            "FIREFLIES_API_KEY_JAKE": "   ",
+        }
+        configs = build_account_configs_from_env(env)
+        assert len(configs) == 1
+
+    def test_defaults_to_os_environ_when_none_passed(self, monkeypatch):
+        monkeypatch.setenv("FIREFLIES_API_KEY", "ff_from_os_environ")
+        configs = build_account_configs_from_env()
+        assert configs[0].api_key == "ff_from_os_environ"
+
+
+class TestIterAllTranscriptsForAccount:
+    def test_uses_the_accounts_api_key(self):
+        resp = _mock_http_response({"data": {"transcripts": []}})
+        captured = {}
+
+        def fake_request(method, url, headers=None, json=None, timeout=None, **kw):
+            captured["headers"] = headers
+            return resp
+
+        account = FirefliesAccountConfig(name="jake", api_key="ff_jakes_key")
+        with patch("integrations.fireflies.client.requests.request", side_effect=fake_request):
+            iter_all_transcripts_for_account(account)
+
+        assert captured["headers"]["Authorization"] == "Bearer ff_jakes_key"
+
+    def test_attributes_transcripts_to_the_account(self):
+        payload = {"data": {"transcripts": [
+            {"id": "t1", "title": "x", "date": "2026-06-01T00:00:00.000Z"},
+        ]}}
+        resp = _mock_http_response(payload)
+        account = FirefliesAccountConfig(name="jake", api_key="ff_jakes_key")
+        with patch("integrations.fireflies.client.requests.request", return_value=resp):
+            transcripts = iter_all_transcripts_for_account(account)
+        assert transcripts[0].fireflies_account == "jake"
+
+
+class TestFirefliesUnknownAccountError:
+    def test_is_a_key_error(self):
+        assert issubclass(FirefliesUnknownAccountError, KeyError)
+
+    def test_message_contains_account_name(self):
+        err = FirefliesUnknownAccountError("phantom")
+        assert "phantom" in str(err)

--- a/tests/unit/test_fireflies_serializer.py
+++ b/tests/unit/test_fireflies_serializer.py
@@ -1,0 +1,175 @@
+"""
+Tests for src/integrations/fireflies/serializer.py — pure Markdown/frontmatter
+generation, no I/O. Written before the implementation (TDD).
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+_SRC_DIR = Path(__file__).parent.parent.parent / "src"
+sys.path.insert(0, str(_SRC_DIR))
+
+from integrations.fireflies.client import (  # noqa: E402
+    ACCOUNT_PRIMARY,
+    FirefliesAttendee,
+    FirefliesSentence,
+    FirefliesSummary,
+    FirefliesTranscript,
+)
+from integrations.fireflies.serializer import (  # noqa: E402
+    transcript_filename,
+    transcript_to_markdown,
+    transcript_vault_path,
+)
+
+
+def _make_transcript(
+    tid: str = "abc123",
+    title: str = "Sales call with Acme",
+    date: datetime = datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc),
+    account: str = ACCOUNT_PRIMARY,
+    action_items: str = "- Follow up with Acme on pricing\n- Send proposal by Friday",
+) -> FirefliesTranscript:
+    return FirefliesTranscript(
+        id=tid,
+        title=title,
+        date=date,
+        duration=1800,
+        transcript_url="https://app.fireflies.ai/view/abc123",
+        meeting_link="https://meet.google.com/xyz",
+        host_email="alex@example.com",
+        organizer_email="alex@example.com",
+        participants=["alex@example.com", "prospect@acme.com"],
+        meeting_attendees=[
+            FirefliesAttendee(name="Alex", email="alex@example.com"),
+            FirefliesAttendee(name="Prospect Person", email="prospect@acme.com"),
+        ],
+        summary=FirefliesSummary(
+            overview="Discovery call about Acme's CRM needs.",
+            action_items=action_items,
+            keywords=["CRM", "pricing"],
+            outline="1. Intro\n2. Needs\n3. Next steps",
+        ),
+        sentences=[
+            FirefliesSentence(
+                index=0, speaker_name="Alex", speaker_id="1",
+                text="Thanks for joining today.", start_time=0.0, end_time=2.5,
+            ),
+            FirefliesSentence(
+                index=1, speaker_name="Prospect Person", speaker_id="2",
+                text="Happy to be here.", start_time=2.5, end_time=4.0,
+            ),
+        ],
+        fireflies_account=account,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Filenames / vault paths
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptFilename:
+    def test_filename_format(self):
+        t = _make_transcript()
+        assert transcript_filename(t) == "2026-06-01-sales-call-with-acme.md"
+
+    def test_untitled_falls_back(self):
+        t = _make_transcript(title="")
+        # FirefliesTranscript defaults title to "" here directly (not via parser),
+        # serializer must still produce a safe filename.
+        assert transcript_filename(t).endswith(".md")
+        assert " " not in transcript_filename(t)
+
+
+class TestTranscriptVaultPath:
+    def test_path_uses_fireflies_root_and_year_month(self):
+        t = _make_transcript()
+        assert transcript_vault_path(t) == "fireflies/2026/06/2026-06-01-sales-call-with-acme.md"
+
+    def test_path_falls_back_to_untitled_date_when_date_missing(self):
+        t = _make_transcript(date=None)
+        path = transcript_vault_path(t)
+        assert path.startswith("fireflies/")
+        assert path.endswith(".md")
+
+
+# ---------------------------------------------------------------------------
+# Markdown body / frontmatter
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptToMarkdown:
+    def test_frontmatter_contains_core_fields(self):
+        t = _make_transcript()
+        md = t and transcript_to_markdown(t)
+        assert "id: abc123" in md
+        assert 'title: "Sales call with Acme"' in md
+        assert "source: fireflies" in md
+        assert f"fireflies_account: {ACCOUNT_PRIMARY}" in md
+
+    def test_named_account_in_frontmatter(self):
+        t = _make_transcript(account="jake")
+        md = transcript_to_markdown(t)
+        assert "fireflies_account: jake" in md
+
+    def test_title_heading_in_body(self):
+        t = _make_transcript()
+        md = transcript_to_markdown(t)
+        assert "# Sales call with Acme" in md
+
+    def test_action_items_section_present(self):
+        """
+        The 'summarize sales calls and turn them into a CRM with next actions'
+        ask means action_items must be a clearly labelled, easy-to-find section
+        — not buried inside a generic summary blob.
+        """
+        t = _make_transcript()
+        md = transcript_to_markdown(t)
+        assert "## Action Items" in md
+        assert "Follow up with Acme on pricing" in md
+        assert "Send proposal by Friday" in md
+
+    def test_no_action_items_shows_placeholder(self):
+        t = _make_transcript(action_items="")
+        md = transcript_to_markdown(t)
+        assert "## Action Items" in md
+        assert "_No action items" in md
+
+    def test_overview_section_present(self):
+        t = _make_transcript()
+        md = transcript_to_markdown(t)
+        assert "## Overview" in md
+        assert "Discovery call about Acme's CRM needs." in md
+
+    def test_transcript_section_present(self):
+        t = _make_transcript()
+        md = transcript_to_markdown(t)
+        assert "## Transcript" in md
+        assert "**Alex**" in md
+        assert "Thanks for joining today." in md
+        assert "**Prospect Person**" in md
+
+    def test_no_sentences_shows_placeholder(self):
+        t = _make_transcript()
+        t_no_sentences = FirefliesTranscript(
+            id=t.id, title=t.title, date=t.date, sentences=[],
+        )
+        md = transcript_to_markdown(t_no_sentences)
+        assert "_No transcript available._" in md
+
+    def test_attendees_in_frontmatter(self):
+        t = _make_transcript()
+        md = transcript_to_markdown(t)
+        assert '"Alex"' in md
+        assert '"alex@example.com"' in md
+
+    def test_transcript_url_in_frontmatter(self):
+        t = _make_transcript()
+        md = transcript_to_markdown(t)
+        assert "https://app.fireflies.ai/view/abc123" in md

--- a/tests/unit/test_fireflies_sync.py
+++ b/tests/unit/test_fireflies_sync.py
@@ -1,0 +1,222 @@
+"""
+Tests for src/integrations/fireflies/sync.py
+
+Covers:
+1. _merge_transcripts_deduplicated — pure merge/dedup across accounts
+2. _fetch_transcripts_with_detail — per-account API key routing (regression
+   test for the Granola bug where the wrong account's key could be used)
+3. run_sync — end-to-end orchestration with mocked client/vault_writer calls
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_SRC_DIR = Path(__file__).parent.parent.parent / "src"
+sys.path.insert(0, str(_SRC_DIR))
+
+from integrations.fireflies.client import (  # noqa: E402
+    ACCOUNT_PRIMARY,
+    FirefliesAccountConfig,
+    FirefliesAPIError,
+    FirefliesAuthError,
+    FirefliesTranscript,
+    FirefliesUnknownAccountError,
+)
+from integrations.fireflies.sync import (  # noqa: E402
+    _fetch_transcripts_with_detail,
+    _merge_transcripts_deduplicated,
+    run_sync,
+)
+
+
+def _make_transcript(tid: str = "t1", title: str = "Call", account: str = ACCOUNT_PRIMARY) -> FirefliesTranscript:
+    return FirefliesTranscript(
+        id=tid,
+        title=title,
+        date=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        fireflies_account=account,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _merge_transcripts_deduplicated
+# ---------------------------------------------------------------------------
+
+
+class TestMergeTranscriptsDeduplicated:
+    def test_non_overlapping_all_kept(self):
+        result = _merge_transcripts_deduplicated({
+            ACCOUNT_PRIMARY: [_make_transcript("a"), _make_transcript("b")],
+            "jake": [_make_transcript("c", account="jake")],
+        })
+        assert {t.id for t in result} == {"a", "b", "c"}
+
+    def test_primary_wins_on_duplicate_id(self):
+        shared_id = "shared"
+        primary_t = _make_transcript(shared_id, title="primary version", account=ACCOUNT_PRIMARY)
+        jake_t = _make_transcript(shared_id, title="jake version", account="jake")
+        result = _merge_transcripts_deduplicated({
+            ACCOUNT_PRIMARY: [primary_t],
+            "jake": [jake_t],
+        })
+        assert len(result) == 1
+        assert result[0].title == "primary version"
+
+    def test_empty_accounts_returns_empty(self):
+        assert _merge_transcripts_deduplicated({}) == []
+
+    def test_account_field_preserved(self):
+        result = _merge_transcripts_deduplicated({
+            ACCOUNT_PRIMARY: [_make_transcript("a", account=ACCOUNT_PRIMARY)],
+            "ben": [_make_transcript("b", account="ben")],
+        })
+        by_id = {t.id: t for t in result}
+        assert by_id["a"].fireflies_account == ACCOUNT_PRIMARY
+        assert by_id["b"].fireflies_account == "ben"
+
+    def test_many_named_accounts_all_merged(self):
+        """
+        Unlike Granola's merge (hardcoded to 'primary'/'secondary'), this must
+        handle an arbitrary number of named accounts since Fireflies account
+        discovery is dynamic.
+        """
+        result = _merge_transcripts_deduplicated({
+            ACCOUNT_PRIMARY: [_make_transcript("a")],
+            "jake": [_make_transcript("b", account="jake")],
+            "ben": [_make_transcript("c", account="ben")],
+            "priya": [_make_transcript("d", account="priya")],
+        })
+        assert {t.id for t in result} == {"a", "b", "c", "d"}
+
+
+# ---------------------------------------------------------------------------
+# _fetch_transcripts_with_detail — per-account API key routing
+# ---------------------------------------------------------------------------
+
+PRIMARY_KEY = "ff_primary_key"
+JAKE_KEY = "ff_jake_key"
+
+
+class TestFetchTranscriptsWithDetail:
+    def _accounts(self) -> list[FirefliesAccountConfig]:
+        return [
+            FirefliesAccountConfig(name=ACCOUNT_PRIMARY, api_key=PRIMARY_KEY),
+            FirefliesAccountConfig(name="jake", api_key=JAKE_KEY),
+        ]
+
+    @patch("integrations.fireflies.sync.get_transcript")
+    def test_primary_account_uses_primary_key(self, mock_get):
+        t = _make_transcript("a", account=ACCOUNT_PRIMARY)
+        mock_get.return_value = t
+        _fetch_transcripts_with_detail([t], self._accounts())
+        assert mock_get.call_args.kwargs.get("api_key") == PRIMARY_KEY
+
+    @patch("integrations.fireflies.sync.get_transcript")
+    def test_named_account_uses_its_own_key(self, mock_get):
+        t = _make_transcript("b", account="jake")
+        mock_get.return_value = t
+        _fetch_transcripts_with_detail([t], self._accounts())
+        assert mock_get.call_args.kwargs.get("api_key") == JAKE_KEY
+
+    @patch("integrations.fireflies.sync.get_transcript")
+    def test_unknown_account_raises_not_silent_fallback(self, mock_get):
+        t = _make_transcript("x", account="ghost")
+        with pytest.raises(FirefliesUnknownAccountError):
+            _fetch_transcripts_with_detail([t], self._accounts())
+        mock_get.assert_not_called()
+
+    @patch("integrations.fireflies.sync.get_transcript")
+    def test_api_error_falls_back_to_summary(self, mock_get):
+        t = _make_transcript("a", account=ACCOUNT_PRIMARY)
+        mock_get.side_effect = FirefliesAPIError(500, "boom")
+        result = _fetch_transcripts_with_detail([t], self._accounts())
+        assert result == [t]
+
+
+# ---------------------------------------------------------------------------
+# run_sync — end to end with mocked account discovery / client / vault writer
+# ---------------------------------------------------------------------------
+
+
+class TestRunSync:
+    def test_no_accounts_configured_returns_failed(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("integrations.fireflies.sync.build_account_configs_from_env", lambda: [])
+        monkeypatch.setattr("integrations.fireflies.sync._STATE_FILE", tmp_path / "state.json")
+        result = run_sync()
+        assert result["status"] == "failed"
+        assert "FIREFLIES_API_KEY" in result["message"]
+
+    def test_auth_error_returns_failed(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "integrations.fireflies.sync.build_account_configs_from_env",
+            lambda: [FirefliesAccountConfig(name=ACCOUNT_PRIMARY, api_key="bad")],
+        )
+        monkeypatch.setattr("integrations.fireflies.sync._STATE_FILE", tmp_path / "state.json")
+        monkeypatch.setattr(
+            "integrations.fireflies.sync.iter_all_transcripts_for_account",
+            MagicMock(side_effect=FirefliesAuthError()),
+        )
+        result = run_sync()
+        assert result["status"] == "failed"
+
+    def test_no_new_transcripts_returns_success_with_zero(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "integrations.fireflies.sync.build_account_configs_from_env",
+            lambda: [FirefliesAccountConfig(name=ACCOUNT_PRIMARY, api_key="k")],
+        )
+        monkeypatch.setattr("integrations.fireflies.sync._STATE_FILE", tmp_path / "state.json")
+        monkeypatch.setattr(
+            "integrations.fireflies.sync.iter_all_transcripts_for_account",
+            MagicMock(return_value=[]),
+        )
+        result = run_sync()
+        assert result["status"] == "success"
+        assert result["transcripts_written"] == 0
+
+    def test_dry_run_does_not_write_or_persist_state(self, tmp_path, monkeypatch):
+        state_file = tmp_path / "state.json"
+        t = _make_transcript("a")
+        monkeypatch.setattr(
+            "integrations.fireflies.sync.build_account_configs_from_env",
+            lambda: [FirefliesAccountConfig(name=ACCOUNT_PRIMARY, api_key="k")],
+        )
+        monkeypatch.setattr("integrations.fireflies.sync._STATE_FILE", state_file)
+        monkeypatch.setattr(
+            "integrations.fireflies.sync.iter_all_transcripts_for_account",
+            MagicMock(return_value=[t]),
+        )
+        monkeypatch.setattr("integrations.fireflies.sync.get_transcript", MagicMock(return_value=t))
+
+        result = run_sync(dry_run=True)
+        assert result["status"] == "dry_run"
+        assert not state_file.exists()
+
+    def test_successful_sync_writes_to_vault_and_updates_state(self, tmp_path, monkeypatch):
+        state_file = tmp_path / "state.json"
+        vault_path = tmp_path / "vault"
+        t = _make_transcript("a", title="Real Call")
+        monkeypatch.setattr(
+            "integrations.fireflies.sync.build_account_configs_from_env",
+            lambda: [FirefliesAccountConfig(name=ACCOUNT_PRIMARY, api_key="k")],
+        )
+        monkeypatch.setattr("integrations.fireflies.sync._STATE_FILE", state_file)
+        monkeypatch.setattr("integrations.fireflies.sync._VAULT_PATH", vault_path)
+        monkeypatch.setattr(
+            "integrations.fireflies.sync.iter_all_transcripts_for_account",
+            MagicMock(return_value=[t]),
+        )
+        monkeypatch.setattr("integrations.fireflies.sync.get_transcript", MagicMock(return_value=t))
+
+        result = run_sync()
+
+        assert result["status"] == "success"
+        assert result["transcripts_written"] == 1
+        assert state_file.exists()
+        written_file = vault_path / "fireflies" / "2026" / "06" / "2026-06-01-real-call.md"
+        assert written_file.exists()

--- a/tests/unit/test_fireflies_vault_writer.py
+++ b/tests/unit/test_fireflies_vault_writer.py
@@ -1,0 +1,86 @@
+"""
+Tests for src/integrations/fireflies/vault_writer.py
+
+Uses a real tmp_path as the vault root (fast, no mocking needed for
+filesystem ops) but mocks subprocess/git calls are exercised for real since
+git is available in the test environment and operations are cheap.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+_SRC_DIR = Path(__file__).parent.parent.parent / "src"
+sys.path.insert(0, str(_SRC_DIR))
+
+from integrations.fireflies.client import ACCOUNT_PRIMARY, FirefliesTranscript  # noqa: E402
+from integrations.fireflies.vault_writer import write_transcript, write_transcripts_batch  # noqa: E402
+
+
+def _make_transcript(tid: str = "abc123", title: str = "Sales call") -> FirefliesTranscript:
+    return FirefliesTranscript(
+        id=tid,
+        title=title,
+        date=datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc),
+    )
+
+
+class TestWriteTranscript:
+    def test_writes_new_file(self, tmp_path: Path):
+        t = _make_transcript()
+        was_written, detail = write_transcript(t, vault_path=tmp_path)
+        assert was_written is True
+        expected = tmp_path / "fireflies" / "2026" / "06" / "2026-06-01-sales-call.md"
+        assert expected.exists()
+        assert "id: abc123" in expected.read_text()
+
+    def test_unchanged_content_is_skipped(self, tmp_path: Path):
+        t = _make_transcript()
+        write_transcript(t, vault_path=tmp_path)
+        was_written, detail = write_transcript(t, vault_path=tmp_path)
+        assert was_written is False
+        assert detail == "unchanged"
+
+    def test_changed_title_rewrites_file(self, tmp_path: Path):
+        t1 = _make_transcript(title="Old Title")
+        t2 = FirefliesTranscript(id="abc123", title="Old Title", date=t1.date)
+        write_transcript(t1, vault_path=tmp_path)
+
+        # Same path (title unchanged) but different content (e.g. new action items)
+        t3 = FirefliesTranscript(
+            id="abc123", title="Old Title", date=t1.date,
+            host_email="new@example.com",
+        )
+        was_written, _ = write_transcript(t3, vault_path=tmp_path)
+        assert was_written is True
+
+
+class TestWriteTranscriptsBatch:
+    def test_writes_all_and_commits(self, tmp_path: Path):
+        transcripts = [_make_transcript("t1", "Call One"), _make_transcript("t2", "Call Two")]
+        result = write_transcripts_batch(transcripts, vault_path=tmp_path, commit=True)
+        assert result.n_written == 2
+        assert result.n_skipped == 0
+        assert result.n_errors == 0
+        assert result.committed is True
+
+    def test_second_run_skips_unchanged(self, tmp_path: Path):
+        transcripts = [_make_transcript("t1", "Call One")]
+        write_transcripts_batch(transcripts, vault_path=tmp_path, commit=True)
+        result = write_transcripts_batch(transcripts, vault_path=tmp_path, commit=True)
+        assert result.n_written == 0
+        assert result.n_skipped == 1
+
+    def test_commit_false_does_not_commit(self, tmp_path: Path):
+        transcripts = [_make_transcript("t1", "Call One")]
+        result = write_transcripts_batch(transcripts, vault_path=tmp_path, commit=False)
+        assert result.committed is False
+
+    def test_git_repo_initialised(self, tmp_path: Path):
+        transcripts = [_make_transcript("t1", "Call One")]
+        write_transcripts_batch(transcripts, vault_path=tmp_path, commit=True)
+        assert (tmp_path / ".git").exists()


### PR DESCRIPTION
## Problem

An Eloso team member asked in Slack whether Wallace can pull Fireflies call transcripts and turn them into a CRM with next actions. There was no Fireflies integration in the repo at all — only Granola (`src/integrations/granola/`).

## What this does

Adds `src/integrations/fireflies/` — a GraphQL client, Markdown serializer, idempotent Obsidian vault writer, and incremental sync entry point — mirroring the existing Granola integration's shape and conventions (same HTTP/retry pattern, same `granola/YYYY/MM/...`-style vault layout, same account-attribution approach). No existing file is modified; this is purely additive.

**Auth model:** Fireflies uses bearer-token GraphQL auth (`Authorization: Bearer <key>` against `https://api.fireflies.ai/graphql`), confirmed against the public docs at docs.fireflies.ai. `transcripts` (list) is paginated via `skip`/`limit`, capped at 50/page per Fireflies' documented limit — the client clamps any larger requested limit down to 50 rather than sending an invalid value.

**Multi-account discovery is dynamic, not hardcoded.** While reading Granola's integration for the pattern to follow, I found `build_account_configs_from_env()` there only recognizes `GRANOLA_API_KEY`/`GRANOLA_API_KEY_2` — it silently ignores `GRANOLA_API_KEY_JAKE`/`GRANOLA_API_KEY_BEN`, which are already set in `config.env`. That bug is not reproduced here: Fireflies' `build_account_configs_from_env()` scans the environment for any `FIREFLIES_API_KEY_<NAME>` variable and registers it automatically (alphabetically ordered after primary, for deterministic output). Adding a new teammate's account is a config.env edit, not a code change. (I did not fix the pre-existing Granola bug in this PR — that's a separate, already-tracked issue — but I made sure not to copy the same failure mode.)

**Action items get top billing.** The driving use case is "summarize sales calls and turn them into a CRM with next actions," so each vault note leads with a dedicated `## Action Items` section (Fireflies' own AI-generated `summary.action_items` field) before the general overview and full transcript — not folded into a generic summary blob where it's easy to miss.

**No live cron job yet.** `scheduled-tasks/fireflies-sync.sh` + `scheduled-tasks/tasks/fireflies-sync.md` are committed (mirrors `granola-sync.sh`/`granola-sync.md`), but I deliberately did not call `create_scheduled_job` to install a live systemd timer, since no `FIREFLIES_API_KEY` exists yet — installing a 30-minute timer with nothing to poll would just generate repeated no-op/failure noise. The wrapper script itself guards against this too: it exits 0 (not a failure) when `FIREFLIES_API_KEY` is unset, so once it is activated it won't false-alarm during any gap before the key lands.

## What Drew needs to do to make this operational

1. Get a Fireflies API key: log into the Fireflies account → **Integrations** → **Fireflies API** → copy the key.
2. Add to `~/lobster-config/config.env`:
   - `FIREFLIES_API_KEY=<primary account's key>`
   - Optionally, for teammates: `FIREFLIES_API_KEY_JAKE=...`, `FIREFLIES_API_KEY_BEN=...`, etc. — any suffix works, no code change needed.
3. Once at least `FIREFLIES_API_KEY` is set, ask me (or run directly) `uv run python -m integrations.fireflies.sync --dry-run` to confirm connectivity, then activate the 30-minute sync via `create_scheduled_job` (details in `scheduled-tasks/tasks/fireflies-sync.md`).

## Functional patterns used

Immutable frozen dataclasses for all domain types (`FirefliesTranscript`, `FirefliesAccountConfig`, etc.); pure parsing/serialization functions with no I/O (`_parse_transcript`, `transcript_to_markdown`, `_merge_transcripts_deduplicated`); side effects (HTTP, filesystem, git) isolated to the boundary functions (`_call_api`, `write_transcript`, `_git_commit`); no mutation of caller-provided dicts/lists.

## Out of scope

- No changes to the existing Granola integration or its known account-discovery bug (separate, already-tracked issue).
- No live systemd timer installed (see above — deliberate, pending the API key).
- No LLM-based summarization layer on top of Fireflies' own summary/action_items — this PR is the ingest/sync layer only, matching how Granola's sync is scoped.
- This is not a multi-step flow/state-machine change (no existing behavior altered), so no before/after flow diagram is included.

## Tests run

- [x] `uv run pytest tests/unit/test_fireflies_client.py tests/unit/test_fireflies_serializer.py tests/unit/test_fireflies_vault_writer.py tests/unit/test_fireflies_sync.py -q` — 69 passed, 0 failed (34 client, 14 serializer, 7 vault writer, 14 sync)
- [x] Falsifiability check: `src/integrations/fireflies/` implementation directory removed, all 4 test files failed on collection (`ModuleNotFoundError`) confirming the tests are not vacuous; implementation restored, all 69 passed again
- [x] `uv run pytest tests/unit/test_granola_client.py tests/unit/test_granola_multi_account.py tests/unit/test_granola_sync_multi_account.py tests/unit/test_granola_storage.py tests/unit/test_granola_state.py tests/unit/test_granola_archive_multi_account.py -q` — 98 passed, 0 failed (regression check on the adjacent integration; no existing file was touched, so this is a sanity check, not an expectation of change)
- [ ] Full `tests/unit/` suite — attempted, hung past 2 minutes on something unrelated to this change (pytest.ini references a `timeout` option but the `pytest-timeout` plugin isn't installed in this environment, so a pre-existing hanging test elsewhere in the suite blocks indefinitely rather than timing out). Killed the run rather than debug an unrelated pre-existing issue. Scoped test runs above cover every file this PR touches or is adjacent to.
- [ ] Live Fireflies API call — blocked: no `FIREFLIES_API_KEY` exists yet (see "What Drew needs to do" above). All HTTP interaction is exercised via mocked `requests.request` in the client tests instead (list, get, pagination, 401/403, GraphQL `errors` array incl. auth-shaped messages, 429 retry-then-succeed, retry exhaustion, missing key).

**Blocked items needing attention before merge:** none — the two unchecked items above are expected/documented gaps (pre-existing test-suite issue unrelated to this change; no API key yet), not blockers to merging this integration.

## Manual test

No systemd/cron unit was installed live (see above), no external service was actually called (no key available), and no production runtime state was touched — vault writes were only exercised via `tmp_path` fixtures in `test_fireflies_vault_writer.py` and `test_fireflies_sync.py`, never against the real Obsidian vault. Once `FIREFLIES_API_KEY` is added, recommend running `uv run python -m integrations.fireflies.sync --dry-run` first (fetches but does not write/commit) before enabling the scheduled job.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [ ] Integration/manual test run — blocked on Drew providing `FIREFLIES_API_KEY` (see above)
- [ ] User-visible outcome verified — not yet possible without a real key; recommend a `--dry-run` + review of one written vault note once the key is added
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume (no live timer installed; wrapper no-ops without a key)
- [x] External service calls: mocked in all automated tests; no manual run was made against the real Fireflies API (none was available)

Closes #2110