### PR TITLE
Capture and validate authenticated identity in OAuth token storage

### DIFF
--- a/src/integrations/gmail/token_store.py
+++ b/src/integrations/gmail/token_store.py
@@ -31,7 +31,8 @@ Token schema on disk::
         "access_token":  "<string>",
         "expires_at":    "<ISO 8601 UTC>",
         "scope":         "<space-separated scopes>",
-        "refresh_token": "<string or null>"
+        "refresh_token": "<string or null>",
+        "email":         "<string or null -- authenticated account, issue #2153>"
     }
 
 Design principles
@@ -154,6 +155,7 @@ def _token_to_dict(token: TokenData) -> dict:
         "expires_at": token.expires_at.isoformat(),
         "scope": token.scope,
         "refresh_token": token.refresh_token,
+        "email": token.email,
     }
 
 
@@ -167,6 +169,7 @@ def _dict_to_token(data: dict) -> TokenData:
         expires_at=expires_at,
         scope=data.get("scope", ""),
         refresh_token=data.get("refresh_token"),
+        email=data.get("email"),
     )
 
 
@@ -457,12 +460,13 @@ def get_valid_token(
         )
         return None
 
-    # Merge: preserve scope and refresh_token from the stored token
+    # Merge: preserve scope, refresh_token, and email from the stored token
     refreshed = TokenData(
         access_token=refreshed_partial.access_token,
         expires_at=refreshed_partial.expires_at,
         scope=token.scope,           # preserve original scope
         refresh_token=token.refresh_token,  # Google doesn't return new refresh_token here
+        email=token.email,           # preserve identity metadata across refresh
     )
 
     _save_token_local(user_id, refreshed, token_dir)

--- a/src/integrations/google_auth/identity.py
+++ b/src/integrations/google_auth/identity.py
@@ -1,0 +1,252 @@
+"""
+Token identity metadata — capturing and validating *who* actually granted
+an OAuth token, not just trusting the chat_id it was pushed for.
+
+Why this exists (issue #2153)
+------------------------------
+The Calendar/Gmail/Workspace push-token receivers in ``inbox_server_http.py``
+validate a signed, single-use session token proving "this push corresponds
+to the OAuth transaction requested by chat_id=X". That proves the
+*transaction* is legitimate. It does NOT prove that the Google account
+which completed the consent screen belongs to the person who owns chat_id=X
+— a consent link that gets shared, forwarded, or clicked while a different
+Google account is active in the browser produces a token that is bound to
+the right chat_id but authenticated by the wrong human. Without any
+identity claim captured from Google itself, that mixup is invisible until
+something explicitly reads the account's data.
+
+This module captures the authenticated email at grant time (via Google's
+``userinfo`` endpoint, called with the just-issued access_token — no client
+secret required) and provides pure comparison functions so callers can
+detect a mismatch immediately instead of silently.
+
+Two independent checks are supported, since neither alone covers every case:
+
+- ``check_identity_consistency`` — self-consistency: does the newly granted
+  email match the email captured for this chat_id last time? Works out of
+  the box with no external data, but has nothing to compare against on a
+  chat_id's very first grant.
+- ``check_expected_identity`` — checks the newly granted email against an
+  optional ``known-users.json`` registry (chat_id -> expected email), which
+  *does* cover the first-grant case, provided the registry has been
+  populated for that chat_id.
+
+Design principles
+------------------
+- Side effects (the HTTP call to Google, reading the registry file) are
+  isolated to dedicated functions; the comparison logic is pure.
+- Never raises on failure to fetch or parse — callers get ``None``/a
+  descriptive status, never an exception, so a userinfo hiccup can never
+  block a token from being saved and used.
+- No token or email values are ever logged at a level that would leak
+  outside this instance's own log files; log messages here only echo
+  chat_id and the (non-secret) email address for operator visibility.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Google userinfo endpoint
+# ---------------------------------------------------------------------------
+
+#: Google's OpenID-Connect-compatible userinfo endpoint. Requires the access
+#: token to have been granted with at least one of the `email`, `profile`,
+#: or `openid` scopes -- if the consent grant didn't request one of those,
+#: this call fails with 403 and fetch_authenticated_email returns None.
+GOOGLE_USERINFO_URL: str = "https://www.googleapis.com/oauth2/v3/userinfo"
+
+_HTTP_TIMEOUT: int = 10
+
+
+def fetch_authenticated_email(
+    access_token: str,
+    *,
+    userinfo_url: str = GOOGLE_USERINFO_URL,
+    timeout: int = _HTTP_TIMEOUT,
+) -> Optional[str]:
+    """Return the email address of the Google account that granted this token.
+
+    Calls Google's userinfo endpoint directly with the access_token as
+    bearer auth -- this requires no client secret, so it works from an
+    instance (like this one) that never holds GCP credentials locally.
+
+    Args:
+        access_token: The just-issued (or just-refreshed) access token.
+        userinfo_url: Injectable for testing.
+        timeout:      HTTP timeout in seconds.
+
+    Returns:
+        The account's email address, or None if the call fails for any
+        reason (network error, non-2xx response, missing/empty email in the
+        payload, insufficient scope). Never raises.
+    """
+    if not access_token:
+        return None
+
+    try:
+        resp = requests.get(
+            userinfo_url,
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=timeout,
+        )
+    except requests.exceptions.RequestException as exc:
+        log.warning("userinfo fetch failed (network error): %s", exc)
+        return None
+
+    if not resp.ok:
+        log.warning(
+            "userinfo endpoint returned %d -- token may lack email/profile "
+            "scope, or the access_token is invalid/expired.",
+            resp.status_code,
+        )
+        return None
+
+    try:
+        data = resp.json()
+        email = data.get("email")
+    except (ValueError, AttributeError) as exc:
+        log.warning("userinfo endpoint returned unparseable payload: %s", exc)
+        return None
+
+    if not email or not isinstance(email, str):
+        log.warning("userinfo endpoint response had no usable email field.")
+        return None
+
+    return email
+
+
+# ---------------------------------------------------------------------------
+# Identity check result (pure comparison logic)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class IdentityCheckResult:
+    """Outcome of comparing a newly granted email against a baseline.
+
+    Attributes:
+        status:   One of:
+                  - "match"             baseline and new email agree
+                  - "mismatch"          baseline and new email disagree
+                  - "no_baseline"       nothing to compare against (first
+                                        grant for this chat_id / registry has
+                                        no entry) -- not an error, just
+                                        unverifiable
+                  - "email_unavailable" the new grant's email could not be
+                                        captured at all (userinfo call
+                                        failed) -- can't compare
+        baseline_email: The email being compared against (previously stored,
+                        or expected from the registry). None if unavailable.
+        new_email:      The newly granted email. None if unavailable.
+    """
+
+    status: str
+    baseline_email: Optional[str]
+    new_email: Optional[str]
+
+    @property
+    def is_mismatch(self) -> bool:
+        return self.status == "mismatch"
+
+
+def check_identity_consistency(
+    previous_email: Optional[str],
+    new_email: Optional[str],
+) -> IdentityCheckResult:
+    """Compare a newly granted email against the previously stored one.
+
+    Pure function -- no I/O. Self-consistency check: catches a re-auth
+    (reconnect) landing on a different Google account than the one already
+    on file for this chat_id. Cannot catch a mixup on the very first grant
+    (nothing to compare against) -- see ``check_expected_identity`` for that.
+    """
+    if new_email is None:
+        return IdentityCheckResult("email_unavailable", previous_email, None)
+    if previous_email is None:
+        return IdentityCheckResult("no_baseline", None, new_email)
+    if previous_email == new_email:
+        return IdentityCheckResult("match", previous_email, new_email)
+    return IdentityCheckResult("mismatch", previous_email, new_email)
+
+
+def check_expected_identity(
+    expected_email: Optional[str],
+    new_email: Optional[str],
+) -> IdentityCheckResult:
+    """Compare a newly granted email against a caller-supplied expected value.
+
+    Pure function -- no I/O (see ``expected_email_for_chat_id`` for the
+    registry lookup). Semantically identical comparison to
+    ``check_identity_consistency`` but kept as a separate entry point since
+    the two baselines (prior grant vs. registry) are conceptually distinct
+    and callers may want to run both.
+    """
+    return check_identity_consistency(expected_email, new_email)
+
+
+def format_mismatch_warning(result: IdentityCheckResult, *, chat_id: str) -> Optional[str]:
+    """Return a short, user-facing warning string for a mismatch, or None.
+
+    Pure function. Only ever returns non-None for status == "mismatch" --
+    "no_baseline" and "email_unavailable" are not surfaced to the user as
+    warnings (they're not evidence of anything wrong, just "couldn't verify").
+    """
+    if result.status != "mismatch":
+        return None
+    return (
+        "\n\nHeads up: this connection is authenticated as "
+        f"{result.new_email}, but the account previously on file for this "
+        f"chat was {result.baseline_email}. If that's not expected, "
+        "someone may have connected the wrong Google account -- consider "
+        "disconnecting and reconnecting with the correct one."
+    )
+
+
+# ---------------------------------------------------------------------------
+# known-users.json registry (optional, for the first-grant case)
+# ---------------------------------------------------------------------------
+
+_HOME: Path = Path.home()
+_MESSAGES_DIR: Path = Path(os.environ.get("LOBSTER_MESSAGES", str(_HOME / "messages")))
+
+#: Optional operator-maintained registry mapping chat_id -> expected email,
+#: e.g. {"1111111111": "account-a@example.com", "2222222222": "account-b@example.com"}.
+#: Entirely optional: absent or empty file means "no expectation on file",
+#: which check_expected_identity reports as "no_baseline", never an error.
+KNOWN_USERS_PATH: Path = _MESSAGES_DIR / "config" / "known-users.json"
+
+
+def expected_email_for_chat_id(
+    chat_id: str,
+    known_users_path: Path = KNOWN_USERS_PATH,
+) -> Optional[str]:
+    """Look up the expected email for a chat_id in the known-users registry.
+
+    Degrades gracefully to None if the file is absent, unreadable, not valid
+    JSON, or has no entry for this chat_id -- this registry is optional
+    metadata, never a hard dependency.
+    """
+    if not known_users_path.exists():
+        return None
+    try:
+        data = json.loads(known_users_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning("Failed to parse known-users.json: %s", exc)
+        return None
+    if not isinstance(data, dict):
+        return None
+    email = data.get(chat_id)
+    if not email or not isinstance(email, str):
+        return None
+    return email

--- a/src/integrations/google_calendar/oauth.py
+++ b/src/integrations/google_calendar/oauth.py
@@ -70,12 +70,20 @@ class TokenData:
         refresh_token: Long-lived credential used to obtain new access tokens.
                        May be None when refreshing (Google only sends it on
                        first authorisation or when prompt=consent is used).
+        email:         The Google account email that granted this token,
+                       captured via the userinfo endpoint at grant time (see
+                       integrations.google_auth.identity.fetch_authenticated_email).
+                       None for tokens saved before this field existed, or if
+                       the userinfo call failed/was not attempted (issue #2153
+                       -- storing this is what lets a cross-account mixup be
+                       detected instead of staying silent).
     """
 
     access_token: str
     expires_at: datetime
     scope: str
     refresh_token: Optional[str] = None
+    email: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/integrations/google_calendar/token_store.py
+++ b/src/integrations/google_calendar/token_store.py
@@ -29,7 +29,8 @@ Token schema on disk::
         "access_token":  "<string>",
         "expires_at":    "<ISO 8601 UTC>",
         "scope":         "<space-separated scopes>",
-        "refresh_token": "<string or null>"
+        "refresh_token": "<string or null>",
+        "email":         "<string or null -- authenticated account, issue #2153>"
     }
 
 Design principles
@@ -149,6 +150,7 @@ def _token_to_dict(token: TokenData) -> dict:
         "expires_at": token.expires_at.isoformat(),
         "scope": token.scope,
         "refresh_token": token.refresh_token,
+        "email": token.email,
     }
 
 
@@ -162,6 +164,7 @@ def _dict_to_token(data: dict) -> TokenData:
         expires_at=expires_at,
         scope=data.get("scope", ""),
         refresh_token=data.get("refresh_token"),
+        email=data.get("email"),
     )
 
 
@@ -455,12 +458,13 @@ def get_valid_token(
         )
         return None
 
-    # Merge: preserve scope and refresh_token from the stored token
+    # Merge: preserve scope, refresh_token, and email from the stored token
     refreshed = TokenData(
         access_token=refreshed_partial.access_token,
         expires_at=refreshed_partial.expires_at,
         scope=token.scope,           # preserve original scope
         refresh_token=token.refresh_token,  # Google doesn't return new refresh_token here
+        email=token.email,           # preserve identity metadata across refresh
     )
 
     _save_token_local(user_id, refreshed, token_dir)

--- a/src/integrations/google_workspace/token_store.py
+++ b/src/integrations/google_workspace/token_store.py
@@ -31,7 +31,8 @@ Token schema on disk::
         "access_token":  "<string>",
         "expires_at":    "<ISO 8601 UTC>",
         "scope":         "<space-separated scopes>",
-        "refresh_token": "<string or null>"
+        "refresh_token": "<string or null>",
+        "email":         "<string or null -- authenticated account, issue #2153>"
     }
 
 Design principles
@@ -144,6 +145,7 @@ def _token_to_dict(token: TokenData) -> dict:
         "expires_at": token.expires_at.isoformat(),
         "scope": token.scope,
         "refresh_token": token.refresh_token,
+        "email": token.email,
     }
 
 
@@ -157,6 +159,7 @@ def _dict_to_token(data: dict) -> TokenData:
         expires_at=expires_at,
         scope=data.get("scope", ""),
         refresh_token=data.get("refresh_token"),
+        email=data.get("email"),
     )
 
 
@@ -395,12 +398,13 @@ def get_valid_token(
         )
         return None
 
-    # Merge: preserve scope and refresh_token from the stored token
+    # Merge: preserve scope, refresh_token, and email from the stored token
     refreshed = TokenData(
         access_token=refreshed_partial.access_token,
         expires_at=refreshed_partial.expires_at,
         scope=token.scope,           # preserve original scope
         refresh_token=token.refresh_token,  # Google doesn't return new refresh_token here
+        email=token.email,           # preserve identity metadata across refresh
     )
 
     _save_token_local(user_id, refreshed, token_dir)

--- a/src/integrations/oauth_vault/client.py
+++ b/src/integrations/oauth_vault/client.py
@@ -379,12 +379,13 @@ def get_valid_token(
         )
         return None
 
-    # Merge: preserve scope and refresh_token from the stored token
+    # Merge: preserve scope, refresh_token, and email from the stored token
     refreshed = TokenData(
         access_token=refreshed_partial.access_token,
         expires_at=refreshed_partial.expires_at,
         scope=token.scope,                  # preserve original scope
         refresh_token=token.refresh_token,  # Google doesn't return new refresh_token here
+        email=token.email,                  # preserve identity metadata across refresh
     )
 
     _save_token(user_id, refreshed, effective_token_dir)

--- a/src/integrations/oauth_vault/vault_store.py
+++ b/src/integrations/oauth_vault/vault_store.py
@@ -22,7 +22,8 @@ Token schema on disk (unchanged from the three predecessors)::
         "access_token":  "<string>",
         "expires_at":    "<ISO 8601 UTC>",
         "scope":         "<space-separated scopes>",
-        "refresh_token": "<string or null>"
+        "refresh_token": "<string or null>",
+        "email":         "<string or null -- authenticated account, issue #2153>"
     }
 
 Design principles
@@ -90,6 +91,7 @@ def _token_to_dict(token: TokenData) -> dict:
         "expires_at": token.expires_at.isoformat(),
         "scope": token.scope,
         "refresh_token": token.refresh_token,
+        "email": token.email,
     }
 
 
@@ -103,6 +105,7 @@ def _dict_to_token(data: dict) -> TokenData:
         expires_at=expires_at,
         scope=data.get("scope", ""),
         refresh_token=data.get("refresh_token"),
+        email=data.get("email"),
     )
 
 

--- a/src/mcp/inbox_server_http.py
+++ b/src/mcp/inbox_server_http.py
@@ -741,6 +741,90 @@ def _fetch_workspace_preview(chat_id: str) -> Optional[str]:
     return f"Recently modified in My Drive: {latest.name}"
 
 
+# ---------------------------------------------------------------------------
+# Issue #2153: identity metadata capture, shared by all three push endpoints
+# ---------------------------------------------------------------------------
+# A signed session token (see _verify_calendar_session_token and friends,
+# above) proves a push corresponds to the OAuth transaction requested by a
+# given chat_id. It does NOT prove that the Google account which completed
+# the consent screen belongs to the person who owns that chat_id -- a shared
+# or forwarded consent link, clicked with a different Google account active
+# in the browser, produces exactly that mismatch. Capturing which email
+# actually authenticated, and comparing it to what was on file before, is
+# what lets this surface immediately instead of silently (the production
+# incident that prompted this issue: chat_id 1111111111's Workspace token
+# turned out to be authenticated as a different person's Google account,
+# undetected until an explicit API call revealed it).
+
+
+def _fetch_authenticated_email(access_token: str) -> Optional[str]:
+    """Lazily-imported wrapper around identity.fetch_authenticated_email.
+
+    Kept as a thin module-level function (rather than a top-level import)
+    to match this module's existing convention of importing `integrations.*`
+    lazily inside functions (see _fetch_calendar_preview et al., above) --
+    and to remain patchable by name in tests
+    (`patch(f"{_MODULE}._fetch_authenticated_email")`).
+    """
+    from integrations.google_auth.identity import fetch_authenticated_email
+
+    return fetch_authenticated_email(access_token)
+
+
+def _read_previous_token_email(token_path: Path) -> Optional[str]:
+    """Best-effort read of the `email` field from an existing token file.
+
+    Returns None on any failure (file absent, corrupt JSON, no email key) --
+    this is a baseline for a self-consistency check, never a hard dependency.
+    Must be called BEFORE the token file at `token_path` is overwritten.
+    """
+    if not token_path.exists():
+        return None
+    try:
+        data = json.loads(token_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    email = data.get("email")
+    return email if isinstance(email, str) and email else None
+
+
+def _capture_identity_metadata(
+    *,
+    chat_id: str,
+    access_token: str,
+    token_path: Path,
+    scope_label: str,
+) -> tuple[Optional[str], str]:
+    """Fetch the newly granted email, compare it to what's on file, and
+    return ``(new_email, warning_suffix)``.
+
+    ``warning_suffix`` is either "" (nothing to warn about -- match, or
+    nothing to compare against yet) or a short string to append to the
+    push confirmation text sent to the user, so a mismatch is surfaced in
+    the same message that tells them the connection succeeded, rather than
+    staying silent. Never raises: a userinfo failure degrades to
+    ``(None, "")``, and the token is still saved/usable.
+    """
+    from integrations.google_auth.identity import (
+        check_identity_consistency,
+        format_mismatch_warning,
+    )
+
+    previous_email = _read_previous_token_email(token_path)
+    new_email = _fetch_authenticated_email(access_token)
+
+    result = check_identity_consistency(previous_email, new_email)
+    if result.is_mismatch:
+        logger.warning(
+            "%s token identity mismatch for chat_id=%r: previously authenticated "
+            "as %r, now authenticated as %r -- possible cross-account mixup "
+            "(issue #2153). Token was still saved; investigate before trusting it.",
+            scope_label, chat_id, previous_email, new_email,
+        )
+
+    return new_email, format_mismatch_warning(result, chat_id=chat_id) or ""
+
+
 async def push_calendar_token_endpoint(scope, receive, send):
     """POST /api/push-calendar-token — receive a token pushed by myownlobster.ai.
 
@@ -839,16 +923,28 @@ async def push_calendar_token_endpoint(scope, receive, send):
         await response(scope, receive, send)
         return
 
+    _GCAL_TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+    token_path = _GCAL_TOKEN_DIR / f"{safe_chat_id}.json"
+
+    # Issue #2153: capture the authenticated email BEFORE overwriting any
+    # existing token file, so the self-consistency check has the true prior
+    # value to compare against.
+    new_email, identity_warning = _capture_identity_metadata(
+        chat_id=safe_chat_id,
+        access_token=access_token,
+        token_path=token_path,
+        scope_label="Calendar",
+    )
+
     token_data = {
         "access_token": access_token,
         "expires_at": expires_at.isoformat(),
         "scope": scope_str,
         "refresh_token": refresh_token,
+        "email": new_email,
     }
 
     try:
-        _GCAL_TOKEN_DIR.mkdir(parents=True, exist_ok=True)
-        token_path = _GCAL_TOKEN_DIR / f"{safe_chat_id}.json"
         tmp_path = token_path.with_suffix(".json.tmp")
         payload = json.dumps(token_data, indent=2)
         fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _TOKEN_FILE_MODE)
@@ -875,6 +971,7 @@ async def push_calendar_token_endpoint(scope, receive, send):
         connected_text=(
             "Google Calendar connected. "
             "I can now read and create events on your calendar."
+            f"{identity_warning}"
         ),
         fetch_preview=lambda: _fetch_calendar_preview(safe_chat_id),
         source=confirm_source,
@@ -1076,16 +1173,28 @@ async def push_gmail_token_endpoint(scope, receive, send):
         await response(scope, receive, send)
         return
 
+    _GMAIL_TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+    token_path = _GMAIL_TOKEN_DIR / f"{safe_chat_id}.json"
+
+    # Issue #2153: capture the authenticated email BEFORE overwriting any
+    # existing token file, so the self-consistency check has the true prior
+    # value to compare against.
+    new_email, identity_warning = _capture_identity_metadata(
+        chat_id=safe_chat_id,
+        access_token=access_token,
+        token_path=token_path,
+        scope_label="Gmail",
+    )
+
     token_data = {
         "access_token": access_token,
         "expires_at": expires_at.isoformat(),
         "scope": scope_str,
         "refresh_token": refresh_token,
+        "email": new_email,
     }
 
     try:
-        _GMAIL_TOKEN_DIR.mkdir(parents=True, exist_ok=True)
-        token_path = _GMAIL_TOKEN_DIR / f"{safe_chat_id}.json"
         tmp_path = token_path.with_suffix(".json.tmp")
         payload = json.dumps(token_data, indent=2)
         fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _TOKEN_FILE_MODE)
@@ -1114,6 +1223,7 @@ async def push_gmail_token_endpoint(scope, receive, send):
         connected_text=(
             "Gmail connected. "
             "I can now read and search your emails."
+            f"{identity_warning}"
         ),
         fetch_preview=lambda: _fetch_gmail_preview(safe_chat_id),
     )
@@ -1568,16 +1678,31 @@ async def push_workspace_token_endpoint(scope, receive, send):
         await response(scope, receive, send)
         return
 
+    _WORKSPACE_TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+    token_path = _WORKSPACE_TOKEN_DIR / f"{safe_chat_id}.json"
+
+    # Issue #2153: capture the authenticated email BEFORE overwriting any
+    # existing token file, so the self-consistency check has the true prior
+    # value to compare against. This is the exact code path that let the
+    # production cross-account mixup (chat_id 1111111111 holding a different
+    # person's Workspace token) go undetected until an explicit API call
+    # revealed it.
+    new_email, identity_warning = _capture_identity_metadata(
+        chat_id=safe_chat_id,
+        access_token=access_token,
+        token_path=token_path,
+        scope_label="Workspace",
+    )
+
     token_data = {
         "access_token": access_token,
         "expires_at": expires_at.isoformat(),
         "scope": scope_str,
         "refresh_token": refresh_token,
+        "email": new_email,
     }
 
     try:
-        _WORKSPACE_TOKEN_DIR.mkdir(parents=True, exist_ok=True)
-        token_path = _WORKSPACE_TOKEN_DIR / f"{safe_chat_id}.json"
         tmp_path = token_path.with_suffix(".json.tmp")
         payload = json.dumps(token_data, indent=2)
         fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _TOKEN_FILE_MODE)
@@ -1608,6 +1733,7 @@ async def push_workspace_token_endpoint(scope, receive, send):
         connected_text=(
             "Google Workspace connected. "
             "You can now use /gdocs, /gdrive, and /gsheets."
+            f"{identity_warning}"
         ),
         fetch_preview=lambda: _fetch_workspace_preview(safe_chat_id),
     )

--- a/tests/unit/test_integrations/test_gmail_token_store.py
+++ b/tests/unit/test_integrations/test_gmail_token_store.py
@@ -438,3 +438,72 @@ class TestTokenIsolation:
         # Loading from gmail dir must return None (not the gcal token)
         result = ts._load_token_local("99", gmail_dir)
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Identity metadata (issue #2153) -- email captured at grant time survives
+# save/load and is preserved across a refresh.
+# ---------------------------------------------------------------------------
+
+
+class TestEmailIdentityMetadata:
+    def test_roundtrip_preserves_email(self, tmp_path):
+        token = TokenData(
+            access_token="tok",
+            expires_at=_FUTURE,
+            scope="https://mail.google.com/",
+            refresh_token="refresh",
+            email="account-a@example.com",
+        )
+        ts.save_token("chat_a", token, token_dir=tmp_path)
+        loaded = ts.load_token("chat_a", token_dir=tmp_path)
+        assert loaded.email == "account-a@example.com"
+
+    def test_missing_email_key_loads_as_none(self, tmp_path):
+        """Tokens saved before this field existed must still load cleanly."""
+        (tmp_path / "legacy_user.json").write_text(
+            json.dumps(
+                {
+                    "access_token": "tok",
+                    "expires_at": _FUTURE.isoformat(),
+                    "scope": "",
+                    "refresh_token": "refresh",
+                }
+            )
+        )
+        loaded = ts.load_token("legacy_user", token_dir=tmp_path)
+        assert loaded is not None
+        assert loaded.email is None
+
+    def test_two_chat_ids_store_independent_emails(self, tmp_path):
+        """The exact scenario from the production incident: two different
+        chat_ids must each retain their OWN email, with no cross-contamination."""
+        token_a = TokenData(
+            access_token="tok-a", expires_at=_FUTURE, scope="s",
+            refresh_token="r", email="account-a@example.com",
+        )
+        token_b = TokenData(
+            access_token="tok-b", expires_at=_FUTURE, scope="s",
+            refresh_token="r", email="account-b@example.com",
+        )
+        ts.save_token("1111111111", token_a, token_dir=tmp_path)
+        ts.save_token("2222222222", token_b, token_dir=tmp_path)
+
+        assert ts.load_token("1111111111", token_dir=tmp_path).email == "account-a@example.com"
+        assert ts.load_token("2222222222", token_dir=tmp_path).email == "account-b@example.com"
+
+    def test_email_preserved_across_refresh(self, tmp_path):
+        expired = TokenData(
+            access_token="expired-tok", expires_at=_EXPIRED, scope="s",
+            refresh_token="valid-refresh", email="account-a@example.com",
+        )
+        ts.save_token("user_refresh_email", expired, token_dir=tmp_path)
+
+        refreshed_partial = TokenData(
+            access_token="refreshed-tok", expires_at=_FUTURE, scope="", refresh_token=None,
+        )
+        with patch.object(ts, "_refresh_token_via_proxy", return_value=refreshed_partial):
+            result = ts.get_valid_token("user_refresh_email", token_dir=tmp_path)
+
+        assert result.email == "account-a@example.com"
+        assert ts.load_token("user_refresh_email", token_dir=tmp_path).email == "account-a@example.com"

--- a/tests/unit/test_integrations/test_google_auth_identity.py
+++ b/tests/unit/test_integrations/test_google_auth_identity.py
@@ -1,0 +1,221 @@
+"""
+Tests for integrations.google_auth.identity (issue #2153).
+
+Covers:
+- fetch_authenticated_email: success, HTTP error, network error, missing
+  email field, missing/empty access_token -- never raises.
+- check_identity_consistency: pure comparison logic (match / mismatch /
+  no_baseline / email_unavailable).
+- format_mismatch_warning: only surfaces text for an actual mismatch.
+- expected_email_for_chat_id: registry lookup, graceful on missing/invalid
+  file.
+
+These are the tests that would fail if the fix in issue #2153 were
+reverted: in particular test_check_identity_consistency_detects_mismatch
+and test_two_distinct_chat_ids_produce_independent_results directly assert
+the cross-account-mixup detection this issue introduces.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from integrations.google_auth.identity import (
+    IdentityCheckResult,
+    check_expected_identity,
+    check_identity_consistency,
+    expected_email_for_chat_id,
+    fetch_authenticated_email,
+    format_mismatch_warning,
+)
+
+_MODULE = "integrations.google_auth.identity"
+
+
+# ---------------------------------------------------------------------------
+# fetch_authenticated_email
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_authenticated_email_success():
+    mock_resp = MagicMock(ok=True)
+    mock_resp.json.return_value = {"email": "account-a@example.com", "email_verified": True}
+    with patch(f"{_MODULE}.requests.get", return_value=mock_resp) as mock_get:
+        result = fetch_authenticated_email("ya29.fake-token")
+    assert result == "account-a@example.com"
+    # Bearer auth, not the token in the URL/query string.
+    _, kwargs = mock_get.call_args
+    assert kwargs["headers"]["Authorization"] == "Bearer ya29.fake-token"
+
+
+def test_fetch_authenticated_email_http_error_returns_none():
+    mock_resp = MagicMock(ok=False, status_code=403)
+    with patch(f"{_MODULE}.requests.get", return_value=mock_resp):
+        assert fetch_authenticated_email("ya29.fake-token") is None
+
+
+def test_fetch_authenticated_email_network_error_returns_none():
+    with patch(
+        f"{_MODULE}.requests.get",
+        side_effect=requests.exceptions.ConnectionError("no route to host"),
+    ):
+        assert fetch_authenticated_email("ya29.fake-token") is None
+
+
+def test_fetch_authenticated_email_missing_email_field_returns_none():
+    mock_resp = MagicMock(ok=True)
+    mock_resp.json.return_value = {"sub": "12345"}  # no "email" key
+    with patch(f"{_MODULE}.requests.get", return_value=mock_resp):
+        assert fetch_authenticated_email("ya29.fake-token") is None
+
+
+def test_fetch_authenticated_email_unparseable_json_returns_none():
+    mock_resp = MagicMock(ok=True)
+    mock_resp.json.side_effect = ValueError("not json")
+    with patch(f"{_MODULE}.requests.get", return_value=mock_resp):
+        assert fetch_authenticated_email("ya29.fake-token") is None
+
+
+def test_fetch_authenticated_email_empty_token_returns_none_without_network_call():
+    with patch(f"{_MODULE}.requests.get") as mock_get:
+        assert fetch_authenticated_email("") is None
+    mock_get.assert_not_called()
+
+
+def test_fetch_authenticated_email_never_raises_on_unexpected_exception():
+    """Defense in depth: even an exception type the code doesn't explicitly
+    catch must not propagate out of fetch_authenticated_email (a userinfo
+    hiccup must never block a token save)."""
+    with patch(f"{_MODULE}.requests.get", side_effect=requests.exceptions.Timeout("slow")):
+        assert fetch_authenticated_email("ya29.fake-token") is None
+
+
+# ---------------------------------------------------------------------------
+# check_identity_consistency (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_check_identity_consistency_first_grant_has_no_baseline():
+    result = check_identity_consistency(previous_email=None, new_email="account-a@example.com")
+    assert result.status == "no_baseline"
+    assert result.is_mismatch is False
+
+
+def test_check_identity_consistency_match():
+    result = check_identity_consistency(previous_email="account-a@example.com", new_email="account-a@example.com")
+    assert result.status == "match"
+    assert result.is_mismatch is False
+
+
+def test_check_identity_consistency_detects_mismatch():
+    """The core regression test for issue #2153: a reconnect that lands on a
+    different Google account than the one already on file must be flagged."""
+    result = check_identity_consistency(previous_email="account-a@example.com", new_email="account-b@example.com")
+    assert result.status == "mismatch"
+    assert result.is_mismatch is True
+    assert result.baseline_email == "account-a@example.com"
+    assert result.new_email == "account-b@example.com"
+
+
+def test_check_identity_consistency_email_unavailable_when_new_email_missing():
+    result = check_identity_consistency(previous_email="account-a@example.com", new_email=None)
+    assert result.status == "email_unavailable"
+    assert result.is_mismatch is False
+
+
+def test_check_expected_identity_mismatch():
+    """Registry-based check (covers the first-grant case, where
+    check_identity_consistency alone has no baseline)."""
+    result = check_expected_identity(expected_email="account-a@example.com", new_email="account-b@example.com")
+    assert result.status == "mismatch"
+    assert result.is_mismatch is True
+
+
+# ---------------------------------------------------------------------------
+# format_mismatch_warning (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_format_mismatch_warning_returns_none_for_match():
+    result = IdentityCheckResult("match", "account-a@example.com", "account-a@example.com")
+    assert format_mismatch_warning(result, chat_id="1111111111") is None
+
+
+def test_format_mismatch_warning_returns_none_for_no_baseline():
+    result = IdentityCheckResult("no_baseline", None, "account-a@example.com")
+    assert format_mismatch_warning(result, chat_id="1111111111") is None
+
+
+def test_format_mismatch_warning_returns_none_when_email_unavailable():
+    result = IdentityCheckResult("email_unavailable", "account-a@example.com", None)
+    assert format_mismatch_warning(result, chat_id="1111111111") is None
+
+
+def test_format_mismatch_warning_surfaces_both_emails_on_mismatch():
+    result = IdentityCheckResult("mismatch", "account-a@example.com", "account-b@example.com")
+    warning = format_mismatch_warning(result, chat_id="1111111111")
+    assert warning is not None
+    assert "account-a@example.com" in warning
+    assert "account-b@example.com" in warning
+
+
+# ---------------------------------------------------------------------------
+# expected_email_for_chat_id (registry lookup)
+# ---------------------------------------------------------------------------
+
+
+def test_expected_email_for_chat_id_missing_file_returns_none(tmp_path):
+    registry = tmp_path / "known-users.json"
+    assert expected_email_for_chat_id("1111111111", known_users_path=registry) is None
+
+
+def test_expected_email_for_chat_id_loads_registry(tmp_path):
+    registry = tmp_path / "known-users.json"
+    registry.write_text(json.dumps({"1111111111": "account-a@example.com", "2222222222": "account-b@example.com"}))
+    assert expected_email_for_chat_id("1111111111", known_users_path=registry) == "account-a@example.com"
+    assert expected_email_for_chat_id("2222222222", known_users_path=registry) == "account-b@example.com"
+
+
+def test_expected_email_for_chat_id_no_entry_returns_none(tmp_path):
+    registry = tmp_path / "known-users.json"
+    registry.write_text(json.dumps({"2222222222": "account-b@example.com"}))
+    assert expected_email_for_chat_id("1111111111", known_users_path=registry) is None
+
+
+def test_expected_email_for_chat_id_invalid_json_returns_none(tmp_path):
+    registry = tmp_path / "known-users.json"
+    registry.write_text("{not valid json")
+    assert expected_email_for_chat_id("1111111111", known_users_path=registry) is None
+
+
+def test_expected_email_for_chat_id_non_dict_json_returns_none(tmp_path):
+    registry = tmp_path / "known-users.json"
+    registry.write_text(json.dumps(["not", "a", "dict"]))
+    assert expected_email_for_chat_id("1111111111", known_users_path=registry) is None
+
+
+# ---------------------------------------------------------------------------
+# Two-chat-id isolation (the exact scenario from the production incident)
+# ---------------------------------------------------------------------------
+
+
+def test_two_distinct_chat_ids_produce_independent_results(tmp_path):
+    """chat_id A and Person B's chat_id must each be checked against their
+    OWN expected email, never cross-contaminating."""
+    registry = tmp_path / "known-users.json"
+    registry.write_text(json.dumps({"1111111111": "account-a@example.com", "2222222222": "account-b@example.com"}))
+
+    expected_a = expected_email_for_chat_id("1111111111", known_users_path=registry)
+    expected_b = expected_email_for_chat_id("2222222222", known_users_path=registry)
+
+    # Simulate the production incident: chat_id A received Person B's token.
+    result_a = check_expected_identity(expected_email=expected_a, new_email="account-b@example.com")
+    result_b = check_expected_identity(expected_email=expected_b, new_email="account-b@example.com")
+
+    assert result_a.status == "mismatch", "the second account's email under the first chat_id must be flagged"
+    assert result_b.status == "match", "the second account's email under its own chat_id must NOT be flagged"

--- a/tests/unit/test_integrations/test_google_calendar_token_store.py
+++ b/tests/unit/test_integrations/test_google_calendar_token_store.py
@@ -889,3 +889,75 @@ class TestSaveTokenAtomicWriteFailure:
         assert not (tmp_path / "user1.json.tmp").exists()
         # And no final file should exist either, since rename never succeeded.
         assert not (tmp_path / "user1.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Identity metadata (issue #2153) -- email captured at grant time survives
+# save/load and is preserved across a refresh.
+# ---------------------------------------------------------------------------
+
+
+class TestEmailIdentityMetadata:
+    def test_roundtrip_preserves_email(self, tmp_path):
+        token = TokenData(
+            access_token=_FAKE_ACCESS_TOKEN,
+            expires_at=_FUTURE_EXPIRES,
+            scope=_FAKE_SCOPE,
+            refresh_token=_FAKE_REFRESH_TOKEN,
+            email="account-a@example.com",
+        )
+        save_token("chat_a", token, token_dir=tmp_path)
+        loaded = load_token("chat_a", token_dir=tmp_path)
+        assert loaded.email == "account-a@example.com"
+
+    def test_missing_email_key_loads_as_none(self, tmp_path):
+        """Tokens saved before this field existed must still load cleanly."""
+        (tmp_path / "legacy_user.json").write_text(
+            json.dumps(
+                {
+                    "access_token": _FAKE_ACCESS_TOKEN,
+                    "expires_at": _FUTURE_EXPIRES.isoformat(),
+                    "scope": _FAKE_SCOPE,
+                    "refresh_token": _FAKE_REFRESH_TOKEN,
+                }
+            )
+        )
+        loaded = load_token("legacy_user", token_dir=tmp_path)
+        assert loaded is not None
+        assert loaded.email is None
+
+    def test_two_chat_ids_store_independent_emails(self, tmp_path):
+        """The exact scenario from the production incident: two different
+        chat_ids must each retain their OWN email, with no cross-contamination."""
+        token_a = TokenData(
+            access_token="tok-a", expires_at=_FUTURE_EXPIRES, scope=_FAKE_SCOPE,
+            refresh_token="r", email="account-a@example.com",
+        )
+        token_b = TokenData(
+            access_token="tok-b", expires_at=_FUTURE_EXPIRES, scope=_FAKE_SCOPE,
+            refresh_token="r", email="account-b@example.com",
+        )
+        save_token("1111111111", token_a, token_dir=tmp_path)
+        save_token("2222222222", token_b, token_dir=tmp_path)
+
+        assert load_token("1111111111", token_dir=tmp_path).email == "account-a@example.com"
+        assert load_token("2222222222", token_dir=tmp_path).email == "account-b@example.com"
+
+    def test_email_preserved_across_refresh(self, tmp_path):
+        expired = TokenData(
+            access_token="expired-tok", expires_at=_EXPIRED_EXPIRES, scope=_FAKE_SCOPE,
+            refresh_token="valid-refresh", email="account-a@example.com",
+        )
+        save_token("user_refresh_email", expired, token_dir=tmp_path)
+
+        refreshed_partial = TokenData(
+            access_token="refreshed-tok", expires_at=_FUTURE_EXPIRES, scope="", refresh_token=None,
+        )
+        with patch(
+            "integrations.google_calendar.token_store._refresh_token_via_proxy",
+            return_value=refreshed_partial,
+        ):
+            result = get_valid_token("user_refresh_email", token_dir=tmp_path)
+
+        assert result.email == "account-a@example.com"
+        assert load_token("user_refresh_email", token_dir=tmp_path).email == "account-a@example.com"

--- a/tests/unit/test_integrations/test_oauth_vault_client.py
+++ b/tests/unit/test_integrations/test_oauth_vault_client.py
@@ -425,3 +425,31 @@ class TestRefreshTokenViaProxy:
     def test_raises_for_unknown_provider(self) -> None:
         with pytest.raises(ValueError, match="Unknown oauth_vault provider"):
             ovc._refresh_token_via_proxy("not_a_real_provider", "refresh-tok")
+
+
+# ---------------------------------------------------------------------------
+# Identity metadata (issue #2153) -- email is preserved across a refresh,
+# consistently with the three predecessor token_store.py modules'
+# get_valid_token behavior.
+# ---------------------------------------------------------------------------
+
+
+class TestEmailIdentityMetadata:
+    def test_email_preserved_across_refresh(self, tmp_path: Path) -> None:
+        expired = TokenData(
+            access_token=_FAKE_ACCESS_TOKEN,
+            expires_at=_EXPIRED_EXPIRES,
+            scope=_FAKE_SCOPE,
+            refresh_token=_FAKE_REFRESH_TOKEN,
+            email="account-a@example.com",
+        )
+        save_token("user1", expired, tmp_path)
+
+        proxy_result = TokenData(
+            access_token="ya29.refreshed", expires_at=_FUTURE_EXPIRES, scope="", refresh_token=None,
+        )
+        with patch(f"{ovc.__name__}._refresh_token_via_proxy", return_value=proxy_result):
+            result = get_valid_token(_PROVIDER, "user1", token_dir=tmp_path)
+
+        assert result.email == "account-a@example.com"
+        assert load_token("user1", tmp_path).email == "account-a@example.com"

--- a/tests/unit/test_integrations/test_oauth_vault_store.py
+++ b/tests/unit/test_integrations/test_oauth_vault_store.py
@@ -255,3 +255,55 @@ class TestProviderTokenDir:
         a = provider_token_dir("provider_a", vault_root=tmp_path)
         b = provider_token_dir("provider_b", vault_root=tmp_path)
         assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Identity metadata (issue #2153) -- email captured at grant time survives
+# save/load, consistently with the three predecessor token_store.py modules.
+# ---------------------------------------------------------------------------
+
+
+class TestEmailIdentityMetadata:
+    def test_roundtrip_preserves_email(self, tmp_path):
+        token = TokenData(
+            access_token="tok",
+            expires_at=datetime(2099, 1, 1, tzinfo=timezone.utc),
+            scope="s",
+            refresh_token="r",
+            email="account-a@example.com",
+        )
+        save_token("chat_a", token, tmp_path)
+        loaded = load_token("chat_a", tmp_path)
+        assert loaded.email == "account-a@example.com"
+
+    def test_missing_email_key_loads_as_none(self, tmp_path):
+        (tmp_path / "legacy_user.json").write_text(
+            json.dumps(
+                {
+                    "access_token": "tok",
+                    "expires_at": datetime(2099, 1, 1, tzinfo=timezone.utc).isoformat(),
+                    "scope": "s",
+                    "refresh_token": "r",
+                }
+            )
+        )
+        loaded = load_token("legacy_user", tmp_path)
+        assert loaded is not None
+        assert loaded.email is None
+
+    def test_two_chat_ids_store_independent_emails(self, tmp_path):
+        """The exact scenario from the production incident: two different
+        chat_ids must each retain their OWN email, with no cross-contamination."""
+        token_a = TokenData(
+            access_token="tok-a", expires_at=datetime(2099, 1, 1, tzinfo=timezone.utc),
+            scope="s", refresh_token="r", email="account-a@example.com",
+        )
+        token_b = TokenData(
+            access_token="tok-b", expires_at=datetime(2099, 1, 1, tzinfo=timezone.utc),
+            scope="s", refresh_token="r", email="account-b@example.com",
+        )
+        save_token("1111111111", token_a, tmp_path)
+        save_token("2222222222", token_b, tmp_path)
+
+        assert load_token("1111111111", tmp_path).email == "account-a@example.com"
+        assert load_token("2222222222", tmp_path).email == "account-b@example.com"

--- a/tests/unit/test_integrations/test_workspace_token_store.py
+++ b/tests/unit/test_integrations/test_workspace_token_store.py
@@ -218,3 +218,88 @@ class TestNoTokenValuesInLogs:
 
         for record in caplog.records:
             assert "test-access-token" not in record.getMessage()
+
+
+# ---------------------------------------------------------------------------
+# Identity metadata (issue #2153) -- email captured at grant time survives
+# save/load and is preserved across a refresh.
+# ---------------------------------------------------------------------------
+
+
+class TestEmailIdentityMetadata:
+    def test_roundtrip_preserves_email(self, tmp_path):
+        token = TokenData(
+            access_token="tok",
+            expires_at=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+            scope="https://www.googleapis.com/auth/documents",
+            refresh_token="refresh",
+            email="account-a@example.com",
+        )
+        token_store.save_token("chat_a", token, token_dir=tmp_path)
+        loaded = token_store.load_token("chat_a", token_dir=tmp_path)
+        assert loaded.email == "account-a@example.com"
+
+    def test_missing_email_key_loads_as_none(self, tmp_path):
+        """Tokens saved before this field existed must still load cleanly."""
+        (tmp_path / "legacy_user.json").write_text(
+            json.dumps(
+                {
+                    "access_token": "tok",
+                    "expires_at": (datetime.now(tz=timezone.utc) + timedelta(hours=1)).isoformat(),
+                    "scope": "",
+                    "refresh_token": "refresh",
+                }
+            )
+        )
+        loaded = token_store.load_token("legacy_user", token_dir=tmp_path)
+        assert loaded is not None
+        assert loaded.email is None
+
+    def test_two_chat_ids_store_independent_emails(self, tmp_path):
+        """The exact scenario from the production incident: two different
+        chat_ids must each retain their OWN email, with no cross-contamination."""
+        token_a = TokenData(
+            access_token="tok-a",
+            expires_at=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+            scope="s",
+            refresh_token="r",
+            email="account-a@example.com",
+        )
+        token_b = TokenData(
+            access_token="tok-b",
+            expires_at=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+            scope="s",
+            refresh_token="r",
+            email="account-b@example.com",
+        )
+        token_store.save_token("1111111111", token_a, token_dir=tmp_path)
+        token_store.save_token("2222222222", token_b, token_dir=tmp_path)
+
+        loaded_a = token_store.load_token("1111111111", token_dir=tmp_path)
+        loaded_b = token_store.load_token("2222222222", token_dir=tmp_path)
+
+        assert loaded_a.email == "account-a@example.com"
+        assert loaded_b.email == "account-b@example.com"
+
+    def test_email_preserved_across_refresh(self, tmp_path):
+        expired = TokenData(
+            access_token="expired-tok",
+            expires_at=datetime.now(tz=timezone.utc) - timedelta(hours=1),
+            scope="s",
+            refresh_token="valid-refresh",
+            email="account-a@example.com",
+        )
+        token_store.save_token("user_refresh_email", expired, token_dir=tmp_path)
+
+        refreshed_partial = TokenData(
+            access_token="refreshed-tok",
+            expires_at=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+            scope="",
+            refresh_token=None,
+        )
+        with patch.object(token_store, "_refresh_token_via_proxy", return_value=refreshed_partial):
+            result = token_store.get_valid_token("user_refresh_email", token_dir=tmp_path)
+
+        assert result.email == "account-a@example.com"
+        persisted = token_store.load_token("user_refresh_email", token_dir=tmp_path)
+        assert persisted.email == "account-a@example.com"

--- a/tests/unit/test_mcp_server/test_push_calendar_token_confirmation.py
+++ b/tests/unit/test_mcp_server/test_push_calendar_token_confirmation.py
@@ -68,6 +68,7 @@ def client_and_dirs(tmp_path):
         patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", False),
         patch(f"{_MODULE}._seen_calendar_session_nonces", {}),
         patch(f"{_MODULE}._seen_push_confirmations", {}),
+        patch(f"{_MODULE}._fetch_authenticated_email", return_value="test-user@example.com"),
     ):
         from src.mcp.inbox_server_http import app
 
@@ -168,6 +169,7 @@ class TestPostAuthConfirmation:
             patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", False),
             patch(f"{_MODULE}._seen_calendar_session_nonces", {}),
             patch(f"{_MODULE}._seen_push_confirmations", {}),
+            patch(f"{_MODULE}._fetch_authenticated_email", return_value="test-user@example.com"),
             patch(f"{_MODULE}._fetch_calendar_preview", return_value="preview"),
         ):
             from src.mcp.inbox_server_http import app
@@ -199,6 +201,7 @@ class TestPostAuthConfirmation:
             patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", False),
             patch(f"{_MODULE}._seen_calendar_session_nonces", {}),
             patch(f"{_MODULE}._seen_push_confirmations", {}),
+            patch(f"{_MODULE}._fetch_authenticated_email", return_value="test-user@example.com"),
             patch(f"{_MODULE}._fetch_calendar_preview", return_value="preview"),
         ):
             from src.mcp.inbox_server_http import app

--- a/tests/unit/test_mcp_server/test_push_calendar_token_endpoint.py
+++ b/tests/unit/test_mcp_server/test_push_calendar_token_endpoint.py
@@ -115,6 +115,11 @@ def client_and_token_dir(tmp_path):
         patch(f"{_MODULE}._SESSION_HMAC_SECRET", _SESSION_HMAC_SECRET),
         patch(f"{_MODULE}._ENFORCE_SIGNED_SESSION", False),
         patch(f"{_MODULE}._seen_calendar_session_nonces", {}),
+        # Issue #2153: identity capture makes a real Google userinfo call by
+        # default -- patched out here so tests never touch the network. The
+        # default test email is deliberately unremarkable; tests exercising
+        # identity-specific behavior override this per-test.
+        patch(f"{_MODULE}._fetch_authenticated_email", return_value="test-user@example.com"),
     ):
         from src.mcp.inbox_server_http import app
 

--- a/tests/unit/test_mcp_server/test_push_gmail_token_confirmation.py
+++ b/tests/unit/test_mcp_server/test_push_gmail_token_confirmation.py
@@ -68,6 +68,7 @@ def client_and_dirs(tmp_path):
         patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", False),
         patch(f"{_MODULE}._seen_gmail_session_nonces", {}),
         patch(f"{_MODULE}._seen_push_confirmations", {}),
+        patch(f"{_MODULE}._fetch_authenticated_email", return_value="test-user@example.com"),
     ):
         from src.mcp.inbox_server_http import app
 
@@ -161,6 +162,7 @@ class TestPostAuthConfirmation:
             patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", False),
             patch(f"{_MODULE}._seen_gmail_session_nonces", {}),
             patch(f"{_MODULE}._seen_push_confirmations", {}),
+            patch(f"{_MODULE}._fetch_authenticated_email", return_value="test-user@example.com"),
             patch(f"{_MODULE}._fetch_gmail_preview", return_value="preview"),
         ):
             from src.mcp.inbox_server_http import app
@@ -192,6 +194,7 @@ class TestPostAuthConfirmation:
             patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", False),
             patch(f"{_MODULE}._seen_gmail_session_nonces", {}),
             patch(f"{_MODULE}._seen_push_confirmations", {}),
+            patch(f"{_MODULE}._fetch_authenticated_email", return_value="test-user@example.com"),
             patch(f"{_MODULE}._fetch_gmail_preview", return_value="preview"),
         ):
             from src.mcp.inbox_server_http import app

--- a/tests/unit/test_mcp_server/test_push_gmail_token_endpoint.py
+++ b/tests/unit/test_mcp_server/test_push_gmail_token_endpoint.py
@@ -113,6 +113,9 @@ def client_and_token_dir(tmp_path):
         patch(f"{_MODULE}._SESSION_HMAC_SECRET", _SESSION_HMAC_SECRET),
         patch(f"{_MODULE}._ENFORCE_GMAIL_SIGNED_SESSION", False),
         patch(f"{_MODULE}._seen_gmail_session_nonces", {}),
+        # Issue #2153: identity capture makes a real Google userinfo call by
+        # default -- patched out here so tests never touch the network.
+        patch(f"{_MODULE}._fetch_authenticated_email", return_value="test-user@example.com"),
     ):
         from src.mcp.inbox_server_http import app
 

--- a/tests/unit/test_mcp_server/test_push_workspace_token_confirmation.py
+++ b/tests/unit/test_mcp_server/test_push_workspace_token_confirmation.py
@@ -65,6 +65,7 @@ def client_and_dirs(tmp_path):
         patch(f"{_MODULE}._ENFORCE_WORKSPACE_SIGNED_SESSION", False),
         patch(f"{_MODULE}._seen_workspace_session_nonces", {}),
         patch(f"{_MODULE}._seen_push_confirmations", {}),
+        patch(f"{_MODULE}._fetch_authenticated_email", return_value="test-user@example.com"),
     ):
         from src.mcp.inbox_server_http import app
 
@@ -125,6 +126,48 @@ class TestPostAuthConfirmation:
         reply = _read_only_outbox_file(outbox_dir)
         assert "roadmap.gdoc" in reply["text"]
 
+    def test_identity_mismatch_warning_appears_in_confirmation_text(self, client_and_dirs):
+        """Issue #2153: reconnecting with a different Google account than
+        the one already on file must surface a warning in the SAME message
+        that confirms the connection succeeded -- not stay silent until an
+        explicit API call happens to reveal the mixup (the production
+        incident this issue fixes)."""
+        import src.mcp.inbox_server_http as mod
+
+        client, _, outbox_dir = client_and_dirs
+
+        with (
+            patch(f"{_MODULE}._fetch_authenticated_email", return_value="account-a@example.com"),
+            patch(f"{_MODULE}._fetch_workspace_preview", return_value=None),
+        ):
+            client.post(
+                "/api/push-workspace-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+
+        # Clear outbox + de-dupe state so the second push's confirmation is
+        # actually queued rather than skipped as a duplicate within the
+        # 5-minute TTL (_CONFIRM_DEDUPE_TTL_SECONDS).
+        for f in outbox_dir.glob("*.json"):
+            f.unlink()
+        mod._seen_push_confirmations.clear()
+
+        with (
+            patch(f"{_MODULE}._fetch_authenticated_email", return_value="account-b@example.com"),
+            patch(f"{_MODULE}._fetch_workspace_preview", return_value=None),
+        ):
+            resp = client.post(
+                "/api/push-workspace-token",
+                json=_VALID_BODY,
+                headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+            )
+
+        assert resp.status_code == 200
+        reply = _read_only_outbox_file(outbox_dir)
+        assert "account-a@example.com" in reply["text"]
+        assert "account-b@example.com" in reply["text"]
+
     def test_confirmation_degrades_gracefully_when_preview_fetch_fails(self, client_and_dirs, caplog):
         """BIS-744: a live-data fetch failure must never silence the confirmation."""
         import logging
@@ -164,6 +207,7 @@ class TestPostAuthConfirmation:
             patch(f"{_MODULE}._ENFORCE_WORKSPACE_SIGNED_SESSION", False),
             patch(f"{_MODULE}._seen_workspace_session_nonces", {}),
             patch(f"{_MODULE}._seen_push_confirmations", {}),
+            patch(f"{_MODULE}._fetch_authenticated_email", return_value="test-user@example.com"),
             patch(f"{_MODULE}._fetch_workspace_preview", return_value="preview"),
         ):
             from src.mcp.inbox_server_http import app
@@ -204,6 +248,7 @@ class TestPostAuthConfirmation:
             patch(f"{_MODULE}._ENFORCE_WORKSPACE_SIGNED_SESSION", False),
             patch(f"{_MODULE}._seen_workspace_session_nonces", {}),
             patch(f"{_MODULE}._seen_push_confirmations", {}),
+            patch(f"{_MODULE}._fetch_authenticated_email", return_value="test-user@example.com"),
             patch(f"{_MODULE}._fetch_workspace_preview", return_value="preview"),
         ):
             import logging as _logging

--- a/tests/unit/test_mcp_server/test_push_workspace_token_endpoint.py
+++ b/tests/unit/test_mcp_server/test_push_workspace_token_endpoint.py
@@ -109,6 +109,9 @@ def client_and_token_dir(tmp_path):
         patch(f"{_MODULE}._SESSION_HMAC_SECRET", _SESSION_HMAC_SECRET),
         patch(f"{_MODULE}._ENFORCE_WORKSPACE_SIGNED_SESSION", False),
         patch(f"{_MODULE}._seen_workspace_session_nonces", {}),
+        # Issue #2153: identity capture makes a real Google userinfo call by
+        # default -- patched out here so tests never touch the network.
+        patch(f"{_MODULE}._fetch_authenticated_email", return_value="test-user@example.com"),
     ):
         from src.mcp.inbox_server_http import app
 
@@ -465,3 +468,84 @@ def test_nonce_reuse_rejected_under_enforcement(client_and_token_dir):
         assert first.status_code == 200
         assert second.status_code == 401
         assert (token_dir / f"{_VALID_BODY['chat_id']}.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Issue #2153 -- identity metadata capture and cross-account mixup detection
+# ---------------------------------------------------------------------------
+
+
+def test_email_captured_and_stored_in_token_file(client_and_token_dir):
+    client, workspace_token_dir = client_and_token_dir
+    with patch(f"{_MODULE}._fetch_authenticated_email", return_value="account-a@example.com"):
+        resp = client.post(
+            "/api/push-workspace-token",
+            json=_VALID_BODY,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+    assert resp.status_code == 200
+    data = json.loads((workspace_token_dir / f"{_VALID_BODY['chat_id']}.json").read_text())
+    assert data["email"] == "account-a@example.com"
+
+
+def test_two_chat_ids_get_isolated_emails(client_and_token_dir):
+    """The exact scenario from the production incident this issue fixes:
+    two different chat_ids pushing tokens must never cross-contaminate each
+    other's stored email."""
+    client, workspace_token_dir = client_and_token_dir
+
+    body_a = {**_VALID_BODY, "chat_id": "1111111111"}
+    body_b = {**_VALID_BODY, "chat_id": "2222222222"}
+
+    with patch(f"{_MODULE}._fetch_authenticated_email", return_value="account-a@example.com"):
+        resp_a = client.post(
+            "/api/push-workspace-token",
+            json=body_a,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+    with patch(f"{_MODULE}._fetch_authenticated_email", return_value="account-b@example.com"):
+        resp_b = client.post(
+            "/api/push-workspace-token",
+            json=body_b,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+    assert resp_a.status_code == 200
+    assert resp_b.status_code == 200
+
+    data_a = json.loads((workspace_token_dir / "1111111111.json").read_text())
+    data_b = json.loads((workspace_token_dir / "2222222222.json").read_text())
+    assert data_a["email"] == "account-a@example.com"
+    assert data_b["email"] == "account-b@example.com"
+
+
+def test_reconnect_with_different_email_is_logged_as_mismatch(client_and_token_dir, caplog):
+    """A reconnect that lands on a different Google account than the one
+    already on file for this chat_id must be logged loudly (issue #2153 --
+    the production incident this fixes was invisible until an explicit API
+    call surfaced it; a mismatch must now surface at push time instead)."""
+    client, workspace_token_dir = client_and_token_dir
+
+    with patch(f"{_MODULE}._fetch_authenticated_email", return_value="account-a@example.com"):
+        client.post(
+            "/api/push-workspace-token",
+            json=_VALID_BODY,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+    with (
+        patch(f"{_MODULE}._fetch_authenticated_email", return_value="account-b@example.com"),
+        caplog.at_level(logging.WARNING),
+    ):
+        resp = client.post(
+            "/api/push-workspace-token",
+            json=_VALID_BODY,
+            headers={"Authorization": f"Bearer {_VALID_SECRET}"},
+        )
+
+    assert resp.status_code == 200  # token is still saved -- never blocks the push
+    data = json.loads((workspace_token_dir / f"{_VALID_BODY['chat_id']}.json").read_text())
+    assert data["email"] == "account-b@example.com"
+    assert any(
+        "identity mismatch" in r.getMessage().lower() for r in caplog.records
+    ), "A cross-account mismatch must be logged loudly, not silently swallowed"


### PR DESCRIPTION
## Problem

The Google OAuth token stores (Calendar, Gmail, Workspace, and the newer
provider-parameterized `oauth_vault`) persist only `access_token`,
`expires_at`, `scope`, and `refresh_token` — keyed by `chat_id`. Nothing
records which Google account actually completed the consent screen. In
production, a chat_id's Workspace token turned out to be authenticated as a
different person's Google account, undetected until an explicit API call
happened to reveal whose data it was returning.

The push-token receivers (`push_calendar_token_endpoint`,
`push_gmail_token_endpoint`, `push_workspace_token_endpoint` in
`inbox_server_http.py`) validate a signed, single-use session token proving
"this push corresponds to the OAuth transaction requested by chat_id=X." That
check is real and valuable — it stops a forged push writing to an arbitrary
chat_id. What it cannot prove is that the Google account which completed the
consent screen belongs to the person who owns chat_id=X. A shared or
forwarded consent link, clicked while a different Google account is active
in the browser, produces exactly that gap — and with no identity captured
from Google at grant time, the mixup was invisible until something explicitly
read the account's data.

## Fix

Adds `src/integrations/google_auth/identity.py`:
- `fetch_authenticated_email(access_token)` — calls Google's `userinfo`
  endpoint directly with the just-issued access token (no client secret
  needed, so it works from an instance that never holds GCP credentials
  locally). Never raises; degrades to `None` on any failure.
- `check_identity_consistency(previous_email, new_email)` — pure comparison:
  `match` / `mismatch` / `no_baseline` (first grant, nothing to compare yet)
  / `email_unavailable`.
- `expected_email_for_chat_id` / `check_expected_identity` — an optional,
  operator-maintained `known-users.json` registry (chat_id -> expected
  email) for the first-grant case, where self-consistency alone has no prior
  value to compare against. Absent or empty file degrades gracefully to "no
  expectation on file," never a hard dependency.
- `format_mismatch_warning` — pure formatting of a short, human-readable
  warning string, only for an actual mismatch.

`TokenData` (the dataclass shared by all four token stores) gains an
`email: Optional[str] = None` field. All four serialization layers
(`google_calendar/token_store.py`, `gmail/token_store.py`,
`google_workspace/token_store.py`, `oauth_vault/vault_store.py`) persist and
reload it, and all four `get_valid_token` refresh paths preserve it across a
refresh — the same pattern already used for `scope` and `refresh_token`.
Tokens saved before this field existed load cleanly with `email=None`.

All three push endpoints now:
1. Read the *previous* stored email for that chat_id (if any) before
   overwriting the file.
2. Fetch the newly granted email via the userinfo call.
3. Store it as `email` in the token JSON.
4. Compare old vs. new. On a mismatch: log at WARNING with both emails (not
   secrets, safe to log), and append a short warning to the *same* push
   confirmation message already sent to the user on Telegram/Slack — so the
   mixup surfaces immediately instead of staying silent until an explicit API
   call reveals it. The token is still saved either way — a userinfo hiccup
   or a genuine mismatch never blocks the push.

### Scope note

myownlobster.ai (the external service holding the GCP client secret) is out
of this repo — but it currently may not request the `email`/`profile` scope
from Google, which the userinfo call depends on. If that scope isn't granted,
`fetch_authenticated_email` fails gracefully (`email` stored as `null`,
logged clearly) rather than blocking the token. Flagged in the issue as a
necessary follow-up outside this repo; not something this PR can fix on its
own.

I deliberately left `google_calendar/callback_server.py` (the standalone,
manually-run local OAuth flow, not part of the always-on push architecture)
untouched — it already exchanges the code directly with Google and isn't
the code path that produced the production incident. Extending it the same
way would be a reasonable follow-up but isn't required for this fix.

### Functional patterns used

- `TokenData` and `IdentityCheckResult` are immutable frozen dataclasses.
- `fetch_authenticated_email`, `check_identity_consistency`,
  `check_expected_identity`, and `format_mismatch_warning` are pure or have
  isolated side effects (the one HTTP call is separated from the comparison
  logic, which takes plain values and returns a plain result with no I/O).
- The push endpoints compose these pure functions with the existing
  load -> compare -> save -> confirm pipeline rather than branching
  imperatively on a mutable "did this fail" flag.

## Flow: what changes for a push

```
Before:
  push arrives -> validate session -> write token file -> queue confirmation
                                       (access_token, expires_at, scope, refresh_token)

After:
  push arrives -> validate session -> read PREVIOUS email (if a token
                                       already exists for this chat_id)
                                    -> fetch NEW email via userinfo
                                    -> write token file
                                       (+ email)
                                    -> compare previous vs. new:
                                         match / no_baseline -> confirmation unchanged
                                         mismatch -> WARNING logged +
                                           short warning appended to the
                                           SAME confirmation message
                                    -> queue confirmation
```

No existing transition is removed; the only new state is the mismatch
warning path, which is additive to the confirmation text and never blocks
the token write or the 200 response.

## Tests run

- [x] `uv run pytest tests/unit/test_integrations/test_google_auth_identity.py` — 22 passed (new module: `fetch_authenticated_email` success/HTTP-error/network-error/malformed-payload/empty-token cases; pure comparison logic; registry lookup; two-chat_id isolation)
- [x] `uv run pytest tests/unit/test_integrations/test_{gmail,google_calendar,workspace,oauth_vault_store,oauth_vault_client}_token_store*.py` — 226 passed (roundtrip preserves `email`, legacy tokens without `email` load as `None`, two chat_ids store independent emails, `email` preserved across refresh)
- [x] `uv run pytest tests/unit/test_mcp_server/test_push_{calendar,gmail,workspace}_token_{endpoint,confirmation}.py tests/unit/test_mcp_server/test_push_token_confirmation_shared.py` — 346 passed, 6 failed. The 6 failures are pre-existing and unrelated to this change (`instance_id_mismatch` against `LOBSTER_INSTANCE_URL`, reproduced identically on `main` before this PR's changes — confirmed via `git stash`).
- [x] `uv run pytest tests/unit -m "not slow"` (full unit suite) — 3868 passed, 16 failed, 31 skipped. All 16 failures are pre-existing/unrelated (same 6 push-endpoint env failures above, plus hook/script tests unrelated to OAuth).
- [x] Falsifiability check: reverted `identity.py` and the `TokenData`/token-store/`inbox_server_http.py` changes (via `git stash` + moving the new file aside), re-ran the new/updated tests — all failed with exactly the expected errors (`ModuleNotFoundError`, `TypeError: unexpected keyword argument 'email'`, `AttributeError: no attribute '_fetch_authenticated_email'`). Restored the changes and confirmed all tests passed again.

## Manual test

Ran a standalone script (not part of the test suite) that exercises the real
`save_token`/`load_token`/`check_identity_consistency`/
`expected_email_for_chat_id` functions directly against real temp-directory
files (only the outbound Google `userinfo` HTTP call was faked, since this
sandbox has no live Google OAuth token):
1. `fetch_authenticated_email` against a userinfo-shaped response -> returned the expected email.
2. Two chat_ids each called `save_token`/`load_token` for real -- inspected the actual JSON files on disk and confirmed each held its own distinct `email`, no cross-contamination.
3. Simulated the production incident directly: `check_identity_consistency(previous="<account A>", new="<account B>")` -> `status="mismatch"`, and `format_mismatch_warning` produced the exact warning string that gets appended to the Telegram confirmation.
4. `expected_email_for_chat_id` against a real `known-users.json` file -> correct lookup.

This is an internal token-storage change with no independent Telegram/Slack
delivery path beyond the existing `_queue_push_confirmation` mechanism
(already covered by the automated confirmation tests above, which assert the
mismatch warning text lands in the outbox file exactly as
`OutboxHandler.process_reply()` would deliver it) — there is no separate
user-facing surface to verify beyond what those tests already exercise.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests -- the one outbound Google `userinfo` call is always mocked in tests via `_fetch_authenticated_email`)
- [x] Manual verification run (see above) -- real file I/O against a temp directory, real function calls, only the Google network boundary faked
- [x] User-visible outcome verified via the existing outbox-confirmation test harness (the mismatch warning is asserted present in the actual text `_queue_push_confirmation` would deliver to Telegram/Slack)
- [x] Side-effect audit: no floods, no unscoped writes (all new file I/O goes through `tmp_path`-scoped fixtures in tests; production paths are unchanged, just an added `email` key alongside existing writes); no unintended volume
- [x] External service calls: the only new outbound call (`userinfo`) is mocked in every test; no manual run was made against the real Google endpoint since no live token exists in this environment -- degradation-on-failure is unit-tested instead (`test_fetch_authenticated_email_http_error_returns_none`, `_network_error_returns_none`, `_unparseable_json_returns_none`)

Closes #2153.