### PR TITLE
fix: correct nightly-consolidation step 10 bridge sync command

### DIFF
--- a/.claude/agents/nightly-consolidation.md
+++ b/.claude/agents/nightly-consolidation.md
@@ -166,19 +166,32 @@ Include the GitHub activity summary in the synthesis for rolling-summary.md and 
    If handoff.md has no PR table, skip step 9b silently. If `gh` is unavailable, skip step 9b and note it in `write_result`. If the PR table format is unexpected, leave the table unchanged and note it in `write_result` — do not crash.
 
 10. **Sync canonical files into the user model DB.**
-   Run the bridge pass to push projects, priorities, and preferences from canonical markdown files into the user model DB. This also generates the pre-computed `_context.md` via `write_context_cache()`:
+   Run the bridge pass to push projects, priorities, and preferences from canonical markdown files into the user model DB. This also generates the pre-computed `_context.md` via `write_context_cache()`.
+
+   **Do not call `run_bridges()`** — it takes a single `workspace_path` used for both reads and writes, but in this deployment the canonical read root (`~/lobster-user-config`) and the `_context.md` write root (`~/lobster-workspace`) are different directories. Calling it with one shared path finds no canonical data and silently overwrites the populated `_context.md` with a near-empty stub. Call the three bridge functions directly instead, passing the correct root to each:
    ```bash
    cd ~/lobster && uv run python -c "
-   import sys; sys.path.insert(0, 'src')
-   from mcp.user_model.bridges import run_bridges
-   import sqlite3, os
-   db_path = os.path.expanduser('~/lobster-workspace/data/memory.db')
-   conn = sqlite3.connect(db_path)
-   result = run_bridges(conn)
+   import sys, os
+   sys.path.insert(0, os.path.join(os.getcwd(), 'src', 'mcp'))
+   from user_model.db import open_db
+   from user_model.bridges import sync_projects_to_arcs, sync_priorities_to_attention, write_context_cache
+   from pathlib import Path
+   conn = open_db(Path(os.path.expanduser('~/lobster-workspace/data/memory.db')))
+   canonical_ws = os.path.expanduser('~/lobster-user-config')
+   output_ws = os.path.expanduser('~/lobster-workspace')
+   proj = sync_projects_to_arcs(conn, canonical_ws)
+   pri = sync_priorities_to_attention(conn, canonical_ws)
+   write_context_cache(conn, output_ws)
+   conn.commit()
    conn.close()
-   print(result)
+   print(proj, pri)
    "
    ```
+   Notes on this invocation:
+   - Import `user_model.db` / `user_model.bridges` directly (no `mcp.` prefix) after putting `src/mcp` itself on `sys.path`. Importing via `from mcp.user_model.bridges import ...` after `sys.path.insert(0, 'src')` breaks because `mcp` resolves to the installed MCP SDK package in site-packages, not `src/mcp/`.
+   - Open the connection with `user_model.db.open_db()`, not a bare `sqlite3.connect()`. `open_db()` sets `conn.row_factory = sqlite3.Row`, which the bridge query functions require for dict-style row access — without it, queries fail and are silently swallowed by broad `except` blocks, again producing a near-empty `_context.md`.
+   - `sync_projects_to_arcs` and `sync_priorities_to_attention` read from `canonical_ws` (canonical memory files); `write_context_cache` writes into `output_ws` (the workspace `_context.md` lives under). Do not use the same variable for both.
+
    This syncs `projects/*.md` as narrative arcs and `priorities.md` as attention items, and writes the pre-computed `~/lobster-workspace/user-model/_context.md`.
    If the script fails (e.g. DB not initialized), continue to step 11.
 


### PR DESCRIPTION
## Summary
- Step 10 of `.claude/agents/nightly-consolidation.md` documented calling `run_bridges(conn)`, which uses a single `workspace_path` for both the canonical-memory read root and the `_context.md` write root. Those roots differ in this deployment (`~/lobster-user-config` vs `~/lobster-workspace`), so the documented call found no canonical data and silently overwrote the populated `_context.md` with a near-empty stub.
- Also fixes the documented `sys.path.insert(0, 'src'); from mcp.user_model.bridges import ...` import, which breaks due to a PEP 420 namespace-package collision with the installed `mcp` SDK package — switched to putting `src/mcp` on `sys.path` and importing `user_model.bridges` directly, matching the pattern already used in `tests/test_user_model_v2.py`.
- Also switches from a bare `sqlite3.connect()` to `user_model.db.open_db()`, which sets `row_factory = sqlite3.Row` — required by the bridge query functions, whose dict-style row access otherwise raises and gets silently swallowed by broad `except` blocks.
- Step 10 now calls `sync_projects_to_arcs`, `sync_priorities_to_attention`, and `write_context_cache` directly (rather than `run_bridges()`) so the canonical read root and workspace write root can be passed separately.

Fixes #2135

## Test plan
- [ ] Ran the corrected step-10 command against the live DB during investigation — confirmed it syncs 7 project arcs and 5 priority items and writes a populated `_context.md` (done manually while diagnosing; not re-run as part of this PR since it mutates the live user-model DB)
- [x] Doc-only change reviewed against `src/mcp/user_model/bridges.py` and `src/mcp/user_model/db.py` for signature accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)