### PR TITLE
Warn on known-leaked personal emails as commit author

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,6 +13,11 @@
 #   - Per-name allowlist regex configured alongside each name in blocked-names.txt
 #   - Comments with # noname on the same line — allowed
 #
+# Also warns (with a confirm-to-proceed prompt) when the commit's author or
+# committer email matches a blocklist of known-leaked personal addresses, as
+# configured in ~/lobster-user-config/blocked-commit-emails.txt (gitignored,
+# private). See the "Commit-Author Email Check" section below for details.
+#
 # Bypass: git commit --no-verify
 #===============================================================================
 
@@ -271,5 +276,123 @@ scan_staged_diff_for_names() {
 }
 
 scan_staged_diff_for_names
+
+#===============================================================================
+# Commit-Author Email Check: warn on known-leaked personal emails
+#
+# Checks every email address that could end up recorded as this commit's
+# author or committer against a blocklist of known-leaked personal addresses,
+# configured in ~/lobster-user-config/blocked-commit-emails.txt (gitignored,
+# private). If no config file exists, this check is a silent no-op.
+#
+# Config file: ${LOBSTER_USER_CONFIG_DIR:-~/lobster-user-config}/blocked-commit-emails.txt
+# Format (one address per line):
+#   personal@example.com
+#   Lines starting with # are comments; empty lines are ignored. Matching is
+#   case-insensitive exact-address match (no regex).
+#
+# This is a warn + confirm gate, not a hard block — same UX as the PII
+# confirmation prompt in .githooks/pre-push. There can be legitimate reasons
+# to commit under one of these addresses, so this is a habit-breaking nudge,
+# not a lock.
+#
+# Sources checked (covers every way an author/committer email can be set):
+#   - git config user.email        (default author AND committer)
+#   - GIT_AUTHOR_EMAIL              (set by `git commit --author=...`)
+#   - GIT_COMMITTER_EMAIL           (set by `-c user.email=...` overrides)
+#
+# CI / non-interactive mode: if no controlling terminal is available (probed
+# by attempting to open /dev/tty), the warning is printed but the commit is
+# NOT blocked — same policy intent as pre-push's IS_TTY=0 handling. A
+# scripted/automated commit has no one to answer a confirmation prompt, so
+# blocking would just hang forever. (git connects a pre-commit hook's own
+# stdin to /dev/null unconditionally, so checking stdin — as pre-push does —
+# would never detect interactivity here; probing /dev/tty directly is the
+# reliable signal.)
+#
+# Bypass: git commit --no-verify
+#===============================================================================
+
+check_commit_author_email() {
+    local _cae_config="${LOBSTER_USER_CONFIG_DIR:-$HOME/lobster-user-config}/blocked-commit-emails.txt"
+
+    [ -f "$_cae_config" ] || return 0
+
+    local -a _cae_blocked=()
+    local _cae_line _cae_normalized
+    while IFS= read -r _cae_line; do
+        [[ "$_cae_line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${_cae_line// }" ]] && continue
+        _cae_normalized="$(echo "$_cae_line" | tr '[:upper:]' '[:lower:]' | xargs)"
+        [ -z "$_cae_normalized" ] && continue
+        _cae_blocked+=("$_cae_normalized")
+    done < "$_cae_config"
+
+    [ "${#_cae_blocked[@]}" -eq 0 ] && return 0
+
+    local -a _cae_candidates=()
+    local _cae_configured_email
+    _cae_configured_email="$(git config user.email 2>/dev/null || true)"
+    [ -n "$_cae_configured_email" ] && _cae_candidates+=("$_cae_configured_email")
+    [ -n "${GIT_AUTHOR_EMAIL:-}" ] && _cae_candidates+=("$GIT_AUTHOR_EMAIL")
+    [ -n "${GIT_COMMITTER_EMAIL:-}" ] && _cae_candidates+=("$GIT_COMMITTER_EMAIL")
+
+    local _cae_match=""
+    local _cae_candidate _cae_candidate_lc _cae_blocked_email
+    for _cae_candidate in "${_cae_candidates[@]}"; do
+        _cae_candidate_lc="$(echo "$_cae_candidate" | tr '[:upper:]' '[:lower:]')"
+        for _cae_blocked_email in "${_cae_blocked[@]}"; do
+            if [ "$_cae_candidate_lc" = "$_cae_blocked_email" ]; then
+                _cae_match="$_cae_candidate"
+                break 2
+            fi
+        done
+    done
+
+    [ -z "$_cae_match" ] && return 0
+
+    echo ""
+    echo -e "${RED}${BOLD}WARNING: commit author/committer email is on the leaked-email blocklist:${NC}"
+    echo -e "         ${BOLD}${_cae_match}${NC}"
+    echo "         This address has previously leaked into this repo's history."
+    echo "         (configure via ~/lobster-user-config/blocked-commit-emails.txt)"
+    echo ""
+
+    # Non-interactive (CI/scripted) commits: warn but never block — there is
+    # no one to answer a confirmation prompt.
+    #
+    # NOTE: git always connects a pre-commit hook's own stdin (fd 0) to
+    # /dev/null, regardless of whether the invoking shell is interactive —
+    # so `[ -t 0 ]` can never distinguish interactive from non-interactive
+    # here (verified empirically; this differs from pre-push, whose stdin
+    # instead carries the ref-update list). The only reliable signal is
+    # whether a controlling terminal is available at all: try to open
+    # /dev/tty for reading and see if that succeeds.
+    if ! exec 3</dev/tty 2>/dev/null; then
+        echo "No controlling terminal available — proceeding with warning only (not blocking)."
+        echo ""
+        return 0
+    fi
+    exec 3<&-
+
+    read -r -p "Continue committing with this email? [y/N]: " _cae_response </dev/tty
+    _cae_response="${_cae_response:-N}"
+    if [[ "$_cae_response" =~ ^[Yy]([Ee][Ss])?$ ]]; then
+        echo ""
+        echo -e "${GREEN}Confirmed. Proceeding with commit.${NC}"
+        echo ""
+        return 0
+    else
+        echo ""
+        echo -e "${RED}Commit aborted.${NC} Fix your git author config and retry, e.g.:"
+        echo "  git config user.email \"you@example.com\""
+        echo ""
+        echo "Emergency bypass: git commit --no-verify"
+        echo ""
+        return 1
+    fi
+}
+
+check_commit_author_email || exit 1
 
 exit 0

--- a/tests/unit/test_pre_commit_email_check.sh
+++ b/tests/unit/test_pre_commit_email_check.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# =============================================================================
+# test_pre_commit_email_check.sh
+# Behavioral tests for the commit-author-email blocklist check added to
+# .githooks/pre-commit (issue #2162).
+#
+# These tests exercise the REAL hook file against REAL throwaway git repos —
+# not a synthetic re-implementation — by invoking `git commit` end-to-end with
+# core.hooksPath pointed at the repo's .githooks directory.
+#
+# Covers:
+#   1. No blocklist file present               -> no-op (commit succeeds, no warning)
+#   2. Blocklist present, user.email matches    -> warns; non-interactive commit
+#                                                   still succeeds (CI policy)
+#   3. Blocklist present, user.email matches    -> interactive prompt via a real
+#                                                   pty (expect) blocks on "n",
+#                                                   proceeds on "y"
+#   4. Blocklist present, --author matches      -> warns (GIT_AUTHOR_EMAIL path)
+#   5. Blocklist present, user.email does NOT
+#      match any entry                          -> silent pass, no warning
+#   6. Comments / blank lines in blocklist file are ignored
+#
+# Run: bash tests/unit/test_pre_commit_email_check.sh
+# Requires: bash, git, expect (for the interactive-prompt test)
+# =============================================================================
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK_SRC="$REPO_ROOT/.githooks/pre-commit"
+
+# Placeholder/example addresses only — never the real leaked addresses from
+# this repo's history. See issue #2162: do not hardcode real leaked emails
+# anywhere that gets committed to the repo.
+TEST_BLOCKED_EMAIL="leaked-example@example.com"
+TEST_BLOCKED_EMAIL_2="other-leaked@example.org"
+TEST_CLEAN_EMAIL="clean-dev@example.com"
+
+WARNING_MARKER="leaked-email blocklist"
+
+ok()   { echo "  PASS: $1"; ((PASS++)) || true; }
+fail() { echo "  FAIL: $1"; ((FAIL++)) || true; }
+
+TMP_DIRS=()
+cleanup() {
+    for d in "${TMP_DIRS[@]:-}"; do
+        [ -n "$d" ] && rm -rf "$d"
+    done
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Helper: build a throwaway repo wired to the real .githooks/pre-commit hook,
+# with an isolated LOBSTER_USER_CONFIG_DIR (so we never touch the real
+# ~/lobster-user-config on the machine running these tests).
+# ---------------------------------------------------------------------------
+make_repo() {
+    local repo_dir
+    repo_dir="$(mktemp -d /tmp/test_pre_commit_email_repo_XXXXXX)"
+    TMP_DIRS+=("$repo_dir")
+
+    git init -q "$repo_dir"
+    mkdir -p "$repo_dir/.githooks"
+    cp "$HOOK_SRC" "$repo_dir/.githooks/pre-commit"
+    chmod +x "$repo_dir/.githooks/pre-commit"
+
+    (
+        cd "$repo_dir" || exit 1
+        git config core.hooksPath .githooks
+        git config user.name "Test User"
+        git config user.email "$TEST_CLEAN_EMAIL"
+    )
+
+    echo "$repo_dir"
+}
+
+# Isolated config dir per test — never the real user config dir.
+make_config_dir() {
+    local cfg_dir
+    cfg_dir="$(mktemp -d /tmp/test_pre_commit_email_cfg_XXXXXX)"
+    TMP_DIRS+=("$cfg_dir")
+    echo "$cfg_dir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: no blocklist file present -> no-op
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 1: no blocklist file -> silent no-op ==="
+
+REPO1="$(make_repo)"
+CFG1="$(make_config_dir)"   # empty dir, no blocked-commit-emails.txt inside it
+
+(
+    cd "$REPO1" || exit 1
+    echo "hello" > file.txt
+    git add file.txt
+    LOBSTER_USER_CONFIG_DIR="$CFG1" git commit -m "test commit" < /dev/null > /tmp/test1_out.txt 2>&1
+)
+EXIT1=$?
+OUT1="$(cat /tmp/test1_out.txt)"
+rm -f /tmp/test1_out.txt
+
+if [ "$EXIT1" -eq 0 ] && ! echo "$OUT1" | grep -qi "blocklist"; then
+    ok "no blocklist file -> commit succeeds with no blocklist-related output"
+else
+    fail "expected clean commit with no blocklist mention; exit=$EXIT1 output='$OUT1'"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: blocklist present, user.email matches, non-interactive -> warns,
+# commit still succeeds (CI/non-interactive policy: never hang, never block)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 2: matching email, non-interactive -> warns but does not block ==="
+
+REPO2="$(make_repo)"
+CFG2="$(make_config_dir)"
+printf '%s\n' "$TEST_BLOCKED_EMAIL" > "$CFG2/blocked-commit-emails.txt"
+
+(
+    cd "$REPO2" || exit 1
+    git config user.email "$TEST_BLOCKED_EMAIL"
+    echo "hello" > file.txt
+    git add file.txt
+    LOBSTER_USER_CONFIG_DIR="$CFG2" git commit -m "test commit" < /dev/null > /tmp/test2_out.txt 2>&1
+)
+EXIT2=$?
+OUT2="$(cat /tmp/test2_out.txt)"
+rm -f /tmp/test2_out.txt
+
+if [ "$EXIT2" -eq 0 ] && echo "$OUT2" | grep -qi "$WARNING_MARKER" && echo "$OUT2" | grep -q "$TEST_BLOCKED_EMAIL"; then
+    ok "matching email (non-interactive) -> warning printed, commit not blocked"
+else
+    fail "expected warning + successful commit; exit=$EXIT2 output='$OUT2'"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: blocklist present, user.email matches, INTERACTIVE (real pty via
+# expect) -> confirmation prompt actually gates the commit
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 3: matching email, interactive pty -> confirmation prompt gates commit ==="
+
+if ! command -v expect >/dev/null 2>&1; then
+    echo "  SKIP: 'expect' not installed — cannot drive a real pty for this test"
+else
+    REPO3A="$(make_repo)"
+    CFG3="$(make_config_dir)"
+    printf '%s\n' "$TEST_BLOCKED_EMAIL" > "$CFG3/blocked-commit-emails.txt"
+    (
+        cd "$REPO3A" || exit 1
+        git config user.email "$TEST_BLOCKED_EMAIL"
+        echo "hello" > file.txt
+        git add file.txt
+    )
+
+    # 3a: answer "n" (or default Enter) -> commit is ABORTED
+    EXPECT_SCRIPT_N=$(mktemp /tmp/test_pre_commit_expect_n_XXXXXX.exp)
+    TMP_DIRS+=("$EXPECT_SCRIPT_N")
+    cat > "$EXPECT_SCRIPT_N" << EOF
+set timeout 10
+spawn env LOBSTER_USER_CONFIG_DIR=$CFG3 git -C $REPO3A commit -m "test commit"
+expect "Continue committing with this email?"
+send "n\r"
+expect eof
+catch wait result
+exit [lindex \$result 3]
+EOF
+    OUT3A="$(expect "$EXPECT_SCRIPT_N" 2>&1)"
+    EXIT3A=$?
+
+    if [ "$EXIT3A" -ne 0 ] && echo "$OUT3A" | grep -qi "Commit aborted"; then
+        ok "interactive 'n' response aborts the commit"
+    else
+        fail "expected 'n' to abort commit; exit=$EXIT3A output='$OUT3A'"
+    fi
+
+    if (cd "$REPO3A" && git log --oneline 2>/dev/null | grep -q "test commit"); then
+        fail "commit should NOT exist in history after 'n' response"
+    else
+        ok "no commit was created in history after 'n' response"
+    fi
+
+    # 3b: answer "y" -> commit PROCEEDS
+    REPO3B="$(make_repo)"
+    (
+        cd "$REPO3B" || exit 1
+        git config user.email "$TEST_BLOCKED_EMAIL"
+        echo "hello" > file.txt
+        git add file.txt
+    )
+
+    EXPECT_SCRIPT_Y=$(mktemp /tmp/test_pre_commit_expect_y_XXXXXX.exp)
+    TMP_DIRS+=("$EXPECT_SCRIPT_Y")
+    cat > "$EXPECT_SCRIPT_Y" << EOF
+set timeout 10
+spawn env LOBSTER_USER_CONFIG_DIR=$CFG3 git -C $REPO3B commit -m "test commit"
+expect "Continue committing with this email?"
+send "y\r"
+expect eof
+catch wait result
+exit [lindex \$result 3]
+EOF
+    OUT3B="$(expect "$EXPECT_SCRIPT_Y" 2>&1)"
+    EXIT3B=$?
+
+    if [ "$EXIT3B" -eq 0 ] && echo "$OUT3B" | grep -qi "Confirmed. Proceeding"; then
+        ok "interactive 'y' response proceeds with the commit"
+    else
+        fail "expected 'y' to proceed with commit; exit=$EXIT3B output='$OUT3B'"
+    fi
+
+    if (cd "$REPO3B" && git log --oneline 2>/dev/null | grep -q "test commit"); then
+        ok "commit exists in history after 'y' response"
+    else
+        fail "commit should exist in history after 'y' response"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: blocklist present, matched via `git commit --author=...`
+# (GIT_AUTHOR_EMAIL path, not git config user.email)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 4: --author override matches blocklist -> warns ==="
+
+REPO4="$(make_repo)"
+CFG4="$(make_config_dir)"
+printf '%s\n' "$TEST_BLOCKED_EMAIL_2" > "$CFG4/blocked-commit-emails.txt"
+
+(
+    cd "$REPO4" || exit 1
+    # git config user.email stays clean; only --author is the leaked address
+    echo "hello" > file.txt
+    git add file.txt
+    LOBSTER_USER_CONFIG_DIR="$CFG4" git commit --author="Someone <$TEST_BLOCKED_EMAIL_2>" -m "test commit" < /dev/null > /tmp/test4_out.txt 2>&1
+)
+EXIT4=$?
+OUT4="$(cat /tmp/test4_out.txt)"
+rm -f /tmp/test4_out.txt
+
+if [ "$EXIT4" -eq 0 ] && echo "$OUT4" | grep -qi "$WARNING_MARKER" && echo "$OUT4" | grep -q "$TEST_BLOCKED_EMAIL_2"; then
+    ok "--author=... override matching blocklist triggers warning (GIT_AUTHOR_EMAIL path)"
+else
+    fail "expected warning via --author path; exit=$EXIT4 output='$OUT4'"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: blocklist present, user.email does NOT match any entry -> silent
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 5: non-matching email -> silent pass ==="
+
+REPO5="$(make_repo)"
+CFG5="$(make_config_dir)"
+printf '%s\n%s\n' "$TEST_BLOCKED_EMAIL" "$TEST_BLOCKED_EMAIL_2" > "$CFG5/blocked-commit-emails.txt"
+
+(
+    cd "$REPO5" || exit 1
+    git config user.email "$TEST_CLEAN_EMAIL"
+    echo "hello" > file.txt
+    git add file.txt
+    LOBSTER_USER_CONFIG_DIR="$CFG5" git commit -m "test commit" < /dev/null > /tmp/test5_out.txt 2>&1
+)
+EXIT5=$?
+OUT5="$(cat /tmp/test5_out.txt)"
+rm -f /tmp/test5_out.txt
+
+if [ "$EXIT5" -eq 0 ] && ! echo "$OUT5" | grep -qi "blocklist"; then
+    ok "non-matching email -> commit succeeds with no blocklist warning"
+else
+    fail "expected silent successful commit; exit=$EXIT5 output='$OUT5'"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: comments and blank lines in the blocklist file are ignored
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 6: comment lines and blank lines in blocklist are ignored ==="
+
+REPO6="$(make_repo)"
+CFG6="$(make_config_dir)"
+cat > "$CFG6/blocked-commit-emails.txt" << CFGEOF
+# This is a comment, not an email
+
+$TEST_BLOCKED_EMAIL
+CFGEOF
+
+(
+    cd "$REPO6" || exit 1
+    git config user.email "$TEST_BLOCKED_EMAIL"
+    echo "hello" > file.txt
+    git add file.txt
+    LOBSTER_USER_CONFIG_DIR="$CFG6" git commit -m "test commit" < /dev/null > /tmp/test6_out.txt 2>&1
+)
+EXIT6=$?
+OUT6="$(cat /tmp/test6_out.txt)"
+rm -f /tmp/test6_out.txt
+
+if [ "$EXIT6" -eq 0 ] && echo "$OUT6" | grep -qi "$WARNING_MARKER"; then
+    ok "comment/blank lines ignored; real entry on later line still matches"
+else
+    fail "expected warning despite leading comment/blank lines; exit=$EXIT6 output='$OUT6'"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Results: ${PASS} passed, ${FAIL} failed"
+echo ""
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Problem

Two personal Gmail addresses have leaked into this repo's git history as commit author/committer emails: one used on 479 `main` commits (1005 across all branches, still growing daily), the other on 10 commits from a single day (a one-off local git-config lapse by a different contributor). Rewriting existing history to fix this is a separate, explicit, destructive decision that's out of scope here. But until now, nothing stopped either address — or any future leak — from being used on a **new** commit. This closes that forward-looking gap. No existing commit is touched, rewritten, or amended by this change.

## What changed

`.githooks/pre-commit` gained a check that inspects every email address that could end up recorded as this commit's author/committer:
- `git config user.email` (default author and committer)
- `GIT_AUTHOR_EMAIL` (set when `--author=...` is used)
- `GIT_COMMITTER_EMAIL` (set via `-c user.email=...` overrides)

These are compared case-insensitively against an optional blocklist at `${LOBSTER_USER_CONFIG_DIR:-~/lobster-user-config}/blocked-commit-emails.txt` — gitignored, private, one address per line, `#`-comments and blank lines ignored. This is the exact same load-a-private-config-with-silent-no-op-fallback convention already used by `blocked-names.txt` and `instance-domains.txt` in `.githooks/pre-push`. If the file doesn't exist, the check is a complete no-op — no behavior change for anyone who hasn't opted in. **No real leaked address is hardcoded anywhere in the repo** — only `@example.com`/`@example.org` placeholders in the test fixtures below.

On a match, the hook prints a loud warning naming the matched address and requires an explicit `y`/`yes` response to proceed (default: abort) — this mirrors the existing PII confirmation prompt UX in `.githooks/pre-push` exactly. It is a warn-and-confirm nudge, not a hard block, since there can be legitimate reasons to commit under one of these addresses.

### A wrinkle worth flagging for review

`.githooks/pre-push` decides interactive-vs-CI by checking `[ -t 0 ]` (is stdin a tty). I initially mirrored that for pre-commit, and my own tests caught that it doesn't work: **git unconditionally connects a `pre-commit` hook's own stdin to `/dev/null`**, regardless of whether the invoking shell is interactive (verified empirically — see `readlink /proc/self/fd/0` output in the manual test below, and the git-internals rationale in the code comment). That means `[ -t 0 ]` inside a pre-commit hook is *always* false, so a naive port of pre-push's check would silently disable the confirmation prompt in all real usage — it would always fall through to "no controlling terminal, don't block." Note that pre-push's own `[ -t 0 ]` check has the same problem for a different reason (its stdin carries the ref-update list, never a tty), which I confirmed but did **not** touch — that's pre-existing pre-push behavior and out of scope for this issue.

Fix: this hook instead probes for a controlling terminal directly (`exec 3</dev/tty 2>/dev/null`), which correctly returns true under a real interactive shell (or a real pty, as used in the automated pty test below) and false when there's no controlling terminal at all (verified with `setsid`).

## Functional patterns

The check is a single pure-ish function (`check_commit_author_email`) that reads inputs (config file, git config, env vars), computes a match, and only then performs the one necessary side effect (the confirm prompt) — no staged-file mutation, no hidden state. Blocklist parsing and the candidate-email/blocklist comparison are simple map/filter-style loops over arrays with no external dependencies beyond `git config`.

## Out of scope

- No history rewrite of any kind — the two known leaks in existing commits are untouched, per the issue.
- No changes to `.githooks/pre-push` (its `[ -t 0 ]` behavior is pre-existing and unrelated — flagged above for visibility only).
- No install.sh/upgrade.sh scaffolding added, since `blocked-names.txt` / `instance-domains.txt` have none either — these are purely optional, user-authored files with no install-time templating.

## Tests run

- [x] `bash tests/unit/test_pre_commit_email_check.sh` — 9/9 assertions passed. Builds real throwaway git repos, wires `core.hooksPath` to the actual (not reimplemented) `.githooks/pre-commit`, and runs real `git commit` invocations:
  - no blocklist file → silent no-op
  - blocklist + matching `user.email`, non-interactive → warns, does not block (CI policy)
  - blocklist + matching email, **real pty via `expect`** → confirmation prompt actually gates the commit (`n` aborts and no commit is created; `y` proceeds and the commit exists in history)
  - blocklist + matching `--author=...` (GIT_AUTHOR_EMAIL path) → warns
  - blocklist + non-matching email → silent pass
  - comments/blank lines in the blocklist file are ignored
- [x] Falsifiability check: reverted `.githooks/pre-commit` to the pre-change version (`git stash`), re-ran the test file — 6 of 9 assertions failed as expected (the 3 that still passed test only the pre-existing no-op/non-match paths, which didn't change). Restored the implementation and confirmed all 9 pass again.
- [x] `bash tests/unit/test_pre_push_scan_diff_timeout.sh` — 8/8 still passing (no regression to the neighboring hook)
- [x] `bash -n .githooks/pre-commit` — syntax check clean
- [ ] `shellcheck` — not installed in this environment, skipped

## Manual test

Real throwaway repo (`/tmp/manual-test-pre-commit-*`, since deleted), `.githooks/pre-commit` copied in verbatim from this branch, `core.hooksPath` set to `.githooks`, `LOBSTER_USER_CONFIG_DIR` pointed at an isolated temp config dir (never touched the real `~/lobster-user-config` on this machine).

**Step 1 — blocked email, answer `n` (abort), via a real pty (`expect`):**
```
$ echo "leaked-personal-example@example.com" > $CFG/blocked-commit-emails.txt
$ git config user.email "leaked-personal-example@example.com"
$ git add file1.txt
$ git commit -m "commit under blocked email"
WARNING: commit author/committer email is on the leaked-email blocklist:
         leaked-personal-example@example.com
         This address has previously leaked into this repo's history.
         (configure via ~/lobster-user-config/blocked-commit-emails.txt)

Continue committing with this email? [y/N]: n

Commit aborted. Fix your git author config and retry, e.g.:
  git config user.email "you@example.com"

Emergency bypass: git commit --no-verify
$ git log --oneline
fatal: your current branch 'master' does not have any commits yet
```

**Step 2 — same blocked email, answer `y` (confirm override):**
```
$ git commit -m "commit under blocked email, confirmed"
WARNING: commit author/committer email is on the leaked-email blocklist:
         leaked-personal-example@example.com
         ...
Continue committing with this email? [y/N]: y

Confirmed. Proceeding with commit.

[master (root-commit) 2312a75] commit under blocked email, confirmed
 1 file changed, 1 insertion(+)
```

**Step 3 — clean, non-blocklisted email — no warning at all:**
```
$ git config user.email "clean-dev-example@example.com"
$ git commit -m "commit under clean email"
[master 1f64001] commit under clean email
 1 file changed, 1 insertion(+)
```
(no blocklist-related output — commit went straight through)

**Step 4 — no blocklist file configured at all (even with `user.email` set to the same address as step 1) — silent no-op:**
```
$ git commit -m "commit with no blocklist file configured"
[master e6dfdcb] commit with no blocklist file configured
 1 file changed, 1 insertion(+)
```

All four observed outcomes match the spec exactly. Repo and config dirs deleted afterward — nothing left on disk.

## Definition of Done

- [x] Unit tests pass with proper mocking-equivalent isolation (real repos, isolated `LOBSTER_USER_CONFIG_DIR`, never touches the real `~/lobster-user-config`)
- [x] Manual test run — see `## Manual test` above
- [x] User-visible outcome verified: the actual terminal output shown above (warning text, prompt, abort/confirm messages) is exactly what a developer would see running `git commit` locally
- [x] Side-effect audit: no network calls, no shared state, no floods — the hook only reads a local file and git config, and prompts/writes to the invoking terminal
- [x] External service calls: none (this hook is entirely local)

Closes #2162