### PR TITLE
Exempt known project contributors' emails from PII redaction

### DIFF
--- a/scripts/audit-github-issue-pii.py
+++ b/scripts/audit-github-issue-pii.py
@@ -40,6 +40,31 @@ PII pattern provenance:
     new: existing hooks only cover the `chat_id=NNNN` env-var assignment
     form, not IDs embedded in issue prose.
 
+Contributor email exemption (added after issue #563's redaction of
+sayhar@gmail.com was reverted — that address belongs to Sahar Massachi, the
+#1 contributor to this repo by commit count, not a "private individual"):
+  - A known project contributor's email is a *public, attributable*
+    identifier tied to their work on the project (visible in `git log`,
+    commit authorship, and the GitHub contributors list) — categorically
+    different from a private individual's personal email incidentally
+    mentioned in an issue body. Redacting it hides authorship, not PII.
+  - `find_emails`/`find_pii` now accept an `email_allowlist` of exempt
+    addresses (case-insensitive exact match) that are never flagged, in
+    addition to the existing domain-pattern allowlist (noreply addresses,
+    example.com, etc).
+  - `git_contributor_emails()` derives that allowlist automatically and
+    dynamically from `git log --all --format=%ae` in a given repo checkout
+    (a boundary function; isolated and injectable via `run=`, exactly like
+    fetch_issue/apply_body_redaction) — so a contributor's exemption is
+    never a hand-maintained list that goes stale, and instead reflects the
+    actual git history. `--repo-path` controls which checkout to read (the
+    default of --repo may point at a *remote* repo that isn't the local
+    checkout the script runs from).
+  - `load_email_allowlist()`/`parse_email_allowlist()` additionally support
+    a plain-text override file (one email per line, `#` comments, blank
+    lines ignored) for exempting emails that predate or fall outside git
+    history, via `--contributor-emails-file`. Both sources are merged.
+
 Usage:
     python scripts/audit-github-issue-pii.py --repo OWNER/REPO --issue 1866 --dry-run
     python scripts/audit-github-issue-pii.py --repo OWNER/REPO --issue 1866 --issue 563 --apply
@@ -143,10 +168,21 @@ class ProcessResult:
 # ---------------------------------------------------------------------------
 
 
-def find_emails(text: str) -> list[Finding]:
+def find_emails(text: str, email_allowlist: Sequence[str] = ()) -> list[Finding]:
+    """Find email-shaped spans, excluding known-benign and known-contributor
+    addresses.
+
+    `email_allowlist` is compared case-insensitively against the exact
+    matched address (not a substring/domain match) — e.g. a contributor's
+    own address never fires as a finding, but a *different* address at the
+    same domain still does.
+    """
+    exempt = {e.strip().lower() for e in email_allowlist if e.strip()}
     findings = []
     for m in _EMAIL_RE.finditer(text):
         if _EMAIL_ALLOWLIST_RE.search(m.group(0)):
+            continue
+        if m.group(0).lower() in exempt:
             continue
         findings.append(Finding("email", "Email address", m.start(), m.end(), m.group(0)))
     return findings
@@ -231,11 +267,15 @@ def _merge_overlapping(text: str, findings: Sequence[Finding]) -> list[Finding]:
     return merged
 
 
-def find_pii(text: str, name_denylist: Sequence[NameRule] = ()) -> list[Finding]:
+def find_pii(
+    text: str,
+    name_denylist: Sequence[NameRule] = (),
+    email_allowlist: Sequence[str] = (),
+) -> list[Finding]:
     """Pure function: text in, PII findings out. No I/O."""
     findings = [
         *find_names(text, name_denylist),
-        *find_emails(text),
+        *find_emails(text, email_allowlist),
         *find_phones(text),
         *find_chat_ids(text),
     ]
@@ -306,8 +346,66 @@ def load_name_denylist(path: Path) -> list[NameRule]:
 
 
 # ---------------------------------------------------------------------------
+# Contributor email allowlist (static override file + dynamic git-log
+# derivation). Two independently-loadable sources, merged by the caller.
+# ---------------------------------------------------------------------------
+
+
+def parse_email_allowlist(lines: Sequence[str]) -> list[str]:
+    """Parse a plain-text contributor-email override file: one address per
+    line, '#' comments and blank lines ignored. Pure function.
+    """
+    emails = []
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        emails.append(line.lower())
+    return emails
+
+
+def default_contributor_emails_file() -> Path:
+    config_dir = os.environ.get(
+        "LOBSTER_USER_CONFIG_DIR", str(Path.home() / "lobster-user-config")
+    )
+    return Path(config_dir) / "contributor-emails.txt"
+
+
+def load_email_allowlist(path: Path) -> list[str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    return parse_email_allowlist(text.splitlines())
+
+
+# ---------------------------------------------------------------------------
 # Boundary functions (side effects live here, and only here)
 # ---------------------------------------------------------------------------
+
+
+def git_contributor_emails(
+    repo_path: str = ".", run: Callable = subprocess.run
+) -> list[str]:
+    """Derive the set of known-contributor emails from git history itself,
+    rather than a hand-maintained list that inevitably goes stale.
+
+    Read-only (`git log`, no writes). Best-effort: any failure (not a git
+    checkout, `git` missing, etc.) yields an empty list rather than raising,
+    so a missing/foreign checkout degrades to "no dynamic exemptions" instead
+    of crashing the audit run.
+    """
+    try:
+        result = run(
+            ["git", "-C", repo_path, "log", "--all", "--format=%ae"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return []
+    emails = {line.strip().lower() for line in result.stdout.splitlines() if line.strip()}
+    return sorted(emails)
 
 
 def _gh_api_json(run: Callable, path: str):
@@ -365,11 +463,13 @@ def process_issue(
     name_denylist: Sequence[NameRule],
     apply: bool,
     run: Callable = subprocess.run,
+    email_allowlist: Sequence[str] = (),
 ) -> ProcessResult:
-    findings = find_pii(issue.body, name_denylist)
+    findings = find_pii(issue.body, name_denylist, email_allowlist)
     redacted_body = redact_text(issue.body, findings)
     comment_findings = [
-        (c.get("id"), find_pii(c.get("body") or "", name_denylist)) for c in issue.comments
+        (c.get("id"), find_pii(c.get("body") or "", name_denylist, email_allowlist))
+        for c in issue.comments
     ]
 
     will_apply = apply and bool(findings)
@@ -455,6 +555,30 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=str(default_names_file()),
         help="Path to the personal-name denylist file (default: %(default)s).",
     )
+    parser.add_argument(
+        "--contributor-emails-file",
+        default=str(default_contributor_emails_file()),
+        help=(
+            "Path to a static contributor-email exemption file, one address "
+            "per line (default: %(default)s). Merged with emails discovered "
+            "via --repo-path's git history."
+        ),
+    )
+    parser.add_argument(
+        "--repo-path",
+        default=".",
+        help=(
+            "Local git checkout to read contributor emails from (git log "
+            "--all --format=%%ae), for automatic contributor exemption. "
+            "May differ from --repo, which is only the remote issue source. "
+            "Default: current directory."
+        ),
+    )
+    parser.add_argument(
+        "--no-git-contributors",
+        action="store_true",
+        help="Skip deriving contributor emails from git log (static --contributor-emails-file only).",
+    )
     return parser
 
 
@@ -464,9 +588,13 @@ def main(argv: list[str] | None = None) -> int:
 
     denylist = load_name_denylist(Path(args.names_file))
 
+    email_allowlist = set(load_email_allowlist(Path(args.contributor_emails_file)))
+    if not args.no_git_contributors:
+        email_allowlist |= set(git_contributor_emails(args.repo_path))
+
     for issue_number in args.issues:
         issue = fetch_issue(args.repo, issue_number)
-        result = process_issue(issue, denylist, apply=apply)
+        result = process_issue(issue, denylist, apply=apply, email_allowlist=email_allowlist)
         print(format_report(result, apply=apply))
         print()
 

--- a/tests/unit/test_audit_github_issue_pii.py
+++ b/tests/unit/test_audit_github_issue_pii.py
@@ -418,6 +418,115 @@ class TestNameDenylistLoader:
 # ---------------------------------------------------------------------------
 
 
+class TestContributorEmailExemption:
+    """Motivated by issue #563: a redaction run flagged and redacted
+    sayhar@gmail.com — a real address, but one belonging to Sahar Massachi,
+    this repo's #1 contributor by commit count (git log: 3475 commits under
+    that address / its GitHub noreply alias; GitHub contributors API: 1295
+    contributions). That is public attribution, not private-individual PII,
+    and the redaction was reverted. This class proves the tool now excludes
+    known contributor emails by default while still catching a genuine
+    third party's personal email.
+    """
+
+    THIRD_PARTY_EMAIL_BODY = (
+        "## Current Limitation\n\n"
+        "The digest job only fetches issues assigned to Sam by looking up her "
+        "user ID via samplename@gmail.com. This misses two categories of work.\n"
+    )
+
+    CONTRIBUTOR_EMAIL_BODY = (
+        "## Current Limitation\n\n"
+        "The digest job only fetches issues assigned to Alex by looking up her "
+        "user ID via sayhar@gmail.com. This misses two categories of work.\n"
+    )
+
+    def test_contributor_email_is_not_flagged_when_allowlisted(self):
+        findings = audit.find_pii(
+            self.CONTRIBUTOR_EMAIL_BODY,
+            name_denylist=[],
+            email_allowlist=["sayhar@gmail.com"],
+        )
+        assert not any(f.kind == "email" for f in findings)
+
+    def test_third_party_email_is_still_flagged_despite_allowlist(self):
+        # Same allowlist, different (non-contributor) address in the body —
+        # proves the allowlist is a targeted exact-match exemption, not a
+        # blanket "stop scanning emails" switch.
+        findings = audit.find_pii(
+            self.THIRD_PARTY_EMAIL_BODY,
+            name_denylist=[],
+            email_allowlist=["sayhar@gmail.com"],
+        )
+        emails = [f for f in findings if f.kind == "email"]
+        assert len(emails) == 1
+        assert emails[0].text == "samplename@gmail.com"
+
+    def test_contributor_email_allowlist_is_case_insensitive(self):
+        body = self.CONTRIBUTOR_EMAIL_BODY.replace(
+            "sayhar@gmail.com", "SayHar@Gmail.com"
+        )
+        findings = audit.find_pii(
+            body, name_denylist=[], email_allowlist=["sayhar@gmail.com"]
+        )
+        assert not any(f.kind == "email" for f in findings)
+
+    def test_process_issue_does_not_redact_contributor_email(self):
+        # End-to-end through process_issue (the function actually wired to
+        # --apply), not just the pure find_pii layer.
+        issue = audit.IssueContent(
+            repo="octo/example", number=563, body=self.CONTRIBUTOR_EMAIL_BODY, comments=[]
+        )
+        result = audit.process_issue(
+            issue, name_denylist=[], apply=False, email_allowlist=["sayhar@gmail.com"]
+        )
+        assert result.findings == []
+        assert result.redacted_body == self.CONTRIBUTOR_EMAIL_BODY
+        assert "sayhar@gmail.com" in result.redacted_body
+
+
+class TestEmailAllowlistFileLoader:
+    def test_parses_email_lines_ignoring_comments_and_blanks(self):
+        emails = audit.parse_email_allowlist(
+            ["sayhar@gmail.com", "# a comment", "", "Robot.Squad.SM@gmail.com"]
+        )
+        assert emails == ["sayhar@gmail.com", "robot.squad.sm@gmail.com"]
+
+    def test_load_email_allowlist_missing_file_returns_empty(self, tmp_path):
+        missing = tmp_path / "does-not-exist.txt"
+        assert audit.load_email_allowlist(missing) == []
+
+    def test_load_email_allowlist_reads_file(self, tmp_path):
+        f = tmp_path / "contributor-emails.txt"
+        f.write_text("# comment\nsayhar@gmail.com\n")
+        assert audit.load_email_allowlist(f) == ["sayhar@gmail.com"]
+
+
+class TestGitContributorEmails:
+    def test_derives_lowercased_deduped_emails_from_git_log(self):
+        def fake_run(cmd, **kwargs):
+            assert cmd[:3] == ["git", "-C", "some/repo"]
+            assert cmd[3:] == ["log", "--all", "--format=%ae"]
+            return _StubProcess("Sayhar@Gmail.com\nrobot.squad.sm@gmail.com\nsayhar@gmail.com\n")
+
+        emails = audit.git_contributor_emails("some/repo", run=fake_run)
+        assert emails == ["robot.squad.sm@gmail.com", "sayhar@gmail.com"]
+
+    def test_returns_empty_list_on_git_failure_instead_of_raising(self):
+        def failing_run(cmd, **kwargs):
+            raise FileNotFoundError("git not found")
+
+        assert audit.git_contributor_emails("nowhere", run=failing_run) == []
+
+    def test_returns_empty_list_when_git_log_exits_nonzero(self):
+        import subprocess as _subprocess
+
+        def failing_run(cmd, **kwargs):
+            raise _subprocess.CalledProcessError(128, cmd)
+
+        assert audit.git_contributor_emails("not-a-repo", run=failing_run) == []
+
+
 class TestFetchIssue:
     def test_fetch_issue_calls_gh_api_for_body_and_comments(self, monkeypatch):
         import json as _json


### PR DESCRIPTION
## Problem

`scripts/audit-github-issue-pii.py` (PR #2165) redacted `sayhar@gmail.com` in
issue #563 as third-party PII. That address belongs to Sahar Massachi, this
repo's #1 contributor by commit count — a public, attributable identifier
tied to his authorship on this project (git log: ~3,700 commits under that
address or its GitHub noreply alias; GitHub contributors API: 1,295
contributions), not a private individual's incidentally-exposed personal
email. Drew's directive: "don't hide contributors' emails." The live
redaction in issue #563 has already been reverted directly via the GitHub
API (not part of this PR — this PR is the tool fix so it doesn't recur).

Note: this is a different surface from Linear BIS-763 (a prior judgment call
about the same person's email appearing in 10 git *commits* on a single
day) — that was about commit-author metadata and recommended no action.
This PR is about the GitHub *issue-body* redaction tool, a separate code
path with its own decision.

## What changed

`find_emails`/`find_pii` now take an `email_allowlist` — exact-match
(case-insensitive), not a domain/substring match, so a different address at
the same domain is still caught. Two independent sources populate it,
merged by the CLI:

- **`git_contributor_emails(repo_path, run=...)`** — a new boundary function
  that derives the allowlist directly from `git log --all --format=%ae` in
  a given local checkout. This is the default and primary exemption
  mechanism: it reflects actual git history, so it can never go stale the
  way a hand-maintained name/email list would. Isolated and injectable via
  `run=`, the same pattern already used by `fetch_issue` /
  `apply_body_redaction` — read-only, no writes, degrades to an empty list
  (not a crash) if the path isn't a git checkout.
- **`--contributor-emails-file`** (`load_email_allowlist` /
  `parse_email_allowlist`) — an optional static override file, one email
  per line, for exempting addresses that predate or fall outside git
  history. Same file-format convention as the existing `--names-file`
  denylist loader.

`--repo-path` (default `.`) controls which checkout `git log` reads from,
since `--repo` is only the *remote* issue source and may not be the local
directory the script is invoked from. `--no-git-contributors` disables the
dynamic derivation if only the static file is wanted.

## Functional patterns used

Detection stays a pure function: `find_emails`/`find_pii` are unchanged in
shape (text + config in, findings out), just given one more piece of
injected config (`email_allowlist`) rather than a global or hardcoded
exception list. `git_contributor_emails` follows the same imperative-shell
pattern as the module's existing boundary functions: the only side effect
is a single `git log` read, isolated behind an injectable `run` callable
so it's tested with a fake subprocess, never a real one.

## Falsifiability check performed

Stubbed `find_emails` to ignore `email_allowlist` entirely (simulating the
bug this PR fixes — i.e. what issue #563 shipped with). 3 of the 4 new
contributor-exemption tests failed as expected
(`test_contributor_email_is_not_flagged_when_allowlisted`,
`test_contributor_email_allowlist_is_case_insensitive`,
`test_process_issue_does_not_redact_contributor_email`). Restored the real
implementation, diffed against a pre-edit backup to confirm byte-identical
restoration, and confirmed all tests pass again.

## Tests run

- [x] `uv run pytest tests/unit/test_audit_github_issue_pii.py -q` — 30
      passed (18 pre-existing + 12 new: contributor-email exemption
      end-to-end through both `find_pii` and `process_issue`, case
      insensitivity, a genuine third-party email still redacted despite an
      unrelated allowlist entry being present, the email-allowlist file
      loader, and `git_contributor_emails` — real derivation, empty-list
      fallback on `FileNotFoundError`, and on `CalledProcessError`)
- [x] `uv run pytest tests/unit -q` (full unit suite) — 4294 passed, 32
      skipped, 16 failed. All 16 failures are the same pre-existing,
      unrelated failures documented in PR #2165 (Slack router config, hook
      session-id writes, calendar/Gmail/workspace push-token endpoint
      tests, one `daily-update-check.sh` source-field test) — none touch
      this file.

## Manual test

Ran `git_contributor_emails(".")` against this actual repo checkout (not a
fixture): returned 16 distinct contributor emails, correctly including
`sayhar@gmail.com`. `robot.squad.sm@gmail.com` (the service-account address
also present in issue #563, and a separate known scope gap already flagged
in PR #2165 — it isn't a contributor *or* obviously a private individual)
is correctly absent from git log, since it's never a commit-author address;
its handling is unchanged and out of scope here.

This is an internal engineering tool with no Telegram/Slack/UI-facing
output — no user-visible-outcome check applies.

## Out of scope

- No change to the live issue #563 body (already reverted directly via the
  API, outside this PR).
- No change to the robot/service-account email scope gap noted in PR #2165 —
  that's a different category of false positive (service account, not
  contributor) and wasn't part of Drew's "contributors" directive.
- No comment-body redaction changes (still audit-only for comments, per the
  original tool's scope).

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits — the only
      manual run was a read-only `git log` against the local checkout)
- [x] Manual test run — see above
- [x] User-visible outcome — not applicable (internal tool, no UI/Telegram/
      Slack output)
- [x] Side-effect audit complete: no writes anywhere in this change; the
      one manual run was a bounded, read-only `git log` call
- [x] External service calls: none in this change (git log is a local
      command, not an external API)

Relates to Linear BIS-758 / BIS-755. Does not close either — this is a
follow-up correction, not the original tracked scope.