### PR TITLE
Pin all dependencies to exact versions + enforcement hook

### DIFF
--- a/DEPENDENCY_NOTES.md
+++ b/DEPENDENCY_NOTES.md
@@ -108,3 +108,24 @@ SAME already-pinned version, not to whatever a fresh resolve returns.
    process, felt like scope creep with real risk of breaking unrelated
    builds. If the system owner wants the policy extended to those repos, that should be
    a separate, explicit follow-up per repo.
+
+## Pre-existing test suite status (not caused by this PR)
+
+`uv run pytest tests/unit/ --tb=no -q` currently reports **16 pre-existing
+failures** (not 8 — an earlier count in this PR undercounted them), spread
+across **7 files**, none related to dependency pinning:
+
+- `tests/unit/test_bot/test_slack_router_config.py` — 1
+- `tests/unit/test_hooks/test_context_monitor.py` — 1
+- `tests/unit/test_hooks/test_on_compact_write_claude_session_id.py` — 7
+- `tests/unit/test_mcp_server/test_push_calendar_token_endpoint.py` — 2
+- `tests/unit/test_mcp_server/test_push_gmail_token_endpoint.py` — 2
+- `tests/unit/test_mcp_server/test_push_workspace_token_endpoint.py` — 2
+- `tests/unit/test_script_inbox_sources.py` — 1
+
+Confirmed identical (same 16, same files) on both `main` and this branch —
+this PR does not introduce, fix, or otherwise touch any of them. Scope is
+`pytest tests/unit/` per this repo's own Makefile; a literal unscoped `uv
+run pytest --tb=no -q` from repo root additionally produces 43 collection
+errors on both branches, a pre-existing monorepo/subproject
+dependency-isolation issue also unrelated to this PR.

--- a/DEPENDENCY_NOTES.md
+++ b/DEPENDENCY_NOTES.md
@@ -1,0 +1,110 @@
+# Dependency Pinning Policy
+
+**Effective 2026-08-04.** Prompted by a Shai-Hulud-style npm supply-chain
+worm investigation (system found clean, but the risk of a compromised
+package silently landing via a `^`/`~`/unbounded range was judged real
+enough to close off structurally, not just by vigilance).
+
+## Policy
+
+Every dependency manifest in this system is pinned to an **exact** version.
+No `^`, `~`, `~=`, `>=`, `<=`, `!=`, `>`, `<`, `*`, or `"latest"` ranges.
+`npm install` / `pip install` / `uv sync` / equivalent must never be able to
+silently resolve a dependency to a newer version than what a human
+explicitly reviewed and pinned.
+
+Bumping a pinned version is still fully supported — it just has to be a
+deliberate edit to the manifest (changing `=="1.2.3"` to `=="1.3.0"`), not
+something a package manager decides for you.
+
+## Enforcement
+
+- `hooks/pin-dependencies-guard.py` — Claude Code PreToolUse hook. Blocks
+  Edit/Write/NotebookEdit calls that introduce an unpinned range into a
+  manifest, and blocks Bash package-manager invocations that could resolve
+  to "whatever is newest right now" (bare `npm install <pkg>`, `npm
+  update`, `pip install <pkg>` without `==`, `pip install --upgrade`, `uv
+  add <pkg>` without `==`, `uv sync`/`uv lock` with `--upgrade`). See the
+  module docstring for the full, precise list of what does and doesn't
+  trigger a block.
+- `hooks/pre-commit` — a defense-in-depth backstop at `git commit` time,
+  scanning staged manifest content with the same detection logic (via
+  `pin-dependencies-guard.py --scan-file`). This catches edits made outside
+  Claude Code's own tools (a plain editor, `git apply`, an ad hoc script).
+- Escape hatch: `LOBSTER_ALLOW_DEPENDENCY_CHANGE=true` in the environment
+  bypasses both checks for one deliberate, reviewed bump. This is a
+  dedicated variable, separate from `LOBSTER_DEBUG` (which is already set
+  to `true` persistently in this system's `settings.json` for unrelated
+  reasons — reusing it here would make the hook a permanent no-op).
+
+## Manifests covered and current pin status
+
+| Manifest | Status as of audit | Notes |
+|---|---|---|
+| `pyproject.toml` (root) | Pinned | All `>=` ranges replaced with the version already resolved in `uv.lock`. `hatchling==1.31.0` verified from local `uv` cache (the version actually used to build). |
+| `uv.lock` (root) | Regenerated | `uv lock` re-run after pinning; only removes "this is the floor of a range" metadata — resolved versions unchanged. |
+| `connectors/whatsapp/package.json` | Pinned | Removed `^` from all three deps (already at latest-compatible: chokidar 3.6.0, qrcode 1.5.4, whatsapp-web.js 1.26.0). |
+| `connectors/whatsapp/package-lock.json` | **Not committed — see Known Gaps** | This directory's own `.gitignore` blanket-excludes lock files. |
+| `lobster-shop/multiplayer-telegram-bot/pyproject.toml` | Pinned | `setuptools==83.0.0`, `pytest==9.0.2` (both dev-dependency declarations aligned). Verified via `uv pip install --dry-run` (no local install existed). |
+| `lobster-shop/multiplayer-telegram-bot/uv.lock` | Regenerated | `uv lock` re-run; no version changes. |
+| `lobster-shop/obsidian-km/requirements.txt` | Pinned | `mcp==1.26.0` and `python-dotenv==1.2.1` aligned to the root project's pins (this MCP server runs standalone but sharing a pin avoids two different resolved versions of the same package existing in the system for no reason). `python-frontmatter==1.3.0` verified via dry-run resolve (no existing anchor). |
+| `tests/requirements-test.txt` | Pinned | Packages that also appear in root `pyproject.toml` are pinned to the SAME version as root (see "Why not just pin to latest" below). Test-only packages (`docker`, `aioresponses`, `faker`, `aiofiles`) pinned to a dry-run resolve; `responses==0.26.0` and `freezegun==1.5.5` pinned to the versions actually found installed on this host. |
+| `lobster-shop/camofox-browser/server/package.json` | **Not touched — see Known Gaps** | External vendored product, out of scope. |
+
+## Why not just pin test deps to "whatever's latest today"
+
+Before pinning, `tests/requirements-test.txt` had `mcp>=1.0.0`,
+`pytest>=8.0.0`, `python-telegram-bot>=20.7`, all unbounded. A dry-run
+resolve of that file as it stood (`uv pip install --dry-run -r
+tests/requirements-test.txt` against a scratch venv) came back with
+`mcp==2.0.0` and `python-telegram-bot==22.8` — a full major version ahead
+of the versions actually pinned in the root project (`mcp==1.26.0`,
+`python-telegram-bot==22.6`). That is precisely the failure mode this
+policy exists to close: a test run today would have silently exercised
+different dependency versions than the running system. The fix applied
+here was to pin every package that's shared with the root project to the
+SAME already-pinned version, not to whatever a fresh resolve returns.
+
+## Known gaps / things flagged rather than silently worked around
+
+1. **`connectors/whatsapp/package-lock.json` does not exist and is not
+   committed.** `connectors/whatsapp/.gitignore` has a blanket
+   `# Lock files (generated)` exclusion covering `package-lock.json` and
+   `yarn.lock`. Direct dependencies in `package.json` are now pinned
+   exactly, but without a committed lockfile, *transitive* dependencies of
+   `whatsapp-web.js` (which pulls in `puppeteer`, which downloads a
+   platform-specific Chromium binary) are still free to float on every
+   fresh `npm install`. Generating and committing a lockfile there conflicts
+   with an existing, deliberate repo convention — this needs an explicit
+   decision from the system owner rather than being overridden unilaterally.
+
+2. **`lobster-shop/camofox-browser/server` was not modified.** It is
+   vendored into this tree as a nested git checkout (a "gitlink" — `git
+   diff` shows it as a `160000` mode entry) but has no corresponding
+   `.gitmodules` registration, and its `origin` remote points at a separate
+   product repo (`jo-inc/camofox-browser`, maintained by Jo Inc, not part of
+   the Lobster system). Its `package.json` still uses `^` ranges for
+   `express`, `playwright-core`, `prom-client`, `swagger-jsdoc`,
+   `camoufox-js`, and its devDependencies. It does carry its own
+   `package-lock.json`, so transitive resolution is currently frozen at
+   whatever that lockfile last resolved to — but the `^` ranges mean a
+   plain `npm update` inside that nested repo would still float. Editing a
+   foreign repo's own manifest/history from inside this task felt out of
+   scope and risky without the system owner or Jo Inc's maintainers reviewing it
+   separately; flagging here rather than silently leaving it un-mentioned.
+
+3. **Scope of this pass was the `~/lobster` system repo itself**, not every
+   directory under `~/lobster-workspace/projects/`. Everything else living
+   in `lobster-workspace/projects/` that is a *worktree of this same repo*
+   (`feature-issue-*`, `fix-issue-*`, `bis-74*`, etc.) is automatically
+   covered once this branch merges to `main`, since they share the same
+   git history. But `lobster-workspace/projects/` also holds a number of
+   entirely separate, unrelated products with their own git repos and
+   dependency surfaces (Eloso Bisque, Paperclip, MyOwnLobster, vault-api /
+   vault-ws, networkmaps, bisque-booking, bottleneck-beta, lobster-watcher)
+   — these were surveyed at a high level but deliberately not modified.
+   "The Lobster system" was read as this repo; pinning across a dozen-plus
+   unrelated client codebases in the same pass, each with its own release
+   process, felt like scope creep with real risk of breaking unrelated
+   builds. If the system owner wants the policy extended to those repos, that should be
+   a separate, explicit follow-up per repo.

--- a/connectors/whatsapp/package.json
+++ b/connectors/whatsapp/package.json
@@ -8,9 +8,9 @@
     "test": "node test/mock-test.js"
   },
   "dependencies": {
-    "chokidar": "^3.6.0",
-    "qrcode": "^1.5.4",
-    "whatsapp-web.js": "^1.26.0"
+    "chokidar": "3.6.0",
+    "qrcode": "1.5.4",
+    "whatsapp-web.js": "1.26.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/hooks/pin-dependencies-guard.py
+++ b/hooks/pin-dependencies-guard.py
@@ -58,7 +58,11 @@ tree Claude is operating in — not restricted to one directory):
     NOT treated as separators, since they are not shell operators. Heredoc
     bodies (`<<EOF ... EOF`) are treated as literal data, not sub-commands,
     so example install-command *text* embedded in a heredoc's file content
-    does not get independently evaluated as a real invocation.
+    (e.g. `cat > f.sh <<EOF`) does not get independently evaluated as a real
+    invocation — UNLESS the heredoc is being fed to a real interpreter
+    (`bash <<EOF`, `sh <<EOF`, `zsh <<EOF`, `ssh host <<EOF`, `cat <<EOF |
+    bash`, etc.), in which case the body genuinely executes as shell code and
+    is still scanned line-by-line for real install invocations.
 
 **What does NOT trigger a block:**
   - `npm install` / `npm ci` / `pnpm install` / `yarn install` with no
@@ -272,17 +276,53 @@ _SUB_CMD_SPLIT_RE = re.compile(r"[|;&\n]")
 # A heredoc opener, e.g. `<<EOF`, `<<-EOF`, `<<'EOF'`, `<<"EOF"`.
 _HEREDOC_START_RE = re.compile(r"<<-?\s*(['\"]?)(\w+)\1")
 
+# Real command/script interpreters that will EXECUTE a heredoc body as code
+# rather than treat it as inert data (contrast with `cat > f.sh <<EOF`, where
+# the body is file content). If any of these appears as a whitespace-
+# delimited token on the same physical line as the heredoc opener — either
+# as the command consuming the heredoc directly (`bash <<EOF`, `ssh host
+# <<EOF`) or as the far end of a pipe on that same line (`cat <<EOF |
+# bash`) — the heredoc body is real, executable shell code and must still be
+# scanned for install invocations.
+_INTERPRETER_NAMES = {
+    "bash", "sh", "zsh", "ksh", "dash", "ssh",
+    "python", "python2", "python3",
+}
+
+
+def _line_invokes_interpreter(line: str) -> bool:
+    """True if `line` contains a shell/script interpreter as a distinct
+    command token (matched by exact basename after stripping any path
+    prefix, e.g. `/bin/bash` or `venv/bin/python3`), so a filename that
+    merely ends in these letters (e.g. `f.sh`) does not false-positive
+    match."""
+    for tok in line.split():
+        name = tok.rsplit("/", 1)[-1]
+        if name in _INTERPRETER_NAMES:
+            return True
+    return False
+
 
 def _mask_heredocs(command: str) -> str:
     """Blank out heredoc body lines (between a `<<DELIM` marker and the line
-    containing that bare DELIM) before sub-command splitting. A heredoc body
-    is literal data being redirected into a command (e.g. file content for
-    `cat > f.sh <<EOF ... EOF`), not additional shell commands — treating
-    each of its lines as an independent sub-command (as a naive `\\n` split
-    would) causes false positives when the body merely contains example
-    install-command *text*. The line with the opening marker itself (a real
-    command) is preserved; only body lines are blanked, so line offsets and
-    the overall sub-command count elsewhere in the string are unaffected."""
+    containing that bare DELIM) before sub-command splitting — UNLESS the
+    heredoc is being fed to a real interpreter (see _line_invokes_interpreter),
+    in which case the body is left intact so it still gets split into
+    sub-commands and scanned.
+
+    A heredoc body is normally literal data being redirected into a command
+    (e.g. file content for `cat > f.sh <<EOF ... EOF`), not additional shell
+    commands — treating each of its lines as an independent sub-command (as
+    a naive `\\n` split would) causes false positives when the body merely
+    contains example install-command *text*. But `bash <<EOF ... EOF` (or
+    `sh`/`zsh`/`ssh host`/a pipe into one of these, e.g. `cat <<EOF |
+    bash`) genuinely executes its body as shell code — masking it there
+    would silently hide a real, unpinned install (this was a regression:
+    the original naive `\\n` split caught this case, purely by accident,
+    before heredoc-awareness was added). The line with the opening marker
+    itself (a real command) is always preserved; only body lines are
+    conditionally blanked, so line offsets elsewhere in the string are
+    unaffected either way."""
     lines = command.split("\n")
     out = []
     i = 0
@@ -292,9 +332,10 @@ def _mask_heredocs(command: str) -> str:
         m = _HEREDOC_START_RE.search(line)
         if m:
             delim = m.group(2)
+            executed = _line_invokes_interpreter(line)
             i += 1
             while i < len(lines) and lines[i].strip() != delim:
-                out.append("")
+                out.append(lines[i] if executed else "")
                 i += 1
             if i < len(lines):
                 out.append("")  # blank the closing delimiter line too

--- a/hooks/pin-dependencies-guard.py
+++ b/hooks/pin-dependencies-guard.py
@@ -63,6 +63,22 @@ tree Claude is operating in — not restricted to one directory):
     (`bash <<EOF`, `sh <<EOF`, `zsh <<EOF`, `ssh host <<EOF`, `cat <<EOF |
     bash`, etc.), in which case the body genuinely executes as shell code and
     is still scanned line-by-line for real install invocations.
+  - Any code string that is actually handed to an interpreter for execution
+    is recursively scanned with these same rules, no matter how it is
+    embedded in the outer command: a shell/interpreter's `-c "<code>"` (or
+    `-c '<code>'`) argument (`bash -c "pip install requests"`, including
+    nested through wrapper commands like `docker exec bash -c "..."` or
+    `sudo bash -c "..."`, and double-nested like `bash -c "sh -c \"...\""`),
+    a here-string body (`bash <<< "pip install requests"`), an `eval
+    "<code>"` argument, `$(...)`/backtick command substitution, and a
+    literal `echo "<text>" | <interpreter>` / `printf "<text>" | <interpreter>`
+    pipe. These are genuinely-executed code, unlike a heredoc's inert
+    file-content body (`cat > f.sh <<EOF`) — the distinction that matters is
+    whether the text is handed to an interpreter to run, not merely the
+    syntax used to embed it. Deliberately NOT covered, and not coverable by
+    any static text scan: piping an *opaque* producer into a shell (`cat
+    unknown-file | bash`, `curl url | bash`) — the risk there is unknown
+    runtime content, not a shell-syntax gap.
 
 **What does NOT trigger a block:**
   - `npm install` / `npm ci` / `pnpm install` / `yarn install` with no
@@ -345,6 +361,129 @@ def _mask_heredocs(command: str) -> str:
     return "\n".join(out)
 
 
+# ---------------------------------------------------------------------------
+# Recursive scanning of code payloads handed directly to an interpreter for
+# execution: `-c "<code>"`, here-strings (`<<<`), `eval "<code>"`, and
+# `$(...)`/backtick command substitution.
+#
+# Round 5 bypass (independent review, PR #2151, issuecomment-5187771322):
+# `bash -c "pip install requests"` and `bash <<< "pip install requests"` were
+# both silently ALLOWED. Root cause: `_HEREDOC_START_RE` never matches a
+# here-string (`<<<` is not `<<`), and `-c "<code>"` never enters heredoc
+# handling at all — the whole thing is one sub-command starting with
+# `bash`/`sh`/`zsh`, so the quoted code string inside is never independently
+# scanned by the install-detection regexes below (which are anchored at
+# sub-command start, not applied recursively to quoted string arguments).
+#
+# Fix: before the existing sub-command-split logic runs, pull out every code
+# string that is genuinely handed to an interpreter for execution — a `-c`
+# argument, a here-string body, an `eval` argument, or a `$(...)`/backtick
+# substitution — and recursively run this same detection on each one. This
+# is intentionally a search (not an anchored match) so the interpreter
+# invocation can appear anywhere in the command (`docker exec bash -c "..."`,
+# `sudo bash -c "..."`), and it is intentionally recursive so nested forms
+# (`bash -c "sh -c \"pip install requests\""`) resolve one layer at a time:
+# each recursive call unescapes one level of quoting and re-scans, so the
+# innermost real command is what ultimately gets matched against the
+# install-detection regexes.
+# ---------------------------------------------------------------------------
+
+_INTERPRETER_ALT = r"(?:bash|sh|zsh|ksh|dash|python[0-9.]*)"
+
+# `<interpreter> [flags] -c "<code>"` / `-c '<code>'`, wherever it appears in
+# the command (not anchored) so wrapper commands (`docker exec`, `sudo`,
+# `ssh host`, etc.) preceding the interpreter don't hide it. The closing
+# quote must not be escaped (`(?<!\\)`), so a nested/escaped quote inside the
+# code (`bash -c "sh -c \"...\""`) is not mistaken for the end of the string.
+_DASH_C_PAYLOAD_RE = re.compile(
+    r"(?:^|[\s;|&()])(?:[\w./\-]*/)?" + _INTERPRETER_ALT + r"\b"
+    r"(?:\s+-{1,2}[A-Za-z][\w-]*)*"
+    r"\s+-c\s+"
+    r"(['\"])(.*?)(?<!\\)\1",
+    re.DOTALL,
+)
+
+# `<interpreter> ... <<< "<code>"` / `<<< '<code>'` / `<<< bareword` — a
+# here-string, whose body is a real argument fed to the interpreter's stdin,
+# not inert heredoc file content.
+_HERE_STRING_PAYLOAD_RE = re.compile(
+    r"(?:^|[\s;|&()])(?:[\w./\-]*/)?" + _INTERPRETER_ALT + r"\b"
+    r"[^\n<]*?<<<\s*"
+    r"(?:(['\"])(.*?)(?<!\\)\1|(\S+))",
+    re.DOTALL,
+)
+
+# `eval "<code>"` / `eval '<code>'` — eval always executes its argument.
+_EVAL_PAYLOAD_RE = re.compile(
+    r"(?:^|[\s;|&(])eval\s+(['\"])(.*?)(?<!\\)\1",
+    re.DOTALL,
+)
+
+# `$(<code>)` / `` `<code>` `` command substitution. Non-greedy: this hook is
+# a heuristic regex scan (see module docstring), not a shell parser, so
+# balanced/nested parens inside `$(...)` are out of scope — realistic
+# single-level substitutions are what this guards against.
+_CMD_SUBST_RE = re.compile(r"\$\((.*?)\)", re.DOTALL)
+_BACKTICK_RE = re.compile(r"`([^`]*)`", re.DOTALL)
+
+# `echo "<text>" | <interpreter>` / `printf "<text>" | <interpreter>` — a
+# literal string produced by echo/printf and piped straight into a shell is
+# executed exactly like a here-string (`<<< "<text>"`); it is the same bug
+# class as the round-5 bypass, just spelled with a pipe instead of `<<<`.
+# Deliberately narrow: only a literal quoted/bareword argument to echo/printf
+# is statically knowable. A producer whose output can't be known ahead of
+# execution (`cat somefile | bash`, `curl url | bash`) is NOT — and cannot
+# be made — coverable by this or any other static text scan, since the
+# actual danger is in unknown-until-runtime content, not in shell syntax
+# this hook failed to parse. That gap is a disclosed, inherent limitation
+# of static analysis (see module docstring), not a bug in this regex.
+_ECHO_PRINTF_PIPE_RE = re.compile(
+    r"(?:^|[\s;|&])(?:echo|printf)\s+(?:-\S+\s+)*"
+    r"(?:(['\"])(.*?)(?<!\\)\1|([^|]+?))"
+    r"\s*\|\s*(?:[\w./\-]*/)?" + _INTERPRETER_ALT + r"\b",
+    re.DOTALL,
+)
+
+
+def _unescape_shell_quotes(s: str) -> str:
+    """Undo one level of `\\"` / `\\'` escaping, so a payload extracted from
+    inside an outer quoted string (e.g. the inner `sh -c \\"...\\"` of
+    `bash -c "sh -c \\"...\\""`) can be re-scanned by the same regexes on
+    the next recursive call as if it were typed directly."""
+    return s.replace('\\"', '"').replace("\\'", "'")
+
+
+def _extract_executed_payloads(command: str) -> list[str]:
+    """Return every code string in `command` that is actually handed to an
+    interpreter/eval/subshell for execution — as opposed to inert heredoc
+    file content — so the caller can recursively scan each one."""
+    payloads: list[str] = []
+    for m in _DASH_C_PAYLOAD_RE.finditer(command):
+        payloads.append(_unescape_shell_quotes(m.group(2)))
+    for m in _HERE_STRING_PAYLOAD_RE.finditer(command):
+        code = m.group(2) if m.group(2) is not None else m.group(3)
+        if code:
+            payloads.append(_unescape_shell_quotes(code))
+    for m in _EVAL_PAYLOAD_RE.finditer(command):
+        payloads.append(_unescape_shell_quotes(m.group(2)))
+    for m in _CMD_SUBST_RE.finditer(command):
+        payloads.append(m.group(1))
+    for m in _BACKTICK_RE.finditer(command):
+        payloads.append(m.group(1))
+    for m in _ECHO_PRINTF_PIPE_RE.finditer(command):
+        code = m.group(2) if m.group(2) is not None else m.group(3)
+        if code:
+            payloads.append(_unescape_shell_quotes(code.strip()))
+    return payloads
+
+
+# Recursion guard: each recursive call operates on a strictly shorter payload
+# extracted from inside its parent's quoting, so real input always
+# terminates quickly — this bound only protects against a pathological
+# edge case, not normal nesting depths.
+_MAX_PAYLOAD_RECURSION_DEPTH = 8
+
+
 # Leading wrapper commands that pass through to a real argv without
 # themselves being the package manager: `env FOO=bar pip install x`,
 # `command npm install x`, or a bare `FOO=bar pip install x` assignment
@@ -535,9 +674,21 @@ def _uv_run_with_unpinned(rest: str) -> list[str]:
     return unpinned
 
 
-def bash_introduces_unpinned_dependency(command: str) -> str | None:
+def bash_introduces_unpinned_dependency(command: str, _depth: int = 0) -> str | None:
     """Return a description of the offending fragment if `command` could
-    silently resolve to a newer-than-pinned dependency version, else None."""
+    silently resolve to a newer-than-pinned dependency version, else None.
+
+    Before the sub-command split below, recursively scan every code payload
+    that is genuinely handed to an interpreter for execution (a `-c`
+    argument, a here-string body, an `eval` argument, or `$(...)`/backtick
+    command substitution) — see the "Recursive scanning of code payloads"
+    section above for why this is necessary and how it terminates."""
+    if _depth <= _MAX_PAYLOAD_RECURSION_DEPTH:
+        for payload in _extract_executed_payloads(command):
+            found = bash_introduces_unpinned_dependency(payload, _depth + 1)
+            if found:
+                return found
+
     command = _mask_heredocs(command)
     for raw_sub in _SUB_CMD_SPLIT_RE.split(command):
         raw_sub = raw_sub.strip()

--- a/hooks/pin-dependencies-guard.py
+++ b/hooks/pin-dependencies-guard.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook: enforce exact dependency pinning across the Lobster system.
+
+Blocks any Edit/Write/NotebookEdit that would introduce an unpinned (range-
+style) dependency version into a manifest file, and blocks any Bash command
+that would let a package manager silently resolve to a newer-than-currently-
+pinned version.
+
+**Covered manifest files** (by basename / suffix, wherever they live under the
+tree Claude is operating in — not restricted to one directory):
+  - package.json                          (npm/yarn/pnpm)
+  - pyproject.toml                        (uv/pip/hatch/setuptools deps)
+  - requirements*.txt                     (pip)
+  - Pipfile                               (pipenv)
+
+**What triggers a block (Edit/Write/NotebookEdit):**
+  - A dependency version string using a range operator instead of an exact
+    pin: `^`, `~`, `~=`, `>=`, `<=`, `!=`, `>`, `<`, `*`, or the literal
+    string "latest" — in a package.json dependency value, or in a
+    pyproject.toml / requirements.txt / Pipfile version specifier.
+  - Detection runs against the changed text only (`new_string` for Edit,
+    `content` for Write/NotebookEdit) — this is a heuristic regex scan, not a
+    full parse, matching the style of hooks/secret-scanner.py and
+    hooks/system-file-protect.py. False negatives (an edit that manages to
+    smuggle a range past the regex) are possible; false positives on
+    unrelated text are unlikely because the regex requires the range
+    operator to sit immediately inside a quoted value or after a bare
+    package-name token, which is the shape of an actual dependency line.
+
+**What triggers a block (Bash):**
+  - Any package-manager invocation that can silently resolve to "whatever is
+    newest right now" instead of an exact, already-decided version:
+      npm/pnpm/yarn: `install|i|add <pkg>` with no `@<version>` suffix,
+                      or `update`/`upgrade`/`up` (any form, with or without
+                      a package name)
+      pip:            `install <pkg>` with no `==`, or `-U`/`--upgrade`
+      uv:             `add <pkg>` with no `==`, `sync`/`lock` with
+                      `-U`/`--upgrade`/`--upgrade-package`,
+                      `pip install <pkg>` with no `==`
+
+**What does NOT trigger a block:**
+  - `npm install` / `npm ci` / `pnpm install` / `yarn install` with no
+    package name (installs from the existing lockfile — does not upgrade).
+  - `uv sync` / `uv lock` with no upgrade flag (resolves from pyproject.toml
+    pins / regenerates the lock without bumping anything).
+  - `pip install -r <file>` / `uv pip install -r <file>` (installs from a
+    requirements file; the file itself is covered by the Edit/Write check
+    above).
+  - Any command or edit that specifies an exact version (`==`, `@1.2.3`,
+    or a bare exact version with no operator).
+  - Edits to files that are not dependency manifests.
+
+**Deliberately out of scope:** generated lockfiles themselves
+(package-lock.json, uv.lock, pnpm-lock.yaml, yarn.lock) are NOT blocked from
+being edited/written — regenerating them via `uv lock` / `npm install
+--package-lock-only` after a manifest change is expected and desired. Only
+the *manifest* files (and the Bash commands that mutate them or bypass them)
+are gated. Lockfile *content* still reflects whatever the pinned manifest
+resolves to, so an attacker/mistake would have to also flip the manifest
+pin, which this hook blocks.
+
+**Escape hatch (explicit, reviewed override):**
+Set `LOBSTER_ALLOW_DEPENDENCY_CHANGE=true` in the environment for the one
+command/edit that is a deliberate, reviewed dependency bump, then unset it.
+This is a SEPARATE variable from `LOBSTER_DEBUG` on purpose: LOBSTER_DEBUG is
+already set to "true" persistently in this system's settings.json (it exists
+to unlock system-file-protect.py for normal dev work), so gating on it here
+would make this hook a permanent no-op. Requiring a distinct, purpose-built
+override keeps dependency bumps a conscious, separate decision.
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+_ENV_OVERRIDE = "LOBSTER_ALLOW_DEPENDENCY_CHANGE"
+
+DENY_REASON_EDIT = (
+    "Blocked: {path!r} would introduce an unpinned dependency version "
+    "({match!r}). Lobster policy requires every dependency to be pinned to "
+    "an exact version (no ^, ~, >=, <=, >, <, *, or \"latest\" ranges) so "
+    "installs can never silently pull a newer version. Pin to the exact "
+    "version you intend to use. If this is a deliberate, reviewed version "
+    "bump, re-run with LOBSTER_ALLOW_DEPENDENCY_CHANGE=true set."
+)
+
+DENY_REASON_BASH = (
+    "Blocked: this command can silently resolve to a newer package version "
+    "than what is currently pinned ({command!r}). Use an exact version "
+    "(e.g. `npm install pkg@1.2.3`, `pip install pkg==1.2.3`, "
+    "`uv add pkg==1.2.3`) or install from the existing lockfile/manifest "
+    "instead. If this is a deliberate, reviewed version bump, re-run with "
+    "LOBSTER_ALLOW_DEPENDENCY_CHANGE=true set."
+)
+
+# ---------------------------------------------------------------------------
+# Manifest file detection
+# ---------------------------------------------------------------------------
+
+_MANIFEST_RE = re.compile(
+    r"(^|/)(package\.json|pyproject\.toml|requirements[^/]*\.txt|Pipfile)$"
+)
+
+
+def is_dependency_manifest(file_path: str) -> bool:
+    if not file_path:
+        return False
+    return bool(_MANIFEST_RE.search(file_path))
+
+
+def _is_package_json(file_path: str) -> bool:
+    return file_path.endswith("package.json")
+
+
+# ---------------------------------------------------------------------------
+# Range-operator detection in manifest text
+# ---------------------------------------------------------------------------
+
+# package.json: a quoted dependency value starting with a range operator,
+# e.g. "chokidar": "^3.6.0" or "qrcode": "~1.5.4" or "foo": "latest"
+_JSON_RANGE_RE = re.compile(
+    r'"\s*:\s*"\s*(\^|~(?!=)|>=|<=|!=|>|<|\*|latest)',
+    re.IGNORECASE,
+)
+
+# pyproject.toml / requirements.txt / Pipfile: a package token immediately
+# followed by a range operator, e.g. "mcp>=1.0.0" or mcp>=1.0.0 or
+# package[extra]~=2.0
+_PY_RANGE_RE = re.compile(
+    r"[A-Za-z0-9_.\-]+(?:\[[A-Za-z0-9_,\-]+\])?\s*(>=|<=|~=|!=|>|<|\^)\s*[0-9]"
+)
+
+# A bare "*" or "latest" as an entire pinned-looking value (Pipfile style:
+# requests = "*")
+_STAR_LATEST_RE = re.compile(r'=\s*"(\*|latest)"', re.IGNORECASE)
+
+
+def find_unpinned_range(text: str, is_package_json: bool) -> str | None:
+    """Return the offending match text if `text` contains an unpinned
+    dependency range, else None."""
+    if is_package_json:
+        m = _JSON_RANGE_RE.search(text)
+        if m:
+            # Return a small window of context around the match for the
+            # error message.
+            start = max(0, m.start() - 20)
+            return text[start : m.end() + 10].strip()
+        return None
+
+    m = _PY_RANGE_RE.search(text)
+    if m:
+        return m.group(0)
+    m = _STAR_LATEST_RE.search(text)
+    if m:
+        return m.group(0)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Bash command detection
+# ---------------------------------------------------------------------------
+
+# Split a compound shell command into sub-commands on common separators.
+_SUB_CMD_SPLIT_RE = re.compile(r"[|;&\n]|\band\b|\bor\b")
+
+# npm/pnpm/yarn: install|i|add <pkg-with-no-@version>, or any update/upgrade
+_NODE_INSTALL_RE = re.compile(r"^\s*(npm|pnpm|yarn)\s+(install|i|add)\b(.*)$")
+_NODE_UPGRADE_RE = re.compile(r"^\s*(npm|pnpm|yarn)\s+(update|upgrade|up)\b")
+
+# pip: install <pkg-with-no-==>, or -U/--upgrade anywhere
+_PIP_INSTALL_RE = re.compile(r"^\s*(pip3?|uv\s+pip)\s+install\b(.*)$")
+_PIP_UPGRADE_FLAG_RE = re.compile(r"(^|\s)(-U|--upgrade)(\s|$)")
+
+# uv add <pkg-with-no-==>
+_UV_ADD_RE = re.compile(r"^\s*uv\s+add\b(.*)$")
+# uv sync/lock with an upgrade flag
+_UV_SYNC_LOCK_RE = re.compile(r"^\s*uv\s+(sync|lock)\b(.*)$")
+_UV_UPGRADE_FLAG_RE = re.compile(
+    r"(^|\s)(-U|--upgrade|--upgrade-package(=\S+)?)(\s|$)"
+)
+
+
+def _tokens_are_all_flags_or_files(rest: str) -> bool:
+    """True if every whitespace-delimited token in `rest` is a flag
+    (starts with -) or a requirements-file reference — i.e. no bare package
+    name is being installed."""
+    tokens = [t for t in rest.split() if t]
+    for tok in tokens:
+        if tok.startswith("-"):
+            continue
+        # `-r requirements.txt` — the filename itself following -r/-e is fine
+        continue
+    return True  # handled by caller via a simpler heuristic; see below
+
+
+def _node_package_args_unpinned(rest: str) -> list[str]:
+    """Return package names in `rest` that lack an explicit @version."""
+    unpinned = []
+    for tok in rest.split():
+        if tok.startswith("-"):
+            continue
+        # scoped or unscoped package name, optionally with @version.
+        # e.g. "lodash", "lodash@4.17.21", "@scope/pkg", "@scope/pkg@1.0.0"
+        # A version is present only if there is an "@" after position 0
+        # (scoped packages start with "@" at position 0, which is not a
+        # version marker).
+        at_idx = tok.rfind("@")
+        if at_idx > 0:
+            version = tok[at_idx + 1 :]
+            if version and version[0].isdigit():
+                continue  # pinned, e.g. pkg@1.2.3
+        unpinned.append(tok)
+    return unpinned
+
+
+def _pip_uv_package_args_unpinned(rest: str) -> list[str]:
+    """Return package names in `rest` that lack an explicit ==version."""
+    unpinned = []
+    skip_next = False
+    for tok in rest.split():
+        if skip_next:
+            skip_next = False
+            continue
+        if tok in ("-r", "--requirement", "-e", "--editable", "-c",
+                    "--constraint", "--index-url", "--extra-index-url"):
+            skip_next = True
+            continue
+        if tok.startswith("-"):
+            continue
+        if tok in (".", "..") or tok.startswith("./") or tok.startswith("../"):
+            continue
+        if "==" in tok:
+            continue
+        if tok.startswith("git+") or tok.startswith("http://") or tok.startswith("https://"):
+            # VCS/URL installs are already an explicit, fully-specified
+            # reference (commit/tag in the URL) — not a silent-latest risk
+            # in the same sense as a bare "requests" pull.
+            continue
+        unpinned.append(tok)
+    return unpinned
+
+
+def bash_introduces_unpinned_dependency(command: str) -> str | None:
+    """Return a description of the offending fragment if `command` could
+    silently resolve to a newer-than-pinned dependency version, else None."""
+    for sub in _SUB_CMD_SPLIT_RE.split(command):
+        sub = sub.strip()
+        if not sub:
+            continue
+
+        if _NODE_UPGRADE_RE.search(sub):
+            return sub
+
+        m = _NODE_INSTALL_RE.match(sub)
+        if m:
+            rest = m.group(3)
+            unpinned = _node_package_args_unpinned(rest)
+            if unpinned:
+                return sub
+
+        if _PIP_UPGRADE_FLAG_RE.search(sub) and re.search(r"\bpip3?\b", sub):
+            return sub
+
+        m = _PIP_INSTALL_RE.match(sub)
+        if m:
+            rest = m.group(2)
+            unpinned = _pip_uv_package_args_unpinned(rest)
+            if unpinned:
+                return sub
+
+        m = _UV_ADD_RE.match(sub)
+        if m:
+            rest = m.group(1)
+            unpinned = _pip_uv_package_args_unpinned(rest)
+            if unpinned:
+                return sub
+
+        m = _UV_SYNC_LOCK_RE.match(sub)
+        if m and _UV_UPGRADE_FLAG_RE.search(m.group(2)):
+            return sub
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def _is_override_set() -> bool:
+    return os.environ.get(_ENV_OVERRIDE, "").lower() == "true"
+
+
+def _deny(reason: str) -> None:
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    sys.exit(0)
+
+
+def _scan_file_cli(path: str) -> None:
+    """CLI mode used by hooks/pre-commit (git commit-time check, independent
+    of the PreToolUse path above — catches manifest edits made outside
+    Claude Code's Edit/Write tools, e.g. a plain shell editor or `git apply`).
+
+    Usage: pin-dependencies-guard.py --scan-file <path> [--text -]
+    Reads manifest text from stdin (the staged blob content, as passed by
+    `git show :path` in hooks/pre-commit) and exits 1 with a message on
+    stderr if an unpinned range is found, else exits 0 silently.
+    """
+    if _is_override_set():
+        sys.exit(0)
+    text = sys.stdin.read()
+    match = find_unpinned_range(text, _is_package_json(path))
+    if match:
+        print(
+            f"pin-dependencies-guard: {path!r} contains an unpinned "
+            f"dependency version ({match!r}). Pin to an exact version, or "
+            f"set LOBSTER_ALLOW_DEPENDENCY_CHANGE=true for a deliberate, "
+            f"reviewed bump.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    sys.exit(0)
+
+
+def main() -> None:
+    if len(sys.argv) >= 3 and sys.argv[1] == "--scan-file":
+        _scan_file_cli(sys.argv[2])
+        return
+
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    if _is_override_set():
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {})
+
+    if tool_name == "Bash":
+        command = str(tool_input.get("command", ""))
+        offending = bash_introduces_unpinned_dependency(command)
+        if offending:
+            _deny(DENY_REASON_BASH.format(command=offending))
+        sys.exit(0)
+
+    if tool_name not in ("Edit", "Write", "NotebookEdit"):
+        sys.exit(0)
+
+    file_path = str(tool_input.get("file_path", ""))
+    if not is_dependency_manifest(file_path):
+        sys.exit(0)
+
+    if tool_name == "Edit":
+        text = str(tool_input.get("new_string", ""))
+    else:
+        # Write and NotebookEdit both carry the new content under
+        # "content" for our purposes (NotebookEdit's cell "new_source" is
+        # not a manifest format, so this branch is realistically Write-only
+        # for manifest files; NotebookEdit is included in the matcher only
+        # for symmetry with system-file-protect.py's convention).
+        text = str(tool_input.get("content", tool_input.get("new_source", "")))
+
+    if not text:
+        sys.exit(0)
+
+    match = find_unpinned_range(text, _is_package_json(file_path))
+    if match:
+        _deny(DENY_REASON_EDIT.format(path=file_path, match=match))
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/pin-dependencies-guard.py
+++ b/hooks/pin-dependencies-guard.py
@@ -27,6 +27,12 @@ tree Claude is operating in — not restricted to one directory):
     unrelated text are unlikely because the regex requires the range
     operator to sit immediately inside a quoted value or after a bare
     package-name token, which is the shape of an actual dependency line.
+  - For non-JSON manifests (pyproject.toml / requirements*.txt / Pipfile),
+    whole-line comments (`# ...`) are excluded from the scan first, so prose
+    that merely mentions a range in passing (e.g. `# needs numpy>=1.20
+    installed separately`) is not treated as a dependency declaration. An
+    inline trailing comment on a real dependency line does not suppress
+    detection of that line.
 
 **What triggers a block (Bash):**
   - Any package-manager invocation that can silently resolve to "whatever is
@@ -34,10 +40,25 @@ tree Claude is operating in — not restricted to one directory):
       npm/pnpm/yarn: `install|i|add <pkg>` with no `@<version>` suffix,
                       or `update`/`upgrade`/`up` (any form, with or without
                       a package name)
-      pip:            `install <pkg>` with no `==`, or `-U`/`--upgrade`
+      pip:            `install <pkg>` with no `==`, or `-U`/`--upgrade`,
+                      including via `python -m pip` / `python3 -m pip`
       uv:             `add <pkg>` with no `==`, `sync`/`lock` with
                       `-U`/`--upgrade`/`--upgrade-package`,
-                      `pip install <pkg>` with no `==`
+                      `pip install <pkg>` with no `==`,
+                      `run --with <pkg>` with no `==` (installs an
+                      ephemeral, unpinned dependency for the run)
+  - Detection resolves the actual binary being invoked rather than matching
+    only the literal string "pip"/"npm"/"uv" at position 0: a leading `env`
+    or `command` wrapper, a leading `VAR=val` assignment prefix, and a path
+    prefix on the command itself (`/usr/bin/pip`, `venv/bin/pip`,
+    `node_modules/.bin/npm`) are all normalized away first, so none of these
+    ordinary invocation forms bypass the check.
+  - A compound command is split into sub-commands on real shell separators
+    only (`|`, `;`, `&`, newline) — the bare English words "and"/"or" are
+    NOT treated as separators, since they are not shell operators. Heredoc
+    bodies (`<<EOF ... EOF`) are treated as literal data, not sub-commands,
+    so example install-command *text* embedded in a heredoc's file content
+    does not get independently evaluated as a real invocation.
 
 **What does NOT trigger a block:**
   - `npm install` / `npm ci` / `pnpm install` / `yarn install` with no
@@ -49,6 +70,9 @@ tree Claude is operating in — not restricted to one directory):
     above).
   - Any command or edit that specifies an exact version (`==`, `@1.2.3`,
     or a bare exact version with no operator).
+  - `npm install <local-path>` (e.g. `./local-pkg`, `../sibling`,
+    `/abs/path`) or an already-fully-specified tarball/URL/VCS reference —
+    not a registry resolution that can silently drift to a newer version.
   - Edits to files that are not dependency manifests.
 
 **Deliberately out of scope:** generated lockfiles themselves
@@ -162,6 +186,20 @@ _PY_RANGE_RE = re.compile(
 # requests = "*")
 _STAR_LATEST_RE = re.compile(r'=\s*"(\*|latest)"', re.IGNORECASE)
 
+# A whole-line comment (TOML/requirements.txt style: '#' as the first
+# non-whitespace character on the line). Prose like
+# "# needs numpy>=1.20 installed separately" merely mentions a version range
+# in passing — it is not a dependency declaration, so it must not be scanned.
+# Inline trailing comments (`mcp>=1.0.0  # note`) are left alone: the real
+# declaration earlier on the same line still needs to be caught.
+_FULL_LINE_COMMENT_RE = re.compile(r"^[ \t]*#.*$", re.MULTILINE)
+
+
+def _strip_full_line_comments(text: str) -> str:
+    """Blank out lines that are wholly a comment, preserving line count/
+    offsets (so this is safe to apply before either python-style regex)."""
+    return _FULL_LINE_COMMENT_RE.sub("", text)
+
 
 def _find_unpinned_range_in_package_json(text: str) -> str | None:
     """package.json-specific check. Prefers a real JSON parse (possible when
@@ -208,6 +246,7 @@ def find_unpinned_range(text: str, is_package_json: bool) -> str | None:
     if is_package_json:
         return _find_unpinned_range_in_package_json(text)
 
+    text = _strip_full_line_comments(text)
     m = _PY_RANGE_RE.search(text)
     if m:
         return m.group(0)
@@ -221,8 +260,120 @@ def find_unpinned_range(text: str, is_package_json: bool) -> str | None:
 # Bash command detection
 # ---------------------------------------------------------------------------
 
-# Split a compound shell command into sub-commands on common separators.
-_SUB_CMD_SPLIT_RE = re.compile(r"[|;&\n]|\band\b|\bor\b")
+# Split a compound shell command into sub-commands on REAL shell separators
+# only: pipe, semicolon, background '&' (this also splits '&&'/'||' since
+# each char in the class is matched individually, leaving an empty fragment
+# between them, which is filtered out below), and newline. Deliberately does
+# NOT split on the bare English words "and"/"or" — those are not shell
+# operators (that was a false-positive bug: `echo hello or npm install foo`
+# is a single `echo` invocation with literal args, not two commands).
+_SUB_CMD_SPLIT_RE = re.compile(r"[|;&\n]")
+
+# A heredoc opener, e.g. `<<EOF`, `<<-EOF`, `<<'EOF'`, `<<"EOF"`.
+_HEREDOC_START_RE = re.compile(r"<<-?\s*(['\"]?)(\w+)\1")
+
+
+def _mask_heredocs(command: str) -> str:
+    """Blank out heredoc body lines (between a `<<DELIM` marker and the line
+    containing that bare DELIM) before sub-command splitting. A heredoc body
+    is literal data being redirected into a command (e.g. file content for
+    `cat > f.sh <<EOF ... EOF`), not additional shell commands — treating
+    each of its lines as an independent sub-command (as a naive `\\n` split
+    would) causes false positives when the body merely contains example
+    install-command *text*. The line with the opening marker itself (a real
+    command) is preserved; only body lines are blanked, so line offsets and
+    the overall sub-command count elsewhere in the string are unaffected."""
+    lines = command.split("\n")
+    out = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        out.append(line)
+        m = _HEREDOC_START_RE.search(line)
+        if m:
+            delim = m.group(2)
+            i += 1
+            while i < len(lines) and lines[i].strip() != delim:
+                out.append("")
+                i += 1
+            if i < len(lines):
+                out.append("")  # blank the closing delimiter line too
+                i += 1
+            continue
+        i += 1
+    return "\n".join(out)
+
+
+# Leading wrapper commands that pass through to a real argv without
+# themselves being the package manager: `env FOO=bar pip install x`,
+# `command npm install x`, or a bare `FOO=bar pip install x` assignment
+# prefix (valid shell syntax with no wrapper word at all). Stripped
+# iteratively so `env command pip install x` also resolves.
+_WRAPPER_WORD_RE = re.compile(r"^(?:env|command)\b\s*")
+_LEADING_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=\S*\s+")
+
+
+def _strip_wrappers(sub: str) -> str:
+    s = sub
+    while True:
+        m = _WRAPPER_WORD_RE.match(s)
+        if m:
+            s = s[m.end():]
+            continue
+        m = _LEADING_ASSIGNMENT_RE.match(s)
+        if m:
+            s = s[m.end():]
+            continue
+        break
+    return s
+
+
+# Resolve the actual binary being invoked rather than pattern-matching only
+# the literal string "pip"/"npm"/"uv" sitting at position 0: a path prefix
+# (`/usr/bin/pip`, `venv/bin/pip`, `node_modules/.bin/npm`) must not defeat
+# detection, since none of that changes what actually runs.
+_FIRST_TOKEN_RE = re.compile(r"^(\s*)(\S+)(.*)$", re.DOTALL)
+
+
+def _normalize_command_name(sub: str) -> str:
+    """If the leading token is a path (contains '/'), replace it with just
+    its basename so path-prefixed invocations are recognized the same as
+    the bare command."""
+    m = _FIRST_TOKEN_RE.match(sub)
+    if not m:
+        return sub
+    lead, token, rest = m.groups()
+    if "/" in token:
+        token = token.rsplit("/", 1)[-1]
+    return f"{lead}{token}{rest}"
+
+
+# `python -m pip install ...` / `python3 -m pip install ...` is one of the
+# most commonly recommended ways to invoke pip and must be treated exactly
+# like a bare `pip install`.
+_PYTHON_DASH_M_PIP_RE = re.compile(
+    r"^(\s*)(python[0-9]*(?:\.[0-9]+)?)\s+-m\s+pip\b(.*)$", re.DOTALL
+)
+
+
+def _normalize_python_dash_m_pip(sub: str) -> str:
+    m = _PYTHON_DASH_M_PIP_RE.match(sub)
+    if not m:
+        return sub
+    lead, _pybin, rest = m.groups()
+    return f"{lead}pip{rest}"
+
+
+def _resolve_subcommand(sub: str) -> str:
+    """Normalize a sub-command so the pattern matchers below see the actual
+    binary/subcommand being invoked, regardless of wrapper prefixes, path
+    prefixes, or the `python -m pip` invocation form."""
+    sub = _strip_wrappers(sub)
+    sub = _normalize_command_name(sub)
+    sub = _normalize_python_dash_m_pip(sub)
+    sub = _normalize_command_name(sub)
+    return sub
+
 
 # npm/pnpm/yarn: install|i|add <pkg-with-no-@version>, or any update/upgrade
 _NODE_INSTALL_RE = re.compile(r"^\s*(npm|pnpm|yarn)\s+(install|i|add)\b(.*)$")
@@ -239,6 +390,14 @@ _UV_SYNC_LOCK_RE = re.compile(r"^\s*uv\s+(sync|lock)\b(.*)$")
 _UV_UPGRADE_FLAG_RE = re.compile(
     r"(^|\s)(-U|--upgrade|--upgrade-package(=\S+)?)(\s|$)"
 )
+
+# uv run --with <pkg> — installs an ephemeral, unpinned dependency for the
+# duration of the run, the same silent-latest risk as `uv add`/`pip install`
+# with no version pin. `--with-requirements <file>` is a different flag
+# (installs from a file, covered by the Edit/Write check on that file) and
+# is deliberately NOT matched here since nothing directly follows "--with".
+_UV_RUN_RE = re.compile(r"^\s*uv\s+run\b(.*)$", re.DOTALL)
+_UV_RUN_WITH_PKG_RE = re.compile(r"--with(?:=|\s+)(\S+)")
 
 
 def _tokens_are_all_flags_or_files(rest: str) -> bool:
@@ -259,6 +418,23 @@ def _node_package_args_unpinned(rest: str) -> list[str]:
     unpinned = []
     for tok in rest.split():
         if tok.startswith("-"):
+            continue
+        # A local filesystem path (`./local-pkg`, `../sibling`, `/abs/path`)
+        # or an already-fully-specified tarball/URL/VCS reference is not a
+        # registry resolution that can silently drift to "latest" — the
+        # exact code is whatever is at that path/URL right now, unaffected
+        # by npm's version-resolution step this hook guards against.
+        if (
+            tok.startswith("./")
+            or tok.startswith("../")
+            or tok.startswith("/")
+            or tok.startswith("~/")
+            or tok.startswith("git+")
+            or tok.startswith("git://")
+            or tok.startswith("http://")
+            or tok.startswith("https://")
+            or tok.endswith((".tgz", ".tar.gz"))
+        ):
             continue
         # scoped or unscoped package name, optionally with @version.
         # e.g. "lodash", "lodash@4.17.21", "@scope/pkg", "@scope/pkg@1.0.0"
@@ -301,44 +477,74 @@ def _pip_uv_package_args_unpinned(rest: str) -> list[str]:
     return unpinned
 
 
+def _uv_run_with_unpinned(rest: str) -> list[str]:
+    """Return `--with` package specs in a `uv run ...` invocation's tail
+    that lack an explicit `==version`."""
+    unpinned = []
+    for m in _UV_RUN_WITH_PKG_RE.finditer(rest):
+        for spec in m.group(1).split(","):
+            spec = spec.strip()
+            if not spec or spec.startswith("-"):
+                continue
+            if "==" in spec:
+                continue
+            if spec.startswith("./") or spec.startswith("../") or spec.startswith("/"):
+                continue
+            unpinned.append(spec)
+    return unpinned
+
+
 def bash_introduces_unpinned_dependency(command: str) -> str | None:
     """Return a description of the offending fragment if `command` could
     silently resolve to a newer-than-pinned dependency version, else None."""
-    for sub in _SUB_CMD_SPLIT_RE.split(command):
-        sub = sub.strip()
-        if not sub:
+    command = _mask_heredocs(command)
+    for raw_sub in _SUB_CMD_SPLIT_RE.split(command):
+        raw_sub = raw_sub.strip()
+        if not raw_sub:
             continue
 
+        # Resolve wrapper/path/`-m pip` forms to the canonical command shape
+        # the pattern matchers below expect, but report the original text
+        # back to the caller so the deny message shows what was actually
+        # typed.
+        sub = _resolve_subcommand(raw_sub)
+
         if _NODE_UPGRADE_RE.search(sub):
-            return sub
+            return raw_sub
 
         m = _NODE_INSTALL_RE.match(sub)
         if m:
             rest = m.group(3)
             unpinned = _node_package_args_unpinned(rest)
             if unpinned:
-                return sub
+                return raw_sub
 
         if _PIP_UPGRADE_FLAG_RE.search(sub) and re.search(r"\bpip3?\b", sub):
-            return sub
+            return raw_sub
 
         m = _PIP_INSTALL_RE.match(sub)
         if m:
             rest = m.group(2)
             unpinned = _pip_uv_package_args_unpinned(rest)
             if unpinned:
-                return sub
+                return raw_sub
 
         m = _UV_ADD_RE.match(sub)
         if m:
             rest = m.group(1)
             unpinned = _pip_uv_package_args_unpinned(rest)
             if unpinned:
-                return sub
+                return raw_sub
 
         m = _UV_SYNC_LOCK_RE.match(sub)
         if m and _UV_UPGRADE_FLAG_RE.search(m.group(2)):
-            return sub
+            return raw_sub
+
+        m = _UV_RUN_RE.match(sub)
+        if m:
+            unpinned = _uv_run_with_unpinned(m.group(1))
+            if unpinned:
+                return raw_sub
 
     return None
 

--- a/hooks/pin-dependencies-guard.py
+++ b/hooks/pin-dependencies-guard.py
@@ -119,12 +119,37 @@ def _is_package_json(file_path: str) -> bool:
 # Range-operator detection in manifest text
 # ---------------------------------------------------------------------------
 
-# package.json: a quoted dependency value starting with a range operator,
-# e.g. "chokidar": "^3.6.0" or "qrcode": "~1.5.4" or "foo": "latest"
+# package.json dependency-block keys that actually get resolved/installed by
+# npm/yarn/pnpm. Deliberately EXCLUDES "engines" (and similar environment-
+# constraint blocks like "engines-strict", "volta", "packageManager") — those
+# specify a compatible runtime range for humans/tooling to check against, not
+# a package version npm/yarn/pnpm resolves and installs, so a range there
+# (e.g. "node": ">=18.0.0") is normal and is not the silent-upgrade risk this
+# hook exists to catch.
+_JSON_DEPENDENCY_KEYS = {
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+    "resolutions",
+    "overrides",
+}
+
+# package.json: a quoted "<key>": "<range-value>" pair, e.g.
+# "chokidar": "^3.6.0" or "qrcode": "~1.5.4" or "foo": "latest". Captures the
+# key so callers can exclude known non-dependency keys (see
+# _JSON_DEPENDENCY_KEYS above) when the surrounding block can't be
+# determined (i.e. for Edit fragments, where a full JSON parse of the
+# surrounding object usually isn't possible).
 _JSON_RANGE_RE = re.compile(
-    r'"\s*:\s*"\s*(\^|~(?!=)|>=|<=|!=|>|<|\*|latest)',
+    r'"([A-Za-z0-9_@/.\-]+)"\s*:\s*"\s*(\^|~(?!=)|>=|<=|!=|>|<|\*|latest)',
     re.IGNORECASE,
 )
+
+# Keys that are never themselves a dependency name, even though their value
+# looks like a version range — these are the environment-constraint blocks
+# called out above. Matches on these keys are ignored.
+_JSON_NON_DEPENDENCY_KEYS = {"node", "npm", "yarn", "pnpm", "vscode"}
 
 # pyproject.toml / requirements.txt / Pipfile: a package token immediately
 # followed by a range operator, e.g. "mcp>=1.0.0" or mcp>=1.0.0 or
@@ -138,17 +163,50 @@ _PY_RANGE_RE = re.compile(
 _STAR_LATEST_RE = re.compile(r'=\s*"(\*|latest)"', re.IGNORECASE)
 
 
+def _find_unpinned_range_in_package_json(text: str) -> str | None:
+    """package.json-specific check. Prefers a real JSON parse (possible when
+    `text` is a whole-file Write) restricted to actual dependency-block keys
+    — this is exact, with no risk of flagging "engines" or similar
+    environment-constraint blocks. Falls back to a key-aware regex scan
+    (needed for Edit fragments, which are partial and rarely valid JSON on
+    their own), which still excludes the known non-dependency key names in
+    _JSON_NON_DEPENDENCY_KEYS (e.g. "engines": {"node": ">=18.0.0"})."""
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        parsed = None
+
+    if isinstance(parsed, dict):
+        for block_key in _JSON_DEPENDENCY_KEYS:
+            block = parsed.get(block_key)
+            if not isinstance(block, dict):
+                continue
+            for pkg, version in block.items():
+                if not isinstance(version, str):
+                    continue
+                if re.match(
+                    r"^\s*(\^|~(?!=)|>=|<=|!=|>|<|\*|latest)",
+                    version,
+                    re.IGNORECASE,
+                ):
+                    return f'"{pkg}": "{version}"'
+        return None
+
+    # Fragment fallback: regex scan, excluding known non-dependency keys.
+    for m in _JSON_RANGE_RE.finditer(text):
+        key = m.group(1)
+        if key in _JSON_NON_DEPENDENCY_KEYS:
+            continue
+        start = max(0, m.start() - 5)
+        return text[start : m.end() + 10].strip()
+    return None
+
+
 def find_unpinned_range(text: str, is_package_json: bool) -> str | None:
     """Return the offending match text if `text` contains an unpinned
     dependency range, else None."""
     if is_package_json:
-        m = _JSON_RANGE_RE.search(text)
-        if m:
-            # Return a small window of context around the match for the
-            # error message.
-            start = max(0, m.start() - 20)
-            return text[start : m.end() + 10].strip()
-        return None
+        return _find_unpinned_range_in_package_json(text)
 
     m = _PY_RANGE_RE.search(text)
     if m:

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -5,12 +5,21 @@
 # inside scripts/ and hooks/ directories.  Install by copying to
 # .git/hooks/pre-commit (install.sh does this automatically).
 #
+# Also enforces exact dependency pinning on staged manifest files
+# (package.json, pyproject.toml, requirements*.txt, Pipfile) as a
+# defense-in-depth backstop to the Claude Code PreToolUse hook
+# (hooks/pin-dependencies-guard.py) — this catches manifest edits made
+# outside Claude Code's Edit/Write tools (a plain editor, `git apply`,
+# a script, etc.) that the PreToolUse hook never saw.
+#
 # Only Added (A) and Modified (M) files are checked — deletions and renames
 # are skipped.
 
 set -euo pipefail
 
 failed=0
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+PIN_GUARD="$REPO_ROOT/hooks/pin-dependencies-guard.py"
 
 # git ls-files --stage output format: "<mode> <blob> <stage>\t<path>"
 # The tab separates the metadata from the path; fields within metadata
@@ -48,9 +57,29 @@ while IFS= read -r line; do
     fi
 done < <(git ls-files --stage -- 'scripts/*.sh' 'scripts/*.exp' 'hooks/*')
 
+# --- Dependency pinning check on staged manifest files ---------------------
+if [ -f "$PIN_GUARD" ] && command -v python3 &>/dev/null; then
+    while IFS= read -r line; do
+        meta="${line%%$'\t'*}"
+        path="${line#*$'\t'}"
+
+        status=$(git diff --cached --name-status -- "$path" | awk '{print $1}' | head -1) || true
+        case "$status" in
+            A|M) ;;
+            D*|R*) continue ;;
+            *) continue ;;
+        esac
+
+        read -r _mode blob _stage <<< "$meta"
+        if ! git cat-file blob "$blob" 2>/dev/null | python3 "$PIN_GUARD" --scan-file "$path"; then
+            failed=1
+        fi
+    done < <(git ls-files --stage -- '*package.json' '*pyproject.toml' '*requirements*.txt' '*Pipfile')
+fi
+
 if [ "$failed" -ne 0 ]; then
     echo "" >&2
-    echo "Commit aborted: fix execute bits on the files listed above, then retry." >&2
+    echo "Commit aborted: fix the execute-bit and/or dependency-pinning issues listed above, then retry." >&2
     exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -2037,6 +2037,29 @@ else
     info "Skipping system-file-protect hook (settings.json not yet created)"
 fi
 
+# Set up Claude Code PreToolUse hook to enforce exact dependency pinning
+# (blocks unpinned ranges in manifests and silent-latest package-manager
+# invocations; see hooks/pin-dependencies-guard.py docstring for full scope)
+chmod +x "$INSTALL_DIR/hooks/pin-dependencies-guard.py" || true
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    if ! jq -e '.hooks.PreToolUse[]? | select(.hooks[]?.command | contains("pin-dependencies-guard"))' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+        TMP_SETTINGS=$(mktemp)
+        jq '.hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+            "matcher": "Edit|Write|NotebookEdit|Bash",
+            "hooks": [{
+                "type": "command",
+                "command": "python3 '"$INSTALL_DIR"'/hooks/pin-dependencies-guard.py",
+                "timeout": 5
+            }]
+        }]' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+        success "pin-dependencies-guard hook installed"
+    else
+        info "pin-dependencies-guard hook already configured in Claude Code settings"
+    fi
+else
+    info "Skipping pin-dependencies-guard hook (settings.json not yet created)"
+fi
+
 # Set up Claude Code PostToolUse hook to restore execute bit after Edit/Write
 chmod +x "$INSTALL_DIR/hooks/restore-exec-bit.py" || true
 if [ -f "$CLAUDE_SETTINGS" ]; then

--- a/lobster-shop/multiplayer-telegram-bot/pyproject.toml
+++ b/lobster-shop/multiplayer-telegram-bot/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=67"]
+requires = ["setuptools==83.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,7 +10,7 @@ requires-python = ">=3.11"
 dependencies = []
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0"]
+dev = ["pytest==9.0.2"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -21,5 +21,5 @@ pythonpath = ["src"]
 
 [dependency-groups]
 dev = [
-    "pytest>=9.0.2",
+    "pytest==9.0.2",
 ]

--- a/lobster-shop/multiplayer-telegram-bot/uv.lock
+++ b/lobster-shop/multiplayer-telegram-bot/uv.lock
@@ -36,11 +36,11 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" }]
+requires-dist = [{ name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.2" }]
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.2" }]
+dev = [{ name = "pytest", specifier = "==9.0.2" }]
 
 [[package]]
 name = "packaging"

--- a/lobster-shop/obsidian-km/requirements.txt
+++ b/lobster-shop/obsidian-km/requirements.txt
@@ -1,4 +1,9 @@
 # Obsidian KM MCP Server dependencies
-mcp>=1.0.0
-python-frontmatter>=1.0.0
-python-dotenv>=1.0.0
+# Pinned per the dependency-pinning policy (see DEPENDENCY_NOTES.md at repo
+# root). mcp/python-dotenv aligned to the same version pinned in the root
+# pyproject.toml; python-frontmatter has no root anchor and was pinned to
+# the version a fresh resolve returned (no prior local install to verify
+# against). Audit date: 2026-08-04.
+mcp==1.26.0
+python-frontmatter==1.3.0
+python-dotenv==1.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,19 +4,19 @@ version = "0.1.0"
 description = "Always-on AI assistant with Telegram/Slack integration"
 requires-python = ">=3.11"
 dependencies = [
-    "mcp>=1.0.0",
-    "httpx>=0.27.0",
-    "watchdog>=4.0.0",
-    "psutil>=5.9.0",
-    "python-telegram-bot>=21.0",
-    "python-dotenv>=1.0.0",
-    "starlette>=0.37.0",
-    "uvicorn>=0.29.0",
-    "sqlite-vec>=0.1.7a1",
-    "fastembed>=0.3.0",
-    "twilio>=9.0.0",
-    "websockets>=13.0",
-    "cryptography>=42.0.0",
+    "mcp==1.26.0",
+    "httpx==0.28.1",
+    "watchdog==6.0.0",
+    "psutil==7.2.2",
+    "python-telegram-bot==22.6",
+    "python-dotenv==1.2.1",
+    "starlette==0.52.1",
+    "uvicorn==0.41.0",
+    "sqlite-vec==0.1.7a10",
+    "fastembed==0.7.4",
+    "twilio==9.10.3",
+    "websockets==16.0",
+    "cryptography==46.0.5",
 ]
 
 [project.optional-dependencies]
@@ -27,29 +27,29 @@ windows = [
     # zoneinfo (stdlib, Python 3.9+) needs this package on Windows
     # because Windows ships without the IANA timezone database.
     # Linux and macOS use the system tzdata and do not need this.
-    "tzdata>=2024.1",
+    "tzdata==2026.1",
 ]
 browser = [
-    "playwright>=1.40.0",
+    "playwright==1.58.0",
 ]
 slack = [
-    "slack-sdk>=3.27.0",
-    "slack-bolt>=1.18.0",
+    "slack-sdk==3.40.1",
+    "slack-bolt==1.27.0",
 ]
 test = [
-    "pytest>=8.0.0",
-    "pytest-asyncio>=0.23.0",
-    "pytest-timeout>=2.2.0",
-    "pytest-cov>=5.0.0",
+    "pytest==9.0.2",
+    "pytest-asyncio==1.3.0",
+    "pytest-timeout==2.4.0",
+    "pytest-cov==7.0.0",
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.31.0"]
 build-backend = "hatchling.build"
 
 [tool.uv]
 override-dependencies = [
-    "pillow>=12.1.1",
+    "pillow==12.1.1",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -57,6 +57,6 @@ packages = ["src"]
 
 [dependency-groups]
 dev = [
-    "pytest>=9.0.2",
-    "pytest-asyncio>=1.3.0",
+    "pytest==9.0.2",
+    "pytest-asyncio==1.3.0",
 ]

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -3223,6 +3223,50 @@ M88_PYEOF
         fi
     fi
 
+    # Migration 97: Register pin-dependencies-guard.py PreToolUse hook.
+    # Enforces the dependency-pinning policy: blocks Edit/Write/NotebookEdit
+    # calls that introduce an unpinned (^, ~, >=, <=, >, <, *, "latest")
+    # dependency version into package.json/pyproject.toml/requirements*.txt/
+    # Pipfile, and blocks Bash package-manager invocations that could
+    # silently resolve to a newer-than-pinned version (bare `npm install
+    # <pkg>`, `npm update`, `pip install <pkg>` without `==`, `pip install
+    # --upgrade`, `uv add <pkg>` without `==`, `uv sync/lock --upgrade`).
+    # See hooks/pin-dependencies-guard.py docstring for full scope and the
+    # LOBSTER_ALLOW_DEPENDENCY_CHANGE=true escape hatch for deliberate bumps.
+    if [ -f "$CLAUDE_SETTINGS" ] && command -v jq &>/dev/null; then
+        local _m97_present
+        _m97_present=$(jq -r '
+            [.hooks.PreToolUse[]?.hooks[]? |
+             select((.command // "") | test("pin-dependencies-guard"))]
+            | length' "$CLAUDE_SETTINGS" 2>/dev/null || echo "0")
+
+        if [[ "${_m97_present:-0}" -eq 0 ]]; then
+            local _m97_tmp
+            _m97_tmp=$(mktemp)
+            if jq --arg install_dir "$LOBSTER_DIR" '
+                .hooks.PreToolUse = (.hooks.PreToolUse // []) + [{
+                    "matcher": "Edit|Write|NotebookEdit|Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": ("python3 " + $install_dir + "/hooks/pin-dependencies-guard.py"),
+                        "timeout": 5
+                    }]
+                }]
+            ' "$CLAUDE_SETTINGS" > "$_m97_tmp" \
+                && mv "$_m97_tmp" "$CLAUDE_SETTINGS" 2>/dev/null; then
+                substep "Migration 97: registered pin-dependencies-guard.py PreToolUse hook"
+                migrated=$((migrated + 1))
+            else
+                rm -f "$_m97_tmp" 2>/dev/null || true
+                warn "Migration 97: could not update settings.json — jq transform failed"
+            fi
+        else
+            substep "Migration 97: pin-dependencies-guard.py hook already registered — skipping"
+        fi
+    else
+        substep "Migration 97: settings.json or jq not found — skipping"
+    fi
+
     if [ "$migrated" -eq 0 ]; then
         success "No migrations needed"
     else

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,31 +1,42 @@
 # Lobster Test Dependencies
+#
+# Pinned to exact versions per the dependency-pinning policy (see
+# DEPENDENCY_NOTES.md at repo root). Where a package is also a root
+# project dependency, pinned to the SAME version as pyproject.toml/uv.lock
+# to avoid the test env silently drifting from the main env (verified via
+# `uv pip install --dry-run` against an unpinned copy of this file, which
+# resolved mcp to 2.0.0 and python-telegram-bot to 22.8 -- both newer than
+# the pins in the main project -- confirming the drift this policy exists
+# to prevent). Test-only packages (no root anchor) are pinned to the
+# version actually installed locally where one exists, else to the version
+# a fresh resolve returns today. Audit date: 2026-08-04.
 
-# Core testing
-pytest>=8.0.0
-pytest-asyncio>=0.23.0
-pytest-timeout>=2.2.0
-pytest-cov>=4.1.0
+# Core testing (pinned to match root pyproject.toml / uv.lock)
+pytest==9.0.2
+pytest-asyncio==1.3.0
+pytest-timeout==2.4.0
+pytest-cov==7.0.0
 
 # Async HTTP for mocks
-aiohttp>=3.9.0
-aiofiles>=23.2.0
+aiohttp==3.13.3
+aiofiles==25.1.0
 
 # Docker integration
-docker>=7.0.0
+docker==7.2.0
 
 # HTTP mocking
-aioresponses>=0.7.6
-responses>=0.24.0
+aioresponses==0.7.9
+responses==0.26.0
 
 # System utilities (required by test_memory.py)
-psutil>=5.9.0
+psutil==7.2.2
 
 # General utilities
-faker>=22.0.0
-freezegun>=1.2.0
+faker==40.36.0
+freezegun==1.5.5
 
-# Already in main project but ensure available
-python-telegram-bot>=20.7
-watchdog>=3.0.0
-mcp>=1.0.0
-httpx>=0.27.0
+# Already in main project but ensure available (pinned to match root)
+python-telegram-bot==22.6
+watchdog==6.0.0
+mcp==1.26.0
+httpx==0.28.1

--- a/tests/unit/test_hooks/test_pin_dependencies_guard.py
+++ b/tests/unit/test_hooks/test_pin_dependencies_guard.py
@@ -880,6 +880,81 @@ class TestHookOverrideBypass:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# (e5) Heredoc-masking regression: a heredoc body fed to a real interpreter
+# (bash/sh/zsh/ssh/etc.) must still be scanned, even though a heredoc body
+# used as inert file content (e.g. `cat > f.sh <<EOF`) stays exempt
+# (independent-reviewer NEEDS-WORK, round 2: `bash <<EOF\npip install
+# requests\nEOF` was silently allowed by the e3 heredoc fix above)
+# ---------------------------------------------------------------------------
+
+
+class TestHeredocInterpreterExecutionStillScanned:
+    """The e3 fix (see TestBashFalsePositivesPureFunction above) made
+    _mask_heredocs blank out every heredoc body unconditionally, to stop
+    inert example text (`cat > f.sh <<EOF\\nnpm install lodash\\nEOF`) from
+    being misread as a real command. But when the heredoc's body is piped
+    into an actual shell/interpreter instead of a file, that body *is* real,
+    executable shell code — masking it created a silent bypass. These cases
+    must be BLOCKED."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "bash <<EOF\npip install requests\nEOF\n",
+            "bash <<'EOF'\npip install requests\nEOF\n",
+            "sh <<EOF\npip install requests\nEOF\n",
+            "zsh <<EOF\npip install requests\nEOF\n",
+            "ssh myhost <<EOF\npip install requests\nEOF\n",
+            "cat <<EOF | bash\npip install requests\nEOF\n",
+        ],
+    )
+    def test_interpreter_heredoc_with_real_install_blocked(self, command):
+        assert bash_introduces_unpinned_dependency(command) is not None
+
+    def test_original_inert_text_heredoc_fix_not_regressed(self):
+        """The exact case the e3 fix targeted (npm install text written as
+        file content, not executed) must remain ALLOWED."""
+        command = "cat > install.sh <<'EOF'\nnpm install lodash\nEOF\n"
+        assert bash_introduces_unpinned_dependency(command) is None
+
+    def test_interpreter_heredoc_with_pinned_install_still_allowed(self):
+        """A heredoc fed to bash whose body is a real but already-pinned
+        install must not be blocked — same rule as any other Bash command."""
+        command = "bash <<EOF\npip install requests==2.31.0\nEOF\n"
+        assert bash_introduces_unpinned_dependency(command) is None
+
+    def test_tee_heredoc_still_treated_as_inert_file_content(self):
+        """`tee` (like `cat >`) writes the heredoc body to a file rather
+        than executing it — must stay exempt."""
+        command = "tee script.sh <<EOF\nnpm install lodash\nEOF\n"
+        assert bash_introduces_unpinned_dependency(command) is None
+
+
+class TestHookHeredocInterpreterExecutionIntegration:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "bash <<EOF\npip install requests\nEOF\n",
+            "sh <<EOF\npip install requests\nEOF\n",
+            "zsh <<EOF\npip install requests\nEOF\n",
+            "ssh myhost <<EOF\npip install requests\nEOF\n",
+            "cat <<EOF | bash\npip install requests\nEOF\n",
+        ],
+    )
+    def test_interpreter_heredoc_blocked_via_full_hook(self, command):
+        rc, stdout, _ = _run_hook(_bash_payload(command))
+        assert rc == 0
+        assert _is_denied(stdout)
+
+    def test_inert_heredoc_still_allowed_via_full_hook(self):
+        rc, stdout, _ = _run_hook(
+            _bash_payload("cat > install.sh <<'EOF'\nnpm install lodash\nEOF\n")
+        )
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+
 class TestHookGracefulHandling:
     @pytest.mark.parametrize("tool_name", ["Read", "Glob", "Grep", "Task", "TodoWrite"])
     def test_non_covered_tool_exits_0_no_deny(self, tool_name):

--- a/tests/unit/test_hooks/test_pin_dependencies_guard.py
+++ b/tests/unit/test_hooks/test_pin_dependencies_guard.py
@@ -51,6 +51,12 @@ _is_package_json = _mod._is_package_json
 find_unpinned_range = _mod.find_unpinned_range
 bash_introduces_unpinned_dependency = _mod.bash_introduces_unpinned_dependency
 _is_override_set = _mod._is_override_set
+_strip_full_line_comments = _mod._strip_full_line_comments
+_mask_heredocs = _mod._mask_heredocs
+_strip_wrappers = _mod._strip_wrappers
+_normalize_command_name = _mod._normalize_command_name
+_normalize_python_dash_m_pip = _mod._normalize_python_dash_m_pip
+_resolve_subcommand = _mod._resolve_subcommand
 
 
 # ---------------------------------------------------------------------------
@@ -514,6 +520,287 @@ class TestHookBashIntegration:
     )
     def test_bash_allowed(self, command):
         rc, stdout, _ = _run_hook(_bash_payload(command))
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+
+# ---------------------------------------------------------------------------
+# (e2) Bash bypass-gap fixes: python -m pip, path-prefixed binaries,
+# env/command wrappers, uv run --with (independent-reviewer NEEDS-WORK #1)
+# ---------------------------------------------------------------------------
+
+
+class TestBashBypassGapsPureFunction:
+    """Every one of these is an ordinary, everyday invocation (not
+    adversarial evasion) that silently installed an unpinned package with
+    zero block before the fix — demonstrated directly by the independent
+    reviewer on PR #2151."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # python -m pip: one of the most commonly recommended ways to
+            # invoke pip at all.
+            "python -m pip install requests",
+            "python3 -m pip install requests",
+            "python3.12 -m pip install requests",
+            # path-prefixed / wrapper-prefixed binaries: the regexes only
+            # matched when npm/pip/uv sat literally at position 0.
+            "/usr/bin/pip install requests",
+            "/usr/local/bin/pip3 install requests",
+            "venv/bin/pip install requests",
+            "node_modules/.bin/npm install lodash",
+            "/usr/local/bin/npm install lodash",
+            "env pip install requests",
+            "command pip install requests",
+            "env command pip install requests",
+            "FOO=bar pip install requests",
+            "env FOO=bar pip install requests",
+            # python -m pip through a path-prefixed python binary too.
+            "/usr/bin/python3 -m pip install requests",
+            # uv run --with <pkg>: installs an ephemeral unpinned dependency.
+            "uv run --with requests python foo.py",
+            "uv run --with=requests python foo.py",
+            "uv run --with requests --with pandas python foo.py",
+            "uv run --with requests,pandas python foo.py",
+        ],
+    )
+    def test_bypass_gap_now_blocked(self, command):
+        assert bash_introduces_unpinned_dependency(command) is not None, (
+            f"expected {command!r} to be detected as an unpinned install"
+        )
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Pinned via the same forms — must NOT be blocked.
+            "python -m pip install requests==2.31.0",
+            "python3 -m pip install requests==2.31.0",
+            "/usr/bin/pip install requests==2.31.0",
+            "venv/bin/pip install requests==2.31.0",
+            "env pip install requests==2.31.0",
+            "FOO=bar pip install requests==2.31.0",
+            "uv run --with requests==2.31.0 python foo.py",
+            "uv run python foo.py",
+            "uv run --with-requirements reqs.txt python foo.py",
+            # lockfile-respecting forms via a path prefix.
+            "/usr/local/bin/npm ci",
+            "venv/bin/pip install -r requirements.txt",
+        ],
+    )
+    def test_pinned_or_lockfile_forms_via_new_paths_not_blocked(self, command):
+        assert bash_introduces_unpinned_dependency(command) is None
+
+
+class TestNormalizationHelpers:
+    def test_normalize_command_name_strips_path_prefix(self):
+        assert _normalize_command_name("/usr/bin/pip install x") == "pip install x"
+        assert (
+            _normalize_command_name("node_modules/.bin/npm install x")
+            == "npm install x"
+        )
+
+    def test_normalize_command_name_leaves_bare_command_alone(self):
+        assert _normalize_command_name("npm install x") == "npm install x"
+
+    def test_strip_wrappers_env_and_command(self):
+        assert _strip_wrappers("env pip install x") == "pip install x"
+        assert _strip_wrappers("command pip install x") == "pip install x"
+        assert _strip_wrappers("env command pip install x") == "pip install x"
+
+    def test_strip_wrappers_leading_assignment(self):
+        assert _strip_wrappers("FOO=bar pip install x") == "pip install x"
+        assert _strip_wrappers("env FOO=bar pip install x") == "pip install x"
+
+    def test_strip_wrappers_no_wrapper_is_noop(self):
+        assert _strip_wrappers("pip install x") == "pip install x"
+
+    def test_normalize_python_dash_m_pip(self):
+        assert (
+            _normalize_python_dash_m_pip("python -m pip install x")
+            == "pip install x"
+        )
+        assert (
+            _normalize_python_dash_m_pip("python3 -m pip install x")
+            == "pip install x"
+        )
+
+    def test_normalize_python_dash_m_pip_noop_for_non_pip(self):
+        assert (
+            _normalize_python_dash_m_pip("python -m venv .venv")
+            == "python -m venv .venv"
+        )
+
+    def test_resolve_subcommand_full_pipeline(self):
+        assert (
+            _resolve_subcommand("/usr/bin/python3 -m pip install x")
+            == "pip install x"
+        )
+
+
+class TestHookBashBypassGapsIntegration:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "python -m pip install requests",
+            "python3 -m pip install requests",
+            "/usr/bin/pip install requests",
+            "venv/bin/pip install requests",
+            "node_modules/.bin/npm install lodash",
+            "env pip install requests",
+            "command pip install requests",
+            "uv run --with requests python foo.py",
+        ],
+    )
+    def test_bypass_gap_blocked_via_full_hook(self, command):
+        rc, stdout, _ = _run_hook(_bash_payload(command))
+        assert rc == 0
+        assert _is_denied(stdout)
+
+
+# ---------------------------------------------------------------------------
+# (e3) Bash false-positive fixes: heredoc bodies, bare "and"/"or", local-path
+# npm installs (independent-reviewer NEEDS-WORK #2)
+# ---------------------------------------------------------------------------
+
+
+class TestBashFalsePositivesPureFunction:
+    def test_heredoc_body_containing_install_text_not_blocked(self):
+        command = "cat > install.sh <<'EOF'\nnpm install lodash\nEOF\n"
+        assert bash_introduces_unpinned_dependency(command) is None
+
+    def test_heredoc_unquoted_delimiter_not_blocked(self):
+        command = "cat > install.sh <<EOF\npip install requests\nEOF\n"
+        assert bash_introduces_unpinned_dependency(command) is None
+
+    def test_heredoc_dash_variant_not_blocked(self):
+        command = "cat > install.sh <<-EOF\nnpm install lodash\nEOF\n"
+        assert bash_introduces_unpinned_dependency(command) is None
+
+    def test_real_command_before_heredoc_still_detected(self):
+        command = "npm install lodash\ncat > f.sh <<EOF\nsome text\nEOF\n"
+        assert bash_introduces_unpinned_dependency(command) is not None
+
+    def test_real_command_after_heredoc_still_detected(self):
+        command = "cat > f.sh <<EOF\nsome text\nEOF\nnpm install lodash\n"
+        assert bash_introduces_unpinned_dependency(command) is not None
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "echo hello or npm install foo",
+            "echo hello and npm install foo",
+            "echo command and control",
+        ],
+    )
+    def test_bare_and_or_words_not_treated_as_separators(self, command):
+        assert bash_introduces_unpinned_dependency(command) is None
+
+    def test_real_and_operator_still_splits(self):
+        assert (
+            bash_introduces_unpinned_dependency("echo hi && npm install lodash")
+            is not None
+        )
+
+    def test_real_or_operator_still_splits(self):
+        assert (
+            bash_introduces_unpinned_dependency("npm ci || npm install lodash")
+            is not None
+        )
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "npm install ./local-package",
+            "npm install ../sibling-package",
+            "npm install /abs/path/to/package",
+            "npm i ./local-package",
+        ],
+    )
+    def test_local_path_npm_install_not_blocked(self, command):
+        assert bash_introduces_unpinned_dependency(command) is None
+
+    def test_local_path_alongside_real_unpinned_package_still_detected(self):
+        assert (
+            bash_introduces_unpinned_dependency(
+                "npm install ./local-package lodash"
+            )
+            is not None
+        )
+
+
+class TestHookBashFalsePositivesIntegration:
+    def test_heredoc_install_text_allowed_via_full_hook(self):
+        rc, stdout, _ = _run_hook(
+            _bash_payload("cat > install.sh <<'EOF'\nnpm install lodash\nEOF\n")
+        )
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_bare_or_word_allowed_via_full_hook(self):
+        rc, stdout, _ = _run_hook(_bash_payload("echo hello or npm install foo"))
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_local_path_npm_install_allowed_via_full_hook(self):
+        rc, stdout, _ = _run_hook(_bash_payload("npm install ./local-package"))
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+
+# ---------------------------------------------------------------------------
+# (e4) Manifest false positive: prose comments merely mentioning a range
+# (independent-reviewer NEEDS-WORK #2.4)
+# ---------------------------------------------------------------------------
+
+
+class TestManifestCommentFalsePositive:
+    def test_full_line_comment_mentioning_range_not_blocked(self):
+        text = "# needs numpy>=1.20 installed separately\n"
+        assert find_unpinned_range(text, is_package_json=False) is None
+
+    def test_full_line_comment_with_leading_whitespace_not_blocked(self):
+        text = "    # needs numpy>=1.20 installed separately\n"
+        assert find_unpinned_range(text, is_package_json=False) is None
+
+    def test_comment_alongside_real_dependency_line_still_blocked(self):
+        text = (
+            "# needs numpy>=1.20 installed separately\n"
+            'dependencies = [\n    "mcp>=1.0.0",\n]\n'
+        )
+        match = find_unpinned_range(text, is_package_json=False)
+        assert match is not None
+        assert "mcp" in match
+
+    def test_inline_trailing_comment_does_not_suppress_real_match(self):
+        text = "mcp>=1.0.0  # some note\n"
+        assert find_unpinned_range(text, is_package_json=False) is not None
+
+    def test_strip_full_line_comments_helper(self):
+        text = "# numpy>=1.20\nmcp==1.26.0\n"
+        stripped = _strip_full_line_comments(text)
+        assert "numpy" not in stripped
+        assert "mcp==1.26.0" in stripped
+
+
+class TestHookManifestCommentFalsePositiveIntegration:
+    def test_edit_prose_comment_in_requirements_allowed(self):
+        rc, stdout, _ = _run_hook(
+            _edit_payload(
+                "requirements.txt",
+                "# needs numpy>=1.20 installed separately\n",
+            )
+        )
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_edit_prose_comment_in_pyproject_allowed(self):
+        rc, stdout, _ = _run_hook(
+            _edit_payload(
+                "pyproject.toml",
+                "# needs numpy>=1.20 installed separately\n",
+            )
+        )
         assert rc == 0
         assert not _is_denied(stdout)
 

--- a/tests/unit/test_hooks/test_pin_dependencies_guard.py
+++ b/tests/unit/test_hooks/test_pin_dependencies_guard.py
@@ -1,0 +1,640 @@
+"""
+Unit tests for hooks/pin-dependencies-guard.py
+
+Tests cover:
+- Manifest detection: package.json, pyproject.toml, requirements*.txt, Pipfile
+  detected; non-manifest files ignored (find_unpinned_range / is_dependency_manifest)
+- Every range operator (^, ~, ~=, >=, <=, !=, >, <, *, "latest") is blocked,
+  both as a pure-function check and via full hook invocation for Edit
+  (new_string) and Write (content)
+- Exact pins (==, @1.2.3) are NOT blocked
+- The package.json "engines" regression (commit 10a1ee95): "engines":
+  {"node": ">=18.0.0"} must NOT be flagged, for both a full-file Write and an
+  Edit fragment
+- Bash command detection: npm/pip/uv unpinned installs and upgrade flags are
+  blocked; lockfile-respecting / already-pinned commands are not
+- LOBSTER_ALLOW_DEPENDENCY_CHANGE=true bypasses both Edit/Write and Bash checks
+- Non-Edit/Write/Bash tool calls and malformed/missing stdin are handled
+  gracefully (exit 0, no crash, no deny)
+
+Convention: pure functions are imported directly via importlib.util (as in
+test_auto_register_agent.py); full hook behavior (stdin -> stdout JSON / exit
+code) is exercised via subprocess, matching the sibling
+test_require_reply_to_message_id.py convention for stdin/stdout-driven hooks.
+"""
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+HOOK_PATH = _HOOKS_DIR / "pin-dependencies-guard.py"
+
+_ENV_OVERRIDE = "LOBSTER_ALLOW_DEPENDENCY_CHANGE"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("pin_dependencies_guard", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_module()
+is_dependency_manifest = _mod.is_dependency_manifest
+_is_package_json = _mod._is_package_json
+find_unpinned_range = _mod.find_unpinned_range
+bash_introduces_unpinned_dependency = _mod.bash_introduces_unpinned_dependency
+_is_override_set = _mod._is_override_set
+
+
+# ---------------------------------------------------------------------------
+# Subprocess helper for full hook invocation
+# ---------------------------------------------------------------------------
+
+
+def _clean_env(overrides: dict | None = None) -> dict:
+    """os.environ copy with LOBSTER_ALLOW_DEPENDENCY_CHANGE explicitly unset
+    unless the caller opts in via overrides, so tests are isolated from
+    whatever the host process happens to have set."""
+    env = os.environ.copy()
+    env.pop(_ENV_OVERRIDE, None)
+    if overrides:
+        env.update(overrides)
+    return env
+
+
+def _run_hook(payload: dict, env: dict | None = None) -> tuple[int, str, str]:
+    result = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=_clean_env(env),
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def _run_hook_raw_stdin(stdin_text: str, env: dict | None = None) -> tuple[int, str, str]:
+    result = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        env=_clean_env(env),
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def _is_denied(stdout: str) -> bool:
+    """True if the hook's stdout JSON represents a permissionDecision=deny."""
+    if not stdout.strip():
+        return False
+    data = json.loads(stdout)
+    return (
+        data.get("hookSpecificOutput", {}).get("permissionDecision") == "deny"
+    )
+
+
+def _edit_payload(file_path: str, new_string: str) -> dict:
+    return {
+        "tool_name": "Edit",
+        "tool_input": {"file_path": file_path, "new_string": new_string},
+    }
+
+
+def _write_payload(file_path: str, content: str) -> dict:
+    return {
+        "tool_name": "Write",
+        "tool_input": {"file_path": file_path, "content": content},
+    }
+
+
+def _bash_payload(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+# ---------------------------------------------------------------------------
+# (a) Manifest detection
+# ---------------------------------------------------------------------------
+
+
+class TestManifestDetection:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "package.json",
+            "connectors/whatsapp/package.json",
+            "pyproject.toml",
+            "lobster-shop/multiplayer-telegram-bot/pyproject.toml",
+            "requirements.txt",
+            "tests/requirements-test.txt",
+            "requirements-dev.txt",
+            "Pipfile",
+            "some/nested/dir/Pipfile",
+        ],
+    )
+    def test_manifest_files_detected(self, path):
+        assert is_dependency_manifest(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "",
+            "README.md",
+            "src/main.py",
+            "package.json.bak",
+            "requirements.txt.orig",
+            "package-lock.json",
+            "uv.lock",
+            "notpyproject.toml.txt",
+            "Pipfile.lock",
+        ],
+    )
+    def test_non_manifest_files_ignored(self, path):
+        assert is_dependency_manifest(path) is False
+
+    def test_none_like_empty_string_is_not_a_manifest(self):
+        assert is_dependency_manifest("") is False
+
+
+class TestIsPackageJson:
+    def test_package_json_true(self):
+        assert _is_package_json("package.json") is True
+        assert _is_package_json("connectors/whatsapp/package.json") is True
+
+    @pytest.mark.parametrize(
+        "path", ["pyproject.toml", "requirements.txt", "Pipfile", ""]
+    )
+    def test_non_package_json_false(self, path):
+        assert _is_package_json(path) is False
+
+
+# ---------------------------------------------------------------------------
+# (b) + (c) Range operator detection: pure-function level, python-style manifests
+# ---------------------------------------------------------------------------
+
+
+class TestFindUnpinnedRangePython:
+    """pyproject.toml / requirements.txt / Pipfile-style detection
+    (find_unpinned_range with is_package_json=False)."""
+
+    @pytest.mark.parametrize(
+        "text,operator",
+        [
+            ("requests>=2.0.0", ">="),
+            ("requests<=2.0.0", "<="),
+            ("requests~=2.0.0", "~="),
+            ("requests!=2.0.0", "!="),
+            ("requests>2.0.0", ">"),
+            ("requests<2.0.0", "<"),
+            ("requests^2.0.0", "^"),
+        ],
+    )
+    def test_operator_blocked(self, text, operator):
+        match = find_unpinned_range(text, is_package_json=False)
+        assert match is not None, f"expected {operator!r} range to be flagged in {text!r}"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            'requests = "*"',
+            'requests = "latest"',
+            'requests = "LATEST"',
+        ],
+    )
+    def test_star_and_latest_blocked_pipfile_style(self, text):
+        match = find_unpinned_range(text, is_package_json=False)
+        assert match is not None
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "requests==2.0.0",
+            'mcp==1.26.0',
+            "package[extra]==1.0.0",
+            "hatchling==1.31.0",
+        ],
+    )
+    def test_exact_pin_not_blocked(self, text):
+        assert find_unpinned_range(text, is_package_json=False) is None
+
+    def test_realistic_pyproject_dependency_line_blocked(self):
+        text = 'dependencies = [\n    "mcp>=1.0.0",\n]\n'
+        assert find_unpinned_range(text, is_package_json=False) is not None
+
+    def test_realistic_pyproject_dependency_line_pinned_not_blocked(self):
+        text = 'dependencies = [\n    "mcp==1.26.0",\n]\n'
+        assert find_unpinned_range(text, is_package_json=False) is None
+
+
+# ---------------------------------------------------------------------------
+# (b) + (c) + (d) Range operator detection: package.json
+# ---------------------------------------------------------------------------
+
+
+class TestFindUnpinnedRangePackageJson:
+    @pytest.mark.parametrize(
+        "operator,value",
+        [
+            ("^", "^3.6.0"),
+            ("~", "~3.6.0"),
+            (">=", ">=3.6.0"),
+            ("<=", "<=3.6.0"),
+            ("!=", "!=3.6.0"),
+            (">", ">3.6.0"),
+            ("<", "<3.6.0"),
+            ("*", "*"),
+            ("latest", "latest"),
+        ],
+    )
+    def test_operator_blocked_as_edit_fragment(self, operator, value):
+        """Edit fragments are rarely valid standalone JSON, so this exercises
+        the regex-fallback path in _find_unpinned_range_in_package_json."""
+        fragment = f'  "chokidar": "{value}",\n'
+        match = find_unpinned_range(fragment, is_package_json=True)
+        assert match is not None, f"expected {operator!r} to be flagged in fragment {fragment!r}"
+
+    @pytest.mark.parametrize(
+        "operator,value",
+        [
+            ("^", "^3.6.0"),
+            ("~", "~3.6.0"),
+            (">=", ">=3.6.0"),
+            ("<=", "<=3.6.0"),
+            ("!=", "!=3.6.0"),
+            (">", ">3.6.0"),
+            ("<", "<3.6.0"),
+            ("*", "*"),
+            ("latest", "latest"),
+        ],
+    )
+    def test_operator_blocked_as_full_write_content(self, operator, value):
+        """Full-file Write content is valid JSON, exercising the json.loads
+        parse path (restricted to real dependency-block keys)."""
+        content = json.dumps({"dependencies": {"chokidar": value}})
+        match = find_unpinned_range(content, is_package_json=True)
+        assert match is not None, f"expected {operator!r} to be flagged in {content!r}"
+
+    @pytest.mark.parametrize(
+        "value", ["3.6.0", "1.5.4"],
+    )
+    def test_exact_pin_not_blocked_fragment(self, value):
+        fragment = f'  "chokidar": "{value}",\n'
+        assert find_unpinned_range(fragment, is_package_json=True) is None
+
+    def test_exact_pin_not_blocked_full_write(self):
+        content = json.dumps({"dependencies": {"chokidar": "3.6.0"}})
+        assert find_unpinned_range(content, is_package_json=True) is None
+
+    @pytest.mark.parametrize(
+        "block_key",
+        [
+            "dependencies",
+            "devDependencies",
+            "peerDependencies",
+            "optionalDependencies",
+            "resolutions",
+            "overrides",
+        ],
+    )
+    def test_all_dependency_blocks_covered_full_write(self, block_key):
+        content = json.dumps({block_key: {"lodash": "^4.17.21"}})
+        assert find_unpinned_range(content, is_package_json=True) is not None
+
+    # -- The "engines" regression (commit 10a1ee95) --------------------------
+
+    def test_engines_range_not_blocked_full_write(self):
+        """A full package.json Write with only an engines block containing
+        a range must NOT be flagged — this was the bug fixed in 10a1ee95."""
+        content = json.dumps({"engines": {"node": ">=18.0.0"}})
+        assert find_unpinned_range(content, is_package_json=True) is None
+
+    def test_engines_range_not_blocked_edit_fragment(self):
+        """Same check for the Edit-fragment (regex fallback) path."""
+        fragment = '  "engines": {\n    "node": ">=18.0.0"\n  },\n'
+        assert find_unpinned_range(fragment, is_package_json=True) is None
+
+    def test_engines_alongside_real_dependency_range_full_write(self):
+        """engines must be ignored, but a real dependency range in the same
+        file must still be caught."""
+        content = json.dumps(
+            {
+                "engines": {"node": ">=18.0.0"},
+                "dependencies": {"chokidar": "^3.6.0"},
+            }
+        )
+        match = find_unpinned_range(content, is_package_json=True)
+        assert match is not None
+        assert "chokidar" in match
+
+    def test_engines_alongside_real_dependency_range_fragment(self):
+        fragment = (
+            '  "engines": {\n    "node": ">=18.0.0"\n  },\n'
+            '  "dependencies": {\n    "chokidar": "^3.6.0"\n  }\n'
+        )
+        match = find_unpinned_range(fragment, is_package_json=True)
+        assert match is not None
+
+
+# ---------------------------------------------------------------------------
+# (b)/(c)/(d) Full hook integration for Edit and Write
+# ---------------------------------------------------------------------------
+
+
+class TestHookEditWriteIntegration:
+    def test_edit_package_json_range_blocked(self):
+        rc, stdout, _ = _run_hook(
+            _edit_payload("connectors/whatsapp/package.json", '"chokidar": "^3.6.0"')
+        )
+        assert rc == 0
+        assert _is_denied(stdout)
+
+    def test_write_package_json_range_blocked(self):
+        content = json.dumps({"dependencies": {"chokidar": "^3.6.0"}})
+        rc, stdout, _ = _run_hook(_write_payload("package.json", content))
+        assert rc == 0
+        assert _is_denied(stdout)
+
+    def test_edit_pyproject_range_blocked(self):
+        rc, stdout, _ = _run_hook(
+            _edit_payload("pyproject.toml", 'dependencies = ["mcp>=1.0.0"]')
+        )
+        assert rc == 0
+        assert _is_denied(stdout)
+
+    def test_write_pyproject_range_blocked(self):
+        rc, stdout, _ = _run_hook(
+            _write_payload("pyproject.toml", 'dependencies = ["mcp>=1.0.0"]\n')
+        )
+        assert rc == 0
+        assert _is_denied(stdout)
+
+    def test_edit_pyproject_exact_pin_allowed(self):
+        rc, stdout, _ = _run_hook(
+            _edit_payload("pyproject.toml", 'dependencies = ["mcp==1.26.0"]')
+        )
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_write_package_json_exact_pin_allowed(self):
+        content = json.dumps({"dependencies": {"chokidar": "3.6.0"}})
+        rc, stdout, _ = _run_hook(_write_payload("package.json", content))
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_write_package_json_engines_only_allowed(self):
+        """Full hook run of the exact 10a1ee95 regression scenario."""
+        content = json.dumps({"engines": {"node": ">=18.0.0"}})
+        rc, stdout, _ = _run_hook(_write_payload("package.json", content))
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_edit_package_json_engines_only_allowed(self):
+        rc, stdout, _ = _run_hook(
+            _edit_payload(
+                "connectors/whatsapp/package.json",
+                '  "engines": {\n    "node": ">=18.0.0"\n  },\n',
+            )
+        )
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_edit_non_manifest_file_allowed_even_with_range_looking_text(self):
+        rc, stdout, _ = _run_hook(
+            _edit_payload("src/main.py", 'VERSION_CONSTRAINT = "requests>=2.0.0"')
+        )
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_edit_requirements_test_range_blocked(self):
+        rc, stdout, _ = _run_hook(
+            _edit_payload("tests/requirements-test.txt", "pytest>=8.0.0\n")
+        )
+        assert rc == 0
+        assert _is_denied(stdout)
+
+    def test_edit_empty_new_string_allowed(self):
+        rc, stdout, _ = _run_hook(_edit_payload("pyproject.toml", ""))
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+
+# ---------------------------------------------------------------------------
+# (e) Bash detection
+# ---------------------------------------------------------------------------
+
+
+class TestBashDetectionPureFunction:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "npm install lodash",
+            "npm i lodash",
+            "npm add lodash",
+            "npm update",
+            "npm upgrade",
+            "npm up lodash",
+            "pip install requests",
+            "pip3 install requests",
+            "pip install --upgrade requests",
+            "pip install -U requests",
+            "uv add requests",
+            "uv sync --upgrade",
+            "uv sync -U",
+            "uv lock --upgrade-package requests",
+        ],
+    )
+    def test_blocked_commands(self, command):
+        assert bash_introduces_unpinned_dependency(command) is not None
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "npm ci",
+            "npm install",
+            "npm install --save-dev",
+            "uv sync",
+            "uv lock",
+            "pip install -r requirements.txt",
+            "uv pip install -r requirements.txt",
+            "npm install lodash@4.17.21",
+            "pip install requests==2.31.0",
+            "uv add requests==2.31.0",
+            "pip install -e .",
+            "pip install git+https://github.com/org/repo.git",
+        ],
+    )
+    def test_allowed_commands(self, command):
+        assert bash_introduces_unpinned_dependency(command) is None
+
+    def test_compound_command_with_blocked_segment(self):
+        assert (
+            bash_introduces_unpinned_dependency("echo hi && npm install lodash")
+            is not None
+        )
+
+    def test_compound_command_all_segments_allowed(self):
+        assert (
+            bash_introduces_unpinned_dependency("echo hi && npm ci && echo done")
+            is None
+        )
+
+
+class TestHookBashIntegration:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "npm install lodash",
+            "npm update",
+            "pip install requests",
+            "pip install --upgrade requests",
+            "uv add requests",
+            "uv sync --upgrade",
+        ],
+    )
+    def test_bash_blocked(self, command):
+        rc, stdout, _ = _run_hook(_bash_payload(command))
+        assert rc == 0
+        assert _is_denied(stdout)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "npm ci",
+            "npm install",
+            "uv sync",
+            "pip install -r requirements.txt",
+        ],
+    )
+    def test_bash_allowed(self, command):
+        rc, stdout, _ = _run_hook(_bash_payload(command))
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+
+# ---------------------------------------------------------------------------
+# (f) LOBSTER_ALLOW_DEPENDENCY_CHANGE bypass
+# ---------------------------------------------------------------------------
+
+
+class TestOverrideEnvVar:
+    def test_is_override_set_true(self, monkeypatch):
+        monkeypatch.setenv(_ENV_OVERRIDE, "true")
+        assert _is_override_set() is True
+
+    def test_is_override_set_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv(_ENV_OVERRIDE, "True")
+        assert _is_override_set() is True
+        monkeypatch.setenv(_ENV_OVERRIDE, "TRUE")
+        assert _is_override_set() is True
+
+    def test_is_override_set_false_when_absent(self, monkeypatch):
+        monkeypatch.delenv(_ENV_OVERRIDE, raising=False)
+        assert _is_override_set() is False
+
+    def test_is_override_not_set_for_other_values(self, monkeypatch):
+        monkeypatch.setenv(_ENV_OVERRIDE, "1")
+        assert _is_override_set() is False
+
+    def test_override_does_not_bypass_via_lobster_debug(self, monkeypatch):
+        """LOBSTER_DEBUG is a separate, unrelated variable and must not
+        trigger the bypass (this is the whole point of using a dedicated
+        env var per the module docstring)."""
+        monkeypatch.delenv(_ENV_OVERRIDE, raising=False)
+        monkeypatch.setenv("LOBSTER_DEBUG", "true")
+        assert _is_override_set() is False
+
+
+class TestHookOverrideBypass:
+    def test_override_bypasses_edit_block(self):
+        rc, stdout, _ = _run_hook(
+            _edit_payload("pyproject.toml", 'dependencies = ["mcp>=1.0.0"]'),
+            env={_ENV_OVERRIDE: "true"},
+        )
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_override_bypasses_write_block(self):
+        content = json.dumps({"dependencies": {"chokidar": "^3.6.0"}})
+        rc, stdout, _ = _run_hook(
+            _write_payload("package.json", content), env={_ENV_OVERRIDE: "true"}
+        )
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_override_bypasses_bash_block(self):
+        rc, stdout, _ = _run_hook(
+            _bash_payload("npm install lodash"), env={_ENV_OVERRIDE: "true"}
+        )
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_override_false_value_does_not_bypass(self):
+        rc, stdout, _ = _run_hook(
+            _bash_payload("npm install lodash"), env={_ENV_OVERRIDE: "false"}
+        )
+        assert rc == 0
+        assert _is_denied(stdout)
+
+    def test_override_absent_does_not_bypass(self):
+        rc, stdout, _ = _run_hook(_bash_payload("npm install lodash"), env=None)
+        assert rc == 0
+        assert _is_denied(stdout)
+
+
+# ---------------------------------------------------------------------------
+# (g) Non-covered tools, malformed / missing stdin
+# ---------------------------------------------------------------------------
+
+
+class TestHookGracefulHandling:
+    @pytest.mark.parametrize("tool_name", ["Read", "Glob", "Grep", "Task", "TodoWrite"])
+    def test_non_covered_tool_exits_0_no_deny(self, tool_name):
+        rc, stdout, _ = _run_hook(
+            {"tool_name": tool_name, "tool_input": {"file_path": "package.json"}}
+        )
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_malformed_json_stdin_exits_0(self):
+        rc, stdout, stderr = _run_hook_raw_stdin("not-valid-json{{{")
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_empty_stdin_exits_0(self):
+        rc, stdout, _ = _run_hook_raw_stdin("")
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_missing_tool_input_exits_0(self):
+        rc, stdout, _ = _run_hook({"tool_name": "Edit"})
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_edit_missing_file_path_exits_0(self):
+        rc, stdout, _ = _run_hook(
+            {"tool_name": "Edit", "tool_input": {"new_string": "foo>=1.0.0"}}
+        )
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_bash_missing_command_exits_0(self):
+        rc, stdout, _ = _run_hook({"tool_name": "Bash", "tool_input": {}})
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+    def test_notebook_edit_non_manifest_allowed(self):
+        rc, stdout, _ = _run_hook(
+            {
+                "tool_name": "NotebookEdit",
+                "tool_input": {"file_path": "notebook.ipynb", "new_source": "x = 1"},
+            }
+        )
+        assert rc == 0
+        assert not _is_denied(stdout)

--- a/tests/unit/test_hooks/test_pin_dependencies_guard.py
+++ b/tests/unit/test_hooks/test_pin_dependencies_guard.py
@@ -955,6 +955,198 @@ class TestHookHeredocInterpreterExecutionIntegration:
         assert not _is_denied(stdout)
 
 
+# ---------------------------------------------------------------------------
+# (e6) Round-5 bypass: interpreter `-c "<code>"` and here-strings (`<<<`)
+# never got scanned at all — the whole thing was one sub-command starting
+# with `bash`/`sh`/`zsh`, so the quoted/here-string install command inside
+# was invisible to the install-detection regexes (independent review,
+# PR #2151, issuecomment-5187771322).
+# ---------------------------------------------------------------------------
+
+
+class TestDashCAndHereStringBypassPureFunction:
+    """The exact 5 bypass commands the round-4 independent review
+    demonstrated as silently ALLOWED must now be BLOCKED, plus the nested
+    wrapper-command forms (docker exec, sudo) that go through the same
+    code path."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'bash -c "pip install requests"',
+            'bash <<< "pip install requests"',
+            'sh -c "uv add requests"',
+            'zsh -c "pip install requests"',
+            'bash -c "npm install lodash"',
+            'docker exec bash -c "pip install requests"',
+            'sudo bash -c "npm install foo"',
+        ],
+    )
+    def test_named_bypass_now_blocked(self, command):
+        assert bash_introduces_unpinned_dependency(command) is not None, (
+            f"expected {command!r} to be detected as an unpinned install"
+        )
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Pinned installs through the same forms must stay ALLOWED.
+            'bash -c "pip install requests==2.31.0"',
+            'bash <<< "pip install requests==2.31.0"',
+            'sh -c "uv add requests==2.31.0"',
+            'zsh -c "pip install requests==2.31.0"',
+            'bash -c "npm install lodash@4.17.21"',
+            'docker exec bash -c "pip install requests==2.31.0"',
+            'sudo bash -c "npm install foo@1.0.0"',
+            # Lockfile-respecting forms through -c must also stay ALLOWED.
+            'bash -c "npm ci"',
+            'bash -c "uv sync"',
+        ],
+    )
+    def test_pinned_or_lockfile_via_dash_c_or_here_string_not_blocked(self, command):
+        assert bash_introduces_unpinned_dependency(command) is None
+
+    def test_original_inert_heredoc_file_content_still_not_regressed(self):
+        """The round-2 false positive this fix must not reintroduce: example
+        install-command *text* used as file content in a heredoc (not
+        executed) must remain ALLOWED."""
+        command = "cat > f.sh <<EOF\npip install requests\nEOF\n"
+        assert bash_introduces_unpinned_dependency(command) is None
+
+    def test_interpreter_heredoc_execution_still_blocked(self):
+        """Existing (round-4) heredoc-fed-to-a-real-interpreter detection
+        must not regress."""
+        command = "bash <<EOF\npip install requests\nEOF\n"
+        assert bash_introduces_unpinned_dependency(command) is not None
+
+
+class TestHookDashCAndHereStringBypassIntegration:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'bash -c "pip install requests"',
+            'bash <<< "pip install requests"',
+            'sh -c "uv add requests"',
+            'zsh -c "pip install requests"',
+            'bash -c "npm install lodash"',
+            'docker exec bash -c "pip install requests"',
+            'sudo bash -c "npm install foo"',
+        ],
+    )
+    def test_named_bypass_blocked_via_full_hook(self, command):
+        rc, stdout, _ = _run_hook(_bash_payload(command))
+        assert rc == 0
+        assert _is_denied(stdout)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'bash -c "pip install requests==2.31.0"',
+            'bash <<< "pip install requests==2.31.0"',
+            'bash -c "npm ci"',
+        ],
+    )
+    def test_pinned_or_lockfile_via_dash_c_allowed_via_full_hook(self, command):
+        rc, stdout, _ = _run_hook(_bash_payload(command))
+        assert rc == 0
+        assert not _is_denied(stdout)
+
+
+class TestAdversarialPayloadVectorsPureFunction:
+    """Vectors beyond the 5 named bypasses, exercised in the round-5
+    self-review: eval, command substitution, and double-nested -c. These
+    confirm the fix is a general "scan any code actually handed to an
+    interpreter" mechanism, not a regex tuned to the 5 named cases."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'eval "pip install requests"',
+            "eval 'npm install lodash'",
+            "$(pip install requests)",
+            "`pip install requests`",
+            # Double-nested -c: bash -> sh -> pip install requests
+            'bash -c "sh -c \\"pip install requests\\""',
+            # -c mixed with an unrelated heredoc elsewhere in the same
+            # command: both must be independently evaluated.
+            'bash -c "npm install lodash" && cat > f.sh <<EOF\nsome text\nEOF\n',
+        ],
+    )
+    def test_adversarial_vector_blocked(self, command):
+        assert bash_introduces_unpinned_dependency(command) is not None, (
+            f"expected {command!r} to be detected as an unpinned install"
+        )
+
+    def test_double_nested_dash_c_pinned_not_blocked(self):
+        command = 'bash -c "sh -c \\"pip install requests==2.31.0\\""'
+        assert bash_introduces_unpinned_dependency(command) is None
+
+    def test_eval_pinned_not_blocked(self):
+        assert bash_introduces_unpinned_dependency('eval "pip install requests==2.31.0"') is None
+
+
+# ---------------------------------------------------------------------------
+# (e7) Round-5 self-review finding: `echo "<text>" | <interpreter>` /
+# `printf "<text>" | <interpreter>` is the same "literal executed text"
+# bug class as the here-string bypass, just spelled with a pipe. Found
+# during the mandatory adversarial self-review (no external reviewer this
+# round), not among the 5 named bypasses — demonstrates the fix generalizes
+# rather than pattern-matching the named cases.
+# ---------------------------------------------------------------------------
+
+
+class TestEchoPrintfPipeBypassPureFunction:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'echo "pip install requests" | bash',
+            'printf "pip install requests" | sh',
+            'echo pip install requests | bash',
+            'echo "npm install lodash" | zsh',
+            'printf "uv add requests" | bash',
+        ],
+    )
+    def test_echo_printf_pipe_to_interpreter_blocked(self, command):
+        assert bash_introduces_unpinned_dependency(command) is not None, (
+            f"expected {command!r} to be detected as an unpinned install"
+        )
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'echo "pip install requests==2.31.0" | bash',
+            'echo hi | bash',
+            'printf "just some text" | sh',
+            'echo hi && npm ci',
+            'echo hello or npm install foo',
+        ],
+    )
+    def test_echo_printf_pipe_pinned_or_unrelated_not_blocked(self, command):
+        assert bash_introduces_unpinned_dependency(command) is None
+
+    def test_opaque_producer_piped_to_interpreter_is_a_documented_out_of_scope_gap(self):
+        """`cat <unknown file> | bash` cannot be statically evaluated — the
+        file's contents aren't known ahead of execution. This is a
+        deliberate, disclosed limitation (see module docstring), not a
+        regression: only a *literal* echo/printf argument is staticaly
+        knowable."""
+        assert bash_introduces_unpinned_dependency("cat unknownfile.sh | bash") is None
+
+
+class TestHookEchoPrintfPipeBypassIntegration:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'echo "pip install requests" | bash',
+            'echo pip install requests | bash',
+        ],
+    )
+    def test_echo_printf_pipe_blocked_via_full_hook(self, command):
+        rc, stdout, _ = _run_hook(_bash_payload(command))
+        assert rc == 0
+        assert _is_denied(stdout)
+
+
 class TestHookGracefulHandling:
     @pytest.mark.parametrize("tool_name", ["Read", "Glob", "Grep", "Task", "TodoWrite"])
     def test_non_covered_tool_exits_0_no_deny(self, tool_name):

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "pillow", specifier = ">=12.1.1" }]
+overrides = [{ name = "pillow", specifier = "==12.1.1" }]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -914,34 +914,34 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cryptography", specifier = ">=42.0.0" },
-    { name = "fastembed", specifier = ">=0.3.0" },
-    { name = "httpx", specifier = ">=0.27.0" },
-    { name = "mcp", specifier = ">=1.0.0" },
-    { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.40.0" },
-    { name = "psutil", specifier = ">=5.9.0" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=5.0.0" },
-    { name = "pytest-timeout", marker = "extra == 'test'", specifier = ">=2.2.0" },
-    { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "python-telegram-bot", specifier = ">=21.0" },
-    { name = "slack-bolt", marker = "extra == 'slack'", specifier = ">=1.18.0" },
-    { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.27.0" },
-    { name = "sqlite-vec", specifier = ">=0.1.7a1" },
-    { name = "starlette", specifier = ">=0.37.0" },
-    { name = "twilio", specifier = ">=9.0.0" },
-    { name = "tzdata", marker = "extra == 'windows'", specifier = ">=2024.1" },
-    { name = "uvicorn", specifier = ">=0.29.0" },
-    { name = "watchdog", specifier = ">=4.0.0" },
-    { name = "websockets", specifier = ">=13.0" },
+    { name = "cryptography", specifier = "==46.0.5" },
+    { name = "fastembed", specifier = "==0.7.4" },
+    { name = "httpx", specifier = "==0.28.1" },
+    { name = "mcp", specifier = "==1.26.0" },
+    { name = "playwright", marker = "extra == 'browser'", specifier = "==1.58.0" },
+    { name = "psutil", specifier = "==7.2.2" },
+    { name = "pytest", marker = "extra == 'test'", specifier = "==9.0.2" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = "==1.3.0" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = "==7.0.0" },
+    { name = "pytest-timeout", marker = "extra == 'test'", specifier = "==2.4.0" },
+    { name = "python-dotenv", specifier = "==1.2.1" },
+    { name = "python-telegram-bot", specifier = "==22.6" },
+    { name = "slack-bolt", marker = "extra == 'slack'", specifier = "==1.27.0" },
+    { name = "slack-sdk", marker = "extra == 'slack'", specifier = "==3.40.1" },
+    { name = "sqlite-vec", specifier = "==0.1.7a10" },
+    { name = "starlette", specifier = "==0.52.1" },
+    { name = "twilio", specifier = "==9.10.3" },
+    { name = "tzdata", marker = "extra == 'windows'", specifier = "==2026.1" },
+    { name = "uvicorn", specifier = "==0.41.0" },
+    { name = "watchdog", specifier = "==6.0.0" },
+    { name = "websockets", specifier = "==16.0" },
 ]
 provides-extras = ["dashboard", "windows", "browser", "slack", "test"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = ">=9.0.2" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest", specifier = "==9.0.2" },
+    { name = "pytest-asyncio", specifier = "==1.3.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Prompted by a Shai-Hulud-style npm supply-chain worm investigation (this system was found clean, but the risk of a compromised package silently landing via a `^`/`~`/unbounded range was judged real enough to close off structurally, not just by vigilance). This PR establishes a pin-everything policy across the Lobster system's dependency manifests and adds tooling to enforce it going forward.

- Every dependency manifest in this repo (`pyproject.toml` + `uv.lock` at root, `connectors/whatsapp/package.json`, `lobster-shop/multiplayer-telegram-bot/{pyproject.toml,uv.lock}`, `lobster-shop/obsidian-km/requirements.txt`, `tests/requirements-test.txt`) is now pinned to an exact version — no `^`, `~`, `~=`, `>=`, `<=`, `!=`, `>`, `<`, `*`, or `"latest"` ranges. See `DEPENDENCY_NOTES.md` for the full per-manifest audit trail and rationale (including why test deps are pinned to the *same* version as root rather than "whatever's latest today" — a dry-run resolve of the old unbounded `tests/requirements-test.txt` came back a full major version ahead of what's actually running).
- A new `hooks/pin-dependencies-guard.py` PreToolUse hook blocks:
  - Edit/Write/NotebookEdit calls that would introduce an unpinned range into a manifest file (`package.json`, `pyproject.toml`, `requirements*.txt`, `Pipfile`)
  - Bash package-manager commands that could silently resolve to "whatever is newest right now": bare `npm install <pkg>` / `npm update`, `pip install <pkg>` without `==` / `pip install --upgrade`, `uv add <pkg>` without `==`, `uv sync`/`uv lock --upgrade`, `uv run --with <pkg>` without `==` — including via `python -m pip`, a path-prefixed binary (`/usr/bin/pip`, `venv/bin/pip`, `node_modules/.bin/npm`), or an `env`/`command`/`VAR=val` wrapper prefix (see "Fixes from independent review" below)
  - Commands/edits that use an existing lockfile or an exact pin (`npm ci`, `uv sync` with no flags, `pip install -r file.txt`, `pkg==1.2.3`, `pkg@1.2.3`), or a local-path npm install (`npm install ./local-pkg`), are correctly left alone.
- `hooks/pre-commit` gets the same detection logic wired in as a defense-in-depth backstop at commit time (catches manifest edits made outside Claude Code's own tools).
- `install.sh` and `scripts/upgrade.sh` (migration 97) register the new hook for fresh installs and upgrades.

**Escape hatch:** set `LOBSTER_ALLOW_DEPENDENCY_CHANGE=true` in the environment for one deliberate, reviewed version bump. This is intentionally a separate variable from `LOBSTER_DEBUG` (which is already persistently `true` in this system's settings.json for unrelated reasons — reusing it here would make the hook a permanent no-op).

## Fixes from independent review (NEEDS-WORK → addressed)

An independent reviewer found real gaps in `hooks/pin-dependencies-guard.py`, demonstrated by direct invocation. All three are fixed, with new falsifiable test coverage for each:

1. **Bash bypass gaps** — `python -m pip install <pkg>` (no `==`), pip/npm invoked via a path (`/usr/bin/pip`, `venv/bin/pip`, `node_modules/.bin/npm`), `env`/`command` wrapper prefixes, and `uv run --with <pkg>` all previously evaded detection entirely. Fixed by resolving the actual binary/subcommand being invoked (stripping wrapper/assignment prefixes, normalizing path-prefixed command names, recognizing `python -m pip` as `pip`) before pattern matching, and adding dedicated `uv run --with` detection.
2. **False positives** — a heredoc containing an example install command as file *content* (not an actual invocation) was blocked, because every `\n` was treated as a command boundary; the literal words "and"/"or" anywhere in a command were misparsed as shell operators; `npm install ./local-package` (a local-path install) was flagged as "unpinned"; and a prose comment in a manifest merely mentioning a version range (e.g. `# needs numpy>=1.20 installed separately`) was blocked identically to a real dependency line. Fixed by masking heredoc bodies before sub-command splitting, restricting the splitter to real shell operators only (`|`, `;`, `&`, newline — not bare "and"/"or"), skipping local-path/URL/tarball npm install targets, and stripping whole-line comments before scanning non-JSON manifests.
3. **Pre-existing-failure count corrected** — see below.

## Known gaps (flagged, not silently worked around — see `DEPENDENCY_NOTES.md` for full detail)

1. **`connectors/whatsapp/package-lock.json` does not exist and is not committed.** That directory's own `.gitignore` blanket-excludes lock files. Direct deps in `package.json` are pinned exactly, but transitive deps of `whatsapp-web.js` (which pulls in `puppeteer`) can still float on a fresh `npm install` without a committed lockfile. This conflicts with an existing, deliberate repo convention, so it's flagged for an explicit decision rather than overridden unilaterally.
2. **`lobster-shop/camofox-browser/server` was not modified.** It's vendored as a nested git checkout (gitlink, no `.gitmodules`) whose `origin` points at a separate product repo (`jo-inc/camofox-browser`), not part of the Lobster system. Its `package.json` still uses `^` ranges. Editing a foreign repo's manifest/history from inside this task felt out of scope; flagging here rather than leaving it unmentioned.

## NOT included in this PR

**Activating this hook in the live `~/.claude/settings.json` on any running instance is a deliberate, separate follow-up decision** — not part of this PR. This PR only adds the capability (the hook script itself), the `install.sh` registration for fresh installs, and `upgrade.sh` migration 97 for existing installs to pick it up. No live settings.json anywhere has been touched.

## Test plan / evidence

- **Automated test suite:** `tests/unit/test_hooks/test_pin_dependencies_guard.py` — **211 test cases, all passing** (141 original + 70 added for the independent-review fixes above: bypass-gap coverage for `python -m pip`, path-prefixed binaries, `env`/`command`/assignment wrappers, and `uv run --with`; false-positive coverage for heredoc bodies, bare "and"/"or", local-path npm installs, and prose comments in manifests).

  ```
  211 passed, 1 warning in 5.7s
  ```

- **Falsifiability check performed for the new fixes** (proves the new tests aren't vacuous): three targeted mutations were applied directly to the real `hooks/pin-dependencies-guard.py`, tested, then reverted via file restore before moving to the next:
  1. Neutered `_resolve_subcommand` (made it a no-op) and removed the `uv run --with` check → 26 of the 37 bypass-gap-related tests failed (all 18 `test_bypass_gap_now_blocked` cases + all 8 `TestHookBashBypassGapsIntegration` cases); the 11-case pinned/lockfile sanity class stayed green as expected
  2. Reverted the sub-command splitter to include bare "and"/"or", removed heredoc masking, and removed the local-path skip in `_node_package_args_unpinned` → 12 of the 18 false-positive-related tests failed (3 heredoc, 2 bare-and/or, 4 local-path pure-function cases, plus all 3 full-hook-integration cases); the 6 "still correctly detected" sanity cases in the same classes stayed green
  3. Removed the whole-line-comment strip from `find_unpinned_range` → 5 of the 7 manifest-comment tests failed (3 pure-function + both integration cases); the inline-trailing-comment case and the `_strip_full_line_comments` helper unit test (which doesn't go through `find_unpinned_range`) stayed green as expected

  Working tree confirmed identical (`diff` clean) to the fixed version after each restore, and the full 211-test suite re-confirmed green afterward.

  (Original falsifiability check for the base 141 tests, from the prior review round, still holds: neutering `_PY_RANGE_RE` failed 11 tests, removing the "engines" exclusion failed exactly the 5 engines-regression tests, stubbing `bash_introduces_unpinned_dependency` to always return `None` failed all 23 Bash-related tests.)

- **`uv sync --frozen`** run clean from repo root: `Checked 78 packages in 2ms` — no regressions from the hook changes.

- **Pre-existing test failures — corrected count.** `uv run pytest tests/unit/ --tb=no -q` reports **16 pre-existing failures** (not 8), across **7 files**, none related to dependency pinning or this hook:
  - `tests/unit/test_bot/test_slack_router_config.py` — 1
  - `tests/unit/test_hooks/test_context_monitor.py` — 1
  - `tests/unit/test_hooks/test_on_compact_write_claude_session_id.py` — 7
  - `tests/unit/test_mcp_server/test_push_calendar_token_endpoint.py` — 2
  - `tests/unit/test_mcp_server/test_push_gmail_token_endpoint.py` — 2
  - `tests/unit/test_mcp_server/test_push_workspace_token_endpoint.py` — 2
  - `tests/unit/test_script_inbox_sources.py` — 1

  Reconfirmed on this branch after the fixes above (`3949 passed, 16 failed, 31 skipped` on `tests/unit/`), same 16/7 as before these changes and as on `main` — this PR does not introduce, fix, or otherwise touch any of them. See `DEPENDENCY_NOTES.md` for the full corrected breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
