### PR TITLE
fix(#55): guard against inherited unrendered {{USER_CONFIG_DIR}} placeholder

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -146,6 +146,15 @@ LOBSTER_USER="${LOBSTER_USER:-${USER:-$(whoami)}}"
 LOBSTER_GROUP="${LOBSTER_GROUP:-${USER:-$(whoami)}}"
 LOBSTER_HOME="${LOBSTER_HOME:-$HOME}"
 CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+# NOTE: "${LOBSTER_USER_CONFIG:-default}" only falls back when the var is
+# UNSET/EMPTY. If this process inherited LOBSTER_USER_CONFIG from a parent
+# environment (e.g. a systemd unit) that itself still has the raw
+# {{USER_CONFIG_DIR}} placeholder, that bad value is "set" and defeats the
+# fallback, silently re-poisoning every service file this script generates.
+# Sanitize it before applying the default.
+case "${LOBSTER_USER_CONFIG:-}" in
+    *'{{'*) unset LOBSTER_USER_CONFIG ;;
+esac
 USER_CONFIG_DIR="${LOBSTER_USER_CONFIG:-$HOME/lobster-user-config}"
 
 #===============================================================================

--- a/scripts/lib/template.sh
+++ b/scripts/lib/template.sh
@@ -44,6 +44,33 @@ _tmpl_generate_from_template() {
         return 1
     fi
 
+    # Guard: reject poisoned inputs before substitution.
+    #
+    # LOBSTER_* vars are frequently defaulted with "${LOBSTER_FOO:-default}"
+    # by callers. That pattern only applies the default when the variable is
+    # UNSET or EMPTY — if a parent process (e.g. a systemd unit whose
+    # Environment= line itself still has a raw {{PLACEHOLDER}}) exports the
+    # variable with a bad value, the default is silently skipped and the bad
+    # value flows straight through sed, re-poisoning every freshly generated
+    # service file forever. Catch that here, at the one place all callers
+    # funnel through, instead of relying on every caller to remember to
+    # validate its own inputs.
+    local _var _val
+    for _var in LOBSTER_USER LOBSTER_GROUP LOBSTER_HOME LOBSTER_INSTALL_DIR \
+                LOBSTER_WORKSPACE LOBSTER_MESSAGES LOBSTER_CONFIG_DIR LOBSTER_USER_CONFIG; do
+        _val="${!_var:-}"
+        case "$_val" in
+            *'{{'*)
+                echo "[ERROR] $_var is set to an unrendered template placeholder: '$_val'" >&2
+                echo "[ERROR] Refusing to render $template — this would re-poison $output." >&2
+                echo "[ERROR] Check what exported $_var (e.g. 'env | grep $_var', or the" >&2
+                echo "[ERROR] Environment= lines of the systemd unit this process inherited" >&2
+                echo "[ERROR] its environment from) and fix or unset it before retrying." >&2
+                return 1
+                ;;
+        esac
+    done
+
     sed -e "s|{{USER}}|${LOBSTER_USER}|g" \
         -e "s|{{GROUP}}|${LOBSTER_GROUP}|g" \
         -e "s|{{HOME}}|${LOBSTER_HOME}|g" \

--- a/scripts/update-lobster.sh
+++ b/scripts/update-lobster.sh
@@ -444,6 +444,16 @@ update_systemd() {
     LOBSTER_WORKSPACE="$WORKSPACE_DIR"
     LOBSTER_MESSAGES="$MESSAGES_DIR"
     # LOBSTER_CONFIG_DIR is already set at the top of this script
+    # NOTE: "${LOBSTER_USER_CONFIG:-default}" only falls back when the var is
+    # UNSET/EMPTY. This script runs as a child of lobster-claude.service (or is
+    # invoked from a shell that inherited its environment); if that unit's
+    # Environment=LOBSTER_USER_CONFIG=... line still has the raw
+    # {{USER_CONFIG_DIR}} placeholder, the bad value is "set" and defeats the
+    # fallback, silently re-poisoning every service file update_systemd()
+    # regenerates. Sanitize before applying the default.
+    case "${LOBSTER_USER_CONFIG:-}" in
+        *'{{'*) unset LOBSTER_USER_CONFIG ;;
+    esac
     LOBSTER_USER_CONFIG="${LOBSTER_USER_CONFIG:-${LOBSTER_HOME}/lobster-user-config}"
 
     # Source the shared template library (repo is present — we just pulled it).

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -40,6 +40,15 @@ LOBSTER_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
 WORKSPACE_DIR="${LOBSTER_WORKSPACE:-$HOME/lobster-workspace}"
 MESSAGES_DIR="${LOBSTER_MESSAGES:-$HOME/messages}"
 LOBSTER_CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
+# NOTE: "${LOBSTER_USER_CONFIG:-default}" only falls back when the var is
+# UNSET/EMPTY. This script commonly runs as a child of lobster-claude.service;
+# if that unit's Environment=LOBSTER_USER_CONFIG=... line still has the raw
+# {{USER_CONFIG_DIR}} placeholder, the bad value is "set" and defeats the
+# fallback, silently re-poisoning every service file this script regenerates.
+# Sanitize before applying the default.
+case "${LOBSTER_USER_CONFIG:-}" in
+    *'{{'*) unset LOBSTER_USER_CONFIG ;;
+esac
 USER_CONFIG_DIR="${LOBSTER_USER_CONFIG:-$HOME/lobster-user-config}"
 BACKUP_BASE="$HOME/lobster-backups"
 CONFIG_FILE="$LOBSTER_CONFIG_DIR/config.env"

--- a/tests/test-template-generator.sh
+++ b/tests/test-template-generator.sh
@@ -182,6 +182,33 @@ _tmpl_generate_from_template "$ALL_PLACEHOLDERS_TEMPLATE" "$OUTPUT"
 _tmpl_generate_from_template "$ALL_PLACEHOLDERS_TEMPLATE" "$OUTPUT"
 assert_file_not_contains "idempotent: still no {{ after second run" "$OUTPUT" '{{'
 
+echo ""
+echo "Poisoned input variable (shadowlobster#55 regression):"
+
+# Regression test for shadowlobster#55: a caller's own default fallback
+# (e.g. "${LOBSTER_USER_CONFIG:-default}") is defeated when the variable is
+# already *set* to a literal unrendered placeholder — inherited from a
+# parent process such as a systemd unit whose own Environment= line still
+# has {{USER_CONFIG_DIR}}. Validate every input variable up front so this
+# is diagnosed at its actual source with a clear message, not just detected
+# incidentally downstream by the unresolved-placeholder-in-output check.
+POISON_OUTPUT="$TEST_TMPDIR/poisoned.service"
+ORIG_USER_CONFIG="$LOBSTER_USER_CONFIG"
+export LOBSTER_USER_CONFIG='{{USER_CONFIG_DIR}}'
+POISON_STDERR="$TEST_TMPDIR/poison-stderr.txt"
+if _tmpl_generate_from_template "$ALL_PLACEHOLDERS_TEMPLATE" "$POISON_OUTPUT" 2>"$POISON_STDERR"; then
+    fail "poisoned LOBSTER_USER_CONFIG input returns error" "expected non-zero exit"
+else
+    pass "poisoned LOBSTER_USER_CONFIG input returns error"
+fi
+assert_file_not_exists "no output file when input variable is poisoned" "$POISON_OUTPUT"
+if grep -q "LOBSTER_USER_CONFIG is set to an unrendered template placeholder" "$POISON_STDERR"; then
+    pass "error message identifies the poisoned variable by name"
+else
+    fail "error message identifies the poisoned variable by name" "stderr: $(cat "$POISON_STDERR")"
+fi
+export LOBSTER_USER_CONFIG="$ORIG_USER_CONFIG"
+
 # --- Summary -----------------------------------------------------------------
 
 echo ""


### PR DESCRIPTION
## Summary

- `install.sh`, `scripts/update-lobster.sh`, and `scripts/upgrade.sh` each default `LOBSTER_USER_CONFIG` with `"${LOBSTER_USER_CONFIG:-$HOME/lobster-user-config}"`. That fallback only fires when the variable is **unset or empty** — if the process inherits `LOBSTER_USER_CONFIG` from a parent environment that's already poisoned (e.g. a systemd unit whose own `Environment=` line still has the raw `{{USER_CONFIG_DIR}}` marker), the variable counts as "set" and the fallback never applies. `sed` then substitutes `{{USER_CONFIG_DIR}}` → `{{USER_CONFIG_DIR}}` (a no-op) and writes that straight back out, re-poisoning every service file the script regenerates — a self-reinforcing loop across every future install/update run.
- `scripts/lib/template.sh`'s `_tmpl_generate_from_template()` now validates all 8 input `LOBSTER_*` variables up front and refuses to render (with a clear, named-variable error) if any still contains a raw `{{` marker, instead of relying on each caller to have sanitized its own inputs correctly.
- `install.sh`, `scripts/upgrade.sh`, `scripts/update-lobster.sh` additionally `unset LOBSTER_USER_CONFIG` before applying the default if it's already poisoned, so a bad inherited value can't defeat the default in the first place (belt-and-suspenders with the library-level guard).

## Alternatives considered

- **Only fix the library guard, not the three callers' default-assignment lines.** Rejected: without the caller-side sanitize, a poisoned inherited `LOBSTER_USER_CONFIG` would still hard-fail every install/update run (correctly refusing to write a bad file — a real improvement over today's silent corruption) but would leave the operator stuck unable to self-heal without manually `unset`-ing the variable first. Sanitizing at the call site lets the script recover to a sane default automatically, which matches the intent of `${VAR:-default}` in the first place.
- **Validate placeholder-freedom of the rendered output only (already existed).** This is the pre-existing guard and is necessary but not sufficient: it happens to catch this specific bug only because the poisoned value literally contains the string `{{`, which is incidental. Validating inputs up front gives a clearer, faster, more targeted diagnostic (names the exact offending variable and suggests checking the parent process's environment) rather than a generic "unresolved placeholders in output" message discovered after the fact.

## Tests run

- [x] `bash tests/test-template-generator.sh` — 18 passed, 0 failed (15 pre-existing + 3 new regression tests added in this PR for the exact poisoned-input scenario from #55)
- [x] `bash -n install.sh && bash -n scripts/update-lobster.sh && bash -n scripts/upgrade.sh && bash -n scripts/lib/template.sh` — all syntax-clean
- [x] Manual end-to-end repro: exported `LOBSTER_USER_CONFIG={{USER_CONFIG_DIR}}` (reproducing the exact poisoned state observed on the affected host's `lobster-claude.service`), ran the patched `update_systemd()` sanitize-then-render flow — correctly falls back to `/home/admin/lobster-user-config` and renders a clean `lobster-mcp.service`. Before the fix, the same repro produced a version with the raw placeholder still present, matching the corrupted host state exactly.
- [ ] `docker compose -f tests/docker/docker-compose.test.yml up install-test` — skipped: out of scope for this narrowly-targeted fix; the manual repro plus unit tests cover the actual failure mode directly, and a full install simulation wasn't warranted given time constraints.
- [ ] Live Telegram test — blocked: requires restarting `lobster-claude`, which was intentionally not done as part of this change (see below).

**Blocked items needing attention before merge:** none — the docker install-test and live Telegram test are skipped as out-of-scope/blocked-by-design, not failures.

## Functional patterns used

- Pure guard-clause validation (early return on invalid input) added to the single shared `_tmpl_generate_from_template()` implementation rather than duplicated across callers.
- No mutation of shared state beyond the pre-existing `sed`-to-file pattern.

## Breaking changes / migration notes

None for normal operation. **Behavior change for already-broken installs:** if a host currently has a poisoned `LOBSTER_USER_CONFIG` baked into a running service's environment (as this host did), the next `install.sh` / `update-lobster.sh` / `upgrade.sh` run will now correctly self-heal to the default path instead of perpetuating the bad value — this is the intended fix, not a regression.

Live systemd units on the affected host (`lobster-mcp.service`, `lobster-mcp-local.service`, `lobster-claude.service`) were corrected out-of-band as part of triaging this issue (re-rendered with a clean environment, installed, `daemon-reload`'d). **`lobster-claude` itself still needs a restart** to pick up the corrected `LOBSTER_USER_CONFIG` in its own running process (its current process memory still has the old poisoned value) — intentionally not restarted as part of this fix per instructions; flagged separately.

Closes SiderealPress/shadowlobster#55 (bug 1). See PR comment / issue comment for bug 2 (`compaction-state.json`) status — root cause partially clarified but not resolved in this PR; tracked separately.
