### PR TITLE
Fix .githooks/pre-push doc-file exemption that let a real Telegram bot token leak

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -25,12 +25,20 @@
 # binaries, breaks test fixtures that intentionally contain fake values, and
 # loops on its own output.
 #
-# Exclusions (never scanned):
+# Exclusions (never scanned by ANY check):
 #   - Test directories: tests/, test/, spec/, or any path with /test
-#   - Documentation: .md, .mdx, .rst, .txt, .adoc (examples/placeholders by design)
 #   - Binary files: detected by extension
 #   - The hook files themselves (.githooks/*)
 #   - Files listed in .githooks/security-allowlist.txt
+#
+# Documentation files (.md, .mdx, .rst, .txt, .adoc) get a NARROWER exemption:
+# they are skipped for PII / instance-identifier / personal-name checks
+# (examples and placeholder values are legitimate documentation content), but
+# they ARE scanned for high-confidence secret/token patterns (API keys,
+# private keys, Telegram bot tokens, etc). A real secret pasted into a doc
+# file is still a leak — see #2160, where a real Telegram bot token sat
+# undetected in docs/DOCKER-TESTING.md for months because the old exemption
+# covered secrets too.
 #
 # Inline suppressions (in source files):
 #   - '# nosec' or '# noqa' — suppress security/PII match on that line
@@ -120,8 +128,10 @@ is_allowlisted() {
     return 1
 }
 
-# Returns 0 (skip) if the file should not be scanned.
-should_skip_file() {
+# Returns 0 (skip) if the file should never be scanned by ANY check —
+# the hook's own source, test fixtures, and binary/generated files. These
+# exclusions apply uniformly regardless of check category (PII vs secrets).
+should_skip_file_common() {
     local filepath="$1"
     local ext="${filepath##*.}"
 
@@ -138,11 +148,6 @@ should_skip_file() {
         return 0
     fi
 
-    # Skip documentation files — example/placeholder values by design
-    case "$filepath" in
-        *.md|*.mdx|*.rst|*.txt|*.adoc) return 0 ;;
-    esac
-
     # Skip known binary/generated/lock file extensions
     case "$ext" in
         png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|mp3|mp4|zip|tar|gz|bz2|xz|pdf) return 0 ;;
@@ -150,6 +155,38 @@ should_skip_file() {
         lock) return 0 ;;
     esac
 
+    return 1
+}
+
+# Returns 0 if filepath is a documentation file (*.md, *.mdx, *.rst, *.txt,
+# *.adoc). Doc files are exempt from PII/instance/name checks (examples and
+# placeholder values are legitimate documentation content) but are NOT
+# exempt from high-confidence secret/token checks (SECURITY_PATTERNS) — a
+# real secret pasted into a doc file is still a leak. This is the fix for
+# #2160: a real Telegram bot token committed to docs/DOCKER-TESTING.md went
+# undetected for months because the old should_skip_file() exempted docs
+# from every check, secrets included.
+is_doc_file() {
+    local filepath="$1"
+    case "$filepath" in
+        *.md|*.mdx|*.rst|*.txt|*.adoc) return 0 ;;
+    esac
+    return 1
+}
+
+# Returns 0 (skip) for the PII/instance/name check categories: files that
+# should never be scanned at all, plus doc files (which remain exempt from
+# these specific categories only — see is_doc_file() above).
+#
+# Note: the SECURITY_PATTERNS (secret/token) category deliberately does NOT
+# use this function — it is gated only by should_skip_file_common(), so it
+# does NOT exempt doc files. High-confidence secret shapes (Telegram bot
+# tokens, API keys, private keys, etc) are real leaks no matter which file
+# type they land in (see scan_diff() below and #2160).
+should_skip_file() {
+    local filepath="$1"
+    should_skip_file_common "$filepath" && return 0
+    is_doc_file "$filepath" && return 0
     return 1
 }
 
@@ -359,8 +396,10 @@ scan_diff() {
 
             local content="${raw_line:1}"  # strip leading '+'
 
-            # Skip if file should not be scanned
-            if [ -n "$current_file" ] && should_skip_file "$current_file"; then
+            # Skip files that should never be scanned by any check (hook
+            # source, test fixtures, binaries). Doc-file exemption is NOT
+            # applied here — it is narrower and category-specific (see below).
+            if [ -n "$current_file" ] && should_skip_file_common "$current_file"; then
                 continue
             fi
 
@@ -371,7 +410,17 @@ scan_diff() {
 
             local fp="${current_file:-<unknown>}"
 
+            # Doc files (*.md, *.mdx, *.rst, *.txt, *.adoc) are exempt from
+            # PII / instance / personal-name checks below, but NOT from the
+            # secret/token checks (SECURITY_PATTERNS) — see is_doc_file()
+            # and #2160 for why that split matters.
+            local skip_pii_checks=0
+            if [ -n "$current_file" ] && is_doc_file "$current_file"; then
+                skip_pii_checks=1
+            fi
+
             # --- Instance-specific patterns ---
+            if [ "$skip_pii_checks" -eq 0 ]; then
             for pattern_def in "${INSTANCE_PATTERNS[@]}"; do
                 local iname iregex idesc
                 iname="$(echo "$pattern_def" | awk -F'@@' '{print $1}')"
@@ -385,8 +434,10 @@ scan_diff() {
                     add_finding "$fp" "$line_num" "$idesc" "$content"
                 fi
             done
+            fi
 
             # --- PII patterns ---
+            if [ "$skip_pii_checks" -eq 0 ]; then
             for pattern_def in "${PII_PATTERNS[@]}"; do
                 local pname pregex pdesc
                 pname="$(echo "$pattern_def" | awk -F'@@' '{print $1}')"
@@ -421,8 +472,11 @@ scan_diff() {
 
                 add_finding "$fp" "$line_num" "$pdesc" "$content"
             done
+            fi
 
             # --- Security patterns ---
+            # Always runs, regardless of skip_pii_checks — doc files are
+            # scanned for secrets/tokens too (fix for #2160).
             for pattern_def in "${SECURITY_PATTERNS[@]}"; do
                 local sname sregex sdesc
                 sname="$(echo "$pattern_def" | awk -F'@@' '{print $1}')"
@@ -457,6 +511,7 @@ scan_diff() {
                 continue
             fi
 
+            if [ "$skip_pii_checks" -eq 0 ]; then
             for pattern_def in "${NAME_PATTERNS[@]}"; do
                 local nname nregex ndesc nallow
                 nname="$(echo "$pattern_def" | awk -F'@@' '{print $1}')"
@@ -481,6 +536,7 @@ scan_diff() {
 
                 add_finding "$fp" "$line_num" "$ndesc" "$content"
             done
+            fi
         fi
     done <<< "$diff_text"
 }

--- a/tests/unit/test_pre_push_doc_secret_exemption.sh
+++ b/tests/unit/test_pre_push_doc_secret_exemption.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# =============================================================================
+# test_pre_push_doc_secret_exemption.sh
+# Regression tests for issue #2160: .githooks/pre-push's should_skip_file()
+# used to exempt ALL doc files (*.md, *.mdx, *.rst, *.txt, *.adoc) from EVERY
+# check, including high-confidence secret/token patterns. That let a real
+# Telegram bot token committed to docs/DOCKER-TESTING.md go undetected for
+# months (2026-03-14 to 2026-07-17).
+#
+# The fix splits the exemption:
+#   - Doc files REMAIN exempt from PII_PATTERNS / NAME_PATTERNS / INSTANCE_PATTERNS
+#     (example names/emails/addresses are legitimate documentation content).
+#   - Doc files are NO LONGER exempt from SECURITY_PATTERNS (API keys, private
+#     keys, Telegram bot tokens, etc — high-confidence secret shapes).
+#
+# This test sources the REAL function/pattern definitions out of the live
+# .githooks/pre-push file (everything before the "# Main" execution section)
+# so it always exercises production logic rather than a reimplementation.
+#
+# Falsifiability check (see PR body for command transcript):
+#   1. Run this test against the fixed hook -> all tests PASS.
+#   2. `git stash` the .githooks/pre-push change (restore old should_skip_file
+#      that exempts docs from everything) -> rerun -> the "real token in .md
+#      file is flagged" test FAILS.
+#   3. `git stash pop` to restore the fix -> rerun -> PASS again.
+#
+# Run: bash tests/unit/test_pre_push_doc_secret_exemption.sh
+# Requires: bash (4.4+, for associative/indexed array features already used
+#           by the hook itself), grep -P (PCRE support)
+# =============================================================================
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$REPO_ROOT/.githooks/pre-push"
+
+ok()   { echo "  PASS: $1"; ((PASS++)) || true; }
+fail() { echo "  FAIL: $1"; ((FAIL++)) || true; }
+
+# ---------------------------------------------------------------------------
+# Extract only the function/pattern-array definitions from the real hook
+# (everything before the "# Main" execution section marker) and source them
+# into THIS process. We deliberately avoid sourcing the whole file because
+# the "Main" section calls `exit` and reads from /dev/tty, which would kill
+# or hang this test process.
+# ---------------------------------------------------------------------------
+
+FUNCS_FILE="$(mktemp /tmp/pre_push_funcs_XXXXXX.sh)"
+trap 'rm -f "$FUNCS_FILE"' EXIT
+
+awk '/^# Main$/{exit} {print}' "$HOOK" > "$FUNCS_FILE"
+
+if ! grep -q "scan_diff()" "$FUNCS_FILE"; then
+    echo "FATAL: could not extract scan_diff() from $HOOK — '# Main' marker missing or moved?"
+    exit 2
+fi
+
+# shellcheck source=/dev/null
+source "$FUNCS_FILE"
+
+# ---------------------------------------------------------------------------
+# Test helper: run scan_diff on a synthetic unified diff and report whether
+# ANY finding mentions a given substring (e.g. "Telegram bot token").
+# ---------------------------------------------------------------------------
+
+run_scan() {
+    local diff_text="$1"
+    FINDINGS=()
+    ISSUES_FOUND=0
+    scan_diff "$diff_text"
+}
+
+findings_mention() {
+    local needle="$1"
+    local f
+    for f in "${FINDINGS[@]}"; do
+        if [[ "$f" == *"$needle"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# A real-token-shaped string: 9 digits + ':' + exactly 35 chars of
+# [A-Za-z0-9_-], matching the telegram_token pattern
+# `\b\d{8,10}:[A-Za-z0-9_-]{35}\b`. (Deliberately fake — not a real credential.)
+REAL_TELEGRAM_TOKEN="123456789:AAHrM5Nthistotallyisnotarealtoken12"
+
+# ---------------------------------------------------------------------------
+# Test 1: real Telegram-token-shaped string in a .md file IS flagged
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Test 1: real-token-shaped string in .md file is flagged ==="
+
+DIFF_TOKEN_IN_MD=$(cat <<EOF
+diff --git a/docs/DOCKER-TESTING.md b/docs/DOCKER-TESTING.md
+index 0000000..1111111 100644
+--- a/docs/DOCKER-TESTING.md
++++ b/docs/DOCKER-TESTING.md
+@@ -1,2 +1,3 @@
+ # Docker Testing
++Bot token: ${REAL_TELEGRAM_TOKEN}
+EOF
+)
+
+run_scan "$DIFF_TOKEN_IN_MD"
+
+if [ "$ISSUES_FOUND" -gt 0 ] && findings_mention "Telegram bot token"; then
+    ok "real Telegram-token-shaped string in docs/DOCKER-TESTING.md is flagged"
+else
+    fail "expected a Telegram bot token finding for docs/DOCKER-TESTING.md; got ISSUES_FOUND=$ISSUES_FOUND FINDINGS=${FINDINGS[*]:-<empty>}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: an obvious placeholder token in a .md file stays clean
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Test 2: placeholder token in .md file is NOT flagged ==="
+
+DIFF_PLACEHOLDER_IN_MD=$(cat <<'EOF'
+diff --git a/docs/DOCKER-TESTING.md b/docs/DOCKER-TESTING.md
+index 0000000..2222222 100644
+--- a/docs/DOCKER-TESTING.md
++++ b/docs/DOCKER-TESTING.md
+@@ -1,2 +1,3 @@
+ # Docker Testing
++Bot token: <YOUR_BOT_TOKEN>
+EOF
+)
+
+run_scan "$DIFF_PLACEHOLDER_IN_MD"
+
+if [ "$ISSUES_FOUND" -eq 0 ]; then
+    ok "placeholder token <YOUR_BOT_TOKEN> in .md file is not flagged"
+else
+    fail "expected no findings for placeholder token; got FINDINGS=${FINDINGS[*]}"
+fi
+
+echo ""
+echo "=== Test 2b: sk-xxx-placeholder-do-not-use in .md file is NOT flagged ==="
+
+DIFF_SK_PLACEHOLDER=$(cat <<'EOF'
+diff --git a/docs/DOCKER-TESTING.md b/docs/DOCKER-TESTING.md
+index 0000000..3333333 100644
+--- a/docs/DOCKER-TESTING.md
++++ b/docs/DOCKER-TESTING.md
+@@ -1,2 +1,3 @@
+ # Docker Testing
++API key: sk-xxx-placeholder-do-not-use
+EOF
+)
+
+run_scan "$DIFF_SK_PLACEHOLDER"
+
+if [ "$ISSUES_FOUND" -eq 0 ]; then
+    ok "sk-xxx-placeholder-do-not-use in .md file is not flagged"
+else
+    fail "expected no findings for sk-xxx placeholder; got FINDINGS=${FINDINGS[*]}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3 (regression): PII (email) in a .md file REMAINS exempt
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Test 3: PII (email) in .md file remains exempt (regression) ==="
+
+DIFF_EMAIL_IN_MD=$(cat <<'EOF'
+diff --git a/docs/CONTRIBUTING.md b/docs/CONTRIBUTING.md
+index 0000000..4444444 100644
+--- a/docs/CONTRIBUTING.md
++++ b/docs/CONTRIBUTING.md
+@@ -1,2 +1,3 @@
+ # Contributing
++Contact: someone@not-an-allowlisted-domain.com
+EOF
+)
+
+run_scan "$DIFF_EMAIL_IN_MD"
+
+if [ "$ISSUES_FOUND" -eq 0 ]; then
+    ok "email address in docs/CONTRIBUTING.md remains exempt from PII checks"
+else
+    fail "expected docs to remain PII-exempt; got FINDINGS=${FINDINGS[*]}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4 (regression): personal name in a .md file REMAINS exempt
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Test 4: personal name in .md file remains exempt (regression) ==="
+
+DIFF_NAME_IN_MD=$(cat <<'EOF'
+diff --git a/docs/CONTRIBUTING.md b/docs/CONTRIBUTING.md
+index 0000000..5555555 100644
+--- a/docs/CONTRIBUTING.md
++++ b/docs/CONTRIBUTING.md
+@@ -1,2 +1,3 @@
+ # Contributing
++Thanks to alice for the original patch.
+EOF
+)
+
+run_scan "$DIFF_NAME_IN_MD"
+
+if [ "$ISSUES_FOUND" -eq 0 ]; then
+    ok "personal name in docs/CONTRIBUTING.md remains exempt from name checks"
+else
+    fail "expected docs to remain name-exempt; got FINDINGS=${FINDINGS[*]}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5 (control): real token in a .py (non-doc) file is still flagged
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Test 5: real-token-shaped string in .py file is still flagged (control) ==="
+
+DIFF_TOKEN_IN_PY=$(cat <<EOF
+diff --git a/src/bot/config.py b/src/bot/config.py
+index 0000000..6666666 100644
+--- a/src/bot/config.py
++++ b/src/bot/config.py
+@@ -1,2 +1,3 @@
+ # config
++BOT_TOKEN = "${REAL_TELEGRAM_TOKEN}"
+EOF
+)
+
+run_scan "$DIFF_TOKEN_IN_PY"
+
+if [ "$ISSUES_FOUND" -gt 0 ] && findings_mention "Telegram bot token"; then
+    ok "real-token-shaped string in src/bot/config.py is flagged (unaffected control case)"
+else
+    fail "expected a Telegram bot token finding for a .py file; got FINDINGS=${FINDINGS[*]:-<empty>}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6 (regression): hook files themselves remain fully exempt, even from
+# secret patterns — they legitimately contain the regexes as strings.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Test 6: .githooks/* files remain fully exempt, including from secret checks ==="
+
+DIFF_TOKEN_IN_HOOK=$(cat <<EOF
+diff --git a/.githooks/pre-push b/.githooks/pre-push
+index 0000000..7777777 100644
+--- a/.githooks/pre-push
++++ b/.githooks/pre-push
+@@ -1,2 +1,3 @@
+ # hook
++# example: ${REAL_TELEGRAM_TOKEN}
+EOF
+)
+
+run_scan "$DIFF_TOKEN_IN_HOOK"
+
+if [ "$ISSUES_FOUND" -eq 0 ]; then
+    ok ".githooks/* files remain exempt from all checks, including secrets"
+else
+    fail "expected .githooks/* to remain fully exempt; got FINDINGS=${FINDINGS[*]}"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "============================================================"
+echo "Results: $PASS passed, $FAIL failed"
+echo "============================================================"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Problem

`.githooks/pre-push` is the pre-push hook actually wired up on this repo (`core.hooksPath=.githooks`, confirmed via `git config --get core.hooksPath`) — not `scripts/pre-push-security-scan.sh`, which already has correct patterns but is not installed anywhere. Inside `.githooks/pre-push`, `should_skip_file()` unconditionally exempted `*.md|*.mdx|*.rst|*.txt|*.adoc` from **every** scan category — PII *and* secrets alike — on the assumption that docs only contain examples/placeholders.

That assumption is exactly how a real Telegram bot token leaked: it was committed to `docs/DOCKER-TESTING.md` on 2026-03-14 and sat exposed on a public repo until it was manually scrubbed in PR #2116 on 2026-07-17. The file never reached the scanner at all — the doc-file exemption skipped it before any pattern was even checked.

## What changed

Split the single `should_skip_file()` exemption into two functions with different scope:

- `should_skip_file_common(filepath)` — hook's own source, test fixtures, binaries. Skipped by every check category, unchanged from before.
- `is_doc_file(filepath)` — `*.md|*.mdx|*.rst|*.txt|*.adoc`.
- `should_skip_file(filepath)` = `should_skip_file_common` OR `is_doc_file`. Used to gate `INSTANCE_PATTERNS`, `PII_PATTERNS`, and `NAME_PATTERNS` — doc files remain exempt from these, since example names/emails/addresses are legitimate documentation content.
- `SECURITY_PATTERNS` (API keys, private keys, Telegram bot tokens, AWS keys, JWTs, etc) is now gated **only** by `should_skip_file_common` — doc files are no longer exempt from this category. A real secret pasted into a doc is still a leak.

`scan_diff()`'s per-line loop now computes a `skip_pii_checks` flag once per added line (true only for doc files past the common-skip check) and wraps the `INSTANCE_PATTERNS`/`PII_PATTERNS`/`NAME_PATTERNS` loops with it, while the `SECURITY_PATTERNS` loop runs unconditionally (subject only to the common skip). This keeps the pattern arrays and existing per-pattern logic (placeholder filtering, allowlist, email/IP false-positive filters) completely untouched — only the file-type gating changed.

**Functional patterns used:** `is_doc_file` and `should_skip_file_common` are small pure predicates (filepath in, boolean out, no side effects); `should_skip_file` composes them rather than duplicating logic; the per-line `skip_pii_checks` flag is computed once and read (not mutated) by each pattern-category block, avoiding scattered repeated file-type checks.

**Out of scope:** `scripts/pre-push-security-scan.sh` was **not touched**. It is a separate, currently-uninstalled script with its own `should_skip_file` in `scripts/security-scan-lib.sh` — not the hook that's actually active on this repo. This PR only changes `.githooks/pre-push`.

No multi-step flow/state machine changed here — this is a single-function gating change inside one script's diff-scanning loop, so no before/after flow diagram is needed.

## Tests run

- [x] `bash tests/unit/test_pre_push_doc_secret_exemption.sh` (new) — 7 passed, 0 failed. Covers: real Telegram-token-shaped string in `.md` now flagged; `<YOUR_BOT_TOKEN>` and `sk-xxx-placeholder-do-not-use` placeholders in `.md` still pass clean; email/personal-name in `.md` remain exempt (regression); real token in `.py` still flagged (control); `.githooks/*` remains fully exempt including from secrets (regression).
- [x] `bash tests/unit/test_pre_push_scan_diff_timeout.sh` (pre-existing) — 8 passed, 0 failed. Confirms the `SCAN_DIFF_TIMEOUT_SECONDS` loop-timeout logic added in #2037 is untouched.
- [x] `bash tests/test-security-scan.sh` (pre-existing) — 39 passed, 0 failed. Confirms `scripts/pre-push-security-scan.sh` / `scripts/security-scan-lib.sh` behavior is unaffected (out of scope, untouched).

**Falsifiability check** (new test against the fix, then reverted, then restored):

```
$ bash tests/unit/test_pre_push_doc_secret_exemption.sh   # against the FIX
Results: 7 passed, 0 failed

$ git stash push -- .githooks/pre-push                     # revert ONLY the hook to origin/main's version
$ bash tests/unit/test_pre_push_doc_secret_exemption.sh    # against the OLD (unfixed) hook
=== Test 1: real-token-shaped string in .md file is flagged ===
  FAIL: expected a Telegram bot token finding for docs/DOCKER-TESTING.md; got ISSUES_FOUND=0 FINDINGS=<empty>
Results: 6 passed, 1 failed

$ git stash pop                                             # restore the fix
$ bash tests/unit/test_pre_push_doc_secret_exemption.sh
Results: 7 passed, 0 failed
```

Only Test 1 (the exact bug this issue targets) fails on the old code; the 6 regression/control tests already passed before the fix, confirming they exercise pre-existing behavior correctly rather than trivially passing.

## Manual test

Built a throwaway git setup under `/tmp` (bare "remote" + local clone) with `core.hooksPath=.githooks` pointing at a copy of the fixed hook, matching this repo's actual wiring.

**1. Real-token-shaped string in a doc file — real `git push`:**
```
$ git push origin master
...
[WARN] Non-interactive mode (CI). Running scan but will not block push.

Potential PII/secrets found (CI mode — not blocking):
  [FINDING] docs/DOCKER-TESTING.md:5 - Telegram bot token
           BOT_TOKEN=123456789:AAHrM5Nthistotallyisnotarealtoken12

[WARN] Review these findings before merging.
To ../remote.git
   2d272d2..9f6c82b  master -> master
```
(CI-mode here because the harness's stdin isn't a tty — this is pre-existing, documented hook behavior, not something this PR changes. The finding is printed either way.)

**2. Same push against the OLD (unfixed) hook, for direct comparison — reproduces the actual leak:**
```
$ git push origin master   # identical commit, old should_skip_file()
...
[WARN] Non-interactive mode (CI). Running scan but will not block push.
Scan complete. No issues detected.
```

**3. Interactive blocking, invoked directly under a real pty (via `expect`) so the terminal-prompt path is actually exercised — default answer (Enter = "Y" = abort):**
```
$ expect drive_hook_direct.exp   # spawns `bash .githooks/pre-push` under a pty
...
[FINDING] docs/ANOTHER.md:2 - AWS Access Key ID
           AWS_KEY=AKIAABCDEFGHIJKLMNOP
[FINDING] docs/DOCKER-TESTING.md:5 - Telegram bot token
           BOT_TOKEN=123456789:AAHrM5Nthistotallyisnotarealtoken12
...
Found potential PII. Abort push? [Y/n]:
Push aborted. Fix the findings above before pushing.
HOOK_DIRECT_EXIT_CODE=1
```

**4. Clean docs-only push (placeholders only) — both interactive and via real `git push`:**
```
$ expect drive_clean.exp        # bash .githooks/pre-push under a pty, doc contains
                                 # <YOUR_BOT_TOKEN> and sk-xxx-placeholder-do-not-use
Scan complete. No PII or instance-specific data detected.
This is a PUBLIC OSS repo. Confirm you have checked for PII. [y/N]: y
Confirmed. Proceeding with push.
HOOK_DIRECT_EXIT_CODE=0

$ git push origin master
[WARN] Non-interactive mode (CI). Running scan but will not block push.
Scan complete. No issues detected.
To ../remote.git
   242602c..5aa7c91  master -> master
```

Side-effect audit: all pushes were to disposable bare repos under `/tmp`, deleted after the test. No production data or shared state touched.

## Known gaps / observations for the reviewer

- **Pre-existing, out-of-scope observation:** `IS_TTY` is detected via `[ -t 0 ]` (stdin). Git's pre-push hook protocol always redirects the hook's stdin to a pipe carrying ref-update data — even during a normal interactive `git push` from a real terminal — so `IS_TTY` evaluates to `0` (CI mode) for *every* real `git push`, not just actual CI. This means the interactive abort/confirm prompts (which correctly read from `/dev/tty`, not stdin) are effectively only reachable when the hook is invoked directly rather than through `git push`. This is unrelated to the doc-file exemption bug and outside this issue's scope, but worth a maintainer's attention separately — it affects when the "abort" default actually has a chance to fire versus falling through to non-blocking CI-mode printing.
- Regex correctness for `SECURITY_PATTERNS` (Telegram token shape, AWS key, etc.) is unchanged from the existing array — only the file-type gating around it changed. Worth double-checking there isn't a doc file in the existing repo history that would now legitimately trip a finding (this PR doesn't scan the whole repo, only new pushes going forward).
- Areas to scrutinize: the `skip_pii_checks` flag placement in `scan_diff()`'s per-line loop, and confirming `SECURITY_PATTERNS` truly runs unconditionally (not accidentally still gated by the old `should_skip_file`).