### PR TITLE
fix: correct systemctl invocation in MCP orphan-reaper guard

### DIFF
--- a/scripts/claude-persistent.sh
+++ b/scripts/claude-persistent.sh
@@ -377,7 +377,20 @@ kill_orphaned_mcp_processes() {
         # Skip systemd-managed services — they are independently lifecycle-managed,
         # not orphans. Killing them causes a restart race where Claude initializes
         # before the MCP server comes back up, leaving the session without MCP tools.
-        if systemctl status --pid "$pid" >/dev/null 2>&1; then
+        #
+        # NOTE: `systemctl status` has no `--pid` option. `systemctl status --pid
+        # "$pid"` always fails with "Unknown option '--pid'." (exit 1), which
+        # silently defeated this guard for every PID since it was added in #1551:
+        # the "systemd-managed" branch never triggered, so lobster-mcp-local.service
+        # was always treated as an orphan and SIGTERM'd here on every dispatcher
+        # restart (including the routine ~2h proactive session-age restart from
+        # #2060). RestartSec=0 masked the user-visible impact of the restart
+        # itself, but the service bounce still wiped in-memory session/lock state,
+        # producing spurious session-lost-reminder / dispatcher-marked-dead
+        # notifications with no actual dispatcher crash. See investigation for
+        # issues #2124 / #2142. The correct invocation takes the PID as a bare
+        # positional argument.
+        if systemctl status "$pid" >/dev/null 2>&1; then
             log "CLEANUP: MCP PID $pid is a systemd-managed service — skipping"
             skipped=$((skipped + 1))
             continue


### PR DESCRIPTION
## Summary
- `kill_orphaned_mcp_processes()` in `scripts/claude-persistent.sh` uses `systemctl status --pid "$pid"` to skip systemd-managed MCP servers before treating remaining processes as orphans to SIGTERM.
- `--pid` is not a valid `systemctl status` option. It always fails (`Unknown option '--pid'.`, exit 1), so the "skip systemd-managed service" branch has never actually fired since it was added in #1551. `lobster-mcp-local.service` (PPID=1 under systemd) falls through the tmux-lineage check too, so it's classified as an orphan and SIGTERM'd on **every** `launch_claude()` call — including the routine ~2h proactive session-age restart from #2060.
- `RestartSec=0` (drop-in `restart-fast.conf`) masks the worst symptom (tools failing to load), but each bounce of `lobster-mcp-local.service` still wipes its in-memory session/dispatcher-lock state, which writes a `session-lost-reminder` to the inbox and — depending on timing — marks the still-alive dispatcher session "dead" via the `>120min` stale-`running`-session cleanup in `session_store.py`. That surfaces to the user as a spurious "SESSION LOST" / dispatcher-marked-dead restart notification even though the dispatcher never actually crashed.

## Evidence
Investigated a cluster of 4 such restart notifications between 2026-07-31 18:12 EDT and 2026-08-01 00:24 EDT with zero user activity in between. `journalctl -u lobster-mcp-local` shows the service cleanly restarting (`Deactivated successfully`) at 18:12:07, 20:16:07, 22:20:07, 00:24:07 — each exactly 7440s apart and within ~6s of `health-check-v3.sh`'s `check_session_age()` sending the proactive SIGTERM to the dispatcher PID (confirmed in `health-check.log`: `SESSION AGE LIMIT: session is 7430s old ... sending SIGTERM`).

Reproduced directly on the host:
```
$ systemctl status --pid $(pgrep -f inbox_server.py)
systemctl: unrecognized option '--pid'
$ echo $?
1
$ systemctl status $(pgrep -f inbox_server.py)   # bare PID — correct syntax
● lobster-mcp-local.service - Lobster MCP Server (local HTTP transport)
     Active: active (running) ...
```

This is a plausible root cause (or contributor) to the long-standing nightly crash-loop tracked in #2124 — it fires on a fixed ~2h cadence independent of user activity, which matches the "3 AM alert" pattern whenever a cycle lands near 3 AM, and explains why prior mitigations in #2124 (cron staggering, alert suppression) didn't stop it: none of them touched this orphan-reaper guard.

Also relevant to #2142 — the wait_for_messages 300s-idle-abort hypothesis. I did not find evidence of that specific client-side abort in this cluster's logs (wait_for_messages calls were logging normally throughout), so it may be a separate/lower-priority issue; this PR does not address it.

## Fix
Pass the PID positionally: `systemctl status "$pid"` (no `--pid` flag), matching the intent of the guard added in #1551.

## Test plan
- [ ] Confirm `systemctl status "$pid"` correctly returns 0 for `lobster-mcp-local.service`'s PID and non-zero for a non-systemd dispatcher-spawned MCP process (e.g. an `npx obsidian-mcp` child) in a staging/dev environment.
- [ ] After deploy, monitor `journalctl -u lobster-mcp-local` across several ~2h proactive session-age restart cycles and confirm the service no longer bounces (`Deactivated successfully` / restart counter no longer increments) when the dispatcher does its routine 7200s SIGTERM restart.
- [ ] Confirm `CLEANUP: MCP PID $pid is a systemd-managed service — skipping` now appears in `claude-persistent.sh` logs on restart, instead of `CLEANUP: Killing orphaned MCP PID $pid (SIGTERM)`.
- [ ] Watch for a reduction/elimination of `session-lost-reminder` and dispatcher-marked-dead reconciler notifications correlated with routine restarts.

Related: #2124, #2142, #1551, #2060

🤖 Generated with [Claude Code](https://claude.com/claude-code)