### PR TITLE
fix: disable client-side MCP idle watchdog for wait_for_messages (#2142)

### DIFF
--- a/config/config.env.example
+++ b/config/config.env.example
@@ -19,6 +19,20 @@ LOBSTER_DEBUG=false
 #   systemctl restart lobster-mcp-local
 LOBSTER_DEV_MODE=false
 
+# Disable Claude Code's client-side MCP tool idle-progress watchdog (issue #2142).
+# wait_for_messages() is a legitimate long-poll: it blocks for up to its
+# requested `timeout` (default 72000s / 20h) with zero MCP-protocol response or
+# progress frames while the inbox is idle — that's the intended design, not a
+# hang. Claude Code's CLI enforces its own idle-progress abort on MCP tool
+# calls, well under 72000s, independent of the tool's own timeout param and
+# invisible to the dispatcher-heartbeat/wfm-active signal files (those only
+# inform the external health-check script, not the CLI's MCP client). Without
+# this, the CLI aborts wait_for_messages early and the dispatcher must
+# immediately re-issue the call, burning a fresh idle window each time with no
+# way to actually block for the requested duration. 0 disables the watchdog
+# (per the CLI's own error message suggestion).
+CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=0
+
 # Telegram Bot (from @BotFather)
 TELEGRAM_BOT_TOKEN=your_bot_token_here
 TELEGRAM_ALLOWED_USERS=your_user_id_here

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -3191,6 +3191,38 @@ M88_PYEOF
         migrated=$((migrated + 1))
     fi
 
+    # Migration 96: Add CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=0 to config.env if missing
+    # (issue #2142). wait_for_messages() is a legitimate long-poll that blocks for
+    # up to its requested `timeout` (default 72000s / 20h) with zero MCP-protocol
+    # response/progress frames while idle — that is the intended design, not a
+    # hang. Claude Code's CLI enforces its own client-side idle-progress watchdog
+    # on MCP tool calls (default well under 72000s) independent of the tool's own
+    # timeout param, and independent of the dispatcher-heartbeat / wfm-active
+    # signal files added in PR #1646 (those only inform the external health-check
+    # script — they are invisible to the CLI's own MCP client). When the watchdog
+    # fires it aborts the call with "sent no response or progress for Ns;
+    # aborting... set CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT (ms) globally (0
+    # disables)." This forces the dispatcher to immediately re-issue
+    # wait_for_messages, burning a fresh idle window every time with no way to
+    # actually block for the requested duration. Setting this to 0 (the value
+    # the client's own error message recommends) disables that client-side idle
+    # abort globally for this instance's Claude Code session.
+    if [ -f "$CONFIG_FILE" ]; then
+        # shellcheck source=/dev/null
+        source "$CONFIG_FILE" 2>/dev/null || true
+        if [ -z "${CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT:-}" ]; then
+            echo "" >> "$CONFIG_FILE"
+            echo "# Disable Claude Code's client-side MCP tool idle-progress watchdog." >> "$CONFIG_FILE"
+            echo "# wait_for_messages() legitimately blocks up to 20h with no progress" >> "$CONFIG_FILE"
+            echo "# frames; without this, the CLI aborts the call early (issue #2142)." >> "$CONFIG_FILE"
+            echo "CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=0" >> "$CONFIG_FILE"
+            substep "Migration 96: added CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=0 to config.env (issue #2142)"
+            migrated=$((migrated + 1))
+        else
+            substep "Migration 96: CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT already set — skipping"
+        fi
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else


### PR DESCRIPTION
## Summary
- `wait_for_messages()` is a legitimate long-poll: it blocks for up to its requested `timeout` (default 72000s/20h) sending zero MCP-protocol progress frames while the inbox is idle. That's the intended design, not a hang.
- Claude Code's CLI enforces its own client-side idle-progress abort on MCP tool calls, well under 72000s, independent of the tool's own `timeout` param — and invisible to the `dispatcher-heartbeat`/`wfm-active` signal files added in #1646 (those only inform the external health-check script, not the CLI's own MCP client).
- Without a fix, the CLI aborts `wait_for_messages` early with `"sent no response or progress for Ns; aborting"`, forcing the dispatcher to immediately re-issue the call — burning a fresh idle window every retry with no way to actually block for the requested duration. Live-observed recurring 3x in a row on the `eloso` instance (idle wall ~1800s per that occurrence vs. ~300s originally reported in #2142 — exact default appears to vary by CLI version/session, but the root cause and fix are the same either way).
- Adds `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=0` (the value the CLI's own error message recommends) to `config/config.env.example` for fresh installs, and a new `upgrade.sh` migration (96) to backfill existing installs' `config.env`, following the same append-if-missing pattern as migrations 56/57 (`LOBSTER_ADMIN_CHAT_ID`, `LOBSTER_INTERNAL_SECRET`).

## Why not a code change in inbox_server.py
A more surgical fix would have `wait_for_messages` emit periodic MCP progress notifications while blocked (issue #2142's option (c)), scoping the fix to just this one tool instead of disabling the client-side watchdog globally. That's a real MCP protocol change to the tool implementation and carries more risk/review surface than this env var. Filing this as the safe, immediate fix; the progress-notification approach is worth a follow-up issue if the blanket disable proves too coarse (e.g. it also stops catching a genuinely-hung MCP server on any other tool call).

## Test plan
- [x] `bash -n scripts/upgrade.sh` — syntax OK
- [x] Migration 96 logic extracted and run standalone against a copy of a real instance config.env with the var stripped: appends the var + comment correctly on first run, correctly no-ops (skips) on a second run — confirmed idempotent
- [ ] Full `upgrade.sh` dry run against a real existing install (not run here — touches systemd/sudo paths outside the scope of this investigation task)
- [ ] Manual confirmation from Drew that `wait_for_messages` blocks past the previous abort point after the next natural `lobster-claude` restart (this PR does not restart any live service)

Closes #2142