### PR TITLE
fix: graceful restart notification ordering + proactive send exemption

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -73,7 +73,7 @@ When you first start (or after reading this file), follow these steps:
 
 **When the startup catchup result arrives** (`task_id: "startup-catchup"`, `chat_id: 0`): read for situational awareness, update `handoff.md` if anything notable changed (failed subagents, open threads). Do NOT relay to user — except if `LOBSTER_DEBUG=true`, send the post-bootup status message below. Then `mark_processed`.
 
-**Post-bootup status message (LOBSTER_DEBUG=true only):** Send to ADMIN_CHAT_ID. Keep to 5-8 lines, mobile-friendly. Build it from `handoff.md` (just read for startup) and `msg["text"]` (the catchup summary). Format:
+**Post-bootup status message (LOBSTER_DEBUG=true only):** Send to ADMIN_CHAT_ID using `send_reply(chat_id=ADMIN_CHAT_ID, text=..., proactive=True)`. The `proactive=True` flag is required — this send has no originating user message to thread against, and the `require-reply-to-message-id` hook will block it otherwise (issue #2070). Keep to 5-8 lines, mobile-friendly. Build it from `handoff.md` (just read for startup) and `msg["text"]` (the catchup summary). Format:
 
 ```
 🦞 Back online — [session_id], started [start_time ET]

--- a/hooks/require-reply-to-message-id.py
+++ b/hooks/require-reply-to-message-id.py
@@ -9,17 +9,37 @@ but omit or set reply_to_message_id=0.
 Exemptions (always allowed):
   - Non-Telegram sources (slack, sms, whatsapp, bot-talk, system, ...)
   - System/proactive sends where chat_id == 0 (no incoming message context)
+  - Proactive dispatcher sends where proactive=true is explicitly set
   - Calls where reply_to_message_id is already set to a positive integer
+
+The proactive=true exemption is for dispatcher-initiated sends that have no
+originating user message to thread against: startup status, graceful restart
+notifications, scheduled job summaries, health alerts routed through MCP.
+Unlike chat_id=0, these sends target a real chat_id — pass proactive=True
+explicitly to signal intent. The hook trusts the caller.
 
 Exit codes:
   0 - Allow the call
   2 - Block the call (Claude Code shows stderr message to Claude)
 
-Issue: #1168
+Issue: #1168, #2075
 """
 
 import json
 import sys
+
+
+def _is_truthy(value: object) -> bool:
+    """Return True if value represents a truthy proactive flag.
+
+    Accepts Python bool True, or the strings 'true'/'1' (case-insensitive).
+    Everything else (False, 'false', 0, None, absent) is falsy.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("true", "1")
+    return False
 
 
 def main() -> None:
@@ -40,6 +60,11 @@ def main() -> None:
 
     # Only enforce on Telegram (source absent defaults to telegram per API contract)
     if source != "telegram":
+        sys.exit(0)
+
+    # Exempt explicitly proactive sends: dispatcher-initiated messages with no
+    # originating user message (startup status, graceful restart notifications, etc.)
+    if _is_truthy(tool_input.get("proactive")):
         sys.exit(0)
 
     # Exempt proactive/system sends: chat_id == 0 means no originating user message
@@ -66,7 +91,7 @@ def main() -> None:
         "Telegram message ID shown in wait_for_messages output as\n"
         "'pass as reply_to_message_id') to thread the reply correctly.\n\n"
         "If this is a proactive/system send with no originating message,\n"
-        "pass chat_id=0 to exempt this check.",
+        "pass proactive=True (preferred) or chat_id=0 to exempt this check.",
         file=sys.stderr,
     )
     sys.exit(2)

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -1371,18 +1371,26 @@ check_session_age() {
         return 0
     fi
 
+    # Notify BEFORE sending SIGTERM (issue #2075) so the message reaches the user
+    # even if the session exits immediately once SIGTERM is delivered — if the
+    # alert were sent after kill -TERM, a fast process death could drop it
+    # entirely. Text is plain-language (a planned restart, not a crash), not
+    # internal state (PID, session age, hard-limit seconds) — the previous
+    # wording gave the user no way to distinguish a graceful restart from a
+    # health-check kill or OOM crash. Still gated on LOBSTER_DEBUG (2026-06-14
+    # noise-reduction change) — this fix only corrects ordering and wording for
+    # instances that have debug alerts enabled; it does not re-enable the alert
+    # for non-debug instances.
+    if [[ "${LOBSTER_DEBUG:-false}" == "true" ]]; then
+        send_telegram_alert_deduped "proactive-session-restart" "Restarting now — this is the planned graceful restart. Back in ~30 seconds."
+    else
+        log_info "Proactive-restart Telegram alert suppressed (LOBSTER_DEBUG not set)"
+    fi
+
     # Send SIGTERM. The Stop hook fires, writes the tombstone, and claude-persistent.sh
     # restarts Claude. This is a graceful exit, not a crash.
     if kill -TERM "$dispatcher_pid" 2>/dev/null; then
         log_warn "Session age: SIGTERM sent to dispatcher PID $dispatcher_pid"
-        if [[ "${LOBSTER_DEBUG:-false}" == "true" ]]; then
-            send_telegram_alert_deduped "proactive-session-restart" "Lobster: proactive restart at ${session_age}s (before the 7440s CC hard limit).
-
-Dispatcher PID $dispatcher_pid sent SIGTERM. Stop hook will fire, session will restart cleanly.
-Next session will start fresh — no context lost from hard limit."
-        else
-            log_info "Proactive-restart Telegram alert suppressed (LOBSTER_DEBUG not set)"
-        fi
         # Delete the start timestamp so a subsequent health check run (within the
         # next 4 minutes) does not send a second SIGTERM before the restart completes.
         rm -f "$DISPATCHER_SESSION_START_FILE" 2>/dev/null || true

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -1861,6 +1861,16 @@ async def list_tools() -> list[Tool]:
                             "even if the subagent forgets to pass sent_reply_to_user=True."
                         ),
                     },
+                    "proactive": {
+                        "type": "boolean",
+                        "description": (
+                            "If true, marks this as a proactive send (not a reply to a user message). "
+                            "Proactive sends are exempt from the require-reply-to-message-id hook enforcement — "
+                            "they do not need a reply_to_message_id. Use for startup status messages, "
+                            "graceful restart notifications, scheduled job summaries, and other sends that are "
+                            "not in response to a specific incoming message."
+                        ),
+                    },
                 },
                 "required": ["chat_id", "text"],
             },

--- a/tests/test-health-check-session-age.sh
+++ b/tests/test-health-check-session-age.sh
@@ -215,7 +215,7 @@ echo "$past_start" > "$DISPATCHER_SESSION_START_FILE"
 check_session_age
 assert_exit $? 0
 
-# 11. Telegram alert is sent when SIGTERM fires
+# 11. Telegram alert is sent when SIGTERM fires (LOBSTER_DEBUG=true)
 begin_test "telegram_alert_sent_on_sigterm"
 reset_state
 sleep 600 &
@@ -223,12 +223,71 @@ target_pid=$!
 echo "$target_pid" > "$DISPATCHER_PID_FILE"
 past_start=$(( $(date +%s) - SESSION_AGE_LIMIT_SECONDS - 60 ))
 echo "$past_start" > "$DISPATCHER_SESSION_START_FILE"
-check_session_age
+LOBSTER_DEBUG=true check_session_age
 kill "$target_pid" 2>/dev/null || true
 if [[ -f "$TELEGRAM_ALERTS_FILE" ]] && grep -q "proactive-session-restart" "$TELEGRAM_ALERTS_FILE"; then
     pass
 else
     fail "no Telegram alert with key 'proactive-session-restart' found after SIGTERM"
+fi
+
+# 12. Notification text is user-friendly (issue #2075): plain language, not raw
+# PID / session-age implementation detail ("Dispatcher PID N sent SIGTERM" /
+# "before the 7440s CC hard limit").
+begin_test "notification_text_is_user_friendly"
+reset_state
+sleep 600 &
+target_pid=$!
+echo "$target_pid" > "$DISPATCHER_PID_FILE"
+past_start=$(( $(date +%s) - SESSION_AGE_LIMIT_SECONDS - 60 ))
+echo "$past_start" > "$DISPATCHER_SESSION_START_FILE"
+LOBSTER_DEBUG=true check_session_age
+kill "$target_pid" 2>/dev/null || true
+if [[ -f "$TELEGRAM_ALERTS_FILE" ]]; then
+    alert_text=$(cat "$TELEGRAM_ALERTS_FILE")
+    if echo "$alert_text" | grep -qiE "planned|graceful restart|back in" \
+        && ! echo "$alert_text" | grep -qE "Dispatcher PID|7440s"; then
+        pass
+    else
+        fail "notification text is not plain-language (or still leaks implementation detail): $alert_text"
+    fi
+else
+    fail "no Telegram alert file found"
+fi
+
+# 13. Notification fires BEFORE SIGTERM (issue #2075): verify the source ordering
+# structurally. bash is single-threaded within a function body; if
+# send_telegram_alert_deduped appears before the executable 'kill -TERM' line in
+# check_session_age(), the alert is guaranteed to fire before SIGTERM delivery —
+# so a session that dies immediately on SIGTERM still got the message out.
+begin_test "notification_fires_before_sigterm"
+fn_body=$(sed -n '/^check_session_age()/,/^}/p' "$HEALTH_SCRIPT")
+alert_line=$(echo "$fn_body" | grep -n "send_telegram_alert_deduped" | head -1 | cut -d: -f1)
+kill_line=$(echo "$fn_body" | grep -n 'if kill -TERM' | head -1 | cut -d: -f1)
+if [[ -z "$alert_line" || -z "$kill_line" ]]; then
+    fail "could not locate send_telegram_alert_deduped or executable 'kill -TERM' in check_session_age() — alert_line='$alert_line' kill_line='$kill_line'"
+elif [[ "$alert_line" -lt "$kill_line" ]]; then
+    pass
+else
+    fail "send_telegram_alert_deduped (line $alert_line) is NOT before kill -TERM (line $kill_line) in check_session_age()"
+fi
+
+# 14. LOBSTER_DEBUG not set (or false) → alert still suppressed entirely (existing
+# noise-reduction behavior from 2026-06-14 must be preserved by this fix — the
+# ordering/wording fix must not turn this back on for non-debug instances).
+begin_test "telegram_alert_suppressed_when_debug_false"
+reset_state
+sleep 600 &
+target_pid=$!
+echo "$target_pid" > "$DISPATCHER_PID_FILE"
+past_start=$(( $(date +%s) - SESSION_AGE_LIMIT_SECONDS - 60 ))
+echo "$past_start" > "$DISPATCHER_SESSION_START_FILE"
+LOBSTER_DEBUG=false check_session_age
+kill "$target_pid" 2>/dev/null || true
+if [[ ! -f "$TELEGRAM_ALERTS_FILE" ]]; then
+    pass
+else
+    fail "Telegram alert was sent even though LOBSTER_DEBUG=false: $(cat "$TELEGRAM_ALERTS_FILE")"
 fi
 
 #===============================================================================

--- a/tests/unit/test_hooks/test_require_reply_to_message_id.py
+++ b/tests/unit/test_hooks/test_require_reply_to_message_id.py
@@ -141,3 +141,52 @@ class TestRequireReplyToMessageId:
         })
         assert rc == 2
         assert "chat_id=0" in stderr
+
+    # -------------------------------------------------------------------------
+    # proactive=true exemption (issue #2075 / fix for #2070)
+    #
+    # Dispatcher-initiated sends with no originating user message (startup
+    # status, graceful restart notifications, scheduled summaries) have a real
+    # chat_id (not 0) but nothing to thread against. Without this exemption the
+    # hook blocks them, silently dropping the message (issue #2070).
+    # -------------------------------------------------------------------------
+
+    def test_proactive_true_exempts_telegram_send_without_reply_id(self):
+        """proactive=True allows a Telegram send_reply with no reply_to_message_id."""
+        rc, _, _ = _run({
+            "source": "telegram",
+            "chat_id": 123456,
+            "text": "Back online.",
+            "proactive": True,
+        })
+        assert rc == 0
+
+    def test_proactive_string_true_is_accepted(self):
+        """proactive='true' (string, as some callers may pass it) is also honored."""
+        rc, _, _ = _run({
+            "source": "telegram",
+            "chat_id": 123456,
+            "text": "Back online.",
+            "proactive": "true",
+        })
+        assert rc == 0
+
+    def test_proactive_false_does_not_exempt(self):
+        """proactive=False must not bypass enforcement — still blocked without reply id."""
+        rc, _, stderr = _run({
+            "source": "telegram",
+            "chat_id": 123456,
+            "text": "Hello!",
+            "proactive": False,
+        })
+        assert rc == 2
+        assert "reply_to_message_id" in stderr
+
+    def test_proactive_absent_is_unaffected(self):
+        """Omitting proactive entirely preserves existing behavior — still blocked."""
+        rc, _, _ = _run({
+            "source": "telegram",
+            "chat_id": 123456,
+            "text": "Hello!",
+        })
+        assert rc == 2


### PR DESCRIPTION
## Problem

The dispatcher's planned ~2-hour graceful restart (`check_session_age()` in `scripts/health-check-v3.sh`, firing before Claude Code's 7440s hard session limit) had two independent bugs:

1. **Notification fired after the kill, not before.** `send_telegram_alert_deduped` was called only after `kill -TERM` succeeded. If the session exited before the alert's curl call completed, the user never saw it — exactly the case this restart mechanism is meant to be graceful about.
2. **Message text leaked internals.** The alert read "Lobster: proactive restart at 7260s (before the 7440s CC hard limit). Dispatcher PID N sent SIGTERM..." — there was no way for the user to tell a planned restart apart from a health-check kill or an OOM crash from the text alone.

Separately, `hooks/require-reply-to-message-id.py` (the PreToolUse hook that enforces Telegram reply threading) had no exemption for proactive dispatcher-initiated sends that target a real chat_id but have no originating user message — startup status pings, restart notifications, scheduled summaries. `chat_id=0` was the only escape hatch, and none of those sends use `chat_id=0`. Result: the post-bootup debug status message was silently dropped (issue #2070).

This PR recreates the two verified bug fixes from stale PR #2076 (opened May 8, functionally untouched for 3 months, conflicting against current main) fresh against today's main. #2076 and 7 related siblings from the same May session-handoff/EventBus redesign batch are being closed separately as stale/superseded — see comments on those PRs for why. This PR is scoped to just the two live, still-unfixed bugs.

## What changed

**`scripts/health-check-v3.sh`** — `check_session_age()` now sends the notification *before* `kill -TERM`, with plain-language text ("Restarting now — this is the planned graceful restart. Back in ~30 seconds."). The `LOBSTER_DEBUG` gate around the alert (added 2026-06-14, after #2076 was opened, to cut restart-notification noise) is preserved unchanged — this fix only corrects ordering and wording for instances that already have debug alerts on; it does not turn the alert back on for non-debug instances.

```
Before:  kill -TERM → [session may die here] → send alert (may be lost)
After:   send alert → kill -TERM → [session dies cleanly, alert already sent]
```

**`hooks/require-reply-to-message-id.py`** — adds a `proactive=True` exemption, checked before the `chat_id=0` exemption. Unlike `chat_id=0`, this targets sends with a real chat_id that still have no message to thread against. The block message's guidance text now mentions `proactive=True` as the preferred exemption alongside the existing `chat_id=0` path.

**`src/mcp/inbox_server.py`** — declares `proactive` (boolean) in `send_reply`'s tool schema so the dispatcher knows the parameter exists. Purely additive to the schema.

**`.claude/sys.dispatcher.bootup.md`** — the post-bootup debug status message instruction now specifies `send_reply(..., proactive=True)`.

## Functional patterns

Both fixes are pure/local: `_is_truthy()` in the hook is a pure predicate with no side effects; the health-check reordering has no new branching, just a moved statement gated by the same existing conditional. No shared mutable state introduced.

## Out of scope

- Does not touch anything from the other 7 PRs in the same stale batch (EventBus redesign, IPC bridge, wfm-lifecycle-logger, compact-catchup notification determinism, reflection-prompt sidecar) — those are closed separately as stale/superseded, with their underlying issues left open for future fresh work if still wanted.
- Does not change the `LOBSTER_DEBUG` gate itself (whether the alert should be on by default) — out of scope for this fix.

## Tests run

- [x] `bash tests/test-health-check-session-age.sh` — 14/14 passed, including two new tests (`notification_text_is_user_friendly`, `notification_fires_before_sigterm`) and a regression guard (`telegram_alert_suppressed_when_debug_false`, confirming the fix doesn't re-enable the alert for non-debug instances)
- [x] `uv run -m pytest tests/unit/test_hooks/test_require_reply_to_message_id.py -q` — 15/15 passed, including 4 new tests for the `proactive` exemption (bool True, string "true", bool False still blocked, absent still blocked)
- [x] Falsifiability check on both fixes: reverted each implementation file individually (test files kept), confirmed the new tests fail (2/14 and 2/15 respectively) without the fix, then restored and confirmed green again
- [x] `bash -n scripts/health-check-v3.sh` — syntax OK
- [x] `python3 -m py_compile hooks/require-reply-to-message-id.py src/mcp/inbox_server.py` — OK
- [x] Broader regression check: `uv run -m pytest tests/unit/test_hooks/ tests/unit/test_mcp_server/ -q` — 1558 passed, 14 pre-existing failures (confirmed identical on a clean, unmodified main checkout before any of this PR's changes — unrelated to this diff)

## Manual test

- Ran the hook directly with a realistic PreToolUse payload (`proactive: true`, no `reply_to_message_id`) — exit 0 (allowed). Same payload without `proactive` — exit 2 (blocked), confirming the existing enforcement path is untouched.
- Extracted `check_session_age()` into a standalone harness with a real backgrounded process standing in for the dispatcher PID, `LOBSTER_DEBUG=true`: confirmed the alert file is written *before* the SIGTERM removes the process (verified via `kill -0` after the call), with the new plain-language text and no PID/session-age/hard-limit-seconds leakage.
- No Telegram/live-service verification needed — both changes are internal (hook exit code, notification ordering); no code path here sends to a real Telegram chat during tests or manual verification.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests — the bash test stubs `send_telegram_alert_deduped`, no real Telegram call)
- [x] Manual test run — see above
- [x] User-visible outcome: not independently verified against a live Telegram send in this PR (the alert text itself is the user-visible artifact and is asserted directly in both the automated test and the manual harness); no live send was made
- [x] Side-effect audit: no floods, no unscoped writes — the health-check change only reorders two existing statements; the hook change only adds a new opt-in exemption path, default behavior for all existing callers is unchanged
- [x] External service calls: none in this diff