### PR TITLE
Suppress owner Telegram push for empty-content subagent recovery notifications (#2175)

### DIFF
--- a/src/mcp/inbox_server.py
+++ b/src/mcp/inbox_server.py
@@ -4539,6 +4539,13 @@ def _get_owner_chat_id_and_source() -> tuple[int | str | None, str]:
         return None, "telegram"
 
 
+# Marker inserted by hooks/require-write-result.py's _write_synthetic_inbox_message
+# to separate the fixed preamble from actual salvaged transcript content. Its
+# presence/absence in a subagent_recovered message's text is the single source of
+# truth for whether anything real was recovered — see _enqueue_recovery_notification.
+_RECOVERY_CONTENT_MARKER = "Recovered content:\n\n"
+
+
 def _enqueue_recovery_notification(msg: dict) -> None:
     """Write a subagent_notification to the owner's inbox when a subagent_recovered event arrives.
 
@@ -4547,9 +4554,30 @@ def _enqueue_recovery_notification(msg: dict) -> None:
     to the owner's chat_id (resolved from config.env) — not to the original
     chat_id carried by the recovery message, which is always 0 (unknown).
 
+    Suppression (issue #2175): when the salvaged transcript content is empty —
+    i.e. the SubagentStop fallback found nothing worth recovering — no owner-facing
+    Telegram notification is written. This is the case for phantom/harness-noise
+    SubagentStop fires (no real agent work was ever lost) and was, empirically, the
+    entire content of a ~140-notification overnight spam incident. The internal
+    subagent_recovered message this is derived from is written unconditionally by
+    the hook regardless of this suppression, and still flows through the dispatcher
+    for mark_processed as before — only the owner-facing push is suppressed here.
+    When there IS salvaged content, the notification is still sent unchanged: that
+    case represents real, potentially-lost work the owner should know about.
+
     Best-effort: any failure is logged but never raises.
     """
     try:
+        task_id = msg.get("task_id") or "unknown"
+        raw_text = msg.get("text", "")
+
+        if _RECOVERY_CONTENT_MARKER not in raw_text:
+            log.info(
+                f"subagent_recovered: task {task_id!r} had no salvageable transcript "
+                "content — suppressing owner Telegram notification (issue #2175)"
+            )
+            return
+
         owner_chat_id, owner_source = _get_owner_chat_id_and_source()
         if owner_chat_id is None:
             log.warning(
@@ -4558,20 +4586,12 @@ def _enqueue_recovery_notification(msg: dict) -> None:
             )
             return
 
-        task_id = msg.get("task_id") or "unknown"
-        raw_text = msg.get("text", "")
-
-        # Extract a brief summary (first 300 chars of salvaged content, if any).
-        summary_marker = "Recovered content:\n\n"
-        summary: str
-        if summary_marker in raw_text:
-            salvaged = raw_text.split(summary_marker, 1)[1]
-            summary = salvaged[:300].strip()
-            if len(salvaged) > 300:
-                summary += "…"
-            summary_line = f"Last known activity: {summary}"
-        else:
-            summary_line = "No recoverable transcript content was found."
+        # Extract a brief summary (first 300 chars of salvaged content).
+        salvaged = raw_text.split(_RECOVERY_CONTENT_MARKER, 1)[1]
+        summary = salvaged[:300].strip()
+        if len(salvaged) > 300:
+            summary += "…"
+        summary_line = f"Last known activity: {summary}"
 
         notification_text = (
             f"Agent `{task_id}` failed to write a result (exited without calling write_result).\n"

--- a/tests/unit/test_mcp_server/test_message_tools.py
+++ b/tests/unit/test_mcp_server/test_message_tools.py
@@ -1398,8 +1398,9 @@ class TestEnqueueRecoveryNotification:
     _write_synthetic_inbox_message (in require-write-result.py) and
     _enqueue_recovery_notification (in inbox_server.py). These tests verify
     that the marker correctly identifies the boundary, that content after it
-    is used as the notification summary, and that the no-content fallback
-    works when the marker is absent.
+    is used as the notification summary, and — per issue #2175 — that the
+    owner-facing Telegram notification is suppressed entirely when the marker
+    is absent (i.e. nothing was salvaged from the transcript).
     """
 
     def _call_enqueue(self, inbox_dir: Path, msg: dict, owner_chat_id: int = 99999) -> dict:
@@ -1471,8 +1472,22 @@ class TestEnqueueRecoveryNotification:
         # The full 400-char content should not appear verbatim.
         assert long_content not in notification["text"]
 
-    def test_no_summary_marker_uses_fallback(self, tmp_path):
-        """When text does not contain the summary marker, fallback message is used."""
+    def _call_enqueue_expect_no_file(self, inbox_dir: Path, msg: dict, owner_chat_id: int = 99999) -> None:
+        """Call _enqueue_recovery_notification and assert no notification file was written."""
+        from src.mcp.inbox_server import _enqueue_recovery_notification
+
+        with patch("src.mcp.inbox_server._get_owner_chat_id_and_source", return_value=(owner_chat_id, "telegram")), \
+             patch.multiple("src.mcp.inbox_server", INBOX_DIR=inbox_dir):
+            _enqueue_recovery_notification(msg)
+
+        assert list(inbox_dir.glob("*.json")) == []
+
+    def test_no_summary_marker_suppresses_notification(self, tmp_path):
+        """When text does not contain the summary marker (nothing salvaged), no
+        owner-facing Telegram notification is written — see issue #2175: this exact
+        shape ("(No recoverable transcript content found.)") was the entire content
+        of a ~140-notification overnight spam incident.
+        """
         inbox_dir = tmp_path / "inbox"
         inbox_dir.mkdir()
 
@@ -1480,20 +1495,36 @@ class TestEnqueueRecoveryNotification:
             "task_id": "agent-no-content",
             "text": "Agent exited without calling write_result.\n\n(No recoverable transcript content found.)",
         }
-        notification = self._call_enqueue(inbox_dir, msg)
+        self._call_enqueue_expect_no_file(inbox_dir, msg)
 
-        assert "No recoverable transcript content was found." in notification["text"]
-        assert "Last known activity:" not in notification["text"]
-
-    def test_empty_text_uses_fallback(self, tmp_path):
-        """Empty text field (no transcript content at all) uses the fallback message."""
+    def test_empty_text_suppresses_notification(self, tmp_path):
+        """Empty text field (no transcript content at all) suppresses the notification."""
         inbox_dir = tmp_path / "inbox"
         inbox_dir.mkdir()
 
         msg = {"task_id": "agent-empty", "text": ""}
+        self._call_enqueue_expect_no_file(inbox_dir, msg)
+
+    def test_salvaged_content_still_sends_notification(self, tmp_path):
+        """When the transcript salvage is non-empty (real work was in flight when the
+        agent died without calling write_result), the owner-facing notification is
+        still sent — this is the case that represents genuinely lost work.
+        """
+        inbox_dir = tmp_path / "inbox"
+        inbox_dir.mkdir()
+
+        msg = {
+            "task_id": "agent-real-work",
+            "text": (
+                "Agent exited without calling write_result."
+                "\n\nRecovered content:\n\n"
+                "Drafted the fix for issue #99 and was about to open a PR."
+            ),
+        }
         notification = self._call_enqueue(inbox_dir, msg)
 
-        assert "No recoverable transcript content was found." in notification["text"]
+        assert notification["type"] == "subagent_notification"
+        assert "Drafted the fix for issue #99" in notification["text"]
 
     def test_notification_uses_owner_chat_id(self, tmp_path):
         """Recovery notification is addressed to the owner, not to chat_id=0."""
@@ -1501,21 +1532,31 @@ class TestEnqueueRecoveryNotification:
         inbox_dir.mkdir()
 
         owner_id = 123456789
-        msg = {"task_id": "agent-chat", "text": ""}
+        msg = {
+            "task_id": "agent-chat",
+            "text": "Preamble.\n\nRecovered content:\n\nSomething real happened.",
+        }
         notification = self._call_enqueue(inbox_dir, msg, owner_chat_id=owner_id)
 
         assert notification["chat_id"] == owner_id
         assert notification["type"] == "subagent_notification"
 
     def test_owner_chat_id_none_skips_notification(self, tmp_path):
-        """When owner chat_id cannot be resolved, no notification file is written."""
+        """When owner chat_id cannot be resolved, no notification file is written —
+        even when there is salvaged content to report (distinct from the issue #2175
+        empty-content suppression, which returns before owner chat_id is even resolved).
+        """
         inbox_dir = tmp_path / "inbox"
         inbox_dir.mkdir()
 
         from src.mcp.inbox_server import _enqueue_recovery_notification
 
+        msg = {
+            "task_id": "x",
+            "text": "Preamble.\n\nRecovered content:\n\nSomething real happened.",
+        }
         with patch("src.mcp.inbox_server._get_owner_chat_id_and_source", return_value=(None, "telegram")), \
              patch.multiple("src.mcp.inbox_server", INBOX_DIR=inbox_dir):
-            _enqueue_recovery_notification({"task_id": "x", "text": ""})
+            _enqueue_recovery_notification(msg)
 
         assert list(inbox_dir.glob("*.json")) == []


### PR DESCRIPTION
## Problem

Phantom `SubagentStop` hook fires — harness-level events with no corresponding real Task/Agent spawn, no transcript, no `agent_sessions.db` row — are tracked and root-caused (mechanism-wise) in #2175. A small, still-unexplained subset of these get retried up to `MAX_HOOK_FIRES=5` by `hooks/require-write-result.py`, which then falls back to writing a synthetic `subagent_recovered` message. `inbox_server.py`'s `_enqueue_recovery_notification()` turns every one of those into an owner-facing "SUBAGENT RECOVERY" Telegram push.

Over one overnight window this fired **~140 times**, roughly every 4-6 minutes for 10+ hours. Every single instance inspected during the investigation carried **zero actual signal** — the salvaged-transcript text was literally `(No recoverable transcript content found.)` in all of them, because these are phantom fires: there was never any real agent work in flight to salvage.

**This PR does not fix the phantom-fire mechanism itself** — that remains unroot-caused per #2175 (strace/ptrace are unavailable in this container, which is the main blocker to going further). It fixes the user-visible symptom: stop pushing empty, zero-signal notifications to the owner's phone.

## What changed

`_enqueue_recovery_notification()` in `src/mcp/inbox_server.py` already computed whether anything was salvaged, using the presence of a `"Recovered content:\n\n"` marker (written by `hooks/require-write-result.py`'s `_write_synthetic_inbox_message` only when transcript content was actually recovered) to decide the summary line. That marker is now checked *first*, as an early return: when it's absent — nothing was salvaged — the function logs and returns without resolving the owner's chat_id or writing a notification file at all. When it's present, behavior is unchanged: the Telegram push is still built and sent exactly as before.

**What is explicitly unchanged:**
- The internal `subagent_recovered` message is still written unconditionally by `hooks/require-write-result.py`, regardless of content. It still flows through `check_inbox`'s pre-processor and the dispatcher still `mark_processed`s it — nothing about that path changed.
- Non-empty salvage (an agent that had done real work before dying without calling `write_result`) still triggers the owner notification exactly as before. That case represents genuinely lost work and the owner should still be alerted.
- The phantom-fire mechanism, the hook-fire retry logic (`MAX_HOOK_FIRES`, `/tmp/lobster-hook-fires-*` tracking/cleanup) are untouched — out of scope for this PR, not root-caused, not touched.

## Functional patterns

- Early return on a pure boolean check (marker presence) instead of branching deep inside the function body — the empty-content case short-circuits before any of the function's side effects (owner-chat-id resolution, file write, logging) occur.
- No new mutable state; the existing marker-based signal (`_RECOVERY_CONTENT_MARKER`, previously an inline literal) was hoisted to a module-level constant so the same string is the single source of truth for both branches.

## Flow diagram

```
Before:
  subagent_recovered arrives → _enqueue_recovery_notification()
    → resolve owner chat_id
    → build summary_line (salvaged text OR "No recoverable transcript content was found.")
    → ALWAYS write subagent_notification → Telegram push to owner

After:
  subagent_recovered arrives → _enqueue_recovery_notification()
    → marker absent (nothing salvaged)?
        yes → log + return. No owner chat_id lookup. No file written. No Telegram push.
        no  → resolve owner chat_id → build summary_line (salvaged text) → write
              subagent_notification → Telegram push to owner (unchanged from before)
```

The internal `subagent_recovered` message → dispatcher `mark_processed` path is unaffected in both branches.

## Tests run
- [x] `uv run pytest tests/unit/test_mcp_server/test_message_tools.py tests/unit/test_hooks/test_require_write_result.py -q` — 78 passed, 0 failed. Includes updated/new tests in `TestEnqueueRecoveryNotification`: `test_no_summary_marker_suppresses_notification`, `test_empty_text_suppresses_notification` (empty content → no file written), `test_salvaged_content_still_sends_notification` (non-empty content → notification still sent, salvaged text present), plus updated `test_owner_chat_id_none_skips_notification` to exercise the None-chat-id branch with non-empty content (previously it accidentally only exercised the now-earlier empty-content return).
- [x] `uv run pytest tests/unit/ -q` — 4323 passed, 22 failed, 32 skipped. Verified via `git stash` that all 22 failures are pre-existing on `main` (unrelated: missing `ANTHROPIC_API_KEY` for PII-scan-guard tests, slack-poller float-precision tests, push-token endpoint tests, etc.) — none touch `inbox_server.py`'s recovery-notification path or the modified test file.

## Manual test

N/A — this change only affects what gets written to `~/messages/inbox/` inside `_enqueue_recovery_notification()`, a pure function of its `msg` dict input with no systemd/cron/external-service/DB-schema surface. Verified via unit tests with mocked `_get_owner_chat_id_and_source` and a real `tmp_path` inbox directory (see `TestEnqueueRecoveryNotification._call_enqueue` / `_call_enqueue_expect_no_file` helpers) — these assert directly on whether a notification file is written, which is the actual mechanism gating the Telegram push, so no live Telegram send was needed to verify this behavior. No production Telegram messages were sent as part of testing this change.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run — not applicable, see `## Manual test` above
- [x] User-visible outcome verified: file-write-or-not is the exact mechanism gating the Telegram push, and is asserted directly in the new tests
- [x] Side-effect audit complete: this change can only *reduce* Telegram volume (early return short-circuits before any write), never increase it; no shared-state writes beyond the existing inbox-file write path; no unscoped production calls made during testing
- [x] External service calls: none in this change (no direct Telegram API call — the notification is written to the inbox file for the dispatcher to relay, same as before)

Closes the user-visible spam described in #2175. Does **not** close #2175 itself — the underlying phantom `SubagentStop` fire mechanism and why a small subset of fires retry to the fallback threshold remain unexplained, per that issue's "Known unknowns" section.