### PR TITLE
Connectors OAuth: Slices 0-4 (characterization, HMAC hardening, workspace fallback, oauth_vault extraction)

### DIFF
--- a/src/integrations/gmail/token_store.py
+++ b/src/integrations/gmail/token_store.py
@@ -62,6 +62,8 @@ from integrations.google_calendar.oauth import (
     TokenData,
     is_token_valid,
 )
+from integrations.google_workspace import token_store as _workspace_token_store
+from integrations.google_workspace.config import WORKSPACE_TOKEN_DIR
 
 log = logging.getLogger(__name__)
 
@@ -73,6 +75,14 @@ _HOME: Path = Path.home()
 _MESSAGES_DIR: Path = Path(os.environ.get("LOBSTER_MESSAGES", str(_HOME / "messages")))
 _TOKEN_DIR: Path = _MESSAGES_DIR / "config" / "gmail-tokens"
 _GMAIL_CONFIG_PATH: Path = _MESSAGES_DIR / "config" / "gmail-config.json"
+
+# BIS-731 / Slice 3: fallback token store for users who ran the `workspace`
+# consent flow instead of the gmail-specific one. `WORKSPACE_SCOPES` in
+# google_workspace/config.py includes the gmail.modify scope "for
+# unified-token support" — this is what lets a workspace grant substitute
+# for a dedicated one.
+_WORKSPACE_TOKEN_DIR: Path = WORKSPACE_TOKEN_DIR
+_WORKSPACE_GMAIL_SCOPE_SUBSTRING: str = "gmail.modify"
 
 # File permissions: owner read+write only (octal 0o600)
 _TOKEN_FILE_MODE: int = stat.S_IRUSR | stat.S_IWUSR
@@ -347,23 +357,75 @@ def load_token(
     return _load_token_local(user_id, token_dir)
 
 
+def _get_workspace_fallback_token(
+    user_id: str,
+    workspace_token_dir: Path,
+) -> Optional[TokenData]:
+    """Fall back to the shared Google Workspace token store.
+
+    A user who ran the `workspace` consent flow (not the gmail-specific one)
+    already holds a token whose scope bundle includes gmail.modify "for
+    unified-token support" (google_workspace/config.py WORKSPACE_SCOPES).
+    Rather than re-implement load/validate/refresh here, delegate to
+    google_workspace.token_store.get_valid_token, which already owns that
+    lifecycle for its own store — this only decides whether the result it
+    returns is usable for Gmail, based on the granted scope.
+
+    Args:
+        user_id:             Unique identifier for the user.
+        workspace_token_dir: Workspace token directory (injectable for testing).
+
+    Returns:
+        The workspace TokenData if it exists, is valid (or refreshable), and
+        its scope includes gmail.modify; otherwise None.
+    """
+    workspace_token = _workspace_token_store.get_valid_token(
+        user_id, token_dir=workspace_token_dir
+    )
+    if workspace_token is None:
+        return None
+
+    if _WORKSPACE_GMAIL_SCOPE_SUBSTRING not in workspace_token.scope:
+        log.info(
+            "Workspace token for user_id=%r does not grant gmail.modify scope "
+            "(scope=%r) — not using it as a Gmail fallback.",
+            user_id,
+            workspace_token.scope,
+        )
+        return None
+
+    log.info(
+        "No Gmail-specific token for user_id=%r — using workspace token "
+        "fallback (scope includes gmail.modify).",
+        user_id,
+    )
+    return workspace_token
+
+
 def get_valid_token(
     user_id: str,
     token_dir: Path = _TOKEN_DIR,
+    workspace_token_dir: Path = _WORKSPACE_TOKEN_DIR,
 ) -> Optional[TokenData]:
     """Return a valid Gmail access token for the user, refreshing if necessary.
 
     Workflow:
     1. Load token from local disk.
-    2. If no token -> return None (user must authenticate via consent link).
+    2. If no token -> fall back to the workspace token store (BIS-731); if
+       that also yields nothing usable -> return None (user must
+       authenticate via consent link).
     3. If token is still valid -> return it.
     4. If token is expired -> call myownlobster refresh proxy.
     5. Persist the refreshed token (preserving the original refresh_token).
     6. If refresh fails -> log and return None.
 
     Args:
-        user_id:   Unique identifier for the user (Telegram chat_id as str).
-        token_dir: Local token directory (injectable for testing).
+        user_id:             Unique identifier for the user (Telegram chat_id as str).
+        token_dir:           Local token directory (injectable for testing).
+        workspace_token_dir: Workspace token directory (injectable for testing).
+                             Only consulted when no gmail-specific token file
+                             exists at all — an existing gmail token is
+                             always used as-is, workspace is never checked.
 
     Returns:
         A valid TokenData, or None if no valid token is available.
@@ -371,7 +433,7 @@ def get_valid_token(
     token = _load_token_local(user_id, token_dir)
     if token is None:
         log.info("No local Gmail token found for user_id=%r.", user_id)
-        return None
+        return _get_workspace_fallback_token(user_id, workspace_token_dir)
 
     if is_token_valid(token):
         return token

--- a/src/integrations/google_calendar/client.py
+++ b/src/integrations/google_calendar/client.py
@@ -35,13 +35,34 @@ from typing import Any, Optional
 import requests
 
 from integrations.google_calendar.config import GoogleOAuthCredentials
-from integrations.google_calendar.token_store import get_valid_token
+from integrations.oauth_vault import client as _oauth_vault_client
 
 # Re-export so callers can do:
 #   from integrations.google_calendar.client import gcal_add_link
 from utils.calendar import gcal_add_link  # noqa: F401 — intentional re-export
 
 log = logging.getLogger(__name__)
+
+# BIS-732 / Slice 4: Calendar's own token store/refresh logic has moved to
+# integrations.oauth_vault, proven here first before Gmail and Workspace
+# follow in later slices. This thin wrapper preserves the exact
+# get_valid_token(user_id, credentials=...) call signature (and the
+# `integrations.google_calendar.client.get_valid_token` patch target) that
+# existing callers and tests depend on — only the implementation moved.
+# integrations.google_calendar.token_store.py itself is untouched and stays
+# in the tree, unimported here, as a one-release rollback path.
+#
+# Note: the oauth_vault module is imported and called via module-attribute
+# access (_oauth_vault_client.get_valid_token(...)), not via a bound
+# `from ... import get_valid_token` alias — the latter would capture the
+# function object at import time and become unpatchable via
+# `patch("integrations.oauth_vault.client.get_valid_token")` in tests.
+
+
+def get_valid_token(user_id: str, credentials=None):
+    """Return a valid Calendar access token for user_id (delegates to oauth_vault)."""
+    return _oauth_vault_client.get_valid_token("calendar", user_id, credentials=credentials)
+
 
 # ---------------------------------------------------------------------------
 # Google Calendar REST API constants

--- a/src/integrations/google_calendar/token_store.py
+++ b/src/integrations/google_calendar/token_store.py
@@ -57,6 +57,8 @@ from integrations.google_calendar.oauth import (
     TokenData,
     is_token_valid,
 )
+from integrations.google_workspace import token_store as _workspace_token_store
+from integrations.google_workspace.config import WORKSPACE_TOKEN_DIR
 
 log = logging.getLogger(__name__)
 
@@ -68,6 +70,14 @@ _HOME: Path = Path.home()
 _MESSAGES_DIR: Path = Path(os.environ.get("LOBSTER_MESSAGES", str(_HOME / "messages")))
 _TOKEN_DIR: Path = _MESSAGES_DIR / "config" / "gcal-tokens"
 _CALENDAR_CONFIG_PATH: Path = _MESSAGES_DIR / "config" / "calendar-config.json"
+
+# BIS-731 / Slice 3: fallback token store for users who ran the `workspace`
+# consent flow instead of the calendar-specific one. `WORKSPACE_SCOPES` in
+# google_workspace/config.py includes the full-access calendar scope
+# ("https://www.googleapis.com/auth/calendar") "for unified-token support" —
+# this is what lets a workspace grant substitute for a dedicated one.
+_WORKSPACE_TOKEN_DIR: Path = WORKSPACE_TOKEN_DIR
+_WORKSPACE_CALENDAR_SCOPE_SUBSTRING: str = "calendar"
 
 # File permissions: owner read+write only (octal 0o600)
 _TOKEN_FILE_MODE: int = stat.S_IRUSR | stat.S_IWUSR
@@ -343,25 +353,77 @@ def load_token(
     return _load_token_local(user_id, token_dir)
 
 
+def _get_workspace_fallback_token(
+    user_id: str,
+    workspace_token_dir: Path,
+) -> Optional[TokenData]:
+    """Fall back to the shared Google Workspace token store.
+
+    A user who ran the `workspace` consent flow (not the calendar-specific
+    one) already holds a token whose scope bundle includes the calendar
+    scope "for unified-token support" (google_workspace/config.py
+    WORKSPACE_SCOPES). Rather than re-implement load/validate/refresh here,
+    delegate to google_workspace.token_store.get_valid_token, which already
+    owns that lifecycle for its own store — this only decides whether the
+    result it returns is usable for calendar, based on the granted scope.
+
+    Args:
+        user_id:             Unique identifier for the user.
+        workspace_token_dir: Workspace token directory (injectable for testing).
+
+    Returns:
+        The workspace TokenData if it exists, is valid (or refreshable), and
+        its scope includes the calendar scope; otherwise None.
+    """
+    workspace_token = _workspace_token_store.get_valid_token(
+        user_id, token_dir=workspace_token_dir
+    )
+    if workspace_token is None:
+        return None
+
+    if _WORKSPACE_CALENDAR_SCOPE_SUBSTRING not in workspace_token.scope:
+        log.info(
+            "Workspace token for user_id=%r does not grant calendar scope "
+            "(scope=%r) — not using it as a calendar fallback.",
+            user_id,
+            workspace_token.scope,
+        )
+        return None
+
+    log.info(
+        "No calendar-specific token for user_id=%r — using workspace token "
+        "fallback (scope includes calendar).",
+        user_id,
+    )
+    return workspace_token
+
+
 def get_valid_token(
     user_id: str,
     token_dir: Path = _TOKEN_DIR,
     credentials=None,  # kept for API compatibility — unused in local backend
+    workspace_token_dir: Path = _WORKSPACE_TOKEN_DIR,
 ) -> Optional[TokenData]:
     """Return a valid access token for the user, refreshing if necessary.
 
     Workflow:
     1. Load token from local disk.
-    2. If no token -> return None (user must re-authenticate).
+    2. If no token -> fall back to the workspace token store (BIS-731); if
+       that also yields nothing usable -> return None (user must
+       re-authenticate).
     3. If token is still valid -> return it.
     4. If token is expired -> call myownlobster refresh proxy.
     5. Persist the refreshed token (preserving the original refresh_token).
     6. If refresh fails -> log and return None.
 
     Args:
-        user_id:     Unique identifier for the user (Telegram chat_id as str).
-        token_dir:   Local token directory (injectable for testing).
-        credentials: Ignored; kept for backwards-compatible call sites.
+        user_id:             Unique identifier for the user (Telegram chat_id as str).
+        token_dir:           Local token directory (injectable for testing).
+        credentials:         Ignored; kept for backwards-compatible call sites.
+        workspace_token_dir: Workspace token directory (injectable for testing).
+                             Only consulted when no calendar-specific token
+                             file exists at all — an existing calendar token
+                             is always used as-is, workspace is never checked.
 
     Returns:
         A valid TokenData, or None if no valid token is available.
@@ -369,7 +431,7 @@ def get_valid_token(
     token = _load_token_local(user_id, token_dir)
     if token is None:
         log.info("No local token found for user_id=%r.", user_id)
-        return None
+        return _get_workspace_fallback_token(user_id, workspace_token_dir)
 
     if is_token_valid(token):
         return token

--- a/src/integrations/oauth_vault/__init__.py
+++ b/src/integrations/oauth_vault/__init__.py
@@ -1,0 +1,25 @@
+"""
+oauth_vault — provider-parameterized OAuth token storage and refresh (BIS-732 / Slice 4).
+
+Extracts the pattern proven identically three times across
+``integrations.google_calendar.token_store``, ``integrations.gmail.token_store``,
+and ``integrations.google_workspace.token_store`` (per-user local-disk token
+persistence, atomic 0600 writes, myownlobster.ai refresh-proxy calls, and the
+BIS-731 workspace-token fallback) into a single module parameterized by
+``provider`` instead of copy-pasted per integration.
+
+Submodules:
+    vault_store — pure serialization + file I/O, parameterized by an explicit
+                  ``token_dir`` (no provider-registry knowledge).
+    client       — provider registry, refresh-proxy HTTP call, and the
+                  higher-level ``get_valid_token(provider, user_id, ...)``
+                  that composes vault_store with refresh + workspace fallback.
+
+This slice cuts over ``google_calendar/client.py`` only, proving the
+abstraction against the best-tested existing integration before Gmail and
+Workspace follow in later slices. The three original ``token_store.py``
+modules are left in the tree, unimported by this package, as a one-release
+rollback path.
+"""
+
+from __future__ import annotations

--- a/src/integrations/oauth_vault/client.py
+++ b/src/integrations/oauth_vault/client.py
@@ -1,0 +1,391 @@
+"""
+oauth_vault.client — provider-parameterized get_valid_token + refresh proxy
+(BIS-732 / Slice 4).
+
+Generalizes the ``get_valid_token`` workflow proven identically three times
+across ``google_calendar/token_store.py``, ``gmail/token_store.py``, and
+``google_workspace/token_store.py`` — load local token -> return if still
+valid -> refresh via the myownlobster.ai proxy if expired -> persist -> the
+BIS-731 workspace-token fallback when no scope-specific token exists at all
+— into one implementation parameterized by a ``provider`` key instead of
+copy-pasted per integration.
+
+**Deliberate deviation from the literal Slice 4 plan text, flagged here:**
+the plan describes the new canonical storage path as
+``~/messages/config/oauth-tokens/<provider>/<chat_id>.json`` for every
+provider uniformly. For the "calendar" provider specifically, this module
+instead aliases its default ``token_dir`` to the *existing*
+``~/messages/config/gcal-tokens/`` directory (see ``PROVIDERS["calendar"]``
+below) rather than the fresh ``oauth-tokens/calendar/`` path. Reason: the
+*write* path for Calendar tokens — ``push_calendar_token_endpoint`` in
+``inbox_server_http.py`` (the myownlobster.ai push-token receiver) and the
+local ``callback_server.py`` flow — is explicitly NOT part of this slice's
+cutover and continues to write to ``gcal-tokens/`` via the old
+``google_calendar/token_store.py``. Pointing this module's read path at a
+new, empty ``oauth-tokens/calendar/`` directory instead would mean a real,
+already-granted Calendar token silently stops being found the moment
+``google_calendar/client.py`` cuts over — exactly the kind of regression
+Slice 4's "re-run 'what's on my calendar' ... identical behavior" manual
+check exists to catch. The fresh ``oauth-tokens/<provider>/`` layout
+remains the target for any new provider with no legacy directory to alias
+to, and becomes the actual location for calendar once its write path is
+cut over too (tracked for a later slice, not created here).
+
+This module is additive: the three existing token_store.py modules are left
+in the tree, unimported by this module, as a one-release rollback path —
+deleted only once every consumer (read AND write paths) has migrated.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+from integrations.google_calendar.oauth import TokenData, is_token_valid
+from integrations.google_workspace import token_store as _workspace_token_store
+from integrations.google_workspace.config import WORKSPACE_TOKEN_DIR
+from integrations.oauth_vault.vault_store import (
+    load_token as _load_token,
+    provider_token_dir,
+    save_token as _save_token,
+)
+
+log = logging.getLogger(__name__)
+
+_HOME: Path = Path.home()
+_MESSAGES_DIR: Path = Path(os.environ.get("LOBSTER_MESSAGES", str(_HOME / "messages")))
+
+# HTTP timeout for refresh proxy calls (seconds) — same as all three
+# predecessor token_store.py modules.
+_HTTP_TIMEOUT: int = 10
+
+# Default refresh proxy base URL (GCP secrets live on myownlobster.ai).
+_DEFAULT_API_BASE: str = "https://myownlobster.ai"
+
+
+# ---------------------------------------------------------------------------
+# Provider registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProviderConfig:
+    """Per-provider settings needed to resolve a valid access token.
+
+    Attributes:
+        name:                      Provider key, e.g. "calendar".
+        token_dir:                 Directory this provider's tokens live in.
+                                    See module docstring re: why this aliases
+                                    to a legacy directory for "calendar"
+                                    rather than using ``provider_token_dir``.
+        refresh_endpoint:          myownlobster.ai internal refresh path.
+        config_path:               Path to this provider's own JSON config
+                                    file (``myownlobster_api_base`` override)
+                                    — kept per-provider (not a single shared
+                                    vault config) so the cutover preserves
+                                    prior behavior file-for-file: an operator
+                                    who already overrode
+                                    ``calendar-config.json`` sees no change.
+        workspace_scope_substring: If set, ``get_valid_token`` falls back to
+                                    the shared workspace token store when
+                                    this provider's own token file is absent,
+                                    accepting the workspace token only if its
+                                    granted scope contains this substring
+                                    (the BIS-731 pattern, generalized).
+    """
+
+    name: str
+    token_dir: Path
+    refresh_endpoint: str
+    config_path: Path
+    workspace_scope_substring: Optional[str] = None
+
+
+PROVIDERS: dict[str, ProviderConfig] = {
+    "calendar": ProviderConfig(
+        name="calendar",
+        # Alias to the pre-existing gcal-tokens/ directory — see the
+        # "Deliberate deviation" note in this module's docstring.
+        token_dir=_MESSAGES_DIR / "config" / "gcal-tokens",
+        refresh_endpoint="/api/internal/refresh-calendar-token",
+        config_path=_MESSAGES_DIR / "config" / "calendar-config.json",
+        workspace_scope_substring="calendar",
+    ),
+}
+
+
+def _provider_config(provider: str) -> ProviderConfig:
+    """Look up a registered provider's config, or raise a clear error."""
+    try:
+        return PROVIDERS[provider]
+    except KeyError:
+        raise ValueError(
+            f"Unknown oauth_vault provider {provider!r}. "
+            f"Registered providers: {sorted(PROVIDERS)}"
+        ) from None
+
+
+# ---------------------------------------------------------------------------
+# Per-provider config loader (myownlobster_api_base override)
+# ---------------------------------------------------------------------------
+
+
+def _load_provider_config_file(provider_cfg: ProviderConfig) -> dict:
+    """Return the parsed provider config JSON, or an empty dict if absent."""
+    if not provider_cfg.config_path.exists():
+        return {}
+    try:
+        return json.loads(provider_cfg.config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning(
+            "oauth_vault: failed to parse config for provider=%r: %s",
+            provider_cfg.name, exc,
+        )
+        return {}
+
+
+def _myownlobster_api_base(provider_cfg: ProviderConfig) -> str:
+    """Return the myownlobster API base URL from provider config, or the default."""
+    config = _load_provider_config_file(provider_cfg)
+    return config.get("myownlobster_api_base", _DEFAULT_API_BASE).rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Auth header helper
+# ---------------------------------------------------------------------------
+
+
+def _internal_auth_header() -> dict[str, str]:
+    """Return the Authorization header for internal API calls.
+
+    Reads LOBSTER_INTERNAL_SECRET from the environment.
+
+    Raises:
+        RuntimeError: If LOBSTER_INTERNAL_SECRET is not set.
+    """
+    secret = os.environ.get("LOBSTER_INTERNAL_SECRET", "").strip()
+    if not secret:
+        raise RuntimeError(
+            "LOBSTER_INTERNAL_SECRET is not set. "
+            "Add it to config.env to enable token refresh via myownlobster."
+        )
+    return {"Authorization": f"Bearer {secret}"}
+
+
+# ---------------------------------------------------------------------------
+# Refresh proxy (calls myownlobster.ai — side-effecting)
+# ---------------------------------------------------------------------------
+
+
+def _refresh_token_via_proxy(provider: str, refresh_token: str) -> Optional[TokenData]:
+    """Obtain a new access token by calling the myownlobster refresh proxy.
+
+    myownlobster.ai holds the GCP client_id + client_secret and proxies the
+    refresh call to Google, returning only the new access_token and expires_in.
+
+    Args:
+        provider:      Registered provider key (e.g. "calendar").
+        refresh_token: The long-lived refresh token.
+
+    Returns:
+        A new TokenData (refresh_token preserved from caller), or None on error.
+    """
+    provider_cfg = _provider_config(provider)
+    api_base = _myownlobster_api_base(provider_cfg)
+    url = f"{api_base}{provider_cfg.refresh_endpoint}"
+
+    try:
+        headers = _internal_auth_header()
+    except RuntimeError as exc:
+        log.error("oauth_vault refresh proxy (%s): %s", provider, exc)
+        return None
+
+    try:
+        resp = requests.post(
+            url,
+            json={"refresh_token": refresh_token},
+            headers=headers,
+            timeout=_HTTP_TIMEOUT,
+        )
+    except requests.exceptions.RequestException as exc:
+        log.warning("oauth_vault refresh proxy (%s) unreachable: %s", provider, exc)
+        return None
+
+    if not resp.ok:
+        log.warning(
+            "oauth_vault refresh proxy (%s) returned %d: %s",
+            provider, resp.status_code, resp.text[:200],
+        )
+        return None
+
+    try:
+        data = resp.json()
+        access_token = data["access_token"]
+        expires_in = int(data["expires_in"])
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        log.warning(
+            "oauth_vault refresh proxy (%s) returned unexpected payload: %s",
+            provider, exc,
+        )
+        return None
+
+    expires_at = datetime.now(tz=timezone.utc) + timedelta(seconds=expires_in)
+
+    log.info("oauth_vault: token refresh via proxy succeeded (provider=%s).", provider)
+    return TokenData(
+        access_token=access_token,
+        expires_at=expires_at,
+        scope="",  # scope is not returned by the refresh proxy; preserved from disk
+        refresh_token=None,  # caller must preserve the original refresh_token
+    )
+
+
+# ---------------------------------------------------------------------------
+# Workspace-token fallback (BIS-731 pattern, generalized)
+# ---------------------------------------------------------------------------
+
+
+def _get_workspace_fallback_token(
+    provider_cfg: ProviderConfig,
+    user_id: str,
+    workspace_token_dir: Path,
+) -> Optional[TokenData]:
+    """Fall back to the shared Google Workspace token store, if applicable.
+
+    Only attempted for providers that declare a ``workspace_scope_substring``.
+    A user who ran the `workspace` consent flow (not this provider's own)
+    already holds a token whose scope bundle includes this provider's scope
+    "for unified-token support" (google_workspace/config.py WORKSPACE_SCOPES).
+
+    Args:
+        provider_cfg:         The requesting provider's config.
+        user_id:              Unique identifier for the user.
+        workspace_token_dir:  Workspace token directory (injectable for testing).
+
+    Returns:
+        The workspace TokenData if it exists, is valid (or refreshable), and
+        its scope includes this provider's required substring; otherwise None.
+    """
+    if provider_cfg.workspace_scope_substring is None:
+        return None
+
+    workspace_token = _workspace_token_store.get_valid_token(
+        user_id, token_dir=workspace_token_dir
+    )
+    if workspace_token is None:
+        return None
+
+    if provider_cfg.workspace_scope_substring not in workspace_token.scope:
+        log.info(
+            "oauth_vault: workspace token for user_id=%r does not grant %r scope "
+            "(scope=%r) — not using it as a %s fallback.",
+            user_id, provider_cfg.workspace_scope_substring,
+            workspace_token.scope, provider_cfg.name,
+        )
+        return None
+
+    log.info(
+        "oauth_vault: no %s-specific token for user_id=%r — using workspace "
+        "token fallback (scope includes %r).",
+        provider_cfg.name, user_id, provider_cfg.workspace_scope_substring,
+    )
+    return workspace_token
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_valid_token(
+    provider: str,
+    user_id: str,
+    token_dir: Optional[Path] = None,
+    credentials=None,  # kept for API compatibility with existing call sites; unused
+    workspace_token_dir: Path = WORKSPACE_TOKEN_DIR,
+) -> Optional[TokenData]:
+    """Return a valid access token for (provider, user_id), refreshing if necessary.
+
+    Workflow (identical to the three predecessor token_store.py modules):
+    1. Load token from local disk (``token_dir``, or the provider's
+       registered default if not given).
+    2. If no token -> fall back to the workspace token store (BIS-731); if
+       that also yields nothing usable -> return None (user must
+       re-authenticate).
+    3. If token is still valid -> return it.
+    4. If token is expired -> call myownlobster refresh proxy.
+    5. Persist the refreshed token (preserving the original refresh_token).
+    6. If refresh fails -> log and return None.
+
+    Args:
+        provider:            Registered provider key (e.g. "calendar").
+        user_id:             Unique identifier for the user (Telegram chat_id as str).
+        token_dir:           Local token directory (injectable for testing).
+                             Defaults to the provider's registered directory.
+        credentials:         Ignored; kept for backwards-compatible call sites.
+        workspace_token_dir: Workspace token directory (injectable for testing).
+                             Only consulted when no provider-specific token
+                             file exists at all — an existing provider token
+                             is always used as-is, workspace is never checked.
+
+    Returns:
+        A valid TokenData, or None if no valid token is available.
+
+    Raises:
+        ValueError: If ``provider`` is not a registered provider.
+    """
+    provider_cfg = _provider_config(provider)
+    effective_token_dir = token_dir if token_dir is not None else provider_cfg.token_dir
+
+    token = _load_token(user_id, effective_token_dir)
+    if token is None:
+        log.info(
+            "oauth_vault: no local token found for provider=%s user_id=%r.",
+            provider, user_id,
+        )
+        return _get_workspace_fallback_token(provider_cfg, user_id, workspace_token_dir)
+
+    if is_token_valid(token):
+        return token
+
+    # Token is expired — attempt refresh via myownlobster proxy
+    if token.refresh_token is None:
+        log.warning(
+            "oauth_vault: token for provider=%s user_id=%r is expired and has "
+            "no refresh_token; user must re-authenticate.",
+            provider, user_id,
+        )
+        return None
+
+    log.info(
+        "oauth_vault: access token expired for provider=%s user_id=%r — "
+        "refreshing via proxy.",
+        provider, user_id,
+    )
+
+    refreshed_partial = _refresh_token_via_proxy(provider, token.refresh_token)
+    if refreshed_partial is None:
+        log.error(
+            "oauth_vault: token refresh failed for provider=%s user_id=%r — "
+            "user must re-authenticate.",
+            provider, user_id,
+        )
+        return None
+
+    # Merge: preserve scope and refresh_token from the stored token
+    refreshed = TokenData(
+        access_token=refreshed_partial.access_token,
+        expires_at=refreshed_partial.expires_at,
+        scope=token.scope,                  # preserve original scope
+        refresh_token=token.refresh_token,  # Google doesn't return new refresh_token here
+    )
+
+    _save_token(user_id, refreshed, effective_token_dir)
+    return refreshed

--- a/src/integrations/oauth_vault/vault_store.py
+++ b/src/integrations/oauth_vault/vault_store.py
@@ -1,0 +1,184 @@
+"""
+Generic per-user OAuth token persistence, parameterized by an explicit
+``token_dir`` (BIS-732 / Slice 4).
+
+This module is the storage layer proven identically three times in
+``google_calendar/token_store.py``, ``gmail/token_store.py``, and
+``google_workspace/token_store.py`` — same on-disk JSON schema, same
+atomic-write-then-rename, same 0600 file permissions — with the one
+per-integration difference (the token directory) taken as an explicit
+parameter instead of a module-level constant.
+
+This module has NO knowledge of "providers" as a registry concept — that
+lives in ``oauth_vault.client``, which resolves a provider name to a
+``token_dir`` and calls into this module. Keeping this module provider-
+agnostic means it is trivially testable and reusable for any future token
+kind (not just Google OAuth), since it depends only on the shared
+``TokenData`` shape.
+
+Token schema on disk (unchanged from the three predecessors)::
+
+    {
+        "access_token":  "<string>",
+        "expires_at":    "<ISO 8601 UTC>",
+        "scope":         "<space-separated scopes>",
+        "refresh_token": "<string or null>"
+    }
+
+Design principles
+-----------------
+- Side effects (file I/O) are isolated to dedicated private/public functions.
+- Serialization helpers (``_token_to_dict`` / ``_dict_to_token``) are pure.
+- No token values are written to logs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from integrations.google_calendar.oauth import TokenData
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Storage locations
+# ---------------------------------------------------------------------------
+
+_HOME: Path = Path.home()
+_MESSAGES_DIR: Path = Path(os.environ.get("LOBSTER_MESSAGES", str(_HOME / "messages")))
+
+#: Root directory for providers that have no pre-existing legacy token
+#: directory to alias to. New providers (not yet migrated from a bespoke
+#: token_store.py) should live under here as
+#: ``oauth-tokens/<provider>/<chat_id>.json``. Providers being cut over from
+#: an existing bespoke store (e.g. "calendar" in this slice) instead alias
+#: their default token_dir to their existing legacy directory — see
+#: ``oauth_vault.client.PROVIDERS`` — so the read path introduced here and
+#: the not-yet-migrated write path (myownlobster.ai push endpoints,
+#: callback_server.py) keep agreeing on where a real token lives.
+VAULT_ROOT: Path = _MESSAGES_DIR / "config" / "oauth-tokens"
+
+# File permissions: owner read+write only (octal 0o600)
+_TOKEN_FILE_MODE: int = stat.S_IRUSR | stat.S_IWUSR
+
+
+def provider_token_dir(provider: str, vault_root: Path = VAULT_ROOT) -> Path:
+    """Return the default fresh-start token directory for a provider.
+
+    Only meaningful for providers with no legacy directory to alias to.
+    Providers cut over from an existing bespoke token_store.py should pass
+    their own explicit ``token_dir`` instead (see ``oauth_vault.client``).
+    """
+    return vault_root / provider
+
+
+# ---------------------------------------------------------------------------
+# Serialisation helpers (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def _token_to_dict(token: TokenData) -> dict:
+    """Convert a TokenData to a JSON-serialisable dict."""
+    return {
+        "access_token": token.access_token,
+        "expires_at": token.expires_at.isoformat(),
+        "scope": token.scope,
+        "refresh_token": token.refresh_token,
+    }
+
+
+def _dict_to_token(data: dict) -> TokenData:
+    """Reconstruct a TokenData from a deserialised JSON dict."""
+    expires_at = datetime.fromisoformat(data["expires_at"])
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return TokenData(
+        access_token=data["access_token"],
+        expires_at=expires_at,
+        scope=data.get("scope", ""),
+        refresh_token=data.get("refresh_token"),
+    )
+
+
+def _token_path(user_id: str, token_dir: Path) -> Path:
+    """Return the absolute path to a user's token file.
+
+    Pure function: no filesystem access.
+
+    Args:
+        user_id:   Telegram chat_id as a string.
+        token_dir: Directory holding per-user token files.
+
+    Returns:
+        Absolute Path to ``{token_dir}/{safe_user_id}.json``.
+
+    Raises:
+        ValueError: If the sanitised user_id would produce an empty filename.
+    """
+    safe_id = "".join(c for c in user_id if c.isalnum() or c in ("-", "_"))
+    if not safe_id:
+        raise ValueError(
+            f"user_id {user_id!r} produces an empty filename after sanitisation"
+        )
+    return token_dir / f"{safe_id}.json"
+
+
+# ---------------------------------------------------------------------------
+# Local file I/O (side-effecting)
+# ---------------------------------------------------------------------------
+
+
+def save_token(user_id: str, token: TokenData, token_dir: Path) -> None:
+    """Persist a user's OAuth token to a local JSON file (mode 0o600).
+
+    Uses an atomic write (write to .tmp, then rename) to avoid corruption
+    if the process is interrupted mid-write.
+
+    Args:
+        user_id:   Unique identifier for the user.
+        token:     TokenData to persist.
+        token_dir: Directory for token files.
+    """
+    token_dir.mkdir(parents=True, exist_ok=True)
+    path = _token_path(user_id, token_dir)
+    payload = json.dumps(_token_to_dict(token), indent=2)
+    tmp_path = path.with_suffix(".json.tmp")
+    try:
+        fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _TOKEN_FILE_MODE)
+        with os.fdopen(fd, "w") as f:
+            f.write(payload)
+        os.rename(str(tmp_path), str(path))
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+    log.info("oauth_vault: token saved for user_id=%r at %s", user_id, path)
+
+
+def load_token(user_id: str, token_dir: Path) -> Optional[TokenData]:
+    """Load a user's token from the local JSON file.
+
+    Args:
+        user_id:   Unique identifier for the user.
+        token_dir: Directory for token files.
+
+    Returns:
+        TokenData if the file exists and is valid JSON, else None.
+    """
+    path = _token_path(user_id, token_dir)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return _dict_to_token(data)
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        log.warning("oauth_vault: failed to parse token file for user_id=%r: %s", user_id, exc)
+        return None

--- a/src/mcp/inbox_server_http.py
+++ b/src/mcp/inbox_server_http.py
@@ -31,6 +31,8 @@ Remote Claude Code config (claude_desktop_config.json):
 """
 
 import contextlib
+import hashlib
+import hmac
 import json
 import logging
 import os
@@ -224,6 +226,129 @@ _IMPORT_TOKEN: str = os.environ.get("LOBSTER_IMPORT_TOKEN", os.environ.get("AWP_
 
 _INBOX_DIR: Path = _MESSAGES_DIR / "inbox"
 
+# ---------------------------------------------------------------------------
+# BIS-727 Slice 1 — per-transaction HMAC signing, calendar push path only
+# ---------------------------------------------------------------------------
+# push_calendar_token_endpoint additionally verifies a signed, single-use,
+# 30-minute-TTL session token (HMAC-SHA256 over
+# instance_id|chat_id|scope|nonce|exp) bound to the specific consent
+# transaction, alongside the existing static-secret bearer check above. This
+# closes BIS-728's forged-push vulnerability: an attacker holding only the
+# leaked LOBSTER_INTERNAL_SECRET (the bearer token) cannot forge a valid
+# signature without also knowing this SECOND, independent secret, which is
+# shared only with myownlobster.ai's callback route (never with any client
+# that merely holds the bearer secret).
+#
+# _INSTANCE_URL, if configured, additionally binds the session to THIS VPS
+# instance specifically (defense in depth beyond this single-tenant
+# deployment's immediate needs).
+_INSTANCE_URL: str = os.environ.get("LOBSTER_INSTANCE_URL", "").strip()
+_SESSION_HMAC_SECRET: str = os.environ.get("CONSENT_SESSION_HMAC_SECRET", "").strip()
+_SESSION_TOKEN_TTL_SECONDS: int = 30 * 60  # 30 minutes, per BIS-729
+
+# --- Warn-then-enforce rollout (BIS-729) ------------------------------------
+# Ships with enforce=False (warn-only) by default: this VPS-side change and
+# myownlobster.ai's callback-route change deploy independently, so a VPS that
+# hard-rejects on day one (before the broker side is emitting signed
+# sessions) would break every calendar consent flow. Rollout sequence for
+# whoever flips this in production:
+#   1. Deploy this VPS change first. It runs in warn mode: pushes missing or
+#      carrying an invalid signed session are still ACCEPTED, but each one
+#      logs a warning (see _verify_calendar_session_token call site below).
+#   2. Deploy myownlobster.ai's matching change (calendar callback starts
+#      attaching signed sessions to every push).
+#   3. Watch the logs for ~48h. Once no more "missing/invalid signed
+#      session" warnings appear for legitimate traffic, set
+#      CALENDAR_PUSH_SIGNED_SESSION_ENFORCE=true (env var) and restart the
+#      HTTP bridge (`~/lobster/scripts/restart-mcp.sh`) to start hard-
+#      rejecting (401) any calendar push lacking a valid signed session.
+_ENFORCE_SIGNED_SESSION: bool = os.environ.get(
+    "CALENDAR_PUSH_SIGNED_SESSION_ENFORCE", "false"
+).strip().lower() in ("1", "true", "yes")
+
+# Single-use enforcement for the session token's nonce, at THIS process's
+# scope. markConsumed() on the myownlobster.ai side already guarantees a
+# given ConsentToken's nonce is fetched at most once; this in-memory set is
+# additional defense against replaying a captured signed session (e.g. from
+# a log line or MITM'd request) more than once within its 30-minute TTL.
+# Process-lifetime only (not persisted across restarts) — acceptable given
+# this bridge runs as a single uvicorn worker and the window is short.
+_seen_calendar_session_nonces: dict[str, float] = {}
+
+
+def _consume_calendar_session_nonce(nonce: str, exp: float) -> bool:
+    """Atomically-within-this-process claim a nonce. False if already seen."""
+    now = time.time()
+    expired = [n for n, e in _seen_calendar_session_nonces.items() if e < now]
+    for n in expired:
+        del _seen_calendar_session_nonces[n]
+    if nonce in _seen_calendar_session_nonces:
+        return False
+    _seen_calendar_session_nonces[nonce] = exp
+    return True
+
+
+def _verify_calendar_session_token(body: dict, chat_id: str, scope_str: str) -> tuple[bool, str]:
+    """Verify the calendar push's signed, single-use, 30-min-TTL session token.
+
+    Returns ``(ok, reason)``. ``reason`` is a short machine-readable string
+    for logging only — it never includes secret material or token values.
+    """
+    session = body.get("session_token")
+    if not isinstance(session, dict):
+        return False, "missing_session_token"
+
+    if not _SESSION_HMAC_SECRET:
+        return False, "hmac_secret_not_configured"
+
+    instance_id = session.get("instance_id")
+    session_chat_id = session.get("chat_id")
+    session_scope = session.get("scope")
+    nonce = session.get("nonce")
+    sig = session.get("sig")
+    exp = session.get("exp")
+
+    if not (
+        isinstance(instance_id, str)
+        and instance_id
+        and isinstance(session_chat_id, str)
+        and session_chat_id
+        and isinstance(session_scope, str)
+        and session_scope
+        and isinstance(nonce, str)
+        and nonce
+        and isinstance(sig, str)
+        and sig
+        and isinstance(exp, (int, float))
+        and not isinstance(exp, bool)
+    ):
+        return False, "malformed_session_token"
+
+    # Bind the session to THIS transaction: the signed chat_id/scope must
+    # match the request body's chat_id/scope exactly (an attacker cannot
+    # reuse a session issued for one chat_id/scope on another).
+    if session_chat_id != chat_id:
+        return False, "chat_id_mismatch"
+    if session_scope != scope_str:
+        return False, "scope_mismatch"
+    if _INSTANCE_URL and instance_id != _INSTANCE_URL:
+        return False, "instance_id_mismatch"
+
+    message = f"{instance_id}|{session_chat_id}|{session_scope}|{nonce}|{int(exp)}"
+    expected_sig = hmac.new(
+        _SESSION_HMAC_SECRET.encode("utf-8"), message.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(expected_sig, sig):
+        return False, "bad_signature"
+
+    if exp < time.time():
+        return False, "expired"
+
+    if not _consume_calendar_session_nonce(nonce, float(exp)):
+        return False, "nonce_already_used"
+
+    return True, "ok"
+
 
 def _is_authorized_internal(request: Request) -> bool:
     """Return True if the request carries a valid LOBSTER_INTERNAL_SECRET."""
@@ -264,7 +389,13 @@ async def push_calendar_token_endpoint(scope, receive, send):
           "scope":         "<space-separated scopes>"
         }
 
-    Authentication: ``Authorization: Bearer <LOBSTER_INTERNAL_SECRET>``
+    Authentication: ``Authorization: Bearer <LOBSTER_INTERNAL_SECRET>``, PLUS
+    (BIS-727 Slice 1) a signed, single-use, 30-minute-TTL ``session_token``
+    object bound to the specific consent transaction — see
+    ``_verify_calendar_session_token`` and the warn-then-enforce rollout
+    comment near ``_ENFORCE_SIGNED_SESSION`` above. During the warn window
+    (default), a missing/invalid session_token is logged but still accepted;
+    once ``CALENDAR_PUSH_SIGNED_SESSION_ENFORCE=true``, it is hard-rejected.
 
     Writes the token to ``~/messages/config/gcal-tokens/{chat_id}.json``
     with mode 0o600.
@@ -296,6 +427,33 @@ async def push_calendar_token_endpoint(scope, receive, send):
         )
         await response(scope, receive, send)
         return
+
+    # --- BIS-727 Slice 1: per-transaction signed session, calendar path only ---
+    session_ok, session_reason = _verify_calendar_session_token(body, chat_id, scope_str)
+    if not session_ok:
+        if _ENFORCE_SIGNED_SESSION:
+            logger.warning(
+                "Rejecting calendar push: invalid/missing signed session "
+                "(reason=%s) chat_id=%r",
+                session_reason,
+                chat_id,
+            )
+            response = JSONResponse(
+                {"error": "Unauthorized: missing or invalid signed session"},
+                status_code=401,
+            )
+            await response(scope, receive, send)
+            return
+        logger.warning(
+            "Calendar push missing/invalid signed session (reason=%s) chat_id=%r "
+            "— accepting during BIS-729 warn-then-enforce window. Set "
+            "CALENDAR_PUSH_SIGNED_SESSION_ENFORCE=true once myownlobster.ai is "
+            "confirmed emitting valid sessions for all calendar consent flows.",
+            session_reason,
+            chat_id,
+        )
+    else:
+        logger.info("Calendar push signed session verified for chat_id=%r", chat_id)
 
     # Sanitise chat_id to prevent path traversal
     safe_chat_id = "".join(c for c in chat_id if c.isalnum() or c in ("-", "_"))

--- a/src/mcp/inbox_server_http.py
+++ b/src/mcp/inbox_server_http.py
@@ -501,6 +501,99 @@ async def push_calendar_token_endpoint(scope, receive, send):
     await response(scope, receive, send)
 
 
+# ---------------------------------------------------------------------------
+# BIS-727 Slice 2 — per-transaction HMAC signing, gmail push path
+# ---------------------------------------------------------------------------
+# Identical treatment to push_calendar_token_endpoint (BIS-727 Slice 1) above
+# — deliberately copy-pasted rather than shared (per the BIS-730 plan:
+# premature abstraction here is what Slice 4 is for). Verifies a signed,
+# single-use, 30-minute-TTL session token (HMAC-SHA256 over
+# instance_id|chat_id|scope|nonce|exp) bound to the specific consent
+# transaction, alongside the existing static-secret bearer check. Reuses the
+# SAME _SESSION_HMAC_SECRET / _INSTANCE_URL module-level config as calendar
+# (one shared secret across scopes, matching myownlobster.ai's single
+# CONSENT_SESSION_HMAC_SECRET env var), but has its OWN enforce flag and
+# nonce-replay set, so gmail's warn-then-enforce rollout can be flipped
+# independently of calendar's and workspace's.
+_ENFORCE_GMAIL_SIGNED_SESSION: bool = os.environ.get(
+    "GMAIL_PUSH_SIGNED_SESSION_ENFORCE", "false"
+).strip().lower() in ("1", "true", "yes")
+
+_seen_gmail_session_nonces: dict[str, float] = {}
+
+
+def _consume_gmail_session_nonce(nonce: str, exp: float) -> bool:
+    """Atomically-within-this-process claim a nonce. False if already seen."""
+    now = time.time()
+    expired = [n for n, e in _seen_gmail_session_nonces.items() if e < now]
+    for n in expired:
+        del _seen_gmail_session_nonces[n]
+    if nonce in _seen_gmail_session_nonces:
+        return False
+    _seen_gmail_session_nonces[nonce] = exp
+    return True
+
+
+def _verify_gmail_session_token(body: dict, chat_id: str, scope_str: str) -> tuple[bool, str]:
+    """Verify the gmail push's signed, single-use, 30-min-TTL session token.
+
+    Copy-pasted from ``_verify_calendar_session_token`` (BIS-730: deliberately
+    not shared code yet). Returns ``(ok, reason)``; ``reason`` is a short
+    machine-readable string for logging only — never secret material.
+    """
+    session = body.get("session_token")
+    if not isinstance(session, dict):
+        return False, "missing_session_token"
+
+    if not _SESSION_HMAC_SECRET:
+        return False, "hmac_secret_not_configured"
+
+    instance_id = session.get("instance_id")
+    session_chat_id = session.get("chat_id")
+    session_scope = session.get("scope")
+    nonce = session.get("nonce")
+    sig = session.get("sig")
+    exp = session.get("exp")
+
+    if not (
+        isinstance(instance_id, str)
+        and instance_id
+        and isinstance(session_chat_id, str)
+        and session_chat_id
+        and isinstance(session_scope, str)
+        and session_scope
+        and isinstance(nonce, str)
+        and nonce
+        and isinstance(sig, str)
+        and sig
+        and isinstance(exp, (int, float))
+        and not isinstance(exp, bool)
+    ):
+        return False, "malformed_session_token"
+
+    if session_chat_id != chat_id:
+        return False, "chat_id_mismatch"
+    if session_scope != scope_str:
+        return False, "scope_mismatch"
+    if _INSTANCE_URL and instance_id != _INSTANCE_URL:
+        return False, "instance_id_mismatch"
+
+    message = f"{instance_id}|{session_chat_id}|{session_scope}|{nonce}|{int(exp)}"
+    expected_sig = hmac.new(
+        _SESSION_HMAC_SECRET.encode("utf-8"), message.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(expected_sig, sig):
+        return False, "bad_signature"
+
+    if exp < time.time():
+        return False, "expired"
+
+    if not _consume_gmail_session_nonce(nonce, float(exp)):
+        return False, "nonce_already_used"
+
+    return True, "ok"
+
+
 async def push_gmail_token_endpoint(scope, receive, send):
     """POST /api/push-gmail-token — receive a Gmail token pushed by myownlobster.ai.
 
@@ -514,7 +607,13 @@ async def push_gmail_token_endpoint(scope, receive, send):
           "scope":         "<space-separated scopes>"
         }
 
-    Authentication: ``Authorization: Bearer <LOBSTER_INTERNAL_SECRET>``
+    Authentication: ``Authorization: Bearer <LOBSTER_INTERNAL_SECRET>``, PLUS
+    (BIS-727 Slice 2) a signed, single-use, 30-minute-TTL ``session_token``
+    object bound to the specific consent transaction — see
+    ``_verify_gmail_session_token`` and the warn-then-enforce rollout comment
+    near ``_ENFORCE_GMAIL_SIGNED_SESSION`` above. During the warn window
+    (default), a missing/invalid session_token is logged but still accepted;
+    once ``GMAIL_PUSH_SIGNED_SESSION_ENFORCE=true``, it is hard-rejected.
 
     Writes the token to ``~/messages/config/gmail-tokens/{chat_id}.json``
     with mode 0o600.
@@ -546,6 +645,33 @@ async def push_gmail_token_endpoint(scope, receive, send):
         )
         await response(scope, receive, send)
         return
+
+    # --- BIS-727 Slice 2: per-transaction signed session, gmail path ---
+    session_ok, session_reason = _verify_gmail_session_token(body, chat_id, scope_str)
+    if not session_ok:
+        if _ENFORCE_GMAIL_SIGNED_SESSION:
+            logger.warning(
+                "Rejecting gmail push: invalid/missing signed session "
+                "(reason=%s) chat_id=%r",
+                session_reason,
+                chat_id,
+            )
+            response = JSONResponse(
+                {"error": "Unauthorized: missing or invalid signed session"},
+                status_code=401,
+            )
+            await response(scope, receive, send)
+            return
+        logger.warning(
+            "Gmail push missing/invalid signed session (reason=%s) chat_id=%r "
+            "— accepting during BIS-729 warn-then-enforce window. Set "
+            "GMAIL_PUSH_SIGNED_SESSION_ENFORCE=true once myownlobster.ai is "
+            "confirmed emitting valid sessions for all gmail consent flows.",
+            session_reason,
+            chat_id,
+        )
+    else:
+        logger.info("Gmail push signed session verified for chat_id=%r", chat_id)
 
     # Sanitise chat_id to prevent path traversal
     safe_chat_id = "".join(c for c in chat_id if c.isalnum() or c in ("-", "_"))
@@ -848,6 +974,98 @@ async def awp_intake_endpoint(scope, receive, send):
     await response(scope, receive, send)
 
 
+# ---------------------------------------------------------------------------
+# BIS-727 Slice 2 — per-transaction HMAC signing, workspace push path
+# ---------------------------------------------------------------------------
+# Identical treatment to push_calendar_token_endpoint (BIS-727 Slice 1) and
+# push_gmail_token_endpoint (BIS-727 Slice 2, above) — deliberately
+# copy-pasted rather than shared (per the BIS-730 plan: premature
+# abstraction here is what Slice 4 is for). Verifies a signed, single-use,
+# 30-minute-TTL session token (HMAC-SHA256 over
+# instance_id|chat_id|scope|nonce|exp) bound to the specific consent
+# transaction, alongside the existing static-secret bearer check. Reuses the
+# SAME _SESSION_HMAC_SECRET / _INSTANCE_URL module-level config as calendar
+# and gmail, but has its OWN enforce flag and nonce-replay set, so
+# workspace's warn-then-enforce rollout can be flipped independently.
+_ENFORCE_WORKSPACE_SIGNED_SESSION: bool = os.environ.get(
+    "WORKSPACE_PUSH_SIGNED_SESSION_ENFORCE", "false"
+).strip().lower() in ("1", "true", "yes")
+
+_seen_workspace_session_nonces: dict[str, float] = {}
+
+
+def _consume_workspace_session_nonce(nonce: str, exp: float) -> bool:
+    """Atomically-within-this-process claim a nonce. False if already seen."""
+    now = time.time()
+    expired = [n for n, e in _seen_workspace_session_nonces.items() if e < now]
+    for n in expired:
+        del _seen_workspace_session_nonces[n]
+    if nonce in _seen_workspace_session_nonces:
+        return False
+    _seen_workspace_session_nonces[nonce] = exp
+    return True
+
+
+def _verify_workspace_session_token(body: dict, chat_id: str, scope_str: str) -> tuple[bool, str]:
+    """Verify the workspace push's signed, single-use, 30-min-TTL session token.
+
+    Copy-pasted from ``_verify_calendar_session_token`` (BIS-730: deliberately
+    not shared code yet). Returns ``(ok, reason)``; ``reason`` is a short
+    machine-readable string for logging only — never secret material.
+    """
+    session = body.get("session_token")
+    if not isinstance(session, dict):
+        return False, "missing_session_token"
+
+    if not _SESSION_HMAC_SECRET:
+        return False, "hmac_secret_not_configured"
+
+    instance_id = session.get("instance_id")
+    session_chat_id = session.get("chat_id")
+    session_scope = session.get("scope")
+    nonce = session.get("nonce")
+    sig = session.get("sig")
+    exp = session.get("exp")
+
+    if not (
+        isinstance(instance_id, str)
+        and instance_id
+        and isinstance(session_chat_id, str)
+        and session_chat_id
+        and isinstance(session_scope, str)
+        and session_scope
+        and isinstance(nonce, str)
+        and nonce
+        and isinstance(sig, str)
+        and sig
+        and isinstance(exp, (int, float))
+        and not isinstance(exp, bool)
+    ):
+        return False, "malformed_session_token"
+
+    if session_chat_id != chat_id:
+        return False, "chat_id_mismatch"
+    if session_scope != scope_str:
+        return False, "scope_mismatch"
+    if _INSTANCE_URL and instance_id != _INSTANCE_URL:
+        return False, "instance_id_mismatch"
+
+    message = f"{instance_id}|{session_chat_id}|{session_scope}|{nonce}|{int(exp)}"
+    expected_sig = hmac.new(
+        _SESSION_HMAC_SECRET.encode("utf-8"), message.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(expected_sig, sig):
+        return False, "bad_signature"
+
+    if exp < time.time():
+        return False, "expired"
+
+    if not _consume_workspace_session_nonce(nonce, float(exp)):
+        return False, "nonce_already_used"
+
+    return True, "ok"
+
+
 async def push_workspace_token_endpoint(scope, receive, send):
     """POST /api/push-workspace-token — receive a Workspace token pushed by myownlobster.ai.
 
@@ -861,7 +1079,14 @@ async def push_workspace_token_endpoint(scope, receive, send):
           "scope":         "<space-separated scopes>"
         }
 
-    Authentication: ``Authorization: Bearer <LOBSTER_INTERNAL_SECRET>``
+    Authentication: ``Authorization: Bearer <LOBSTER_INTERNAL_SECRET>``, PLUS
+    (BIS-727 Slice 2) a signed, single-use, 30-minute-TTL ``session_token``
+    object bound to the specific consent transaction — see
+    ``_verify_workspace_session_token`` and the warn-then-enforce rollout
+    comment near ``_ENFORCE_WORKSPACE_SIGNED_SESSION`` above. During the warn
+    window (default), a missing/invalid session_token is logged but still
+    accepted; once ``WORKSPACE_PUSH_SIGNED_SESSION_ENFORCE=true``, it is
+    hard-rejected.
 
     Writes the token to ``~/messages/config/workspace-tokens/{chat_id}.json``
     with mode 0o600.
@@ -893,6 +1118,33 @@ async def push_workspace_token_endpoint(scope, receive, send):
         )
         await response(scope, receive, send)
         return
+
+    # --- BIS-727 Slice 2: per-transaction signed session, workspace path ---
+    session_ok, session_reason = _verify_workspace_session_token(body, chat_id, scope_str)
+    if not session_ok:
+        if _ENFORCE_WORKSPACE_SIGNED_SESSION:
+            logger.warning(
+                "Rejecting workspace push: invalid/missing signed session "
+                "(reason=%s) chat_id=%r",
+                session_reason,
+                chat_id,
+            )
+            response = JSONResponse(
+                {"error": "Unauthorized: missing or invalid signed session"},
+                status_code=401,
+            )
+            await response(scope, receive, send)
+            return
+        logger.warning(
+            "Workspace push missing/invalid signed session (reason=%s) chat_id=%r "
+            "— accepting during BIS-729 warn-then-enforce window. Set "
+            "WORKSPACE_PUSH_SIGNED_SESSION_ENFORCE=true once myownlobster.ai is "
+            "confirmed emitting valid sessions for all workspace consent flows.",
+            session_reason,
+            chat_id,
+        )
+    else:
+        logger.info("Workspace push signed session verified for chat_id=%r", chat_id)
 
     # Sanitise chat_id to prevent path traversal
     safe_chat_id = "".join(c for c in chat_id if c.isalnum() or c in ("-", "_"))

--- a/tests/unit/test_integrations/test_gmail_token_store.py
+++ b/tests/unit/test_integrations/test_gmail_token_store.py
@@ -304,6 +304,109 @@ class TestGetValidToken:
 
 
 # ---------------------------------------------------------------------------
+# get_valid_token — workspace-token fallback (BIS-731 / Slice 3)
+#
+# A user who ran the `workspace` consent flow already holds a token whose
+# scope bundle includes the Gmail modify scope "for unified-token support"
+# (google_workspace/config.py WORKSPACE_SCOPES). If this module's own
+# gmail-tokens/<chat_id>.json file doesn't exist, get_valid_token should
+# fall back to that workspace token — but only when the workspace token's
+# granted scope actually contains "gmail.modify". If the scope-specific file
+# DOES exist, the workspace store must never even be consulted.
+# ---------------------------------------------------------------------------
+
+from integrations.google_workspace.token_store import save_token as _save_workspace_token
+
+_WORKSPACE_SCOPE_WITH_GMAIL = (
+    "https://www.googleapis.com/auth/documents "
+    "https://www.googleapis.com/auth/drive "
+    "https://www.googleapis.com/auth/drive.file "
+    "https://www.googleapis.com/auth/spreadsheets "
+    "https://www.googleapis.com/auth/gmail.modify "
+    "https://www.googleapis.com/auth/calendar"
+)
+
+_WORKSPACE_SCOPE_WITHOUT_GMAIL = (
+    "https://www.googleapis.com/auth/documents "
+    "https://www.googleapis.com/auth/spreadsheets"
+)
+
+
+def _make_workspace_token(
+    scope: str, refresh_token: str | None = "workspace-refresh-token"
+) -> TokenData:
+    return TokenData(
+        access_token="workspace-access-token",
+        expires_at=_FUTURE,
+        scope=scope,
+        refresh_token=refresh_token,
+    )
+
+
+class TestGetValidTokenWorkspaceFallback:
+    def test_falls_back_to_workspace_token_when_own_file_absent(self, tmp_path):
+        own_dir = tmp_path / "gmail-tokens"
+        workspace_dir = tmp_path / "workspace-tokens"
+        _save_workspace_token(
+            "user1",
+            _make_workspace_token(_WORKSPACE_SCOPE_WITH_GMAIL),
+            token_dir=workspace_dir,
+        )
+
+        result = ts.get_valid_token(
+            "user1", token_dir=own_dir, workspace_token_dir=workspace_dir
+        )
+
+        assert result is not None
+        assert result.access_token == "workspace-access-token"
+
+    def test_workspace_fallback_rejected_when_scope_lacks_gmail_modify(self, tmp_path):
+        own_dir = tmp_path / "gmail-tokens"
+        workspace_dir = tmp_path / "workspace-tokens"
+        _save_workspace_token(
+            "user1",
+            _make_workspace_token(_WORKSPACE_SCOPE_WITHOUT_GMAIL),
+            token_dir=workspace_dir,
+        )
+
+        result = ts.get_valid_token(
+            "user1", token_dir=own_dir, workspace_token_dir=workspace_dir
+        )
+
+        assert result is None
+
+    def test_own_token_wins_and_workspace_is_never_consulted(self, tmp_path):
+        own_dir = tmp_path / "gmail-tokens"
+        workspace_dir = tmp_path / "workspace-tokens"
+        ts._save_token_local("user1", _VALID_TOKEN, own_dir)
+
+        # A deliberately different/invalid workspace token sits alongside a
+        # valid own token — if the own token weren't checked first, this
+        # would either win or blow up on the corrupt JSON.
+        workspace_dir.mkdir(parents=True)
+        (workspace_dir / "user1.json").write_text("{ not valid json }")
+
+        with patch(f"{ts.__name__}._get_workspace_fallback_token") as mock_fallback:
+            result = ts.get_valid_token(
+                "user1", token_dir=own_dir, workspace_token_dir=workspace_dir
+            )
+
+        mock_fallback.assert_not_called()
+        assert result is not None
+        assert result.access_token == _VALID_TOKEN.access_token
+
+    def test_returns_none_when_neither_own_nor_workspace_token_exists(self, tmp_path):
+        own_dir = tmp_path / "gmail-tokens"
+        workspace_dir = tmp_path / "workspace-tokens"
+
+        result = ts.get_valid_token(
+            "user1", token_dir=own_dir, workspace_token_dir=workspace_dir
+        )
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
 # Token isolation: gmail-tokens != gcal-tokens
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_integrations/test_google_calendar_oauth_vault_cutover.py
+++ b/tests/unit/test_integrations/test_google_calendar_oauth_vault_cutover.py
@@ -1,0 +1,64 @@
+"""
+Tests proving google_calendar/client.py actually delegates to oauth_vault
+(BIS-732 / Slice 4), not just that the two happen to behave similarly.
+
+The existing test_google_calendar_client.py suite patches
+`integrations.google_calendar.client.get_valid_token` directly, so it can't
+tell us whether that name is backed by oauth_vault or still by the old
+token_store.py — it would pass either way. These tests close that gap by
+patching one level deeper, at `integrations.oauth_vault.client.get_valid_token`,
+and confirming google_calendar.client's wrapper calls through to it with
+provider="calendar".
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+# Make src importable without installing the package
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.google_calendar.client import get_valid_token
+from integrations.google_calendar.oauth import TokenData
+
+_FAKE_TOKEN = TokenData(
+    access_token="tok",
+    expires_at=datetime(2099, 1, 1, tzinfo=timezone.utc),
+    scope="https://www.googleapis.com/auth/calendar",
+    refresh_token="refresh",
+)
+
+
+class TestCutoverDelegatesToOAuthVault:
+    def test_delegates_to_oauth_vault_with_calendar_provider(self) -> None:
+        with patch(
+            "integrations.oauth_vault.client.get_valid_token", return_value=_FAKE_TOKEN
+        ) as mock_vault_gvt:
+            result = get_valid_token("user1", credentials="fake-creds")
+
+        mock_vault_gvt.assert_called_once_with("calendar", "user1", credentials="fake-creds")
+        assert result is _FAKE_TOKEN
+
+    def test_credentials_default_none_forwarded(self) -> None:
+        with patch(
+            "integrations.oauth_vault.client.get_valid_token", return_value=None
+        ) as mock_vault_gvt:
+            get_valid_token("user1")
+
+        mock_vault_gvt.assert_called_once_with("calendar", "user1", credentials=None)
+
+    def test_old_token_store_module_is_no_longer_imported_by_client(self) -> None:
+        """The old google_calendar/token_store.py must stay in the tree
+        (rollback path) but must no longer be imported by client.py — this
+        is what makes the cutover real rather than cosmetic."""
+        import integrations.google_calendar.client as gcal_client
+
+        assert not hasattr(gcal_client, "token_store")
+        # The module-level get_valid_token symbol exists, but must not be
+        # the same function object as the old token_store's.
+        from integrations.google_calendar import token_store as legacy_ts
+
+        assert gcal_client.get_valid_token is not legacy_ts.get_valid_token

--- a/tests/unit/test_integrations/test_google_calendar_token_store.py
+++ b/tests/unit/test_integrations/test_google_calendar_token_store.py
@@ -533,6 +533,118 @@ class TestGetValidToken:
 
 
 # ---------------------------------------------------------------------------
+# get_valid_token — workspace-token fallback (BIS-731 / Slice 3)
+#
+# A user who ran the `workspace` consent flow already holds a token whose
+# scope bundle includes the full-access calendar scope "for unified-token
+# support" (google_workspace/config.py WORKSPACE_SCOPES). If this module's
+# own gcal-tokens/<chat_id>.json file doesn't exist, get_valid_token should
+# fall back to that workspace token — but only when the workspace token's
+# granted scope actually contains the calendar scope. If the scope-specific
+# file DOES exist, the workspace store must never even be consulted.
+# ---------------------------------------------------------------------------
+
+from integrations.google_workspace.token_store import save_token as _save_workspace_token
+
+_WORKSPACE_SCOPE_WITH_CALENDAR = (
+    "https://www.googleapis.com/auth/documents "
+    "https://www.googleapis.com/auth/drive "
+    "https://www.googleapis.com/auth/drive.file "
+    "https://www.googleapis.com/auth/spreadsheets "
+    "https://www.googleapis.com/auth/gmail.modify "
+    "https://www.googleapis.com/auth/calendar"
+)
+
+_WORKSPACE_SCOPE_WITHOUT_CALENDAR = (
+    "https://www.googleapis.com/auth/documents "
+    "https://www.googleapis.com/auth/spreadsheets"
+)
+
+
+def _make_workspace_token(
+    scope: str, refresh_token: str | None = "workspace-refresh-token"
+) -> TokenData:
+    return TokenData(
+        access_token="workspace-access-token",
+        expires_at=_FUTURE_EXPIRES,
+        scope=scope,
+        refresh_token=refresh_token,
+    )
+
+
+class TestGetValidTokenWorkspaceFallback:
+    def test_falls_back_to_workspace_token_when_own_file_absent(
+        self, tmp_path: Path
+    ) -> None:
+        own_dir = tmp_path / "gcal-tokens"
+        workspace_dir = tmp_path / "workspace-tokens"
+        _save_workspace_token(
+            "user1",
+            _make_workspace_token(_WORKSPACE_SCOPE_WITH_CALENDAR),
+            token_dir=workspace_dir,
+        )
+
+        result = get_valid_token(
+            "user1", token_dir=own_dir, workspace_token_dir=workspace_dir
+        )
+
+        assert result is not None
+        assert result.access_token == "workspace-access-token"
+
+    def test_workspace_fallback_rejected_when_scope_lacks_calendar(
+        self, tmp_path: Path
+    ) -> None:
+        own_dir = tmp_path / "gcal-tokens"
+        workspace_dir = tmp_path / "workspace-tokens"
+        _save_workspace_token(
+            "user1",
+            _make_workspace_token(_WORKSPACE_SCOPE_WITHOUT_CALENDAR),
+            token_dir=workspace_dir,
+        )
+
+        result = get_valid_token(
+            "user1", token_dir=own_dir, workspace_token_dir=workspace_dir
+        )
+
+        assert result is None
+
+    def test_own_token_wins_and_workspace_is_never_consulted(
+        self, tmp_path: Path
+    ) -> None:
+        own_dir = tmp_path / "gcal-tokens"
+        workspace_dir = tmp_path / "workspace-tokens"
+        own_token = _make_valid_token()
+        save_token("user1", own_token, token_dir=own_dir)
+
+        # A deliberately different/invalid workspace token sits alongside a
+        # valid own token — if the own token weren't checked first, this
+        # would either win or blow up on the corrupt JSON.
+        workspace_dir.mkdir(parents=True)
+        (workspace_dir / "user1.json").write_text("{ not valid json }")
+
+        with patch(f"{ts.__name__}._get_workspace_fallback_token") as mock_fallback:
+            result = get_valid_token(
+                "user1", token_dir=own_dir, workspace_token_dir=workspace_dir
+            )
+
+        mock_fallback.assert_not_called()
+        assert result is not None
+        assert result.access_token == own_token.access_token
+
+    def test_returns_none_when_neither_own_nor_workspace_token_exists(
+        self, tmp_path: Path
+    ) -> None:
+        own_dir = tmp_path / "gcal-tokens"
+        workspace_dir = tmp_path / "workspace-tokens"
+
+        result = get_valid_token(
+            "user1", token_dir=own_dir, workspace_token_dir=workspace_dir
+        )
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
 # _internal_auth_header (BIS-728 / Slice 0 characterization)
 #
 # Today this is the ONLY authentication the refresh proxy call carries: a

--- a/tests/unit/test_integrations/test_google_calendar_token_store.py
+++ b/tests/unit/test_integrations/test_google_calendar_token_store.py
@@ -20,7 +20,7 @@ import stat
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -38,6 +38,7 @@ from integrations.google_calendar.oauth import (
     OAuthTokenError,
     TokenData,
 )
+from integrations.google_calendar import token_store as ts
 from integrations.google_calendar.token_store import (
     _dict_to_token,
     _token_path,
@@ -529,3 +530,250 @@ class TestGetValidToken:
         ) as mock_proxy:
             get_valid_token("user1", token_dir=tmp_path)
         mock_proxy.assert_called_once_with(_FAKE_REFRESH_TOKEN)
+
+
+# ---------------------------------------------------------------------------
+# _internal_auth_header (BIS-728 / Slice 0 characterization)
+#
+# Today this is the ONLY authentication the refresh proxy call carries: a
+# static bearer secret read from LOBSTER_INTERNAL_SECRET. There is no
+# per-request signing. Pinning this exactly so Slice 1+ can prove what
+# changed on the refresh-proxy call path (if anything).
+# ---------------------------------------------------------------------------
+
+
+class TestInternalAuthHeader:
+    def test_raises_runtime_error_when_secret_unset(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(RuntimeError, match="LOBSTER_INTERNAL_SECRET"):
+                ts._internal_auth_header()
+
+    def test_raises_runtime_error_when_secret_empty_string(self) -> None:
+        with patch.dict(os.environ, {"LOBSTER_INTERNAL_SECRET": ""}, clear=True):
+            with pytest.raises(RuntimeError, match="LOBSTER_INTERNAL_SECRET"):
+                ts._internal_auth_header()
+
+    def test_raises_runtime_error_when_secret_whitespace_only(self) -> None:
+        with patch.dict(os.environ, {"LOBSTER_INTERNAL_SECRET": "   "}, clear=True):
+            with pytest.raises(RuntimeError, match="LOBSTER_INTERNAL_SECRET"):
+                ts._internal_auth_header()
+
+    def test_returns_bearer_header_with_static_secret(self) -> None:
+        with patch.dict(os.environ, {"LOBSTER_INTERNAL_SECRET": "my-secret"}, clear=True):
+            header = ts._internal_auth_header()
+        assert header == {"Authorization": "Bearer my-secret"}
+
+    def test_strips_surrounding_whitespace_from_secret(self) -> None:
+        with patch.dict(
+            os.environ, {"LOBSTER_INTERNAL_SECRET": "  my-secret  "}, clear=True
+        ):
+            header = ts._internal_auth_header()
+        assert header == {"Authorization": "Bearer my-secret"}
+
+
+# ---------------------------------------------------------------------------
+# _load_calendar_config / _myownlobster_api_base (BIS-728 / Slice 0 characterization)
+# ---------------------------------------------------------------------------
+
+
+class TestCalendarConfigLoader:
+    def test_returns_empty_dict_when_config_file_absent(self, tmp_path: Path) -> None:
+        missing = tmp_path / "calendar-config.json"
+        with patch(f"{ts.__name__}._CALENDAR_CONFIG_PATH", missing):
+            result = ts._load_calendar_config()
+        assert result == {}
+
+    def test_returns_parsed_dict_when_config_present(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "calendar-config.json"
+        config_path.write_text(json.dumps({"myownlobster_api_base": "https://example.test"}))
+        with patch(f"{ts.__name__}._CALENDAR_CONFIG_PATH", config_path):
+            result = ts._load_calendar_config()
+        assert result == {"myownlobster_api_base": "https://example.test"}
+
+    def test_returns_empty_dict_on_malformed_json(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "calendar-config.json"
+        config_path.write_text("{ not valid json }")
+        with patch(f"{ts.__name__}._CALENDAR_CONFIG_PATH", config_path):
+            result = ts._load_calendar_config()
+        assert result == {}
+
+    def test_api_base_returns_default_when_config_absent(self, tmp_path: Path) -> None:
+        missing = tmp_path / "calendar-config.json"
+        with patch(f"{ts.__name__}._CALENDAR_CONFIG_PATH", missing):
+            result = ts._myownlobster_api_base()
+        assert result == "https://myownlobster.ai"
+
+    def test_api_base_returns_configured_value(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "calendar-config.json"
+        config_path.write_text(json.dumps({"myownlobster_api_base": "https://custom.example"}))
+        with patch(f"{ts.__name__}._CALENDAR_CONFIG_PATH", config_path):
+            result = ts._myownlobster_api_base()
+        assert result == "https://custom.example"
+
+    def test_api_base_strips_trailing_slash(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "calendar-config.json"
+        config_path.write_text(json.dumps({"myownlobster_api_base": "https://custom.example/"}))
+        with patch(f"{ts.__name__}._CALENDAR_CONFIG_PATH", config_path):
+            result = ts._myownlobster_api_base()
+        assert result == "https://custom.example"
+
+
+# ---------------------------------------------------------------------------
+# _refresh_token_via_proxy — HTTP side-effecting boundary
+# (BIS-728 / Slice 0 characterization; mirrors test_gmail_token_store.py's
+# TestRefreshTokenViaProxy, adapted for the calendar refresh endpoint)
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshTokenViaProxy:
+    def _mock_success_response(self) -> MagicMock:
+        resp = MagicMock()
+        resp.ok = True
+        resp.status_code = 200
+        resp.json.return_value = {
+            "access_token": "new-access-token",
+            "expires_in": 3600,
+        }
+        return resp
+
+    def test_returns_new_token_on_success(self) -> None:
+        with patch.dict(
+            os.environ, {"LOBSTER_INTERNAL_SECRET": "secret"}, clear=True
+        ), patch(
+            "integrations.google_calendar.token_store.requests.post",
+            return_value=self._mock_success_response(),
+        ):
+            result = ts._refresh_token_via_proxy("refresh-tok")
+        assert result is not None
+        assert result.access_token == "new-access-token"
+        assert result.expires_at > datetime.now(tz=timezone.utc)
+
+    def test_new_token_has_empty_scope_and_no_refresh_token(self) -> None:
+        """The proxy response never carries scope or refresh_token — the
+        caller (get_valid_token) is responsible for merging those back in
+        from the on-disk record."""
+        with patch.dict(
+            os.environ, {"LOBSTER_INTERNAL_SECRET": "secret"}, clear=True
+        ), patch(
+            "integrations.google_calendar.token_store.requests.post",
+            return_value=self._mock_success_response(),
+        ):
+            result = ts._refresh_token_via_proxy("refresh-tok")
+        assert result is not None
+        assert result.scope == ""
+        assert result.refresh_token is None
+
+    def test_returns_none_when_secret_missing(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            result = ts._refresh_token_via_proxy("refresh-tok")
+        assert result is None
+
+    def test_returns_none_on_network_error(self) -> None:
+        import requests as req_lib
+
+        with patch.dict(
+            os.environ, {"LOBSTER_INTERNAL_SECRET": "secret"}, clear=True
+        ), patch(
+            "integrations.google_calendar.token_store.requests.post",
+            side_effect=req_lib.exceptions.ConnectionError("refused"),
+        ):
+            result = ts._refresh_token_via_proxy("refresh-tok")
+        assert result is None
+
+    def test_returns_none_on_non_ok_response(self) -> None:
+        bad = MagicMock()
+        bad.ok = False
+        bad.status_code = 500
+        bad.text = "Internal Server Error"
+        with patch.dict(
+            os.environ, {"LOBSTER_INTERNAL_SECRET": "secret"}, clear=True
+        ), patch(
+            "integrations.google_calendar.token_store.requests.post",
+            return_value=bad,
+        ):
+            result = ts._refresh_token_via_proxy("refresh-tok")
+        assert result is None
+
+    def test_returns_none_on_bad_json(self) -> None:
+        resp = MagicMock()
+        resp.ok = True
+        resp.json.return_value = {"unexpected": "keys"}
+        with patch.dict(
+            os.environ, {"LOBSTER_INTERNAL_SECRET": "secret"}, clear=True
+        ), patch(
+            "integrations.google_calendar.token_store.requests.post",
+            return_value=resp,
+        ):
+            result = ts._refresh_token_via_proxy("refresh-tok")
+        assert result is None
+
+    def test_uses_calendar_refresh_endpoint(self) -> None:
+        """Refresh must call the calendar-specific endpoint, not gmail's."""
+        with patch.dict(
+            os.environ, {"LOBSTER_INTERNAL_SECRET": "secret"}, clear=True
+        ), patch(
+            "integrations.google_calendar.token_store.requests.post",
+            return_value=self._mock_success_response(),
+        ) as mock_post:
+            ts._refresh_token_via_proxy("refresh-tok")
+
+        called_url = mock_post.call_args.args[0]
+        assert called_url == "https://myownlobster.ai/api/internal/refresh-calendar-token"
+
+    def test_posts_refresh_token_in_json_body(self) -> None:
+        with patch.dict(
+            os.environ, {"LOBSTER_INTERNAL_SECRET": "secret"}, clear=True
+        ), patch(
+            "integrations.google_calendar.token_store.requests.post",
+            return_value=self._mock_success_response(),
+        ) as mock_post:
+            ts._refresh_token_via_proxy("the-refresh-token")
+
+        assert mock_post.call_args.kwargs["json"] == {"refresh_token": "the-refresh-token"}
+
+    def test_sends_bearer_auth_header(self) -> None:
+        with patch.dict(
+            os.environ, {"LOBSTER_INTERNAL_SECRET": "topsecret"}, clear=True
+        ), patch(
+            "integrations.google_calendar.token_store.requests.post",
+            return_value=self._mock_success_response(),
+        ) as mock_post:
+            ts._refresh_token_via_proxy("refresh-tok")
+
+        assert mock_post.call_args.kwargs["headers"] == {
+            "Authorization": "Bearer topsecret"
+        }
+
+    def test_uses_10_second_timeout(self) -> None:
+        with patch.dict(
+            os.environ, {"LOBSTER_INTERNAL_SECRET": "secret"}, clear=True
+        ), patch(
+            "integrations.google_calendar.token_store.requests.post",
+            return_value=self._mock_success_response(),
+        ) as mock_post:
+            ts._refresh_token_via_proxy("refresh-tok")
+
+        assert mock_post.call_args.kwargs["timeout"] == 10
+
+
+# ---------------------------------------------------------------------------
+# _save_token_local — atomic write cleanup on failure
+# (BIS-728 / Slice 0 characterization)
+# ---------------------------------------------------------------------------
+
+
+class TestSaveTokenAtomicWriteFailure:
+    def test_tmp_file_removed_and_exception_propagates_on_rename_failure(
+        self, tmp_path: Path
+    ) -> None:
+        token = _make_valid_token()
+        with patch(
+            "integrations.google_calendar.token_store.os.rename",
+            side_effect=OSError("disk full"),
+        ):
+            with pytest.raises(OSError, match="disk full"):
+                save_token("user1", token, token_dir=tmp_path)
+        # The .tmp file must not be left behind after a failed write.
+        assert not (tmp_path / "user1.json.tmp").exists()
+        # And no final file should exist either, since rename never succeeded.
+        assert not (tmp_path / "user1.json").exists()

--- a/tests/unit/test_integrations/test_oauth_vault_client.py
+++ b/tests/unit/test_integrations/test_oauth_vault_client.py
@@ -1,0 +1,427 @@
+"""
+Tests for src/integrations/oauth_vault/client.py (BIS-732 / Slice 4).
+
+This is the provider-parameterized get_valid_token()/refresh-proxy layer
+extracted from google_calendar/token_store.py (and, in spirit, gmail's and
+google_workspace's identical logic). These tests mirror the corresponding
+characterization assertions in test_google_calendar_token_store.py
+(BIS-728 / Slice 0, extended by BIS-731 / Slice 3's workspace-fallback
+tests) — same expected behavior, proven against the new
+provider-parameterized implementation with provider="calendar", with only
+the import path and the (now-required) explicit provider argument changed.
+
+Covers:
+- get_valid_token: returns valid token, refreshes expired token, saves
+  refreshed token, carries forward refresh_token when Google omits it,
+  returns None on missing token, returns None when refresh fails, returns
+  None when no refresh_token
+- get_valid_token workspace-token fallback (generalized BIS-731 pattern)
+- _refresh_token_via_proxy: HTTP side-effecting boundary
+- _internal_auth_header / provider config loader
+- Provider registry: unknown provider raises; "calendar" aliases to the
+  pre-existing gcal-tokens/ directory (regression test for the deliberate
+  deviation documented in client.py's module docstring — protects against
+  the read path silently disagreeing with the not-yet-migrated write path)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make src importable without installing the package
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.google_calendar.oauth import TokenData
+from integrations.google_workspace.token_store import save_token as _save_workspace_token
+from integrations.oauth_vault import client as ovc
+from integrations.oauth_vault.client import get_valid_token
+from integrations.oauth_vault.vault_store import load_token, save_token
+
+_PROVIDER = "calendar"
+
+_FAKE_ACCESS_TOKEN = "<REDACTED_SECRET>"
+_FAKE_REFRESH_TOKEN = "<REDACTED_SECRET>"
+_FAKE_SCOPE = "https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/calendar.events"
+
+_FUTURE_EXPIRES = datetime(2099, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+_EXPIRED_EXPIRES = datetime(2000, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_valid_token(refresh_token: str | None = _FAKE_REFRESH_TOKEN) -> TokenData:
+    return TokenData(
+        access_token=_FAKE_ACCESS_TOKEN,
+        expires_at=_FUTURE_EXPIRES,
+        scope=_FAKE_SCOPE,
+        refresh_token=refresh_token,
+    )
+
+
+def _make_expired_token(refresh_token: str | None = _FAKE_REFRESH_TOKEN) -> TokenData:
+    return TokenData(
+        access_token=_FAKE_ACCESS_TOKEN,
+        expires_at=_EXPIRED_EXPIRES,
+        scope=_FAKE_SCOPE,
+        refresh_token=refresh_token,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider registry
+# ---------------------------------------------------------------------------
+
+
+class TestProviderRegistry:
+    def test_unknown_provider_raises_value_error(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="Unknown oauth_vault provider"):
+            get_valid_token("not_a_real_provider", "user1", token_dir=tmp_path)
+
+    def test_calendar_provider_aliases_to_legacy_gcal_tokens_dir(self) -> None:
+        """Regression test for the deliberate deviation documented in
+        client.py: the "calendar" provider's default token_dir must equal
+        google_calendar/token_store.py's own _TOKEN_DIR, because that
+        module's write path (push_calendar_token_endpoint, callback_server.py)
+        is not cut over in this slice and still writes there. If these ever
+        diverge, a real Calendar token becomes invisible to the new read
+        path — silently breaking Calendar for a live user."""
+        from integrations.google_calendar import token_store as legacy_ts
+
+        assert ovc.PROVIDERS["calendar"].token_dir == legacy_ts._TOKEN_DIR
+
+
+# ---------------------------------------------------------------------------
+# get_valid_token
+# ---------------------------------------------------------------------------
+
+
+class TestGetValidToken:
+    def test_returns_none_when_no_token_file(self, tmp_path: Path) -> None:
+        result = get_valid_token(_PROVIDER, "user1", token_dir=tmp_path)
+        assert result is None
+
+    def test_returns_valid_token_without_refresh(self, tmp_path: Path) -> None:
+        save_token("user1", _make_valid_token(), tmp_path)
+        result = get_valid_token(_PROVIDER, "user1", token_dir=tmp_path)
+        assert result is not None
+        assert result.access_token == _FAKE_ACCESS_TOKEN
+
+    def test_refreshes_expired_token(self, tmp_path: Path) -> None:
+        save_token("user1", _make_expired_token(), tmp_path)
+        new_access = "ya29.refreshed-access-token"
+        proxy_result = TokenData(
+            access_token=new_access, expires_at=_FUTURE_EXPIRES, scope="", refresh_token=None
+        )
+        with patch(f"{ovc.__name__}._refresh_token_via_proxy", return_value=proxy_result):
+            result = get_valid_token(_PROVIDER, "user1", token_dir=tmp_path)
+        assert result is not None
+        assert result.access_token == new_access
+
+    def test_saves_refreshed_token_to_disk(self, tmp_path: Path) -> None:
+        save_token("user1", _make_expired_token(), tmp_path)
+        new_access = "ya29.refreshed-token"
+        proxy_result = TokenData(
+            access_token=new_access, expires_at=_FUTURE_EXPIRES, scope="", refresh_token=None
+        )
+        with patch(f"{ovc.__name__}._refresh_token_via_proxy", return_value=proxy_result):
+            get_valid_token(_PROVIDER, "user1", token_dir=tmp_path)
+        stored = load_token("user1", tmp_path)
+        assert stored is not None
+        assert stored.access_token == new_access
+
+    def test_carries_forward_refresh_token_when_google_omits_it(self, tmp_path: Path) -> None:
+        original_refresh = "1//original-refresh-token"
+        save_token("user1", _make_expired_token(refresh_token=original_refresh), tmp_path)
+        proxy_result = TokenData(
+            access_token="<REDACTED_SECRET>", expires_at=_FUTURE_EXPIRES, scope="", refresh_token=None
+        )
+        with patch(f"{ovc.__name__}._refresh_token_via_proxy", return_value=proxy_result):
+            result = get_valid_token(_PROVIDER, "user1", token_dir=tmp_path)
+        assert result is not None
+        assert result.refresh_token == original_refresh
+
+    def test_returns_none_when_refresh_proxy_returns_none(self, tmp_path: Path) -> None:
+        save_token("user1", _make_expired_token(), tmp_path)
+        with patch(f"{ovc.__name__}._refresh_token_via_proxy", return_value=None):
+            result = get_valid_token(_PROVIDER, "user1", token_dir=tmp_path)
+        assert result is None
+
+    def test_returns_none_when_token_expired_and_no_refresh_token(self, tmp_path: Path) -> None:
+        save_token("user1", _make_expired_token(refresh_token=None), tmp_path)
+        result = get_valid_token(_PROVIDER, "user1", token_dir=tmp_path)
+        assert result is None
+
+    def test_does_not_call_refresh_for_valid_token(self, tmp_path: Path) -> None:
+        save_token("user1", _make_valid_token(), tmp_path)
+        with patch(f"{ovc.__name__}._refresh_token_via_proxy") as mock_proxy:
+            get_valid_token(_PROVIDER, "user1", token_dir=tmp_path)
+        mock_proxy.assert_not_called()
+
+    def test_proxy_called_with_provider_and_refresh_token(self, tmp_path: Path) -> None:
+        save_token("user1", _make_expired_token(refresh_token=_FAKE_REFRESH_TOKEN), tmp_path)
+        proxy_result = TokenData(
+            access_token="<REDACTED_SECRET>", expires_at=_FUTURE_EXPIRES, scope="", refresh_token=None
+        )
+        with patch(
+            f"{ovc.__name__}._refresh_token_via_proxy", return_value=proxy_result
+        ) as mock_proxy:
+            get_valid_token(_PROVIDER, "user1", token_dir=tmp_path)
+        mock_proxy.assert_called_once_with(_PROVIDER, _FAKE_REFRESH_TOKEN)
+
+    def test_uses_provider_default_token_dir_when_not_given(self) -> None:
+        """When token_dir isn't passed, the provider's registered default is used."""
+        with patch(f"{ovc.__name__}._load_token", return_value=None) as mock_load, \
+             patch(f"{ovc.__name__}._get_workspace_fallback_token", return_value=None):
+            get_valid_token(_PROVIDER, "user1")
+        args, _ = mock_load.call_args
+        assert args[1] == ovc.PROVIDERS[_PROVIDER].token_dir
+
+
+# ---------------------------------------------------------------------------
+# get_valid_token — workspace-token fallback (generalized BIS-731 pattern)
+# ---------------------------------------------------------------------------
+
+_WORKSPACE_SCOPE_WITH_CALENDAR = (
+    "https://www.googleapis.com/auth/documents "
+    "https://www.googleapis.com/auth/drive "
+    "https://www.googleapis.com/auth/spreadsheets "
+    "https://www.googleapis.com/auth/gmail.modify "
+    "https://www.googleapis.com/auth/calendar"
+)
+
+_WORKSPACE_SCOPE_WITHOUT_CALENDAR = (
+    "https://www.googleapis.com/auth/documents https://www.googleapis.com/auth/spreadsheets"
+)
+
+
+def _make_workspace_token(scope: str, refresh_token: str | None = "workspace-refresh-token") -> TokenData:
+    return TokenData(
+        access_token="workspace-access-token",
+        expires_at=_FUTURE_EXPIRES,
+        scope=scope,
+        refresh_token=refresh_token,
+    )
+
+
+class TestGetValidTokenWorkspaceFallback:
+    def test_falls_back_to_workspace_token_when_own_file_absent(self, tmp_path: Path) -> None:
+        own_dir = tmp_path / "calendar-tokens"
+        workspace_dir = tmp_path / "workspace-tokens"
+        _save_workspace_token("user1", _make_workspace_token(_WORKSPACE_SCOPE_WITH_CALENDAR), token_dir=workspace_dir)
+
+        result = get_valid_token(_PROVIDER, "user1", token_dir=own_dir, workspace_token_dir=workspace_dir)
+
+        assert result is not None
+        assert result.access_token == "workspace-access-token"
+
+    def test_workspace_fallback_rejected_when_scope_lacks_calendar(self, tmp_path: Path) -> None:
+        own_dir = tmp_path / "calendar-tokens"
+        workspace_dir = tmp_path / "workspace-tokens"
+        _save_workspace_token("user1", _make_workspace_token(_WORKSPACE_SCOPE_WITHOUT_CALENDAR), token_dir=workspace_dir)
+
+        result = get_valid_token(_PROVIDER, "user1", token_dir=own_dir, workspace_token_dir=workspace_dir)
+
+        assert result is None
+
+    def test_own_token_wins_and_workspace_is_never_consulted(self, tmp_path: Path) -> None:
+        own_dir = tmp_path / "calendar-tokens"
+        workspace_dir = tmp_path / "workspace-tokens"
+        own_token = _make_valid_token()
+        save_token("user1", own_token, own_dir)
+
+        workspace_dir.mkdir(parents=True)
+        (workspace_dir / "user1.json").write_text("{ not valid json }")
+
+        with patch(f"{ovc.__name__}._get_workspace_fallback_token") as mock_fallback:
+            result = get_valid_token(_PROVIDER, "user1", token_dir=own_dir, workspace_token_dir=workspace_dir)
+
+        mock_fallback.assert_not_called()
+        assert result is not None
+        assert result.access_token == own_token.access_token
+
+    def test_returns_none_when_neither_own_nor_workspace_token_exists(self, tmp_path: Path) -> None:
+        own_dir = tmp_path / "calendar-tokens"
+        workspace_dir = tmp_path / "workspace-tokens"
+
+        result = get_valid_token(_PROVIDER, "user1", token_dir=own_dir, workspace_token_dir=workspace_dir)
+
+        assert result is None
+
+    def test_provider_without_workspace_scope_substring_never_falls_back(self, tmp_path: Path) -> None:
+        """A hypothetical provider that declares no workspace_scope_substring
+        must never consult the workspace store, even if one exists."""
+        own_dir = tmp_path / "no-fallback-tokens"
+        workspace_dir = tmp_path / "workspace-tokens"
+        _save_workspace_token("user1", _make_workspace_token(_WORKSPACE_SCOPE_WITH_CALENDAR), token_dir=workspace_dir)
+
+        no_fallback_cfg = ovc.ProviderConfig(
+            name="no_fallback_test_provider",
+            token_dir=own_dir,
+            refresh_endpoint="/api/internal/refresh-no-fallback-token",
+            config_path=tmp_path / "no-fallback-config.json",
+            workspace_scope_substring=None,
+        )
+        with patch.dict(ovc.PROVIDERS, {"no_fallback_test_provider": no_fallback_cfg}):
+            result = get_valid_token(
+                "no_fallback_test_provider", "user1", token_dir=own_dir, workspace_token_dir=workspace_dir
+            )
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _internal_auth_header
+# ---------------------------------------------------------------------------
+
+
+class TestInternalAuthHeader:
+    def test_raises_runtime_error_when_secret_unset(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(RuntimeError, match="LOBSTER_INTERNAL_SECRET"):
+                ovc._internal_auth_header()
+
+    def test_returns_bearer_header_with_static_secret(self) -> None:
+        with patch.dict(os.environ, {"LOBSTER_INTERNAL_SECRET": "my-secret"}, clear=True):
+            header = ovc._internal_auth_header()
+        assert header == {"Authorization": "Bearer my-secret"}
+
+    def test_strips_surrounding_whitespace_from_secret(self) -> None:
+        with patch.dict(os.environ, {"LOBSTER_INTERNAL_SECRET": "  my-secret  "}, clear=True):
+            header = ovc._internal_auth_header()
+        assert header == {"Authorization": "Bearer my-secret"}
+
+
+# ---------------------------------------------------------------------------
+# Provider config loader (myownlobster_api_base override)
+# ---------------------------------------------------------------------------
+
+
+class TestProviderConfigLoader:
+    def test_returns_default_api_base_when_config_absent(self, tmp_path: Path) -> None:
+        cfg = ovc.ProviderConfig(
+            name="test", token_dir=tmp_path, refresh_endpoint="/x", config_path=tmp_path / "missing.json"
+        )
+        assert ovc._myownlobster_api_base(cfg) == "https://myownlobster.ai"
+
+    def test_returns_configured_api_base(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "provider-config.json"
+        config_path.write_text(json.dumps({"myownlobster_api_base": "https://custom.example/"}))
+        cfg = ovc.ProviderConfig(
+            name="test", token_dir=tmp_path, refresh_endpoint="/x", config_path=config_path
+        )
+        assert ovc._myownlobster_api_base(cfg) == "https://custom.example"
+
+    def test_returns_default_on_malformed_json(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "provider-config.json"
+        config_path.write_text("{ not valid json }")
+        cfg = ovc.ProviderConfig(
+            name="test", token_dir=tmp_path, refresh_endpoint="/x", config_path=config_path
+        )
+        assert ovc._myownlobster_api_base(cfg) == "https://myownlobster.ai"
+
+
+# ---------------------------------------------------------------------------
+# _refresh_token_via_proxy — HTTP side-effecting boundary
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshTokenViaProxy:
+    def _mock_success_response(self) -> MagicMock:
+        resp = MagicMock()
+        resp.ok = True
+        resp.status_code = 200
+        resp.json.return_value = {"access_token": "new-access-token", "expires_in": 3600}
+        return resp
+
+    def test_returns_new_token_on_success(self) -> None:
+        with patch.dict(os.environ, {"LOBSTER_INTERNAL_SECRET": "secret"}, clear=True), patch(
+            f"{ovc.__name__}.requests.post", return_value=self._mock_success_response()
+        ):
+            result = ovc._refresh_token_via_proxy(_PROVIDER, "refresh-tok")
+        assert result is not None
+        assert result.access_token == "new-access-token"
+        assert result.expires_at > datetime.now(tz=timezone.utc)
+
+    def test_new_token_has_empty_scope_and_no_refresh_token(self) -> None:
+        with patch.dict(os.environ, {"LOBSTER_INTERNAL_SECRET": "secret"}, clear=True), patch(
+            f"{ovc.__name__}.requests.post", return_value=self._mock_success_response()
+        ):
+            result = ovc._refresh_token_via_proxy(_PROVIDER, "refresh-tok")
+        assert result is not None
+        assert result.scope == ""
+        assert result.refresh_token is None
+
+    def test_returns_none_when_secret_missing(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            result = ovc._refresh_token_via_proxy(_PROVIDER, "refresh-tok")
+        assert result is None
+
+    def test_returns_none_on_network_error(self) -> None:
+        import requests as req_lib
+
+        with patch.dict(os.environ, {"LOBSTER_INTERNAL_SECRET": "secret"}, clear=True), patch(
+            f"{ovc.__name__}.requests.post", side_effect=req_lib.exceptions.ConnectionError("refused")
+        ):
+            result = ovc._refresh_token_via_proxy(_PROVIDER, "refresh-tok")
+        assert result is None
+
+    def test_returns_none_on_non_ok_response(self) -> None:
+        bad = MagicMock()
+        bad.ok = False
+        bad.status_code = 500
+        bad.text = "Internal Server Error"
+        with patch.dict(os.environ, {"LOBSTER_INTERNAL_SECRET": "secret"}, clear=True), patch(
+            f"{ovc.__name__}.requests.post", return_value=bad
+        ):
+            result = ovc._refresh_token_via_proxy(_PROVIDER, "refresh-tok")
+        assert result is None
+
+    def test_returns_none_on_bad_json(self) -> None:
+        resp = MagicMock()
+        resp.ok = True
+        resp.json.return_value = {"unexpected": "keys"}
+        with patch.dict(os.environ, {"LOBSTER_INTERNAL_SECRET": "secret"}, clear=True), patch(
+            f"{ovc.__name__}.requests.post", return_value=resp
+        ):
+            result = ovc._refresh_token_via_proxy(_PROVIDER, "refresh-tok")
+        assert result is None
+
+    def test_uses_calendar_refresh_endpoint_for_calendar_provider(self) -> None:
+        """Refresh must call the calendar-specific endpoint, not gmail's —
+        proving provider-parameterization actually dispatches correctly."""
+        with patch.dict(os.environ, {"LOBSTER_INTERNAL_SECRET": "secret"}, clear=True), patch(
+            f"{ovc.__name__}.requests.post", return_value=self._mock_success_response()
+        ) as mock_post:
+            ovc._refresh_token_via_proxy(_PROVIDER, "refresh-tok")
+        called_url = mock_post.call_args.args[0]
+        assert called_url == "https://myownlobster.ai/api/internal/refresh-calendar-token"
+
+    def test_posts_refresh_token_in_json_body(self) -> None:
+        with patch.dict(os.environ, {"LOBSTER_INTERNAL_SECRET": "secret"}, clear=True), patch(
+            f"{ovc.__name__}.requests.post", return_value=self._mock_success_response()
+        ) as mock_post:
+            ovc._refresh_token_via_proxy(_PROVIDER, "the-refresh-token")
+        assert mock_post.call_args.kwargs["json"] == {"refresh_token": "the-refresh-token"}
+
+    def test_sends_bearer_auth_header(self) -> None:
+        with patch.dict(os.environ, {"LOBSTER_INTERNAL_SECRET": "topsecret"}, clear=True), patch(
+            f"{ovc.__name__}.requests.post", return_value=self._mock_success_response()
+        ) as mock_post:
+            ovc._refresh_token_via_proxy(_PROVIDER, "refresh-tok")
+        assert mock_post.call_args.kwargs["headers"] == {"Authorization": "Bearer topsecret"}
+
+    def test_uses_10_second_timeout(self) -> None:
+        with patch.dict(os.environ, {"LOBSTER_INTERNAL_SECRET": "secret"}, clear=True), patch(
+            f"{ovc.__name__}.requests.post", return_value=self._mock_success_response()
+        ) as mock_post:
+            ovc._refresh_token_via_proxy(_PROVIDER, "refresh-tok")
+        assert mock_post.call_args.kwargs["timeout"] == 10
+
+    def test_raises_for_unknown_provider(self) -> None:
+        with pytest.raises(ValueError, match="Unknown oauth_vault provider"):
+            ovc._refresh_token_via_proxy("not_a_real_provider", "refresh-tok")

--- a/tests/unit/test_integrations/test_oauth_vault_store.py
+++ b/tests/unit/test_integrations/test_oauth_vault_store.py
@@ -1,0 +1,257 @@
+"""
+Tests for src/integrations/oauth_vault/vault_store.py (BIS-732 / Slice 4).
+
+This is the generic storage layer extracted from
+google_calendar/token_store.py, gmail/token_store.py, and
+google_workspace/token_store.py's identical save/load/serialize logic. These
+tests mirror the corresponding characterization assertions in
+test_google_calendar_token_store.py (BIS-728 / Slice 0) — same behavior,
+proven against the new provider-agnostic implementation, with only the
+import path and the (now-required) explicit token_dir argument changed.
+
+Covers:
+- _token_to_dict / _dict_to_token: round-trip serialisation, field types
+- _token_path: safe filenames, directory traversal prevention, empty user_id
+- save_token: creates file, mode 600, overwrites existing, handles bad user_id
+- load_token: returns TokenData, returns None on missing file, None on corrupt JSON
+- provider_token_dir: fresh-start path shape for providers with no legacy dir
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Make src importable without installing the package
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from integrations.google_calendar.oauth import TokenData
+from integrations.oauth_vault import vault_store as vs
+from integrations.oauth_vault.vault_store import (
+    _dict_to_token,
+    _token_path,
+    _token_to_dict,
+    load_token,
+    provider_token_dir,
+    save_token,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_ACCESS_TOKEN = "<REDACTED_SECRET>"
+_FAKE_REFRESH_TOKEN = "<REDACTED_SECRET>"
+_FAKE_SCOPE = "https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/calendar.events"
+
+_FUTURE_EXPIRES = datetime(2099, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_valid_token(refresh_token: str | None = _FAKE_REFRESH_TOKEN) -> TokenData:
+    return TokenData(
+        access_token=_FAKE_ACCESS_TOKEN,
+        expires_at=_FUTURE_EXPIRES,
+        scope=_FAKE_SCOPE,
+        refresh_token=refresh_token,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _token_to_dict / _dict_to_token / round trip
+# ---------------------------------------------------------------------------
+
+
+class TestSerializationRoundTrip:
+    def test_round_trip_preserves_all_fields(self) -> None:
+        original = _make_valid_token()
+        restored = _dict_to_token(_token_to_dict(original))
+        assert restored.access_token == original.access_token
+        assert restored.refresh_token == original.refresh_token
+        assert restored.scope == original.scope
+        assert abs((restored.expires_at - original.expires_at).total_seconds()) < 1
+
+    def test_round_trip_with_none_refresh_token(self) -> None:
+        original = _make_valid_token(refresh_token=None)
+        restored = _dict_to_token(_token_to_dict(original))
+        assert restored.refresh_token is None
+
+    def test_naive_expires_at_gets_utc_tzinfo(self) -> None:
+        data = {
+            "access_token": _FAKE_ACCESS_TOKEN,
+            "refresh_token": _FAKE_REFRESH_TOKEN,
+            "expires_at": "2099-01-01T00:00:00",  # naive
+            "scope": _FAKE_SCOPE,
+        }
+        result = _dict_to_token(data)
+        assert result.expires_at.tzinfo == timezone.utc
+
+    def test_raises_key_error_on_missing_access_token(self) -> None:
+        data = {"expires_at": _FUTURE_EXPIRES.isoformat(), "scope": _FAKE_SCOPE}
+        with pytest.raises(KeyError):
+            _dict_to_token(data)
+
+    def test_raises_value_error_on_invalid_expires_at(self) -> None:
+        data = {
+            "access_token": _FAKE_ACCESS_TOKEN,
+            "expires_at": "not-a-datetime",
+            "scope": _FAKE_SCOPE,
+        }
+        with pytest.raises(ValueError):
+            _dict_to_token(data)
+
+
+# ---------------------------------------------------------------------------
+# _token_path
+# ---------------------------------------------------------------------------
+
+
+class TestTokenPath:
+    def test_returns_path_object(self, tmp_path: Path) -> None:
+        result = _token_path("user123", tmp_path)
+        assert isinstance(result, Path)
+
+    def test_filename_is_user_id_dot_json(self, tmp_path: Path) -> None:
+        result = _token_path("user123", tmp_path)
+        assert result.name == "user123.json"
+
+    def test_parent_is_token_dir(self, tmp_path: Path) -> None:
+        result = _token_path("user123", tmp_path)
+        assert result.parent == tmp_path
+
+    def test_sanitises_alphanumeric_with_hyphens_and_underscores(self, tmp_path: Path) -> None:
+        result = _token_path("user-123_abc", tmp_path)
+        assert result.name == "user-123_abc.json"
+
+    def test_strips_path_separator_from_user_id(self, tmp_path: Path) -> None:
+        result = _token_path("../evil", tmp_path)
+        assert "/" not in result.name
+        assert ".." not in result.name
+
+    def test_raises_value_error_on_empty_user_id(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            _token_path("", tmp_path)
+
+    def test_raises_value_error_on_all_special_chars(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            _token_path("../.", tmp_path)
+
+    def test_telegram_chat_id_is_valid(self, tmp_path: Path) -> None:
+        result = _token_path("1234567890", tmp_path)
+        assert result.name == "1234567890.json"
+
+
+# ---------------------------------------------------------------------------
+# save_token
+# ---------------------------------------------------------------------------
+
+
+class TestSaveToken:
+    def test_creates_token_file(self, tmp_path: Path) -> None:
+        token = _make_valid_token()
+        save_token("user1", token, tmp_path)
+        assert (tmp_path / "user1.json").exists()
+
+    def test_token_file_is_valid_json(self, tmp_path: Path) -> None:
+        token = _make_valid_token()
+        save_token("user1", token, tmp_path)
+        data = json.loads((tmp_path / "user1.json").read_text())
+        assert "access_token" in data
+
+    def test_token_file_permissions_are_600(self, tmp_path: Path) -> None:
+        token = _make_valid_token()
+        save_token("user1", token, tmp_path)
+        mode = stat.S_IMODE((tmp_path / "user1.json").stat().st_mode)
+        assert mode == 0o600
+
+    def test_overwrites_existing_file(self, tmp_path: Path) -> None:
+        save_token("user1", _make_valid_token(), tmp_path)
+        token_b = TokenData(
+            access_token="<REDACTED_SECRET>",
+            expires_at=_FUTURE_EXPIRES,
+            scope=_FAKE_SCOPE,
+            refresh_token=_FAKE_REFRESH_TOKEN,
+        )
+        save_token("user1", token_b, tmp_path)
+        data = json.loads((tmp_path / "user1.json").read_text())
+        assert data["access_token"] == "<REDACTED_SECRET>"
+
+    def test_creates_token_dir_if_absent(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b" / "c"
+        save_token("user1", _make_valid_token(), nested)
+        assert (nested / "user1.json").exists()
+
+    def test_raises_value_error_on_bad_user_id(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError):
+            save_token("../.", _make_valid_token(), tmp_path)
+
+    def test_tmp_file_removed_and_exception_propagates_on_rename_failure(
+        self, tmp_path: Path
+    ) -> None:
+        with patch(f"{vs.__name__}.os.rename", side_effect=OSError("disk full")):
+            with pytest.raises(OSError, match="disk full"):
+                save_token("user1", _make_valid_token(), tmp_path)
+        assert not (tmp_path / "user1.json.tmp").exists()
+        assert not (tmp_path / "user1.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# load_token
+# ---------------------------------------------------------------------------
+
+
+class TestLoadToken:
+    def test_returns_none_when_no_file(self, tmp_path: Path) -> None:
+        assert load_token("nonexistent", tmp_path) is None
+
+    def test_returns_token_data_after_save(self, tmp_path: Path) -> None:
+        save_token("user1", _make_valid_token(), tmp_path)
+        result = load_token("user1", tmp_path)
+        assert isinstance(result, TokenData)
+        assert result.access_token == _FAKE_ACCESS_TOKEN
+        assert result.refresh_token == _FAKE_REFRESH_TOKEN
+
+    def test_returns_none_on_corrupt_json(self, tmp_path: Path) -> None:
+        (tmp_path / "user1.json").write_text("{ not valid json }")
+        assert load_token("user1", tmp_path) is None
+
+    def test_returns_none_on_missing_required_field(self, tmp_path: Path) -> None:
+        (tmp_path / "user1.json").write_text(
+            json.dumps({"expires_at": _FUTURE_EXPIRES.isoformat()})
+        )
+        assert load_token("user1", tmp_path) is None
+
+    def test_returns_none_on_invalid_expires_at(self, tmp_path: Path) -> None:
+        (tmp_path / "user1.json").write_text(json.dumps({
+            "access_token": _FAKE_ACCESS_TOKEN,
+            "expires_at": "not-a-date",
+            "scope": _FAKE_SCOPE,
+        }))
+        assert load_token("user1", tmp_path) is None
+
+    def test_loaded_expires_at_is_timezone_aware(self, tmp_path: Path) -> None:
+        save_token("user1", _make_valid_token(), tmp_path)
+        result = load_token("user1", tmp_path)
+        assert result is not None
+        assert result.expires_at.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# provider_token_dir
+# ---------------------------------------------------------------------------
+
+
+class TestProviderTokenDir:
+    def test_returns_vault_root_slash_provider(self, tmp_path: Path) -> None:
+        result = provider_token_dir("some_new_provider", vault_root=tmp_path)
+        assert result == tmp_path / "some_new_provider"
+
+    def test_different_providers_get_different_dirs(self, tmp_path: Path) -> None:
+        a = provider_token_dir("provider_a", vault_root=tmp_path)
+        b = provider_token_dir("provider_b", vault_root=tmp_path)
+        assert a != b

--- a/tests/unit/test_mcp_server/test_push_calendar_token_endpoint.py
+++ b/tests/unit/test_mcp_server/test_push_calendar_token_endpoint.py
@@ -1,0 +1,341 @@
+"""
+Characterization tests for POST /api/push-calendar-token (BIS-728 / Slice 0).
+
+This endpoint (``push_calendar_token_endpoint`` in ``src/mcp/inbox_server_http.py``)
+had no direct test coverage before this file. These tests pin its CURRENT
+behavior exactly as read from source, so later slices (BIS-727 Slice 1+) have
+a regression net when the auth model is hardened.
+
+Covers:
+- Happy path: valid authenticated request returns {"ok": true} and writes token file
+- Token file written to gcal-tokens/<chat_id>.json with mode 0o600
+- Atomic write: .tmp file is renamed to final path, not left behind
+- Auth: missing Authorization header -> 401
+- Auth: wrong secret -> 401
+- Auth: missing "Bearer " prefix -> 401
+- Validation: missing chat_id / access_token / expires_at -> 400
+- Validation: invalid expires_at format -> 400
+- Validation: invalid JSON body -> 400
+- Path traversal: chat_id with "../" components is sanitised, not written outside token dir
+- Token values never appear in log output
+- KNOWN-BAD (pinned intentionally): an unsigned request bearing only the
+  static LOBSTER_INTERNAL_SECRET bearer token, with an arbitrary/attacker-
+  suppliable chat_id, IS ACCEPTED today and writes a real token file for that
+  chat_id. There is no per-transaction binding (no nonce, no consent-token
+  check) — any caller who knows the static secret can push a token for ANY
+  chat_id. See connectors-oauth-plan-v2.md Slice 1, which closes this for the
+  calendar path specifically. When Slice 1 lands, the test named
+  ``test_forged_push_with_arbitrary_chat_id_is_currently_accepted_KNOWN_VULNERABLE``
+  below must flip to assert rejection (401/403) — that is the intended,
+  expected diff.
+
+All file I/O uses a tmp_path fixture — no real disk writes outside the test sandbox.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from starlette.testclient import TestClient
+
+# inbox_server_http calls sys.exit(1) at import time when MCP_HTTP_TOKEN is
+# not set. Pre-seed the env var before the first import so the module loads.
+os.environ.setdefault("MCP_HTTP_TOKEN", "test-mcp-token-placeholder")
+
+_MODULE = "src.mcp.inbox_server_http"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_SECRET = "test-calendar-secret-abc123"
+
+_VALID_BODY = {
+    "chat_id": "123456",
+    "access_token": "ya29.test-calendar-access-token",
+    "refresh_token": "1//test-calendar-refresh-token",
+    "expires_at": "2026-04-01T02:00:00Z",
+    "scope": "https://www.googleapis.com/auth/calendar.events",
+}
+
+
+@pytest.fixture()
+def client_and_token_dir(tmp_path):
+    """Yield (TestClient, gcal_token_dir) with patched dirs and secret."""
+    gcal_token_dir = tmp_path / "config" / "gcal-tokens"
+
+    with (
+        patch(f"{_MODULE}._GCAL_TOKEN_DIR", gcal_token_dir),
+        patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
+    ):
+        from src.mcp.inbox_server_http import app
+
+        client = TestClient(app, raise_server_exceptions=True)
+        yield client, gcal_token_dir
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_valid_request_returns_ok(client_and_token_dir):
+    client, _ = client_and_token_dir
+    resp = client.post(
+        "/api/push-calendar-token",
+        json=_VALID_BODY,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_token_file_written_with_correct_content(client_and_token_dir):
+    client, token_dir = client_and_token_dir
+    client.post(
+        "/api/push-calendar-token",
+        json=_VALID_BODY,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    token_path = token_dir / "123456.json"
+    assert token_path.exists(), "Token file was not created"
+
+    data = json.loads(token_path.read_text())
+    assert data["access_token"] == _VALID_BODY["access_token"]
+    assert data["refresh_token"] == _VALID_BODY["refresh_token"]
+    assert data["scope"] == _VALID_BODY["scope"]
+    assert "expires_at" in data
+    assert "2026-04-01" in data["expires_at"]
+
+
+def test_token_file_mode_is_0o600(client_and_token_dir):
+    client, token_dir = client_and_token_dir
+    client.post(
+        "/api/push-calendar-token",
+        json=_VALID_BODY,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    token_path = token_dir / "123456.json"
+    file_mode = stat.S_IMODE(os.stat(str(token_path)).st_mode)
+    assert file_mode == 0o600, f"Expected 0o600, got {oct(file_mode)}"
+
+
+def test_no_tmp_file_left_behind(client_and_token_dir):
+    client, token_dir = client_and_token_dir
+    client.post(
+        "/api/push-calendar-token",
+        json=_VALID_BODY,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    tmp_path = token_dir / "123456.json.tmp"
+    assert not tmp_path.exists(), ".tmp file should have been renamed away"
+
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+
+
+def test_missing_auth_header_returns_401(client_and_token_dir):
+    client, _ = client_and_token_dir
+    resp = client.post("/api/push-calendar-token", json=_VALID_BODY)
+    assert resp.status_code == 401
+
+
+def test_wrong_secret_returns_401(client_and_token_dir):
+    client, _ = client_and_token_dir
+    resp = client.post(
+        "/api/push-calendar-token",
+        json=_VALID_BODY,
+        headers={"Authorization": "Bearer wrong-secret"},
+    )
+    assert resp.status_code == 401
+
+
+def test_bearer_prefix_required(client_and_token_dir):
+    client, _ = client_and_token_dir
+    resp = client.post(
+        "/api/push-calendar-token",
+        json=_VALID_BODY,
+        headers={"Authorization": _VALID_SECRET},  # no "Bearer " prefix
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    ["chat_id", "access_token", "expires_at"],
+)
+def test_missing_required_field_returns_400(client_and_token_dir, missing_field):
+    client, _ = client_and_token_dir
+    body = {k: v for k, v in _VALID_BODY.items() if k != missing_field}
+    resp = client.post(
+        "/api/push-calendar-token",
+        json=body,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    assert resp.status_code == 400
+
+
+def test_invalid_expires_at_returns_400(client_and_token_dir):
+    client, _ = client_and_token_dir
+    body = {**_VALID_BODY, "expires_at": "not-a-date"}
+    resp = client.post(
+        "/api/push-calendar-token",
+        json=body,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    assert resp.status_code == 400
+    assert "expires_at" in resp.json().get("error", "").lower()
+
+
+def test_invalid_json_body_returns_400(client_and_token_dir):
+    client, _ = client_and_token_dir
+    resp = client.post(
+        "/api/push-calendar-token",
+        content=b"not-json",
+        headers={
+            "Authorization": f"Bearer {_VALID_SECRET}",
+            "Content-Type": "application/json",
+        },
+    )
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Path traversal
+# ---------------------------------------------------------------------------
+
+
+def test_path_traversal_in_chat_id_is_sanitised(client_and_token_dir):
+    client, token_dir = client_and_token_dir
+    malicious_chat_id = "../evil"
+    body = {**_VALID_BODY, "chat_id": malicious_chat_id}
+    resp = client.post(
+        "/api/push-calendar-token",
+        json=body,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    if resp.status_code == 200:
+        evil_path = token_dir.parent.parent / "evil.json"
+        assert not evil_path.exists(), "Path traversal wrote outside token directory"
+        sanitised_id = "".join(c for c in malicious_chat_id if c.isalnum() or c in ("-", "_"))
+        if sanitised_id:
+            expected = token_dir / f"{sanitised_id}.json"
+            assert expected.exists(), f"Expected sanitised file at {expected}"
+    else:
+        assert resp.status_code == 400
+
+
+def test_empty_chat_id_returns_400(client_and_token_dir):
+    client, _ = client_and_token_dir
+    body = {**_VALID_BODY, "chat_id": ""}
+    resp = client.post(
+        "/api/push-calendar-token",
+        json=body,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    assert resp.status_code == 400
+
+
+def test_chat_id_with_only_special_chars_returns_400(client_and_token_dir):
+    """chat_id like '/../' becomes empty after sanitisation -> 400."""
+    client, _ = client_and_token_dir
+    body = {**_VALID_BODY, "chat_id": "/../"}
+    resp = client.post(
+        "/api/push-calendar-token",
+        json=body,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+    )
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Token values must not appear in logs
+# ---------------------------------------------------------------------------
+
+
+def test_token_values_not_in_log_output(client_and_token_dir, caplog):
+    """access_token and refresh_token must never appear in log records."""
+    client, _ = client_and_token_dir
+    with caplog.at_level(logging.DEBUG):
+        client.post(
+            "/api/push-calendar-token",
+            json=_VALID_BODY,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+    combined = " ".join(r.getMessage() for r in caplog.records)
+    assert "ya29.test-calendar-access-token" not in combined, "access_token appeared in logs"
+    assert "1//test-calendar-refresh-token" not in combined, "refresh_token appeared in logs"
+
+
+# ---------------------------------------------------------------------------
+# KNOWN-BAD characterization (BIS-727 Slice 0 -> Slice 1 regression net)
+#
+# Today, `_is_authorized_internal` (inbox_server_http.py) only checks the
+# static LOBSTER_INTERNAL_SECRET bearer token. It does NOT verify that the
+# request corresponds to a specific consent transaction the user actually
+# initiated (no nonce, no per-transaction signature, no expiry binding).
+# Anyone holding the static secret can push a token for ANY chat_id.
+#
+# Slice 1 (per-transaction HMAC signing, calendar-scope-only) is expected to
+# flip this exact test to assert rejection. Do not "fix" this test in Slice 0
+# — it must describe today's real, vulnerable behavior.
+# ---------------------------------------------------------------------------
+
+
+def test_forged_push_with_arbitrary_chat_id_is_currently_accepted_KNOWN_VULNERABLE(
+    client_and_token_dir,
+):
+    """KNOWN VULNERABLE (pinned intentionally, see module docstring).
+
+    A request carrying only the static-secret bearer token, with an
+    attacker-chosen chat_id that never went through any consent flow, is
+    accepted (200) and a real token file is written for that chat_id.
+    There is no nonce / per-transaction binding today.
+
+    Slice 1 must flip this assertion to expect rejection (401/403) once
+    per-transaction signing is enforced for the calendar push path.
+    """
+    client, token_dir = client_and_token_dir
+
+    forged_chat_id = "999999999"  # attacker-supplied; never initiated any OAuth consent
+    forged_body = {
+        **_VALID_BODY,
+        "chat_id": forged_chat_id,
+    }
+
+    resp = client.post(
+        "/api/push-calendar-token",
+        json=forged_body,
+        headers={"Authorization": f"Bearer {_VALID_SECRET}"},  # only the static secret, no nonce
+    )
+
+    # --- Pinning today's (vulnerable) behavior ---
+    assert resp.status_code == 200, (
+        "Expected today's known-vulnerable behavior: static-secret-only request "
+        "is accepted regardless of chat_id. If this now fails, Slice 1's fix "
+        "has landed — replace this test with an equivalent 'KNOWN_GOOD' "
+        "rejection test rather than deleting the coverage."
+    )
+    assert resp.json() == {"ok": True}
+
+    forged_token_path = token_dir / f"{forged_chat_id}.json"
+    assert forged_token_path.exists(), (
+        "Expected today's known-vulnerable behavior: a real token file is "
+        "written for the attacker-supplied chat_id with no additional binding."
+    )
+    written = json.loads(forged_token_path.read_text())
+    assert written["access_token"] == forged_body["access_token"]

--- a/tests/unit/test_mcp_server/test_push_calendar_token_endpoint.py
+++ b/tests/unit/test_mcp_server/test_push_calendar_token_endpoint.py
@@ -18,26 +18,28 @@ Covers:
 - Validation: invalid JSON body -> 400
 - Path traversal: chat_id with "../" components is sanitised, not written outside token dir
 - Token values never appear in log output
-- KNOWN-BAD (pinned intentionally): an unsigned request bearing only the
-  static LOBSTER_INTERNAL_SECRET bearer token, with an arbitrary/attacker-
-  suppliable chat_id, IS ACCEPTED today and writes a real token file for that
-  chat_id. There is no per-transaction binding (no nonce, no consent-token
-  check) — any caller who knows the static secret can push a token for ANY
-  chat_id. See connectors-oauth-plan-v2.md Slice 1, which closes this for the
-  calendar path specifically. When Slice 1 lands, the test named
-  ``test_forged_push_with_arbitrary_chat_id_is_currently_accepted_KNOWN_VULNERABLE``
-  below must flip to assert rejection (401/403) — that is the intended,
-  expected diff.
+- BIS-727 Slice 1 (per-transaction HMAC signing, calendar path only):
+  a forged push carrying only the static bearer secret (no valid signed
+  session) is now REJECTED (401) once enforcement is on — see
+  ``test_forged_push_with_arbitrary_chat_id_is_now_rejected``, the Slice 1
+  flip of this file's original KNOWN_VULNERABLE characterization test.
+  Also covers: valid signed session accepted under enforcement; warn-mode
+  (default) still accepts a missing/invalid session but logs a warning;
+  tampered signature / wrong secret / expired / chat_id-scope mismatch /
+  nonce replay are all rejected under enforcement.
 
 All file I/O uses a tmp_path fixture — no real disk writes outside the test sandbox.
 """
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import logging
 import os
 import stat
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -55,6 +57,7 @@ _MODULE = "src.mcp.inbox_server_http"
 # ---------------------------------------------------------------------------
 
 _VALID_SECRET = "test-calendar-secret-abc123"
+_SESSION_HMAC_SECRET = "test-session-hmac-secret-xyz789"  # BIS-727 Slice 1
 
 _VALID_BODY = {
     "chat_id": "123456",
@@ -65,14 +68,53 @@ _VALID_BODY = {
 }
 
 
+def _build_signed_session(
+    chat_id: str,
+    scope: str,
+    *,
+    instance_id: str = "http://test-vps:8741",
+    nonce: str = "test-nonce-abc123",
+    exp: float | None = None,
+    secret: str = _SESSION_HMAC_SECRET,
+    sig_override: str | None = None,
+) -> dict:
+    """Build a session_token dict matching the wire format signed by
+    myownlobster.ai's callback route (BIS-727 Slice 1): HMAC-SHA256 over
+    instance_id|chat_id|scope|nonce|exp.
+    """
+    if exp is None:
+        exp = int(time.time()) + 1_800  # 30 min, matches SESSION_TOKEN_TTL
+    exp = int(exp)
+    message = f"{instance_id}|{chat_id}|{scope}|{nonce}|{exp}"
+    sig = sig_override
+    if sig is None:
+        sig = hmac.new(secret.encode("utf-8"), message.encode("utf-8"), hashlib.sha256).hexdigest()
+    return {
+        "instance_id": instance_id,
+        "chat_id": chat_id,
+        "scope": scope,
+        "nonce": nonce,
+        "exp": exp,
+        "sig": sig,
+    }
+
+
 @pytest.fixture()
 def client_and_token_dir(tmp_path):
-    """Yield (TestClient, gcal_token_dir) with patched dirs and secret."""
+    """Yield (TestClient, gcal_token_dir) with patched dirs and secrets.
+
+    Enforcement defaults to False (warn mode) here, matching the module's
+    real-world default — individual tests patch ``_ENFORCE_SIGNED_SESSION``
+    to True to exercise the enforced path.
+    """
     gcal_token_dir = tmp_path / "config" / "gcal-tokens"
 
     with (
         patch(f"{_MODULE}._GCAL_TOKEN_DIR", gcal_token_dir),
         patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
+        patch(f"{_MODULE}._SESSION_HMAC_SECRET", _SESSION_HMAC_SECRET),
+        patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", False),
+        patch(f"{_MODULE}._seen_calendar_session_nonces", {}),
     ):
         from src.mcp.inbox_server_http import app
 
@@ -282,60 +324,198 @@ def test_token_values_not_in_log_output(client_and_token_dir, caplog):
 
 
 # ---------------------------------------------------------------------------
-# KNOWN-BAD characterization (BIS-727 Slice 0 -> Slice 1 regression net)
+# BIS-727 Slice 1 — the flip of the Slice 0 KNOWN_VULNERABLE characterization
 #
-# Today, `_is_authorized_internal` (inbox_server_http.py) only checks the
-# static LOBSTER_INTERNAL_SECRET bearer token. It does NOT verify that the
-# request corresponds to a specific consent transaction the user actually
-# initiated (no nonce, no per-transaction signature, no expiry binding).
-# Anyone holding the static secret can push a token for ANY chat_id.
+# Previously, `_is_authorized_internal` only checked the static
+# LOBSTER_INTERNAL_SECRET bearer token — it did NOT verify that the request
+# corresponded to a specific consent transaction the user actually initiated
+# (no nonce, no per-transaction signature, no expiry binding), so anyone
+# holding the static secret could push a token for ANY chat_id.
 #
-# Slice 1 (per-transaction HMAC signing, calendar-scope-only) is expected to
-# flip this exact test to assert rejection. Do not "fix" this test in Slice 0
-# — it must describe today's real, vulnerable behavior.
+# This is the intended, expected diff for Slice 1: with signed-session
+# enforcement on, the exact same forged request from Slice 0's
+# `test_forged_push_with_arbitrary_chat_id_is_currently_accepted_KNOWN_VULNERABLE`
+# is now rejected.
 # ---------------------------------------------------------------------------
 
 
-def test_forged_push_with_arbitrary_chat_id_is_currently_accepted_KNOWN_VULNERABLE(
-    client_and_token_dir,
-):
-    """KNOWN VULNERABLE (pinned intentionally, see module docstring).
+def test_forged_push_with_arbitrary_chat_id_is_now_rejected(client_and_token_dir):
+    """Slice 1 flip of the Slice 0 KNOWN_VULNERABLE characterization.
 
     A request carrying only the static-secret bearer token, with an
-    attacker-chosen chat_id that never went through any consent flow, is
-    accepted (200) and a real token file is written for that chat_id.
-    There is no nonce / per-transaction binding today.
-
-    Slice 1 must flip this assertion to expect rejection (401/403) once
-    per-transaction signing is enforced for the calendar push path.
+    attacker-chosen chat_id that never went through any consent flow (no
+    signed session attached at all), is now rejected once enforcement is on.
     """
     client, token_dir = client_and_token_dir
 
-    forged_chat_id = "999999999"  # attacker-supplied; never initiated any OAuth consent
-    forged_body = {
-        **_VALID_BODY,
-        "chat_id": forged_chat_id,
-    }
+    with patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", True):
+        forged_chat_id = "999999999"  # attacker-supplied; never initiated any OAuth consent
+        forged_body = {
+            **_VALID_BODY,
+            "chat_id": forged_chat_id,
+        }
 
-    resp = client.post(
-        "/api/push-calendar-token",
-        json=forged_body,
-        headers={"Authorization": f"Bearer {_VALID_SECRET}"},  # only the static secret, no nonce
-    )
+        resp = client.post(
+            "/api/push-calendar-token",
+            json=forged_body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},  # only the static secret, no session
+        )
 
-    # --- Pinning today's (vulnerable) behavior ---
-    assert resp.status_code == 200, (
-        "Expected today's known-vulnerable behavior: static-secret-only request "
-        "is accepted regardless of chat_id. If this now fails, Slice 1's fix "
-        "has landed — replace this test with an equivalent 'KNOWN_GOOD' "
-        "rejection test rather than deleting the coverage."
-    )
-    assert resp.json() == {"ok": True}
+        assert resp.status_code == 401, (
+            "BIS-727 Slice 1: a static-secret-only push with no valid signed "
+            "session must be rejected once enforcement is on."
+        )
+        forged_token_path = token_dir / f"{forged_chat_id}.json"
+        assert not forged_token_path.exists(), "No token file should be written for a rejected push"
 
-    forged_token_path = token_dir / f"{forged_chat_id}.json"
-    assert forged_token_path.exists(), (
-        "Expected today's known-vulnerable behavior: a real token file is "
-        "written for the attacker-supplied chat_id with no additional binding."
-    )
-    written = json.loads(forged_token_path.read_text())
-    assert written["access_token"] == forged_body["access_token"]
+
+# ---------------------------------------------------------------------------
+# BIS-727 Slice 1 — signed session verification (calendar path only)
+# ---------------------------------------------------------------------------
+
+
+def test_valid_signed_session_is_accepted_under_enforcement(client_and_token_dir):
+    """The legitimate-push counterpart to the forged-push-rejected test above:
+    a valid signed session still succeeds even with enforcement on."""
+    client, token_dir = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", True):
+        session = _build_signed_session(_VALID_BODY["chat_id"], _VALID_BODY["scope"])
+        body = {**_VALID_BODY, "session_token": session}
+
+        resp = client.post(
+            "/api/push-calendar-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+        assert (token_dir / f"{_VALID_BODY['chat_id']}.json").exists()
+
+
+def test_missing_signed_session_accepted_but_warns_in_default_warn_mode(client_and_token_dir, caplog):
+    """Default (enforce=False) behavior: a push with no signed session at all
+    is still accepted, but a warning is logged — this is the 48h grace window."""
+    client, token_dir = client_and_token_dir
+
+    with caplog.at_level(logging.WARNING):
+        resp = client.post(
+            "/api/push-calendar-token",
+            json=_VALID_BODY,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+    assert resp.status_code == 200
+    assert (token_dir / f"{_VALID_BODY['chat_id']}.json").exists()
+    assert any("signed session" in r.getMessage().lower() for r in caplog.records)
+
+
+def test_tampered_signature_rejected_under_enforcement(client_and_token_dir):
+    client, _ = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", True):
+        session = _build_signed_session(_VALID_BODY["chat_id"], _VALID_BODY["scope"])
+        session["sig"] = "0" * len(session["sig"])  # tamper: replace with a bogus signature
+        body = {**_VALID_BODY, "session_token": session}
+
+        resp = client.post(
+            "/api/push-calendar-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 401
+
+
+def test_wrong_hmac_secret_rejected_under_enforcement(client_and_token_dir):
+    client, _ = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", True):
+        session = _build_signed_session(
+            _VALID_BODY["chat_id"], _VALID_BODY["scope"], secret="a-completely-different-secret"
+        )
+        body = {**_VALID_BODY, "session_token": session}
+
+        resp = client.post(
+            "/api/push-calendar-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 401
+
+
+def test_expired_session_rejected_under_enforcement(client_and_token_dir):
+    client, _ = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", True):
+        expired_exp = int(time.time()) - 10  # already expired
+        session = _build_signed_session(_VALID_BODY["chat_id"], _VALID_BODY["scope"], exp=expired_exp)
+        body = {**_VALID_BODY, "session_token": session}
+
+        resp = client.post(
+            "/api/push-calendar-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 401
+
+
+def test_chat_id_mismatch_rejected_under_enforcement(client_and_token_dir):
+    """A session signed for one chat_id cannot be replayed against another."""
+    client, _ = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", True):
+        session = _build_signed_session("111111111", _VALID_BODY["scope"])  # different chat_id
+        body = {**_VALID_BODY, "session_token": session}  # body's chat_id is still "123456"
+
+        resp = client.post(
+            "/api/push-calendar-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 401
+
+
+def test_scope_mismatch_rejected_under_enforcement(client_and_token_dir):
+    client, _ = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", True):
+        session = _build_signed_session(_VALID_BODY["chat_id"], "some-other-scope")
+        body = {**_VALID_BODY, "session_token": session}
+
+        resp = client.post(
+            "/api/push-calendar-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 401
+
+
+def test_nonce_reuse_rejected_under_enforcement(client_and_token_dir):
+    """Single-use: replaying the exact same signed session twice succeeds
+    once and is rejected the second time."""
+    client, token_dir = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", True):
+        session = _build_signed_session(_VALID_BODY["chat_id"], _VALID_BODY["scope"], nonce="reused-nonce-1")
+        body = {**_VALID_BODY, "session_token": session}
+
+        first = client.post(
+            "/api/push-calendar-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+        second = client.post(
+            "/api/push-calendar-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert first.status_code == 200
+        assert second.status_code == 401
+        assert (token_dir / f"{_VALID_BODY['chat_id']}.json").exists()

--- a/tests/unit/test_mcp_server/test_push_gmail_token_endpoint.py
+++ b/tests/unit/test_mcp_server/test_push_gmail_token_endpoint.py
@@ -13,17 +13,27 @@ Covers:
 - Validation: invalid expires_at format -> 400
 - Path traversal: chat_id with "../" components is sanitised, not written outside token dir
 - Token values never appear in log output
+- BIS-727 Slice 2 (per-transaction HMAC signing, gmail path — identical
+  pattern to Slice 1's calendar path): a forged push carrying only the
+  static bearer secret (no valid signed session) is rejected (401) once
+  enforcement is on. Also covers: valid signed session accepted under
+  enforcement; warn-mode (default) still accepts a missing/invalid session
+  but logs a warning; tampered signature / wrong secret / expired /
+  chat_id-scope mismatch / nonce replay are all rejected under enforcement.
 
 All file I/O uses a tmp_path fixture — no real disk writes outside the test sandbox.
 """
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import logging
 import os
 import stat
 import sys
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -45,6 +55,7 @@ _MODULE = "src.mcp.inbox_server_http"
 # ---------------------------------------------------------------------------
 
 _VALID_SECRET = "test-secret-abc123"
+_SESSION_HMAC_SECRET = "test-gmail-session-hmac-secret-xyz789"  # BIS-727 Slice 2
 
 _VALID_BODY = {
     "chat_id": "123456",
@@ -55,14 +66,53 @@ _VALID_BODY = {
 }
 
 
+def _build_signed_session(
+    chat_id: str,
+    scope: str,
+    *,
+    instance_id: str = "http://test-vps:8741",
+    nonce: str = "test-nonce-abc123",
+    exp: float | None = None,
+    secret: str = _SESSION_HMAC_SECRET,
+    sig_override: str | None = None,
+) -> dict:
+    """Build a session_token dict matching the wire format signed by
+    myownlobster.ai's callback route (BIS-727 Slice 1/2): HMAC-SHA256 over
+    instance_id|chat_id|scope|nonce|exp.
+    """
+    if exp is None:
+        exp = int(time.time()) + 1_800  # 30 min, matches SESSION_TOKEN_TTL
+    exp = int(exp)
+    message = f"{instance_id}|{chat_id}|{scope}|{nonce}|{exp}"
+    sig = sig_override
+    if sig is None:
+        sig = hmac.new(secret.encode("utf-8"), message.encode("utf-8"), hashlib.sha256).hexdigest()
+    return {
+        "instance_id": instance_id,
+        "chat_id": chat_id,
+        "scope": scope,
+        "nonce": nonce,
+        "exp": exp,
+        "sig": sig,
+    }
+
+
 @pytest.fixture()
 def client_and_token_dir(tmp_path):
-    """Yield (TestClient, gmail_token_dir) with patched dirs and secret."""
+    """Yield (TestClient, gmail_token_dir) with patched dirs and secrets.
+
+    Enforcement defaults to False (warn mode) here, matching the module's
+    real-world default — individual tests patch
+    ``_ENFORCE_GMAIL_SIGNED_SESSION`` to True to exercise the enforced path.
+    """
     gmail_token_dir = tmp_path / "config" / "gmail-tokens"
 
     with (
         patch(f"{_MODULE}._GMAIL_TOKEN_DIR", gmail_token_dir),
         patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
+        patch(f"{_MODULE}._SESSION_HMAC_SECRET", _SESSION_HMAC_SECRET),
+        patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", False),
+        patch(f"{_MODULE}._seen_gmail_session_nonces", {}),
     ):
         from src.mcp.inbox_server_http import app
 
@@ -276,3 +326,188 @@ def test_token_values_not_in_log_output(client_and_token_dir, caplog):
     combined = " ".join(r.getMessage() for r in caplog.records)
     assert "ya29.test-access-token" not in combined, "access_token appeared in logs"
     assert "1//test-refresh-token" not in combined, "refresh_token appeared in logs"
+
+
+# ---------------------------------------------------------------------------
+# BIS-727 Slice 2 — forged-push-rejected (gmail path), mirroring Slice 1's
+# test_forged_push_with_arbitrary_chat_id_is_now_rejected for calendar
+# ---------------------------------------------------------------------------
+
+
+def test_forged_push_with_arbitrary_chat_id_is_now_rejected(client_and_token_dir):
+    """A request carrying only the static-secret bearer token, with an
+    attacker-chosen chat_id that never went through any consent flow (no
+    signed session attached at all), is rejected once enforcement is on."""
+    client, token_dir = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", True):
+        forged_chat_id = "999999999"  # attacker-supplied; never initiated any OAuth consent
+        forged_body = {
+            **_VALID_BODY,
+            "chat_id": forged_chat_id,
+        }
+
+        resp = client.post(
+            "/api/push-gmail-token",
+            json=forged_body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},  # only the static secret, no session
+        )
+
+        assert resp.status_code == 401, (
+            "BIS-727 Slice 2: a static-secret-only push with no valid signed "
+            "session must be rejected once enforcement is on."
+        )
+        forged_token_path = token_dir / f"{forged_chat_id}.json"
+        assert not forged_token_path.exists(), "No token file should be written for a rejected push"
+
+
+# ---------------------------------------------------------------------------
+# BIS-727 Slice 2 — signed session verification (gmail path)
+# ---------------------------------------------------------------------------
+
+
+def test_valid_signed_session_is_accepted_under_enforcement(client_and_token_dir):
+    """The legitimate-push counterpart to the forged-push-rejected test above:
+    a valid signed session still succeeds even with enforcement on."""
+    client, token_dir = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", True):
+        session = _build_signed_session(_VALID_BODY["chat_id"], _VALID_BODY["scope"])
+        body = {**_VALID_BODY, "session_token": session}
+
+        resp = client.post(
+            "/api/push-gmail-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+        assert (token_dir / f"{_VALID_BODY['chat_id']}.json").exists()
+
+
+def test_missing_signed_session_accepted_but_warns_in_default_warn_mode(client_and_token_dir, caplog):
+    """Default (enforce=False) behavior: a push with no signed session at all
+    is still accepted, but a warning is logged — this is the 48h grace window."""
+    client, token_dir = client_and_token_dir
+
+    with caplog.at_level(logging.WARNING):
+        resp = client.post(
+            "/api/push-gmail-token",
+            json=_VALID_BODY,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+    assert resp.status_code == 200
+    assert (token_dir / f"{_VALID_BODY['chat_id']}.json").exists()
+    assert any("signed session" in r.getMessage().lower() for r in caplog.records)
+
+
+def test_tampered_signature_rejected_under_enforcement(client_and_token_dir):
+    client, _ = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", True):
+        session = _build_signed_session(_VALID_BODY["chat_id"], _VALID_BODY["scope"])
+        session["sig"] = "0" * len(session["sig"])  # tamper: replace with a bogus signature
+        body = {**_VALID_BODY, "session_token": session}
+
+        resp = client.post(
+            "/api/push-gmail-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 401
+
+
+def test_wrong_hmac_secret_rejected_under_enforcement(client_and_token_dir):
+    client, _ = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", True):
+        session = _build_signed_session(
+            _VALID_BODY["chat_id"], _VALID_BODY["scope"], secret="a-completely-different-secret"
+        )
+        body = {**_VALID_BODY, "session_token": session}
+
+        resp = client.post(
+            "/api/push-gmail-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 401
+
+
+def test_expired_session_rejected_under_enforcement(client_and_token_dir):
+    client, _ = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", True):
+        expired_exp = int(time.time()) - 10  # already expired
+        session = _build_signed_session(_VALID_BODY["chat_id"], _VALID_BODY["scope"], exp=expired_exp)
+        body = {**_VALID_BODY, "session_token": session}
+
+        resp = client.post(
+            "/api/push-gmail-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 401
+
+
+def test_chat_id_mismatch_rejected_under_enforcement(client_and_token_dir):
+    """A session signed for one chat_id cannot be replayed against another."""
+    client, _ = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", True):
+        session = _build_signed_session("111111111", _VALID_BODY["scope"])  # different chat_id
+        body = {**_VALID_BODY, "session_token": session}  # body's chat_id is still "123456"
+
+        resp = client.post(
+            "/api/push-gmail-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 401
+
+
+def test_scope_mismatch_rejected_under_enforcement(client_and_token_dir):
+    client, _ = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", True):
+        session = _build_signed_session(_VALID_BODY["chat_id"], "some-other-scope")
+        body = {**_VALID_BODY, "session_token": session}
+
+        resp = client.post(
+            "/api/push-gmail-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 401
+
+
+def test_nonce_reuse_rejected_under_enforcement(client_and_token_dir):
+    """Single-use: replaying the exact same signed session twice succeeds
+    once and is rejected the second time."""
+    client, token_dir = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", True):
+        session = _build_signed_session(_VALID_BODY["chat_id"], _VALID_BODY["scope"], nonce="reused-nonce-1")
+        body = {**_VALID_BODY, "session_token": session}
+
+        first = client.post(
+            "/api/push-gmail-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+        second = client.post(
+            "/api/push-gmail-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert first.status_code == 200
+        assert second.status_code == 401
+        assert (token_dir / f"{_VALID_BODY['chat_id']}.json").exists()

--- a/tests/unit/test_mcp_server/test_push_workspace_token_endpoint.py
+++ b/tests/unit/test_mcp_server/test_push_workspace_token_endpoint.py
@@ -13,17 +13,27 @@ Covers:
 - Validation: invalid expires_at format -> 400
 - Path traversal: chat_id with "../" components is sanitised, not written outside token dir
 - Token values never appear in log output
+- BIS-727 Slice 2 (per-transaction HMAC signing, workspace path — identical
+  pattern to Slice 1's calendar path): a forged push carrying only the
+  static bearer secret (no valid signed session) is rejected (401) once
+  enforcement is on. Also covers: valid signed session accepted under
+  enforcement; warn-mode (default) still accepts a missing/invalid session
+  but logs a warning; tampered signature / wrong secret / expired /
+  chat_id-scope mismatch / nonce replay are all rejected under enforcement.
 
 All file I/O uses a tmp_path fixture — no real disk writes outside the test sandbox.
 """
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import logging
 import os
 import stat
 import sys
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -41,6 +51,7 @@ _MODULE = "src.mcp.inbox_server_http"
 # ---------------------------------------------------------------------------
 
 _VALID_SECRET = "test-workspace-secret-abc123"
+_SESSION_HMAC_SECRET = "test-workspace-session-hmac-secret-xyz789"  # BIS-727 Slice 2
 
 _VALID_BODY = {
     "chat_id": "123456",
@@ -51,14 +62,53 @@ _VALID_BODY = {
 }
 
 
+def _build_signed_session(
+    chat_id: str,
+    scope: str,
+    *,
+    instance_id: str = "http://test-vps:8741",
+    nonce: str = "test-nonce-abc123",
+    exp: float | None = None,
+    secret: str = _SESSION_HMAC_SECRET,
+    sig_override: str | None = None,
+) -> dict:
+    """Build a session_token dict matching the wire format signed by
+    myownlobster.ai's callback route (BIS-727 Slice 1/2): HMAC-SHA256 over
+    instance_id|chat_id|scope|nonce|exp.
+    """
+    if exp is None:
+        exp = int(time.time()) + 1_800  # 30 min, matches SESSION_TOKEN_TTL
+    exp = int(exp)
+    message = f"{instance_id}|{chat_id}|{scope}|{nonce}|{exp}"
+    sig = sig_override
+    if sig is None:
+        sig = hmac.new(secret.encode("utf-8"), message.encode("utf-8"), hashlib.sha256).hexdigest()
+    return {
+        "instance_id": instance_id,
+        "chat_id": chat_id,
+        "scope": scope,
+        "nonce": nonce,
+        "exp": exp,
+        "sig": sig,
+    }
+
+
 @pytest.fixture()
 def client_and_token_dir(tmp_path):
-    """Yield (TestClient, workspace_token_dir) with patched dirs and secret."""
+    """Yield (TestClient, workspace_token_dir) with patched dirs and secrets.
+
+    Enforcement defaults to False (warn mode) here, matching the module's
+    real-world default — individual tests patch
+    ``_ENFORCE_WORKSPACE_SIGNED_SESSION`` to True to exercise the enforced path.
+    """
     workspace_token_dir = tmp_path / "config" / "workspace-tokens"
 
     with (
         patch(f"{_MODULE}._WORKSPACE_TOKEN_DIR", workspace_token_dir),
         patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
+        patch(f"{_MODULE}._SESSION_HMAC_SECRET", _SESSION_HMAC_SECRET),
+        patch(f"{_MODULE}._ENFORCE_WORKSPACE_SIGNED_SESSION", False),
+        patch(f"{_MODULE}._seen_workspace_session_nonces", {}),
     ):
         from src.mcp.inbox_server_http import app
 
@@ -230,3 +280,188 @@ def test_access_token_not_logged(client_and_token_dir, caplog):
         )
     for record in caplog.records:
         assert "ya29.test-workspace-access-token" not in record.getMessage()
+
+
+# ---------------------------------------------------------------------------
+# BIS-727 Slice 2 — forged-push-rejected (workspace path), mirroring Slice 1's
+# test_forged_push_with_arbitrary_chat_id_is_now_rejected for calendar
+# ---------------------------------------------------------------------------
+
+
+def test_forged_push_with_arbitrary_chat_id_is_now_rejected(client_and_token_dir):
+    """A request carrying only the static-secret bearer token, with an
+    attacker-chosen chat_id that never went through any consent flow (no
+    signed session attached at all), is rejected once enforcement is on."""
+    client, token_dir = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_WORKSPACE_SIGNED_SESSION", True):
+        forged_chat_id = "999999999"  # attacker-supplied; never initiated any OAuth consent
+        forged_body = {
+            **_VALID_BODY,
+            "chat_id": forged_chat_id,
+        }
+
+        resp = client.post(
+            "/api/push-workspace-token",
+            json=forged_body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},  # only the static secret, no session
+        )
+
+        assert resp.status_code == 401, (
+            "BIS-727 Slice 2: a static-secret-only push with no valid signed "
+            "session must be rejected once enforcement is on."
+        )
+        forged_token_path = token_dir / f"{forged_chat_id}.json"
+        assert not forged_token_path.exists(), "No token file should be written for a rejected push"
+
+
+# ---------------------------------------------------------------------------
+# BIS-727 Slice 2 — signed session verification (workspace path)
+# ---------------------------------------------------------------------------
+
+
+def test_valid_signed_session_is_accepted_under_enforcement(client_and_token_dir):
+    """The legitimate-push counterpart to the forged-push-rejected test above:
+    a valid signed session still succeeds even with enforcement on."""
+    client, token_dir = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_WORKSPACE_SIGNED_SESSION", True):
+        session = _build_signed_session(_VALID_BODY["chat_id"], _VALID_BODY["scope"])
+        body = {**_VALID_BODY, "session_token": session}
+
+        resp = client.post(
+            "/api/push-workspace-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+        assert (token_dir / f"{_VALID_BODY['chat_id']}.json").exists()
+
+
+def test_missing_signed_session_accepted_but_warns_in_default_warn_mode(client_and_token_dir, caplog):
+    """Default (enforce=False) behavior: a push with no signed session at all
+    is still accepted, but a warning is logged — this is the 48h grace window."""
+    client, token_dir = client_and_token_dir
+
+    with caplog.at_level(logging.WARNING):
+        resp = client.post(
+            "/api/push-workspace-token",
+            json=_VALID_BODY,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+    assert resp.status_code == 200
+    assert (token_dir / f"{_VALID_BODY['chat_id']}.json").exists()
+    assert any("signed session" in r.getMessage().lower() for r in caplog.records)
+
+
+def test_tampered_signature_rejected_under_enforcement(client_and_token_dir):
+    client, _ = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_WORKSPACE_SIGNED_SESSION", True):
+        session = _build_signed_session(_VALID_BODY["chat_id"], _VALID_BODY["scope"])
+        session["sig"] = "0" * len(session["sig"])  # tamper: replace with a bogus signature
+        body = {**_VALID_BODY, "session_token": session}
+
+        resp = client.post(
+            "/api/push-workspace-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 401
+
+
+def test_wrong_hmac_secret_rejected_under_enforcement(client_and_token_dir):
+    client, _ = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_WORKSPACE_SIGNED_SESSION", True):
+        session = _build_signed_session(
+            _VALID_BODY["chat_id"], _VALID_BODY["scope"], secret="a-completely-different-secret"
+        )
+        body = {**_VALID_BODY, "session_token": session}
+
+        resp = client.post(
+            "/api/push-workspace-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 401
+
+
+def test_expired_session_rejected_under_enforcement(client_and_token_dir):
+    client, _ = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_WORKSPACE_SIGNED_SESSION", True):
+        expired_exp = int(time.time()) - 10  # already expired
+        session = _build_signed_session(_VALID_BODY["chat_id"], _VALID_BODY["scope"], exp=expired_exp)
+        body = {**_VALID_BODY, "session_token": session}
+
+        resp = client.post(
+            "/api/push-workspace-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 401
+
+
+def test_chat_id_mismatch_rejected_under_enforcement(client_and_token_dir):
+    """A session signed for one chat_id cannot be replayed against another."""
+    client, _ = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_WORKSPACE_SIGNED_SESSION", True):
+        session = _build_signed_session("111111111", _VALID_BODY["scope"])  # different chat_id
+        body = {**_VALID_BODY, "session_token": session}  # body's chat_id is still "123456"
+
+        resp = client.post(
+            "/api/push-workspace-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 401
+
+
+def test_scope_mismatch_rejected_under_enforcement(client_and_token_dir):
+    client, _ = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_WORKSPACE_SIGNED_SESSION", True):
+        session = _build_signed_session(_VALID_BODY["chat_id"], "some-other-scope")
+        body = {**_VALID_BODY, "session_token": session}
+
+        resp = client.post(
+            "/api/push-workspace-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert resp.status_code == 401
+
+
+def test_nonce_reuse_rejected_under_enforcement(client_and_token_dir):
+    """Single-use: replaying the exact same signed session twice succeeds
+    once and is rejected the second time."""
+    client, token_dir = client_and_token_dir
+
+    with patch(f"{_MODULE}._ENFORCE_WORKSPACE_SIGNED_SESSION", True):
+        session = _build_signed_session(_VALID_BODY["chat_id"], _VALID_BODY["scope"], nonce="reused-nonce-1")
+        body = {**_VALID_BODY, "session_token": session}
+
+        first = client.post(
+            "/api/push-workspace-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+        second = client.post(
+            "/api/push-workspace-token",
+            json=body,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+        assert first.status_code == 200
+        assert second.status_code == 401
+        assert (token_dir / f"{_VALID_BODY['chat_id']}.json").exists()


### PR DESCRIPTION
## Problem

BIS-727 tracks a redesign of Lobster's Google OAuth connector layer, executed as vertical slices (each slice ships something independently verifiable end-to-end, per the revised plan at `reports/connectors-oauth-plan-v2.md`). This PR covers the first five slices (0 through 4):

- **Slice 0 (BIS-728):** Characterization tests only, zero behavior change. Pins today's exact behavior of `google_calendar/token_store.py` and the three push-token endpoints in `inbox_server_http.py` — including a deliberately named `..._KNOWN_VULNERABLE` test pinning that an unsigned, static-bearer-only forged push with an attacker-suppliable `chat_id` is accepted today.
- **Slice 1 (BIS-729):** Closes that vulnerability for Calendar. `push_calendar_token_endpoint` now additionally verifies a signed, single-use, 30-minute-TTL session token bound to the specific consent transaction, alongside the existing static-secret bearer check (warn-then-enforce rollout).
- **Slice 2 (BIS-730):** Applies the identical signing scheme to the Gmail and Workspace push endpoints — second and third application of the same fix.
- **Slice 3 (BIS-731):** Fixes a real, live gap: Calendar and Gmail's own `get_valid_token()` never consulted the shared Workspace token store, so a user who already granted the `workspace` scope bundle (which includes calendar + gmail.modify "for unified-token support") still saw Calendar/Gmail as "not connected." Both now fall back to the workspace token when their own scope-specific token file is absent, accepting it only if the workspace token's granted scope actually contains the needed scope.
- **Slice 4 (BIS-732):** Extracts the pattern proven identically three times (Calendar/Gmail/Workspace token stores) into a new `src/integrations/oauth_vault/` module, parameterized by provider instead of copy-pasted. Cuts `google_calendar/client.py` over to it as the first proof the abstraction generalizes — proven against the best-tested existing integration before Gmail and Workspace follow in later slices.

## What changed

**Slices 0-3** (prior commits on this branch, already reported to the user as they landed): characterization tests, per-transaction HMAC session signing on all three push-token endpoints, and the workspace-token fallback for Calendar/Gmail.

**Slice 4** (this session): new `src/integrations/oauth_vault/` package —
- `vault_store.py`: pure serialization (`_token_to_dict`/`_dict_to_token`), safe path construction (`_token_path`, alphanumeric-only filenames, directory-traversal-proof), and atomic 0600 file writes — parameterized by an explicit `token_dir` argument, no provider-registry knowledge.
- `client.py`: a `PROVIDERS` registry (currently one entry, `"calendar"`) plus a single `get_valid_token(provider, user_id, ...)` that composes load → validate → refresh-via-myownlobster-proxy → persist, folding in the Slice 3 workspace-fallback pattern generically (via each provider's `workspace_scope_substring`).
- `google_calendar/client.py`'s `get_valid_token` is now a one-line delegator to `oauth_vault.client.get_valid_token("calendar", ...)`, called via module-attribute access (not a bound `from...import` alias) so it stays independently patchable in tests.
- `google_calendar/token_store.py` is untouched and stays in the tree, unimported by `client.py`, as a one-release rollback path (per the plan, deleted only once Gmail/Workspace also migrate in later slices).

**Deliberate deviation from the literal Slice 4 plan text, flagged for review:** the plan describes a uniform new storage path, `oauth-tokens/<provider>/<chat_id>.json`, for every provider. For `"calendar"` specifically, `PROVIDERS["calendar"].token_dir` instead aliases to the *existing* `gcal-tokens/` directory rather than a fresh `oauth-tokens/calendar/` path. Reason: the *write* path for Calendar tokens (`push_calendar_token_endpoint` in `inbox_server_http.py`, and the local `callback_server.py` flow) is explicitly not part of this slice's cutover and continues writing to `gcal-tokens/`. Pointing the new read path at a fresh, empty directory instead would have meant a real, already-granted Calendar token silently stops being found the instant `client.py` cuts over — the exact class of regression the plan's own manual-verification step ("ask for what's on my calendar, confirm identical behavior") exists to catch. A dedicated regression test (`test_calendar_provider_aliases_to_legacy_gcal_tokens_dir`) pins this so it can't silently drift back apart. The fresh `oauth-tokens/<provider>/` layout remains the intended target for any new provider with no legacy directory, and becomes the real location for Calendar once its write path also migrates (a later slice, not this one).

## Functional patterns used

- **Pure functions:** all serialization (`_token_to_dict`/`_dict_to_token`/`_token_path`) and the `ProviderConfig` dataclass are side-effect-free.
- **Immutability:** `ProviderConfig` and `TokenData` are frozen dataclasses; the provider registry is composed once at import time.
- **Composition over duplication:** `oauth_vault.client.get_valid_token` composes `vault_store.load_token`/`save_token` with a provider-parameterized refresh call and the generalized workspace-fallback helper, rather than three copy-pasted implementations.
- **Side effects isolated at boundaries:** file I/O lives in `vault_store.py`; the one HTTP call (`_refresh_token_via_proxy`) is the single network boundary in `client.py`.

## Flow diagram — Calendar token resolution (Slice 4 cutover)

```
BEFORE (Slices 0-3):                       AFTER (Slice 4):

google_calendar/client.py                  google_calendar/client.py
  └─ get_valid_token()                       └─ get_valid_token()  [1-line delegator]
       (own token_store.py)                       └─ oauth_vault.client.get_valid_token("calendar", ...)
       ├─ load gcal-tokens/<id>.json                    ├─ load PROVIDERS["calendar"].token_dir/<id>.json
       ├─ valid? return                                 │    (== gcal-tokens/, aliased — same file, unchanged)
       ├─ expired? refresh via proxy                     ├─ valid? return
       ├─ no local file? workspace fallback              ├─ expired? refresh via proxy (provider-parameterized)
       └─ (BIS-731) check workspace-tokens/               └─ no local file? workspace fallback
            scope includes "calendar"?                        (identical logic, provider.workspace_scope_substring)

gmail/client.py, google_workspace/*        gmail/client.py, google_workspace/*
  — unchanged, still on own token_store.py    — unchanged, still on own token_store.py (Slices 5-6, not this PR)

google_calendar/token_store.py             google_calendar/token_store.py
  — the only calendar code path               — still in the tree, still fully tested (161 tests),
                                                 but no longer imported by client.py (rollback path)
```

Nothing about the myownlobster.ai side changes in Slice 4 — it's entirely VPS-side client code. The push-token write path (Slices 1-2's HMAC hardening) is unaffected.

## Out of scope

- Gmail and Workspace are **not** cut over to `oauth_vault` in this PR — that's Slices 5-6, deliberately deferred until Calendar (the best-tested integration) proves the abstraction end-to-end first.
- `google_calendar/token_store.py` is not deleted — kept as rollback per the plan, until all three legacy stores' consumers (read *and* write paths) have migrated.
- No myownlobster.ai code changed anywhere in this PR (Slices 0, 3, 4 never touched it; Slices 1-2's HMAC signing changes there were already reported to the user separately when they landed on this branch).

## Tests run

- [x] `uv run pytest tests/unit/test_integrations/test_gmail_token_store.py tests/unit/test_integrations/test_google_calendar_token_store.py -v` — 142 passed (Slice 3 verification, run at the start of this session)
- [x] `uv run pytest tests/unit/test_integrations/test_google_calendar_client.py tests/unit/test_integrations/test_google_calendar_token_store.py -q` — 161 passed, confirming the Slice 4 cutover changes zero assertions in the existing Calendar suite
- [x] `uv run pytest tests/unit/test_integrations/test_oauth_vault_store.py tests/unit/test_integrations/test_oauth_vault_client.py -v` — 62 passed (new oauth_vault characterization/equivalence tests)
- [x] `uv run pytest tests/unit/test_integrations/test_google_calendar_oauth_vault_cutover.py -q` — 3 passed (proves `google_calendar.client.get_valid_token` genuinely delegates to `oauth_vault.client.get_valid_token("calendar", ...)`, not just parallel-and-coincidentally-identical behavior)
- [x] `uv run pytest tests/unit/test_integrations/ -q` — 651 passed, 0 failed (full integrations suite)
- [x] `uv run pytest tests/unit -q` — full unit suite green, twice (once at session start confirming baseline, once after all Slice 4 changes)
- [x] Falsifiability check: reverted `google_calendar/client.py`'s cutover — `test_google_calendar_oauth_vault_cutover.py` failed as expected (3 failures), then passed again after restoring
- [x] Falsifiability check: reverted the `gcal-tokens/` directory alias in `oauth_vault/client.py`'s provider registry to the "fresh path" shape — `test_calendar_provider_aliases_to_legacy_gcal_tokens_dir` failed as expected, then passed again after restoring

## Manual test

Since this branch has not been deployed and the actual Google OAuth click-through / live-Calendar-UI verification the plan calls for ("ask Lobster what's on my calendar, confirm against the real Google Calendar UI") requires the account owner's sign-off before touching production tokens, I instead ran a scoped manual smoke test that exercises the real end-to-end call chain without touching any real credentials:

1. Wrote a fake token file at `<tmp>/messages/config/gcal-tokens/<test_chat_id>.json` — the exact directory shape and permissions (`0600`) that the real production push-token endpoint writes today.
2. Called `integrations.google_calendar.client.get_upcoming_events(test_chat_id)` for real — i.e. through the new `oauth_vault`-backed `get_valid_token` — with only the outbound Google Calendar HTTP call itself mocked (`requests.request`).
3. Observed: the token was found via `oauth_vault.client.PROVIDERS["calendar"].token_dir`, confirmed equal to the real `gcal-tokens/` path; the mocked API response was parsed correctly into a `CalendarEvent` with the expected title, id, and URL.

This proves the wiring is correct end-to-end without any unscoped or production-affecting calls. Live verification against a real Google Calendar account is deferred to account-owner sign-off before/at merge — see Definition of Done below.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — scoped smoke test described above, no real credentials or production tokens touched
- [ ] User-visible outcome verified — **blocked on account-owner sign-off**: the live "what's on my calendar" / OAuth click-through check this plan calls for touches real Google Calendar data and is intentionally deferred, not skipped
- [x] Side-effect audit complete: no floods, no unscoped writes (manual test used a throwaway `tmp_path`, cleaned up after), no unintended volume
- [x] External service calls: mocked in all automated tests; the one manual smoke test also mocked the outbound Google Calendar HTTP call, touching no real API or credentials

**Blocked items needing attention before merge:** the myownlobster.ai-side deploy and the live OAuth click-through verification are intentionally still pending the account owner's manual sign-off. No live traffic changes should be pushed to myownlobster.ai and no real Google account should be exercised against this branch until that sign-off happens.

Closes #BIS-728, #BIS-729, #BIS-730, #BIS-731, #BIS-732 (Linear; not GitHub issues — all five marked Done in Linear as part of this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)