### PR TITLE
Extract nightly-consolidation step-10 bridge-sync into a tested script

### DIFF
--- a/.claude/agents/nightly-consolidation.md
+++ b/.claude/agents/nightly-consolidation.md
@@ -168,32 +168,18 @@ Include the GitHub activity summary in the synthesis for rolling-summary.md and 
 10. **Sync canonical files into the user model DB.**
    Run the bridge pass to push projects, priorities, and preferences from canonical markdown files into the user model DB. This also generates the pre-computed `_context.md` via `write_context_cache()`.
 
-   **Do not call `run_bridges()`** — it takes a single `workspace_path` used for both reads and writes, but in this deployment the canonical read root (`~/lobster-user-config`) and the `_context.md` write root (`~/lobster-workspace`) are different directories. Calling it with one shared path finds no canonical data and silently overwrites the populated `_context.md` with a near-empty stub. Call the three bridge functions directly instead, passing the correct root to each:
+   Invoke the tested CLI script — do not hand-write the bridge-sync Python inline. Inline copies of this logic have drifted twice already (a `ModuleNotFoundError` from a stale `mcp.`-prefixed import — #2180 — and a `TypeError` from a bare `sqlite3.connect()` missing `row_factory` — #2181), both caught only because someone happened to notice the repo's copy had already been fixed. `scripts/run_nightly_bridge_sync.py` is the single, tested vehicle for this step; call it by path instead of re-embedding its internals:
    ```bash
-   cd ~/lobster && uv run python -c "
-   import sys, os
-   sys.path.insert(0, os.path.join(os.getcwd(), 'src', 'mcp'))
-   from user_model.db import open_db
-   from user_model.bridges import sync_projects_to_arcs, sync_priorities_to_attention, write_context_cache
-   from pathlib import Path
-   conn = open_db(Path(os.path.expanduser('~/lobster-workspace/data/memory.db')))
-   canonical_ws = os.path.expanduser('~/lobster-user-config')
-   output_ws = os.path.expanduser('~/lobster-workspace')
-   proj = sync_projects_to_arcs(conn, canonical_ws)
-   pri = sync_priorities_to_attention(conn, canonical_ws)
-   write_context_cache(conn, output_ws)
-   conn.commit()
-   conn.close()
-   print(proj, pri)
-   "
+   cd ~/lobster && uv run python scripts/run_nightly_bridge_sync.py \
+     --canonical-root ~/lobster-user-config \
+     --workspace-root ~/lobster-workspace
    ```
-   Notes on this invocation:
-   - Import `user_model.db` / `user_model.bridges` directly (no `mcp.` prefix) after putting `src/mcp` itself on `sys.path`. Importing via `from mcp.user_model.bridges import ...` after `sys.path.insert(0, 'src')` breaks because `mcp` resolves to the installed MCP SDK package in site-packages, not `src/mcp/`.
-   - Open the connection with `user_model.db.open_db()`, not a bare `sqlite3.connect()`. `open_db()` sets `conn.row_factory = sqlite3.Row`, which the bridge query functions require for dict-style row access — without it, queries fail and are silently swallowed by broad `except` blocks, again producing a near-empty `_context.md`.
-   - `sync_projects_to_arcs` and `sync_priorities_to_attention` read from `canonical_ws` (canonical memory files); `write_context_cache` writes into `output_ws` (the workspace `_context.md` lives under). Do not use the same variable for both.
+   `--canonical-root` (read root for `projects/*.md` and `priorities.md`) and `--workspace-root` (write root for the user-model DB and `_context.md`) must stay independent arguments — never collapse them into one shared path (see PR #2136: `run_bridges()`'s single `workspace_path` did that and silently overwrote a populated `_context.md` with a near-empty stub).
 
-   This syncs `projects/*.md` as narrative arcs and `priorities.md` as attention items, and writes the pre-computed `~/lobster-workspace/user-model/_context.md`.
+   This syncs `projects/*.md` as narrative arcs and `priorities.md` as attention items, and writes the pre-computed `~/lobster-workspace/user-model/_context.md`. The script prints a JSON summary and exits non-zero if any of the three sub-steps (`projects`, `priorities`, `context_cache`) reported an error.
    If the script fails (e.g. DB not initialized), continue to step 11.
+
+   **Private-overlay note:** if `~/lobster-user-config/.claude/agents/nightly-consolidation.md` carries its own copy of step 10, update it to call this same script by path rather than re-embedding inline Python — that overlay file lives outside this repo and was the source of both #2180 and #2181.
 
 11. **Write `_context.md` (user model summary).**
     Call `model_user_context(deep=True)` to retrieve structured user model data from the DB.

--- a/scripts/run_nightly_bridge_sync.py
+++ b/scripts/run_nightly_bridge_sync.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Nightly bridge-sync CLI: push canonical memory into the user model DB.
+
+Replaces the inline Python that was previously hand-copied into step 10 of
+`.claude/agents/nightly-consolidation.md` (and its private-overlay copy).
+That inline code had two independent bugs, both filed and reproduced live:
+
+- #2180 (ModuleNotFoundError): `sys.path.insert(0, 'src')` followed by an
+  import of `user_model.bridges` rooted at the `mcp` package name resolves
+  `mcp` to the *installed* MCP-SDK package (which has no `user_model`
+  submodule), not to `src/mcp/` — because `src/mcp` has no `__init__.py` and
+  loses import precedence to the installed package. This script sidesteps
+  the collision entirely by putting `src/mcp` itself on `sys.path` and
+  importing `user_model.*` with no `mcp`-package prefix (see
+  `_import_user_model()` below).
+
+- #2181 (TypeError): opening the DB with a bare, unconfigured sqlite3
+  connection leaves `row_factory` as `None`. `user_model.db` helpers (e.g.
+  `get_active_narrative_arcs()`) do dict-style row access (`row["id"]`),
+  which raises `TypeError: tuple indices must be integers or slices, not str`
+  without `row_factory = sqlite3.Row`. This script always opens the
+  connection via `user_model.db.open_db()`, which sets that correctly (see
+  `open_connection()` below).
+
+It also preserves the fix from the earlier bug (PR #2136): `--canonical-root`
+(read root for projects/*.md and priorities.md) and `--workspace-root` (write
+root for the user-model DB and _context.md) are two independent, required
+arguments — never a single shared path used for both reads and writes.
+
+Usage:
+    uv run python scripts/run_nightly_bridge_sync.py \\
+        --canonical-root ~/lobster-user-config \\
+        --workspace-root ~/lobster-workspace
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _import_user_model():
+    """
+    Import user_model.db / user_model.bridges without the `mcp.`-prefix
+    collision described in #2180.
+
+    `src/mcp` has no `__init__.py` (namespace package), so it loses import
+    precedence to the installed MCP-SDK `mcp` package if `import mcp...` is
+    used after only `src` is on sys.path. Putting `src/mcp` itself (not
+    `src`) on sys.path and importing `user_model.*` directly avoids the `mcp`
+    name entirely.
+    """
+    src_mcp_dir = Path(__file__).resolve().parent.parent / "src" / "mcp"
+    src_mcp_str = str(src_mcp_dir)
+    if src_mcp_str not in sys.path:
+        sys.path.insert(0, src_mcp_str)
+
+    from user_model.bridges import (  # type: ignore[import-not-found]
+        sync_priorities_to_attention,
+        sync_projects_to_arcs,
+        write_context_cache,
+    )
+    from user_model.db import open_db  # type: ignore[import-not-found]
+
+    return open_db, sync_projects_to_arcs, sync_priorities_to_attention, write_context_cache
+
+
+def open_connection(db_path: Path) -> sqlite3.Connection:
+    """
+    Open the user-model DB via user_model.db.open_db(), which sets
+    conn.row_factory = sqlite3.Row (required by the bridge functions'
+    dict-style row access — guards against #2181).
+    """
+    open_db, _, _, _ = _import_user_model()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    return open_db(db_path)
+
+
+def run(
+    canonical_root: Path,
+    workspace_root: Path,
+    db_path: Path | None = None,
+) -> dict[str, Any]:
+    """
+    Run the full bridge pass:
+      - sync canonical_root's projects/*.md into narrative arcs
+      - sync canonical_root's priorities.md into attention items
+      - write workspace_root's user-model/_context.md
+
+    canonical_root and workspace_root are independent: canonical_root is
+    read-only (projects/priorities source), workspace_root owns the DB and
+    the generated _context.md. They may point at the same directory, but
+    must never be silently collapsed into one shared path (the bug PR #2136
+    fixed).
+    """
+    _, sync_projects_to_arcs, sync_priorities_to_attention, write_context_cache = (
+        _import_user_model()
+    )
+
+    resolved_db_path = db_path or (workspace_root / "data" / "memory.db")
+    conn = open_connection(resolved_db_path)
+
+    summary: dict[str, Any] = {}
+    try:
+        try:
+            summary["projects"] = sync_projects_to_arcs(conn, str(canonical_root))
+        except Exception as e:  # noqa: BLE001 - summarized, not swallowed silently
+            summary["projects"] = {"error": str(e)}
+
+        try:
+            summary["priorities"] = sync_priorities_to_attention(conn, str(canonical_root))
+        except Exception as e:  # noqa: BLE001
+            summary["priorities"] = {"error": str(e)}
+
+        try:
+            write_context_cache(conn, str(workspace_root))
+            summary["context_cache"] = "written"
+        except Exception as e:  # noqa: BLE001
+            summary["context_cache"] = {"error": str(e)}
+
+        conn.commit()
+    finally:
+        conn.close()
+
+    return summary
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Sync canonical memory (projects, priorities) into the user-model DB "
+        "and regenerate _context.md."
+    )
+    parser.add_argument(
+        "--canonical-root",
+        required=True,
+        type=Path,
+        help="Root directory containing memory/canonical/{projects/,priorities.md} "
+        "(the read source). E.g. ~/lobster-user-config.",
+    )
+    parser.add_argument(
+        "--workspace-root",
+        required=True,
+        type=Path,
+        help="Root directory that owns data/memory.db and receives the written "
+        "user-model/_context.md (the write target). E.g. ~/lobster-workspace.",
+    )
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=None,
+        help="Override the DB path. Defaults to <workspace-root>/data/memory.db.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    canonical_root = args.canonical_root.expanduser().resolve()
+    workspace_root = args.workspace_root.expanduser().resolve()
+    db_path = args.db_path.expanduser().resolve() if args.db_path else None
+
+    result = run(canonical_root=canonical_root, workspace_root=workspace_root, db_path=db_path)
+    print(json.dumps(result, indent=2))
+
+    had_error = any(isinstance(v, dict) and "error" in v for v in result.values())
+    return 1 if had_error else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_run_nightly_bridge_sync.py
+++ b/tests/unit/test_run_nightly_bridge_sync.py
@@ -1,0 +1,237 @@
+"""
+Tests for scripts/run_nightly_bridge_sync.py.
+
+This CLI script replaces the inline Python previously hand-copied into
+`.claude/agents/nightly-consolidation.md` step 10 (and its private-overlay
+copy). Two regressions motivated extracting it into a tested script:
+
+- #2180: `sys.path.insert(0, 'src')` + `from mcp.user_model.bridges import
+  run_bridges` resolves `mcp` to the installed MCP-SDK site-package (which has
+  no `user_model` submodule) rather than to `src/mcp/`, because `src/mcp` has
+  no `__init__.py` and loses precedence to the installed package.
+- #2181: opening the DB with a bare `sqlite3.connect()` instead of
+  `user_model.db.open_db()` leaves `row_factory` as `None`, so `user_model.db`
+  helpers that do dict-style row access (`row["id"]`) raise
+  `TypeError: tuple indices must be integers or slices, not str`.
+
+And the earlier bug PR #2136 already fixed once: `run_bridges()` takes a
+single `workspace_path` used for both reads and writes, which breaks when the
+canonical read root and the workspace write root differ.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the repo root importable so `from scripts.run_nightly_bridge_sync
+# import main` works with a plain import — no sys.path.insert(0, 'src') or
+# `mcp.`-prefix trick required. This mirrors how conftest.py already adds the
+# repo root to sys.path for the rest of the test suite, but this test file
+# does not depend on conftest.py's autouse fixtures, so make it explicit here
+# too.
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def canonical_root(tmp_path: Path) -> Path:
+    """A temp canonical-memory root with sample projects/*.md and priorities.md."""
+    root = tmp_path / "canonical-root"
+    projects_dir = root / "memory" / "canonical" / "projects"
+    projects_dir.mkdir(parents=True)
+
+    (projects_dir / "lobster-core.md").write_text(
+        "# LobsterCore\n\nStatus: active\n\nAlways-on assistant.\n",
+        encoding="utf-8",
+    )
+    (projects_dir / "transformers.md").write_text(
+        "# Transformers\n\nStatus: paused\n\nOn hold.\n",
+        encoding="utf-8",
+    )
+
+    priorities_file = root / "memory" / "canonical" / "priorities.md"
+    priorities_file.write_text(
+        "# Priorities\n\n"
+        "1. **Ship bridge sync fix** — close out #2180 and #2181\n"
+        "2. **Reconcile priorities.md** — nightly consolidation step 7\n",
+        encoding="utf-8",
+    )
+
+    return root
+
+
+@pytest.fixture
+def workspace_root(tmp_path: Path) -> Path:
+    """A temp workspace root (separate from canonical_root) that owns the DB and _context.md output."""
+    root = tmp_path / "workspace-root"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def empty_canonical_root(tmp_path: Path) -> Path:
+    """A canonical root with no projects/priorities files at all."""
+    root = tmp_path / "empty-canonical-root"
+    (root / "memory" / "canonical" / "projects").mkdir(parents=True)
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Import shape (guards #2180)
+# ---------------------------------------------------------------------------
+
+
+class TestImportShape:
+    """The script must be importable with a plain module import."""
+
+    def test_imports_without_sys_path_or_mcp_prefix_trick(self):
+        """
+        A plain `from scripts.run_nightly_bridge_sync import main` must work.
+        If this ever again required `sys.path.insert(0, 'src')` plus a
+        `mcp.user_model...`-prefixed import to reach the real bridges module,
+        #2180's ModuleNotFoundError would be back.
+        """
+        from scripts.run_nightly_bridge_sync import main  # noqa: F401
+
+        assert callable(main)
+
+    def test_module_never_imports_user_model_via_mcp_prefix(self):
+        """
+        Guard against the exact regression shape: source must not contain
+        `from mcp.user_model` or `import mcp.user_model`, which is precisely
+        the import that breaks once the installed MCP-SDK `mcp` package
+        shadows the namespace-package `src/mcp`.
+        """
+        script_path = REPO_ROOT / "scripts" / "run_nightly_bridge_sync.py"
+        source = script_path.read_text(encoding="utf-8")
+        assert "from mcp.user_model" not in source
+        assert "import mcp.user_model" not in source
+
+
+# ---------------------------------------------------------------------------
+# Connection factory (guards #2181)
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionFactory:
+    """The script must always open the DB via open_db(), never bare sqlite3.connect()."""
+
+    def test_open_connection_uses_row_factory_sqlite_row(self, workspace_root: Path):
+        from scripts.run_nightly_bridge_sync import open_connection
+
+        db_path = workspace_root / "data" / "memory.db"
+        conn = open_connection(db_path)
+        try:
+            assert conn.row_factory is sqlite3.Row
+        finally:
+            conn.close()
+
+    def test_module_never_opens_db_with_bare_sqlite3_connect(self):
+        """
+        Guard against the exact regression shape: the script's own connection
+        helper must route through user_model.db.open_db() (which sets
+        row_factory = sqlite3.Row), not a bare sqlite3.connect() call that
+        would leave row_factory as None and break dict-style row access.
+        """
+        script_path = REPO_ROOT / "scripts" / "run_nightly_bridge_sync.py"
+        source = script_path.read_text(encoding="utf-8")
+        assert "open_db(" in source
+        # No bare `sqlite3.connect(` call anywhere in the script.
+        assert "sqlite3.connect(" not in source
+
+
+# ---------------------------------------------------------------------------
+# Happy path: independent canonical_root / workspace_root (guards pre-#2136 bug)
+# ---------------------------------------------------------------------------
+
+
+class TestRunNightlyBridgeSync:
+    def test_syncs_projects_and_injects_priorities_from_canonical_root(
+        self, canonical_root: Path, workspace_root: Path
+    ):
+        from scripts.run_nightly_bridge_sync import run
+
+        result = run(canonical_root=canonical_root, workspace_root=workspace_root)
+
+        assert result["projects"]["synced"] == 2
+        assert result["projects"]["created"] == 2
+        assert result["priorities"]["injected"] == 2
+
+    def test_writes_context_cache_under_workspace_root_not_canonical_root(
+        self, canonical_root: Path, workspace_root: Path
+    ):
+        from scripts.run_nightly_bridge_sync import run
+
+        run(canonical_root=canonical_root, workspace_root=workspace_root)
+
+        context_file = workspace_root / "user-model" / "_context.md"
+        assert context_file.exists()
+        content = context_file.read_text(encoding="utf-8")
+        assert "LobsterCore" in content or "Transformers" in content
+
+        # Never written under canonical_root.
+        assert not (canonical_root / "user-model" / "_context.md").exists()
+
+    def test_canonical_root_and_workspace_root_must_be_independent(
+        self, canonical_root: Path, workspace_root: Path
+    ):
+        """
+        Regression guard for the pre-#2136 bug: run_bridges() took a single
+        shared workspace_path for both reads and writes. If canonical_root
+        and workspace_root were silently collapsed into one path again, a
+        mismatched pair (real canonical data, empty/different workspace)
+        would silently produce a near-empty read instead of the populated one.
+        """
+        from scripts.run_nightly_bridge_sync import run
+
+        # canonical_root has 2 project files and 2 priority items; a *third*,
+        # unrelated empty directory stands in for "the workspace". If reads
+        # were incorrectly rooted at workspace_root instead of canonical_root,
+        # this would report 0 synced / 0 injected instead of 2 / 2.
+        result = run(canonical_root=canonical_root, workspace_root=workspace_root)
+        assert result["projects"]["synced"] == 2
+        assert result["priorities"]["injected"] == 2
+
+        # And swapping them must change the outcome to near-empty, proving
+        # the two roots are not silently aliased to each other.
+        empty_root = workspace_root.parent / "swap-empty-root"
+        empty_root.mkdir()
+        swapped = run(canonical_root=empty_root, workspace_root=canonical_root)
+        assert swapped["projects"]["synced"] == 0
+        assert swapped["priorities"]["injected"] == 0
+
+    def test_empty_canonical_root_reports_zero_without_crashing(
+        self, empty_canonical_root: Path, workspace_root: Path
+    ):
+        from scripts.run_nightly_bridge_sync import run
+
+        result = run(canonical_root=empty_canonical_root, workspace_root=workspace_root)
+        assert result["projects"]["synced"] == 0
+        assert result["priorities"]["injected"] == 0
+
+    def test_main_accepts_canonical_root_and_workspace_root_as_separate_cli_args(
+        self, canonical_root: Path, workspace_root: Path, capsys
+    ):
+        from scripts.run_nightly_bridge_sync import main
+
+        exit_code = main(
+            [
+                "--canonical-root",
+                str(canonical_root),
+                "--workspace-root",
+                str(workspace_root),
+            ]
+        )
+
+        assert exit_code == 0
+        out = capsys.readouterr().out
+        assert '"synced": 2' in out
+        assert (workspace_root / "user-model" / "_context.md").exists()


### PR DESCRIPTION
## Problem

Nightly-consolidation's step 10 ("bridge sync") pushes canonical
`projects/*.md` / `priorities.md` into the user-model DB and regenerates
`_context.md`. The logic for that step has, twice now, been hand-copied as
inline Python between two agent-definition files that live in two different
repos: this repo's `.claude/agents/nightly-consolidation.md`, and a
private-config-overlay copy at `~/lobster-user-config/.claude/agents/nightly-consolidation.md`
(outside `SiderealPress/lobster`, per the overlay pattern in
`docs/CUSTOMIZATION.md`).

PR #2136 fixed two bugs in this repo's copy on 2026-08-02. The overlay copy
was never updated, so a 2026-08-09 run using the overlay's stale command hit
both bugs again, live:

- **#2180** — `ModuleNotFoundError`. The stale command does
  `sys.path.insert(0, 'src')` then `from mcp.user_model.bridges import
  run_bridges`. Because `src/mcp` has no `__init__.py`, it loses import
  precedence to the *installed* MCP-SDK `mcp` package once only `src` (not
  `src/mcp`) is on `sys.path` — so `mcp.user_model` resolves to nothing.
- **#2181** — `TypeError: tuple indices must be integers or slices, not str`.
  Even after working around #2180, the stale command opens the DB with a bare
  `sqlite3.connect()`, leaving `row_factory` unset. `user_model.db` query
  helpers (e.g. `get_active_narrative_arcs()`) do dict-style row access
  (`row["id"]`), which raises without `row_factory = sqlite3.Row`. The error
  is swallowed by `run_bridges()`'s broad `except Exception` and surfaces only
  as `{"projects": {"error": "..."}}` in the returned summary — no crash, no
  traceback, just zero projects synced, easy to miss in a "successful" run.

Copy-pasting the fixed command text into the overlay file again would only
fix this occurrence — the underlying problem (inline logic embedded in agent
markdown, hand-kept in sync with `src/mcp/user_model/*` internals, with
nothing to catch drift) would recur.

## Fix

Extracts the bridge-sync invocation into `scripts/run_nightly_bridge_sync.py`,
a first-class, tested CLI that both this repo's agent file and any
private-overlay copy can invoke by path instead of embedding raw Python:

- `_import_user_model()` puts `src/mcp` itself (not `src`) on `sys.path` and
  imports `user_model.bridges` / `user_model.db` with no `mcp.` prefix,
  sidestepping the namespace-package collision (#2180).
- `open_connection()` always opens the DB via `user_model.db.open_db()`,
  which sets `row_factory = sqlite3.Row` (#2181) — the script never calls
  `sqlite3.connect()` directly.
- `--canonical-root` and `--workspace-root` are kept as two independent,
  required CLI arguments (rather than one shared path), preserving the fix
  PR #2136 already made for a separate, earlier bug where a single shared
  `workspace_path` caused an empty canonical read and a near-empty
  `_context.md` overwrite.
- `run()` reports per-substep errors (`projects` / `priorities` /
  `context_cache`) in its JSON output rather than swallowing them, and
  `main()` exits non-zero if any substep errored — a "successful" run can no
  longer silently hide a partial failure the way `run_bridges()` did.

Updates this repo's `.claude/agents/nightly-consolidation.md` step 10 to call
the script by path, and adds a note that any private-overlay copy of step 10
should do the same. The private-overlay file itself is outside this repo
(`~/lobster-user-config`) and out of scope for this PR — updating it is a
follow-up action, not a code change here.

**Functional patterns used:** `run()` is a pure function of its three inputs
(`canonical_root`, `workspace_root`, `db_path`) plus the DB — no module-level
mutable state; the three sub-syncs are composed sequentially with each
failure isolated and captured in the returned summary dict rather than
raised, so a failure in one sub-step can't hide or corrupt the others'
results; `_import_user_model()` isolates the only side-effecting `sys.path`
mutation at a single boundary.

## Manual test

Both original bugs were reproduced live against a disposable `/tmp` fixture
(not the production DB) and confirmed fixed:

```
# #2180 repro — stale mcp.-prefixed import:
$ uv run python -c "
import sys; sys.path.insert(0, 'src')
from mcp.user_model.bridges import run_bridges"
ModuleNotFoundError: No module named 'mcp.user_model'

# #2181 repro — bare sqlite3.connect(), second run (existing arcs to iterate):
$ uv run python -c "
import sys, os; sys.path.insert(0, os.path.join(os.getcwd(), 'src', 'mcp'))
from user_model.bridges import run_bridges
import sqlite3; conn = sqlite3.connect('/tmp/bridge_repro/data/memory.db')
print(run_bridges(conn, '/tmp/bridge_repro'))"
{'projects': {'error': 'tuple indices must be integers or slices, not str'}, ...}

# Same second run via the new script — no error, row_factory set correctly:
$ uv run python scripts/run_nightly_bridge_sync.py \
    --canonical-root /tmp/bridge_repro --workspace-root /tmp/bridge_repro
{"projects": {"synced": 1, "created": 0, "updated": 1}, "priorities": {"injected": 0}, "context_cache": "written"}
```

Did not run the script against the live `~/lobster-workspace/data/memory.db`
— PR #2136 deliberately avoided this too, since it mutates production
user-model data. The `/tmp` fixture reproduces the same code paths
(`get_active_narrative_arcs()` dict-row access, `open_db()` vs bare
`sqlite3.connect()`) without touching production state.

## Tests run

- [x] `uv run pytest tests/unit/test_run_nightly_bridge_sync.py -v` — 9 passed, 0 failed
- [x] Falsifiability check for #2180: reintroduced the `mcp.`-prefixed import in `_import_user_model()`, reran the suite — 7 of 9 tests failed with `ModuleNotFoundError: No module named 'mcp.user_model'` (the exact regression shape); reverted, 9/9 passed again.
- [x] Falsifiability check for #2181: reintroduced a bare `sqlite3.connect()` in `open_connection()`, reran the suite — 7 of 9 tests failed (`AssertionError: assert None is <class 'sqlite3.Row'>`, `KeyError: 'synced'`, etc.); reverted, 9/9 passed again.
- [ ] Full `tests/unit/` suite — not run; timed out at 2 minutes in this environment before completing (pre-existing suite runtime, unrelated to this change). Scoped run of the new test file completed in ~1.5s.

**Blocked items needing attention before merge:** none. The full-suite timeout is an environment/runtime characteristic, not something this change introduces — the new test file runs standalone and fast.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests — fixtures use `tmp_path`)
- [x] Manual reproduction of both original bugs, against a disposable `/tmp` fixture, confirmed fixed — see `## Manual test`
- [x] Side-effect audit: script only ever writes under its `--workspace-root` argument (test fixtures use `tmp_path`, isolated per test); no writes to production `~/lobster-workspace` were performed by any test or manual run
- [ ] Live production run — not performed; deliberately out of scope (mutates the live user-model DB), consistent with PR #2136's same decision

## Out of scope

- The private-overlay file itself (`~/lobster-user-config/.claude/agents/nightly-consolidation.md`) lives outside this repo and is not touched by this PR — updating it to call the new script is a follow-up action for whoever maintains that overlay.
- No changes to `src/mcp/user_model/bridges.py` or `db.py` — both already behave correctly; the bugs were entirely in how the stale overlay command called them.
- No changes to any other nightly-consolidation step.

Closes #2180
Closes #2181