### PR TITLE
fix: dedicated ANTHROPIC_API_KEY file for docker-worker.sh (not config.env)

### DIFF
--- a/config/docker-worker.env.example
+++ b/config/docker-worker.env.example
@@ -1,0 +1,38 @@
+# docker-worker.env — dedicated credentials for scripts/docker-worker.sh ONLY.
+#
+# Copy this file to ~/lobster-config/docker-worker.env (or
+# $LOBSTER_CONFIG_DIR/docker-worker.env) and fill in a real key.
+#
+# Why this is a SEPARATE file from config.env:
+#
+# config.env is loaded as an EnvironmentFile by nearly every Lobster systemd
+# unit, INCLUDING lobster-claude.service (the dispatcher itself) — see
+# /etc/systemd/system/lobster-claude.service. Any variable placed in
+# config.env therefore enters the dispatcher's own process environment.
+#
+# This bit Lobster once already: an ANTHROPIC_API_KEY was previously kept in
+# config.env "for eloso-bisque outreach generation" but was actually being
+# picked up by the dispatcher's own `claude` CLI auth resolution. Claude
+# Code prefers ANTHROPIC_API_KEY over CLAUDE_CODE_OAUTH_TOKEN when both are
+# present, so the dispatcher was silently running on pay-per-token API
+# billing instead of the intended setup-token OAuth credential. That key was
+# disabled 2026-08-05 (see the commented-out block in config.env) specifically
+# to close this hole — re-adding a shared key to config.env for
+# docker-worker.sh's sake would reopen the exact same bug.
+#
+# docker-worker.sh therefore sources its own key from THIS file instead,
+# which is not referenced as an EnvironmentFile by any systemd unit and so
+# never enters the dispatcher's (or any other service's) auth environment.
+# It is read directly by the script at invocation time.
+#
+# Provision a NEW, DEDICATED Anthropic API key here — do not reuse/copy the
+# shared dispatcher OAuth credential or any other service's key:
+#   https://console.anthropic.com/settings/keys
+# Scope/label it clearly (e.g. "lobster-docker-worker") so usage and spend
+# are attributable if this path is ever actually invoked.
+#
+# As of 2026-08-09: no caller of docker-worker.sh was found anywhere in this
+# host's cron/systemd/codebase, so this key is provisioned for forward
+# compatibility, not because something is actively broken in production. Do
+# not treat an empty value here as an outage.
+ANTHROPIC_API_KEY=

--- a/scripts/docker-worker.sh
+++ b/scripts/docker-worker.sh
@@ -30,17 +30,28 @@ PROMPT="$5"
 #===============================================================================
 # Source config for API key
 #===============================================================================
-CONFIG_ENV="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}/config.env"
+# Deliberately NOT config.env: config.env is loaded as an EnvironmentFile by
+# nearly every Lobster systemd unit, including lobster-claude.service (the
+# dispatcher itself). A key placed there leaks into the dispatcher's own auth
+# environment -- this happened once already with a shared ANTHROPIC_API_KEY
+# (disabled 2026-08-05 after it was found silently overriding the dispatcher's
+# setup-token OAuth credential). docker-worker.sh gets its own dedicated,
+# never-EnvironmentFile'd config file instead. See config/docker-worker.env.example.
+CONFIG_ENV="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}/docker-worker.env"
 
 if [[ ! -f "$CONFIG_ENV" ]]; then
     echo "ERROR: Config file not found: $CONFIG_ENV" >&2
+    echo "  Copy config/docker-worker.env.example to $CONFIG_ENV and fill in a" >&2
+    echo "  dedicated ANTHROPIC_API_KEY (do not reuse the dispatcher's shared key)." >&2
     exit 1
 fi
 
 ANTHROPIC_API_KEY=$(grep '^ANTHROPIC_API_KEY=' "$CONFIG_ENV" | cut -d'=' -f2-)
 
 if [[ -z "$ANTHROPIC_API_KEY" ]]; then
-    echo "ERROR: ANTHROPIC_API_KEY not found in $CONFIG_ENV" >&2
+    echo "ERROR: ANTHROPIC_API_KEY not set in $CONFIG_ENV" >&2
+    echo "  Provision a dedicated key at https://console.anthropic.com/settings/keys" >&2
+    echo "  and set it in $CONFIG_ENV -- see config/docker-worker.env.example." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Resolves the standing open decision on `docker-worker.sh` ANTHROPIC_API_KEY scoping (tracked in priorities.md since 2026-08-06).
- `config.env` is an `EnvironmentFile` for nearly every Lobster systemd unit, including `lobster-claude.service` (the dispatcher). A key placed there leaks into the dispatcher's own auth environment — this already caused a real bug (dispatcher silently running on pay-per-token billing instead of setup-token OAuth, fixed 2026-08-05 by removing the key from `config.env`). Re-adding a shared key there for `docker-worker.sh`'s sake would reopen the same hole.
- `docker-worker.sh` now sources a dedicated `config/docker-worker.env` file (via `$LOBSTER_CONFIG_DIR`), never wired as an `EnvironmentFile` for any systemd unit, so a docker-worker-scoped key can't leak elsewhere.
- Adds `config/docker-worker.env.example` documenting the rationale and where to provision a fresh key.

**Note:** no caller of `docker-worker.sh` was found anywhere in cron/systemd/codebase on this host, so this is closing a design gap, not fixing a live outage. The real `~/lobster-config/docker-worker.env` has been created on the production host with `ANTHROPIC_API_KEY=` left blank — a dedicated key still needs to be provisioned at https://console.anthropic.com/settings/keys before this script can actually run a worker.

## Test plan
- [x] Manual: missing config file → clear error, exit 1
- [x] Manual: config file present, empty key → clear error, exit 1
- [x] Manual: config file present, key set → proceeds past the key check into the docker build step (verified via a throwaway `LOBSTER_CONFIG_DIR`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)