### PR TITLE
fix(startup): write reflection prompts to a sidecar file, not the inbox (#1998)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -54,6 +54,10 @@ When you first start (or after reading this file), follow these steps:
     - `startup-cause: restart` → this was a plain restart (systemd, external kill, or health-check). No compact-reminder will be in the inbox. Spawn `startup-catchup` at step 4 for a normal restart window.
     - Skip if step 2c already sent a restart notification (context-handoff.json was recent).
     - **Do not use `compaction-state.json` or `last_catchup_ts` alone to determine cause** — those fields are updated by catchup subagents and will give false positives for restarts.
+2e. **Check for a debug-mode reflection prompt sidecar** (issue #1998): read `~/messages/bootup-prompt.md`.
+    - If the file does not exist: skip, nothing to do.
+    - If it exists: read its content, then delete it (`rm -f ~/messages/bootup-prompt.md`) — this is a one-shot prompt, not a persistent message. Reflect genuinely on the bootup/compaction experience it asks about: were there friction points, gaps, or improvements worth capturing? If there are substantive observations, file or update GitHub issues in SiderealPress/lobster, or open PRs for straightforward fixes. If nothing is worth capturing, do nothing further — silence is the correct response.
+    - This replaces the old flow where `on-compact.py`/`on-fresh-start.py` wrote a `reflection_prompt` inbox message that the dispatcher had to `mark_processing` + `mark_processed` (2 extra MCP round-trips per restart, only to be read once and discarded). One `Read` call here does the same job with zero claim/process overhead.
 
 3. **Claim any pending user messages immediately** to stop the health-check staleness clock:
     - Call `check_inbox()` to get any messages currently waiting in the inbox
@@ -379,23 +383,11 @@ Rules: never `send_reply` (chat_id: 0).
 
 ---
 
-### reflection_prompt (`type: "reflection_prompt"`)
+### reflection_prompt (`type: "reflection_prompt"`) — legacy, inbox path
 
-Debug-mode prompts written by `on-compact.py` and `on-fresh-start.py` when `LOBSTER_DEBUG=true`. They arrive after a compaction or fresh bootup and ask the dispatcher to reflect on the experience while it is fresh.
+**Superseded by step 2e (issue #1998).** Debug-mode reflection prompts are now written to the `~/messages/bootup-prompt.md` sidecar file and read-and-deleted directly at startup — see step 2e above. `on-compact.py` and `on-fresh-start.py` no longer write `reflection_prompt` messages to the inbox.
 
-```
-1. mark_processing(message_id)
-2. Read msg["text"] — the reflection question
-3. Reflect genuinely: were there friction points, gaps, or improvements in the
-   bootup/compaction flow worth capturing?
-4. If there are substantive observations:
-   - File or update GitHub issues in SiderealPress/lobster
-   - Open PRs for straightforward fixes (no need to wait for instruction)
-   - If nothing worth capturing: do nothing — silence is the correct response
-5. mark_processed(message_id)
-```
-
-Rules: never `send_reply` (chat_id: 0). Reflection is optional — only act if there are real observations.
+If a message of this type is nonetheless encountered (e.g. a pre-#1998 hook version, or one queued before an upgrade landed): `mark_processing(message_id)` then `mark_processed(message_id)` without reflecting — do not act on it. Step 2e already covers reflection for the current startup; re-reflecting on a stale queued copy risks duplicate or contradictory GitHub activity.
 
 ---
 

--- a/hooks/on-compact.py
+++ b/hooks/on-compact.py
@@ -64,6 +64,10 @@ from session_role import (
 INBOX_DIR = Path(os.path.expanduser("~/messages/inbox"))
 PROCESSING_DIR = Path(os.path.expanduser("~/messages/processing"))
 PROCESSED_DIR = Path(os.path.expanduser("~/messages/processed"))
+# Sidecar file for debug-mode reflection prompts (issue #1998). Read-and-deleted
+# by the dispatcher directly at startup instead of flowing through the inbox --
+# avoids 2 MCP round-trips (mark_processing + mark_processed) per restart.
+BOOTUP_PROMPT_FILE = Path(os.path.expanduser("~/messages/bootup-prompt.md"))
 OUTBOX_DIR = Path(
     os.environ.get(
         "LOBSTER_OUTBOX_DIR_OVERRIDE",
@@ -536,44 +540,22 @@ def _is_dispatcher_compact(data: dict) -> bool:
     return True
 
 
-def _reflection_already_exists(msg_id: str) -> bool:
-    """Return True if a reflection message with the given ID already exists.
-
-    Scans inbox/, processing/, and processed/ to prevent concurrent hook
-    invocations from writing duplicate reflection files with the same ID.
-    Multiple subagent SessionStart events may fire within the same second,
-    producing the same msg_id (1-second precision) but different filenames
-    (millisecond-precision).  This check short-circuits all but the first
-    invocation.
-
-    Silent on all errors — must never crash the hook.
-    """
-    for directory in (INBOX_DIR, PROCESSING_DIR, PROCESSED_DIR):
-        if not directory.exists():
-            continue
-        for f in directory.glob("*.json"):
-            try:
-                data = json.loads(f.read_text())
-                if data.get("id") == msg_id:
-                    return True
-            except Exception:  # noqa: BLE001
-                continue
-    return False
-
-
 def _schedule_reflection_prompt(trigger: str) -> None:
-    """In debug mode, write a reflection-prompt message to the inbox.
+    """In debug mode, write a reflection prompt to the bootup-prompt sidecar file.
 
-    When LOBSTER_DEBUG=true, drops a message asking the dispatcher to reflect
-    on the bootup/compaction experience and file GitHub issues with observations.
-    Written immediately — the dispatcher processes inbox messages in order so it
-    will reach this after handling the compact-reminder and catching up.
+    When LOBSTER_DEBUG=true, writes a plain-text prompt asking the dispatcher
+    to reflect on the bootup/compaction experience and file GitHub issues with
+    observations. The dispatcher reads and deletes this file directly at
+    startup (one `Read` call -- see sys.dispatcher.bootup.md step 2e) instead
+    of the prompt flowing through the inbox as a regular message. This
+    eliminates the 2 MCP round-trips per restart (`mark_processing` +
+    `mark_processed`) the inbox path required (issue #1998).
 
-    Dedup: computes the msg_id first and checks inbox/, processing/, and
-    processed/ for an existing file with the same ID.  Concurrent hook
-    invocations within the same second will share the same ID (1-second
-    precision) but write different filenames (millisecond-precision).  The
-    first invocation wins; subsequent ones skip silently.
+    Overwrites any previous sidecar file unconditionally: at most one bootup
+    prompt is ever meaningful at a time (the dispatcher consumes and deletes it
+    on every startup before the next one could be written), so last-writer-wins
+    is correct here -- no ID-based dedup bookkeeping is needed, unlike the old
+    inbox-message path.
 
     Silent on any failure — must never crash the hook.
     """
@@ -581,51 +563,21 @@ def _schedule_reflection_prompt(trigger: str) -> None:
         return
 
     try:
-        INBOX_DIR.mkdir(parents=True, exist_ok=True)
-
-        ts = time.time()
-        msg_id = f"reflection_{trigger}_{int(ts)}"
-
-        # Dedup: skip if a reflection with this ID already exists.
-        if _reflection_already_exists(msg_id):
-            print(
-                f"[on-compact] debug: reflection prompt {msg_id!r} already exists — skipping",
-                file=sys.stderr,
-            )
-            return
-
-        timestamp = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + ".000000"
+        BOOTUP_PROMPT_FILE.parent.mkdir(parents=True, exist_ok=True)
 
         content = (
             f"[Debug] {trigger.capitalize()} reflection prompt:\n\n"
             "How was the experience? Were there friction points, gaps, or improvements "
             "worth capturing?\n\n"
             "If you have observations: file or update GitHub issues in SiderealPress/lobster, "
-            "or open PRs for straightforward fixes. Capture it while it's fresh."
+            "or open PRs for straightforward fixes. Capture it while it's fresh.\n"
         )
 
-        msg = {
-            "id": msg_id,
-            "source": "system",
-            "chat_id": 0,
-            "user_id": 0,
-            "username": "lobster-system",
-            "user_name": "System",
-            "type": "reflection_prompt",
-            "trigger": trigger,
-            "text": content,
-            "timestamp": timestamp,
-        }
-
-        # Use current epoch_ms so this sorts after the compact-reminder (ts_ms=0)
-        # and after any queued user messages, but before future messages.
-        ts_ms = int(ts * 1000)
-        msg_path = INBOX_DIR / f"{ts_ms}_reflection_{trigger}.json"
-        tmp_path = msg_path.with_suffix(".tmp")
-        tmp_path.write_text(json.dumps(msg, indent=2) + "\n")
-        tmp_path.rename(msg_path)
+        tmp_path = BOOTUP_PROMPT_FILE.with_suffix(".tmp")
+        tmp_path.write_text(content)
+        tmp_path.rename(BOOTUP_PROMPT_FILE)
         print(
-            f"[on-compact] debug: wrote reflection prompt to {msg_path}",
+            f"[on-compact] debug: wrote reflection prompt to {BOOTUP_PROMPT_FILE}",
             file=sys.stderr,
         )
     except Exception as exc:  # noqa: BLE001

--- a/hooks/on-fresh-start.py
+++ b/hooks/on-fresh-start.py
@@ -109,6 +109,10 @@ COMPACTION_STATE_FILE = Path(
 INBOX_DIR = Path(os.path.expanduser("~/messages/inbox"))
 PROCESSING_DIR = Path(os.path.expanduser("~/messages/processing"))
 PROCESSED_DIR = Path(os.path.expanduser("~/messages/processed"))
+# Sidecar file for debug-mode reflection prompts (issue #1998). Read-and-deleted
+# by the dispatcher directly at startup instead of flowing through the inbox --
+# avoids 2 MCP round-trips (mark_processing + mark_processed) per restart.
+BOOTUP_PROMPT_FILE = Path(os.path.expanduser("~/messages/bootup-prompt.md"))
 
 # inflight-work.jsonl path — append-only log of subagent spawns and completions.
 # On startup, stale "running" entries with no corresponding "done" are compacted out.
@@ -539,44 +543,22 @@ def _inject_compact_reminder() -> None:
         )
 
 
-def _reflection_already_exists(msg_id: str) -> bool:
-    """Return True if a reflection message with the given ID already exists.
-
-    Scans inbox/, processing/, and processed/ to prevent concurrent hook
-    invocations from writing duplicate reflection files with the same ID.
-    Multiple subagent SessionStart events may fire within the same second,
-    producing the same msg_id (1-second precision) but different filenames
-    (millisecond-precision).  This check short-circuits all but the first
-    invocation.
-
-    Silent on all errors — must never crash the hook.
-    """
-    for directory in (INBOX_DIR, PROCESSING_DIR, PROCESSED_DIR):
-        if not directory.exists():
-            continue
-        for f in directory.glob("*.json"):
-            try:
-                data = json.loads(f.read_text())
-                if data.get("id") == msg_id:
-                    return True
-            except Exception:  # noqa: BLE001
-                continue
-    return False
-
-
 def _schedule_reflection_prompt(trigger: str) -> None:
-    """In debug mode, write a reflection-prompt message to the inbox.
+    """In debug mode, write a reflection prompt to the bootup-prompt sidecar file.
 
-    When LOBSTER_DEBUG=true, drops a message asking the dispatcher to reflect
-    on the bootup/compaction experience and file GitHub issues with observations.
-    Written immediately — the dispatcher processes inbox messages in order so it
-    will reach this after the compact-reminder and catchup handling.
+    When LOBSTER_DEBUG=true, writes a plain-text prompt asking the dispatcher
+    to reflect on the bootup/compaction experience and file GitHub issues with
+    observations. The dispatcher reads and deletes this file directly at
+    startup (one `Read` call -- see sys.dispatcher.bootup.md step 2e) instead
+    of the prompt flowing through the inbox as a regular message. This
+    eliminates the 2 MCP round-trips per restart (`mark_processing` +
+    `mark_processed`) the inbox path required (issue #1998).
 
-    Dedup: computes the msg_id first and checks inbox/, processing/, and
-    processed/ for an existing file with the same ID.  Concurrent hook
-    invocations within the same second will share the same ID (1-second
-    precision) but write different filenames (millisecond-precision).  The
-    first invocation wins; subsequent ones skip silently.
+    Overwrites any previous sidecar file unconditionally: at most one bootup
+    prompt is ever meaningful at a time (the dispatcher consumes and deletes it
+    on every startup before the next one could be written), so last-writer-wins
+    is correct here -- no ID-based dedup bookkeeping is needed, unlike the old
+    inbox-message path.
 
     Silent on any failure — must never crash the hook.
     """
@@ -584,51 +566,21 @@ def _schedule_reflection_prompt(trigger: str) -> None:
         return
 
     try:
-        INBOX_DIR.mkdir(parents=True, exist_ok=True)
-
-        ts = time.time()
-        msg_id = f"reflection_{trigger}_{int(ts)}"
-
-        # Dedup: skip if a reflection with this ID already exists.
-        if _reflection_already_exists(msg_id):
-            print(
-                f"[on-fresh-start] debug: reflection prompt {msg_id!r} already exists — skipping",
-                file=sys.stderr,
-            )
-            return
-
-        timestamp = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + ".000000"
+        BOOTUP_PROMPT_FILE.parent.mkdir(parents=True, exist_ok=True)
 
         content = (
             f"[Debug] {trigger.capitalize()} reflection prompt:\n\n"
             "How was the experience? Were there friction points, gaps, or improvements "
             "worth capturing?\n\n"
             "If you have observations: file or update GitHub issues in SiderealPress/lobster, "
-            "or open PRs for straightforward fixes. Capture it while it's fresh."
+            "or open PRs for straightforward fixes. Capture it while it's fresh.\n"
         )
 
-        msg = {
-            "id": msg_id,
-            "source": "system",
-            "chat_id": 0,
-            "user_id": 0,
-            "username": "lobster-system",
-            "user_name": "System",
-            "type": "reflection_prompt",
-            "trigger": trigger,
-            "text": content,
-            "timestamp": timestamp,
-        }
-
-        # Use current epoch_ms so this sorts after the startup compact-reminder
-        # (ts_ms=0/1) and after any queued user messages.
-        ts_ms = int(ts * 1000)
-        msg_path = INBOX_DIR / f"{ts_ms}_reflection_{trigger}.json"
-        tmp_path = msg_path.with_suffix(".tmp")
-        tmp_path.write_text(json.dumps(msg, indent=2) + "\n")
-        tmp_path.rename(msg_path)
+        tmp_path = BOOTUP_PROMPT_FILE.with_suffix(".tmp")
+        tmp_path.write_text(content)
+        tmp_path.rename(BOOTUP_PROMPT_FILE)
         print(
-            f"[on-fresh-start] debug: wrote reflection prompt to {msg_path}",
+            f"[on-fresh-start] debug: wrote reflection prompt to {BOOTUP_PROMPT_FILE}",
             file=sys.stderr,
         )
     except Exception as exc:  # noqa: BLE001

--- a/tests/unit/test_hooks/test_bootup_prompt_sidecar_dispatcher_flow.py
+++ b/tests/unit/test_hooks/test_bootup_prompt_sidecar_dispatcher_flow.py
@@ -1,0 +1,78 @@
+"""
+Regression test: sys.dispatcher.bootup.md reads the reflection prompt from the
+bootup-prompt.md sidecar file at startup, not from an inbox message (#1998).
+
+Before this fix, on-compact.py / on-fresh-start.py wrote a reflection_prompt
+message to the inbox in debug mode, and the dispatcher had to mark_processing +
+mark_processed it like any other message -- 2 extra MCP round-trips on the
+startup critical path, just to read a one-shot prompt once and discard it.
+
+The fix adds a startup step (2e) that reads and deletes a plain sidecar file
+(~/messages/bootup-prompt.md) directly -- one Read call, zero claim/process
+overhead -- and marks the old inbox-message handler as legacy.
+
+Like test_dispatcher_bootup_single_pass_read.py, this is a characterization
+test over the agent instruction file (markdown, not Python) -- the behavior
+lives in LLM-followed instructions, so the test asserts on the structural
+presence/absence of the relevant instructions.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parents[3]
+_DISPATCHER_BOOTUP = _REPO_ROOT / ".claude" / "sys.dispatcher.bootup.md"
+
+
+def test_bootup_file_exists() -> None:
+    assert _DISPATCHER_BOOTUP.exists(), f"sys.dispatcher.bootup.md not found at {_DISPATCHER_BOOTUP}"
+
+
+def test_startup_reads_bootup_prompt_sidecar() -> None:
+    """Step 2e must instruct the dispatcher to read (and delete) the sidecar
+    file directly, instead of relying on an inbox message + claim/process.
+    """
+    content = _DISPATCHER_BOOTUP.read_text()
+    assert "bootup-prompt.md" in content, (
+        "sys.dispatcher.bootup.md is missing the bootup-prompt.md sidecar file "
+        "reference (issue #1998) -- the dispatcher must read the debug reflection "
+        "prompt directly from this file at startup."
+    )
+    assert "2e" in content, (
+        "sys.dispatcher.bootup.md should add the sidecar-read as an explicit "
+        "startup step (2e) alongside the other lettered startup sub-steps."
+    )
+
+
+def test_reflection_prompt_handler_marked_legacy() -> None:
+    """The old inbox-message reflection_prompt handler must be marked legacy
+    and must not instruct the dispatcher to reflect on it -- reflection now
+    happens once, at step 2e, from the sidecar file.
+    """
+    content = _DISPATCHER_BOOTUP.read_text()
+    assert "legacy" in content.lower(), (
+        "sys.dispatcher.bootup.md's reflection_prompt message handler must be "
+        "marked as legacy/superseded now that step 2e (sidecar file) is the "
+        "canonical path (issue #1998)."
+    )
+
+
+def test_legacy_handler_does_not_reflect_on_stale_messages() -> None:
+    """The legacy reflection_prompt handler must tell the dispatcher to drop a
+    stale/queued message silently (mark_processing + mark_processed, no
+    reflection) -- not to reflect on it. Reflection now happens exactly once,
+    at step 2e, from the sidecar file; re-reflecting on a stale dequeued copy
+    risks duplicate or contradictory GitHub activity.
+    """
+    content = _DISPATCHER_BOOTUP.read_text()
+    assert "Reflect genuinely: were there friction points" not in content, (
+        "sys.dispatcher.bootup.md's legacy reflection_prompt handler still contains "
+        "the old 'Reflect genuinely...' instruction. It should instead say to drop "
+        "the message without reflecting -- see step 2e for the one canonical "
+        "reflection path (issue #1998)."
+    )
+    assert "without reflecting" in content or "do not act on it" in content, (
+        "sys.dispatcher.bootup.md's legacy reflection_prompt handler must explicitly "
+        "instruct the dispatcher not to reflect on a stale/queued message."
+    )

--- a/tests/unit/test_hooks/test_reflection_prompt.py
+++ b/tests/unit/test_hooks/test_reflection_prompt.py
@@ -1,22 +1,29 @@
 """
 Unit tests for _schedule_reflection_prompt() in on-compact.py and on-fresh-start.py.
 
+Issue #1998: reflection prompts used to flow through the inbox as regular
+messages, costing the dispatcher 2 extra MCP round-trips per restart
+(mark_processing + mark_processed) just to read a one-shot debug prompt once
+and discard it. The fix writes the prompt to a sidecar file
+(~/messages/bootup-prompt.md) instead -- the dispatcher reads and deletes it
+directly at startup (one Read call, see sys.dispatcher.bootup.md step 2e).
+
 Verifies:
-- In debug mode, writes a well-formed reflection_prompt message to the inbox
+- In debug mode, writes the prompt to the sidecar file (not the inbox)
 - In non-debug mode, writes nothing
-- Written message has expected fields and content
+- Sidecar content contains the expected trigger and key phrases
 - Atomic write (no .tmp file left behind)
+- A second call (e.g. a later restart) overwrites the sidecar file rather
+  than accumulating -- there is no dedup bookkeeping needed since only the
+  most recent prompt is ever meaningful
 - Silent on filesystem errors (never crashes the hook)
 """
 
 import importlib.util
-import json
 import os
 import sys
 import types
 from pathlib import Path
-
-import pytest
 
 _HOOKS_DIR = Path(__file__).parents[3] / "hooks"
 
@@ -55,12 +62,7 @@ def _make_session_role_stub(is_dispatcher: bool = True):
     return stub
 
 
-def _load_on_compact(
-    inbox_dir: str = None,
-    compaction_state_override: str = None,
-    processing_dir: str = None,
-    processed_dir: str = None,
-):
+def _load_on_compact(bootup_prompt_file: str = None, compaction_state_override: str = None):
     """Load hooks/on-compact.py as a module, with isolated file paths."""
     env_patch = {}
     if compaction_state_override:
@@ -73,23 +75,14 @@ def _load_on_compact(
         sys.modules.setdefault("session_role", _make_session_role_stub())
         spec.loader.exec_module(mod)
 
-    if inbox_dir:
-        mod.INBOX_DIR = Path(inbox_dir)
+    if bootup_prompt_file:
+        mod.BOOTUP_PROMPT_FILE = Path(bootup_prompt_file)
     if compaction_state_override:
         mod.COMPACTION_STATE_FILE = Path(compaction_state_override)
-    if processing_dir:
-        mod.PROCESSING_DIR = Path(processing_dir)
-    if processed_dir:
-        mod.PROCESSED_DIR = Path(processed_dir)
     return mod
 
 
-def _load_on_fresh_start(
-    inbox_dir: str = None,
-    compaction_state_override: str = None,
-    processing_dir: str = None,
-    processed_dir: str = None,
-):
+def _load_on_fresh_start(bootup_prompt_file: str = None, compaction_state_override: str = None):
     """Load hooks/on-fresh-start.py as a module, with isolated file paths."""
     env_patch = {}
     if compaction_state_override:
@@ -102,14 +95,10 @@ def _load_on_fresh_start(
         sys.modules.setdefault("session_role", _make_session_role_stub())
         spec.loader.exec_module(mod)
 
-    if inbox_dir:
-        mod.INBOX_DIR = Path(inbox_dir)
+    if bootup_prompt_file:
+        mod.BOOTUP_PROMPT_FILE = Path(bootup_prompt_file)
     if compaction_state_override:
         mod.COMPACTION_STATE_FILE = Path(compaction_state_override)
-    if processing_dir:
-        mod.PROCESSING_DIR = Path(processing_dir)
-    if processed_dir:
-        mod.PROCESSED_DIR = Path(processed_dir)
     return mod
 
 
@@ -120,94 +109,85 @@ def _load_on_fresh_start(
 class TestScheduleReflectionPromptCompact:
     """Tests for _schedule_reflection_prompt() in on-compact.py."""
 
-    def test_writes_inbox_file_in_debug_mode(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        mod = _load_on_compact(inbox_dir=str(inbox))
+    def test_writes_sidecar_file_in_debug_mode(self, tmp_path):
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_compact(bootup_prompt_file=str(sidecar))
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             mod._schedule_reflection_prompt("compaction")
 
-        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-        assert len(files) == 1, f"expected 1 file, got {[f.name for f in files]}"
+        assert sidecar.exists(), "sidecar file should be written in debug mode"
 
     def test_does_not_write_in_non_debug_mode(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        mod = _load_on_compact(inbox_dir=str(inbox))
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_compact(bootup_prompt_file=str(sidecar))
 
         with _PatchEnv({"LOBSTER_DEBUG": "false"}):
             mod._schedule_reflection_prompt("compaction")
 
-        files = list(inbox.iterdir())
-        assert len(files) == 0
+        assert not sidecar.exists()
 
     def test_does_not_write_when_debug_env_absent(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        mod = _load_on_compact(inbox_dir=str(inbox))
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_compact(bootup_prompt_file=str(sidecar))
 
-        env_without_debug = {k: v for k, v in os.environ.items() if k != "LOBSTER_DEBUG"}
         with _PatchEnv({"LOBSTER_DEBUG": ""}):
             mod._schedule_reflection_prompt("compaction")
 
-        files = list(inbox.iterdir())
-        assert len(files) == 0
+        assert not sidecar.exists()
 
-    def test_written_message_has_correct_type_and_trigger(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        mod = _load_on_compact(inbox_dir=str(inbox))
+    def test_sidecar_content_contains_trigger_and_key_phrases(self, tmp_path):
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_compact(bootup_prompt_file=str(sidecar))
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             mod._schedule_reflection_prompt("compaction")
 
-        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-        data = json.loads(files[0].read_text())
-        assert data["type"] == "reflection_prompt"
-        assert data["trigger"] == "compaction"
-        assert data["source"] == "system"
-        assert data["chat_id"] == 0
-
-    def test_written_message_content_contains_key_phrases(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        mod = _load_on_compact(inbox_dir=str(inbox))
-
-        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
-            mod._schedule_reflection_prompt("compaction")
-
-        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-        data = json.loads(files[0].read_text())
-        text = data["text"]
+        text = sidecar.read_text()
+        assert "Compaction" in text
         assert "friction" in text.lower() or "observations" in text.lower()
         assert "SiderealPress/lobster" in text
 
     def test_no_tmp_file_left_behind(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        mod = _load_on_compact(inbox_dir=str(inbox))
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_compact(bootup_prompt_file=str(sidecar))
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             mod._schedule_reflection_prompt("compaction")
 
-        tmp_files = [f for f in inbox.iterdir() if f.suffix == ".tmp"]
+        tmp_files = list(tmp_path.glob("*.tmp"))
         assert len(tmp_files) == 0, f"tmp files left behind: {tmp_files}"
 
-    def test_creates_inbox_dir_if_absent(self, tmp_path):
-        inbox = tmp_path / "inbox_not_created_yet"
-        mod = _load_on_compact(inbox_dir=str(inbox))
+    def test_creates_parent_dir_if_absent(self, tmp_path):
+        sidecar = tmp_path / "not_created_yet" / "bootup-prompt.md"
+        mod = _load_on_compact(bootup_prompt_file=str(sidecar))
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             mod._schedule_reflection_prompt("compaction")
 
-        assert inbox.exists()
-        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-        assert len(files) == 1
+        assert sidecar.exists()
 
-    def test_silent_on_write_failure(self, tmp_path):
-        """Must not raise when the inbox path is not writable."""
-        mod = _load_on_compact(inbox_dir="/proc/lobster_test_nonexistent/inbox")
+    def test_second_call_overwrites_rather_than_accumulates(self, tmp_path):
+        """A later restart's prompt replaces the previous one -- no dedup
+        bookkeeping needed, since only the most recent prompt matters (issue
+        #1998's sidecar design, unlike the old inbox path's ID-based dedup).
+        """
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_compact(bootup_prompt_file=str(sidecar))
+
+        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
+            mod._schedule_reflection_prompt("compaction")
+            mod._schedule_reflection_prompt("compaction")
+
+        # Still exactly one sidecar file (overwritten), not two, and no leftover
+        # .tmp artifact from either write.
+        assert sidecar.exists()
+        matches = list(sidecar.parent.glob("bootup-prompt.md*"))
+        assert matches == [sidecar], f"expected only the sidecar file, got: {matches}"
+
+    def test_silent_on_write_failure(self):
+        """Must not raise when the sidecar path is not writable."""
+        mod = _load_on_compact(bootup_prompt_file="/proc/lobster_test_nonexistent/bootup-prompt.md")
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             # Must not raise
@@ -221,58 +201,61 @@ class TestScheduleReflectionPromptCompact:
 class TestScheduleReflectionPromptFreshStart:
     """Tests for _schedule_reflection_prompt() in on-fresh-start.py."""
 
-    def test_writes_inbox_file_in_debug_mode(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
+    def test_writes_sidecar_file_in_debug_mode(self, tmp_path):
+        sidecar = tmp_path / "bootup-prompt.md"
         state_file = tmp_path / "compaction-state.json"
         mod = _load_on_fresh_start(
-            inbox_dir=str(inbox),
+            bootup_prompt_file=str(sidecar),
             compaction_state_override=str(state_file),
         )
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             mod._schedule_reflection_prompt("bootup")
 
-        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-        assert len(files) == 1
+        assert sidecar.exists()
 
     def test_does_not_write_in_non_debug_mode(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        mod = _load_on_fresh_start(inbox_dir=str(inbox))
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_fresh_start(bootup_prompt_file=str(sidecar))
 
         with _PatchEnv({"LOBSTER_DEBUG": "false"}):
             mod._schedule_reflection_prompt("bootup")
 
-        files = list(inbox.iterdir())
-        assert len(files) == 0
+        assert not sidecar.exists()
 
-    def test_bootup_trigger_in_message(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        mod = _load_on_fresh_start(inbox_dir=str(inbox))
+    def test_bootup_trigger_in_sidecar_content(self, tmp_path):
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_fresh_start(bootup_prompt_file=str(sidecar))
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             mod._schedule_reflection_prompt("bootup")
 
-        files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-        data = json.loads(files[0].read_text())
-        assert data["trigger"] == "bootup"
-        assert data["type"] == "reflection_prompt"
+        text = sidecar.read_text()
+        assert "Bootup" in text
 
     def test_no_tmp_file_left_behind(self, tmp_path):
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        mod = _load_on_fresh_start(inbox_dir=str(inbox))
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_fresh_start(bootup_prompt_file=str(sidecar))
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             mod._schedule_reflection_prompt("bootup")
 
-        tmp_files = [f for f in inbox.iterdir() if f.suffix == ".tmp"]
+        tmp_files = list(tmp_path.glob("*.tmp"))
         assert len(tmp_files) == 0
 
+    def test_second_call_overwrites_rather_than_accumulates(self, tmp_path):
+        sidecar = tmp_path / "bootup-prompt.md"
+        mod = _load_on_fresh_start(bootup_prompt_file=str(sidecar))
+
+        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
+            mod._schedule_reflection_prompt("bootup")
+            mod._schedule_reflection_prompt("bootup")
+
+        matches = list(sidecar.parent.glob("bootup-prompt.md*"))
+        assert matches == [sidecar], f"expected only the sidecar file, got: {matches}"
+
     def test_silent_on_write_failure(self):
-        mod = _load_on_fresh_start(inbox_dir="/proc/lobster_test_nonexistent/inbox")
+        mod = _load_on_fresh_start(bootup_prompt_file="/proc/lobster_test_nonexistent/bootup-prompt.md")
 
         with _PatchEnv({"LOBSTER_DEBUG": "true"}):
             # Must not raise
@@ -280,226 +263,28 @@ class TestScheduleReflectionPromptFreshStart:
 
 
 # ---------------------------------------------------------------------------
-# Fix #2039 — dedup tests for concurrent hook invocations
+# Regression guards: the old inbox-message path must be gone
 # ---------------------------------------------------------------------------
 
-class TestReflectionDedup:
-    """Tests for _reflection_already_exists() and the dedup path in
-    _schedule_reflection_prompt() — both hooks.
-
-    Issue #2039: concurrent hook invocations within the same second share the
-    same msg_id (1-second precision) but write different filenames.  The first
-    invocation must win; subsequent ones must skip silently, leaving exactly
-    one file in the inbox.
+class TestNoInboxDedupMachinery:
+    """_reflection_already_exists() was only needed for the old inbox-message
+    dedup path (issue #2039). The sidecar file overwrites unconditionally, so
+    this function -- and the ID-based dedup it enabled -- should no longer
+    exist in either hook (issue #1998 cleanup).
     """
 
-    # -- on-compact.py --
-
-    def test_compact_dedup_skips_when_id_already_in_inbox(self, tmp_path):
-        """Second call with same timestamp skips writing when first file is in inbox/."""
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        processing = tmp_path / "processing"
-        processing.mkdir()
-        processed = tmp_path / "processed"
-        processed.mkdir()
-
-        mod = _load_on_compact(
-            inbox_dir=str(inbox),
-            processing_dir=str(processing),
-            processed_dir=str(processed),
+    def test_on_compact_has_no_reflection_already_exists(self, tmp_path):
+        mod = _load_on_compact(bootup_prompt_file=str(tmp_path / "bootup-prompt.md"))
+        assert not hasattr(mod, "_reflection_already_exists"), (
+            "on-compact.py still defines _reflection_already_exists -- this ID-based "
+            "dedup machinery was only needed for the old inbox-message path and should "
+            "be removed now that the sidecar file overwrites unconditionally (issue #1998)."
         )
 
-        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
-            # First call — writes the file.
-            mod._schedule_reflection_prompt("compaction")
-            first_files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-            assert len(first_files) == 1, "first call must write exactly one file"
-
-            existing = json.loads(first_files[0].read_text())
-            existing_id = existing["id"]
-
-            # Call again with the same second → same msg_id → should skip.
-            mod._schedule_reflection_prompt("compaction")
-
-        all_files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-        ids = [json.loads(f.read_text()).get("id") for f in all_files]
-        assert ids.count(existing_id) == 1, (
-            f"expected exactly 1 file with id={existing_id!r}, got ids={ids}"
+    def test_on_fresh_start_has_no_reflection_already_exists(self, tmp_path):
+        mod = _load_on_fresh_start(bootup_prompt_file=str(tmp_path / "bootup-prompt.md"))
+        assert not hasattr(mod, "_reflection_already_exists"), (
+            "on-fresh-start.py still defines _reflection_already_exists -- this ID-based "
+            "dedup machinery was only needed for the old inbox-message path and should "
+            "be removed now that the sidecar file overwrites unconditionally (issue #1998)."
         )
-
-    def test_compact_dedup_skips_when_id_in_processing(self, tmp_path):
-        """Dedup check finds an existing file in processing/ and skips."""
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        processing = tmp_path / "processing"
-        processing.mkdir()
-        processed = tmp_path / "processed"
-        processed.mkdir()
-
-        import time as _time
-        ts = _time.time()
-        msg_id = f"reflection_compaction_{int(ts)}"
-        existing_msg = {
-            "id": msg_id,
-            "type": "reflection_prompt",
-            "trigger": "compaction",
-            "source": "system",
-            "text": "already here",
-        }
-        (processing / f"{int(ts * 1000)}_reflection_compaction.json").write_text(
-            json.dumps(existing_msg)
-        )
-
-        mod = _load_on_compact(
-            inbox_dir=str(inbox),
-            processing_dir=str(processing),
-            processed_dir=str(processed),
-        )
-
-        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
-            with _PatchTime(int(ts)):
-                mod._schedule_reflection_prompt("compaction")
-
-        new_files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-        assert len(new_files) == 0, (
-            "expected no new inbox file when existing file is in processing/"
-        )
-
-    def test_compact_dedup_skips_when_id_in_processed(self, tmp_path):
-        """Dedup check finds an already-processed file and skips re-writing."""
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        processing = tmp_path / "processing"
-        processing.mkdir()
-        processed = tmp_path / "processed"
-        processed.mkdir()
-
-        import time as _time
-        ts = _time.time()
-        msg_id = f"reflection_compaction_{int(ts)}"
-        existing_msg = {
-            "id": msg_id,
-            "type": "reflection_prompt",
-            "trigger": "compaction",
-            "source": "system",
-            "text": "already processed",
-        }
-        (processed / f"{int(ts * 1000)}_reflection_compaction.json").write_text(
-            json.dumps(existing_msg)
-        )
-
-        mod = _load_on_compact(
-            inbox_dir=str(inbox),
-            processing_dir=str(processing),
-            processed_dir=str(processed),
-        )
-
-        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
-            with _PatchTime(int(ts)):
-                mod._schedule_reflection_prompt("compaction")
-
-        new_files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-        assert len(new_files) == 0, (
-            "expected no new inbox file when reflection was already processed"
-        )
-
-    # -- on-fresh-start.py --
-
-    def test_freshstart_dedup_skips_when_id_already_in_inbox(self, tmp_path):
-        """Second call with same timestamp skips writing when first file is in inbox/."""
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        processing = tmp_path / "processing"
-        processing.mkdir()
-        processed = tmp_path / "processed"
-        processed.mkdir()
-
-        mod = _load_on_fresh_start(
-            inbox_dir=str(inbox),
-            processing_dir=str(processing),
-            processed_dir=str(processed),
-        )
-
-        with _PatchEnv({"LOBSTER_DEBUG": "true"}):
-            mod._schedule_reflection_prompt("bootup")
-            first_files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-            assert len(first_files) == 1, "first call must write exactly one file"
-
-            existing = json.loads(first_files[0].read_text())
-            existing_id = existing["id"]
-
-            mod._schedule_reflection_prompt("bootup")
-
-        all_files = [f for f in inbox.iterdir() if f.suffix == ".json"]
-        ids = [json.loads(f.read_text()).get("id") for f in all_files]
-        assert ids.count(existing_id) == 1, (
-            f"expected exactly 1 file with id={existing_id!r}, got ids={ids}"
-        )
-
-    def test_reflection_already_exists_returns_true_for_id_in_inbox(self, tmp_path):
-        """_reflection_already_exists returns True when the ID exists in inbox/."""
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        processing = tmp_path / "processing"
-        processing.mkdir()
-        processed = tmp_path / "processed"
-        processed.mkdir()
-
-        msg_id = "reflection_bootup_9999999"
-        (inbox / "9999999_reflection_bootup.json").write_text(
-            json.dumps({"id": msg_id, "type": "reflection_prompt"})
-        )
-
-        mod = _load_on_fresh_start(
-            inbox_dir=str(inbox),
-            processing_dir=str(processing),
-            processed_dir=str(processed),
-        )
-
-        assert mod._reflection_already_exists(msg_id) is True
-
-    def test_reflection_already_exists_returns_false_for_absent_id(self, tmp_path):
-        """_reflection_already_exists returns False when no file has that ID."""
-        inbox = tmp_path / "inbox"
-        inbox.mkdir()
-        processing = tmp_path / "processing"
-        processing.mkdir()
-        processed = tmp_path / "processed"
-        processed.mkdir()
-
-        mod = _load_on_fresh_start(
-            inbox_dir=str(inbox),
-            processing_dir=str(processing),
-            processed_dir=str(processed),
-        )
-
-        assert mod._reflection_already_exists("reflection_bootup_totally_absent") is False
-
-
-# ---------------------------------------------------------------------------
-# Helpers for time patching
-# ---------------------------------------------------------------------------
-
-class _PatchTime:
-    """Context manager that patches time.time() to return a fixed integer.
-
-    Usage::
-
-        with _PatchTime(1700000000):
-            result = module_under_test._schedule_reflection_prompt("compaction")
-    """
-
-    def __init__(self, fixed_ts: int | float):
-        self._fixed_ts = float(fixed_ts)
-        self._orig = None
-
-    def __enter__(self):
-        import time as _t
-        self._orig = _t.time
-        _t.time = lambda: self._fixed_ts
-        return self
-
-    def __exit__(self, *_):
-        import time as _t
-        _t.time = self._orig


### PR DESCRIPTION
## Problem

Each restart, `inject-bootup-context.py`'s siblings (`on-compact.py` / `on-fresh-start.py`) generate a debug-mode `reflection_bootup_XXXX` message asking the dispatcher to reflect on the bootup/compaction experience. That message lands in the inbox like any other message: the dispatcher must `mark_processing` it and, after reading it once, `mark_processed` it — 2 extra MCP round-trips on the startup critical path, purely to deliver a one-shot prompt that's read once and discarded. This adds latency and inbox noise without providing value the dispatcher couldn't get another way.

This recreates the fix from stale PR #2042 (opened May 9, functionally untouched for 3 months, closed today as conflicting against current main) fresh against today's main.

## What changed

**`hooks/on-compact.py`, `hooks/on-fresh-start.py`** — `_schedule_reflection_prompt()` now writes the prompt to `~/messages/bootup-prompt.md` (atomic tmp-then-rename), still gated on `LOBSTER_DEBUG=true`, instead of dropping a JSON message into the inbox. Removed `_reflection_already_exists()` from both hooks: that ID-based dedup existed only to prevent duplicate *inbox* messages from concurrent hook invocations (issue #2039); the sidecar file is a single location that's overwritten unconditionally and read-and-deleted on every startup, so last-writer-wins is correct and no dedup bookkeeping is needed.

**`.claude/sys.dispatcher.bootup.md`** — new startup step 2e: read `~/messages/bootup-prompt.md` if it exists, reflect genuinely (file/update GitHub issues or open PRs for real observations, do nothing if none), then delete the file. One `Read` call, zero claim/process overhead. The old `reflection_prompt` (`type: "reflection_prompt"`) inbox-message handler is kept only as an explicitly-marked-legacy fallback — if a stale message from a pre-#1998 hook version is ever dequeued, the dispatcher claims and marks it processed without reflecting on it, since step 2e is now the one canonical reflection path (reflecting twice would risk duplicate or contradictory GitHub activity).

```
Before:
  on-compact.py/on-fresh-start.py -> write reflection_prompt message to inbox
  -> dispatcher wait_for_messages() returns it like any other message
  -> mark_processing -> read -> reflect -> mark_processed  (2 extra round-trips)

After:
  on-compact.py/on-fresh-start.py -> write ~/messages/bootup-prompt.md (atomic)
  -> dispatcher startup step 2e: Read the file, reflect, delete it
  -> (no claim/process overhead; nothing enters the message queue)
```

## Functional patterns

`_schedule_reflection_prompt()` remains a pure side-effect-isolated function (build content string, atomic write) with no branching added relative to before — the write target changed, not the control flow. Removing `_reflection_already_exists()` is a net simplification: dead code once dedup-by-ID is no longer needed for a single-slot, overwritten-in-place file.

## Out of scope

- Does not touch the other 2 PRs from the same stale batch (#2043/#1983 — separate PR #2146; #2047/#2003 — left as an open assessment, not recreated).
- Does not change what the reflection prompt asks or how the dispatcher decides whether an observation is worth filing — only where the prompt is delivered from.

## Tests run

`sys.dispatcher.bootup.md` is an LLM-instruction file, not executable Python — there's no function to unit-test directly for step 2e. Following the existing repo precedent (`tests/unit/test_hooks/test_dispatcher_bootup_single_pass_read.py`), the new doc-behavior tests are characterization tests asserting on file content.

- [x] `uv run -m pytest tests/unit/test_hooks/test_reflection_prompt.py -q` — 16/16 passed (rewritten for the sidecar-file behavior: debug-gating, content, atomic write, overwrite-not-accumulate, and 2 regression guards confirming `_reflection_already_exists` is gone from both hooks)
- [x] `uv run -m pytest tests/unit/test_hooks/test_bootup_prompt_sidecar_dispatcher_flow.py -q` — 4/4 passed (new file: asserts step 2e references `bootup-prompt.md`, the legacy handler is marked legacy, and it no longer instructs genuine reflection on a dequeued message)
- [x] Falsifiability check, Python tests: `git stash` the 3 implementation files (hooks + doc), reran `test_reflection_prompt.py` — 9/16 failed (the 7 that still passed are non-discriminating sanity/env-gating checks that hold under both old and new behavior). Reran `test_bootup_prompt_sidecar_dispatcher_flow.py` — 3/4 failed. Restored (`git stash pop`) — both files back to fully green.
- [x] `uv run -m pytest tests/unit/test_hooks/ tests/unit/test_mcp_server/ -q` — 1559 passed, 14 pre-existing failures (same 14 as confirmed on a clean main checkout immediately prior, while reviewing PR #2145/#2146 — unrelated to this diff: `test_context_monitor.py`, `test_on_compact_write_claude_session_id.py`, and the 3 `test_push_*_token_endpoint.py` files)
- [x] `python3 -m py_compile hooks/on-compact.py hooks/on-fresh-start.py` — OK

## Manual test

Ran `_schedule_reflection_prompt("bootup")` directly against `hooks/on-fresh-start.py` (loaded as a module, `session_role` stubbed, `BOOTUP_PROMPT_FILE` pointed at a scratch `/tmp` path, `LOBSTER_DEBUG=true`): confirmed the sidecar file is written with the expected content ("[Debug] Bootup reflection prompt...", the friction/observations question, the `SiderealPress/lobster` pointer) and no `.tmp` file is left behind. Cleaned up the scratch directory afterward.

No live dispatcher restart was performed — step 2e is a markdown instruction with no Python code path to execute in isolation from a real Claude Code session. Verified by diff inspection: the new step reads and deletes the same path (`~/messages/bootup-prompt.md`) the hooks now write to, and the legacy inbox handler no longer instructs reflection.

User-visible outcome: not applicable — this is an internal dispatcher-startup efficiency fix with no direct user-facing message change (the reflection prompt itself was never shown to the user; it's an internal debug-mode self-review nudge).

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits — all tests use `tmp_path` / scratch files, never the real `~/messages/` tree)
- [ ] Integration/manual test — partial (see Manual test): the hook-side write was verified directly; the dispatcher-side read/delete step cannot be exercised outside a live Claude Code session
- [x] User-visible outcome — not applicable, explained above
- [x] Side-effect audit: no floods, no unscoped writes — this changes where one existing debug-gated file write goes (inbox message vs. sidecar file), same trigger conditions and frequency (at most once per compaction/restart when `LOBSTER_DEBUG=true`)
- [x] External service calls: none — purely local file I/O

Closes #1998