### PR TITLE
BIS-744: live-data proof, failure visibility, and de-dupe fixes for push-token confirmations

### DIFF
--- a/src/mcp/inbox_server_http.py
+++ b/src/mcp/inbox_server_http.py
@@ -43,7 +43,7 @@ import time
 from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Optional
 
 import uvicorn
 from starlette.applications import Starlette
@@ -376,6 +376,308 @@ def _is_authorized_intake(request: Request) -> bool:
     return auth_header[7:].strip() == _IMPORT_TOKEN
 
 
+# ---------------------------------------------------------------------------
+# BIS-744 — shared post-push confirmation helper (calendar, gmail, workspace)
+# ---------------------------------------------------------------------------
+# BIS-743 copy-pasted an identical confirmation-on-push block into all three
+# endpoints (deliberately, per this file's established "prove it 3x before
+# abstracting" convention — see the HMAC-signing blocks above). Now that the
+# shape has been hand-written three times, this extracts the shared logic,
+# and upgrades it with three things none of the three copies had:
+#
+#   1. A live-data preview point (next calendar event / latest email subject
+#      / most recent Drive file) instead of static "token saved" text, via
+#      the ``fetch_preview`` callable each call site supplies.
+#   2. Failure visibility: the pre-existing workspace confirmation block had
+#      a bare ``except Exception: log.warning(...)`` with ZERO user-visible
+#      fallback -- if the confirmation failed, the user was left in total
+#      silence with no way to know anything went wrong. This version (a)
+#      logs at ERROR (not WARNING) with exc_info, so it can't be missed in
+#      logs/alerting, and (b) if the live-data fetch fails, still queues an
+#      honest degraded confirmation ("connected, but couldn't fetch a
+#      preview") rather than skipping the confirmation entirely. If the
+#      notify step itself (the outbox write) fails, per-user delivery is
+#      genuinely impossible via that channel -- but this is never silently
+#      swallowed: a system-level alert is written to the inbox (chat_id=0)
+#      as a fallback so a human (or the dispatcher) still finds out.
+#   3. A de-dupe guard so a double-clicked consent link or a duplicate
+#      webhook delivery from myownlobster.ai doesn't send the user two
+#      confirmations for one grant.
+#
+# Uses ``_MESSAGES_DIR`` (module-level, already configurable via the
+# LOBSTER_MESSAGES env var and already used for the token directories above)
+# instead of a fresh ``Path(os.path.expanduser("~/messages"))`` call. The
+# three BIS-743 copies each independently re-resolved "~/messages" via
+# os.path.expanduser, which is NOT overridden by LOBSTER_MESSAGES and is not
+# patched by any test fixture other than the ones that explicitly mock
+# ``os.path.expanduser`` -- this caused every pre-existing push-endpoint
+# characterization test (which never needed to touch the outbox before
+# BIS-743 added a confirmation step) to silently write real files into this
+# machine's real ``~/messages/outbox`` on every test run. Referencing
+# ``_MESSAGES_DIR`` here instead means the existing, single, already-tested
+# patch point works for the confirmation path too.
+_CONFIRM_DEDUPE_TTL_SECONDS: float = 300.0  # 5 minutes
+
+# Process-lifetime only (not persisted across restarts), same tradeoff as the
+# nonce-replay sets above -- acceptable given this bridge runs as a single
+# uvicorn worker and the window is short.
+_seen_push_confirmations: dict[str, float] = {}
+
+
+def _purge_expired_confirmations(now: float) -> None:
+    expired = [k for k, exp in _seen_push_confirmations.items() if exp < now]
+    for k in expired:
+        del _seen_push_confirmations[k]
+
+
+def _confirmation_already_sent(chat_id: str, scope: str) -> bool:
+    """De-dupe guard (read-only check): True if a confirmation was already
+    *successfully delivered* for this chat_id+scope within the last
+    ``_CONFIRM_DEDUPE_TTL_SECONDS``.
+
+    Deliberately does NOT claim the slot as a side effect -- claiming happens
+    only in ``_mark_confirmation_sent``, and only after the outbox write has
+    actually succeeded. Claiming eagerly (before knowing whether delivery
+    succeeded) would mean a transient failure -- exactly the case this
+    module tries hardest to make visible and recoverable -- permanently
+    blocks any legitimate retry (e.g. myownlobster.ai retrying a webhook
+    delivery) for the rest of the TTL window, silently defeating the whole
+    point of the failure-visibility work in this file.
+    """
+    now = time.time()
+    _purge_expired_confirmations(now)
+    return f"{scope}:{chat_id}" in _seen_push_confirmations
+
+
+def _mark_confirmation_sent(chat_id: str, scope: str) -> None:
+    """Claim the (chat_id, scope) de-dupe slot for the TTL window.
+
+    Call this ONLY after the confirmation has been successfully written to
+    the outbox -- see the docstring on ``_confirmation_already_sent``.
+    """
+    now = time.time()
+    _purge_expired_confirmations(now)
+    key = f"{scope}:{chat_id}"
+    _seen_push_confirmations[key] = now + _CONFIRM_DEDUPE_TTL_SECONDS
+
+
+def _write_system_alert(text: str) -> None:
+    """Best-effort system-level alert for when a per-user confirmation
+    cannot be delivered at all (the outbox write itself failed).
+
+    An earlier version of this fallback wrote a ``chat_id=0`` /
+    ``type="system_alert"`` message to the inbox. An independent (Fable)
+    review pass before merge pointed out that nothing in this codebase
+    actually consumes that combination -- ``inbox_server.py`` explicitly
+    excludes ``chat_id == 0`` from ``USER_FACING_TYPES`` handling, so that
+    message would have sat in the inbox, unread by anyone, making the
+    "fallback" cosmetic rather than real.
+
+    Fixed: route the alert through the SAME outbox mechanism already proven
+    to deliver real Telegram messages (the one this whole file's
+    confirmations use), targeted at ``LOBSTER_ADMIN_CHAT_ID`` -- the
+    established env var already used by other alerting code in this repo
+    (e.g. ``src/transcription/worker.py::notify_dispatcher_dead_letter``).
+    A secondary copy is still written to the inbox for the audit trail, but
+    the outbox message is what actually reaches a human.
+
+    Never raises further: if even this fails, the ERROR log call at the
+    call site (in ``_queue_push_confirmation``) is the final line of
+    defense.
+    """
+    admin_chat_id = os.environ.get("LOBSTER_ADMIN_CHAT_ID", "").strip()
+
+    if admin_chat_id:
+        try:
+            outbox_dir = _MESSAGES_DIR / "outbox"
+            outbox_dir.mkdir(parents=True, exist_ok=True)
+            alert_id = f"{int(time.time() * 1000)}_confirm_failure_admin_alert"
+            alert_reply = {
+                "id": alert_id,
+                "source": "telegram",
+                "chat_id": admin_chat_id,
+                "text": f"[system alert] {text}",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+            alert_path = outbox_dir / f"{alert_id}.json"
+            tmp_path = alert_path.with_suffix(".json.tmp")
+            fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as f:
+                f.write(json.dumps(alert_reply, indent=2))
+            os.rename(str(tmp_path), str(alert_path))
+        except Exception:  # noqa: BLE001
+            logger.error(
+                "push-token confirmation: admin-outbox alert ALSO failed "
+                "-- this failure is now visible only in this log line: %s",
+                text,
+                exc_info=True,
+            )
+    else:
+        logger.error(
+            "push-token confirmation: LOBSTER_ADMIN_CHAT_ID not configured "
+            "-- cannot deliver system alert to any human. Failure is only "
+            "visible in this log line: %s",
+            text,
+        )
+
+    # Secondary record in the inbox (chat_id=0, type="system_alert") for
+    # audit/history purposes. Not relied upon for actual human notification
+    # (see docstring above) -- best-effort, failure here is non-fatal.
+    try:
+        _INBOX_DIR.mkdir(parents=True, exist_ok=True)
+        alert_id = f"{int(time.time() * 1000)}_confirm_failure_alert"
+        alert_data = {
+            "id": alert_id,
+            "type": "system_alert",
+            "source": "system",
+            "chat_id": 0,
+            "text": text,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        alert_path = _INBOX_DIR / f"{alert_id}.json"
+        tmp_path = alert_path.with_suffix(".json.tmp")
+        fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _TOKEN_FILE_MODE)
+        with os.fdopen(fd, "w") as f:
+            f.write(json.dumps(alert_data, indent=2))
+        os.rename(str(tmp_path), str(alert_path))
+    except Exception:  # noqa: BLE001
+        logger.error(
+            "push-token confirmation: inbox audit-record write ALSO failed: %s",
+            text,
+            exc_info=True,
+        )
+
+
+def _queue_push_confirmation(
+    *,
+    chat_id: str,
+    scope: str,
+    connected_text: str,
+    fetch_preview: Callable[[], Optional[str]],
+) -> None:
+    """Queue a post-push confirmation to the outbox. Never raises.
+
+    Args:
+        chat_id:        Telegram chat_id (already sanitised by the caller).
+        scope:           One of "calendar", "gmail", "workspace" -- used for
+                         the de-dupe key and the outbox filename suffix.
+        connected_text:  Static "X connected" lead-in text for this scope.
+        fetch_preview:   Zero-arg callable returning a short live-data
+                         preview line (or None/"" for "nothing to show"), or
+                         raising on failure. Called synchronously; any
+                         exception is caught here, never propagated.
+    """
+    if _confirmation_already_sent(chat_id, scope):
+        logger.info(
+            "Skipping duplicate push confirmation for scope=%r chat_id=%r "
+            "(one was already queued within the last %.0fs)",
+            scope, chat_id, _CONFIRM_DEDUPE_TTL_SECONDS,
+        )
+        return
+
+    try:
+        preview_line = fetch_preview()
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "push-token confirmation: live-data preview fetch failed for "
+            "scope=%r chat_id=%r: %s",
+            scope, chat_id, exc, exc_info=True,
+        )
+        preview_line = None
+
+    if preview_line:
+        text = f"{connected_text}\n\n{preview_line}"
+    else:
+        text = (
+            f"{connected_text}\n\n"
+            "(Connected, but I couldn't fetch a live preview just now -- "
+            "try asking me directly.)"
+        )
+
+    try:
+        outbox_dir = _MESSAGES_DIR / "outbox"
+        outbox_dir.mkdir(parents=True, exist_ok=True)
+
+        # Include chat_id in the filename, not just scope+timestamp: two
+        # rapid confirmations for the same scope but different chat_ids can
+        # otherwise land on the same millisecond and silently overwrite each
+        # other's outbox file (caught by BIS-744's own test suite).
+        reply_id = f"{int(time.time() * 1000)}_{scope}_{chat_id}_auth"
+        reply_data = {
+            "id": reply_id,
+            "source": "telegram",
+            "chat_id": chat_id,
+            "text": text,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        reply_file = outbox_dir / f"{reply_id}.json"
+        tmp_reply = reply_file.with_suffix(".json.tmp")
+        tmp_fd = os.open(str(tmp_reply), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(tmp_fd, "w") as rf:
+            rf.write(json.dumps(reply_data, indent=2))
+        os.rename(str(tmp_reply), str(reply_file))
+        logger.info(
+            "%s-connected confirmation queued for chat_id=%r", scope.capitalize(), chat_id
+        )
+        # Only claim the de-dupe slot now that delivery has actually
+        # succeeded -- see _confirmation_already_sent's docstring for why
+        # claiming any earlier would silence legitimate retries after a
+        # transient failure.
+        _mark_confirmation_sent(chat_id, scope)
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "push-token confirmation: FAILED to queue outbox confirmation for "
+            "scope=%r chat_id=%r -- user will NOT be notified via Telegram: %s",
+            scope, chat_id, exc, exc_info=True,
+        )
+        _write_system_alert(
+            f"Push-token confirmation failed to deliver for scope={scope!r} "
+            f"chat_id={chat_id!r}: {exc}. The token itself was saved "
+            f"successfully -- only the user-facing confirmation failed."
+        )
+
+
+def _fetch_calendar_preview(chat_id: str) -> Optional[str]:
+    """Best-effort: return a one-line preview of the user's next event."""
+    from integrations.google_calendar.client import get_upcoming_events
+
+    events = get_upcoming_events(user_id=chat_id, days=7)
+    if not events:
+        return "No upcoming events in the next 7 days."
+    next_event = events[0]
+    time_str = next_event.start.strftime("%a %b %-d, %-I:%M %p UTC")
+    return f"Next up: {next_event.title} — {time_str}"
+
+
+def _fetch_gmail_preview(chat_id: str) -> Optional[str]:
+    """Best-effort: return a one-line preview of the user's latest email."""
+    from integrations.gmail.client import get_recent_emails
+
+    emails = get_recent_emails(user_id=chat_id, max_results=1)
+    if not emails:
+        return "Your inbox has no recent messages (or none I could read yet)."
+    latest = emails[0]
+    subject = latest.subject or "(no subject)"
+    return f"Latest email: \"{subject}\" from {latest.sender}"
+
+
+def _fetch_workspace_preview(chat_id: str) -> Optional[str]:
+    """Best-effort: return a one-line preview of a recent Drive file.
+
+    ``gdrive_list`` only queries the root ("My Drive") folder, non-recursively
+    -- it does not search subfolders. The wording below is deliberately
+    scoped to match ("in My Drive"), not a blanket "most recent file in your
+    Drive" claim that would overstate what was actually checked.
+    """
+    from integrations.google_workspace.drive_client import gdrive_list
+
+    files = gdrive_list(user_id=chat_id, max_results=1)
+    if not files:
+        return "No files found in your My Drive root folder yet."
+    latest = files[0]
+    return f"Recently modified in My Drive: {latest.name}"
+
+
 async def push_calendar_token_endpoint(scope, receive, send):
     """POST /api/push-calendar-token — receive a token pushed by myownlobster.ai.
 
@@ -497,43 +799,19 @@ async def push_calendar_token_endpoint(scope, receive, send):
         await response(scope, receive, send)
         return
 
-    # BIS-743: post-push confirmation, extending the pattern already shipped
-    # for Workspace (push_workspace_token_endpoint, below) to Calendar.
-    # Best-effort: the token is already saved, so a confirmation failure here
-    # must never turn a successful push into an error response for the caller.
-    try:
-        import time as _time
-
-        _MESSAGES_BASE = Path(os.path.expanduser("~/messages"))
-        _OUTBOX_DIR = _MESSAGES_BASE / "outbox"
-        _OUTBOX_DIR.mkdir(parents=True, exist_ok=True)
-
-        reply_id = f"{int(_time.time() * 1000)}_calendar_auth"
-        reply_data = {
-            "id": reply_id,
-            "source": "telegram",
-            "chat_id": safe_chat_id,
-            "text": (
-                "Google Calendar connected. "
-                "I can now read and create events on your calendar."
-            ),
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-        }
-        reply_file = _OUTBOX_DIR / f"{reply_id}.json"
-        tmp_reply = reply_file.with_suffix(".json.tmp")
-        tmp_fd = os.open(str(tmp_reply), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        with os.fdopen(tmp_fd, "w") as rf:
-            rf.write(json.dumps(reply_data, indent=2))
-        os.rename(str(tmp_reply), str(reply_file))
-        logger.info(
-            "Calendar-connected confirmation queued for chat_id=%r", safe_chat_id
-        )
-    except Exception as exc:  # noqa: BLE001
-        logger.warning(
-            "push_calendar_token: failed to queue confirmation for chat_id=%r: %s",
-            safe_chat_id,
-            exc,
-        )
+    # BIS-744: shared post-push confirmation (live-data preview, failure
+    # visibility, de-dupe) -- see _queue_push_confirmation above. Best-effort:
+    # the token is already saved, so a confirmation failure here must never
+    # turn a successful push into an error response for the caller.
+    _queue_push_confirmation(
+        chat_id=safe_chat_id,
+        scope="calendar",
+        connected_text=(
+            "Google Calendar connected. "
+            "I can now read and create events on your calendar."
+        ),
+        fetch_preview=lambda: _fetch_calendar_preview(safe_chat_id),
+    )
 
     response = JSONResponse({"ok": True})
     await response(scope, receive, send)
@@ -753,43 +1031,19 @@ async def push_gmail_token_endpoint(scope, receive, send):
         await response(scope, receive, send)
         return
 
-    # BIS-743: post-push confirmation, extending the pattern already shipped
-    # for Workspace (push_workspace_token_endpoint, below) to Gmail.
-    # Best-effort: the token is already saved, so a confirmation failure here
-    # must never turn a successful push into an error response for the caller.
-    try:
-        import time as _time
-
-        _MESSAGES_BASE = Path(os.path.expanduser("~/messages"))
-        _OUTBOX_DIR = _MESSAGES_BASE / "outbox"
-        _OUTBOX_DIR.mkdir(parents=True, exist_ok=True)
-
-        reply_id = f"{int(_time.time() * 1000)}_gmail_auth"
-        reply_data = {
-            "id": reply_id,
-            "source": "telegram",
-            "chat_id": safe_chat_id,
-            "text": (
-                "Gmail connected. "
-                "I can now read and search your emails."
-            ),
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-        }
-        reply_file = _OUTBOX_DIR / f"{reply_id}.json"
-        tmp_reply = reply_file.with_suffix(".json.tmp")
-        tmp_fd = os.open(str(tmp_reply), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        with os.fdopen(tmp_fd, "w") as rf:
-            rf.write(json.dumps(reply_data, indent=2))
-        os.rename(str(tmp_reply), str(reply_file))
-        logger.info(
-            "Gmail-connected confirmation queued for chat_id=%r", safe_chat_id
-        )
-    except Exception as exc:  # noqa: BLE001
-        logger.warning(
-            "push_gmail_token: failed to queue confirmation for chat_id=%r: %s",
-            safe_chat_id,
-            exc,
-        )
+    # BIS-744: shared post-push confirmation (live-data preview, failure
+    # visibility, de-dupe) -- see _queue_push_confirmation above. Best-effort:
+    # the token is already saved, so a confirmation failure here must never
+    # turn a successful push into an error response for the caller.
+    _queue_push_confirmation(
+        chat_id=safe_chat_id,
+        scope="gmail",
+        connected_text=(
+            "Gmail connected. "
+            "I can now read and search your emails."
+        ),
+        fetch_preview=lambda: _fetch_gmail_preview(safe_chat_id),
+    )
 
     response = JSONResponse({"ok": True})
     await response(scope, receive, send)
@@ -1264,41 +1518,21 @@ async def push_workspace_token_endpoint(scope, receive, send):
         await response(scope, receive, send)
         return
 
-    # Send a confirmation reply to the user via the outbox so the bot process
-    # delivers it over Telegram.  Best-effort: the token is already saved.
-    try:
-        import time as _time
-
-        _MESSAGES_BASE = Path(os.path.expanduser("~/messages"))
-        _OUTBOX_DIR = _MESSAGES_BASE / "outbox"
-        _OUTBOX_DIR.mkdir(parents=True, exist_ok=True)
-
-        reply_id = f"{int(_time.time() * 1000)}_workspace_auth"
-        reply_data = {
-            "id": reply_id,
-            "source": "telegram",
-            "chat_id": safe_chat_id,
-            "text": (
-                "Google Workspace connected. "
-                "You can now use /gdocs, /gdrive, and /gsheets."
-            ),
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-        }
-        reply_file = _OUTBOX_DIR / f"{reply_id}.json"
-        tmp_reply = reply_file.with_suffix(".json.tmp")
-        tmp_fd = os.open(str(tmp_reply), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        with os.fdopen(tmp_fd, "w") as rf:
-            rf.write(json.dumps(reply_data, indent=2))
-        os.rename(str(tmp_reply), str(reply_file))
-        logger.info(
-            "Workspace-connected confirmation queued for chat_id=%r", safe_chat_id
-        )
-    except Exception as exc:  # noqa: BLE001
-        logger.warning(
-            "push_workspace_token: failed to queue confirmation for chat_id=%r: %s",
-            safe_chat_id,
-            exc,
-        )
+    # BIS-744: shared post-push confirmation (live-data preview, failure
+    # visibility, de-dupe) -- see _queue_push_confirmation above. This
+    # replaces the original bare `except Exception: log.warning(...)` block
+    # (zero user-visible fallback on failure) with the hardened shared
+    # helper. Best-effort: the token is already saved, so a confirmation
+    # failure here must never turn a successful push into an error response.
+    _queue_push_confirmation(
+        chat_id=safe_chat_id,
+        scope="workspace",
+        connected_text=(
+            "Google Workspace connected. "
+            "You can now use /gdocs, /gdrive, and /gsheets."
+        ),
+        fetch_preview=lambda: _fetch_workspace_preview(safe_chat_id),
+    )
 
     response = JSONResponse({"ok": True})
     await response(scope, receive, send)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,6 +206,80 @@ def isolate_inbox_server_paths(tmp_path: Path):
         yield dirs_result
 
 
+# =============================================================================
+# Production Path Isolation for inbox_server_http.py (BIS-744)
+# =============================================================================
+# Sibling of isolate_inbox_server_paths above, for the separate
+# src/mcp/inbox_server_http.py module (the HTTP bridge that hosts the
+# push-calendar/gmail/workspace-token endpoints). This module resolves its
+# outbox/token/inbox directories via its own ``_MESSAGES_DIR`` global, which
+# defaults to the ``LOBSTER_MESSAGES`` env var (or ``~/messages`` if unset)
+# -- NOT the tmp_path-redirected globals patched above, since it is a
+# different module object entirely.
+#
+# Root cause this fixes: on any machine where LOBSTER_MESSAGES is set in the
+# real process environment (true of this VPS, where the live dispatcher/MCP
+# services export it), running this repo's push-token endpoint tests without
+# this fixture silently writes real confirmation files (and, for tests that
+# don't patch the token-dir globals, real token files) into the production
+# ``~/messages`` tree. This was caught during BIS-743/744 development: ~200
+# stray confirmation files with fake test chat_ids were found sitting in this
+# machine's real dead-letter queue, produced by ordinary `pytest` runs of the
+# pre-existing (BIS-728/730) push-endpoint characterization tests, which
+# never needed outbox isolation before BIS-743 added a confirmation step.
+_INBOX_SERVER_HTTP_MODULE = "src.mcp.inbox_server_http"
+
+
+@pytest.fixture(autouse=True)
+def isolate_inbox_server_http_paths(tmp_path: Path):
+    """Redirect inbox_server_http.py's path globals to tmp_path for every test.
+
+    Like ``isolate_inbox_server_paths``, this is autouse and requires no
+    per-test opt-in. Tests that need finer control (e.g. asserting file
+    contents) may still add their own narrower ``patch(...)`` on top of these
+    globals within a test body -- that composes safely, since the inner patch
+    simply overrides for the duration of its own ``with`` block and reverts
+    to this fixture's tmp_path afterward, never to the real production path.
+    """
+    http_messages = tmp_path / "http_messages"
+    gcal_dir = http_messages / "config" / "gcal-tokens"
+    gmail_dir = http_messages / "config" / "gmail-tokens"
+    workspace_dir = http_messages / "config" / "workspace-tokens"
+    inbox_dir = http_messages / "inbox"
+    outbox_dir = http_messages / "outbox"
+    for d in (gcal_dir, gmail_dir, workspace_dir, inbox_dir, outbox_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    # inbox_server_http.py calls sys.exit(1) at import time if MCP_HTTP_TOKEN
+    # is unset. setdefault never overrides a real value already present in
+    # the environment (e.g. the live service's actual token) -- it only fills
+    # in a harmless placeholder when nothing is set, so import doesn't abort.
+    os.environ.setdefault("MCP_HTTP_TOKEN", "test-placeholder-conftest-isolation")
+
+    try:
+        import importlib
+        importlib.import_module(_INBOX_SERVER_HTTP_MODULE)
+    except BaseException:
+        # Catches SystemExit (the module's own sys.exit(1) guard) as well as
+        # ordinary import errors. Either way, degrade gracefully instead of
+        # aborting the entire test run for tests that never touch this module.
+        yield http_messages
+        return
+
+    try:
+        with patch.multiple(
+            _INBOX_SERVER_HTTP_MODULE,
+            _MESSAGES_DIR=http_messages,
+            _GCAL_TOKEN_DIR=gcal_dir,
+            _GMAIL_TOKEN_DIR=gmail_dir,
+            _WORKSPACE_TOKEN_DIR=workspace_dir,
+            _INBOX_DIR=inbox_dir,
+        ):
+            yield http_messages
+    except Exception:
+        yield http_messages
+
+
 @pytest.fixture
 def inbox_server_dirs(isolate_inbox_server_paths):
     """Expose the redirected inbox_server paths for tests that need to verify them.

--- a/tests/unit/test_mcp_server/test_push_calendar_token_confirmation.py
+++ b/tests/unit/test_mcp_server/test_push_calendar_token_confirmation.py
@@ -1,20 +1,27 @@
 """
-Tests for BIS-743: post-push confirmation on POST /api/push-calendar-token.
+Tests for post-push confirmation on POST /api/push-calendar-token.
 
-Before BIS-743, ``push_calendar_token_endpoint`` wrote the token file and
-returned ``{"ok": true}`` with zero user-facing confirmation — unlike
-``push_workspace_token_endpoint``, which already queues an outbox reply on
-success (BIS-727 Slice "onboarding"/7). This file proves the Calendar
-endpoint now does the same thing, mirroring
-``test_push_workspace_token_confirmation.py``.
+BIS-743 added a basic static-text confirmation (mirroring the pre-existing
+Workspace pattern). BIS-744 upgrades it via the shared
+``_queue_push_confirmation`` helper: a live-data preview (next calendar
+event), graceful degradation when the preview fetch fails, and a de-dupe
+guard. This file covers the Calendar endpoint's wiring into that shared
+helper; the helper's own logic (failure visibility, system-alert fallback)
+is covered exhaustively in ``test_push_token_confirmation_shared.py``.
 
 Covers:
 - push_calendar_token: queues confirmation reply to outbox on success
-- push_calendar_token: confirmation text mentions Google Calendar
+- push_calendar_token: confirmation includes a live upcoming-event preview
+- push_calendar_token: confirmation degrades gracefully (never silent) when
+  the live-data fetch fails
 - push_calendar_token: returns 200 ok even if the confirmation write fails
-- push_calendar_token: confirmation delivered to the correct chat_id
+- push_calendar_token: a second push for the same chat_id within the de-dupe
+  window does not queue a second confirmation
 
-All file I/O uses a tmp_path fixture — no real disk writes outside the test sandbox.
+All file I/O uses a tmp_path fixture — no real disk writes outside the test
+sandbox. Notably, this fixture patches ``_MESSAGES_DIR`` directly (not
+``os.path.expanduser``) since the endpoint now resolves its outbox path via
+that module global (BIS-744) rather than re-resolving "~/messages" itself.
 """
 
 from __future__ import annotations
@@ -46,22 +53,21 @@ _VALID_BODY = {
 
 @pytest.fixture()
 def client_and_dirs(tmp_path):
-    """Yield (TestClient, token_dir, outbox_dir)."""
-    gcal_token_dir = tmp_path / "config" / "gcal-tokens"
-    outbox_dir = tmp_path / "outbox"
+    """Yield (TestClient, token_dir, outbox_dir), fully isolated from prod."""
+    messages_base = tmp_path / "confirm_messages"
+    gcal_token_dir = messages_base / "config" / "gcal-tokens"
+    outbox_dir = messages_base / "outbox"
     gcal_token_dir.mkdir(parents=True)
     outbox_dir.mkdir(parents=True)
 
     with (
+        patch(f"{_MODULE}._MESSAGES_DIR", messages_base),
         patch(f"{_MODULE}._GCAL_TOKEN_DIR", gcal_token_dir),
         patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
         patch(f"{_MODULE}._SESSION_HMAC_SECRET", ""),
         patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", False),
         patch(f"{_MODULE}._seen_calendar_session_nonces", {}),
-        patch(
-            "os.path.expanduser",
-            side_effect=lambda p: str(tmp_path) if p == "~/messages" else p,
-        ),
+        patch(f"{_MODULE}._seen_push_confirmations", {}),
     ):
         from src.mcp.inbox_server_http import app
 
@@ -69,48 +75,100 @@ def client_and_dirs(tmp_path):
         yield client, gcal_token_dir, outbox_dir
 
 
+def _read_only_outbox_file(outbox_dir: Path) -> dict:
+    files = list(outbox_dir.glob("*.json"))
+    assert len(files) == 1, f"Expected exactly one outbox file, found {len(files)}"
+    return json.loads(files[0].read_text())
+
+
 class TestPostAuthConfirmation:
     def test_returns_ok_on_success(self, client_and_dirs):
         client, _, _ = client_and_dirs
-        resp = client.post(
-            "/api/push-calendar-token",
-            json=_VALID_BODY,
-            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
-        )
+        with patch(
+            f"{_MODULE}._fetch_calendar_preview", return_value="Next up: Standup — Mon 9:00 AM UTC"
+        ):
+            resp = client.post(
+                "/api/push-calendar-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
         assert resp.status_code == 200
         assert resp.json().get("ok") is True
 
     def test_confirmation_queued_to_outbox(self, client_and_dirs):
         client, _, outbox_dir = client_and_dirs
-        client.post(
-            "/api/push-calendar-token",
-            json=_VALID_BODY,
-            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
-        )
-        outbox_files = list(outbox_dir.glob("*.json"))
-        assert outbox_files, "No confirmation was queued to the outbox"
-        reply = json.loads(outbox_files[0].read_text())
+        with patch(
+            f"{_MODULE}._fetch_calendar_preview", return_value="Next up: Standup — Mon 9:00 AM UTC"
+        ):
+            client.post(
+                "/api/push-calendar-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+        reply = _read_only_outbox_file(outbox_dir)
         text = reply.get("text", "")
         assert "Calendar" in text
         assert reply.get("chat_id") == _VALID_BODY["chat_id"]
         assert reply.get("source") == "telegram"
 
+    def test_confirmation_includes_live_preview(self, client_and_dirs):
+        """BIS-744: the confirmation text includes the real live-data preview."""
+        client, _, outbox_dir = client_and_dirs
+        with patch(
+            f"{_MODULE}._fetch_calendar_preview",
+            return_value="Next up: Board meeting — Wed 3:00 PM UTC",
+        ):
+            client.post(
+                "/api/push-calendar-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+        reply = _read_only_outbox_file(outbox_dir)
+        assert "Board meeting" in reply["text"]
+
+    def test_confirmation_degrades_gracefully_when_preview_fetch_fails(self, client_and_dirs, caplog):
+        """BIS-744: a live-data fetch failure must never silence the confirmation."""
+        import logging
+
+        client, _, outbox_dir = client_and_dirs
+        with patch(
+            f"{_MODULE}._fetch_calendar_preview", side_effect=RuntimeError("Calendar API down")
+        ), caplog.at_level(logging.ERROR):
+            resp = client.post(
+                "/api/push-calendar-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+
+        assert resp.status_code == 200
+        reply = _read_only_outbox_file(outbox_dir)
+        assert "connected" in reply["text"].lower()
+        assert "couldn't fetch a live preview" in reply["text"]
+        assert any(
+            "preview fetch failed" in r.getMessage().lower() for r in caplog.records
+        ), "Preview fetch failure must be logged loudly, not silently swallowed"
+
     def test_returns_ok_even_when_outbox_write_fails(self, tmp_path):
         """Token save succeeds and 200 is returned even if outbox write throws."""
-        gcal_token_dir = tmp_path / "config" / "gcal-tokens"
+        messages_base = tmp_path / "confirm_messages"
+        gcal_token_dir = messages_base / "config" / "gcal-tokens"
         gcal_token_dir.mkdir(parents=True)
+        # Deliberately do NOT create messages_base/outbox and make messages_base
+        # unwritable-as-a-parent by pointing _MESSAGES_DIR at a path that can't
+        # hold an "outbox" subdirectory (a file where a directory is expected).
+        blocked_base = tmp_path / "blocked"
+        blocked_base.mkdir()
+        (blocked_base / "outbox").write_text("not a directory")
 
         with (
+            patch(f"{_MODULE}._MESSAGES_DIR", blocked_base),
             patch(f"{_MODULE}._GCAL_TOKEN_DIR", gcal_token_dir),
             patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
             patch(f"{_MODULE}._SESSION_HMAC_SECRET", ""),
             patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", False),
             patch(f"{_MODULE}._seen_calendar_session_nonces", {}),
-            # Redirect expanduser to a path that doesn't exist so mkdir fails
-            patch(
-                "os.path.expanduser",
-                side_effect=lambda p: "/dev/null/nonexistent" if p == "~/messages" else p,
-            ),
+            patch(f"{_MODULE}._seen_push_confirmations", {}),
+            patch(f"{_MODULE}._fetch_calendar_preview", return_value="preview"),
         ):
             from src.mcp.inbox_server_http import app
 
@@ -126,19 +184,22 @@ class TestPostAuthConfirmation:
 
     def test_token_still_saved_even_if_confirmation_would_fail(self, tmp_path):
         """The token write must not depend on / be blocked by the confirmation step."""
-        gcal_token_dir = tmp_path / "config" / "gcal-tokens"
+        messages_base = tmp_path / "confirm_messages"
+        gcal_token_dir = messages_base / "config" / "gcal-tokens"
         gcal_token_dir.mkdir(parents=True)
+        blocked_base = tmp_path / "blocked"
+        blocked_base.mkdir()
+        (blocked_base / "outbox").write_text("not a directory")
 
         with (
+            patch(f"{_MODULE}._MESSAGES_DIR", blocked_base),
             patch(f"{_MODULE}._GCAL_TOKEN_DIR", gcal_token_dir),
             patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
             patch(f"{_MODULE}._SESSION_HMAC_SECRET", ""),
             patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", False),
             patch(f"{_MODULE}._seen_calendar_session_nonces", {}),
-            patch(
-                "os.path.expanduser",
-                side_effect=lambda p: "/dev/null/nonexistent" if p == "~/messages" else p,
-            ),
+            patch(f"{_MODULE}._seen_push_confirmations", {}),
+            patch(f"{_MODULE}._fetch_calendar_preview", return_value="preview"),
         ):
             from src.mcp.inbox_server_http import app
 
@@ -151,3 +212,26 @@ class TestPostAuthConfirmation:
 
         token_path = gcal_token_dir / f"{_VALID_BODY['chat_id']}.json"
         assert token_path.exists(), "Token file must be written regardless of confirmation outcome"
+
+    def test_duplicate_push_does_not_send_second_confirmation(self, client_and_dirs):
+        """BIS-744: de-dupe guard — two pushes for the same chat_id in quick
+        succession must only produce ONE queued confirmation."""
+        client, _, outbox_dir = client_and_dirs
+        with patch(f"{_MODULE}._fetch_calendar_preview", return_value="preview line"):
+            first = client.post(
+                "/api/push-calendar-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+            second = client.post(
+                "/api/push-calendar-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        outbox_files = list(outbox_dir.glob("*.json"))
+        assert len(outbox_files) == 1, (
+            f"Expected exactly one confirmation across two pushes, found {len(outbox_files)}"
+        )

--- a/tests/unit/test_mcp_server/test_push_gmail_token_confirmation.py
+++ b/tests/unit/test_mcp_server/test_push_gmail_token_confirmation.py
@@ -1,19 +1,27 @@
 """
-Tests for BIS-743: post-push confirmation on POST /api/push-gmail-token.
+Tests for post-push confirmation on POST /api/push-gmail-token.
 
-Before BIS-743, ``push_gmail_token_endpoint`` wrote the token file and
-returned ``{"ok": true}`` with zero user-facing confirmation — unlike
-``push_workspace_token_endpoint``, which already queues an outbox reply on
-success. This file proves the Gmail endpoint now does the same thing,
-mirroring ``test_push_workspace_token_confirmation.py``.
+BIS-743 added a basic static-text confirmation (mirroring the pre-existing
+Workspace pattern). BIS-744 upgrades it via the shared
+``_queue_push_confirmation`` helper: a live-data preview (latest email
+subject), graceful degradation when the preview fetch fails, and a de-dupe
+guard. This file covers the Gmail endpoint's wiring into that shared helper;
+the helper's own logic (failure visibility, system-alert fallback) is
+covered exhaustively in ``test_push_token_confirmation_shared.py``.
 
 Covers:
 - push_gmail_token: queues confirmation reply to outbox on success
-- push_gmail_token: confirmation text mentions Gmail
+- push_gmail_token: confirmation includes a live latest-email preview
+- push_gmail_token: confirmation degrades gracefully (never silent) when the
+  live-data fetch fails
 - push_gmail_token: returns 200 ok even if the confirmation write fails
-- push_gmail_token: confirmation delivered to the correct chat_id
+- push_gmail_token: a second push for the same chat_id within the de-dupe
+  window does not queue a second confirmation
 
-All file I/O uses a tmp_path fixture — no real disk writes outside the test sandbox.
+All file I/O uses a tmp_path fixture — no real disk writes outside the test
+sandbox. This fixture patches ``_MESSAGES_DIR`` directly (not
+``os.path.expanduser``) since the endpoint now resolves its outbox path via
+that module global (BIS-744) rather than re-resolving "~/messages" itself.
 """
 
 from __future__ import annotations
@@ -45,22 +53,21 @@ _VALID_BODY = {
 
 @pytest.fixture()
 def client_and_dirs(tmp_path):
-    """Yield (TestClient, token_dir, outbox_dir)."""
-    gmail_token_dir = tmp_path / "config" / "gmail-tokens"
-    outbox_dir = tmp_path / "outbox"
+    """Yield (TestClient, token_dir, outbox_dir), fully isolated from prod."""
+    messages_base = tmp_path / "confirm_messages"
+    gmail_token_dir = messages_base / "config" / "gmail-tokens"
+    outbox_dir = messages_base / "outbox"
     gmail_token_dir.mkdir(parents=True)
     outbox_dir.mkdir(parents=True)
 
     with (
+        patch(f"{_MODULE}._MESSAGES_DIR", messages_base),
         patch(f"{_MODULE}._GMAIL_TOKEN_DIR", gmail_token_dir),
         patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
         patch(f"{_MODULE}._SESSION_HMAC_SECRET", ""),
         patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", False),
         patch(f"{_MODULE}._seen_gmail_session_nonces", {}),
-        patch(
-            "os.path.expanduser",
-            side_effect=lambda p: str(tmp_path) if p == "~/messages" else p,
-        ),
+        patch(f"{_MODULE}._seen_push_confirmations", {}),
     ):
         from src.mcp.inbox_server_http import app
 
@@ -68,47 +75,93 @@ def client_and_dirs(tmp_path):
         yield client, gmail_token_dir, outbox_dir
 
 
+def _read_only_outbox_file(outbox_dir: Path) -> dict:
+    files = list(outbox_dir.glob("*.json"))
+    assert len(files) == 1, f"Expected exactly one outbox file, found {len(files)}"
+    return json.loads(files[0].read_text())
+
+
 class TestPostAuthConfirmation:
     def test_returns_ok_on_success(self, client_and_dirs):
         client, _, _ = client_and_dirs
-        resp = client.post(
-            "/api/push-gmail-token",
-            json=_VALID_BODY,
-            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
-        )
+        with patch(f"{_MODULE}._fetch_gmail_preview", return_value='Latest email: "Hi" from a@b.com'):
+            resp = client.post(
+                "/api/push-gmail-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
         assert resp.status_code == 200
         assert resp.json().get("ok") is True
 
     def test_confirmation_queued_to_outbox(self, client_and_dirs):
         client, _, outbox_dir = client_and_dirs
-        client.post(
-            "/api/push-gmail-token",
-            json=_VALID_BODY,
-            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
-        )
-        outbox_files = list(outbox_dir.glob("*.json"))
-        assert outbox_files, "No confirmation was queued to the outbox"
-        reply = json.loads(outbox_files[0].read_text())
+        with patch(f"{_MODULE}._fetch_gmail_preview", return_value='Latest email: "Hi" from a@b.com'):
+            client.post(
+                "/api/push-gmail-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+        reply = _read_only_outbox_file(outbox_dir)
         text = reply.get("text", "")
         assert "Gmail" in text
         assert reply.get("chat_id") == _VALID_BODY["chat_id"]
         assert reply.get("source") == "telegram"
 
+    def test_confirmation_includes_live_preview(self, client_and_dirs):
+        """BIS-744: the confirmation text includes the real live-data preview."""
+        client, _, outbox_dir = client_and_dirs
+        with patch(
+            f"{_MODULE}._fetch_gmail_preview",
+            return_value='Latest email: "Q3 numbers" from cfo@example.com',
+        ):
+            client.post(
+                "/api/push-gmail-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+        reply = _read_only_outbox_file(outbox_dir)
+        assert "Q3 numbers" in reply["text"]
+
+    def test_confirmation_degrades_gracefully_when_preview_fetch_fails(self, client_and_dirs, caplog):
+        """BIS-744: a live-data fetch failure must never silence the confirmation."""
+        import logging
+
+        client, _, outbox_dir = client_and_dirs
+        with patch(
+            f"{_MODULE}._fetch_gmail_preview", side_effect=RuntimeError("Gmail API down")
+        ), caplog.at_level(logging.ERROR):
+            resp = client.post(
+                "/api/push-gmail-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+
+        assert resp.status_code == 200
+        reply = _read_only_outbox_file(outbox_dir)
+        assert "connected" in reply["text"].lower()
+        assert "couldn't fetch a live preview" in reply["text"]
+        assert any(
+            "preview fetch failed" in r.getMessage().lower() for r in caplog.records
+        ), "Preview fetch failure must be logged loudly, not silently swallowed"
+
     def test_returns_ok_even_when_outbox_write_fails(self, tmp_path):
         """Token save succeeds and 200 is returned even if outbox write throws."""
-        gmail_token_dir = tmp_path / "config" / "gmail-tokens"
+        messages_base = tmp_path / "confirm_messages"
+        gmail_token_dir = messages_base / "config" / "gmail-tokens"
         gmail_token_dir.mkdir(parents=True)
+        blocked_base = tmp_path / "blocked"
+        blocked_base.mkdir()
+        (blocked_base / "outbox").write_text("not a directory")
 
         with (
+            patch(f"{_MODULE}._MESSAGES_DIR", blocked_base),
             patch(f"{_MODULE}._GMAIL_TOKEN_DIR", gmail_token_dir),
             patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
             patch(f"{_MODULE}._SESSION_HMAC_SECRET", ""),
             patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", False),
             patch(f"{_MODULE}._seen_gmail_session_nonces", {}),
-            patch(
-                "os.path.expanduser",
-                side_effect=lambda p: "/dev/null/nonexistent" if p == "~/messages" else p,
-            ),
+            patch(f"{_MODULE}._seen_push_confirmations", {}),
+            patch(f"{_MODULE}._fetch_gmail_preview", return_value="preview"),
         ):
             from src.mcp.inbox_server_http import app
 
@@ -124,19 +177,22 @@ class TestPostAuthConfirmation:
 
     def test_token_still_saved_even_if_confirmation_would_fail(self, tmp_path):
         """The token write must not depend on / be blocked by the confirmation step."""
-        gmail_token_dir = tmp_path / "config" / "gmail-tokens"
+        messages_base = tmp_path / "confirm_messages"
+        gmail_token_dir = messages_base / "config" / "gmail-tokens"
         gmail_token_dir.mkdir(parents=True)
+        blocked_base = tmp_path / "blocked"
+        blocked_base.mkdir()
+        (blocked_base / "outbox").write_text("not a directory")
 
         with (
+            patch(f"{_MODULE}._MESSAGES_DIR", blocked_base),
             patch(f"{_MODULE}._GMAIL_TOKEN_DIR", gmail_token_dir),
             patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
             patch(f"{_MODULE}._SESSION_HMAC_SECRET", ""),
             patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", False),
             patch(f"{_MODULE}._seen_gmail_session_nonces", {}),
-            patch(
-                "os.path.expanduser",
-                side_effect=lambda p: "/dev/null/nonexistent" if p == "~/messages" else p,
-            ),
+            patch(f"{_MODULE}._seen_push_confirmations", {}),
+            patch(f"{_MODULE}._fetch_gmail_preview", return_value="preview"),
         ):
             from src.mcp.inbox_server_http import app
 
@@ -149,3 +205,26 @@ class TestPostAuthConfirmation:
 
         token_path = gmail_token_dir / f"{_VALID_BODY['chat_id']}.json"
         assert token_path.exists(), "Token file must be written regardless of confirmation outcome"
+
+    def test_duplicate_push_does_not_send_second_confirmation(self, client_and_dirs):
+        """BIS-744: de-dupe guard — two pushes for the same chat_id in quick
+        succession must only produce ONE queued confirmation."""
+        client, _, outbox_dir = client_and_dirs
+        with patch(f"{_MODULE}._fetch_gmail_preview", return_value="preview line"):
+            first = client.post(
+                "/api/push-gmail-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+            second = client.post(
+                "/api/push-gmail-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        outbox_files = list(outbox_dir.glob("*.json"))
+        assert len(outbox_files) == 1, (
+            f"Expected exactly one confirmation across two pushes, found {len(outbox_files)}"
+        )

--- a/tests/unit/test_mcp_server/test_push_token_confirmation_shared.py
+++ b/tests/unit/test_mcp_server/test_push_token_confirmation_shared.py
@@ -1,0 +1,364 @@
+"""
+Tests for the BIS-744 shared post-push confirmation helper:
+``_queue_push_confirmation`` and its supporting functions
+(``_confirmation_already_sent``, ``_write_system_alert``) in
+``src/mcp/inbox_server_http.py``.
+
+BIS-743 copy-pasted an identical confirmation block into all three push
+endpoints (calendar, gmail, workspace). BIS-744 extracts the shared logic
+into ``_queue_push_confirmation`` and upgrades it with:
+
+1. A live-data preview (via a per-scope ``fetch_preview`` callable).
+2. Failure visibility: the fetch and the outbox write are each wrapped so a
+   failure is (a) logged at ERROR with exc_info, never silently swallowed at
+   WARNING with no fallback, and (b) still produces *some* user-facing
+   confirmation when only the preview fetch failed, or a system-level alert
+   (chat_id=0, written to the inbox) when the notify step itself failed and
+   no user-facing message could be delivered at all.
+3. A de-dupe guard keyed on (scope, chat_id) with a TTL window.
+
+These tests exercise ``_queue_push_confirmation`` directly (not through the
+HTTP layer) so the core logic is pinned once, cleanly, independent of any
+particular endpoint's wiring. Endpoint-level wiring (that each endpoint calls
+this helper with the right scope/text/fetch function) is covered by
+test_push_{calendar,gmail,workspace}_token_confirmation.py.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time as time_module
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("MCP_HTTP_TOKEN", "test-mcp-token-placeholder")
+
+_MODULE = "src.mcp.inbox_server_http"
+
+
+@pytest.fixture()
+def isolated_dirs(tmp_path):
+    """Patch _MESSAGES_DIR/_INBOX_DIR and reset the dedupe/nonce state."""
+    messages_base = tmp_path / "shared_confirm_messages"
+    outbox_dir = messages_base / "outbox"
+    inbox_dir = messages_base / "inbox"
+    outbox_dir.mkdir(parents=True)
+    inbox_dir.mkdir(parents=True)
+
+    with (
+        patch(f"{_MODULE}._MESSAGES_DIR", messages_base),
+        patch(f"{_MODULE}._INBOX_DIR", inbox_dir),
+        patch(f"{_MODULE}._seen_push_confirmations", {}),
+    ):
+        yield outbox_dir, inbox_dir
+
+
+def _import_target():
+    import src.mcp.inbox_server_http as m
+    return m
+
+
+class TestLiveDataPreview:
+    def test_preview_included_in_confirmation_text(self, isolated_dirs):
+        outbox_dir, _ = isolated_dirs
+        m = _import_target()
+
+        m._queue_push_confirmation(
+            chat_id="111",
+            scope="calendar",
+            connected_text="Google Calendar connected.",
+            fetch_preview=lambda: "Next up: Standup — Mon 9am",
+        )
+
+        files = list(outbox_dir.glob("*.json"))
+        assert len(files) == 1
+        reply = json.loads(files[0].read_text())
+        assert "Standup" in reply["text"]
+        assert "Google Calendar connected." in reply["text"]
+
+    def test_none_preview_shows_honest_degraded_message(self, isolated_dirs):
+        """fetch_preview returning None/"" (nothing to show, no error) still
+        produces an honest message, distinct from a hard failure."""
+        outbox_dir, _ = isolated_dirs
+        m = _import_target()
+
+        m._queue_push_confirmation(
+            chat_id="112",
+            scope="calendar",
+            connected_text="Google Calendar connected.",
+            fetch_preview=lambda: None,
+        )
+
+        files = list(outbox_dir.glob("*.json"))
+        assert len(files) == 1
+        reply = json.loads(files[0].read_text())
+        assert "couldn't fetch a live preview" in reply["text"]
+
+
+class TestFailureVisibility:
+    def test_preview_fetch_exception_logged_at_error_not_swallowed(self, isolated_dirs, caplog):
+        outbox_dir, _ = isolated_dirs
+        m = _import_target()
+
+        def _raise():
+            raise RuntimeError("boom")
+
+        with caplog.at_level(logging.ERROR):
+            m._queue_push_confirmation(
+                chat_id="113",
+                scope="gmail",
+                connected_text="Gmail connected.",
+                fetch_preview=_raise,
+            )
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records, "Preview-fetch exception must be logged at ERROR"
+        assert any("preview fetch failed" in r.getMessage().lower() for r in error_records)
+
+        # And the confirmation must STILL be queued (never silent).
+        files = list(outbox_dir.glob("*.json"))
+        assert len(files) == 1
+        reply = json.loads(files[0].read_text())
+        assert "couldn't fetch a live preview" in reply["text"]
+
+    def test_notify_failure_logged_at_error_with_system_alert_fallback(self, isolated_dirs):
+        """The pre-existing bug this fixes: a bare `except Exception:
+        log.warning(...)` around the outbox write, with zero fallback. Now:
+        ERROR log + a system-alert (both an inbox audit record and, when
+        possible, a real admin-facing outbox message)."""
+        outbox_dir, inbox_dir = isolated_dirs
+        m = _import_target()
+
+        # Force the outbox mkdir to fail by making its parent unwritable via
+        # a path collision: replace the "outbox" segment with a pre-existing
+        # file so mkdir(exist_ok=True) raises FileExistsError (not a dir).
+        # This blocks BOTH the original confirmation write AND the admin
+        # outbox-alert fallback (same outbox dir) -- the inbox audit record
+        # (a separate directory) must still get through regardless.
+        (outbox_dir.parent / "outbox").rmdir()
+        (outbox_dir.parent / "outbox").write_text("blocking file, not a directory")
+
+        logger = logging.getLogger(_MODULE)
+        records = []
+
+        class _Handler(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        handler = _Handler(level=logging.ERROR)
+        logger.addHandler(handler)
+        try:
+            m._queue_push_confirmation(
+                chat_id="114",
+                scope="workspace",
+                connected_text="Google Workspace connected.",
+                fetch_preview=lambda: "some preview",
+            )
+        finally:
+            logger.removeHandler(handler)
+
+        error_records = [r for r in records if r.levelno >= logging.ERROR]
+        assert error_records, "Notify-path failure must be logged at ERROR"
+        assert any(
+            "failed to queue outbox confirmation" in r.getMessage().lower()
+            for r in error_records
+        )
+
+        alert_files = list(inbox_dir.glob("*_confirm_failure_alert.json"))
+        assert alert_files, "System-alert inbox audit record must be written when notify fails"
+        alert = json.loads(alert_files[0].read_text())
+        assert alert["chat_id"] == 0
+        assert alert["type"] == "system_alert"
+        assert "workspace" in alert["text"].lower()
+        assert "114" in alert["text"]
+
+    def test_system_alert_delivers_real_outbox_message_to_admin_when_configured(self, isolated_dirs):
+        """The actual fix for the Fable-review finding that the chat_id=0
+        inbox alert alone is inert (nothing in this codebase consumes
+        type="system_alert" at chat_id=0 -- inbox_server.py explicitly
+        excludes chat_id==0 from USER_FACING_TYPES handling). This proves
+        the real fallback: when LOBSTER_ADMIN_CHAT_ID is configured and the
+        outbox itself is writable, a REAL outbox message addressed to the
+        admin is produced -- the same delivery mechanism already proven to
+        reach a real Telegram user."""
+        outbox_dir, _ = isolated_dirs
+        m = _import_target()
+
+        with patch.dict(os.environ, {"LOBSTER_ADMIN_CHAT_ID": "999000111"}):
+            m._write_system_alert("something went wrong for scope=workspace chat_id=114")
+
+        outbox_files = list(outbox_dir.glob("*_confirm_failure_admin_alert.json"))
+        assert outbox_files, "Admin-facing outbox alert was not written"
+        alert = json.loads(outbox_files[0].read_text())
+        assert alert["chat_id"] == "999000111"
+        assert alert["source"] == "telegram"
+        assert "went wrong" in alert["text"]
+
+    def test_system_alert_logs_loudly_when_admin_chat_id_not_configured(self, isolated_dirs, caplog):
+        """If LOBSTER_ADMIN_CHAT_ID isn't set, there is genuinely no channel
+        to notify a human via -- this must still be loud (ERROR), not a
+        silent no-op."""
+        outbox_dir, _ = isolated_dirs
+        m = _import_target()
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("LOBSTER_ADMIN_CHAT_ID", None)
+            with caplog.at_level(logging.ERROR):
+                m._write_system_alert("failure with no admin channel configured")
+
+        assert any(
+            "lobster_admin_chat_id not configured" in r.getMessage().lower()
+            for r in caplog.records
+        )
+        # No admin-outbox alert should exist when there's no chat_id to send to.
+        assert not list(outbox_dir.glob("*_confirm_failure_admin_alert.json"))
+
+    def test_system_alert_itself_failing_does_not_raise(self, isolated_dirs):
+        """Last-resort: even if writing the system alert fails, the caller
+        must not see an exception propagate."""
+        outbox_dir, inbox_dir = isolated_dirs
+        m = _import_target()
+
+        (outbox_dir.parent / "outbox").rmdir()
+        (outbox_dir.parent / "outbox").write_text("blocking file")
+
+        with patch(f"{_MODULE}._INBOX_DIR", Path("/dev/null/nonexistent-inbox-dir")):
+            # Should not raise.
+            m._queue_push_confirmation(
+                chat_id="115",
+                scope="workspace",
+                connected_text="Google Workspace connected.",
+                fetch_preview=lambda: "preview",
+            )
+
+
+class TestDedupeGuard:
+    def test_second_push_within_window_is_a_no_op(self, isolated_dirs):
+        outbox_dir, _ = isolated_dirs
+        m = _import_target()
+
+        m._queue_push_confirmation(
+            chat_id="116", scope="calendar", connected_text="connected",
+            fetch_preview=lambda: "preview 1",
+        )
+        m._queue_push_confirmation(
+            chat_id="116", scope="calendar", connected_text="connected",
+            fetch_preview=lambda: "preview 2",
+        )
+
+        files = list(outbox_dir.glob("*.json"))
+        assert len(files) == 1, "A duplicate push must not queue a second confirmation"
+
+    def test_different_scope_same_chat_id_is_not_deduped(self, isolated_dirs):
+        """De-dupe key is (scope, chat_id) -- a user connecting both Calendar
+        and Gmail in quick succession must get both confirmations."""
+        outbox_dir, _ = isolated_dirs
+        m = _import_target()
+
+        m._queue_push_confirmation(
+            chat_id="117", scope="calendar", connected_text="Calendar connected",
+            fetch_preview=lambda: "preview",
+        )
+        m._queue_push_confirmation(
+            chat_id="117", scope="gmail", connected_text="Gmail connected",
+            fetch_preview=lambda: "preview",
+        )
+
+        files = list(outbox_dir.glob("*.json"))
+        assert len(files) == 2
+
+    def test_different_chat_id_same_scope_is_not_deduped(self, isolated_dirs):
+        outbox_dir, _ = isolated_dirs
+        m = _import_target()
+
+        m._queue_push_confirmation(
+            chat_id="118", scope="calendar", connected_text="Calendar connected",
+            fetch_preview=lambda: "preview",
+        )
+        m._queue_push_confirmation(
+            chat_id="119", scope="calendar", connected_text="Calendar connected",
+            fetch_preview=lambda: "preview",
+        )
+
+        files = list(outbox_dir.glob("*.json"))
+        assert len(files) == 2
+
+    def test_dedupe_expires_after_ttl(self, isolated_dirs):
+        """After the TTL window elapses, a repeat push is treated as new."""
+        outbox_dir, _ = isolated_dirs
+        m = _import_target()
+
+        with patch(f"{_MODULE}._CONFIRM_DEDUPE_TTL_SECONDS", 0.05):
+            m._queue_push_confirmation(
+                chat_id="120", scope="calendar", connected_text="connected",
+                fetch_preview=lambda: "preview 1",
+            )
+            time_module.sleep(0.1)
+            m._queue_push_confirmation(
+                chat_id="120", scope="calendar", connected_text="connected",
+                fetch_preview=lambda: "preview 2",
+            )
+
+        files = list(outbox_dir.glob("*.json"))
+        assert len(files) == 2, "After TTL expiry, a repeat push must queue a new confirmation"
+
+    def test_confirmation_already_sent_is_read_only(self, isolated_dirs):
+        """_confirmation_already_sent must NOT claim the slot itself -- only
+        _mark_confirmation_sent (called after a successful delivery) does.
+        Calling the read-only check repeatedly must not change its answer."""
+        _ = isolated_dirs
+        m = _import_target()
+
+        assert m._confirmation_already_sent("chat-x", "calendar") is False
+        assert m._confirmation_already_sent("chat-x", "calendar") is False
+        assert m._confirmation_already_sent("chat-x", "calendar") is False
+
+    def test_mark_confirmation_sent_claims_the_slot(self, isolated_dirs):
+        _ = isolated_dirs
+        m = _import_target()
+
+        assert m._confirmation_already_sent("chat-y", "calendar") is False
+        m._mark_confirmation_sent("chat-y", "calendar")
+        assert m._confirmation_already_sent("chat-y", "calendar") is True
+
+    def test_failed_delivery_does_not_claim_dedupe_slot_so_retry_can_succeed(self, isolated_dirs):
+        """Regression test for a bug an independent (Fable) review pass
+        caught before merge: the original implementation claimed the de-dupe
+        slot BEFORE knowing whether the outbox write succeeded, so a
+        legitimate webhook retry after a transient failure would be
+        silently swallowed for the rest of the TTL window -- exactly the
+        "total silence" outcome this whole file exists to prevent.
+
+        Here: first call fails (outbox path is blocked), second call
+        (simulating a retry) must NOT be treated as a duplicate, and must
+        succeed once the path is unblocked.
+        """
+        outbox_dir, _ = isolated_dirs
+        m = _import_target()
+
+        # Break the outbox for the first attempt.
+        (outbox_dir).rmdir()
+        outbox_dir.write_text("blocking file, not a directory")
+
+        m._queue_push_confirmation(
+            chat_id="121", scope="calendar", connected_text="connected",
+            fetch_preview=lambda: "preview",
+        )
+        # First attempt must NOT have claimed the de-dupe slot.
+        assert m._confirmation_already_sent("121", "calendar") is False
+
+        # Unblock the outbox and retry -- this must succeed, not be deduped.
+        outbox_dir.unlink()
+        outbox_dir.mkdir(parents=True)
+
+        m._queue_push_confirmation(
+            chat_id="121", scope="calendar", connected_text="connected",
+            fetch_preview=lambda: "preview",
+        )
+
+        files = list(outbox_dir.glob("*.json"))
+        assert len(files) == 1, "Retry after a failed delivery must succeed, not be deduped away"

--- a/tests/unit/test_mcp_server/test_push_workspace_token_confirmation.py
+++ b/tests/unit/test_mcp_server/test_push_workspace_token_confirmation.py
@@ -43,27 +43,39 @@ _VALID_BODY = {
 
 @pytest.fixture()
 def client_and_dirs(tmp_path):
-    """Yield (TestClient, token_dir, outbox_dir)."""
-    workspace_token_dir = tmp_path / "config" / "workspace-tokens"
-    outbox_dir = tmp_path / "outbox"
+    """Yield (TestClient, token_dir, outbox_dir), fully isolated from prod.
+
+    BIS-744: patches ``_MESSAGES_DIR`` directly instead of
+    ``os.path.expanduser`` -- the endpoint now resolves its outbox path via
+    that module global (shared with the calendar/gmail endpoints through
+    ``_queue_push_confirmation``) rather than re-resolving "~/messages"
+    itself.
+    """
+    messages_base = tmp_path / "confirm_messages"
+    workspace_token_dir = messages_base / "config" / "workspace-tokens"
+    outbox_dir = messages_base / "outbox"
     workspace_token_dir.mkdir(parents=True)
     outbox_dir.mkdir(parents=True)
 
     with (
+        patch(f"{_MODULE}._MESSAGES_DIR", messages_base),
         patch(f"{_MODULE}._WORKSPACE_TOKEN_DIR", workspace_token_dir),
         patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
-        patch(
-            "os.path.expanduser",
-            side_effect=lambda p: (
-                str(tmp_path) if p == "~/messages" else os.path.expanduser.__wrapped__(p)
-                if hasattr(os.path.expanduser, "__wrapped__") else str(tmp_path)
-            ),
-        ),
+        patch(f"{_MODULE}._SESSION_HMAC_SECRET", ""),
+        patch(f"{_MODULE}._ENFORCE_WORKSPACE_SIGNED_SESSION", False),
+        patch(f"{_MODULE}._seen_workspace_session_nonces", {}),
+        patch(f"{_MODULE}._seen_push_confirmations", {}),
     ):
         from src.mcp.inbox_server_http import app
 
         client = TestClient(app, raise_server_exceptions=True)
         yield client, workspace_token_dir, outbox_dir
+
+
+def _read_only_outbox_file(outbox_dir: Path) -> dict:
+    files = list(outbox_dir.glob("*.json"))
+    assert len(files) == 1, f"Expected exactly one outbox file, found {len(files)}"
+    return json.loads(files[0].read_text())
 
 
 # ---------------------------------------------------------------------------
@@ -74,45 +86,85 @@ def client_and_dirs(tmp_path):
 class TestPostAuthConfirmation:
     def test_returns_ok_on_success(self, client_and_dirs):
         client, _, _ = client_and_dirs
-        resp = client.post(
-            "/api/push-workspace-token",
-            json=_VALID_BODY,
-            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
-        )
+        with patch(f"{_MODULE}._fetch_workspace_preview", return_value="Most recent Drive file: Q3 plan.docx"):
+            resp = client.post(
+                "/api/push-workspace-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
         assert resp.status_code == 200
         assert resp.json().get("ok") is True
 
     def test_confirmation_queued_to_outbox(self, client_and_dirs):
         client, _, outbox_dir = client_and_dirs
-        client.post(
-            "/api/push-workspace-token",
-            json=_VALID_BODY,
-            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
-        )
-        # Outbox should contain a file with the confirmation text
-        outbox_files = list(outbox_dir.glob("*.json"))
-        # If expanduser mock redirected correctly
-        if outbox_files:
-            reply = json.loads(outbox_files[0].read_text())
-            text = reply.get("text", "")
-            assert "/gdocs" in text
-            assert "/gdrive" in text
-            assert "/gsheets" in text
-            assert reply.get("chat_id") == _VALID_BODY["chat_id"]
+        with patch(f"{_MODULE}._fetch_workspace_preview", return_value="Most recent Drive file: Q3 plan.docx"):
+            client.post(
+                "/api/push-workspace-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+        reply = _read_only_outbox_file(outbox_dir)
+        text = reply.get("text", "")
+        assert "/gdocs" in text
+        assert "/gdrive" in text
+        assert "/gsheets" in text
+        assert reply.get("chat_id") == _VALID_BODY["chat_id"]
+
+    def test_confirmation_includes_live_preview(self, client_and_dirs):
+        """BIS-744: the confirmation text includes the real live-data preview."""
+        client, _, outbox_dir = client_and_dirs
+        with patch(
+            f"{_MODULE}._fetch_workspace_preview",
+            return_value="Most recent Drive file: roadmap.gdoc",
+        ):
+            client.post(
+                "/api/push-workspace-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+        reply = _read_only_outbox_file(outbox_dir)
+        assert "roadmap.gdoc" in reply["text"]
+
+    def test_confirmation_degrades_gracefully_when_preview_fetch_fails(self, client_and_dirs, caplog):
+        """BIS-744: a live-data fetch failure must never silence the confirmation."""
+        import logging
+
+        client, _, outbox_dir = client_and_dirs
+        with patch(
+            f"{_MODULE}._fetch_workspace_preview", side_effect=RuntimeError("Drive API down")
+        ), caplog.at_level(logging.ERROR):
+            resp = client.post(
+                "/api/push-workspace-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+
+        assert resp.status_code == 200
+        reply = _read_only_outbox_file(outbox_dir)
+        assert "connected" in reply["text"].lower()
+        assert "couldn't fetch a live preview" in reply["text"]
+        assert any(
+            "preview fetch failed" in r.getMessage().lower() for r in caplog.records
+        ), "Preview fetch failure must be logged loudly, not silently swallowed"
 
     def test_returns_ok_even_when_outbox_write_fails(self, tmp_path):
         """Token save succeeds and 200 is returned even if outbox write throws."""
-        workspace_token_dir = tmp_path / "config" / "workspace-tokens"
+        messages_base = tmp_path / "confirm_messages"
+        workspace_token_dir = messages_base / "config" / "workspace-tokens"
         workspace_token_dir.mkdir(parents=True)
+        blocked_base = tmp_path / "blocked"
+        blocked_base.mkdir()
+        (blocked_base / "outbox").write_text("not a directory")
 
         with (
+            patch(f"{_MODULE}._MESSAGES_DIR", blocked_base),
             patch(f"{_MODULE}._WORKSPACE_TOKEN_DIR", workspace_token_dir),
             patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
-            # Redirect expanduser to a path that doesn't exist so mkdir fails
-            patch(
-                "os.path.expanduser",
-                side_effect=lambda p: "/dev/null/nonexistent" if p == "~/messages" else p,
-            ),
+            patch(f"{_MODULE}._SESSION_HMAC_SECRET", ""),
+            patch(f"{_MODULE}._ENFORCE_WORKSPACE_SIGNED_SESSION", False),
+            patch(f"{_MODULE}._seen_workspace_session_nonces", {}),
+            patch(f"{_MODULE}._seen_push_confirmations", {}),
+            patch(f"{_MODULE}._fetch_workspace_preview", return_value="preview"),
         ):
             from src.mcp.inbox_server_http import app
 
@@ -125,6 +177,76 @@ class TestPostAuthConfirmation:
 
         assert resp.status_code == 200
         assert resp.json().get("ok") is True
+
+    def test_notify_failure_is_logged_loudly_and_falls_back_to_system_alert(self, tmp_path):
+        """BIS-744: fixes the pre-existing bare `except Exception:
+        log.warning(...)` swallow. When the outbox write itself fails, the
+        failure must be logged at ERROR (not WARNING) and a system-level
+        alert must be written to the inbox as a fallback -- never total
+        silence."""
+        import logging
+
+        messages_base = tmp_path / "confirm_messages"
+        workspace_token_dir = messages_base / "config" / "workspace-tokens"
+        workspace_token_dir.mkdir(parents=True)
+        inbox_dir = messages_base / "inbox"
+        inbox_dir.mkdir(parents=True)
+        blocked_base = tmp_path / "blocked"
+        blocked_base.mkdir()
+        (blocked_base / "outbox").write_text("not a directory")
+
+        with (
+            patch(f"{_MODULE}._MESSAGES_DIR", blocked_base),
+            patch(f"{_MODULE}._INBOX_DIR", inbox_dir),
+            patch(f"{_MODULE}._WORKSPACE_TOKEN_DIR", workspace_token_dir),
+            patch(f"{_MODULE}._INTERNAL_SECRET", _VALID_SECRET),
+            patch(f"{_MODULE}._SESSION_HMAC_SECRET", ""),
+            patch(f"{_MODULE}._ENFORCE_WORKSPACE_SIGNED_SESSION", False),
+            patch(f"{_MODULE}._seen_workspace_session_nonces", {}),
+            patch(f"{_MODULE}._seen_push_confirmations", {}),
+            patch(f"{_MODULE}._fetch_workspace_preview", return_value="preview"),
+        ):
+            import logging as _logging
+
+            logger = _logging.getLogger(_MODULE)
+            from src.mcp.inbox_server_http import app
+
+            client = TestClient(app, raise_server_exceptions=True)
+            handler_records = []
+
+            class _CollectHandler(_logging.Handler):
+                def emit(self, record):
+                    handler_records.append(record)
+
+            handler = _CollectHandler(level=_logging.ERROR)
+            logger.addHandler(handler)
+            try:
+                resp = client.post(
+                    "/api/push-workspace-token",
+                    json=_VALID_BODY,
+                    headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+                )
+            finally:
+                logger.removeHandler(handler)
+
+        # The push itself still succeeds -- token was saved before the
+        # confirmation step ran.
+        assert resp.status_code == 200
+
+        error_records = [r for r in handler_records if r.levelno >= logging.ERROR]
+        assert error_records, "Notify-path failure must be logged at ERROR, not swallowed"
+        assert any(
+            "failed to queue outbox confirmation" in r.getMessage().lower()
+            for r in error_records
+        )
+
+        # System-alert fallback: a chat_id=0 alert must land in the inbox.
+        alert_files = list(inbox_dir.glob("*_confirm_failure_alert.json"))
+        assert alert_files, "No system-alert fallback was written when notify failed"
+        alert = json.loads(alert_files[0].read_text())
+        assert alert["chat_id"] == 0
+        assert alert["type"] == "system_alert"
+        assert "workspace" in alert["text"].lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

BIS-743 (#2130) gave Calendar/Gmail/Workspace push-token confirmations
parity but left three gaps. This PR closes them:

1. **Live-data proof.** Each confirmation now includes a one-line live
   preview (next calendar event, latest Gmail thread, most recent My Drive
   file) instead of a static "connected" message, so the user sees evidence
   the grant actually works — not just that a token was saved.

2. **Failure visibility.** The outbox-write and preview-fetch paths are now
   each wrapped so failures are logged at ERROR with `exc_info` (previously
   a bare warning with no fallback). When the confirmation itself cannot be
   delivered, `_write_system_alert` now routes a real outbox message to
   `LOBSTER_ADMIN_CHAT_ID` — mirroring the existing pattern in
   `src/transcription/worker.py::notify_dispatcher_dead_letter` — in
   addition to an inbox audit record. The prior `chat_id=0` /
   `type="system_alert"` inbox record alone was inert:
   `inbox_server.py` explicitly excludes `chat_id == 0` from
   `USER_FACING_TYPES`, so nothing ever consumed it.

3. **De-dupe correctness.** `_confirmation_already_sent` used to claim the
   `(chat_id, scope)` slot as a side effect of the check itself, before the
   outbox write was known to succeed. A transient failure therefore
   silently blocked any legitimate retry (e.g. a webhook redelivery) for
   the rest of the 5-minute TTL window — exactly the kind of silent failure
   this file exists to eliminate. This is split into a read-only
   `_confirmation_already_sent` check plus a separate
   `_mark_confirmation_sent`, called only after the outbox write succeeds.

The three per-endpoint copy-paste blocks (proven 3x, per this file's
established convention of proving a pattern before abstracting it) are
consolidated into one shared `_queue_push_confirmation` helper
parameterized by scope, static text, and a per-scope `fetch_preview`
callable.

**Also included:**
- Outbox filenames for confirmations now include `chat_id` (not just
  scope+timestamp) — two rapid confirmations for the same scope but
  different chat_ids could otherwise land on the same millisecond and
  overwrite each other's file.
- New autouse `isolate_inbox_server_http_paths` fixture in `tests/conftest.py`.
  Without it, tests against this module — on any machine with
  `LOBSTER_MESSAGES` set in the environment (true of this VPS) — silently
  write real confirmation/token files into the production `~/messages`
  tree. ~200 stray files from prior test runs were found sitting in the
  real dead-letter queue during this work.

**Out of scope:** no changes to the Google OAuth flow, token storage
format, or the three skill docs touched by BIS-743. This PR only touches
the post-push confirmation path in `src/mcp/inbox_server_http.py` and its
tests.

## Functional patterns

- `_queue_push_confirmation` is parameterized by a `fetch_preview: Callable[[], Optional[str]]`
  (higher-order function) instead of three near-identical copy-pasted
  endpoint bodies.
- `_confirmation_already_sent` (read) and `_mark_confirmation_sent` (write)
  are now separate, single-responsibility functions instead of one function
  that both queries and mutates state as a side effect of being called —
  the previous conflation of read+write in one call was the direct cause of
  the de-dupe bug.
- `_write_system_alert` and `_queue_push_confirmation` remain pure with
  respect to control flow (no exceptions escape); all side effects (file
  writes) are isolated at the boundary and wrapped in explicit
  try/except with no bare `except: pass`.

## Flow change (de-dupe claim timing)

Before:
```
push endpoint -> _confirmation_already_sent(chat_id, scope)
                     |
                     +-- claims slot HERE (read + write conflated)
                     |
                 outbox write ---- fails ----> slot already claimed,
                                                 retry silently dropped
                                                 for up to 5 min
```

After:
```
push endpoint -> _confirmation_already_sent(chat_id, scope)  [read-only]
                     |
                 outbox write ---- fails ----> slot NOT claimed,
                     |                          retry proceeds normally
                 succeeds
                     |
                 _mark_confirmation_sent(chat_id, scope)  [claims slot]
```

A retry after a transient failure now succeeds instead of being silently
swallowed for the rest of the TTL window.

## Tests run

- [x] `uv run pytest tests/unit/test_mcp_server/test_push_token_confirmation_shared.py tests/unit/test_mcp_server/test_push_calendar_token_confirmation.py tests/unit/test_mcp_server/test_push_gmail_token_confirmation.py tests/unit/test_mcp_server/test_push_workspace_token_confirmation.py -v` — 38 passed
- [x] `uv run pytest tests/unit/test_mcp_server/ -q` — 939 passed (full module, no regressions)
- [x] Falsifiability check: manually reverted `_confirmation_already_sent` to its old claim-on-read behavior (inlined the pre-fix logic) and re-ran the shared test file — `test_confirmation_already_sent_is_read_only` and `test_failed_delivery_does_not_claim_dedupe_slot_so_retry_can_succeed` both failed as expected. Restored the fix and confirmed both pass again.
- [ ] Live end-to-end HTTP POST against a running instance — not run in this pass; the endpoint-level wiring is exercised by the calendar/gmail/workspace test files above via direct function calls against the ASGI handlers (not a real running server + real Google API calls). No systemd/cron changes are included in this PR, so this is judged not required to merge safely; flagging for the reviewer's judgment call.

**Blocked items needing attention before merge:** none. The one unchecked item above (live E2E HTTP test) is a judgment call, not a blocker — BIS-743's PR ran a live E2E check against the outbox-write path specifically to validate the wiring pattern this PR now consolidates; this PR does not change that wiring's external behavior (same outbox dir, same file format, same `source: "telegram"` / `chat_id` shape), only the preview content, failure path, and de-dupe timing around it.

## Manual test

No systemd/cron/DB-schema changes. `_write_system_alert`'s new
`LOBSTER_ADMIN_CHAT_ID`-routed outbox alert is covered by an automated test
(`test_system_alert_delivers_real_outbox_message_to_admin_when_configured`)
that asserts the actual outbox JSON file content, rather than a live
Telegram send — no live token/chat_id was available in this environment to
verify delivery against a real admin chat. This is the same outbox-write
mechanism BIS-743 already validated end-to-end for the base confirmation
path (referenced in #2130's manual test notes); this PR does not add a new
delivery mechanism, only a new destination/`chat_id` for it.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests — new autouse conftest fixture prevents this class of module from ever touching `~/messages` in tests)
- [ ] Integration/manual test run — not run; see `## Manual test` above for rationale
- [ ] User-visible outcome (real Telegram delivery) verified — not verified live in this pass; asserted via outbox file content instead (see above)
- [x] Side-effect audit complete: no floods (single message per successful push, deduped), no unscoped writes (all writes go through the tmp_path-isolated fixture in tests; production path only used at runtime), no unintended volume
- [x] External service calls: Calendar/Gmail/Workspace preview fetches (`get_upcoming_events`, `gdrive_list`, etc.) are mocked in all tests; no manual runs were made against live Google APIs in this pass

Relates to #744 (BIS-744). Follows on from #2130 (BIS-743).