### PR TITLE
fix(fireflies): isolate per-account sync failures, add late-arrival lookback

### DIFF
--- a/src/integrations/fireflies/sync.py
+++ b/src/integrations/fireflies/sync.py
@@ -36,7 +36,7 @@ import os
 import sys
 import urllib.error
 import urllib.request
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -66,6 +66,23 @@ _WORKSPACE = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-wor
 _STATE_FILE = _WORKSPACE / "data" / "fireflies-sync-state.json"
 _VAULT_PATH = Path(os.environ.get("FIREFLIES_VAULT_PATH", _WORKSPACE / "obsidian-vault"))
 _JOB_NAME = "fireflies-sync"
+
+# Fireflies' `fromDate` filter is applied against the transcript's *meeting*
+# date, not the time it was ingested/finalised by Fireflies' processing
+# pipeline. A transcript can therefore be created/finalised well after its
+# meeting date (e.g. a delayed upload, or Fireflies' own summarisation
+# pipeline taking time to complete). If we queried using the raw
+# `last_sync_at` watermark, any such late-arriving transcript whose meeting
+# date falls before that watermark would never be returned by a subsequent
+# sync and would be silently skipped forever.
+#
+# Mitigation: subtract a lookback buffer from the watermark before using it
+# as the query filter, so each sync re-requests a trailing window of
+# already-synced meeting dates. This is safe because the vault writer is
+# idempotent (content-hash comparison) — re-fetched transcripts that are
+# unchanged are skipped, not duplicated. The buffer trades a small amount of
+# redundant fetching for correctness.
+_LATE_ARRIVAL_LOOKBACK = timedelta(days=3)
 
 
 # ---------------------------------------------------------------------------
@@ -235,10 +252,15 @@ def run_sync(dry_run: bool = False) -> dict[str, Any]:
 
     last_sync_str: Optional[str] = state.get("last_sync_at")
     since: Optional[datetime] = None
+    query_since: Optional[datetime] = None
     if last_sync_str:
         try:
             since = datetime.fromisoformat(last_sync_str.replace("Z", "+00:00"))
-            log.info("Incremental sync since: %s", since.isoformat())
+            query_since = since - _LATE_ARRIVAL_LOOKBACK
+            log.info(
+                "Incremental sync since: %s (querying from %s to catch late-arriving transcripts)",
+                since.isoformat(), query_since.isoformat(),
+            )
         except ValueError:
             log.warning("Could not parse last_sync_at %r — doing full sync", last_sync_str)
     else:
@@ -254,22 +276,30 @@ def run_sync(dry_run: bool = False) -> dict[str, Any]:
     account_names = [a.name for a in accounts]
     log.info("Polling %d Fireflies account(s): %s", len(accounts), ", ".join(account_names))
 
+    # Isolate per-account failures: one account's auth/API failure should not
+    # abort the whole multi-account run. We only fail the entire sync if
+    # *every* configured account failed (nothing usable was fetched at all).
     transcripts_by_account: dict[str, list[FirefliesTranscript]] = {}
+    account_errors: dict[str, str] = {}
     for account in accounts:
         try:
-            account_transcripts = iter_all_transcripts_for_account(account, since=since)
+            account_transcripts = iter_all_transcripts_for_account(account, since=query_since)
             transcripts_by_account[account.name] = account_transcripts
             log.info("Account '%s': %d transcripts fetched", account.name, len(account_transcripts))
         except FirefliesAuthError:
-            msg = f"Fireflies authentication failed for account '{account.name}' — check API key in config.env"
+            msg = f"Fireflies authentication failed for account '{account.name}' — check its API key in config.env"
             log.error(msg)
-            _write_task_output(msg, status="failed")
-            return {"status": "failed", "message": msg}
+            account_errors[account.name] = msg
         except FirefliesAPIError as exc:
             msg = f"Fireflies API error for account '{account.name}': {exc}"
             log.error(msg)
-            _write_task_output(msg, status="failed")
-            return {"status": "failed", "message": msg}
+            account_errors[account.name] = msg
+
+    if not transcripts_by_account:
+        msg = "All Fireflies accounts failed: " + "; ".join(account_errors.values())
+        log.error(msg)
+        _write_task_output(msg, status="failed")
+        return {"status": "failed", "message": msg, "account_errors": account_errors}
 
     transcripts_summary = _merge_transcripts_deduplicated(transcripts_by_account)
     n_fetched = len(transcripts_summary)
@@ -297,6 +327,8 @@ def run_sync(dry_run: bool = False) -> dict[str, Any]:
             "accounts_polled": account_names,
             "message": msg,
         }
+        if account_errors:
+            result["account_errors"] = account_errors
         _write_task_output(json.dumps(result), status="success")
         return result
 
@@ -356,6 +388,10 @@ def run_sync(dry_run: bool = False) -> dict[str, Any]:
 
     if write_result.errors:
         result["errors"] = [{"id": eid, "error": emsg} for eid, emsg in write_result.errors]
+
+    if account_errors:
+        result["account_errors"] = account_errors
+        result["status"] = "partial" if status == "success" else status
 
     output_str = json.dumps(result, indent=2)
     log.info("Sync complete: %s", message)

--- a/tests/unit/test_fireflies_sync.py
+++ b/tests/unit/test_fireflies_sync.py
@@ -10,8 +10,9 @@ Covers:
 
 from __future__ import annotations
 
+import json
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -220,3 +221,95 @@ class TestRunSync:
         assert state_file.exists()
         written_file = vault_path / "fireflies" / "2026" / "06" / "2026-06-01-real-call.md"
         assert written_file.exists()
+
+    def test_one_account_auth_failure_does_not_abort_others(self, tmp_path, monkeypatch):
+        """
+        Design-gap fix: a single account's auth failure must not abort the
+        entire multi-account sync. The healthy account's transcripts should
+        still be fetched and written; the failing account should be reported
+        in `account_errors`, not swallow the whole run.
+        """
+        state_file = tmp_path / "state.json"
+        vault_path = tmp_path / "vault"
+        good_t = _make_transcript("a", title="Good Call", account="jake")
+
+        monkeypatch.setattr(
+            "integrations.fireflies.sync.build_account_configs_from_env",
+            lambda: [
+                FirefliesAccountConfig(name=ACCOUNT_PRIMARY, api_key="bad"),
+                FirefliesAccountConfig(name="jake", api_key="good"),
+            ],
+        )
+        monkeypatch.setattr("integrations.fireflies.sync._STATE_FILE", state_file)
+        monkeypatch.setattr("integrations.fireflies.sync._VAULT_PATH", vault_path)
+
+        def fake_iter(account, since=None):
+            if account.name == ACCOUNT_PRIMARY:
+                raise FirefliesAuthError()
+            return [good_t]
+
+        monkeypatch.setattr("integrations.fireflies.sync.iter_all_transcripts_for_account", fake_iter)
+        monkeypatch.setattr("integrations.fireflies.sync.get_transcript", MagicMock(return_value=good_t))
+
+        result = run_sync()
+
+        assert result["status"] == "partial"
+        assert result["transcripts_written"] == 1
+        assert ACCOUNT_PRIMARY in result["account_errors"]
+        assert "jake" not in result["account_errors"]
+
+    def test_all_accounts_failing_still_returns_failed(self, tmp_path, monkeypatch):
+        """Unlike the partial-failure case, if every account fails, the run fails."""
+        monkeypatch.setattr(
+            "integrations.fireflies.sync.build_account_configs_from_env",
+            lambda: [
+                FirefliesAccountConfig(name=ACCOUNT_PRIMARY, api_key="bad"),
+                FirefliesAccountConfig(name="jake", api_key="also-bad"),
+            ],
+        )
+        monkeypatch.setattr("integrations.fireflies.sync._STATE_FILE", tmp_path / "state.json")
+        monkeypatch.setattr(
+            "integrations.fireflies.sync.iter_all_transcripts_for_account",
+            MagicMock(side_effect=FirefliesAuthError()),
+        )
+
+        result = run_sync()
+
+        assert result["status"] == "failed"
+        assert set(result["account_errors"]) == {ACCOUNT_PRIMARY, "jake"}
+
+    def test_query_since_applies_lookback_buffer_before_watermark(self, tmp_path, monkeypatch):
+        """
+        Design-gap fix: Fireflies' `fromDate` filter is meeting-date based,
+        not ingestion-time based, so late-finalised transcripts with an older
+        meeting date could be silently missed if we queried using the raw
+        watermark. The sync must query a buffer window *before* the stored
+        watermark, not the watermark itself.
+        """
+        from datetime import datetime as dt
+        from datetime import timezone as tz
+
+        state_file = tmp_path / "state.json"
+        watermark = "2026-07-10T00:00:00.000Z"
+        state_file.write_text(json.dumps({"last_sync_at": watermark, "total_synced": 0, "last_run_at": None}))
+
+        monkeypatch.setattr(
+            "integrations.fireflies.sync.build_account_configs_from_env",
+            lambda: [FirefliesAccountConfig(name=ACCOUNT_PRIMARY, api_key="k")],
+        )
+        monkeypatch.setattr("integrations.fireflies.sync._STATE_FILE", state_file)
+
+        captured_since = {}
+
+        def fake_iter(account, since=None):
+            captured_since["value"] = since
+            return []
+
+        monkeypatch.setattr("integrations.fireflies.sync.iter_all_transcripts_for_account", fake_iter)
+
+        run_sync()
+
+        raw_watermark = dt.fromisoformat(watermark.replace("Z", "+00:00"))
+        assert captured_since["value"] is not None
+        assert captured_since["value"] < raw_watermark
+        assert (raw_watermark - captured_since["value"]) == timedelta(days=3)


### PR DESCRIPTION
## Problem

Session notes from the PR #2112 (Fireflies integration) merge flagged two open design gaps, not yet filed as issues:

1. Incremental sync watermark uses meeting-date, not ingestion-time, so a transcript finalized well after its meeting date could fall before the watermark and be silently skipped forever.
2. One account's auth failure aborts the entire multi-account sync run instead of isolating per-account.

## What this does

**Per-account isolation** (`run_sync` in `src/integrations/fireflies/sync.py`): each configured account's `iter_all_transcripts_for_account` call is now tried independently. A single account's `FirefliesAuthError`/`FirefliesAPIError` is recorded in a new `account_errors` map and that account is skipped — the run only fails outright if *every* account fails. A partial-success run (some accounts ok, some failed) now reports `status: "partial"` instead of masking the failure as a full success, or aborting a run that had usable data from healthy accounts.

**Late-arrival lookback**: Fireflies' `fromDate` filter is meeting-date based, not ingestion-time based (confirmed against docs.fireflies.ai — there's no ingestion-time field exposed by the API this client uses). Rather than querying with the raw watermark, sync now subtracts a 3-day `_LATE_ARRIVAL_LOOKBACK` buffer before querying. This is safe because `write_transcripts_batch`'s vault writer is already idempotent (SHA-256 content-hash comparison) — re-fetching a window of already-synced transcripts just results in more `skipped` counts, not duplicates.

## Tests

- `tests/unit/test_fireflies_sync.py::test_one_account_auth_failure_does_not_abort_others` — one bad account + one good account → good account's transcript still written, `status == "partial"`, `account_errors` names only the bad one.
- `tests/unit/test_fireflies_sync.py::test_all_accounts_failing_still_returns_failed` — unchanged behavior when every account fails.
- `tests/unit/test_fireflies_sync.py::test_query_since_applies_lookback_buffer_before_watermark` — asserts the account-discovery call receives `since = watermark - 3 days`, not the raw watermark.

Falsifiability check: reverted `sync.py` to the pre-fix version (keeping the new tests), all 3 new tests failed with the expected pre-fix symptoms (`'failed' != 'partial'`, missing `account_errors` key, `since == watermark` instead of `< watermark`). Restored the fix, all pass again.

```
$ uv run pytest tests/unit/test_fireflies_sync.py tests/unit/test_fireflies_client.py tests/unit/test_fireflies_serializer.py tests/unit/test_fireflies_vault_writer.py -q
72 passed, 1 warning in 3.64s

$ uv run pytest tests/unit/test_granola_client.py tests/unit/test_granola_multi_account.py tests/unit/test_granola_sync_multi_account.py tests/unit/test_granola_storage.py tests/unit/test_granola_state.py tests/unit/test_granola_archive_multi_account.py -q
98 passed, 1 warning in 2.58s
```

## Manual test

```
$ uv run python -m integrations.fireflies.sync --dry-run   # run with no FIREFLIES_API_KEY set
{
  "status": "failed",
  "message": "FIREFLIES_API_KEY not set — check config.env"
}
```

Confirms the existing "no key configured yet" behavior is unaffected by this change — still a clean, documented no-op rather than a crash. A live end-to-end pull against the real Fireflies API is still blocked on a verified `FIREFLIES_API_KEY` being added to this instance's `~/lobster-config/config.env` (out of scope for this PR — instance-specific credential, not OSS code).

## Out of scope

- No changes to Granola's integration.
- No live systemd timer installed/changed.
- No new provider support beyond the two design-gap fixes.