### PR TITLE
Capture real PID at session_start() and use as primary liveness signal (Phase 1: PID ground truth)

### DIFF
--- a/hooks/auto-register-agent.py
+++ b/hooks/auto-register-agent.py
@@ -62,6 +62,40 @@ _LOG_PATH = (
     / "hook-failures.log"
 )
 
+# ---------------------------------------------------------------------------
+# PID ground truth (issue #2148, Phase 1)
+# ---------------------------------------------------------------------------
+#
+# This hook is exec'd fresh, as a direct child of the dispatcher's `claude` OS
+# process, on every Agent-tool call (PostToolUse). Verified live via
+# process-tree inspection (pstree -p) on 2026-08-03: Agent/Task-tool-spawned
+# subagents run in-process as threads of the single dispatcher `claude`
+# process — they have no OS PID of their own to record. What we CAN and do
+# record is the real PID of the dispatcher process this hook is a child of,
+# via a process-tree walk (not a flat os.getppid(), which would only be
+# correct for exactly one hop — the walk handles any intermediate wrapper
+# processes robustly, mirroring hooks/session_role.py's established
+# is_dispatcher_session() process-tree technique).
+_SRC_DIR = str(Path(__file__).resolve().parent.parent / "src")
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, _SRC_DIR)
+
+import agents.pid_liveness as _pid_liveness  # noqa: E402
+
+
+def _capture_dispatcher_pid() -> int | None:
+    """Best-effort: find the real dispatcher PID via a process-tree walk.
+
+    Never raises — any failure (missing /proc, unexpected process tree
+    shape, etc.) is swallowed and treated as "no dispatcher PID available",
+    exactly like a pre-migration row. Registration must never be blocked by
+    a PID-capture failure.
+    """
+    try:
+        return _pid_liveness.find_dispatcher_ancestor_pid()
+    except Exception:  # noqa: BLE001
+        return None
+
 
 # ---------------------------------------------------------------------------
 # Logging (failures only -- never to stdout, never exit non-zero)
@@ -197,6 +231,7 @@ def insert_agent_session(
     session_id: str,
     output_file: str | None,
     input_summary: str | None,
+    dispatcher_pid: int | None = None,
 ) -> None:
     """Insert a 'running' row into agent_sessions.db.
 
@@ -236,18 +271,37 @@ def insert_agent_session(
                 notified_at         TEXT,
                 trigger_message_id  TEXT,
                 trigger_snippet     TEXT,
-                reply_message_ids   TEXT
+                reply_message_ids   TEXT,
+                pid                 INTEGER,
+                dispatcher_pid      INTEGER,
+                pid_captured_at     TEXT
             )
         """)
+        # Additive migration for DBs created before this hook wrote the
+        # pid/dispatcher_pid/pid_captured_at columns (mirrors session_store.py's
+        # _MIGRATION_STMTS pattern). Each ALTER is a no-op on a fresh table that
+        # already has the column from the CREATE TABLE above.
+        for stmt in (
+            "ALTER TABLE agent_sessions ADD COLUMN pid INTEGER",
+            "ALTER TABLE agent_sessions ADD COLUMN dispatcher_pid INTEGER",
+            "ALTER TABLE agent_sessions ADD COLUMN pid_captured_at TEXT",
+        ):
+            try:
+                conn.execute(stmt)
+            except Exception:  # noqa: BLE001
+                pass  # Column already exists — no-op
+
         now = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+        pid_captured_at = now if dispatcher_pid is not None else None
         conn.execute(
             """
             INSERT OR IGNORE INTO agent_sessions
                 (id, task_id, agent_type, description, chat_id, source,
-                 status, output_file, input_summary, spawned_at)
+                 status, output_file, input_summary, spawned_at,
+                 dispatcher_pid, pid_captured_at)
             VALUES
                 (?, ?, 'subagent', 'auto-registered by PostToolUse hook', ?, ?,
-                 'running', ?, ?, ?)
+                 'running', ?, ?, ?, ?, ?)
             """,
             (
                 agent_id,
@@ -257,6 +311,8 @@ def insert_agent_session(
                 output_file,
                 input_summary,
                 now,
+                dispatcher_pid,
+                pid_captured_at,
             ),
         )
         conn.commit()
@@ -298,6 +354,8 @@ def main() -> None:
         # and the dispatcher can reconstruct context if the agent fails.
         input_summary = prompt[:500] if prompt else None
 
+        dispatcher_pid = _capture_dispatcher_pid()
+
         insert_agent_session(
             agent_id=agent_id,
             task_id=metadata["task_id"],
@@ -306,6 +364,7 @@ def main() -> None:
             session_id=session_id,
             output_file=output_file,
             input_summary=input_summary,
+            dispatcher_pid=dispatcher_pid,
         )
 
     except Exception as exc:  # noqa: BLE001

--- a/scripts/agent-monitor.py
+++ b/scripts/agent-monitor.py
@@ -80,6 +80,16 @@ AGENT_OUTPUT_GLOB = _default_agent_output_glob()
 # Pattern for agent JSONL symlink filenames: agent-<hex_id>.jsonl
 AGENT_SYMLINK_PATTERN = re.compile(r"^agent-([0-9a-f]+)\.jsonl$")
 
+# PID ground truth (issue #2148, Phase 1) — shared liveness primitive.
+# agent_sessions.db and this script live in the same repo checkout, so the
+# import path is resolved relative to this file rather than assuming a
+# particular cwd.
+_SRC_DIR = str(Path(__file__).resolve().parent.parent / "src")
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, _SRC_DIR)
+
+from agents.pid_liveness import is_pid_alive  # noqa: E402
+
 # Age threshold for treating an unregistered output file as "active" (minutes)
 UNREGISTERED_ACTIVE_THRESHOLD_MINUTES = 30.0
 
@@ -94,6 +104,8 @@ class AgentRow:
     spawned_at: str
     output_file: str | None
     last_seen_at: str | None
+    pid: int | None = None
+    dispatcher_pid: int | None = None
 
 
 @dataclass(frozen=True)
@@ -238,15 +250,46 @@ def classify(
     output_file_age_minutes: float | None,
     threshold_minutes: float,
     output_file_threshold_minutes: float,
+    pid_alive: bool | None = None,
+    dispatcher_pid_alive: bool | None = None,
 ) -> Classification:
-    """Classify a running agent given age and output file liveness.
+    """Classify a running agent given age, output file liveness, and PID ground truth.
 
-    Logic (all thresholds configurable):
+    PID ground truth (issue #2148, Phase 1) is the PRIMARY signal, taking
+    precedence over the age/output-file heuristics below. Callers precompute
+    pid_alive/dispatcher_pid_alive via agents.pid_liveness.is_pid_alive() and
+    pass plain booleans (or None) here — keeping this function pure/testable
+    without any OS-level calls of its own, exactly like the rest of this
+    module's classification logic.
+
+      - pid_alive is not None (a real pid was recorded for this row): the
+        real OS process's existence is definitive. HEALTHY if alive,
+        GHOST_CONFIRMED if not — regardless of age or output_file mtime.
+      - pid_alive is None and dispatcher_pid_alive is False: no pid of its
+        own (an in-process Agent-tool subagent), but its parent dispatcher
+        process is confirmed dead — the subagent is necessarily dead too.
+        GHOST_CONFIRMED.
+      - pid_alive is None and dispatcher_pid_alive is True: the dispatcher
+        being alive does NOT prove this particular subagent is still
+        active (the dispatcher process running says nothing about any one
+        in-process conversation thread) — falls through to the existing
+        heuristics below, unchanged.
+      - Both None (pre-migration row, or no real process boundary exists):
+        falls through to the existing heuristics below, byte-for-byte
+        unchanged from pre-#2148 behavior.
+
+    Legacy heuristic (all thresholds configurable):
       - age < threshold             → HEALTHY (too young to worry about)
       - age >= threshold, no file   → STALE_NO_FILE (can't check liveness)
       - age >= threshold, file recent → GHOST_SUSPECTED (still writing, maybe slow)
       - age >= threshold, file old/missing → GHOST_CONFIRMED (likely dead)
     """
+    if pid_alive is not None:
+        return "HEALTHY" if pid_alive else "GHOST_CONFIRMED"
+
+    if dispatcher_pid_alive is not None and not dispatcher_pid_alive:
+        return "GHOST_CONFIRMED"
+
     if age_minutes < threshold_minutes:
         return "HEALTHY"
 
@@ -272,7 +315,23 @@ def classify_agent(
 ) -> ClassifiedAgent:
     age = compute_age_minutes(row.spawned_at, now)
     file_age = compute_output_file_age_minutes(row.output_file, now)
-    label = classify(age, row.output_file, file_age, threshold_minutes, output_file_threshold_minutes)
+
+    # PID ground truth (issue #2148) — resolve real-process liveness here,
+    # at the one OS-facing boundary, so classify() itself stays pure.
+    pid_alive: bool | None = is_pid_alive(row.pid) if row.pid is not None else None
+    dispatcher_pid_alive: bool | None = (
+        is_pid_alive(row.dispatcher_pid) if row.dispatcher_pid is not None else None
+    )
+
+    label = classify(
+        age,
+        row.output_file,
+        file_age,
+        threshold_minutes,
+        output_file_threshold_minutes,
+        pid_alive=pid_alive,
+        dispatcher_pid_alive=dispatcher_pid_alive,
+    )
     return ClassifiedAgent(
         row=row,
         classification=label,
@@ -384,7 +443,7 @@ def load_running_agents(db_path: Path) -> list[AgentRow]:
         rows = conn.execute(
             """
             SELECT id, task_id, description, chat_id, status,
-                   spawned_at, output_file, last_seen_at
+                   spawned_at, output_file, last_seen_at, pid, dispatcher_pid
             FROM agent_sessions
             WHERE status IN ('running', 'starting')
             ORDER BY spawned_at ASC
@@ -403,6 +462,8 @@ def load_running_agents(db_path: Path) -> list[AgentRow]:
             spawned_at=row["spawned_at"],
             output_file=row["output_file"],
             last_seen_at=row["last_seen_at"],
+            pid=row["pid"],
+            dispatcher_pid=row["dispatcher_pid"],
         )
         for row in rows
     ]

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -807,6 +807,58 @@ check_claude_process() {
     return 1
 }
 
+#===============================================================================
+# Check: dispatcher PID consistency (issue #2148, Phase 1 — PID ground truth)
+#
+# Additive and observational ONLY — does not replace, gate, or duplicate
+# check_wrapper_process / check_claude_process above, which already
+# independently verify the dispatcher's real liveness via pgrep + tmux-pane
+# ancestry, with no dependency on agent_sessions.db. Per the issue's own
+# scope guidance, the integration point here is reading the same `pid`
+# column session_start() now writes for the dispatcher's own row (recorded
+# via a process-tree walk in inbox_server.py's handle_session_start(), see
+# src/agents/pid_liveness.py), for cross-check consistency with what
+# check_claude_process finds independently — not a parallel reimplementation
+# of liveness detection, and not a rewrite of any of this script's other
+# ~13 checks.
+#
+# Never sets `level` or `restart_reason` — a mismatch here is a signal worth
+# investigating (logged as a warning), not on its own grounds for a restart.
+# Fails open (returns 0, logs and moves on) if the DB or column don't exist
+# yet (pre-migration installs), sqlite3 is unavailable, or the query errors.
+#===============================================================================
+check_dispatcher_pid_consistency() {
+    local db_file="${MESSAGES_DIR}/config/agent_sessions.db"
+    if [[ ! -f "$db_file" ]]; then
+        return 0
+    fi
+
+    local db_pid
+    db_pid=$(sqlite3 "$db_file" \
+        "SELECT pid FROM agent_sessions WHERE agent_type='dispatcher' AND status='running' AND pid IS NOT NULL ORDER BY spawned_at DESC LIMIT 1;" \
+        2>/dev/null)
+
+    if [[ -z "$db_pid" ]]; then
+        log_info "Dispatcher PID consistency: no pid recorded in agent_sessions.db yet (pre-migration row, or dispatcher hasn't re-registered since this deploy) — skipping"
+        return 0
+    fi
+
+    if ! kill -0 "$db_pid" 2>/dev/null; then
+        log_warn "Dispatcher PID consistency: agent_sessions.db reports dispatcher pid $db_pid, but that process is not alive (informational only — check_claude_process above is the authoritative liveness check)"
+        return 0
+    fi
+
+    local claude_pids
+    claude_pids=$(pgrep -x "claude" 2>/dev/null)
+    if echo "$claude_pids" | grep -qw "$db_pid"; then
+        log_info "Dispatcher PID consistency: agent_sessions.db pid $db_pid matches a live 'claude' process — consistent"
+    else
+        log_warn "Dispatcher PID consistency: agent_sessions.db pid $db_pid is alive but is not among the 'claude'-named processes found by pgrep (informational only)"
+    fi
+
+    return 0
+}
+
 # Check if a source is user-facing (should count toward inbox staleness)
 is_user_facing_source() {
     local source="$1"
@@ -1782,6 +1834,9 @@ main() {
         level="RED"
         restart_reason="systemd service not active"
     fi
+
+    # --- Dispatcher PID consistency (issue #2148) — additive, observational only ---
+    check_dispatcher_pid_consistency
 
     # --- Lifecycle-aware Claude checks ---
     #

--- a/src/agents/pid_liveness.py
+++ b/src/agents/pid_liveness.py
@@ -1,0 +1,153 @@
+"""
+PID liveness primitive — Phase 1: PID ground truth (issue #2148).
+
+Scoped from shadowlobster#65's "Deepened design brief". This module is the
+single shared source of truth for "is this OS process actually alive?",
+callable from both Python (session_store.py, agent-monitor.py) and shell
+(health-check-v3.sh, via `python3 -m agents.pid_liveness <pid>` or similar)
+so the three independent liveness classifiers stop disagreeing.
+
+Two responsibilities, both pure/read-only (no writes, no side effects):
+
+  1. is_pid_alive(pid) — ground-truth liveness check via os.kill(pid, 0).
+     This is the PRIMARY signal wherever a real PID was captured. Existing
+     output_file-mtime / stop_reason heuristics remain the fallback for rows
+     where no real process boundary exists (pre-migration rows, or Agent-tool
+     in-process subagents that have no PID of their own — see
+     find_dispatcher_ancestor_pid below).
+
+  2. find_dispatcher_ancestor_pid() — walks the real /proc process tree to
+     find the nearest ancestor process whose executable is literally named
+     "claude" (the dispatcher's own OS process). This is needed because two
+     of the three call sites that must capture a "dispatcher PID" do NOT run
+     inside the dispatcher's own `claude` process:
+
+       - hooks/auto-register-agent.py is exec'd fresh, per Agent-tool call,
+         as a direct child of the `claude` process (one hop up).
+       - src/mcp/inbox_server.py's handle_session_start() (dispatcher
+         self-registration) runs inside the `lobster-inbox` MCP server child
+         process, which Claude Code spawns via stdio per `.mcp.json`
+         (`"type": "stdio"`) — itself a direct child of `claude`, but NOT the
+         same PID as `claude` itself. A plain os.getpid() there would record
+         the MCP server child's PID, not the dispatcher's.
+
+     Verified live (read-only `pstree -p` inspection, no live state touched)
+     against the actual running host on 2026-08-03: Agent/Task-tool-spawned
+     subagents show up as *threads* of the single dispatcher `claude` OS
+     process (pstree's `{claude}(<tid>)` notation), not as separate
+     processes — confirming they have no OS PID of their own to capture.
+     This is exactly the "in-process sub-conversation" case the issue's
+     architectural caveat asked to be verified rather than assumed.
+
+Known limitation — PID reuse race (see docs/engineering-lessons-learned.md,
+"PID Reuse Race"): is_pid_alive() can return a false positive if the PID was
+reused by an unrelated process after the original one exited. This module
+does not attempt to close that race (e.g. via /proc/<pid>/stat start-time
+comparison) — it is documented here as a known limitation per the issue's
+explicit instruction not to over-engineer a fix for it in this slice.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def is_pid_alive(pid: int | None) -> bool:
+    """Return True if `pid` refers to a live OS process, False otherwise.
+
+    Uses os.kill(pid, 0) — sends no actual signal, just probes existence.
+    Treats PermissionError (process exists but we lack privileges to signal
+    it — e.g. owned by a different user) as alive, since the process clearly
+    exists. Treats any other failure (ProcessLookupError, invalid pid, etc.)
+    as not alive.
+
+    Args:
+        pid: The OS process ID to check. None, 0, and negative values are
+             treated as "no real PID" and return False without raising.
+    """
+    if pid is None:
+        return False
+    try:
+        pid_int = int(pid)
+    except (TypeError, ValueError):
+        return False
+    if pid_int <= 0:
+        return False
+
+    try:
+        os.kill(pid_int, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # Process exists; we just can't signal it.
+    except OSError:
+        return False
+    return True
+
+
+def _read_ppid(pid: int) -> int | None:
+    """Return the parent PID of `pid` by reading /proc/<pid>/stat, or None.
+
+    The comm field may itself contain parentheses/spaces, so we split on the
+    last ')' to safely isolate the fields that follow it (state, ppid, ...).
+    """
+    try:
+        with open(f"/proc/{pid}/stat") as f:
+            content = f.read()
+        after_comm = content.rsplit(")", 1)[-1]
+        fields = after_comm.split()
+        ppid = int(fields[1])  # fields[0] is state, fields[1] is ppid
+        return ppid if ppid > 0 else None
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def _read_comm(pid: int) -> str:
+    """Return the process name (comm) for `pid`, or '' if unreadable."""
+    try:
+        with open(f"/proc/{pid}/comm") as f:
+            return f.read().strip()
+    except OSError:
+        return ""
+
+
+def find_dispatcher_ancestor_pid(
+    start_pid: int | None = None,
+    max_depth: int = 20,
+) -> int | None:
+    """Walk up the process tree from `start_pid` to find the dispatcher's PID.
+
+    Returns the PID of the nearest ancestor process whose kernel-reported
+    comm is exactly "claude" (the dispatcher's real OS process — the `claude`
+    CLI binary running inside the lobster tmux session), or None if no such
+    ancestor is found within `max_depth` hops, or if the process tree cannot
+    be read (e.g. running on a non-Linux system without /proc).
+
+    Args:
+        start_pid: PID to start walking from. Defaults to os.getpid() (the
+                   calling process itself).
+        max_depth: Maximum number of parent hops to walk before giving up.
+                   0 means "do not walk at all" (returns None immediately).
+
+    This mirrors the process-tree walk already established and validated in
+    hooks/session_role.py's _is_dispatcher_by_process_tree() / _get_ppid() /
+    _is_claude_process() for is_dispatcher_session() — reused here as the
+    shared, DB-facing counterpart so PID capture at session_start() time uses
+    the same ground truth the hook-side dispatcher detection already relies
+    on. Unlike that helper, this one does not cross-check tmux pane PIDs —
+    it is only used to find a PID to record, not to gate dispatcher-only
+    tool access, so a plain ancestor walk is sufficient and simpler to test.
+    """
+    pid = start_pid if start_pid is not None else os.getpid()
+
+    current = pid
+    for _ in range(max_depth):
+        ppid = _read_ppid(current)
+        if ppid is None or ppid <= 1:
+            return None
+        comm = _read_comm(ppid)
+        if comm == "claude":
+            return ppid
+        current = ppid
+
+    return None

--- a/src/agents/session_store.py
+++ b/src/agents/session_store.py
@@ -35,6 +35,7 @@ if _SRC_DIR not in sys.path:
     sys.path.insert(0, _SRC_DIR)
 
 from utils.agent_types import DISPATCHER_EXCLUSION_SQL  # noqa: E402
+from agents.pid_liveness import is_pid_alive  # noqa: E402
 
 log = logging.getLogger(__name__)
 
@@ -81,7 +82,10 @@ CREATE TABLE IF NOT EXISTS agent_sessions (
     reply_message_ids   TEXT,
     stop_reason         TEXT,
     idempotency         TEXT DEFAULT 'unknown',
-    task_origin         TEXT DEFAULT 'user'
+    task_origin         TEXT DEFAULT 'user',
+    pid                 INTEGER,
+    dispatcher_pid      INTEGER,
+    pid_captured_at     TEXT
 );
 """
 
@@ -127,6 +131,10 @@ _MIGRATION_STMTS = [
     "ALTER TABLE agent_sessions ADD COLUMN stop_reason TEXT",
     "ALTER TABLE agent_sessions ADD COLUMN idempotency TEXT DEFAULT 'unknown'",
     "ALTER TABLE agent_sessions ADD COLUMN task_origin TEXT DEFAULT 'user'",
+    # issue #2148 (Phase 1: PID ground truth) — additive, NULL on pre-migration rows.
+    "ALTER TABLE agent_sessions ADD COLUMN pid INTEGER",
+    "ALTER TABLE agent_sessions ADD COLUMN dispatcher_pid INTEGER",
+    "ALTER TABLE agent_sessions ADD COLUMN pid_captured_at TEXT",
 ]
 
 # Additive migrations for the reports table (BIS-85 multi-instance prep).
@@ -253,6 +261,8 @@ def session_start(
     trigger_snippet: str | None = None,
     idempotency: str | None = None,
     task_origin: str | None = None,
+    pid: int | None = None,
+    dispatcher_pid: int | None = None,
     path: Path | None = None,
 ) -> None:
     """Record a newly-spawned agent session.
@@ -285,6 +295,18 @@ def session_start(
                             'internal'  — system-initiated, no user involved (reconciler,
                                           health check, session management, etc.).
                             Defaults to 'user' when not specified.
+        pid:                Real OS PID, when one exists for this session (docker-worker
+                            subprocess, or dispatcher self-registration). NULL when no
+                            real process boundary exists (e.g. an in-process Agent-tool
+                            subagent — see dispatcher_pid instead). Callers are
+                            responsible for capturing a real PID (e.g. via
+                            agents.pid_liveness.find_dispatcher_ancestor_pid()) —
+                            this function only persists whatever it is given.
+        dispatcher_pid:     PID of the parent dispatcher process this session is running
+                            under, for sessions with no real PID of their own (in-process
+                            Agent-tool subagents). Used as a weaker-but-real ground truth:
+                            if the dispatcher process is confirmed dead, every subagent
+                            registered under it is necessarily dead too.
         path:               DB path override (for tests).
     """
     resolved = path if path is not None else _DEFAULT_DB_PATH
@@ -293,6 +315,7 @@ def session_start(
     snippet = trigger_snippet[:200] if trigger_snippet else None
     idempotency_val = idempotency if idempotency in ("safe", "unsafe", "unknown") else "unknown"
     task_origin_val = task_origin if task_origin in ("user", "scheduled", "internal") else "user"
+    pid_captured_at = now if (pid is not None or dispatcher_pid is not None) else None
 
     conn.execute(
         """
@@ -301,10 +324,10 @@ def session_start(
              output_file, timeout_minutes, input_summary, result_summary,
              parent_id, spawned_at, completed_at, last_seen_at,
              notified_at, trigger_message_id, trigger_snippet, reply_message_ids,
-             idempotency, task_origin)
+             idempotency, task_origin, pid, dispatcher_pid, pid_captured_at)
         VALUES
             (?, ?, ?, ?, ?, ?, 'running', ?, ?, ?, NULL, ?, ?, NULL, NULL,
-             NULL, ?, ?, NULL, ?, ?)
+             NULL, ?, ?, NULL, ?, ?, ?, ?, ?)
         """,
         (
             id,
@@ -322,6 +345,9 @@ def session_start(
             snippet,
             idempotency_val,
             task_origin_val,
+            pid,
+            dispatcher_pid,
+            pid_captured_at,
         ),
     )
     conn.commit()
@@ -529,7 +555,7 @@ def cleanup_stale_running_sessions(
 
     cursor = conn.execute(
         f"""
-        SELECT id, output_file, spawned_at, timeout_minutes
+        SELECT id, output_file, spawned_at, timeout_minutes, pid, dispatcher_pid
         FROM agent_sessions
         WHERE status IN ('running', 'starting')
           AND {DISPATCHER_EXCLUSION_SQL}  -- #781: never reconcile the dispatcher (output_file is legitimately NULL) as a dead subagent
@@ -545,14 +571,86 @@ def cleanup_stale_running_sessions(
         output_file: str | None = row["output_file"]
         spawned_at_raw: str | None = row["spawned_at"]
         timeout_minutes: int | None = row["timeout_minutes"]
+        pid: int | None = row["pid"]
+        dispatcher_pid: int | None = row["dispatcher_pid"]
+
+        # Pre-compute file_status once (needed both by the PID precedence
+        # check below and by the legacy heuristics further down).
+        file_status: str | None = (
+            _read_stop_reason_from_path(Path(output_file)) if output_file else None
+        )
+
+        # -----------------------------------------------------------------
+        # PID ground truth (issue #2148, Phase 1) — PRIMARY signal whenever a
+        # real PID was captured for this session. Overrides the output_file/
+        # elapsed-time heuristics below, *except* when the output file
+        # explicitly reports the agent finished (stop_reason=end_turn) — that
+        # self-reported completion signal outranks a process-existence check.
+        # Rows with no pid/dispatcher_pid (pre-migration, or no real process
+        # boundary — e.g. Agent-tool subagents never registered a dispatcher_pid)
+        # fall through entirely unchanged to the legacy heuristics below.
+        # -----------------------------------------------------------------
+        if file_status != "done" and pid is not None:
+            if not is_pid_alive(pid):
+                conn.execute(
+                    """
+                    UPDATE agent_sessions
+                    SET status = 'dead', completed_at = ?, result_summary = ?
+                    WHERE id = ? AND status = 'running'
+                    """,
+                    (
+                        completed_at,
+                        f"Marked dead at startup: pid {pid} is not alive",
+                        agent_id,
+                    ),
+                )
+                changed_ids.append(agent_id)
+                log.warning(
+                    "[startup-cleanup] session %r marked dead: pid %d is not alive "
+                    "(PID ground truth override)",
+                    agent_id,
+                    pid,
+                )
+            else:
+                log.debug(
+                    "[startup-cleanup] session %r left running: pid %d is alive "
+                    "(PID ground truth override)",
+                    agent_id,
+                    pid,
+                )
+            continue
+
+        if file_status != "done" and pid is None and dispatcher_pid is not None:
+            if not is_pid_alive(dispatcher_pid):
+                conn.execute(
+                    """
+                    UPDATE agent_sessions
+                    SET status = 'dead', completed_at = ?, result_summary = ?
+                    WHERE id = ? AND status = 'running'
+                    """,
+                    (
+                        completed_at,
+                        (
+                            f"Marked dead at startup: dispatcher_pid {dispatcher_pid} "
+                            "is not alive (dispatcher confirmed dead)"
+                        ),
+                        agent_id,
+                    ),
+                )
+                changed_ids.append(agent_id)
+                log.warning(
+                    "[startup-cleanup] session %r marked dead: dispatcher_pid %d is "
+                    "not alive — dispatcher confirmed dead, subagent necessarily dead too",
+                    agent_id,
+                    dispatcher_pid,
+                )
+                continue
+            # dispatcher_pid alive does NOT prove this subagent itself is still
+            # alive (the dispatcher process being up says nothing about any one
+            # in-process conversation thread) — fall through to the legacy
+            # output_file/elapsed-time heuristics below, unchanged.
 
         if output_file:
-            # Read the stop_reason from the output file to determine liveness.
-            # "missing" → file gone, safe to mark dead.
-            # "done"    → agent finished, mark completed.
-            # "running" → agent may still be alive, leave it running.
-            file_status = _read_stop_reason_from_path(Path(output_file))
-
             if file_status == "missing":
                 # Apply a 2-minute grace period before marking dead for a missing
                 # output file.  The file may not yet exist if the agent was just

--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -95,6 +95,9 @@ from agents.tracker import add_pending_agent as _add_pending_agent, remove_pendi
 # Agent session store — SQLite-backed, used directly for new MCP tools
 import agents.session_store as _session_store
 
+# PID ground truth (issue #2148, Phase 1) — dispatcher self-registration capture
+from agents.pid_liveness import find_dispatcher_ancestor_pid as _find_dispatcher_ancestor_pid
+
 # Atomic claim DB — SQLite INSERT OR FAIL claim gate (issue #1360)
 from claims import AtomicClaimDB as _AtomicClaimDB
 
@@ -7957,6 +7960,24 @@ async def handle_session_start(args: dict) -> list[TextContent]:
         except (TypeError, ValueError):
             timeout_minutes = None
 
+    # PID ground truth (issue #2148, Phase 1) — dispatcher self-registration.
+    # handle_session_start() executes inside the stdio `lobster-inbox` MCP
+    # server child process (spawned by the `claude` binary per .mcp.json),
+    # which is NOT the same OS PID as the dispatcher's own `claude` process.
+    # A flat os.getpid() here would record the MCP server child's PID, not
+    # the dispatcher's — so we walk the process tree to the nearest ancestor
+    # process named "claude" instead (same technique hooks/session_role.py
+    # already uses to detect dispatcher sessions). Best-effort: any failure
+    # (missing /proc, no "claude" ancestor found) yields pid=None, which
+    # falls back to the pre-migration heuristics untouched — registration
+    # must never be blocked by a PID-capture failure.
+    dispatcher_pid: int | None = None
+    if agent_type == "dispatcher":
+        try:
+            dispatcher_pid = _find_dispatcher_ancestor_pid()
+        except Exception:  # noqa: BLE001
+            dispatcher_pid = None
+
     try:
         _session_store.session_start(
             id=agent_id,
@@ -7973,6 +7994,7 @@ async def handle_session_start(args: dict) -> list[TextContent]:
             trigger_snippet=trigger_snippet,
             idempotency=idempotency,
             task_origin=task_origin,
+            pid=dispatcher_pid,
         )
     except Exception as exc:
         log.error(f"session_start failed: {exc}", exc_info=True)

--- a/tests/test-health-check-dispatcher-pid-consistency.sh
+++ b/tests/test-health-check-dispatcher-pid-consistency.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+#===============================================================================
+# Test Suite: Health Check v3 - Dispatcher PID Consistency (issue #2148, Phase 1)
+#
+# Tests for check_dispatcher_pid_consistency() — the additive, observational-only
+# cross-check that reads the `pid` column session_start() now writes for the
+# dispatcher's own agent_sessions.db row and compares it against a real `pgrep -x
+# claude` scan / kill -0 liveness probe.
+#
+# This check NEVER sets `level`/`restart_reason` (it must not duplicate or
+# override check_wrapper_process / check_claude_process, which remain the
+# authoritative, independent liveness checks) — it always returns 0 and only
+# logs. These tests assert on log output and return code only.
+#
+# Cases covered:
+#   1. No agent_sessions.db file at all → returns 0, no crash (pre-install / fresh instance)
+#   2. DB exists but no dispatcher row has a non-NULL pid (pre-migration row) → info log, returns 0
+#   3. DB has a dispatcher pid that IS alive and IS among pgrep's "claude" results → consistent, info log
+#   4. DB has a dispatcher pid that is NOT alive (kill -0 fails) → warn log, returns 0 (non-fatal)
+#   5. DB has a dispatcher pid that IS alive but NOT among pgrep's "claude" results → warn log, returns 0
+#
+# Usage: bash tests/test-health-check-dispatcher-pid-consistency.sh
+#===============================================================================
+
+set -u
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts"
+HEALTH_SCRIPT="$SCRIPT_DIR/health-check-v3.sh"
+
+TEST_TMPDIR=$(mktemp -d /tmp/lobster-dispatcher-pid-test-XXXXXX)
+cleanup() { rm -rf "$TEST_TMPDIR"; }
+trap cleanup EXIT
+
+begin_test() { TOTAL=$((TOTAL + 1)); test_name="$1"; }
+pass()  { PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC} $test_name"; }
+fail()  { FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC} $test_name: $1"; }
+
+assert_exit() {
+    local actual="$1" expected="$2"
+    if [[ "$actual" -eq "$expected" ]]; then pass; else fail "expected exit $expected, got $actual"; fi
+}
+
+assert_log_contains() {
+    local needle="$1"
+    if grep -qF "$needle" "$LOG_FILE" 2>/dev/null; then
+        pass
+    else
+        fail "log did not contain: $needle (log: $(cat "$LOG_FILE" 2>/dev/null))"
+    fi
+}
+
+LOG_FILE="$TEST_TMPDIR/health-check.log"
+log()       { echo "[$1] $2" >> "$LOG_FILE" 2>/dev/null; }
+log_info()  { log INFO "$1"; }
+log_warn()  { log WARN "$1"; }
+log_error() { log ERROR "$1"; }
+
+# Load the function definition verbatim from the health check script (same
+# extraction pattern as test-health-check-dispatcher-heartbeat.sh — avoids
+# hand-copied duplication drifting out of sync with the real implementation).
+eval "$(sed -n '/^check_dispatcher_pid_consistency()/,/^}/p' "$HEALTH_SCRIPT")" 2>/dev/null
+
+# Build a fresh agent_sessions.db with a single dispatcher row.
+# Args: $1 = db path, $2 = pid value (or "NULL")
+make_dispatcher_db() {
+    local db_path="$1"
+    local pid_value="$2"
+    sqlite3 "$db_path" <<SQL
+CREATE TABLE agent_sessions (
+    id TEXT, agent_type TEXT, status TEXT, spawned_at TEXT, pid INTEGER
+);
+INSERT INTO agent_sessions (id, agent_type, status, spawned_at, pid)
+VALUES ('lobster-dispatcher', 'dispatcher', 'running', '2026-08-04T00:00:00+00:00', ${pid_value});
+SQL
+}
+
+echo "=== Dispatcher PID Consistency Health Check Tests ==="
+echo ""
+
+# -------------------------------------------------------------------
+# Test 1: No DB file at all → returns 0, no crash
+# -------------------------------------------------------------------
+begin_test "No agent_sessions.db file → returns 0 (fail-open)"
+: > "$LOG_FILE"
+MESSAGES_DIR="$TEST_TMPDIR/no-db-messages"
+mkdir -p "$MESSAGES_DIR/config"
+check_dispatcher_pid_consistency
+assert_exit "$?" 0
+
+# -------------------------------------------------------------------
+# Test 2: DB exists, dispatcher row has NULL pid (pre-migration) → info log, returns 0
+# -------------------------------------------------------------------
+begin_test "Dispatcher row with NULL pid → info log, returns 0"
+: > "$LOG_FILE"
+MESSAGES_DIR="$TEST_TMPDIR/null-pid-messages"
+mkdir -p "$MESSAGES_DIR/config"
+make_dispatcher_db "$MESSAGES_DIR/config/agent_sessions.db" "NULL"
+check_dispatcher_pid_consistency
+assert_exit "$?" 0
+begin_test "Dispatcher row with NULL pid → logs 'no pid recorded'"
+assert_log_contains "no pid recorded"
+
+# -------------------------------------------------------------------
+# Test 3: DB pid alive AND among pgrep's claude results → consistent, info log
+# -------------------------------------------------------------------
+begin_test "Live pid matching pgrep claude list → consistent info log"
+: > "$LOG_FILE"
+MESSAGES_DIR="$TEST_TMPDIR/consistent-messages"
+mkdir -p "$MESSAGES_DIR/config"
+make_dispatcher_db "$MESSAGES_DIR/config/agent_sessions.db" "42424"
+kill() { [[ "$1" == "-0" ]] && return 0; }
+pgrep() { echo "42424"; return 0; }
+check_dispatcher_pid_consistency
+assert_exit "$?" 0
+begin_test "Live pid matching pgrep claude list → logs 'consistent'"
+assert_log_contains "consistent"
+unset -f kill pgrep
+
+# -------------------------------------------------------------------
+# Test 4: DB pid not alive (kill -0 fails) → warn log, returns 0 (non-fatal)
+# -------------------------------------------------------------------
+begin_test "Dead pid (kill -0 fails) → warn log, returns 0"
+: > "$LOG_FILE"
+MESSAGES_DIR="$TEST_TMPDIR/dead-pid-messages"
+mkdir -p "$MESSAGES_DIR/config"
+make_dispatcher_db "$MESSAGES_DIR/config/agent_sessions.db" "99999"
+kill() { return 1; }
+check_dispatcher_pid_consistency
+assert_exit "$?" 0
+begin_test "Dead pid (kill -0 fails) → logs 'not alive'"
+assert_log_contains "not alive"
+unset -f kill
+
+# -------------------------------------------------------------------
+# Test 5: DB pid alive but NOT among pgrep's claude results → warn log, returns 0
+# -------------------------------------------------------------------
+begin_test "Live pid absent from pgrep claude list → warn log, returns 0"
+: > "$LOG_FILE"
+MESSAGES_DIR="$TEST_TMPDIR/mismatch-messages"
+mkdir -p "$MESSAGES_DIR/config"
+make_dispatcher_db "$MESSAGES_DIR/config/agent_sessions.db" "55555"
+kill() { [[ "$1" == "-0" ]] && return 0; }
+pgrep() { echo "11111"; return 0; }
+check_dispatcher_pid_consistency
+assert_exit "$?" 0
+begin_test "Live pid absent from pgrep claude list → logs mismatch warning"
+assert_log_contains "is not among the 'claude'-named processes"
+unset -f kill pgrep
+
+# -------------------------------------------------------------------
+# Test 6: level/restart_reason are never touched by this check
+# -------------------------------------------------------------------
+begin_test "Function never sets level or restart_reason (grep of source)"
+if grep -A 40 '^check_dispatcher_pid_consistency()' "$HEALTH_SCRIPT" | sed -n '1,/^}/p' | grep -qE 'level=|restart_reason='; then
+    fail "check_dispatcher_pid_consistency() must never assign level or restart_reason"
+else
+    pass
+fi
+
+#===============================================================================
+# Syntax check
+#===============================================================================
+
+echo ""
+echo "=== Syntax Check ==="
+
+begin_test "health-check-v3.sh passes bash -n syntax check"
+if bash -n "$HEALTH_SCRIPT" 2>&1; then
+    pass
+else
+    fail "Syntax errors in health-check-v3.sh"
+fi
+
+#===============================================================================
+# Summary
+#===============================================================================
+
+echo ""
+echo "=============================="
+echo "Results: $TOTAL tests"
+echo -e "  ${GREEN}PASS: $PASS${NC}"
+if [ "$FAIL" -gt 0 ]; then
+    echo -e "  ${RED}FAIL: $FAIL${NC}"
+fi
+echo "=============================="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+else
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -9,6 +9,7 @@ Tests:
 
 import os
 import pathlib
+import subprocess
 import sys
 import tempfile
 import time as _time
@@ -821,6 +822,8 @@ def test_cleanup_stale_running_null_spawned_at_no_output_file_skips_with_warning
         "output_file": None,
         "spawned_at": None,
         "timeout_minutes": None,
+        "pid": None,
+        "dispatcher_pid": None,
     }
 
     # Patch _get_connection to return a mock whose .execute().fetchall() returns our row
@@ -1012,3 +1015,244 @@ def test_get_unnotified_completed_excludes_dispatcher_row(isolated_db):
     unnotified = session_store.get_unnotified_completed(since_hours=24, path=db)
 
     assert all(row["id"] != "dispatcher-main-loop" for row in unnotified)
+
+
+# ---------------------------------------------------------------------------
+# PID ground truth (issue #2148 — Phase 1)
+# ---------------------------------------------------------------------------
+
+
+def _spawn_and_kill_pid() -> int:
+    """Spawn a real subprocess, kill and reap it, return its now-dead PID.
+
+    Used to build the 'dead-PID simulation' required by the issue's
+    acceptance criteria — a PID that is guaranteed not to be alive, without
+    relying on any live Lobster process.
+    """
+    proc = subprocess.Popen(["sleep", "30"])
+    pid = proc.pid
+    proc.kill()
+    proc.wait()
+    return pid
+
+
+def test_session_start_persists_pid_and_dispatcher_pid(isolated_db):
+    """session_start() persists pid/dispatcher_pid and stamps pid_captured_at."""
+    db = isolated_db
+
+    session_store.session_start(
+        id="pid-test-1",
+        description="Docker-worker style agent with a real PID",
+        chat_id="123",
+        pid=54321,
+        dispatcher_pid=99999,
+        path=db,
+    )
+
+    result = session_store.find_session("pid-test-1", path=db)
+    assert result["pid"] == 54321
+    assert result["dispatcher_pid"] == 99999
+    assert result["pid_captured_at"] is not None
+
+
+def test_session_start_pid_fields_default_to_null(isolated_db):
+    """Callers that don't pass pid/dispatcher_pid get NULL — fully backward compatible."""
+    db = isolated_db
+
+    session_store.session_start(
+        id="pid-test-2",
+        description="Agent-tool subagent with no real PID of its own",
+        chat_id="123",
+        path=db,
+    )
+
+    result = session_store.find_session("pid-test-2", path=db)
+    assert result["pid"] is None
+    assert result["dispatcher_pid"] is None
+    assert result["pid_captured_at"] is None
+
+
+def test_cleanup_stale_running_dead_pid_overrides_tool_use_file(isolated_db, tmp_path):
+    """A confirmed-dead pid marks the session dead even with a 'still running' output file.
+
+    Required acceptance criterion: simulate a dead PID (spawn subprocess, kill
+    it) and confirm the classifier now correctly reports dead even when the
+    output_file's stop_reason (tool_use) would previously have left it
+    running, and even with an artificially fresh mtime.
+    """
+    db = isolated_db
+    dead_pid = _spawn_and_kill_pid()
+
+    output_file = tmp_path / "docker_worker.output"
+    output_file.write_text('{"stop_reason": "tool_use"}\n')
+    # Artificially fresh mtime — under the old mtime-only heuristic this would
+    # have looked alive. The current code already ignores mtime in favor of
+    # stop_reason parsing, so we additionally verify the *stop_reason* signal
+    # (tool_use == "may still be alive") is overridden by the dead pid.
+    now_ts = _time.time()
+    os.utime(str(output_file), (now_ts, now_ts))
+
+    session_store.session_start(
+        id="dead-pid-agent",
+        description="docker-worker job whose process has actually exited",
+        chat_id="123",
+        output_file=str(output_file),
+        pid=dead_pid,
+        path=db,
+    )
+
+    server_start = datetime.now(timezone.utc)
+    changed = session_store.cleanup_stale_running_sessions(server_start, path=db)
+
+    assert "dead-pid-agent" in changed, (
+        "A dead pid must override the tool_use/fresh-mtime heuristic and mark "
+        "the session dead"
+    )
+    result = session_store.find_session("dead-pid-agent", path=db)
+    assert result["status"] == "dead"
+    assert str(dead_pid) in result["result_summary"]
+
+
+def test_cleanup_stale_running_live_pid_overrides_stale_missing_file(isolated_db, tmp_path):
+    """A confirmed-live pid leaves the session running even with a missing/stale output file.
+
+    Required acceptance criterion: a live, long-running subprocess with a
+    deliberately stale/absent output_file — which would previously cause a
+    false dead/'ghost' classification via the elapsed-time fallback — must be
+    correctly reported alive because the pid check overrides that heuristic.
+    """
+    db = isolated_db
+    live_proc = subprocess.Popen(["sleep", "30"])
+    try:
+        missing_path = str(tmp_path / "never_created.output")
+
+        # Spawned long enough ago, with no output_file, that the old
+        # elapsed-time fallback (timeout_minutes default 120) would have
+        # marked this dead.
+        old_spawned_at = (datetime.now(timezone.utc) - timedelta(minutes=200)).isoformat()
+        session_store._get_connection(db).execute(
+            """
+            INSERT INTO agent_sessions
+                (id, description, chat_id, source, status, spawned_at,
+                 output_file, timeout_minutes, pid)
+            VALUES ('live-pid-agent', 'Long-running docker-worker job', '123',
+                    'telegram', 'running', ?, ?, 60, ?)
+            """,
+            (old_spawned_at, missing_path, live_proc.pid),
+        )
+        session_store._get_connection(db).commit()
+
+        server_start = datetime.now(timezone.utc)
+        changed = session_store.cleanup_stale_running_sessions(server_start, path=db)
+
+        assert "live-pid-agent" not in changed, (
+            "A live pid must override the missing-output-file/elapsed-time "
+            "heuristic and leave the session running"
+        )
+        result = session_store.find_session("live-pid-agent", path=db)
+        assert result["status"] == "running"
+    finally:
+        live_proc.kill()
+        live_proc.wait()
+
+
+def test_cleanup_stale_running_dead_dispatcher_pid_marks_subagent_dead(isolated_db, tmp_path):
+    """A confirmed-dead dispatcher_pid marks an in-process subagent row dead.
+
+    If the dispatcher process itself is confirmed dead, every Agent-tool
+    subagent registered under it (dispatcher_pid, no pid of its own) is
+    necessarily dead too — regardless of what its output_file suggests.
+    """
+    db = isolated_db
+    dead_dispatcher_pid = _spawn_and_kill_pid()
+
+    output_file = tmp_path / "subagent.output"
+    output_file.write_text('{"stop_reason": "tool_use"}\n')
+
+    session_store.session_start(
+        id="orphaned-subagent",
+        description="Agent-tool subagent whose dispatcher has died",
+        chat_id="123",
+        output_file=str(output_file),
+        dispatcher_pid=dead_dispatcher_pid,
+        path=db,
+    )
+
+    server_start = datetime.now(timezone.utc)
+    changed = session_store.cleanup_stale_running_sessions(server_start, path=db)
+
+    assert "orphaned-subagent" in changed
+    result = session_store.find_session("orphaned-subagent", path=db)
+    assert result["status"] == "dead"
+    assert "dispatcher" in result["result_summary"].lower()
+
+
+def test_cleanup_stale_running_live_dispatcher_pid_falls_back_to_existing_heuristics(
+    isolated_db, tmp_path
+):
+    """A live dispatcher_pid does not itself prove the subagent is alive.
+
+    dispatcher_pid alive only rules out the 'dispatcher is dead' shortcut —
+    it must fall back to the existing output_file heuristics for the
+    subagent's own liveness, unchanged from pre-PID behavior.
+    """
+    db = isolated_db
+    live_dispatcher_proc = subprocess.Popen(["sleep", "30"])
+    try:
+        missing_path = str(tmp_path / "missing.output")
+        old_spawned_at = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+        session_store._get_connection(db).execute(
+            """
+            INSERT INTO agent_sessions
+                (id, description, chat_id, source, status, spawned_at,
+                 output_file, dispatcher_pid)
+            VALUES ('subagent-under-live-dispatcher', 'Subagent', '123',
+                    'telegram', 'running', ?, ?, ?)
+            """,
+            (old_spawned_at, missing_path, live_dispatcher_proc.pid),
+        )
+        session_store._get_connection(db).commit()
+
+        server_start = datetime.now(timezone.utc)
+        changed = session_store.cleanup_stale_running_sessions(server_start, path=db)
+
+        # Same outcome as the pre-existing missing-file-past-grace-period
+        # heuristic (test_cleanup_stale_running_output_missing): dead.
+        assert "subagent-under-live-dispatcher" in changed
+        result = session_store.find_session("subagent-under-live-dispatcher", path=db)
+        assert result["status"] == "dead"
+        assert "missing" in result["result_summary"]
+    finally:
+        live_dispatcher_proc.kill()
+        live_dispatcher_proc.wait()
+
+
+def test_cleanup_stale_running_zero_pid_rows_unaffected(isolated_db):
+    """Rows with no pid/dispatcher_pid (pre-migration rows) behave exactly as before.
+
+    Regression guard required by the acceptance criteria: identical scenario
+    and assertions to test_cleanup_stale_running_no_output_file, which
+    predates the pid columns entirely.
+    """
+    db = isolated_db
+
+    old_spawned_at = (datetime.now(timezone.utc) - timedelta(minutes=120)).isoformat()
+    session_store._get_connection(db).execute(
+        """
+        INSERT INTO agent_sessions
+            (id, description, chat_id, source, status, spawned_at, timeout_minutes)
+        VALUES ('zero-pid-stale', 'Old agent, no pid columns', '123', 'telegram',
+                'running', ?, 60)
+        """,
+        (old_spawned_at,),
+    )
+    session_store._get_connection(db).commit()
+
+    server_start = datetime.now(timezone.utc)
+    dead = session_store.cleanup_stale_running_sessions(server_start, path=db)
+
+    assert "zero-pid-stale" in dead
+    result = session_store.find_session("zero-pid-stale", path=db)
+    assert result["status"] == "dead"
+    assert result["pid"] is None
+    assert result["dispatcher_pid"] is None

--- a/tests/test_pid_liveness.py
+++ b/tests/test_pid_liveness.py
@@ -1,0 +1,201 @@
+"""
+Tests for src/agents/pid_liveness.py (issue #2148 — Phase 1: PID ground truth).
+
+Covers the acceptance criteria from the issue directly:
+  - is_pid_alive() returns False for a confirmed-dead PID (spawn, kill, wait)
+  - is_pid_alive() returns True for a confirmed-live PID
+  - is_pid_alive() handles None / zero / negative PIDs safely
+  - find_dispatcher_ancestor_pid() walks the real /proc process tree to find
+    the nearest ancestor process whose executable is named "claude" — proven
+    against a synthetic process tree (no live dispatcher touched).
+"""
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+SRC_DIR = Path(__file__).parent.parent / "src"
+sys.path.insert(0, str(SRC_DIR))
+
+from agents import pid_liveness  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# is_pid_alive
+# ---------------------------------------------------------------------------
+
+
+def test_is_pid_alive_true_for_live_process():
+    """A subprocess we just spawned and are still holding open is alive."""
+    proc = subprocess.Popen(["sleep", "5"])
+    try:
+        assert pid_liveness.is_pid_alive(proc.pid) is True
+    finally:
+        proc.kill()
+        proc.wait()
+
+
+def test_is_pid_alive_false_for_dead_process():
+    """Spawn a subprocess, kill it, wait for reap, confirm dead.
+
+    This is the exact 'dead-PID simulation' required by the issue's
+    acceptance criteria: is_pid_alive() must return False once the process
+    has genuinely exited.
+    """
+    proc = subprocess.Popen(["sleep", "30"])
+    pid = proc.pid
+    proc.kill()
+    proc.wait()  # reap so the kernel fully releases the PID slot's process state
+
+    assert pid_liveness.is_pid_alive(pid) is False
+
+
+def test_is_pid_alive_false_for_none():
+    assert pid_liveness.is_pid_alive(None) is False
+
+
+def test_is_pid_alive_false_for_zero():
+    assert pid_liveness.is_pid_alive(0) is False
+
+
+def test_is_pid_alive_false_for_negative():
+    assert pid_liveness.is_pid_alive(-123) is False
+
+
+def test_is_pid_alive_true_for_self():
+    assert pid_liveness.is_pid_alive(os.getpid()) is True
+
+
+# ---------------------------------------------------------------------------
+# find_dispatcher_ancestor_pid — synthetic process tree
+# ---------------------------------------------------------------------------
+#
+# We cannot use the live dispatcher's `claude` process for this test (per
+# issue instructions: never touch the live host's dispatcher). Instead we
+# build a synthetic process tree that mimics the real shape found by manual
+# inspection of the live host (see PR description for the `pstree -p`
+# evidence): a real ELF binary literally named "claude" (so /proc/<pid>/comm
+# reports "claude", exactly as the kernel reports it for the real dispatcher)
+# with a child process descending from it (standing in for the stdio MCP
+# server child, or a hook subprocess).
+
+
+@pytest.fixture
+def fake_claude_tree(tmp_path):
+    """Spawn a synthetic 'claude' ancestor with a child and grandchild.
+
+    Returns (claude_pid, child_pid, grandchild_pid). All three are real OS
+    processes; caller must not need to kill them (fixture handles teardown).
+
+    Implementation note: renaming a *shell script* to "claude" does NOT
+    produce comm=="claude" — the kernel reports the *interpreter* binary's
+    name for shebang scripts. We copy the actual bash ELF binary to a file
+    named "claude" so the kernel-reported comm matches what pgrep -x "claude"
+    and /proc/<pid>/comm see for the real dispatcher process.
+    """
+    fake_claude_bin = tmp_path / "claude"
+    real_bash = subprocess.run(
+        ["which", "bash"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    fake_claude_bin.write_bytes(Path(real_bash).read_bytes())
+    fake_claude_bin.chmod(0o755)
+
+    # `sleep & wait` forces bash to fork a real child instead of exec-replacing
+    # itself (bash's tail-call optimization would otherwise turn `claude -c
+    # "sleep 60"` into comm=="sleep" for the same PID).
+    claude_proc = subprocess.Popen(
+        [str(fake_claude_bin), "-c", "sleep 60 & child_pid=$!; echo $child_pid > "
+         + str(tmp_path / "child_pid.txt") + "; wait"]
+    )
+
+    # Wait for the child PID file to appear (bash has forked the sleep child).
+    child_pid_file = tmp_path / "child_pid.txt"
+    for _ in range(50):
+        if child_pid_file.exists() and child_pid_file.read_text().strip():
+            break
+        time.sleep(0.1)
+    child_pid = int(child_pid_file.read_text().strip())
+
+    # Spawn a grandchild under the child (stands in for e.g. a hook process
+    # spawned by the stdio MCP server, two levels below the dispatcher).
+    grandchild_proc = subprocess.Popen(["sleep", "60"], preexec_fn=None)
+    # Note: grandchild_proc's true parent is this test process, not child_pid
+    # (Python can't parent a new process under an arbitrary existing PID
+    # without more machinery). For the ancestor-walk test we instead verify
+    # the two-hop case explicitly below using child_pid as the starting point,
+    # which is sufficient to prove the walk logic ascends more than one level.
+
+    yield claude_proc.pid, child_pid, grandchild_proc.pid
+
+    for p in (claude_proc,):
+        p.kill()
+        p.wait()
+    try:
+        os.kill(child_pid, 9)
+    except ProcessLookupError:
+        pass
+    grandchild_proc.kill()
+    grandchild_proc.wait()
+
+
+def test_find_dispatcher_ancestor_pid_direct_parent(fake_claude_tree):
+    """Walking up from a direct child of the fake 'claude' process finds it."""
+    claude_pid, child_pid, _ = fake_claude_tree
+    found = pid_liveness.find_dispatcher_ancestor_pid(start_pid=child_pid)
+    assert found == claude_pid
+
+
+def test_find_dispatcher_ancestor_pid_returns_none_when_absent(monkeypatch):
+    """A process tree with no 'claude'-named ancestor returns None.
+
+    This test previously spawned a real 'sleep' subprocess and walked its
+    *real* /proc ancestry (whose parent is this test process itself),
+    asserting no "claude"-named ancestor would be found. That assumption does
+    not hold in this execution environment: test suites in this repo are
+    frequently run as a background subagent, which itself executes nested
+    inside a real dispatcher `claude` OS process — so the real ancestry chain
+    genuinely does contain a process named "claude" a few hops up, causing a
+    false failure (found a real PID instead of None) that had nothing to do
+    with a bug in find_dispatcher_ancestor_pid() itself.
+
+    Fix: make the negative case fully deterministic by faking the process
+    tree at the _read_ppid/_read_comm layer (the same layer
+    find_dispatcher_ancestor_pid() calls internally) instead of relying on
+    any real OS process's real ancestry. This mirrors the *intent* of the
+    fake_claude_tree fixture used by the positive-case tests above (a
+    synthetic tree standing in for the real shape) without depending on
+    what process happens to be running above the test runner.
+    """
+    # A synthetic tree with no "claude" anywhere in the chain up to PID 1.
+    fake_tree = {
+        100: (10, "sleep"),
+        10: (2, "bash"),
+        2: (1, "python3"),
+    }
+
+    def fake_read_ppid(pid: int) -> int | None:
+        entry = fake_tree.get(pid)
+        return entry[0] if entry else None
+
+    def fake_read_comm(pid: int) -> str:
+        entry = fake_tree.get(pid)
+        return entry[1] if entry else ""
+
+    monkeypatch.setattr(pid_liveness, "_read_ppid", fake_read_ppid)
+    monkeypatch.setattr(pid_liveness, "_read_comm", fake_read_comm)
+
+    found = pid_liveness.find_dispatcher_ancestor_pid(start_pid=100, max_depth=10)
+    assert found is None
+
+
+def test_find_dispatcher_ancestor_pid_respects_max_depth(fake_claude_tree):
+    """max_depth=0 must not walk past the start PID's own parent lookup."""
+    claude_pid, child_pid, _ = fake_claude_tree
+    # max_depth=0 means "don't even check the immediate parent" — should
+    # return None since we refuse to walk at all.
+    found = pid_liveness.find_dispatcher_ancestor_pid(start_pid=child_pid, max_depth=0)
+    assert found is None

--- a/tests/unit/test_agent_monitor_pid_liveness.py
+++ b/tests/unit/test_agent_monitor_pid_liveness.py
@@ -1,0 +1,335 @@
+"""Unit tests for PID ground truth in scripts/agent-monitor.py's classify() (issue #2148, Phase 1).
+
+Mirrors the acceptance criteria already covered for session_store.cleanup_stale_running_sessions()
+in tests/test_agent_sessions.py:
+  - a confirmed-dead pid overrides the age/output-file heuristics → GHOST_CONFIRMED
+  - a confirmed-live pid overrides a stale/missing output file → HEALTHY
+  - a confirmed-dead dispatcher_pid marks an in-process subagent row GHOST_CONFIRMED
+  - a confirmed-live dispatcher_pid does NOT itself prove aliveness — falls back
+    to the existing heuristics unchanged
+  - zero-pid (pre-migration) rows behave byte-for-byte identically to before
+
+classify() itself stays a pure function (takes precomputed pid_alive/
+dispatcher_pid_alive booleans, no OS calls) — classify_agent() is the boundary
+that resolves real PIDs via agents.pid_liveness.is_pid_alive(). Both layers are
+tested here: classify() with synthetic booleans, and classify_agent() with real
+spawned/killed subprocesses for the full acceptance-criteria proof.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+# agent-monitor.py has a hyphenated filename so it can't be imported via
+# normal sys.path manipulation. Use importlib to load it directly (same
+# pattern as tests/unit/test_ghost_detector_filesystem.py).
+_SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "agent-monitor.py"
+_spec = importlib.util.spec_from_file_location("agent_monitor_pid_liveness", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+gd = importlib.util.module_from_spec(_spec)
+sys.modules["agent_monitor_pid_liveness"] = gd
+_spec.loader.exec_module(gd)  # type: ignore[arg-type]
+
+NOW = datetime(2026, 3, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _spawn_and_kill_pid() -> int:
+    """Spawn a real subprocess, kill and reap it, return its now-dead PID."""
+    proc = subprocess.Popen(["sleep", "30"])
+    pid = proc.pid
+    proc.kill()
+    proc.wait()
+    return pid
+
+
+def _make_row(agent_id: str, **overrides) -> "gd.AgentRow":
+    defaults = dict(
+        agent_id=agent_id,
+        task_id=None,
+        description="test agent",
+        chat_id="12345",
+        status="running",
+        spawned_at=(NOW - timedelta(minutes=200)).isoformat(),
+        output_file=None,
+        last_seen_at=None,
+        pid=None,
+        dispatcher_pid=None,
+    )
+    defaults.update(overrides)
+    return gd.AgentRow(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# classify() — pure function, synthetic booleans
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyPidPrecedence:
+    def test_pid_alive_true_overrides_stale_age_and_missing_file(self):
+        """A confirmed-alive pid is HEALTHY even though age/file would say GHOST_CONFIRMED."""
+        label = gd.classify(
+            age_minutes=500.0,
+            output_file=None,
+            output_file_age_minutes=None,
+            threshold_minutes=90.0,
+            output_file_threshold_minutes=10.0,
+            pid_alive=True,
+        )
+        assert label == "HEALTHY"
+
+    def test_pid_alive_false_overrides_fresh_age_and_fresh_file(self):
+        """A confirmed-dead pid is GHOST_CONFIRMED even though age/file would say HEALTHY."""
+        label = gd.classify(
+            age_minutes=1.0,
+            output_file="/tmp/whatever",
+            output_file_age_minutes=0.1,
+            threshold_minutes=90.0,
+            output_file_threshold_minutes=10.0,
+            pid_alive=False,
+        )
+        assert label == "GHOST_CONFIRMED"
+
+    def test_dispatcher_pid_dead_marks_ghost_confirmed(self):
+        """No pid of its own, but dispatcher confirmed dead → subagent necessarily dead too."""
+        label = gd.classify(
+            age_minutes=1.0,
+            output_file="/tmp/whatever",
+            output_file_age_minutes=0.1,
+            threshold_minutes=90.0,
+            output_file_threshold_minutes=10.0,
+            pid_alive=None,
+            dispatcher_pid_alive=False,
+        )
+        assert label == "GHOST_CONFIRMED"
+
+    def test_dispatcher_pid_alive_falls_back_to_legacy_heuristic(self):
+        """Dispatcher alive proves nothing about this subagent — falls through unchanged."""
+        # Same inputs as the pre-existing GHOST_CONFIRMED legacy case (stale age,
+        # output file missing) — dispatcher_pid_alive=True must not rescue it.
+        label = gd.classify(
+            age_minutes=500.0,
+            output_file="/tmp/gone",
+            output_file_age_minutes=None,
+            threshold_minutes=90.0,
+            output_file_threshold_minutes=10.0,
+            pid_alive=None,
+            dispatcher_pid_alive=True,
+        )
+        assert label == "GHOST_CONFIRMED"  # via the legacy "file path recorded but missing" rule
+
+    def test_zero_pid_regression_matches_legacy_behavior(self):
+        """Both pid_alive and dispatcher_pid_alive omitted (pre-migration row) — unchanged."""
+        healthy = gd.classify(
+            age_minutes=5.0,
+            output_file=None,
+            output_file_age_minutes=None,
+            threshold_minutes=90.0,
+            output_file_threshold_minutes=10.0,
+        )
+        assert healthy == "HEALTHY"
+
+        stale_no_file = gd.classify(
+            age_minutes=200.0,
+            output_file=None,
+            output_file_age_minutes=None,
+            threshold_minutes=90.0,
+            output_file_threshold_minutes=10.0,
+        )
+        assert stale_no_file == "STALE_NO_FILE"
+
+        ghost_suspected = gd.classify(
+            age_minutes=200.0,
+            output_file="/tmp/f",
+            output_file_age_minutes=2.0,
+            threshold_minutes=90.0,
+            output_file_threshold_minutes=10.0,
+        )
+        assert ghost_suspected == "GHOST_SUSPECTED"
+
+
+# ---------------------------------------------------------------------------
+# classify_agent() — real subprocess spawn/kill (the required acceptance-
+# criteria proof: a real before/after demonstration, not just mocked booleans)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyAgentRealPid:
+    def test_dead_pid_overrides_healthy_looking_row(self):
+        """A row that looks HEALTHY by age/file alone is GHOST_CONFIRMED once its real pid is dead."""
+        dead_pid = _spawn_and_kill_pid()
+        row = _make_row(
+            "dead-pid-agent",
+            spawned_at=(NOW - timedelta(minutes=1)).isoformat(),  # very young — would be HEALTHY
+            pid=dead_pid,
+        )
+        classified = gd.classify_agent(row, NOW, threshold_minutes=90.0, output_file_threshold_minutes=10.0)
+        assert classified.classification == "GHOST_CONFIRMED"
+
+    def test_live_pid_overrides_ghost_looking_row(self):
+        """A row that looks GHOST_CONFIRMED by age/file alone is HEALTHY once its real pid is alive."""
+        live_proc = subprocess.Popen(["sleep", "30"])
+        try:
+            row = _make_row(
+                "live-pid-agent",
+                spawned_at=(NOW - timedelta(minutes=500)).isoformat(),  # very stale
+                output_file=None,  # STALE_NO_FILE territory under the legacy heuristic
+                pid=live_proc.pid,
+            )
+            classified = gd.classify_agent(
+                row, NOW, threshold_minutes=90.0, output_file_threshold_minutes=10.0
+            )
+            assert classified.classification == "HEALTHY"
+        finally:
+            live_proc.kill()
+            live_proc.wait()
+
+    def test_dead_dispatcher_pid_marks_inprocess_subagent_ghost(self):
+        """No pid of its own; dispatcher confirmed dead → GHOST_CONFIRMED regardless of age."""
+        dead_dispatcher_pid = _spawn_and_kill_pid()
+        row = _make_row(
+            "orphaned-subagent",
+            spawned_at=(NOW - timedelta(minutes=1)).isoformat(),
+            dispatcher_pid=dead_dispatcher_pid,
+        )
+        classified = gd.classify_agent(row, NOW, threshold_minutes=90.0, output_file_threshold_minutes=10.0)
+        assert classified.classification == "GHOST_CONFIRMED"
+
+    def test_zero_pid_row_unaffected(self):
+        """A row with no pid/dispatcher_pid behaves exactly as before (regression guard)."""
+        row = _make_row(
+            "zero-pid-stale",
+            spawned_at=(NOW - timedelta(minutes=200)).isoformat(),
+            output_file=None,
+        )
+        classified = gd.classify_agent(row, NOW, threshold_minutes=90.0, output_file_threshold_minutes=10.0)
+        assert classified.classification == "STALE_NO_FILE"
+
+
+# ---------------------------------------------------------------------------
+# Cross-classifier agreement (issue #2148 required acceptance criterion):
+# session_store.cleanup_stale_running_sessions() and agent-monitor.py's
+# classify_agent() must agree on the same dead/alive verdict for the same
+# synthetic row (same pid, same output_file, same age).
+# ---------------------------------------------------------------------------
+
+
+class TestCrossClassifierAgreement:
+    def test_dead_pid_agreement_between_session_store_and_agent_monitor(self, tmp_path):
+        """The same dead-pid row is classified 'dead'/GHOST_CONFIRMED by both classifiers."""
+        _SRC_DIR = str(Path(__file__).parent.parent.parent / "src")
+        if _SRC_DIR not in sys.path:
+            sys.path.insert(0, _SRC_DIR)
+        from agents import session_store
+
+        dead_pid = _spawn_and_kill_pid()
+        db = tmp_path / "cross_classifier.db"
+        session_store.init_db(db)
+
+        output_file = tmp_path / "shared.output"
+        output_file.write_text('{"stop_reason": "tool_use"}\n')
+
+        spawned_at = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()
+        session_store._get_connection(db).execute(
+            """
+            INSERT INTO agent_sessions
+                (id, description, chat_id, source, status, spawned_at, output_file, pid)
+            VALUES ('cross-agent', 'shared synthetic row', '123', 'telegram',
+                    'running', ?, ?, ?)
+            """,
+            (spawned_at, str(output_file), dead_pid),
+        )
+        session_store._get_connection(db).commit()
+
+        # Verdict 1: session_store.cleanup_stale_running_sessions()
+        server_start = datetime.now(timezone.utc)
+        changed = session_store.cleanup_stale_running_sessions(server_start, path=db)
+        assert "cross-agent" in changed
+        store_result = session_store.find_session("cross-agent", path=db)
+        assert store_result["status"] == "dead"
+
+        # Verdict 2: agent-monitor.py's classify_agent(), fed the exact same
+        # pid/output_file/spawned_at via an AgentRow.
+        row = gd.AgentRow(
+            agent_id="cross-agent",
+            task_id=None,
+            description="shared synthetic row",
+            chat_id="123",
+            status="running",
+            spawned_at=spawned_at,
+            output_file=str(output_file),
+            last_seen_at=None,
+            pid=dead_pid,
+            dispatcher_pid=None,
+        )
+        classified = gd.classify_agent(
+            row,
+            datetime.now(timezone.utc),
+            threshold_minutes=90.0,
+            output_file_threshold_minutes=10.0,
+        )
+
+        # Both classifiers agree: the process is dead, regardless of each
+        # system's own vocabulary for expressing that ('dead' vs GHOST_CONFIRMED).
+        assert classified.classification == "GHOST_CONFIRMED"
+
+    def test_live_pid_agreement_between_session_store_and_agent_monitor(self, tmp_path):
+        """The same live-pid row is classified 'running'/HEALTHY by both classifiers."""
+        _SRC_DIR = str(Path(__file__).parent.parent.parent / "src")
+        if _SRC_DIR not in sys.path:
+            sys.path.insert(0, _SRC_DIR)
+        from agents import session_store
+
+        live_proc = subprocess.Popen(["sleep", "30"])
+        try:
+            db = tmp_path / "cross_classifier_live.db"
+            session_store.init_db(db)
+
+            # Stale by age/missing-file (would be dead/GHOST under legacy heuristics).
+            spawned_at = (datetime.now(timezone.utc) - timedelta(minutes=500)).isoformat()
+            missing_output = str(tmp_path / "never_created.output")
+            session_store._get_connection(db).execute(
+                """
+                INSERT INTO agent_sessions
+                    (id, description, chat_id, source, status, spawned_at,
+                     output_file, timeout_minutes, pid)
+                VALUES ('cross-agent-live', 'shared synthetic row', '123',
+                        'telegram', 'running', ?, ?, 60, ?)
+                """,
+                (spawned_at, missing_output, live_proc.pid),
+            )
+            session_store._get_connection(db).commit()
+
+            server_start = datetime.now(timezone.utc)
+            changed = session_store.cleanup_stale_running_sessions(server_start, path=db)
+            assert "cross-agent-live" not in changed
+            store_result = session_store.find_session("cross-agent-live", path=db)
+            assert store_result["status"] == "running"
+
+            row = gd.AgentRow(
+                agent_id="cross-agent-live",
+                task_id=None,
+                description="shared synthetic row",
+                chat_id="123",
+                status="running",
+                spawned_at=spawned_at,
+                output_file=missing_output,
+                last_seen_at=None,
+                pid=live_proc.pid,
+                dispatcher_pid=None,
+            )
+            classified = gd.classify_agent(
+                row,
+                datetime.now(timezone.utc),
+                threshold_minutes=90.0,
+                output_file_threshold_minutes=10.0,
+            )
+            assert classified.classification == "HEALTHY"
+        finally:
+            live_proc.kill()
+            live_proc.wait()

--- a/tests/unit/test_hooks/test_auto_register_agent.py
+++ b/tests/unit/test_hooks/test_auto_register_agent.py
@@ -424,6 +424,76 @@ class TestHookAgentWithAgentId:
         assert row["input_summary"] is None
 
 
+class TestDispatcherPidCapture:
+    """issue #2148 (Phase 1: PID ground truth) — dispatcher_pid capture.
+
+    This hook fires as a direct child of the dispatcher's `claude` OS process
+    for every Agent-tool call (verified via live process-tree inspection —
+    see PR description). It has no PID of its own to record for the spawned
+    subagent (Agent-tool subagents run in-process, as threads of the
+    dispatcher — see pid_liveness.py docstring), so it instead records the
+    dispatcher's own PID as `dispatcher_pid`, found via a process-tree walk
+    (agents.pid_liveness.find_dispatcher_ancestor_pid), NOT a flat os.getppid()
+    or os.getpid() call.
+    """
+
+    def test_dispatcher_pid_captured_via_process_tree_walk(self, tmp_path):
+        """A successful ancestor-walk result is persisted as dispatcher_pid."""
+        prompt = "---\ntask_id: t-dpid\n---"
+        hook_input = _make_hook_input(
+            prompt=prompt,
+            tool_response={"agentId": "agent-dpid"},
+        )
+        with patch(
+            "agents.pid_liveness.find_dispatcher_ancestor_pid",
+            return_value=424242,
+        ):
+            exit_code, _, _ = _run_hook(hook_input, tmp_path)
+        assert exit_code == 0
+
+        row = _get_row(tmp_path, "agent-dpid")
+        assert row is not None
+        assert row["dispatcher_pid"] == 424242
+        assert row["pid_captured_at"] is not None
+
+    def test_dispatcher_pid_null_when_walk_finds_no_ancestor(self, tmp_path):
+        """No 'claude' ancestor found (e.g. non-standard process tree) → NULL, not a crash."""
+        prompt = "---\ntask_id: t-dpid-none\n---"
+        hook_input = _make_hook_input(
+            prompt=prompt,
+            tool_response={"agentId": "agent-dpid-none"},
+        )
+        with patch(
+            "agents.pid_liveness.find_dispatcher_ancestor_pid",
+            return_value=None,
+        ):
+            exit_code, _, _ = _run_hook(hook_input, tmp_path)
+        assert exit_code == 0
+
+        row = _get_row(tmp_path, "agent-dpid-none")
+        assert row is not None
+        assert row["dispatcher_pid"] is None
+        assert row["pid_captured_at"] is None
+
+    def test_dispatcher_pid_capture_failure_does_not_block_hook(self, tmp_path):
+        """If the ancestor walk raises, the hook still registers the agent (dispatcher_pid=NULL)."""
+        prompt = "---\ntask_id: t-dpid-err\n---"
+        hook_input = _make_hook_input(
+            prompt=prompt,
+            tool_response={"agentId": "agent-dpid-err"},
+        )
+        with patch(
+            "agents.pid_liveness.find_dispatcher_ancestor_pid",
+            side_effect=OSError("simulated /proc read failure"),
+        ):
+            exit_code, _, _ = _run_hook(hook_input, tmp_path)
+        assert exit_code == 0
+
+        row = _get_row(tmp_path, "agent-dpid-err")
+        assert row is not None, "Agent must still be registered even if PID capture fails"
+        assert row["dispatcher_pid"] is None
+
+
 class TestHookNoAgentId:
     def test_missing_agent_id_exits_0_no_write(self, tmp_path):
         """If tool response has no agentId, exit 0 without writing agent_sessions rows."""

--- a/tests/unit/test_mcp_server/test_dispatcher_pid_capture.py
+++ b/tests/unit/test_mcp_server/test_dispatcher_pid_capture.py
@@ -1,0 +1,150 @@
+"""
+Tests for dispatcher self-registration PID capture in handle_session_start()
+(issue #2148, Phase 1 — PID ground truth).
+
+handle_session_start() executes inside the stdio `lobster-inbox` MCP server
+child process (spawned by the `claude` binary per .mcp.json), which is NOT
+the same OS PID as the dispatcher's own `claude` process. A flat os.getpid()
+there would record the MCP server child's PID, not the dispatcher's — so for
+agent_type="dispatcher" self-registration, the real PID must be captured via
+a process-tree walk to the nearest ancestor process named "claude"
+(agents.pid_liveness.find_dispatcher_ancestor_pid), the same technique
+hooks/session_role.py already uses for is_dispatcher_session().
+
+Behaviors tested:
+- agent_type="dispatcher": find_dispatcher_ancestor_pid() is called, and its
+  result is threaded through to session_store.session_start(pid=...).
+- Any other agent_type (or none): find_dispatcher_ancestor_pid() is NOT
+  called, and session_start() receives pid=None — no behavior change for
+  the vast majority of callers (Agent-tool subagents, docker-worker, etc.).
+- find_dispatcher_ancestor_pid() returning None (no "claude" ancestor found)
+  → session_start() receives pid=None, no crash.
+- find_dispatcher_ancestor_pid() raising → best-effort: registration still
+  proceeds with pid=None, never blocked by a PID-capture failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_ROOT = Path(__file__).parents[3]
+for _p in [
+    str(_ROOT / "src" / "mcp"),
+    str(_ROOT / "src" / "agents"),
+    str(_ROOT / "src"),
+    str(_ROOT / "src" / "utils"),
+]:
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import src.mcp.inbox_server  # noqa: F401 — pre-load so patch.multiple resolves it
+
+
+def _mock_session_store() -> MagicMock:
+    store = MagicMock()
+    store.session_start.return_value = None
+    return store
+
+
+def _run_session_start(args: dict, dispatcher_pid_result=424242, dispatcher_pid_side_effect=None):
+    """Run handle_session_start with _session_store and the ancestor-walk mocked.
+
+    Returns (mock_store, mock_ancestor_walk) so callers can assert on calls.
+    """
+    mock_store = _mock_session_store()
+    mock_ancestor_walk = MagicMock()
+    if dispatcher_pid_side_effect is not None:
+        mock_ancestor_walk.side_effect = dispatcher_pid_side_effect
+    else:
+        mock_ancestor_walk.return_value = dispatcher_pid_result
+
+    with patch.multiple(
+        "src.mcp.inbox_server",
+        _session_store=mock_store,
+        _find_dispatcher_ancestor_pid=mock_ancestor_walk,
+        _http_session_manager=None,
+    ):
+        from src.mcp.inbox_server import handle_session_start
+        asyncio.run(handle_session_start(args))
+
+    return mock_store, mock_ancestor_walk
+
+
+class TestDispatcherPidCapture:
+    def test_dispatcher_registration_captures_pid_via_ancestor_walk(self):
+        """agent_type='dispatcher' → ancestor walk is called and its result is passed as pid."""
+        store, ancestor_walk = _run_session_start(
+            {
+                "agent_id": "lobster-dispatcher",
+                "description": "Dispatcher main loop",
+                "chat_id": 12345,
+                "agent_type": "dispatcher",
+            },
+            dispatcher_pid_result=424242,
+        )
+        ancestor_walk.assert_called_once()
+        _, kwargs = store.session_start.call_args
+        assert kwargs["pid"] == 424242
+
+    def test_non_dispatcher_registration_does_not_walk_process_tree(self):
+        """A regular subagent registration never calls the ancestor walk, pid stays None."""
+        store, ancestor_walk = _run_session_start(
+            {
+                "agent_id": "agent-123",
+                "description": "Some subagent",
+                "chat_id": 12345,
+                "agent_type": "general-purpose",
+            },
+        )
+        ancestor_walk.assert_not_called()
+        _, kwargs = store.session_start.call_args
+        assert kwargs["pid"] is None
+
+    def test_missing_agent_type_does_not_walk_process_tree(self):
+        """No agent_type at all → same as non-dispatcher: no walk, pid=None."""
+        store, ancestor_walk = _run_session_start(
+            {
+                "agent_id": "agent-456",
+                "description": "Agent with no type",
+                "chat_id": 12345,
+            },
+        )
+        ancestor_walk.assert_not_called()
+        _, kwargs = store.session_start.call_args
+        assert kwargs["pid"] is None
+
+    def test_dispatcher_registration_pid_none_when_no_ancestor_found(self):
+        """Ancestor walk returning None (no 'claude' ancestor) → pid=None, no crash."""
+        store, ancestor_walk = _run_session_start(
+            {
+                "agent_id": "lobster-dispatcher",
+                "description": "Dispatcher main loop",
+                "chat_id": 12345,
+                "agent_type": "dispatcher",
+            },
+            dispatcher_pid_result=None,
+        )
+        ancestor_walk.assert_called_once()
+        _, kwargs = store.session_start.call_args
+        assert kwargs["pid"] is None
+
+    def test_dispatcher_registration_survives_ancestor_walk_exception(self):
+        """If the ancestor walk raises, registration still proceeds with pid=None."""
+        store, ancestor_walk = _run_session_start(
+            {
+                "agent_id": "lobster-dispatcher",
+                "description": "Dispatcher main loop",
+                "chat_id": 12345,
+                "agent_type": "dispatcher",
+            },
+            dispatcher_pid_side_effect=OSError("simulated /proc read failure"),
+        )
+        ancestor_walk.assert_called_once()
+        assert store.session_start.called, "session_start must still be called even if PID capture fails"
+        _, kwargs = store.session_start.call_args
+        assert kwargs["pid"] is None


### PR DESCRIPTION
## Problem

`session_store.session_start()` records no PID — only `output_file` (a path) plus `spawned_at`/`timeout_minutes`. Three independent consumers (`session_store.cleanup_stale_running_sessions()`, `scripts/agent-monitor.py`'s `classify()`, `scripts/health-check-v3.sh`) each infer liveness from output-file mtimes and parsed stop-reason strings, with their own thresholds, and disagree — producing both false-dead ("ghost") and false-alive verdicts.

This PR gives all three a real, shared ground-truth signal: an actual OS PID, checked via `os.kill(pid, 0)`, that overrides the heuristics whenever it was captured, and falls through unchanged to today's exact behavior whenever it wasn't (pre-migration rows, or sessions with no real process boundary).

## Architectural finding (verified before implementing)

Live `pstree -p` inspection against the running dispatcher confirmed the issue's own open question: Agent/Task-tool subagents run as **threads inside the single dispatcher `claude` OS process**, not as separate processes — there is no PID to capture for them directly. This is why `dispatcher_pid` exists as a distinct, weaker-but-real fallback signal (see below).

A related correction to the issue's literal wording: `handle_session_start()`'s dispatcher self-registration runs inside the **stdio `lobster-inbox` MCP server child process**, not the same PID as the `claude` process itself. A flat `os.getpid()` there would have recorded the wrong process. Both this and `hooks/auto-register-agent.py` instead walk the process tree to the nearest ancestor named `claude` — the same technique `hooks/session_role.py` already uses for dispatcher detection.

## What changed

- **`src/agents/pid_liveness.py`** (new): `is_pid_alive(pid)` and `find_dispatcher_ancestor_pid()` — the one shared, pure liveness primitive all three classifiers now consult.
- **`session_store.py`**: additive `pid` / `dispatcher_pid` / `pid_captured_at` columns; `session_start()` grows optional `pid`/`dispatcher_pid` params (NULL by default, fully backward compatible); `cleanup_stale_running_sessions()` checks a real PID first when present — a confirmed-dead PID overrides the output-file heuristic (even a fresh mtime), a confirmed-live PID overrides it the other way (even a missing output file past the elapsed-time cutoff). A dead `dispatcher_pid` marks its in-process subagent dead directly; a live one does *not* prove the subagent itself is alive and falls through to the existing heuristic unchanged.
- **`hooks/auto-register-agent.py`**: captures the dispatcher's real PID via the ancestor walk and persists it as `dispatcher_pid` on every Agent-tool-registered row. Best-effort — never blocks registration if the walk fails.
- **`src/mcp/inbox_server.py`**: `handle_session_start()` now captures the dispatcher's real PID (same ancestor walk) when `agent_type="dispatcher"`, and passes it through as `pid`. Every other caller is unaffected.
- **`scripts/agent-monitor.py`**: `classify()` takes optional precomputed `pid_alive`/`dispatcher_pid_alive` booleans (kept pure — no OS calls of its own); `classify_agent()` is the one boundary that resolves `row.pid`/`row.dispatcher_pid` via `is_pid_alive()`. Same primary/fallback precedence as `session_store`.
- **`scripts/health-check-v3.sh`**: adds one new, purely observational `check_dispatcher_pid_consistency()` — reads the dispatcher's own `pid` column and cross-checks it against a live `pgrep -x claude` scan, logging (never gating) a mismatch. The ~13 existing checks (`check_claude_process`, `check_wrapper_process`, etc.) are untouched; this does not replace or duplicate their independent, already-correct liveness detection.
- **`docker-worker.sh`**: confirmed via `grep` that nothing in the repo currently calls it, and it does not call `session_start` itself — documented as a no-op finding rather than inventing a new integration point, per the issue's own guidance.

### Flow before / after

```
BEFORE (all three classifiers, independently):
  running row --> output_file mtime / stop_reason parse --> verdict
                   (can be wrong in both directions: fresh mtime on a
                    genuinely dead process, or a missing/stale file on a
                    genuinely live long-running process)

AFTER:
  running row --> pid present? --yes--> os.kill(pid,0) --> verdict (definitive)
                       |
                       no
                       v
               dispatcher_pid present & dead? --yes--> verdict = dead
                       |
                       no (absent, or dispatcher_pid alive)
                       v
               unchanged legacy output_file/elapsed-time heuristic --> verdict
```

No existing reader of the `status` column (e.g. `src/dashboard/collectors.py`) is affected — the column's vocabulary and semantics are unchanged, this only changes *how* a row arrives at `dead` vs `running`/`completed`.

## Fixed along the way: a genuinely flaky test

`tests/test_pid_liveness.py::test_find_dispatcher_ancestor_pid_returns_none_when_absent` failed locally: it spawned a real `sleep` subprocess and walked its *real* ancestry, asserting no "claude"-named process would be found. That assumption doesn't hold when the test itself runs nested inside a real dispatcher `claude` process (as happens when this suite runs inside a background subagent) — the real ancestry chain genuinely does contain a process named `claude` a few hops up. This had nothing to do with a bug in `find_dispatcher_ancestor_pid()` itself. Fixed by faking the process tree at the `_read_ppid`/`_read_comm` layer instead of relying on the real OS process tree — the test is now deterministic regardless of what process happens to be running above the test runner. Confirmed via revert-and-observe: reverting the implementation to always return a fixed PID makes this test (and the sibling positive-case test) fail; restoring it passes again.

## Functional patterns used

Pure functions throughout: `is_pid_alive()`, `find_dispatcher_ancestor_pid()`, and `classify()` in `agent-monitor.py` take plain inputs and return plain outputs with no OS calls of their own inside `classify()` — the one OS-facing boundary (`classify_agent()`) resolves real PIDs into booleans before calling the pure classifier, keeping the classification logic itself trivially testable. Additive-only schema migration (no breaking changes to existing readers). Every new parameter defaults to `None`/backward-compatible behavior.

## Out of scope (per the issue's own Non-goals)

The consolidated `liveness.py` FSM module, the event-bus/EXIT-trap supervisor approach, the "midnight race" TOCTOU, and "stuck but alive" detection are all explicitly out of scope here — this PR answers alive-vs-dead via PID ground truth, nothing more.

## Tests run

- [x] `uv run pytest tests/test_pid_liveness.py tests/test_agent_sessions.py tests/unit/test_agent_monitor_pid_liveness.py tests/unit/test_hooks/test_auto_register_agent.py tests/unit/test_mcp_server/test_dispatcher_pid_capture.py -q` — 109 passed
- [x] `bash tests/test-health-check-dispatcher-pid-consistency.sh` — 11/11 passed
- [x] All other `tests/test-health-check-*.sh` shell suites — no regressions (one pre-existing unrelated failure in `test-health-check-wfm-active.sh`, confirmed present on unmodified `main` too)
- [x] Full suite: `uv run pytest tests/ -q --ignore=tests/stress` — 4403 passed, 34 skipped, 34 failed. All 34 failures confirmed pre-existing on unmodified `main` (re-ran the identical failing test files against `git stash`'d — i.e. unmodified — tree: same 16 + 18 = 34 failures, unrelated to this change: missing WhatsApp service files, unrelated push-token signed-session tests, an unrelated hook test, etc.)
- [x] Falsifiability confirmed for every new/changed test file: reverted each implementation change in turn and observed the corresponding tests fail, then restored and observed them pass again (`pid_liveness.py`, `session_store.py`, `agent-monitor.py`, `inbox_server.py`, `health-check-v3.sh`'s new check).

## Manual test

This touches a DB schema (`agent_sessions.db`) and process-liveness logic feeding the dispatcher's own health-check system, so per the issue's own requirement, unit tests alone aren't sufficient. All manual testing below ran against a **throwaway `/tmp` SQLite DB and real-but-disposable subprocesses in this worktree** — the live host's `agent_sessions.db`, `lobster-claude.service`, and other systemd units were never touched.

1. **Dead-PID scenario (real subprocess, real kill, real reap):** spawned `sleep 60`, wrote a fresh-mtime output file with `stop_reason=tool_use` (would previously have left it "running"), killed and reaped the process, registered the row with the real (now-dead) PID against an isolated `/tmp` DB. `cleanup_stale_running_sessions()` correctly flipped it to `dead`; feeding the identical row through `agent-monitor.py`'s `classify_agent()` independently returned `GHOST_CONFIRMED`. Both classifiers agreed.
2. **Live-PID scenario (real long-running subprocess):** spawned `sleep 30`, registered a row with `spawned_at` 200 minutes in the past and a *missing* output_file (previously guaranteed a false "dead" verdict under the elapsed-time fallback), with the real live PID. `cleanup_stale_running_sessions()` correctly left it `running`; `classify_agent()` independently returned `HEALTHY`.
3. **`check_dispatcher_pid_consistency()` against real processes:** built a throwaway `agent_sessions.db` with a dispatcher row, set its `pid` to this shell's own real PID, and ran the extracted function for real — correctly logged a WARN (real live process, but named `bash` not `claude` — an honest mismatch, not a false positive). Repeated with a spawned-killed-reaped PID — correctly logged a WARN that the process is not alive. Both runs returned exit code 0 (non-fatal, as designed).

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — see `## Manual test` above; all against isolated `/tmp` state, never the live host
- [x] User-visible outcome: not applicable — this is internal liveness-classification plumbing with no direct Telegram/UI surface
- [x] Side-effect audit: no floods, no unscoped writes (all manual runs used disposable `/tmp` DBs), no unintended volume; the new health-check function is read-only against `agent_sessions.db` and never gates a restart
- [x] External service calls: none — this PR has no network or external API surface

## Deploy note

Per the issue's explicit instruction: **this is a PR only.** Not merged to `main`. No changes were made to the live host's running `agent_sessions.db`, and no live systemd unit (including `lobster-claude.service`) was restarted or touched at any point during this work.

Closes #2148