### PR TITLE
fix: silent Slack message drop from float precision bug in poller checkpoint

### DIFF
--- a/src/bot/slack_router.py
+++ b/src/bot/slack_router.py
@@ -803,6 +803,32 @@ def _trim_seen_ts() -> None:
         _seen_ts.update(keep)
 
 
+def _next_oldest_bound(ts_str: str) -> str:
+    """Compute the exclusive-lower-bound ``oldest`` value for the next poll.
+
+    Slack timestamps are always formatted as ``<seconds>.<6-digit-microseconds>``
+    (e.g. ``"1784568407.379109"``). Naively doing ``str(float(ts_str) + 0.000001)``
+    silently corrupts this for large (~10-digit-second, ~2020s+) timestamps: a
+    64-bit float only carries ~15-17 significant decimal digits, and a 10-digit
+    second count plus a 6-digit microsecond count is already 16 digits — right at
+    that limit. Adding a small epsilon can push the result to 7 (or more) decimal
+    places once ``str()``/``repr()`` renders it, e.g. ``"1784568407.3791099"``.
+
+    That extra digit isn't just cosmetic: passing a 7-decimal-place ``oldest`` to
+    Slack's ``conversations.history`` gets misparsed — observed in production as
+    Slack echoing back an ``oldest`` an order of magnitude too large (decimal
+    point shifted), which is far in the future and excludes every message. The
+    API call still returns ``ok: true`` with an empty ``messages`` list — no
+    error, no rate-limit signal, nothing to log — so the channel's checkpoint
+    can never advance again and every future message on that channel is
+    silently dropped forever, with a perfectly healthy-looking heartbeat.
+
+    Formatting with a fixed 6 decimal places guarantees the wire format Slack
+    expects regardless of the input's exact bit pattern.
+    """
+    return f"{float(ts_str) + 0.000001:.6f}"
+
+
 def _load_poll_state() -> dict:
     """Load last-seen timestamps from disk."""
     if _POLL_STATE_FILE.exists():
@@ -857,7 +883,7 @@ def _poll_user_dm_channels(stop_event: Event) -> None:
                 if oldest:
                     # Use exclusive lower bound: oldest + epsilon so the
                     # already-processed message is not re-delivered on restart.
-                    kwargs["oldest"] = str(float(oldest) + 0.000001)
+                    kwargs["oldest"] = _next_oldest_bound(oldest)
 
                 resp = poll_client.conversations_history(**kwargs)
                 messages = resp.get("messages", [])
@@ -1139,7 +1165,7 @@ def _poll_one_channel(channel_id: str) -> None:
 
         kwargs: dict = {"channel": channel_id, "limit": 20}
         if oldest:
-            kwargs["oldest"] = str(float(oldest) + 0.000001)
+            kwargs["oldest"] = _next_oldest_bound(oldest)
 
         resp = _channel_poll_client.conversations_history(**kwargs)
         messages = resp.get("messages", [])

--- a/tests/unit/test_bot/test_slack_poller_oldest_precision.py
+++ b/tests/unit/test_bot/test_slack_poller_oldest_precision.py
@@ -1,0 +1,232 @@
+"""
+Regression tests for a silent-drop bug in the Slack channel/DM pollers'
+``oldest`` checkpoint bump.
+
+Incident: Jake sent a message in #wallace-jake (channel C0B3S6RBFV5) that was
+never delivered, even though the poller's heartbeat looked perfectly healthy
+(fresh timestamps every tick, no errors, no rate-limit warnings). Ground truth
+from Slack's own `conversations.history` showed the message was really there
+and really unanswered.
+
+Root cause: both `_poll_one_channel()` and `_poll_user_dm_channels()` compute
+the next poll's exclusive-lower-bound `oldest` parameter as::
+
+    str(float(oldest) + 0.000001)
+
+Slack timestamps are always ``<10-digit-seconds>.<6-digit-microseconds>`` —
+already 16 significant decimal digits, right at the edge of what a 64-bit
+float can represent exactly. Adding a small epsilon and `str()`-ing the result
+can silently produce *7* decimal digits (e.g. checkpoint
+``"1784568407.379109"`` yields ``"1784568407.3791099"``). Slack's API does not
+reject this malformed value — it misparses it (observed: the decimal point
+shifts, producing an `oldest` far in the future) and returns
+``{"ok": true, "messages": []}``. No exception, no rate-limit signal, nothing
+to log. The channel's on-disk checkpoint then never advances again, and every
+future message on that channel is dropped forever — even though the poller's
+heartbeat (which only proves the *attempt* happened, not that anything useful
+came back) looks completely healthy.
+
+The fix: format the bumped timestamp with a fixed 6 decimal places
+(`f"{...:.6f}"`), which always matches Slack's own timestamp format regardless
+of the input's exact bit pattern.
+"""
+
+import sys
+from pathlib import Path
+
+# Ensure src is importable
+_SRC = Path(__file__).parent.parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# ---------------------------------------------------------------------------
+# Real checkpoint values pulled from the production incident (2026-07-20).
+# Roughly half of real Slack timestamps trigger the bug — it depends on the
+# exact bit pattern of the microsecond value, not anything special about this
+# one channel.
+# ---------------------------------------------------------------------------
+KNOWN_BUGGY_CHECKPOINTS = [
+    "1784568407.379109",  # Jake's channel (C0B3S6RBFV5) — the actual incident
+    "1784278808.621729",  # a second channel that would have hit this too
+]
+KNOWN_SAFE_CHECKPOINTS = [
+    "1784451627.538489",
+    "1784569292.513319",
+    "1784569289.249039",
+]
+
+
+def _old_buggy_bump(ts_str: str) -> str:
+    """The exact pre-fix expression, isolated for comparison in tests."""
+    return str(float(ts_str) + 0.000001)
+
+
+class TestOldBumpWasBuggy:
+    """Document the bug in the old expression so a future refactor can't
+    silently reintroduce it without a test noticing."""
+
+    def test_old_expression_produces_more_than_6_decimal_places(self):
+        offenders = [
+            ts for ts in KNOWN_BUGGY_CHECKPOINTS
+            if len(_old_buggy_bump(ts).split(".")[1]) != 6
+        ]
+        assert offenders, (
+            "Expected at least one known-buggy checkpoint to reproduce the "
+            "7-decimal-place corruption with the old expression"
+        )
+
+    def test_malformed_value_is_rejected_by_a_strict_slack_ts_parser(self):
+        """Simulates Slack's own handling: a well-formed Slack ts always has
+        exactly 6 digits after the decimal point. A value with 7 digits is
+        the exact shape that got misparsed in production (observed: Slack
+        echoed back an `oldest` with the decimal point shifted, excluding
+        every real message)."""
+        buggy = _old_buggy_bump("1784568407.379109")
+        decimals = buggy.split(".")[1]
+        assert len(decimals) == 7, (
+            "This test documents the exact corruption seen in production; "
+            f"got {buggy!r}"
+        )
+
+
+class TestNextOldestBoundFix:
+    """`_next_oldest_bound()` must always yield a well-formed 6-decimal-place
+    Slack timestamp, regardless of the input's floating-point bit pattern."""
+
+    def _load(self):
+        import bot.slack_router as sr
+        return sr
+
+    def test_always_exactly_six_decimal_places(self):
+        m = self._load()
+        for ts in KNOWN_BUGGY_CHECKPOINTS + KNOWN_SAFE_CHECKPOINTS:
+            result = m._next_oldest_bound(ts)
+            decimals = result.split(".")[1]
+            assert len(decimals) == 6, (
+                f"_next_oldest_bound({ts!r}) = {result!r} has "
+                f"{len(decimals)} decimal places, expected 6"
+            )
+
+    def test_result_is_strictly_greater_than_input(self):
+        """The bound must still be a real exclusive lower bound — i.e. not
+        rounded down to equal (or below) the original checkpoint, which would
+        cause the already-processed message to be redelivered forever."""
+        m = self._load()
+        for ts in KNOWN_BUGGY_CHECKPOINTS + KNOWN_SAFE_CHECKPOINTS:
+            result = m._next_oldest_bound(ts)
+            assert float(result) > float(ts), (
+                f"_next_oldest_bound({ts!r}) = {result!r} did not advance "
+                "past the input"
+            )
+
+    def test_matches_the_known_good_manually_computed_value(self):
+        """Regression pin for the exact incident checkpoint: the poller must
+        compute the same bound that was independently verified (via a direct
+        Slack API call in the live incident investigation) to correctly
+        return the previously-missed message."""
+        m = self._load()
+        assert m._next_oldest_bound("1784568407.379109") == "1784568407.379110"
+
+
+class TestPollOneChannelUsesFixedBound:
+    """End-to-end: `_poll_one_channel()` must pass a well-formed `oldest` to
+    `conversations.history`, or Slack silently returns nothing and the
+    channel is wedged forever — exactly the production incident."""
+
+    def _load_module(self, tmp_path):
+        import importlib
+        import os
+        from unittest.mock import MagicMock, patch
+
+        for key in list(sys.modules.keys()):
+            if "slack_router" in key:
+                del sys.modules[key]
+
+        mock_app = MagicMock()
+        mock_app.event.side_effect = lambda *a, **kw: (lambda fn: fn)
+        mock_bolt_mod = MagicMock()
+        mock_bolt_mod.App = MagicMock(return_value=mock_app)
+
+        mock_socket_mod = MagicMock()
+
+        mock_bot_client = MagicMock()
+        mock_bot_client.auth_test.return_value = {"user_id": "UBOTAPP001", "user": "bot"}
+        mock_user_client = MagicMock()
+        mock_user_client.auth_test.return_value = {"user_id": "USELF00001", "user": "self"}
+        mock_user_client.conversations_history.return_value = {"messages": []}
+
+        call_count = [0]
+
+        def webclient_side_effect(token=None, **kw):
+            call_count[0] += 1
+            return mock_bot_client if call_count[0] == 1 else mock_user_client
+
+        mock_sdk_mod = MagicMock()
+        mock_sdk_mod.WebClient = MagicMock(side_effect=webclient_side_effect)
+
+        class _FakeSlackApiError(Exception):
+            def __init__(self, message="error", response=None):
+                super().__init__(message)
+                self.response = response or {}
+
+        mock_errors_mod = MagicMock()
+        mock_errors_mod.SlackApiError = _FakeSlackApiError
+
+        mock_outbox_mod = MagicMock()
+        mock_outbox_mod.OutboxFileHandler = MagicMock()
+        mock_outbox_mod.OutboxWatcher = MagicMock()
+        mock_outbox_mod.drain_outbox = MagicMock()
+
+        env = {
+            "LOBSTER_SLACK_BOT_TOKEN": "xoxb-fake",
+            "LOBSTER_SLACK_APP_TOKEN": "xapp-fake",
+            "LOBSTER_SLACK_USER_TOKEN": "xoxp-fake",
+            "LOBSTER_SLACK_CHANNEL_CONVERSATIONS": "CINCIDENT01",
+            "LOBSTER_SLACK_POLL_CHANNELS": "",
+            "LOBSTER_MESSAGES": str(tmp_path / "messages"),
+            "LOBSTER_WORKSPACE": str(tmp_path / "workspace"),
+        }
+
+        module_patches = {
+            "slack_bolt": mock_bolt_mod,
+            "slack_bolt.adapter": MagicMock(),
+            "slack_bolt.adapter.socket_mode": mock_socket_mod,
+            "slack_sdk": mock_sdk_mod,
+            "slack_sdk.errors": mock_errors_mod,
+            "watchdog": MagicMock(),
+            "watchdog.observers": MagicMock(),
+            "watchdog.events": MagicMock(),
+            "channels.outbox": mock_outbox_mod,
+        }
+
+        import logging
+        null_handler = logging.NullHandler()
+
+        with patch.dict(sys.modules, module_patches), \
+             patch.dict(os.environ, env, clear=True), \
+             patch("pathlib.Path.mkdir"), \
+             patch("logging.handlers.RotatingFileHandler", return_value=null_handler):
+            import src.bot.slack_router as m
+            m.SlackApiError = mock_errors_mod.SlackApiError
+            return m, mock_user_client
+
+    def test_conversations_history_called_with_six_decimal_oldest(self, tmp_path):
+        m, client = self._load_module(tmp_path)
+        m._channel_poll_client = client
+        m._channel_poll_state = {"conv_CINCIDENT01": "1784568407.379109"}
+        m._channel_skip_ids = set()
+        m._channel_backoff = {}
+
+        m._poll_one_channel("CINCIDENT01")
+
+        assert client.conversations_history.called
+        oldest_used = client.conversations_history.call_args.kwargs["oldest"]
+        decimals = oldest_used.split(".")[1]
+        assert len(decimals) == 6, (
+            f"_poll_one_channel passed oldest={oldest_used!r} to "
+            "conversations.history — a malformed (non-6-decimal) value is "
+            "exactly what caused Slack to silently return zero messages in "
+            "the production incident"
+        )
+        assert oldest_used == "1784568407.379110"


### PR DESCRIPTION
## Summary

Root-cause fix for the recurring "a user's Slack messages in a private 1:1 channel go unanswered" escalation. This is a **different bug** from #2125/#2126 — that fix hardened the poller thread against a total silent stall; this bug causes a **per-channel** silent, permanent message drop even while the poller is fully healthy (fresh heartbeat, no errors, no rate-limit warnings).

- `_poll_one_channel()` and `_poll_user_dm_channels()` compute the next poll's exclusive `oldest` bound as `str(float(checkpoint) + 0.000001)`.
- Slack timestamps are `<10-digit-seconds>.<6-digit-microseconds>` — already 16 significant decimal digits, right at the edge of 64-bit float precision.
- Adding the epsilon and `str()`-ing the result can silently overflow to 7+ decimal places (e.g. `"1784568407.379109"` → `"1784568407.3791099"`).
- Slack's `conversations.history` does not reject the malformed value — it misparses it (confirmed live: the echoed-back `oldest` had its decimal point shifted an order of magnitude into the future) and returns `{"ok": true, "messages": []}`.
- No exception, no rate-limit signal, nothing to log. The channel's checkpoint then freezes **forever**, silently dropping every future message on that channel.

## Evidence

- Confirmed via a direct `conversations.history` call (real token, real checkpoint) that Slack genuinely had the user's unanswered message (a short question about a file format) sent 2026-07-20 18:43:24 UTC — absent from local `messages.db`, inbox, processing, and processed directories.
- Reproduced the exact malformed-`oldest` response locally by calling `_poll_one_channel(<channel_id>)` with the real (frozen) production checkpoint against the live Slack API — got `oldest: "17845684073.791099"` back (decimal point shifted), zero messages.
- Watched `~/lobster-workspace/data/slack-poll-state.json` rewrite every ~2-3s with the checkpoint for this channel completely unchanged, while the heartbeat file looked perfectly healthy the whole time.

## Fix

Format the bumped timestamp with a fixed 6 decimal places (`f"{...:.6f}"`), guaranteeing Slack's own wire format regardless of the input's float bit pattern. Applied to both poller call sites via a shared `_next_oldest_bound()` helper.

## Test plan

- [x] New test file `tests/unit/test_bot/test_slack_poller_oldest_precision.py`:
  - Documents the old expression's 7-decimal overflow on real incident checkpoint values
  - Asserts `_next_oldest_bound()` always yields exactly 6 decimal places
  - Pins the exact incident value: `_next_oldest_bound("1784568407.379109") == "1784568407.379110"`
  - End-to-end: mocks `conversations_history` and asserts `_poll_one_channel` passes a well-formed `oldest`
- [x] Verified all new tests **fail** against the pre-fix code (`git stash` to old code): 4/6 fail, including `AttributeError: no attribute '_next_oldest_bound'` and the end-to-end assertion catching the literal `'1784568407.3791099'` malformed value
- [x] Verified all new tests **pass** against the fix: 6/6
- [x] Full `tests/unit/test_bot/` suite: 261 passed, 1 pre-existing unrelated failure (confirmed present on `main` before this change too — `test_warning_logged_when_poll_channels_empty`)
- [x] `lobster-slack-router.service` restarted after deploying this fix; heartbeat confirmed fresh across all 3 channels post-restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)
