### PR TITLE
Consolidate jq --arg JSON-escaping into one shared helper (#2111 retarget)

### DIFF
--- a/scripts/alert.sh
+++ b/scripts/alert.sh
@@ -11,10 +11,15 @@
 
 MESSAGES_DIR="${LOBSTER_MESSAGES:-$HOME/messages}"
 WORKSPACE_DIR="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
+LOBSTER_INSTALL_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
 
 ALERT_LOG="$WORKSPACE_DIR/logs/alerts.log"
 OUTBOX_DIR="$MESSAGES_DIR/outbox"
 ADMIN_CHAT_ID="${LOBSTER_ADMIN_CHAT_ID:-}"
+
+# Shared jq --arg JSON builder (BIS-724, scripts/lib/json_message.sh) — single
+# source of truth for jq-arg-safe JSON construction, see PR history for #2004.
+source "$LOBSTER_INSTALL_DIR/scripts/lib/json_message.sh"
 
 # Ensure directories exist
 mkdir -p "$(dirname "$ALERT_LOG")"
@@ -34,14 +39,11 @@ if [[ -n "$ADMIN_CHAT_ID" ]]; then
 $message
 
 _$(date)_"
-    jq -n \
+    _json_build_message \
         --argjson chat_id "$ADMIN_CHAT_ID" \
         --arg text "$alert_text" \
-        '{
-            "chat_id": $chat_id,
-            "text": $text,
-            "source": "telegram"
-        }' > "$alert_file"
+        --arg source "telegram" \
+        > "$alert_file"
     echo "[$timestamp] Alert sent to Telegram chat $ADMIN_CHAT_ID" >> "$ALERT_LOG"
 fi
 

--- a/scripts/check-agent-outputs.sh
+++ b/scripts/check-agent-outputs.sh
@@ -48,6 +48,10 @@ COMPLETION_THRESHOLD_SECONDS=120
 mkdir -p "$STATE_DIR" "$INBOX_DIR"
 touch "$NOTIFIED_FILE" 2>/dev/null || true
 
+# Shared jq --arg JSON builder (BIS-724, scripts/lib/json_message.sh) — single
+# source of truth for jq-arg-safe JSON construction, see PR history for #2004.
+source "${LOBSTER_INSTALL_DIR:-$HOME/lobster}/scripts/lib/json_message.sh"
+
 # Bail early if pending-agents.json doesn't exist or has no agents
 if [ ! -f "$PENDING_AGENTS_FILE" ]; then
     exit 0
@@ -115,21 +119,17 @@ while IFS= read -r agent_id; do
     # Safely escape agent_id for JSON (alphanumeric + hyphens only expected)
     SAFE_ID=$(echo "$agent_id" | tr -cd 'a-zA-Z0-9_-')
 
-    jq -n \
+    _json_build_message \
         --arg id "${MSG_ID}" \
+        --arg source "system" \
+        --arg type "health_check" \
+        --argjson chat_id 0 \
+        --argjson user_id 0 \
+        --arg username "lobster-system" \
+        --arg user_name "Agent Relay" \
         --arg text "Agent relay check: ${SAFE_ID} output file appears complete. Check task-notifications and relay results to the user." \
         --arg timestamp "${TIMESTAMP}" \
-        '{
-            "id": $id,
-            "source": "system",
-            "type": "health_check",
-            "chat_id": 0,
-            "user_id": 0,
-            "username": "lobster-system",
-            "user_name": "Agent Relay",
-            "text": $text,
-            "timestamp": $timestamp
-        }' > "${INBOX_DIR}/${MSG_ID}.json"
+        > "${INBOX_DIR}/${MSG_ID}.json"
 
     # Mark this agent as notified to prevent re-injection
     echo "$agent_id" >> "$NOTIFIED_FILE"

--- a/scripts/daily-update-check.sh
+++ b/scripts/daily-update-check.sh
@@ -16,6 +16,10 @@ unset _LOBSTER_CONFIG _DEV_MODE
 LOBSTER_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
 INBOX="${LOBSTER_MESSAGES:-$HOME/messages}/inbox"
 
+# Shared jq --arg JSON builder (BIS-724, scripts/lib/json_message.sh) — single
+# source of truth for jq-arg-safe JSON construction, see PR history for #2004.
+source "$LOBSTER_DIR/scripts/lib/json_message.sh"
+
 cd "$LOBSTER_DIR"
 
 # Support both git and tarball installs
@@ -28,18 +32,14 @@ if [ -d "$LOBSTER_DIR/.git" ]; then
     if [ "$LOCAL" != "$REMOTE" ]; then
         BEHIND=$(git rev-list --count "$LOCAL..$REMOTE")
         TIMESTAMP=$(date +%s%3N)
-        jq -n \
+        _json_build_message \
             --arg id "${TIMESTAMP}_update_available" \
+            --arg source "system" \
+            --argjson chat_id 0 \
+            --arg type "update_notification" \
             --arg text "UPDATE AVAILABLE: Lobster is ${BEHIND} commits behind origin/main. Use check_updates for details." \
             --arg timestamp "$(date -Iseconds)" \
-            '{
-                "id": $id,
-                "source": "system",
-                "chat_id": 0,
-                "type": "update_notification",
-                "text": $text,
-                "timestamp": $timestamp
-            }' > "$INBOX/${TIMESTAMP}_update_available.json"
+            > "$INBOX/${TIMESTAMP}_update_available.json"
     fi
 else
     # Tarball mode: check GitHub Releases API
@@ -49,17 +49,13 @@ else
 
     if [ -n "$LATEST_VERSION" ] && [ "$LATEST_VERSION" != "$CURRENT_VERSION" ]; then
         TIMESTAMP=$(date +%s%3N)
-        jq -n \
+        _json_build_message \
             --arg id "${TIMESTAMP}_update_available" \
+            --arg source "system" \
+            --argjson chat_id 0 \
+            --arg type "update_notification" \
             --arg text "UPDATE AVAILABLE: Lobster v${CURRENT_VERSION} -> v${LATEST_VERSION}. Use check_updates for details." \
             --arg timestamp "$(date -Iseconds)" \
-            '{
-                "id": $id,
-                "source": "system",
-                "chat_id": 0,
-                "type": "update_notification",
-                "text": $text,
-                "timestamp": $timestamp
-            }' > "$INBOX/${TIMESTAMP}_update_available.json"
+            > "$INBOX/${TIMESTAMP}_update_available.json"
     fi
 fi

--- a/scripts/lib/json_message.sh
+++ b/scripts/lib/json_message.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#===============================================================================
+# Shared jq-safe JSON object builder (Linear BIS-724)
+#
+# Canonical single implementation of _json_build_message(): builds a flat
+# JSON object from a list of jq argument flags, always routing values through
+# jq --arg/--argjson so quotes, newlines, backslashes, and unicode in the
+# values are escaped into valid JSON. Before this file existed, this exact
+# `jq -n --arg ... '{...}'` shape was reimplemented independently in 4
+# scripts (periodic-self-check.sh, alert.sh, check-agent-outputs.sh,
+# daily-update-check.sh x2) — issue #2004 / PR #2016 / PR #2031 fixed a
+# broken-escaping bug at each site separately before this consolidation.
+#
+# NOTE: This is the single source of truth for jq-arg-safe JSON message
+# construction. Do NOT reimplement the `jq -n --arg ... '{...}'` pattern
+# inline in a new script; source this file and call _json_build_message
+# instead.
+#
+# The 4 call sites build different message shapes (different field sets:
+# inbox messages, outbox messages, with/without a "type" field, etc.), so
+# this helper does not hardcode a fixed schema. Instead it is a thin,
+# documented wrapper around jq's `$ARGS.named` object — every --arg/--argjson
+# flag you pass becomes one key in the resulting flat JSON object, in
+# whatever shape the caller needs.
+#
+# Usage:
+#   source "$(dirname "$0")/lib/json_message.sh"
+#   _json_build_message \
+#       --arg id "$MSG_ID" \
+#       --arg source "system" \
+#       --argjson chat_id 0 \
+#       --arg text "$TEXT" \
+#       --arg timestamp "$TIMESTAMP" \
+#     > "$OUTPUT_FILE"
+#
+# Use --arg for string values (the common case — always safely escaped).
+# Use --argjson for values that are already valid JSON literals (numbers,
+# booleans, 0/1 chat_id placeholders, etc.) — never interpolate those
+# directly into a filter string.
+#===============================================================================
+
+# _json_build_message [--arg NAME VALUE | --argjson NAME VALUE] ...
+#
+# Prints a flat JSON object to stdout with one key per NAME passed, using
+# jq's $ARGS.named so the caller never has to hand-write an object literal
+# (and therefore can never forget to route a value through --arg/--argjson).
+_json_build_message() {
+    jq -n "$@" '$ARGS.named'
+}

--- a/scripts/periodic-self-check.sh
+++ b/scripts/periodic-self-check.sh
@@ -138,20 +138,19 @@ TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%S.%6N)
 EPOCH_MS=$(date +%s%3N)
 MSG_ID="${EPOCH_MS}_self"
 
-jq -n \
+# Shared jq --arg JSON builder (BIS-724, scripts/lib/json_message.sh) — single
+# source of truth for jq-arg-safe JSON construction, see PR history for #2004.
+source "${LOBSTER_INSTALL_DIR:-$HOME/lobster}/scripts/lib/json_message.sh"
+_json_build_message \
     --arg id "${MSG_ID}" \
+    --arg source "system" \
+    --argjson chat_id 0 \
+    --argjson user_id 0 \
+    --arg username "lobster-system" \
+    --arg user_name "Self-Check" \
     --arg text "${SELF_CHECK_TEXT}" \
     --arg timestamp "${TIMESTAMP}" \
-    '{
-        "id": $id,
-        "source": "system",
-        "chat_id": 0,
-        "user_id": 0,
-        "username": "lobster-system",
-        "user_name": "Self-Check",
-        "text": $text,
-        "timestamp": $timestamp
-    }' > "${INBOX_DIR}/${MSG_ID}.json"
+    > "${INBOX_DIR}/${MSG_ID}.json"
 
 # Record timestamp
 date +%s > "$LAST_CHECK_FILE"


### PR DESCRIPTION
## Why

PR #2111 (BIS-724) was merged with its base still pointed at `refactor/bis-723-dispatcher-exclusion-consolidation` (the #2109/BIS-723 branch) instead of `main`. Since this repo has `delete_branch_on_merge: false`, the merge succeeded silently into that side branch and never reached `main` — #2109's content landed in `main` separately as its own squash commit, so the two histories diverged and #2111's actual diff (the jq consolidation) was missing from `main`.

This PR cherry-picks the exact squash commit GitHub produced when #2111 merged (`99443252c605175a4855d3811ed5872d78f7d953`) onto current `main`, unchanged, so the reviewed content lands where it was always supposed to.

## What

Same diff as #2111: adds `scripts/lib/json_message.sh` with `_json_build_message()`, and updates `alert.sh`, `check-agent-outputs.sh`, `daily-update-check.sh`, and `periodic-self-check.sh` to use it instead of each reimplementing `jq -n --arg ... '{...}'` inline.

Verified functionally after cherry-pick:
```
$ bash -c 'source scripts/lib/json_message.sh; _json_build_message --arg id "x" --arg text "hello"'
{"id": "x", "text": "hello"}
```

Part of the BIS-719 epic completion (Drew asked to fully merge all 7 slices).