### PR TITLE
BIS-743: Extend push-token confirmation parity to Calendar and Gmail

### DIFF
--- a/lobster-shop/gcal-links/behavior/system.md
+++ b/lobster-shop/gcal-links/behavior/system.md
@@ -131,7 +131,10 @@ try:
     reply = (
         "To connect your Google Calendar, tap this link (expires in 30 minutes):\n"
         f"[Connect Google Calendar]({url})\n\n"
-        "After connecting, I'll be able to read and create calendar events for you."
+        "After connecting, I'll be able to read and create calendar events for you.\n\n"
+        "Note: Google may show an \"unverified app\" warning screen first — that's "
+        "expected for this app right now, not a sign anything is wrong. Tap "
+        "**Advanced**, then tap the \"Go to ... (unsafe)\" link near the bottom to continue."
     )
 except Exception as exc:
     # Graceful fallback: generate_consent_link raises if env vars are missing

--- a/lobster-shop/gmail/behavior/system.md
+++ b/lobster-shop/gmail/behavior/system.md
@@ -54,7 +54,10 @@ try:
     reply = (
         "To connect your Gmail, tap this link (expires in 30 minutes):\n"
         f"[Connect Gmail]({url})\n\n"
-        "After connecting, I'll be able to read and search your emails."
+        "After connecting, I'll be able to read and search your emails.\n\n"
+        "Note: Google may show an \"unverified app\" warning screen first — that's "
+        "expected for this app right now, not a sign anything is wrong. Tap "
+        "**Advanced**, then tap the \"Go to ... (unsafe)\" link near the bottom to continue."
     )
 except Exception as exc:
     log.warning("generate_consent_link('gmail') failed: %s", exc)
@@ -163,7 +166,10 @@ try:
     reply = (
         "To connect your Gmail, tap this link (expires in 30 minutes):\n"
         f"[Connect Gmail]({url})\n\n"
-        "After connecting, I'll be able to read and search your emails."
+        "After connecting, I'll be able to read and search your emails.\n\n"
+        "Note: Google may show an \"unverified app\" warning screen first — that's "
+        "expected for this app right now, not a sign anything is wrong. Tap "
+        "**Advanced**, then tap the \"Go to ... (unsafe)\" link near the bottom to continue."
     )
 except Exception as exc:
     log.warning("generate_consent_link('gmail') failed — degrading gracefully: %s", exc)

--- a/lobster-shop/google-workspace/behavior/system.md
+++ b/lobster-shop/google-workspace/behavior/system.md
@@ -42,7 +42,10 @@ try:
         "(expires in 30 minutes):\n"
         f"[Connect Google Workspace]({url})\n\n"
         "After connecting, I'll be able to read, create, and edit your Google Docs, "
-        "list Drive files, and read/write Sheets."
+        "list Drive files, and read/write Sheets.\n\n"
+        "Note: Google may show an \"unverified app\" warning screen first — that's "
+        "expected for this app right now, not a sign anything is wrong. Tap "
+        "**Advanced**, then tap the \"Go to ... (unsafe)\" link near the bottom to continue."
     )
 except Exception as exc:
     log.warning("generate_consent_link('workspace') failed: %s", exc)
@@ -110,7 +113,10 @@ try:
         "Tap this link to connect Google Workspace (expires in 30 minutes):\n"
         f"[Connect Google Workspace]({url})\n\n"
         "This grants access to Google Docs, Drive, and Sheets. "
-        "After connecting, try /gdocs, /gdrive, or /gsheets."
+        "After connecting, try /gdocs, /gdrive, or /gsheets.\n\n"
+        "Note: Google may show an \"unverified app\" warning screen first — that's "
+        "expected for this app right now, not a sign anything is wrong. Tap "
+        "**Advanced**, then tap the \"Go to ... (unsafe)\" link near the bottom to continue."
     )
 except Exception as exc:
     log.warning("generate_consent_link('workspace') failed — degrading gracefully: %s", exc)

--- a/src/mcp/inbox_server_http.py
+++ b/src/mcp/inbox_server_http.py
@@ -497,6 +497,44 @@ async def push_calendar_token_endpoint(scope, receive, send):
         await response(scope, receive, send)
         return
 
+    # BIS-743: post-push confirmation, extending the pattern already shipped
+    # for Workspace (push_workspace_token_endpoint, below) to Calendar.
+    # Best-effort: the token is already saved, so a confirmation failure here
+    # must never turn a successful push into an error response for the caller.
+    try:
+        import time as _time
+
+        _MESSAGES_BASE = Path(os.path.expanduser("~/messages"))
+        _OUTBOX_DIR = _MESSAGES_BASE / "outbox"
+        _OUTBOX_DIR.mkdir(parents=True, exist_ok=True)
+
+        reply_id = f"{int(_time.time() * 1000)}_calendar_auth"
+        reply_data = {
+            "id": reply_id,
+            "source": "telegram",
+            "chat_id": safe_chat_id,
+            "text": (
+                "Google Calendar connected. "
+                "I can now read and create events on your calendar."
+            ),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        reply_file = _OUTBOX_DIR / f"{reply_id}.json"
+        tmp_reply = reply_file.with_suffix(".json.tmp")
+        tmp_fd = os.open(str(tmp_reply), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(tmp_fd, "w") as rf:
+            rf.write(json.dumps(reply_data, indent=2))
+        os.rename(str(tmp_reply), str(reply_file))
+        logger.info(
+            "Calendar-connected confirmation queued for chat_id=%r", safe_chat_id
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "push_calendar_token: failed to queue confirmation for chat_id=%r: %s",
+            safe_chat_id,
+            exc,
+        )
+
     response = JSONResponse({"ok": True})
     await response(scope, receive, send)
 
@@ -714,6 +752,44 @@ async def push_gmail_token_endpoint(scope, receive, send):
         response = JSONResponse({"error": "Failed to write token"}, status_code=500)
         await response(scope, receive, send)
         return
+
+    # BIS-743: post-push confirmation, extending the pattern already shipped
+    # for Workspace (push_workspace_token_endpoint, below) to Gmail.
+    # Best-effort: the token is already saved, so a confirmation failure here
+    # must never turn a successful push into an error response for the caller.
+    try:
+        import time as _time
+
+        _MESSAGES_BASE = Path(os.path.expanduser("~/messages"))
+        _OUTBOX_DIR = _MESSAGES_BASE / "outbox"
+        _OUTBOX_DIR.mkdir(parents=True, exist_ok=True)
+
+        reply_id = f"{int(_time.time() * 1000)}_gmail_auth"
+        reply_data = {
+            "id": reply_id,
+            "source": "telegram",
+            "chat_id": safe_chat_id,
+            "text": (
+                "Gmail connected. "
+                "I can now read and search your emails."
+            ),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        reply_file = _OUTBOX_DIR / f"{reply_id}.json"
+        tmp_reply = reply_file.with_suffix(".json.tmp")
+        tmp_fd = os.open(str(tmp_reply), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(tmp_fd, "w") as rf:
+            rf.write(json.dumps(reply_data, indent=2))
+        os.rename(str(tmp_reply), str(reply_file))
+        logger.info(
+            "Gmail-connected confirmation queued for chat_id=%r", safe_chat_id
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "push_gmail_token: failed to queue confirmation for chat_id=%r: %s",
+            safe_chat_id,
+            exc,
+        )
 
     response = JSONResponse({"ok": True})
     await response(scope, receive, send)

--- a/tests/unit/test_integrations/test_google_consent_warning_copy.py
+++ b/tests/unit/test_integrations/test_google_consent_warning_copy.py
@@ -1,0 +1,96 @@
+"""
+Tests for the BIS-743 "unverified app" warning-message copy tweak.
+
+Guards the doc-only change to the three Google connect-flow skill docs
+(gcal-links, gmail, google-workspace `behavior/system.md`): the consent-link
+message now proactively mentions Google's "unverified app" warning screen so
+the user isn't alarmed by it.
+
+This test module exists specifically to catch a bug an independent review
+pass (Fable) found during BIS-743: an early version of this copy tweak left
+a literal, un-interpolated ``(app name)`` placeholder in the user-facing
+string (not inside an f-string, so it would never be substituted with the
+real app name — Telegram users would have seen the literal text
+"Go to (app name) (unsafe)"). These tests pin the fixed wording and prevent
+that class of bug from silently regressing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent
+
+_SKILL_DOC_PATHS = [
+    _REPO_ROOT / "lobster-shop" / "gcal-links" / "behavior" / "system.md",
+    _REPO_ROOT / "lobster-shop" / "gmail" / "behavior" / "system.md",
+    _REPO_ROOT / "lobster-shop" / "google-workspace" / "behavior" / "system.md",
+]
+
+
+@pytest.mark.parametrize("doc_path", _SKILL_DOC_PATHS, ids=lambda p: p.parent.parent.name)
+def test_unverified_app_warning_present(doc_path: Path):
+    """Each consent-flow skill doc mentions the unverified-app warning screen."""
+    text = doc_path.read_text()
+    assert "unverified app" in text.lower(), (
+        f"{doc_path} does not mention Google's 'unverified app' warning screen"
+    )
+
+
+@pytest.mark.parametrize("doc_path", _SKILL_DOC_PATHS, ids=lambda p: p.parent.parent.name)
+def test_no_unfilled_placeholder_in_warning_copy(doc_path: Path):
+    """Regression guard: no literal, un-interpolated '(app name)' placeholder.
+
+    An early draft of this copy tweak wrote a plain string containing
+    "(app name)" as a stand-in for the real app name, but never actually
+    interpolated it (it wasn't inside an f-string) — so the literal text
+    "(app name)" would have been sent to real users. Fable's review caught
+    this before merge; this test pins the fix.
+    """
+    text = doc_path.read_text()
+    assert "(app name)" not in text, (
+        f"{doc_path} contains an unfilled '(app name)' placeholder in "
+        "user-facing message copy"
+    )
+
+
+@pytest.mark.parametrize("doc_path", _SKILL_DOC_PATHS, ids=lambda p: p.parent.parent.name)
+def test_warning_copy_is_syntactically_valid_python_string(doc_path: Path):
+    """The reply string containing the warning must be valid, parseable Python.
+
+    Guards against unescaped quote characters inside the string literal
+    (e.g. a raw '"Go to ... (unsafe)"' embedded in an already-double-quoted
+    Python string, which would be a SyntaxError at runtime).
+    """
+    import ast
+
+    text = doc_path.read_text()
+    # Extract fenced python code blocks and confirm each parses.
+    blocks = []
+    lines = text.splitlines()
+    in_block = False
+    current: list[str] = []
+    for line in lines:
+        if line.strip().startswith("```python"):
+            in_block = True
+            current = []
+            continue
+        if line.strip() == "```" and in_block:
+            in_block = False
+            blocks.append("\n".join(current))
+            continue
+        if in_block:
+            current.append(line)
+
+    assert blocks, f"No python code blocks found in {doc_path}"
+    for block in blocks:
+        if "unverified app" in block.lower():
+            try:
+                ast.parse(block)
+            except SyntaxError as exc:
+                pytest.fail(
+                    f"{doc_path}: python block containing warning copy is "
+                    f"not valid Python: {exc}"
+                )

--- a/tests/unit/test_mcp_server/test_push_calendar_token_confirmation.py
+++ b/tests/unit/test_mcp_server/test_push_calendar_token_confirmation.py
@@ -1,0 +1,153 @@
+"""
+Tests for BIS-743: post-push confirmation on POST /api/push-calendar-token.
+
+Before BIS-743, ``push_calendar_token_endpoint`` wrote the token file and
+returned ``{"ok": true}`` with zero user-facing confirmation — unlike
+``push_workspace_token_endpoint``, which already queues an outbox reply on
+success (BIS-727 Slice "onboarding"/7). This file proves the Calendar
+endpoint now does the same thing, mirroring
+``test_push_workspace_token_confirmation.py``.
+
+Covers:
+- push_calendar_token: queues confirmation reply to outbox on success
+- push_calendar_token: confirmation text mentions Google Calendar
+- push_calendar_token: returns 200 ok even if the confirmation write fails
+- push_calendar_token: confirmation delivered to the correct chat_id
+
+All file I/O uses a tmp_path fixture — no real disk writes outside the test sandbox.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from starlette.testclient import TestClient
+
+# inbox_server_http calls sys.exit(1) at import time when MCP_HTTP_TOKEN is
+# not set.  Pre-seed the env var before the first import.
+os.environ.setdefault("MCP_HTTP_TOKEN", "test-mcp-token-placeholder")
+
+_MODULE = "src.mcp.inbox_server_http"
+_VALID_SECRET = "test-calendar-confirm-secret-xyz"
+
+_VALID_BODY = {
+    "chat_id": "6645894374",
+    "access_token": "ya29.fake-calendar-token",
+    "refresh_token": "1//refresh-fake",
+    "expires_at": (datetime.now(tz=timezone.utc) + timedelta(hours=1)).isoformat(),
+    "scope": "https://www.googleapis.com/auth/calendar.events",
+}
+
+
+@pytest.fixture()
+def client_and_dirs(tmp_path):
+    """Yield (TestClient, token_dir, outbox_dir)."""
+    gcal_token_dir = tmp_path / "config" / "gcal-tokens"
+    outbox_dir = tmp_path / "outbox"
+    gcal_token_dir.mkdir(parents=True)
+    outbox_dir.mkdir(parents=True)
+
+    with (
+        patch(f"{_MODULE}._GCAL_TOKEN_DIR", gcal_token_dir),
+        patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
+        patch(f"{_MODULE}._SESSION_HMAC_SECRET", ""),
+        patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", False),
+        patch(f"{_MODULE}._seen_calendar_session_nonces", {}),
+        patch(
+            "os.path.expanduser",
+            side_effect=lambda p: str(tmp_path) if p == "~/messages" else p,
+        ),
+    ):
+        from src.mcp.inbox_server_http import app
+
+        client = TestClient(app, raise_server_exceptions=True)
+        yield client, gcal_token_dir, outbox_dir
+
+
+class TestPostAuthConfirmation:
+    def test_returns_ok_on_success(self, client_and_dirs):
+        client, _, _ = client_and_dirs
+        resp = client.post(
+            "/api/push-calendar-token",
+            json=_VALID_BODY,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json().get("ok") is True
+
+    def test_confirmation_queued_to_outbox(self, client_and_dirs):
+        client, _, outbox_dir = client_and_dirs
+        client.post(
+            "/api/push-calendar-token",
+            json=_VALID_BODY,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+        outbox_files = list(outbox_dir.glob("*.json"))
+        assert outbox_files, "No confirmation was queued to the outbox"
+        reply = json.loads(outbox_files[0].read_text())
+        text = reply.get("text", "")
+        assert "Calendar" in text
+        assert reply.get("chat_id") == _VALID_BODY["chat_id"]
+        assert reply.get("source") == "telegram"
+
+    def test_returns_ok_even_when_outbox_write_fails(self, tmp_path):
+        """Token save succeeds and 200 is returned even if outbox write throws."""
+        gcal_token_dir = tmp_path / "config" / "gcal-tokens"
+        gcal_token_dir.mkdir(parents=True)
+
+        with (
+            patch(f"{_MODULE}._GCAL_TOKEN_DIR", gcal_token_dir),
+            patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
+            patch(f"{_MODULE}._SESSION_HMAC_SECRET", ""),
+            patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", False),
+            patch(f"{_MODULE}._seen_calendar_session_nonces", {}),
+            # Redirect expanduser to a path that doesn't exist so mkdir fails
+            patch(
+                "os.path.expanduser",
+                side_effect=lambda p: "/dev/null/nonexistent" if p == "~/messages" else p,
+            ),
+        ):
+            from src.mcp.inbox_server_http import app
+
+            client = TestClient(app, raise_server_exceptions=True)
+            resp = client.post(
+                "/api/push-calendar-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json().get("ok") is True
+
+    def test_token_still_saved_even_if_confirmation_would_fail(self, tmp_path):
+        """The token write must not depend on / be blocked by the confirmation step."""
+        gcal_token_dir = tmp_path / "config" / "gcal-tokens"
+        gcal_token_dir.mkdir(parents=True)
+
+        with (
+            patch(f"{_MODULE}._GCAL_TOKEN_DIR", gcal_token_dir),
+            patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
+            patch(f"{_MODULE}._SESSION_HMAC_SECRET", ""),
+            patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", False),
+            patch(f"{_MODULE}._seen_calendar_session_nonces", {}),
+            patch(
+                "os.path.expanduser",
+                side_effect=lambda p: "/dev/null/nonexistent" if p == "~/messages" else p,
+            ),
+        ):
+            from src.mcp.inbox_server_http import app
+
+            client = TestClient(app, raise_server_exceptions=True)
+            client.post(
+                "/api/push-calendar-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+
+        token_path = gcal_token_dir / f"{_VALID_BODY['chat_id']}.json"
+        assert token_path.exists(), "Token file must be written regardless of confirmation outcome"

--- a/tests/unit/test_mcp_server/test_push_gmail_token_confirmation.py
+++ b/tests/unit/test_mcp_server/test_push_gmail_token_confirmation.py
@@ -1,0 +1,151 @@
+"""
+Tests for BIS-743: post-push confirmation on POST /api/push-gmail-token.
+
+Before BIS-743, ``push_gmail_token_endpoint`` wrote the token file and
+returned ``{"ok": true}`` with zero user-facing confirmation — unlike
+``push_workspace_token_endpoint``, which already queues an outbox reply on
+success. This file proves the Gmail endpoint now does the same thing,
+mirroring ``test_push_workspace_token_confirmation.py``.
+
+Covers:
+- push_gmail_token: queues confirmation reply to outbox on success
+- push_gmail_token: confirmation text mentions Gmail
+- push_gmail_token: returns 200 ok even if the confirmation write fails
+- push_gmail_token: confirmation delivered to the correct chat_id
+
+All file I/O uses a tmp_path fixture — no real disk writes outside the test sandbox.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from starlette.testclient import TestClient
+
+# inbox_server_http calls sys.exit(1) at import time when MCP_HTTP_TOKEN is
+# not set.  Pre-seed the env var before the first import.
+os.environ.setdefault("MCP_HTTP_TOKEN", "test-mcp-token-placeholder")
+
+_MODULE = "src.mcp.inbox_server_http"
+_VALID_SECRET = "test-gmail-confirm-secret-xyz"
+
+_VALID_BODY = {
+    "chat_id": "6645894374",
+    "access_token": "ya29.fake-gmail-token",
+    "refresh_token": "1//refresh-fake",
+    "expires_at": (datetime.now(tz=timezone.utc) + timedelta(hours=1)).isoformat(),
+    "scope": "https://www.googleapis.com/auth/gmail.readonly",
+}
+
+
+@pytest.fixture()
+def client_and_dirs(tmp_path):
+    """Yield (TestClient, token_dir, outbox_dir)."""
+    gmail_token_dir = tmp_path / "config" / "gmail-tokens"
+    outbox_dir = tmp_path / "outbox"
+    gmail_token_dir.mkdir(parents=True)
+    outbox_dir.mkdir(parents=True)
+
+    with (
+        patch(f"{_MODULE}._GMAIL_TOKEN_DIR", gmail_token_dir),
+        patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
+        patch(f"{_MODULE}._SESSION_HMAC_SECRET", ""),
+        patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", False),
+        patch(f"{_MODULE}._seen_gmail_session_nonces", {}),
+        patch(
+            "os.path.expanduser",
+            side_effect=lambda p: str(tmp_path) if p == "~/messages" else p,
+        ),
+    ):
+        from src.mcp.inbox_server_http import app
+
+        client = TestClient(app, raise_server_exceptions=True)
+        yield client, gmail_token_dir, outbox_dir
+
+
+class TestPostAuthConfirmation:
+    def test_returns_ok_on_success(self, client_and_dirs):
+        client, _, _ = client_and_dirs
+        resp = client.post(
+            "/api/push-gmail-token",
+            json=_VALID_BODY,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json().get("ok") is True
+
+    def test_confirmation_queued_to_outbox(self, client_and_dirs):
+        client, _, outbox_dir = client_and_dirs
+        client.post(
+            "/api/push-gmail-token",
+            json=_VALID_BODY,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+        outbox_files = list(outbox_dir.glob("*.json"))
+        assert outbox_files, "No confirmation was queued to the outbox"
+        reply = json.loads(outbox_files[0].read_text())
+        text = reply.get("text", "")
+        assert "Gmail" in text
+        assert reply.get("chat_id") == _VALID_BODY["chat_id"]
+        assert reply.get("source") == "telegram"
+
+    def test_returns_ok_even_when_outbox_write_fails(self, tmp_path):
+        """Token save succeeds and 200 is returned even if outbox write throws."""
+        gmail_token_dir = tmp_path / "config" / "gmail-tokens"
+        gmail_token_dir.mkdir(parents=True)
+
+        with (
+            patch(f"{_MODULE}._GMAIL_TOKEN_DIR", gmail_token_dir),
+            patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
+            patch(f"{_MODULE}._SESSION_HMAC_SECRET", ""),
+            patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", False),
+            patch(f"{_MODULE}._seen_gmail_session_nonces", {}),
+            patch(
+                "os.path.expanduser",
+                side_effect=lambda p: "/dev/null/nonexistent" if p == "~/messages" else p,
+            ),
+        ):
+            from src.mcp.inbox_server_http import app
+
+            client = TestClient(app, raise_server_exceptions=True)
+            resp = client.post(
+                "/api/push-gmail-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json().get("ok") is True
+
+    def test_token_still_saved_even_if_confirmation_would_fail(self, tmp_path):
+        """The token write must not depend on / be blocked by the confirmation step."""
+        gmail_token_dir = tmp_path / "config" / "gmail-tokens"
+        gmail_token_dir.mkdir(parents=True)
+
+        with (
+            patch(f"{_MODULE}._GMAIL_TOKEN_DIR", gmail_token_dir),
+            patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
+            patch(f"{_MODULE}._SESSION_HMAC_SECRET", ""),
+            patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", False),
+            patch(f"{_MODULE}._seen_gmail_session_nonces", {}),
+            patch(
+                "os.path.expanduser",
+                side_effect=lambda p: "/dev/null/nonexistent" if p == "~/messages" else p,
+            ),
+        ):
+            from src.mcp.inbox_server_http import app
+
+            client = TestClient(app, raise_server_exceptions=True)
+            client.post(
+                "/api/push-gmail-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+
+        token_path = gmail_token_dir / f"{_VALID_BODY['chat_id']}.json"
+        assert token_path.exists(), "Token file must be written regardless of confirmation outcome"


### PR DESCRIPTION
## Summary
- `push_workspace_token_endpoint` already best-effort-queues an outbox confirmation on a successful token push; `push_calendar_token_endpoint` and `push_gmail_token_endpoint` did not — this was the root cause of Drew having to manually ask "did it work?" instead of getting an automatic confirmation.
- Mirrors the existing workspace confirmation pattern into both endpoints (deliberately copy-pasted, matching this file's established BIS-730 convention: prove a pattern 3x before extracting an abstraction, which BIS-744 will do next).
- Folds in a small, independently-scoped copy tweak to the three Google connect-flow skill docs so the consent-link message proactively mentions Google's "unverified app" warning screen (does not remove the screen — that requires a GCP test-user change Drew is handling separately).

## Review process
Per explicit instruction, this PR's design and diff were independently reviewed by a Fable-model pass before merge (not just self-review by the implementing model). That review caught a real bug: an early draft of the warning-copy tweak left a literal, un-interpolated `(app name)` placeholder (not inside an f-string) across all 5 call sites — Telegram users would have seen the literal text "Go to (app name) (unsafe)". Fixed to "Go to ... (unsafe)" and pinned with a new regression test (`test_google_consent_warning_copy.py`) so this class of bug can't silently reappear.

## Test plan
- [x] New tests (`test_push_calendar_token_confirmation.py`, `test_push_gmail_token_confirmation.py`) prove the confirmation is queued, contains the right chat_id/text, and that the endpoint still returns 200 even if the confirmation write fails.
- [x] Confirmed these tests FAIL when the `src/mcp/inbox_server_http.py` change is reverted (`git stash` the src file only, rerun — 2 failures, exactly the expected ones), then restored.
- [x] New regression test (`test_google_consent_warning_copy.py`) pins the fixed warning copy and would catch the `(app name)` placeholder bug Fable found if it recurred.
- [x] Full test suite: `4336 passed, 29 pre-existing failures` — confirmed identical 29 failures exist on `origin/main` before this change (WhatsApp service-file tests, hook tests tied to local paths, etc. — all environment-specific, unrelated to this diff).
- [x] Manual end-to-end verification: started a real instance of the HTTP server on a scratch port with an isolated `HOME`/`LOBSTER_MESSAGES`, POSTed real requests to both `/api/push-calendar-token` and `/api/push-gmail-token`, and confirmed real outbox JSON files were written with mode `0600`, correct `chat_id`, and the expected confirmation text — proving the full endpoint-to-outbox path, not just the unit tests.

Linear: BIS-743 (sub-issue of BIS-727)

🤖 Generated with [Claude Code](https://claude.com/claude-code)