### PR TITLE
Log pii-scan-guard fail-open events to a durable JSONL trace

### DIFF
--- a/hooks/pii-scan-guard.py
+++ b/hooks/pii-scan-guard.py
@@ -65,6 +65,18 @@ transient errors before that. `LOBSTER_PII_SCAN_SKIP=1` remains the
 deliberate, explicit escape hatch for a push the operator has already
 decided is safe.
 
+**Fail-open observability (issue #2167):** every one of the four fail-open
+reasons above (missing key, network error, timeout, malformed response) also
+appends a durable JSONL record to
+`$LOBSTER_WORKSPACE/logs/pii-scan-guard-failopen.jsonl` (see
+log_failopen_event / _scanner_unavailable_result), in both `warn` and `block`
+mode. Before this, the only trace of a scanner outage was a stderr line on
+the developer's terminal at push time -- nothing durable existed to answer
+"has this scanner been a no-op for a week?" This is instrumentation only: it
+does not add alerting or a cron job (the hook is not installed anywhere yet
+as of this writing), it just makes fail-open events visible somewhere that
+could be checked or wired into alerting later.
+
 **Model:** the scanner runs on Claude Fable 5 (`claude-fable-5`), not Opus.
 This hook previously ran on Opus, which was shown (see the PR/issue history)
 to be foolable by realistic-looking PII wrapped in business, consulting,
@@ -103,6 +115,7 @@ import os
 import re
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -127,6 +140,24 @@ _ZERO_SHA = "0" * 40
 _EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
 _ALLOWLIST_FILENAME = ".security-allowlist"
+
+# ---------------------------------------------------------------------------
+# Fail-open observability logging (issue #2167)
+# ---------------------------------------------------------------------------
+# Every fail-open path (see _scanner_unavailable_result below) previously
+# degraded silently -- a stderr line most workflows never durably surface.
+# These four categories are exactly the four reasons already named in
+# _scanner_unavailable_result's own docstring; this does not invent a new
+# taxonomy, it just gives each of those reasons a stable machine-readable
+# label for the log. Reuses this repo's existing hook-logging convention
+# (see hooks/usage-accumulator.py's ~/lobster-workspace/logs/*.jsonl
+# append-only pattern) rather than a new mechanism.
+_CATEGORY_MISSING_API_KEY = "missing_api_key"
+_CATEGORY_NETWORK_ERROR = "network_error"
+_CATEGORY_TIMEOUT = "timeout"
+_CATEGORY_MALFORMED_RESPONSE = "malformed_response"
+
+_FAILOPEN_LOG_FILENAME = "pii-scan-guard-failopen.jsonl"
 
 # Extensions/basenames that can never carry meaningful PII content and are
 # never scanned. Deliberately narrow — see module docstring for why this does
@@ -508,7 +539,68 @@ def validate_scanner_response(result: object) -> tuple[str, list[dict]] | None:
     return "block", findings
 
 
-def _scanner_unavailable_result(mode: str, reason: str) -> tuple[int, str]:
+def _classify_scanner_exception(exc: Exception) -> str:
+    """Map an exception raised by `call_scanner` onto one of the two
+    exception-shaped fail-open categories (network error vs. timeout).
+
+    Deliberately matches on the exception's type name and message rather
+    than importing the `anthropic` SDK's specific error classes (e.g.
+    `anthropic.APITimeoutError`) -- `call_scanner` imports `anthropic`
+    lazily specifically so pure-function tests never need it installed, and
+    classification must not force that import at module load time either.
+    """
+    name = type(exc).__name__.lower()
+    text = str(exc).lower()
+    if "timeout" in name or "timeout" in text:
+        return _CATEGORY_TIMEOUT
+    return _CATEGORY_NETWORK_ERROR
+
+
+def _default_failopen_log_path(env: dict) -> Path:
+    """Resolve the durable fail-open log location from $LOBSTER_WORKSPACE,
+    mirroring dispatcher-state-stop.py's _resolve_inflight_path and
+    usage-accumulator.py's logs/ convention."""
+    workspace = Path(env.get("LOBSTER_WORKSPACE", str(Path.home() / "lobster-workspace")))
+    return workspace / "logs" / _FAILOPEN_LOG_FILENAME
+
+
+def log_failopen_event(
+    env: dict,
+    category: str,
+    reason: str,
+    mode: str,
+    log_path: Path | str | None = None,
+) -> None:
+    """Append one durable, greppable JSONL record of a fail-open event.
+
+    This is instrumentation, not part of the decision path: any failure
+    writing the record (unwritable directory, log_path pointing at a
+    directory, permissions) is swallowed rather than raised or surfaced,
+    so a logging problem can never change the hook's exit code or message.
+    """
+    target = Path(log_path) if log_path is not None else _default_failopen_log_path(env)
+    record = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "hook": "pii-scan-guard",
+        "category": category,
+        "reason": reason,
+        "mode": mode,
+    }
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError:
+        pass
+
+
+def _scanner_unavailable_result(
+    mode: str,
+    reason: str,
+    category: str,
+    env: dict,
+    log_path: Path | str | None = None,
+) -> tuple[int, str]:
     """Decide the outcome when the scanner itself could not produce a
     verdict at all -- no API key, a network error, a timeout, a malformed
     response. Anything that lands here means we cannot claim the push is
@@ -526,7 +618,13 @@ def _scanner_unavailable_result(mode: str, reason: str) -> tuple[int, str]:
     enforcement, so a scanner outage there should still just warn -- it
     would be surprising and wrong for a hook nobody has enabled blocking on
     yet to start blocking pushes because of its own transient errors.
+
+    Always logs the event (see log_failopen_event, issue #2167) regardless
+    of mode -- a scanner outage is exactly as invisible in warn mode as in
+    block mode, since warn mode's non-blocking behavior only affects the
+    push outcome, not whether the outage itself deserves a durable record.
     """
+    log_failopen_event(env=env, category=category, reason=reason, mode=mode, log_path=log_path)
     remediation = (
         f"Investigate the scanner error, or set {_ENV_BYPASS}=1 to "
         "deliberately bypass this one push if you've reviewed it yourself."
@@ -549,12 +647,16 @@ def run(
     env: dict,
     repo_root: str,
     call_scanner_fn=call_scanner,
+    failopen_log_path: Path | str | None = None,
 ) -> tuple[int, str]:
     """Decide the push outcome. Returns (exit_code, message-for-stderr).
 
     This is the fully-testable core: every side effect (the network call,
     the environment, the stdin payload) is passed in, so callers (tests, or
-    main()) control all of it."""
+    main()) control all of it. `failopen_log_path` is injected the same way
+    `call_scanner_fn` is -- tests pass a tmp_path file; main() leaves it
+    None so _scanner_unavailable_result falls back to the real
+    $LOBSTER_WORKSPACE/logs location (see _default_failopen_log_path)."""
     mode = env.get(_ENV_MODE, "off").strip().lower()
     if mode == "off":
         return 0, ""
@@ -594,13 +696,17 @@ def run(
         api_key = load_api_key(find_config_file(), env)
         if not api_key:
             return _scanner_unavailable_result(
-                mode, "no ANTHROPIC_API_KEY configured — cannot run PII scan"
+                mode, "no ANTHROPIC_API_KEY configured — cannot run PII scan",
+                _CATEGORY_MISSING_API_KEY, env, failopen_log_path,
             )
 
         try:
             result = call_scanner_fn(prompt, api_key)
         except Exception as exc:  # noqa: BLE001 - any scanner failure fails closed
-            return _scanner_unavailable_result(mode, f"scanner call failed ({exc})")
+            return _scanner_unavailable_result(
+                mode, f"scanner call failed ({exc})",
+                _classify_scanner_exception(exc), env, failopen_log_path,
+            )
 
         validated = validate_scanner_response(result)
         if validated is None:
@@ -612,7 +718,8 @@ def run(
             # mode, so route through the same _scanner_unavailable_result
             # path (fails closed in block mode, warns in warn mode).
             return _scanner_unavailable_result(
-                mode, f"scanner returned an invalid response ({result!r})"
+                mode, f"scanner returned an invalid response ({result!r})",
+                _CATEGORY_MALFORMED_RESPONSE, env, failopen_log_path,
             )
         verdict, findings = validated
 

--- a/hooks/pii-scan-guard.py
+++ b/hooks/pii-scan-guard.py
@@ -75,7 +75,14 @@ the developer's terminal at push time -- nothing durable existed to answer
 "has this scanner been a no-op for a week?" This is instrumentation only: it
 does not add alerting or a cron job (the hook is not installed anywhere yet
 as of this writing), it just makes fail-open events visible somewhere that
-could be checked or wired into alerting later.
+could be checked or wired into alerting later. The persisted record never
+contains the raw exception text: exception-derived reasons are logged as a
+fixed-shape "type name + HTTP status" summary
+(_summarize_scanner_exception_for_log), with a literal-value redaction
+backstop (_redact_secret) for the API key wherever it's in scope -- a
+network/timeout/malformed-response failure can otherwise raise or return
+almost anything, and nothing upstream guarantees that content excludes
+request data.
 
 **Model:** the scanner runs on Claude Fable 5 (`claude-fable-5`), not Opus.
 This hook previously ran on Opus, which was shown (see the PR/issue history)
@@ -556,6 +563,57 @@ def _classify_scanner_exception(exc: Exception) -> str:
     return _CATEGORY_NETWORK_ERROR
 
 
+
+# Anchored on a "code"/"status" keyword immediately before the digits so a
+# port number (e.g. "api.anthropic.com:443") is never misread as an HTTP
+# status -- the anthropic SDK's own error strings read "Error code: 401 -
+# ...", which this matches directly.
+_HTTP_STATUS_RE = re.compile(r"(?:code|status)[:\s]+([1-5]\d{2})\b", re.IGNORECASE)
+
+
+def _summarize_scanner_exception_for_log(exc: Exception) -> str:
+    """Produce a fixed-shape, secret-free summary of a scanner exception for
+    the durable fail-open log: the exception's type name, plus an HTTP
+    status code if one appears in the message.
+
+    This deliberately does NOT persist `str(exc)` verbatim. CodeQL flagged
+    the original version of this logging (which wrote `str(exc)` -- via the
+    `reason` string built two lines below `call_scanner_fn(prompt, api_key)`
+    -- straight into the durable JSONL log) as a clear-text-storage-of-
+    sensitive-information path: `exc` can be anything the `anthropic` SDK or
+    a lower HTTP layer chooses to raise, and nothing guarantees that never
+    includes request content (the API key, headers, etc.) -- e.g. a
+    client-side validation error or a debug-mode HTTP dump. A fixed-shape
+    "type name + status" summary carries enough signal to alert/triage on
+    ("the scanner failed N times, mostly TimeoutError") without ever
+    reading (and thus risking persisting) the raw exception text. The
+    caller-facing stderr message (`_scanner_unavailable_result`'s `reason`
+    parameter, printed at push time) is unchanged and still carries the
+    full detail for local operator debugging -- only the durable, greppable
+    log record is restricted to this summary.
+    """
+    name = type(exc).__name__
+    match = _HTTP_STATUS_RE.search(str(exc))
+    if match:
+        return f"{name} (status {match.group(1)})"
+    return name
+
+
+def _redact_secret(text: str, secret: str | None) -> str:
+    """Defense-in-depth backstop: remove any literal occurrence of `secret`
+    (the real API key, when known at the call site) from `text` before it
+    is ever persisted to the durable fail-open log. This is a second,
+    independent layer under _summarize_scanner_exception_for_log -- it
+    covers reasons that were never exception-derived in the first place
+    (e.g. the malformed-response reason, built from the scanner's own
+    response body) on the off chance the key ever ends up embedded there
+    too, and costs nothing when `secret` is falsy (the missing-API-key
+    path, where there is no key to leak)."""
+    if not secret:
+        return text
+    return text.replace(secret, "[REDACTED]")
+
+
 def _default_failopen_log_path(env: dict) -> Path:
     """Resolve the durable fail-open log location from $LOBSTER_WORKSPACE,
     mirroring dispatcher-state-stop.py's _resolve_inflight_path and
@@ -600,6 +658,8 @@ def _scanner_unavailable_result(
     category: str,
     env: dict,
     log_path: Path | str | None = None,
+    log_reason: str | None = None,
+    api_key: str | None = None,
 ) -> tuple[int, str]:
     """Decide the outcome when the scanner itself could not produce a
     verdict at all -- no API key, a network error, a timeout, a malformed
@@ -623,8 +683,23 @@ def _scanner_unavailable_result(
     of mode -- a scanner outage is exactly as invisible in warn mode as in
     block mode, since warn mode's non-blocking behavior only affects the
     push outcome, not whether the outage itself deserves a durable record.
+
+    The persisted log record is never the raw `reason` string verbatim:
+    `log_reason` (a fixed-shape, secret-free summary -- see
+    _summarize_scanner_exception_for_log) is used in its place when the
+    caller supplies one, and -- regardless -- any literal occurrence of
+    `api_key` is stripped as a defense-in-depth backstop (see
+    _redact_secret). `reason` itself, and the stderr message built from it
+    below, are unchanged: the operator still sees full detail at push time,
+    only the durable/greppable log is restricted. See issue #2167 and the
+    CodeQL "clear-text storage of sensitive information" finding on the PR
+    that added this logging in the first place -- `exc` from a scanner
+    failure can be anything the anthropic SDK or a lower HTTP layer raises,
+    with no guarantee it excludes request content (including api_key).
     """
-    log_failopen_event(env=env, category=category, reason=reason, mode=mode, log_path=log_path)
+    raw_log_reason = log_reason if log_reason is not None else reason
+    sanitized_log_reason = _redact_secret(raw_log_reason, api_key)
+    log_failopen_event(env=env, category=category, reason=sanitized_log_reason, mode=mode, log_path=log_path)
     remediation = (
         f"Investigate the scanner error, or set {_ENV_BYPASS}=1 to "
         "deliberately bypass this one push if you've reviewed it yourself."
@@ -706,6 +781,8 @@ def run(
             return _scanner_unavailable_result(
                 mode, f"scanner call failed ({exc})",
                 _classify_scanner_exception(exc), env, failopen_log_path,
+                log_reason=_summarize_scanner_exception_for_log(exc),
+                api_key=api_key,
             )
 
         validated = validate_scanner_response(result)
@@ -720,6 +797,7 @@ def run(
             return _scanner_unavailable_result(
                 mode, f"scanner returned an invalid response ({result!r})",
                 _CATEGORY_MALFORMED_RESPONSE, env, failopen_log_path,
+                api_key=api_key,
             )
         verdict, findings = validated
 

--- a/tests/unit/test_hooks/test_pii_scan_guard.py
+++ b/tests/unit/test_hooks/test_pii_scan_guard.py
@@ -15,6 +15,11 @@ Tests cover:
   on scanner exceptions, and the actual block/allow/no-op decisions
 - Full CLI subprocess invocation for the mode gate and bypass (no network
   required for these paths)
+- Fail-open observability logging (issue #2167): every fail-open path (missing
+  API key, network error, timeout, malformed response) appends a durable
+  JSONL record with the correct reason category; logging never changes the
+  hook's exit code even if the log write itself fails; the happy path (a real
+  allow/block verdict) writes nothing
 
 Convention: pure functions are imported directly via importlib.util (as in
 test_pin_dependencies_guard.py); the orchestration core is exercised via
@@ -63,6 +68,12 @@ format_findings_message = _mod.format_findings_message
 run = _mod.run
 _MAX_DIFF_CHARS = _mod._MAX_DIFF_CHARS
 _EMPTY_TREE_SHA = _mod._EMPTY_TREE_SHA
+_classify_scanner_exception = _mod._classify_scanner_exception
+log_failopen_event = _mod.log_failopen_event
+_CATEGORY_MISSING_API_KEY = _mod._CATEGORY_MISSING_API_KEY
+_CATEGORY_NETWORK_ERROR = _mod._CATEGORY_NETWORK_ERROR
+_CATEGORY_TIMEOUT = _mod._CATEGORY_TIMEOUT
+_CATEGORY_MALFORMED_RESPONSE = _mod._CATEGORY_MALFORMED_RESPONSE
 
 
 # ---------------------------------------------------------------------------
@@ -938,3 +949,263 @@ class TestCliSubprocess:
     def test_empty_stdin_exits_zero(self, git_repo):
         result = _run_hook_cli("", {_ENV_MODE: "block"}, str(git_repo))
         assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Fail-open observability logging (issue #2167)
+# ---------------------------------------------------------------------------
+#
+# PR #2156's independent reviewer flagged that every fail-open path here
+# (missing API key, network error, timeout, malformed response) degraded
+# silently: the push succeeds (in warn mode) or is blocked (in block mode)
+# with only a stderr line most workflows never durably surface. These tests
+# prove each of the four reasons documented in _scanner_unavailable_result's
+# docstring lands as a distinct, durable, greppable JSONL record -- reusing
+# this repo's existing hooks/usage-accumulator.py-style append-only JSONL
+# convention rather than a new logging mechanism -- and that a broken logging
+# call can never change the hook's actual exit code or message (instrumentation
+# must never become part of the decision path).
+
+
+class TestClassifyScannerException:
+    """`call_scanner`'s network boundary can raise anything -- a real
+    `anthropic` SDK error, a bare `TimeoutError`, a `ConnectionError`, etc.
+    `_classify_scanner_exception` maps any of those onto one of the two
+    exception-shaped fail-open categories already implied by the module's own
+    fail-closed docstring ("a network error, a timeout"), without importing
+    the anthropic SDK's specific error classes (call_scanner imports
+    anthropic lazily; classification must not force that import)."""
+
+    def test_timeout_error_classified_as_timeout(self):
+        assert _classify_scanner_exception(TimeoutError("scan timed out")) == _CATEGORY_TIMEOUT
+
+    def test_message_mentioning_timeout_classified_as_timeout(self):
+        # Some SDK errors are a generic Exception subclass whose *message*
+        # says "timeout" rather than a dedicated TimeoutError type.
+        assert _classify_scanner_exception(RuntimeError("request timeout after 180s")) == _CATEGORY_TIMEOUT
+
+    def test_connection_error_classified_as_network_error(self):
+        assert _classify_scanner_exception(ConnectionError("could not reach api.anthropic.com")) == _CATEGORY_NETWORK_ERROR
+
+    def test_generic_exception_classified_as_network_error(self):
+        assert _classify_scanner_exception(RuntimeError("500 Internal Server Error")) == _CATEGORY_NETWORK_ERROR
+
+
+class TestLogFailopenEvent:
+    """Direct coverage of the logging primitive: JSONL record shape and the
+    never-raises guarantee."""
+
+    def test_appends_one_json_line_with_expected_fields(self, tmp_path):
+        log_path = tmp_path / "pii-scan-guard-failopen.jsonl"
+        log_failopen_event(
+            env={}, category=_CATEGORY_TIMEOUT, reason="scanner call failed (timed out)",
+            mode="block", log_path=log_path,
+        )
+        lines = log_path.read_text().splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["hook"] == "pii-scan-guard"
+        assert record["category"] == _CATEGORY_TIMEOUT
+        assert record["reason"] == "scanner call failed (timed out)"
+        assert record["mode"] == "block"
+        assert "ts" in record and record["ts"]
+
+    def test_appends_without_truncating_prior_entries(self, tmp_path):
+        log_path = tmp_path / "failopen.jsonl"
+        log_failopen_event(env={}, category=_CATEGORY_TIMEOUT, reason="r1", mode="block", log_path=log_path)
+        log_failopen_event(env={}, category=_CATEGORY_NETWORK_ERROR, reason="r2", mode="warn", log_path=log_path)
+        lines = log_path.read_text().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0])["reason"] == "r1"
+        assert json.loads(lines[1])["reason"] == "r2"
+
+    def test_creates_parent_directory_if_missing(self, tmp_path):
+        log_path = tmp_path / "nested" / "logs" / "failopen.jsonl"
+        log_failopen_event(env={}, category=_CATEGORY_MISSING_API_KEY, reason="r", mode="block", log_path=log_path)
+        assert log_path.exists()
+
+    def test_unwritable_log_path_does_not_raise(self, tmp_path):
+        # A directory where a file is expected: opening it for append must
+        # fail with OSError/IsADirectoryError. Logging is instrumentation --
+        # it must swallow this, not propagate.
+        log_path = tmp_path  # a directory, not a file path
+        log_failopen_event(env={}, category=_CATEGORY_TIMEOUT, reason="r", mode="block", log_path=log_path)
+        # No exception means the test passed.
+
+
+class TestRunLogsEachFailOpenReason:
+    """Integration-level: each fail-open path through `run()` writes exactly
+    one log record with the matching category. Mirrors the four reasons
+    named in this hook's own fail-closed docstring: missing key, network
+    error, timeout, malformed response."""
+
+    def _push_a_change(self, git_repo):
+        (git_repo / "a.txt").write_text("v1\n")
+        _run_git(["add", "-A"], git_repo)
+        _run_git(["commit", "-q", "-m", "c1"], git_repo)
+        remote_sha = _git_rev(git_repo)
+        (git_repo / "a.txt").write_text("v2 with content\n")
+        _run_git(["add", "-A"], git_repo)
+        _run_git(["commit", "-q", "-m", "c2"], git_repo)
+        local_sha = _git_rev(git_repo)
+        return remote_sha, local_sha
+
+    def _stdin_for(self, git_repo):
+        remote_sha, local_sha = self._push_a_change(git_repo)
+        return f"refs/heads/main {local_sha} refs/heads/main {remote_sha}\n"
+
+    def _read_records(self, log_path):
+        if not log_path.exists():
+            return []
+        return [json.loads(line) for line in log_path.read_text().splitlines()]
+
+    def test_missing_api_key_logs_missing_api_key_category(self, git_repo, tmp_path, monkeypatch):
+        stdin = self._stdin_for(git_repo)
+        log_path = tmp_path / "failopen.jsonl"
+        monkeypatch.setattr(_mod, "find_config_file", lambda: None)
+        code, _msg = run(
+            stdin, {_ENV_MODE: "block", "ANTHROPIC_API_KEY": ""}, str(git_repo),
+            call_scanner_fn=_fake_scanner_returning("allow"),
+            failopen_log_path=log_path,
+        )
+        assert code == 1
+        records = self._read_records(log_path)
+        assert len(records) == 1
+        assert records[0]["category"] == _CATEGORY_MISSING_API_KEY
+        assert "ANTHROPIC_API_KEY" in records[0]["reason"]
+
+    def test_network_error_logs_network_error_category(self, git_repo, tmp_path):
+        stdin = self._stdin_for(git_repo)
+        log_path = tmp_path / "failopen.jsonl"
+        code, _msg = run(
+            stdin, {_ENV_MODE: "block", "ANTHROPIC_API_KEY": "sk-test-fake"}, str(git_repo),
+            call_scanner_fn=_fake_scanner_raising(ConnectionError("could not reach api")),
+            failopen_log_path=log_path,
+        )
+        assert code == 1
+        records = self._read_records(log_path)
+        assert len(records) == 1
+        assert records[0]["category"] == _CATEGORY_NETWORK_ERROR
+
+    def test_timeout_logs_timeout_category(self, git_repo, tmp_path):
+        stdin = self._stdin_for(git_repo)
+        log_path = tmp_path / "failopen.jsonl"
+        code, _msg = run(
+            stdin, {_ENV_MODE: "block", "ANTHROPIC_API_KEY": "sk-test-fake"}, str(git_repo),
+            call_scanner_fn=_fake_scanner_raising(TimeoutError("scan timed out")),
+            failopen_log_path=log_path,
+        )
+        assert code == 1
+        records = self._read_records(log_path)
+        assert len(records) == 1
+        assert records[0]["category"] == _CATEGORY_TIMEOUT
+
+    def test_malformed_response_logs_malformed_response_category(self, git_repo, tmp_path):
+        stdin = self._stdin_for(git_repo)
+        log_path = tmp_path / "failopen.jsonl"
+        code, _msg = run(
+            stdin, {_ENV_MODE: "block", "ANTHROPIC_API_KEY": "sk-test-fake"}, str(git_repo),
+            call_scanner_fn=lambda prompt, key: {"verdict": "not-a-real-verdict"},
+            failopen_log_path=log_path,
+        )
+        assert code == 1
+        records = self._read_records(log_path)
+        assert len(records) == 1
+        assert records[0]["category"] == _CATEGORY_MALFORMED_RESPONSE
+
+    def test_warn_mode_still_logs_even_though_it_does_not_block(self, git_repo, tmp_path):
+        # A scanner outage in warn mode is exactly as invisible today as one
+        # in block mode -- warn mode not blocking the push must not be
+        # conflated with warn mode not logging the outage.
+        stdin = self._stdin_for(git_repo)
+        log_path = tmp_path / "failopen.jsonl"
+        code, _msg = run(
+            stdin, {_ENV_MODE: "warn", "ANTHROPIC_API_KEY": "sk-test-fake"}, str(git_repo),
+            call_scanner_fn=_fake_scanner_raising(TimeoutError("scan timed out")),
+            failopen_log_path=log_path,
+        )
+        assert code == 0
+        records = self._read_records(log_path)
+        assert len(records) == 1
+        assert records[0]["category"] == _CATEGORY_TIMEOUT
+        assert records[0]["mode"] == "warn"
+
+    def test_successful_allow_verdict_writes_no_log_entry(self, git_repo, tmp_path):
+        stdin = self._stdin_for(git_repo)
+        log_path = tmp_path / "failopen.jsonl"
+        code, _msg = run(
+            stdin, {_ENV_MODE: "block", "ANTHROPIC_API_KEY": "sk-test-fake"}, str(git_repo),
+            call_scanner_fn=_fake_scanner_returning("allow"),
+            failopen_log_path=log_path,
+        )
+        assert code == 0
+        assert not log_path.exists()
+
+    def test_successful_block_verdict_writes_no_log_entry(self, git_repo, tmp_path):
+        # A confident, well-formed "block" verdict is the scanner working
+        # correctly -- not a fail-open event -- and must not be logged here.
+        stdin = self._stdin_for(git_repo)
+        log_path = tmp_path / "failopen.jsonl"
+        finding = {"file": "a.txt", "line": 1, "category": "pii", "snippet": "x", "reason": "y"}
+        code, _msg = run(
+            stdin, {_ENV_MODE: "block", "ANTHROPIC_API_KEY": "sk-test-fake"}, str(git_repo),
+            call_scanner_fn=_fake_scanner_returning("block", [finding]),
+            failopen_log_path=log_path,
+        )
+        assert code == 1
+        assert not log_path.exists()
+
+    def test_default_log_path_resolves_under_lobster_workspace(self, git_repo, tmp_path, monkeypatch):
+        # No failopen_log_path override: the hook must resolve its own
+        # durable default location under $LOBSTER_WORKSPACE/logs, mirroring
+        # hooks/usage-accumulator.py's token-usage.jsonl / hook-failures.log
+        # convention, rather than requiring every caller to supply a path.
+        # run() is a pure function of its `env` argument (not os.environ), so
+        # LOBSTER_WORKSPACE is passed through the same injected env dict as
+        # every other setting -- mirroring how ANTHROPIC_API_KEY resolution
+        # works elsewhere in this module.
+        fake_workspace = tmp_path / "fake-workspace"
+        monkeypatch.setattr(_mod, "find_config_file", lambda: None)
+        stdin = self._stdin_for(git_repo)
+        code, _msg = run(
+            stdin,
+            {_ENV_MODE: "block", "ANTHROPIC_API_KEY": "", "LOBSTER_WORKSPACE": str(fake_workspace)},
+            str(git_repo),
+            call_scanner_fn=_fake_scanner_returning("allow"),
+        )
+        assert code == 1
+        default_log = fake_workspace / "logs" / "pii-scan-guard-failopen.jsonl"
+        assert default_log.exists()
+        record = json.loads(default_log.read_text().splitlines()[0])
+        assert record["category"] == _CATEGORY_MISSING_API_KEY
+
+
+class TestFailopenLoggingNeverBreaksOutcome:
+    """Falsifiability guard: logging is instrumentation bolted onto the
+    decision path, not part of it. If the log write itself fails (e.g. the
+    log path is a directory, not a file), the hook's exit code and message
+    must be completely unaffected."""
+
+    def _push_a_change(self, git_repo):
+        (git_repo / "a.txt").write_text("v1\n")
+        _run_git(["add", "-A"], git_repo)
+        _run_git(["commit", "-q", "-m", "c1"], git_repo)
+        remote_sha = _git_rev(git_repo)
+        (git_repo / "a.txt").write_text("v2 with content\n")
+        _run_git(["add", "-A"], git_repo)
+        _run_git(["commit", "-q", "-m", "c2"], git_repo)
+        local_sha = _git_rev(git_repo)
+        return remote_sha, local_sha
+
+    def test_unwritable_log_path_does_not_change_block_outcome(self, git_repo, tmp_path):
+        remote_sha, local_sha = self._push_a_change(git_repo)
+        stdin = f"refs/heads/main {local_sha} refs/heads/main {remote_sha}\n"
+        broken_log_path = tmp_path  # a directory: opening it for append raises
+        code, message = run(
+            stdin, {_ENV_MODE: "block", "ANTHROPIC_API_KEY": "sk-test-fake"}, str(git_repo),
+            call_scanner_fn=_fake_scanner_raising(TimeoutError("scan timed out")),
+            failopen_log_path=broken_log_path,
+        )
+        assert code == 1
+        assert "BLOCKED" in message
+        assert "failing closed" in message

--- a/tests/unit/test_hooks/test_pii_scan_guard.py
+++ b/tests/unit/test_hooks/test_pii_scan_guard.py
@@ -69,6 +69,8 @@ run = _mod.run
 _MAX_DIFF_CHARS = _mod._MAX_DIFF_CHARS
 _EMPTY_TREE_SHA = _mod._EMPTY_TREE_SHA
 _classify_scanner_exception = _mod._classify_scanner_exception
+_summarize_scanner_exception_for_log = _mod._summarize_scanner_exception_for_log
+_redact_secret = _mod._redact_secret
 log_failopen_event = _mod.log_failopen_event
 _CATEGORY_MISSING_API_KEY = _mod._CATEGORY_MISSING_API_KEY
 _CATEGORY_NETWORK_ERROR = _mod._CATEGORY_NETWORK_ERROR
@@ -991,6 +993,55 @@ class TestClassifyScannerException:
         assert _classify_scanner_exception(RuntimeError("500 Internal Server Error")) == _CATEGORY_NETWORK_ERROR
 
 
+class TestSummarizeScannerExceptionForLog:
+    """CodeQL flagged the original fail-open logging as a "clear-text
+    storage of sensitive information" path: the durable log persisted
+    `str(exc)` verbatim, and `exc` can be anything the anthropic SDK or a
+    lower HTTP layer chooses to raise -- including, potentially, request
+    content such as the API key used two lines earlier in
+    `call_scanner_fn(prompt, api_key)`. `_summarize_scanner_exception_for_log`
+    replaces the raw exception text with a fixed-shape "type name + HTTP
+    status" summary that structurally cannot carry that content, rather
+    than trying to scrub an open-ended string after the fact."""
+
+    def test_summary_never_contains_the_original_message_text(self):
+        exc = RuntimeError("connection refused to api.anthropic.com:443, retry exhausted")
+        summary = _summarize_scanner_exception_for_log(exc)
+        assert "connection refused" not in summary
+        assert "api.anthropic.com" not in summary
+        assert summary == "RuntimeError"
+
+    def test_summary_extracts_http_status_when_present(self):
+        exc = RuntimeError("Error code: 401 - {'type': 'error'}")
+        assert _summarize_scanner_exception_for_log(exc) == "RuntimeError (status 401)"
+
+    def test_summary_uses_exception_type_name(self):
+        assert _summarize_scanner_exception_for_log(TimeoutError("scan timed out")) == "TimeoutError"
+
+    def test_summary_never_contains_a_realistic_api_key_embedded_in_message(self):
+        # The exact scenario CodeQL's taint tracker flagged: an exception
+        # message that happens to echo request content, here a
+        # realistic-looking Anthropic API key.
+        fake_key = "sk-ant-api03-totally-fake-not-a-real-secret-1234567890abcdef"
+        exc = RuntimeError(f"request failed; sent header x-api-key: {fake_key}")
+        summary = _summarize_scanner_exception_for_log(exc)
+        assert fake_key not in summary
+
+
+class TestRedactSecret:
+    def test_removes_literal_occurrence_of_secret(self):
+        assert _redact_secret("failed with key sk-ant-abc123", "sk-ant-abc123") == "failed with key [REDACTED]"
+
+    def test_no_op_when_secret_is_none(self):
+        assert _redact_secret("some text", None) == "some text"
+
+    def test_no_op_when_secret_is_empty_string(self):
+        assert _redact_secret("some text", "") == "some text"
+
+    def test_removes_multiple_occurrences(self):
+        assert _redact_secret("k=sk-1 and again sk-1", "sk-1") == "k=[REDACTED] and again [REDACTED]"
+
+
 class TestLogFailopenEvent:
     """Direct coverage of the logging primitive: JSONL record shape and the
     never-raises guarantee."""
@@ -1099,6 +1150,36 @@ class TestRunLogsEachFailOpenReason:
         records = self._read_records(log_path)
         assert len(records) == 1
         assert records[0]["category"] == _CATEGORY_TIMEOUT
+
+    def test_exception_message_containing_api_key_is_not_logged_verbatim(self, git_repo, tmp_path):
+        # Regression test for the CodeQL "clear-text storage of sensitive
+        # information" finding: a scanner-call exception whose message
+        # happens to echo request content (here, a realistic-looking
+        # Anthropic API key) must never reach the durable log verbatim.
+        # `_summarize_scanner_exception_for_log`'s fixed-shape summary
+        # should already prevent this; this test proves the end-to-end
+        # `run()` path, not just the helper in isolation.
+        fake_key = "sk-ant-api03-totally-fake-not-a-real-secret-1234567890abcdef"
+        stdin = self._stdin_for(git_repo)
+        log_path = tmp_path / "failopen.jsonl"
+        code, message = run(
+            stdin, {_ENV_MODE: "block", "ANTHROPIC_API_KEY": fake_key}, str(git_repo),
+            call_scanner_fn=_fake_scanner_raising(
+                RuntimeError(f"connection failed; sent header x-api-key: {fake_key}")
+            ),
+            failopen_log_path=log_path,
+        )
+        assert code == 1
+        records = self._read_records(log_path)
+        assert len(records) == 1
+        assert records[0]["category"] == _CATEGORY_NETWORK_ERROR
+        # The persisted record -- serialized exactly as it was written to
+        # disk -- must not contain the key in any form.
+        assert fake_key not in json.dumps(records[0])
+        # The stderr message shown to the operator at push time is
+        # unchanged/full-detail (not part of this fix's scope -- only the
+        # durable, greppable log is restricted).
+        assert fake_key in message
 
     def test_malformed_response_logs_malformed_response_category(self, git_repo, tmp_path):
         stdin = self._stdin_for(git_repo)


### PR DESCRIPTION
## Problem

`hooks/pii-scan-guard.py` (PR #2156) fails open on four conditions -- no API key, a network error, a timeout, a malformed scanner response -- and until now the only trace of that was a single stderr line at push time. There was no durable way to answer "has this scanner been silently doing nothing for a week?" This closes that visibility gap. Stretch/lower-priority slice of the PII-scanner remediation plan (Linear BIS-760); the hook itself is not installed anywhere yet, so this is instrumentation only -- no alerting, no cron job.

## What changed

Every fail-open path already funnels through one function, `_scanner_unavailable_result`. It now appends one JSONL record to `$LOBSTER_WORKSPACE/logs/pii-scan-guard-failopen.jsonl` before returning, in both `warn` and `block` mode:

```json
{"ts": "...", "hook": "pii-scan-guard", "category": "missing_api_key", "reason": "...", "mode": "block"}
```

`category` is one of `missing_api_key` / `network_error` / `timeout` / `malformed_response` -- the same four reasons already named in `_scanner_unavailable_result`'s own docstring, not a new taxonomy. A new pure function, `_classify_scanner_exception`, maps any exception raised by the scanner call onto `timeout` vs `network_error` by inspecting the exception's type name/message (it deliberately avoids importing the `anthropic` SDK's specific error classes, since `call_scanner` imports `anthropic` lazily so pure-function tests never need it installed).

The logging call itself (`log_failopen_event`) reuses this repo's existing hook-logging convention -- the same append-only `~/lobster-workspace/logs/*.jsonl` pattern `hooks/usage-accumulator.py` already uses -- rather than inventing a new mechanism. Path resolution mirrors `dispatcher-state-stop.py`'s `_resolve_inflight_path` (`$LOBSTER_WORKSPACE`-based, with a `Path.home()` fallback).

Logging is wired in as dependency injection, the same pattern `call_scanner_fn` already uses: `run()` gained an optional `failopen_log_path` parameter so tests (and, if ever needed, callers) can redirect it; `main()` leaves it `None` and the real default path is used. Writing the record is wrapped in `try/except OSError: pass` -- a broken log write (bad permissions, path collision) can never change the hook's exit code or block message, since this is instrumentation bolted onto the decision path, not part of it.

## Functional patterns

- `log_failopen_event` and `_classify_scanner_exception` are pure/near-pure: given the same inputs they produce the same record shape / same category, with the one necessary side effect (the file write) isolated to a single `try/except` boundary at the very edge
- Dependency injection (`failopen_log_path`) over a global/singleton logger, consistent with how `call_scanner_fn` is already injected in this file
- No new state, no new taxonomy, no new mechanism — this reuses what the function already decides and what the repo already does for hook-level JSONL logging

## Out of scope

No cron job, alerting pipeline, or health check was added -- deliberately, per the issue. No change to the hook's actual block/allow/fail-closed decision logic; `_scanner_unavailable_result`'s return values (exit code, stderr message) are byte-for-byte the same as before for every input, verified by the full pre-existing test suite passing unchanged. No change to `install.sh` /  the rollout gate -- the hook remains uninstalled anywhere, same as before this PR.

## Tests run

- [x] `uv run pytest tests/unit/test_hooks/test_pii_scan_guard.py tests/unit/test_install_pii_scan_hook.py -q` — 111 passed, 1 skipped (the pre-existing opt-in live-model test, unrelated to this change), 0 failed
- [x] `uv run pytest tests/unit/ -q` — same 8 pre-existing failures as on `origin/main` before this change (`test_context_monitor.py`, `test_on_compact_write_claude_session_id.py` — confirmed via `git stash` + rerun on unmodified `origin/main`; unrelated to this diff, environment-dependent in this sandbox), 1011+ passed otherwise
- [x] Falsifiability check: commented out the `log_failopen_event(...)` call inside `_scanner_unavailable_result`, reran the new tests — 6 of them failed as expected (`TestRunLogsEachFailOpenReason` x5, `test_default_log_path_resolves_under_lobster_workspace`), confirming they are not vacuous. Restored the call, reran, all 104 tests in the file passed again.

New test coverage added (`tests/unit/test_hooks/test_pii_scan_guard.py`):
- `TestClassifyScannerException` — timeout vs. network-error classification from exception type/message
- `TestLogFailopenEvent` — JSONL record shape, multi-append behavior, parent-dir creation, and the never-raises guarantee for an unwritable path
- `TestRunLogsEachFailOpenReason` — one test per fail-open reason (missing key, network error, timeout, malformed response) asserting the correct category lands in the log via `run()`; plus warn-mode-still-logs, real-verdict-writes-nothing, and default-path-resolution-under-`$LOBSTER_WORKSPACE`
- `TestFailopenLoggingNeverBreaksOutcome` — an unwritable log path (a directory passed as the log file) does not change the block outcome or message

## Manual test

Ran the actual `hooks/pii-scan-guard.py` CLI (not a mock) against a scratch git repo, with a scratch `$LOBSTER_WORKSPACE`, isolating `$HOME` where needed so the real production config/API key could not be picked up as a fallback:

1. **Real network/auth fail-open** (warn mode): piped a real pre-push stdin ref line into the hook with `ANTHROPIC_API_KEY=sk-ant-deliberately-invalid-key-for-manual-test`. This made a real HTTPS call to the Anthropic API, which returned a real `401 authentication_error`. Hook printed a WARNING and exited 0 (as expected in warn mode), and appended:
   ```json
   {"ts": "2026-08-05T19:53:46.562511+00:00", "hook": "pii-scan-guard", "category": "network_error", "reason": "scanner call failed (Error code: 401 - {'type': 'error', 'error': {'type': 'authentication_error', 'message': 'invalid x-api-key'}, 'request_id': 'req_011CdkBopmueoEMkPTEJuspb'})", "mode": "warn"}
   ```
2. **Same real 401, block mode**: hook printed BLOCKED and exited 1 (fail-closed, as designed), and appended a second real record with `"mode": "block"`.
3. **True missing key** (isolated `$HOME` so no config file could be found, empty `ANTHROPIC_API_KEY`), block mode: hook printed BLOCKED / exited 1, and appended:
   ```json
   {"ts": "2026-08-05T19:55:16.961900+00:00", "hook": "pii-scan-guard", "category": "missing_api_key", "reason": "no ANTHROPIC_API_KEY configured — cannot run PII scan", "mode": "block"}
   ```

All three records were read back directly off disk from the scratch `$LOBSTER_WORKSPACE/logs/pii-scan-guard-failopen.jsonl` path with `cat`/`json.tool` -- this is the actual content the hook wrote, not a mock or a description of what it should write.

**Side-effect note:** an earlier attempt at reproducing "missing key" (before I isolated `$HOME`) accidentally fell back to this box's real production `ANTHROPIC_API_KEY` via `~/lobster-config/config.env` (the hook's own documented config-file fallback, working as designed) and made one real scan call against a harmless scratch diff (no real PII, a fake `jane.doe@example-corp-real.com` string in a throwaway temp repo). No cost/volume concern beyond that single call; flagging for transparency. All manual-test artifacts (`/tmp/pii-manual-test-*`) were deleted after capturing the log contents above; nothing was written to the real `~/lobster-workspace/logs/`.

**User-visible outcome:** N/A -- this hook produces no Telegram/user-facing output; its only observable surface is the git push stderr line (unchanged behavior) and the new log file, both verified directly above.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in the automated `pytest` suite — the fake-scanner injection pattern this file already uses)
- [x] Manual test run against the real hook with a real (intentionally invalid) API key — see Manual test above
- [x] User-visible outcome: not applicable (no user-facing output from this hook)
- [x] Side-effect audit: no floods, no unscoped writes (isolated `$LOBSTER_WORKSPACE` and `$HOME` used for all manual runs), no unintended volume beyond the one flagged incidental real-key call above
- [x] External service calls: injected/faked in all automated tests; the two real calls in manual testing were both deliberate 401s to a scratch environment, plus the one flagged incidental real-key call