### PR TITLE
fix: make compaction recovery notification deterministic (#1983)

### DIFF
--- a/.claude/agents/compact-catchup.md
+++ b/.claude/agents/compact-catchup.md
@@ -216,6 +216,41 @@ After Phase 3, verify that open commitments in the session notes are also captur
     ```
     If `rolling-summary.md` could not be read or written during Phase 4, note the failure but do not abort catchup.
 
+### Phase 5: Debug recovery notification
+
+The "🔄 Back online" recovery notification used to be sent by the dispatcher
+manually after receiving this agent's `write_result` (only when
+`LOBSTER_DEBUG=true`). That made the signal contingent on dispatcher
+behavior: if the dispatcher skipped the step, crashed before reaching it, or
+mishandled the result, the notification silently never fired — while looking,
+when it did fire, like confirmation that recovery succeeded. A signal that
+fires "most of the time" is worse than no signal: it creates false confidence
+on success and ambiguous silence on failure (issue #1983).
+
+22. After Phase 4 completes (and before calling `write_result`), check
+    `LOBSTER_DEBUG`. If it is not `true`, skip this phase entirely — proceed
+    directly to `write_result`.
+
+23. If `LOBSTER_DEBUG=true`, determine ADMIN_CHAT_ID:
+    - Primary: `LOBSTER_ADMIN_CHAT_ID` environment variable.
+    - Fallback: the first entry in `TELEGRAM_ALLOWED_USERS` from `config.env`.
+    - If neither is available, skip this phase silently (never block
+      `write_result` on a missing admin chat id).
+
+24. Convert `window_start` and `now` (from Phase 1) from UTC ISO to ET
+    (EDT UTC-4 mid-March through early November, EST UTC-5 otherwise) and
+    send, via `send_reply`, to ADMIN_CHAT_ID:
+    `"🔄 Back online. Context recovered from [window_start] to [now]. [N messages] processed, [M subagents] were running."`
+    (N and M come from the same counts used in the Phase 1 output.) Pass
+    `proactive=True` — this send has no originating user message to thread
+    against (see `hooks/require-reply-to-message-id.py`).
+
+25. This phase never blocks or fails catchup: if the send errors for any
+    reason (missing admin chat id, tool failure), swallow the error and
+    continue to `write_result` as normal. The notification is best-effort;
+    the rest of catchup's work (session file, rolling summary) must not be
+    lost because of it.
+
 ## Session notes reading
 
 Read session notes from `~/lobster-user-config/memory/canonical/sessions/` in tiers:
@@ -301,7 +336,7 @@ Keep each line to one sentence. The dispatcher is on mobile -- brevity matters.
 
 ## Rules
 
-- Do NOT call `send_reply` -- this is internal context recovery, not a user message.
+- Do NOT call `send_reply` -- this is internal context recovery, not a user message -- **except** the Phase 5 debug recovery notification (`LOBSTER_DEBUG=true` only), which this agent sends directly so it fires deterministically regardless of dispatcher behavior.
 - Do NOT relay catch-up content to the user unless an event is urgent (e.g. a failed subagent that the user has not been notified about).
 - If `check_inbox` returns no messages in the window, that is valid -- report "Nothing to report" in the inbox section but still populate the session file.
 - If `compaction-state.json` is missing or corrupt, default to scanning the last 6 hours.

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -300,11 +300,10 @@ After a context compaction you lose situational awareness of the last ~30 minute
 
 **When the compact_catchup result arrives** (`task_id: "compact-catchup"`, `chat_id: 0`):
 - Read `msg["text"]` to restore situational awareness
-- Do NOT send_reply — this is internal context, except:
-  - If `LOBSTER_DEBUG=true`: send a brief status to ADMIN_CHAT_ID:
-    `"🔄 Back online. Context recovered from [window_start] to [now]. [N messages] processed, [M subagents] were running."`
-    (Fill in N and M from `msg["text"]`. ADMIN_CHAT_ID is injected at startup — read it from the top of your context.)
-    **Before composing this message, convert `[window_start]` and `[now]` from UTC ISO timestamps to ET (e.g. "5:29 AM ET"). Rule: EDT (UTC-4) mid-March through early November, EST (UTC-5) otherwise. Never send raw UTC ISO strings to the user.**
+- Do NOT send_reply — this is internal context. The debug-mode "🔄 Back online" recovery
+  notification (issue #1983) is sent by the `compact-catchup` agent itself (Phase 5, `LOBSTER_DEBUG=true`
+  only) before it calls `write_result` — no dispatcher action needed, and this fires deterministically
+  regardless of dispatcher behavior.
 - `mark_processed`
 
 ---

--- a/tests/unit/test_hooks/test_compact_catchup_notification_determinism.py
+++ b/tests/unit/test_hooks/test_compact_catchup_notification_determinism.py
@@ -1,0 +1,105 @@
+"""
+Regression test: compaction recovery notification is sent deterministically by
+the compact-catchup agent itself, not manually by the dispatcher (issue #1983).
+
+Before this fix, the "🔄 Back online" notification was sent by the dispatcher
+after it received compact-catchup's write_result, gated on LOBSTER_DEBUG. This
+made the signal contingent on dispatcher behavior: if the dispatcher skipped
+the step, crashed before reaching it, or mishandled the result, the
+notification silently never fired -- while looking, when it did fire, like
+confirmation that recovery succeeded. Issue #1983 calls this "epistemic rot":
+a signal that fires "most of the time" is worse than no signal, because its
+presence cannot be trusted and its absence is ambiguous.
+
+The fix moves the notification into compact-catchup.md as a new Phase 5,
+sent directly by the agent before write_result -- so it fires (or doesn't)
+based on the agent's own completion, not on downstream dispatcher handling.
+
+These are characterization tests over the agent instruction files (markdown,
+not Python) -- the behavior lives in LLM-followed instructions, so the test
+asserts on the structural presence/absence of the relevant instructions
+rather than executing code. This mirrors the existing regression-guard
+pattern in test_dispatcher_bootup_single_pass_read.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parents[3]
+_COMPACT_CATCHUP = _REPO_ROOT / ".claude" / "agents" / "compact-catchup.md"
+_DISPATCHER_BOOTUP = _REPO_ROOT / ".claude" / "sys.dispatcher.bootup.md"
+
+
+def test_compact_catchup_file_exists() -> None:
+    assert _COMPACT_CATCHUP.exists(), f"compact-catchup.md not found at {_COMPACT_CATCHUP}"
+
+
+def test_dispatcher_bootup_file_exists() -> None:
+    assert _DISPATCHER_BOOTUP.exists(), f"sys.dispatcher.bootup.md not found at {_DISPATCHER_BOOTUP}"
+
+
+def test_compact_catchup_sends_notification_itself() -> None:
+    """compact-catchup.md must instruct the agent to send the recovery
+    notification itself (Phase 5), gated on LOBSTER_DEBUG, before write_result.
+    """
+    content = _COMPACT_CATCHUP.read_text()
+    assert "Phase 5" in content, (
+        "compact-catchup.md is missing the 'Phase 5' debug recovery notification "
+        "phase (issue #1983) -- the agent must send the 'Back online' notification "
+        "itself so it fires deterministically."
+    )
+    assert "LOBSTER_DEBUG" in content, (
+        "compact-catchup.md's Phase 5 must gate the notification on LOBSTER_DEBUG, "
+        "matching the existing debug-only behavior."
+    )
+    assert "Back online" in content, (
+        "compact-catchup.md must contain the 'Back online' recovery notification text "
+        "as part of Phase 5."
+    )
+    assert "proactive=True" in content, (
+        "compact-catchup.md's Phase 5 send_reply must pass proactive=True -- this "
+        "notification has no originating user message to thread against "
+        "(hooks/require-reply-to-message-id.py)."
+    )
+
+
+def test_compact_catchup_rules_document_send_reply_exception() -> None:
+    """The 'Do NOT call send_reply' rule must document the Phase 5 exception,
+    otherwise the blanket rule contradicts the new Phase 5 instruction.
+    """
+    content = _COMPACT_CATCHUP.read_text()
+    assert "except" in content and "Phase 5" in content, (
+        "compact-catchup.md's Rules section must carve out an explicit exception "
+        "for the Phase 5 debug notification send_reply call."
+    )
+
+
+def test_dispatcher_no_longer_sends_notification_manually() -> None:
+    """sys.dispatcher.bootup.md must NOT instruct the dispatcher to manually
+    send the 'Back online' notification -- that responsibility now lives
+    entirely inside the compact-catchup agent (Phase 5).
+    """
+    content = _DISPATCHER_BOOTUP.read_text()
+    assert "send a brief status to ADMIN_CHAT_ID" not in content, (
+        "sys.dispatcher.bootup.md still instructs the dispatcher to manually send "
+        "the recovery notification. Issue #1983's fix moves this into "
+        "compact-catchup.md Phase 5 so it fires deterministically regardless of "
+        "dispatcher behavior -- remove the manual instruction."
+    )
+    assert "Back online. Context recovered from [window_start]" not in content, (
+        "sys.dispatcher.bootup.md still contains the manual 'Back online' "
+        "notification template. This must be removed -- the compact-catchup agent "
+        "sends it directly now (issue #1983)."
+    )
+
+
+def test_dispatcher_bootup_references_agent_owned_notification() -> None:
+    """sys.dispatcher.bootup.md's compact_catchup-result handler must note that
+    the notification is agent-owned, so a reader doesn't wonder where it went.
+    """
+    content = _DISPATCHER_BOOTUP.read_text()
+    assert "#1983" in content, (
+        "sys.dispatcher.bootup.md should reference issue #1983 near the "
+        "compact_catchup result handler to explain why no manual send is needed."
+    )


### PR DESCRIPTION
## Problem

The debug-mode "🔄 Back online. Context recovered from X to Y." notification was sent by the dispatcher manually, after it received `compact-catchup`'s `write_result`, gated on `LOBSTER_DEBUG=true`. This made the signal contingent on dispatcher behavior:

1. If the dispatcher processes the result correctly → notification fires.
2. If the dispatcher skips the step, crashes before reaching it, or mishandles the result → silence, with no error raised.

A signal that fires "most of the time" is worse than no signal at all: when it fires, it looks like confirmation that recovery succeeded; when it doesn't, there's no way to tell whether recovery failed or the dispatcher just forgot to notify. Issue #1983 calls this epistemic rot.

This recreates the fix from stale PR #2043 (opened May 8, functionally untouched for 3 months, closed today as conflicting against current main) fresh against today's main — same design, verified independently against the current dispatcher/agent files rather than rebased through 3 months of drift.

## What changed

**`.claude/agents/compact-catchup.md`** — new Phase 5: after Phases 1–4 complete, if `LOBSTER_DEBUG=true`, the agent sends the recovery notification directly to `ADMIN_CHAT_ID` (with `proactive=True`, per the `require-reply-to-message-id` hook's exemption) before calling `write_result`. The notification now fires — or doesn't — based on the agent's own completion, not on downstream dispatcher handling. Failure to send (missing admin chat id, tool error) is swallowed and never blocks `write_result`. The "Do NOT call `send_reply`" rule is updated to carve out this one exception.

**`.claude/sys.dispatcher.bootup.md`** — the manual notification instructions (6 lines: check `LOBSTER_DEBUG`, build the message, convert timestamps to ET) are replaced with a one-line note that the agent already handled it.

```
Before:
  compact-catchup agent -> write_result(chat_id=0)
  -> dispatcher receives result -> reads msg["text"]
  -> IF LOBSTER_DEBUG: dispatcher sends "Back online" (may be skipped/missed)
  -> dispatcher mark_processed

After:
  compact-catchup agent
  -> Phase 5: send_reply("Back online", proactive=True) if LOBSTER_DEBUG (always attempted)
  -> write_result(chat_id=0)
  -> dispatcher receives result -> reads msg["text"]
  -> dispatcher mark_processed (no send needed -- agent already sent it)
```

## Functional patterns

Phase 5 is a pure addition with no side effects on Phases 1–4 — it reads from state already computed earlier in the same agent run (window_start/now/N/M) and is wrapped in a swallow-and-continue failure boundary, so a notification failure never mutates or blocks the rest of catchup's work (session file, rolling summary, commitment carry-forward).

## Out of scope

- Does not touch the other 3 PRs from the same stale batch (#2034/#1895, #2047/#2003, #2042/#1998) — those are being assessed separately.
- Does not change the `LOBSTER_DEBUG` gate itself, or anything about *what* the notification says — only *where* it's sent from.

## Tests run

Both `compact-catchup.md` and `sys.dispatcher.bootup.md` are LLM-instruction files, not executable Python — there's no function to unit-test directly. Following the existing precedent in this repo (`tests/unit/test_hooks/test_dispatcher_bootup_single_pass_read.py`), the automated tests are characterization tests over the file content: they assert the specific instruction text that encodes the new/old behavior is present/absent.

- [x] `uv run -m pytest tests/unit/test_hooks/test_compact_catchup_notification_determinism.py -q` — 6/6 passed (new test file)
- [x] Falsifiability check: `git stash` the two `.claude/*.md` edits (reverting to pre-fix content), reran the same test file — 4/6 failed (the two file-existence sanity checks still passed, as expected). Restored the edits (`git stash pop`) and confirmed 6/6 green again.
- [x] `uv run -m pytest tests/unit/test_hooks/ -q` — 621 passed, 8 pre-existing failures (`test_context_monitor.py::test_settings_json_uses_fixed_matcher` and 7 in `test_on_compact_write_claude_session_id.py`) — same failures present on a clean main checkout before this diff (confirmed while reviewing PR #2145 immediately prior to this one), unrelated to this change.

## Manual test

No live compaction was triggered — this is a debug-only Telegram notification, and the change is scoped to two markdown instruction files with no Python code path to execute. Verified by direct diff inspection: the 6-line manual-send instruction in `sys.dispatcher.bootup.md` is gone, replaced by a 1-line note; the new Phase 5 in `compact-catchup.md` reproduces the same message template, ET conversion requirement, and `LOBSTER_DEBUG` gate that the old dispatcher-side code had, just relocated.

User-visible outcome: not independently verified against a live Telegram send (would require a real compaction with `LOBSTER_DEBUG=true`). This mirrors how the same limitation was handled and disclosed in the original attempt (PR #2043).

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits — no Telegram call in the characterization tests)
- [ ] Integration/manual test — not run; requires a live compaction, no test environment exists for this. Documented above rather than skipped silently.
- [ ] User-visible outcome — not independently verified (see Manual test)
- [x] Side-effect audit: no floods, no unscoped writes — this only relocates one existing debug-gated Telegram send from the dispatcher to the agent; send volume (at most one message per compaction when LOBSTER_DEBUG=true) is unchanged
- [x] External service calls: `send_reply` is an existing, already-tested MCP tool; no new external call surface introduced

Closes #1983