### PR TITLE
fix(update): stop update-lobster.sh from killing itself mid-update

### DIFF
--- a/scripts/update-lobster.sh
+++ b/scripts/update-lobster.sh
@@ -43,13 +43,36 @@ MESSAGES_DIR="${LOBSTER_MESSAGES:-$HOME/messages}"
 LOBSTER_CONFIG_DIR="${LOBSTER_CONFIG_DIR:-$HOME/lobster-config}"
 CONFIG_FILE="$LOBSTER_CONFIG_DIR/config.env"
 
-# Lock file
-LOCK_FILE="/tmp/lobster-update.lock"
+# Lock file (overridable for test isolation; production default unchanged)
+LOCK_FILE="${LOBSTER_UPDATE_LOCK_FILE:-/tmp/lobster-update.lock}"
 
-# Services (in stop order - claude first, then mcp-local, then router)
-SERVICES_STOP=("lobster-claude" "lobster-mcp-local" "lobster-router")
+#-------------------------------------------------------------------------------
+# Services
+#
+# lobster-claude is deliberately EXCLUDED from SERVICES_STOP/SERVICES_START
+# (issue #2179). This script is normally invoked via a Bash tool call from
+# inside the live lobster-claude dispatcher session itself, which makes its
+# own process tree a descendant of lobster-claude.service's cgroup. Stopping
+# lobster-claude mid-flow (as the old code did, first, via SERVICES_STOP)
+# tears down that whole cgroup -- including this very script -- before
+# git_update()/update_dependencies()/update_systemd() or the mcp-local/router
+# restart ever run. systemd's Restart=on-failure then silently brings
+# lobster-claude back up, which looks like "update finished" but nothing
+# after the "Stopping lobster-claude..." log line ever executed.
+#
+# Fix: lobster-claude is never stopped/started as part of the normal
+# stop-work-start cycle. Only lobster-mcp-local and lobster-router (which are
+# NOT the cgroup this script runs in) are cycled mid-flow. lobster-claude is
+# bounced via restart_self_last() as the literal last statement of main(),
+# after every meaningful step (git update, deps, systemd regen, CLI update,
+# mcp-local/router restart, health checks, success notification, lock
+# cleanup) has already completed -- so if this process dies right there, the
+# update has already actually happened.
+#-------------------------------------------------------------------------------
+SERVICE_SELF="lobster-claude"
+SERVICES_STOP=("lobster-mcp-local" "lobster-router")
 # Start order is reversed
-SERVICES_START=("lobster-router" "lobster-mcp-local" "lobster-claude")
+SERVICES_START=("lobster-router" "lobster-mcp-local")
 
 # State files to backup
 STATE_FILES=(
@@ -221,8 +244,10 @@ create_backup() {
         claude --version 2>/dev/null > "$BACKUP_DIR/claude-version.txt" || echo "unknown" > "$BACKUP_DIR/claude-version.txt"
     fi
 
-    # Save service states
-    for service in "${SERVICES_STOP[@]}"; do
+    # Save service states (SERVICES_STOP plus lobster-claude, which is
+    # handled separately by restart_self_last() -- see comment at the
+    # SERVICES_STOP/SERVICES_START declaration)
+    for service in "${SERVICES_STOP[@]}" "$SERVICE_SELF"; do
         if systemctl is-active --quiet "$service" 2>/dev/null; then
             echo "active" > "$BACKUP_DIR/${service}.state"
         else
@@ -240,35 +265,16 @@ create_backup() {
 stop_services() {
     log STEP "Stopping services"
 
+    # NOTE: lobster-claude is never in this array -- see comment at the
+    # SERVICES_STOP declaration. It is handled separately, last, by
+    # restart_self_last().
     for service in "${SERVICES_STOP[@]}"; do
         if systemctl is-active --quiet "$service" 2>/dev/null; then
             if $DRY_RUN; then
                 log INFO "Would stop $service"
             else
                 log INFO "Stopping $service..."
-
-                # For lobster-claude, wait for Claude to finish current work
-                if [ "$service" = "lobster-claude" ]; then
-                    # Send SIGTERM and wait up to 60 seconds
-                    sudo systemctl stop "$service" --no-block 2>/dev/null || true
-
-                    local wait_count=0
-                    while systemctl is-active --quiet "$service" 2>/dev/null && [ $wait_count -lt 60 ]; do
-                        sleep 1
-                        ((wait_count++))
-                        if [ $((wait_count % 10)) -eq 0 ]; then
-                            log INFO "Waiting for lobster-claude to finish... (${wait_count}s)"
-                        fi
-                    done
-
-                    if systemctl is-active --quiet "$service" 2>/dev/null; then
-                        log WARN "lobster-claude didn't stop gracefully, forcing..."
-                        sudo systemctl kill "$service" 2>/dev/null || true
-                        sleep 2
-                    fi
-                else
-                    sudo systemctl stop "$service" 2>/dev/null || true
-                fi
+                sudo systemctl stop "$service" 2>/dev/null || true
 
                 if ! systemctl is-active --quiet "$service" 2>/dev/null; then
                     log OK "$service stopped"
@@ -311,6 +317,39 @@ start_services() {
         return 1
     fi
     return 0
+}
+
+#-------------------------------------------------------------------------------
+# Restart self (lobster-claude) -- LAST, on purpose (issue #2179)
+#
+# Must only ever be called after every other meaningful step has already
+# completed: git update, deps, systemd regen, CLI update, mcp-local/router
+# restart, health checks, success notification, and lock cleanup. By the
+# time this runs, there is nothing left that this process dying mid-flight
+# could leave incomplete.
+#
+# Uses --no-block deliberately: this call may itself trigger the cgroup
+# teardown that kills the very process making the call (when invoked from
+# inside the live lobster-claude session), so it must not wait around for a
+# result. systemd's Restart=on-failure (or the graceful stop/start pair this
+# triggers) brings lobster-claude back up on its own with the newly updated
+# code.
+#-------------------------------------------------------------------------------
+restart_self_last() {
+    log STEP "Restarting $SERVICE_SELF (last step)"
+
+    if $DRY_RUN; then
+        log INFO "Would restart $SERVICE_SELF"
+        return 0
+    fi
+
+    if systemctl is-active --quiet "$SERVICE_SELF" 2>/dev/null; then
+        log INFO "Restarting $SERVICE_SELF..."
+        sudo systemctl restart "$SERVICE_SELF" --no-block 2>/dev/null || true
+    else
+        log INFO "Starting $SERVICE_SELF..."
+        sudo systemctl start "$SERVICE_SELF" --no-block 2>/dev/null || true
+    fi
 }
 
 #-------------------------------------------------------------------------------
@@ -604,8 +643,11 @@ health_checks() {
         return 0
     fi
 
-    # Check services running
-    for service in "${SERVICES_START[@]}"; do
+    # Check services running (SERVICES_START plus lobster-claude, which
+    # hasn't been touched yet at this point -- it's restarted separately,
+    # last, by restart_self_last() -- so this just confirms it's still
+    # healthy going into that final step)
+    for service in "${SERVICES_START[@]}" "$SERVICE_SELF"; do
         if systemctl is-active --quiet "$service" 2>/dev/null; then
             log OK "$service is running"
         else
@@ -613,6 +655,20 @@ health_checks() {
             failed=true
         fi
     done
+
+    # Verify the repo actually landed on the commit git_update() merged to
+    # (issue #2179, suggested-fix option 3: catch a partial/interrupted
+    # update instead of letting it silently look like success).
+    if [ -n "$CURRENT_COMMIT" ]; then
+        local actual_head
+        actual_head=$(cd "$LOBSTER_DIR" && git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+        if [ "$actual_head" = "$CURRENT_COMMIT" ]; then
+            log OK "Repository HEAD confirmed at $CURRENT_COMMIT"
+        else
+            log ERROR "Repository HEAD is $actual_head, expected $CURRENT_COMMIT -- update did not fully apply"
+            failed=true
+        fi
+    fi
 
     # Check MCP server registration
     if claude mcp list 2>/dev/null | grep -q "lobster-inbox"; then
@@ -676,6 +732,16 @@ health_checks() {
 #-------------------------------------------------------------------------------
 
 perform_rollback() {
+    # $1: "true" to also bounce lobster-claude (self) as the last step, once
+    # everything else below has finished. Only pass "true" for the explicit
+    # `--rollback` CLI invocation. In-flow failure-recovery call sites (git
+    # merge failed / services failed to start / health checks failed) must
+    # NOT pass this -- lobster-claude was never touched in those cases (it's
+    # only ever stopped/started by restart_self_last(), which hasn't run
+    # yet), so there is nothing to restart and doing so would cause an
+    # unnecessary, unrelated bounce of a perfectly healthy service.
+    local restart_self="${1:-false}"
+
     log STEP "Performing rollback"
 
     # Find most recent backup
@@ -716,6 +782,10 @@ perform_rollback() {
 
     # Start services
     start_services
+
+    if [ "$restart_self" = "true" ]; then
+        restart_self_last
+    fi
 
     log OK "Rollback complete"
 }
@@ -849,7 +919,11 @@ main() {
     trap cleanup_lock EXIT
 
     if $ROLLBACK; then
-        perform_rollback
+        # restart_self=true: an explicit --rollback changes the checked-out
+        # commit, so lobster-claude should pick up the restored code, same
+        # as the normal update path -- as the last step, after rollback work
+        # (git checkout, state restore, mcp-local/router restart) is done.
+        perform_rollback true
         cleanup_lock
         exit 0
     fi
@@ -934,6 +1008,15 @@ main() {
     fi
 
     cleanup_lock
+
+    # Phase 11 (LAST, on purpose -- issue #2179): bounce lobster-claude only
+    # now that everything above -- git update, deps, systemd regen, CLI
+    # update, mcp-local/router restart, health checks, HEAD verification,
+    # success notification, and lock cleanup -- has already completed. If
+    # this call triggers this very process's own termination (invoked from
+    # inside the live lobster-claude session), the update has already
+    # actually happened by this point.
+    restart_self_last
 }
 
 # Run main with all arguments

--- a/tests/test-update-lobster-self-restart-last.sh
+++ b/tests/test-update-lobster-self-restart-last.sh
@@ -1,0 +1,385 @@
+#!/bin/bash
+#===============================================================================
+# Test Suite: update-lobster.sh no longer kills itself mid-update (issue #2179)
+#
+# Root cause: SERVICES_STOP used to list "lobster-claude" first. When
+# update-lobster.sh runs as a descendant of lobster-claude.service's cgroup
+# (the normal way it gets invoked -- via a Bash tool call from inside the
+# live dispatcher session), stop_services()'s `systemctl stop lobster-claude`
+# tears down that whole cgroup, including the running update-lobster.sh
+# process itself, before git_update()/update_dependencies()/update_systemd()
+# or the mcp-local/router restart ever run. systemd's Restart=on-failure then
+# silently brings lobster-claude back up, which looks like "update finished"
+# but nothing meaningful ever happened.
+#
+# Fix: lobster-claude is excluded from SERVICES_STOP/SERVICES_START entirely
+# and is only ever bounced by restart_self_last(), called as the literal
+# last statement of main() -- after git update, deps, systemd regen, CLI
+# update, mcp-local/router restart, health checks, success notification, and
+# lock cleanup have already completed.
+#
+# Part A: SERVICES_STOP/SERVICES_START/SERVICE_SELF constants -- pure check,
+#         no process spawning.
+# Part B: Full integration run of the real script, in a hermetic fake
+#         environment, with systemctl/sudo/curl/claude mocked. The mock
+#         systemctl reproduces the actual cgroup-kill dynamic: whenever it is
+#         asked to touch "lobster-claude" (with self-kill simulation
+#         enabled), it sends SIGTERM then SIGKILL to the running
+#         update-lobster.sh process itself -- exactly what a real cgroup
+#         teardown does. This proves the meaningful work (git update to the
+#         target commit, mcp-local/router restart with new code, success
+#         notification, lock cleanup) all completes BEFORE lobster-claude is
+#         ever touched, so the update is not silently a no-op if that touch
+#         happens to kill this process.
+# Part C: Same hermetic run without self-kill simulation, to confirm the
+#         reordering did not break the normal (non-self-hosted) update path.
+#
+# Usage: bash tests/test-update-lobster-self-restart-last.sh
+#===============================================================================
+
+set -u
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UPDATE_SCRIPT="$REPO_ROOT/scripts/update-lobster.sh"
+
+begin_test() { TOTAL=$((TOTAL + 1)); test_name="$1"; }
+pass()  { PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC} $test_name"; }
+fail()  { FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC} $test_name: $1"; }
+
+assert_eq() {
+    local actual="$1" expected="$2"
+    if [[ "$actual" == "$expected" ]]; then pass; else fail "expected '$expected', got '$actual'"; fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2"
+    if [[ "$haystack" != *"$needle"* ]]; then pass; else fail "did not expect to find '$needle' in: $haystack"; fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2"
+    if [[ "$haystack" == *"$needle"* ]]; then pass; else fail "expected to find '$needle' in: $haystack"; fi
+}
+
+assert_file_absent() {
+    local path="$1"
+    if [[ ! -f "$path" ]]; then pass; else fail "expected file to NOT exist: $path"; fi
+}
+
+echo "=== update-lobster.sh self-restart-last tests (issue #2179) ==="
+echo ""
+
+# ===================================================================
+# Part A: SERVICES_STOP / SERVICES_START / SERVICE_SELF constants
+# ===================================================================
+echo "--- Part A: service ordering constants ---"
+
+# Extract just the variable declarations (avoid sourcing the whole script,
+# which unconditionally runs main() at the bottom).
+eval "$(sed -n '/^SERVICE_SELF=/,/^SERVICES_START=/p' "$UPDATE_SCRIPT")"
+
+begin_test "SERVICE_SELF is lobster-claude"
+assert_eq "$SERVICE_SELF" "lobster-claude"
+
+begin_test "SERVICES_STOP does not include lobster-claude"
+assert_not_contains "${SERVICES_STOP[*]}" "lobster-claude"
+
+begin_test "SERVICES_START does not include lobster-claude"
+assert_not_contains "${SERVICES_START[*]}" "lobster-claude"
+
+begin_test "SERVICES_STOP still includes lobster-mcp-local and lobster-router"
+assert_contains "${SERVICES_STOP[*]}" "lobster-mcp-local"
+begin_test "SERVICES_STOP includes lobster-router"
+assert_contains "${SERVICES_STOP[*]}" "lobster-router"
+
+echo ""
+
+# ===================================================================
+# Shared harness for Parts B and C: build a hermetic fake environment and
+# run the real script against it with systemctl/sudo/curl/claude mocked.
+# ===================================================================
+
+# setup_fixture: builds a fresh fake origin+clone repo, config, and mock bin
+# dir. Sets globals used by run_scenario / assertions.
+setup_fixture() {
+    FIXTURE_DIR=$(mktemp -d /tmp/lobster-update-selfrestart-test-XXXXXX)
+    FAKE_HOME="$FIXTURE_DIR/home"
+    FAKE_LOBSTER_DIR="$FIXTURE_DIR/lobster"
+    FAKE_ORIGIN_DIR="$FIXTURE_DIR/origin"
+    FAKE_WORKSPACE_DIR="$FIXTURE_DIR/workspace"
+    FAKE_MESSAGES_DIR="$FIXTURE_DIR/messages"
+    FAKE_CONFIG_DIR="$FIXTURE_DIR/lobster-config"
+    MOCK_BIN="$FIXTURE_DIR/bin"
+    STATE_DIR="$FIXTURE_DIR/svc-state"
+    CALL_LOG="$FIXTURE_DIR/systemctl-calls.log"
+    CURL_LOG="$FIXTURE_DIR/curl-calls.log"
+    TARGET_PID_FILE="$FIXTURE_DIR/target.pid"
+    LOCK_FILE="$FIXTURE_DIR/update.lock"
+    OUTPUT_LOG="$FIXTURE_DIR/update-output.log"
+
+    mkdir -p "$FAKE_HOME" "$FAKE_WORKSPACE_DIR" "$FAKE_MESSAGES_DIR/processed" \
+             "$FAKE_CONFIG_DIR" "$MOCK_BIN" "$STATE_DIR"
+
+    # --- fake origin repo: base commit, then one commit ahead (the "update") ---
+    git init -q -b main "$FAKE_ORIGIN_DIR"
+    git -C "$FAKE_ORIGIN_DIR" config user.email test@example.invalid
+    git -C "$FAKE_ORIGIN_DIR" config user.name "Test"
+    mkdir -p "$FAKE_ORIGIN_DIR/scripts/lib"
+    # Minimal stub so update_systemd()'s `source scripts/lib/template.sh`
+    # succeeds even though this fixture has no real service templates.
+    cat > "$FAKE_ORIGIN_DIR/scripts/lib/template.sh" <<'STUB'
+_tmpl_generate_from_template() { return 0; }
+STUB
+    echo "base" > "$FAKE_ORIGIN_DIR/VERSION"
+    git -C "$FAKE_ORIGIN_DIR" add -A
+    git -C "$FAKE_ORIGIN_DIR" commit -q -m "base commit"
+    BASE_COMMIT=$(git -C "$FAKE_ORIGIN_DIR" rev-parse HEAD)
+
+    echo "updated" > "$FAKE_ORIGIN_DIR/VERSION"
+    git -C "$FAKE_ORIGIN_DIR" add -A
+    git -C "$FAKE_ORIGIN_DIR" commit -q -m "the update the test is proving gets applied"
+    NEW_COMMIT_SHORT=$(git -C "$FAKE_ORIGIN_DIR" rev-parse --short HEAD)
+
+    # --- local clone, rolled back to the base commit (origin/main stays ahead) ---
+    git clone -q "$FAKE_ORIGIN_DIR" "$FAKE_LOBSTER_DIR"
+    git -C "$FAKE_LOBSTER_DIR" config user.email test@example.invalid
+    git -C "$FAKE_LOBSTER_DIR" config user.name "Test"
+    git -C "$FAKE_LOBSTER_DIR" reset -q --hard "$BASE_COMMIT"
+
+    # --- config ---
+    cat > "$FAKE_CONFIG_DIR/config.env" <<CFG
+TELEGRAM_BOT_TOKEN=test-token-123
+TELEGRAM_ALLOWED_USERS=999
+CFG
+
+    # --- initial simulated service state: all three "active" ---
+    echo "active" > "$STATE_DIR/lobster-claude"
+    echo "active" > "$STATE_DIR/lobster-mcp-local"
+    echo "active" > "$STATE_DIR/lobster-router"
+
+    : > "$CALL_LOG"
+    : > "$CURL_LOG"
+
+    build_mocks
+}
+
+build_mocks() {
+    # --- mock systemctl: tracks simulated service state, logs every call,
+    # and (when self-kill simulation is enabled) reproduces the real cgroup
+    # teardown by sending SIGTERM/SIGKILL to the running update-lobster.sh
+    # process the moment it is asked to touch lobster-claude. ---
+    cat > "$MOCK_BIN/systemctl" <<'MOCK'
+#!/bin/bash
+STATE_DIR="${LOBSTER_TEST_SVC_STATE_DIR:?}"
+LOG="${LOBSTER_TEST_SYSTEMCTL_LOG:-/dev/null}"
+echo "$*" >> "$LOG"
+
+action=""
+service=""
+for arg in "$@"; do
+    case "$arg" in
+        --no-block|--quiet) ;;
+        is-active|stop|start|restart|kill|daemon-reload)
+            [ -z "$action" ] && action="$arg" ;;
+        *) [ -z "$service" ] && service="$arg" ;;
+    esac
+done
+
+case "$action" in
+    is-active)
+        state=$(cat "$STATE_DIR/$service" 2>/dev/null || echo "inactive")
+        [ "$state" = "active" ]
+        exit $?
+        ;;
+    stop|kill)
+        echo "inactive" > "$STATE_DIR/$service"
+        ;;
+    start|restart)
+        echo "active" > "$STATE_DIR/$service"
+        ;;
+    daemon-reload)
+        exit 0
+        ;;
+esac
+
+# Reproduce the cgroup-teardown dynamic: touching lobster-claude while this
+# script is (simulated to be) a descendant of its cgroup kills this process.
+if [ "$service" = "lobster-claude" ] && [ "$action" != "is-active" ] \
+   && [ "${LOBSTER_TEST_SIMULATE_SELF_KILL:-0}" = "1" ]; then
+    pid_file="${LOBSTER_TEST_TARGET_PID_FILE:?}"
+    if [ -f "$pid_file" ]; then
+        target_pid=$(cat "$pid_file")
+        kill -TERM "$target_pid" 2>/dev/null || true
+        sleep 0.2
+        kill -KILL "$target_pid" 2>/dev/null || true
+    fi
+fi
+
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/systemctl"
+
+    # --- mock sudo: logs, then delegates systemctl calls to the mock above
+    # (everything else -- e.g. `sudo cp`, `sudo chmod` -- is executed for
+    # real, but this fixture's fake repo has none of the files that would
+    # trigger those paths, so nothing outside the fixture is ever touched). ---
+    cat > "$MOCK_BIN/sudo" <<'MOCK'
+#!/bin/bash
+echo "$*" >> "${LOBSTER_TEST_SUDO_LOG:-/dev/null}"
+if [ "$1" = "systemctl" ]; then
+    shift
+    exec "${MOCK_SYSTEMCTL:?}" "$@"
+fi
+exec "$@"
+MOCK
+    chmod +x "$MOCK_BIN/sudo"
+
+    # --- mock claude: satisfies create_backup()'s `claude --version` and
+    # health_checks()'s `claude mcp list`. ---
+    cat > "$MOCK_BIN/claude" <<'MOCK'
+#!/bin/bash
+case "${1:-}" in
+    mcp) echo "lobster-inbox  connected"; exit 0 ;;
+    --version) echo "1.0.0-test"; exit 0 ;;
+    *) exit 0 ;;
+esac
+MOCK
+    chmod +x "$MOCK_BIN/claude"
+
+    # --- mock curl: logs every call (so notify_success/notify_starting/
+    # notify_failure POSTs can be asserted on) and fakes just enough
+    # response content for preflight connectivity + telegram checks to pass,
+    # without ever making a real network call. ---
+    cat > "$MOCK_BIN/curl" <<'MOCK'
+#!/bin/bash
+echo "$*" >> "${LOBSTER_TEST_CURL_LOG:-/dev/null}"
+url=""
+for arg in "$@"; do
+    case "$arg" in http*) url="$arg" ;; esac
+done
+case "$url" in
+    *getMe*) echo '{"ok":true}' ;;
+    *sendMessage*) echo '{"ok":true,"result":{}}' ;;
+    *) : ;;
+esac
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/curl"
+}
+
+# run_scenario SIMULATE_SELF_KILL -- runs the real update-lobster.sh against
+# the fixture built by setup_fixture, in the background, recording its PID
+# where the mock systemctl can find it. Sets RUN_EXIT_CODE.
+run_scenario() {
+    local simulate_kill="$1"
+
+    PATH="$MOCK_BIN:$PATH" \
+    HOME="$FAKE_HOME" \
+    LOBSTER_INSTALL_DIR="$FAKE_LOBSTER_DIR" \
+    LOBSTER_WORKSPACE="$FAKE_WORKSPACE_DIR" \
+    LOBSTER_MESSAGES="$FAKE_MESSAGES_DIR" \
+    LOBSTER_CONFIG_DIR="$FAKE_CONFIG_DIR" \
+    LOBSTER_UPDATE_LOCK_FILE="$LOCK_FILE" \
+    MOCK_SYSTEMCTL="$MOCK_BIN/systemctl" \
+    LOBSTER_TEST_SVC_STATE_DIR="$STATE_DIR" \
+    LOBSTER_TEST_SYSTEMCTL_LOG="$CALL_LOG" \
+    LOBSTER_TEST_CURL_LOG="$CURL_LOG" \
+    LOBSTER_TEST_TARGET_PID_FILE="$TARGET_PID_FILE" \
+    LOBSTER_TEST_SIMULATE_SELF_KILL="$simulate_kill" \
+    bash "$UPDATE_SCRIPT" --skip-claude > "$OUTPUT_LOG" 2>&1 &
+    local pid=$!
+    echo "$pid" > "$TARGET_PID_FILE"
+    wait "$pid"
+    RUN_EXIT_CODE=$?
+}
+
+cleanup_fixture() {
+    [ -n "${FIXTURE_DIR:-}" ] && rm -rf "$FIXTURE_DIR"
+}
+
+# ===================================================================
+# Part B: self-kill simulation -- the actual issue #2179 scenario
+# ===================================================================
+echo "--- Part B: reproduces the cgroup self-kill while touching lobster-claude ---"
+
+setup_fixture
+run_scenario 1
+
+FINAL_HEAD=$(git -C "$FAKE_LOBSTER_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+begin_test "git update completed before lobster-claude was ever touched"
+assert_eq "$FINAL_HEAD" "$NEW_COMMIT_SHORT"
+
+begin_test "lobster-mcp-local was restarted (with the new code) before lobster-claude was touched"
+assert_contains "$(cat "$CALL_LOG")" "start lobster-mcp-local"
+
+begin_test "lobster-router was restarted (with the new code) before lobster-claude was touched"
+assert_contains "$(cat "$CALL_LOG")" "start lobster-router"
+
+begin_test "lobster-claude was still eventually bounced (self-restart step actually ran)"
+CLAUDE_CALL_LINE=$(grep -n "lobster-claude" "$CALL_LOG" | tail -1 | cut -d: -f1)
+if [ -n "$CLAUDE_CALL_LINE" ]; then pass; else fail "no systemctl call ever touched lobster-claude"; fi
+
+begin_test "lobster-claude was touched only AFTER mcp-local/router were restarted (self-last ordering)"
+MCP_LOCAL_LINE=$(grep -n "start lobster-mcp-local" "$CALL_LOG" | head -1 | cut -d: -f1)
+ROUTER_LINE=$(grep -n "start lobster-router" "$CALL_LOG" | head -1 | cut -d: -f1)
+if [ -n "$CLAUDE_CALL_LINE" ] && [ -n "$MCP_LOCAL_LINE" ] && [ -n "$ROUTER_LINE" ] \
+   && [ "$CLAUDE_CALL_LINE" -gt "$MCP_LOCAL_LINE" ] && [ "$CLAUDE_CALL_LINE" -gt "$ROUTER_LINE" ]; then
+    pass
+else
+    fail "expected lobster-claude call (line $CLAUDE_CALL_LINE) after mcp-local (line $MCP_LOCAL_LINE) and router (line $ROUTER_LINE)"
+fi
+
+begin_test "success notification was sent before the self-kill point"
+assert_contains "$(cat "$CURL_LOG")" "sendMessage"
+begin_test "success notification text confirms the update, not a failure"
+assert_contains "$(cat "$CURL_LOG")" "updated successfully"
+
+begin_test "lock file was cleaned up even though the process was killed"
+assert_file_absent "$LOCK_FILE"
+
+cleanup_fixture
+
+echo ""
+
+# ===================================================================
+# Part C: normal run (no self-kill) still completes cleanly end-to-end --
+# regression guard that reordering did not break the happy path.
+# ===================================================================
+echo "--- Part C: normal run without self-kill still completes end-to-end ---"
+
+setup_fixture
+run_scenario 0
+
+FINAL_HEAD_C=$(git -C "$FAKE_LOBSTER_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+begin_test "exits 0 on a clean run"
+assert_eq "$RUN_EXIT_CODE" "0"
+
+begin_test "git update completed"
+assert_eq "$FINAL_HEAD_C" "$NEW_COMMIT_SHORT"
+
+begin_test "lobster-claude ends up restarted"
+assert_eq "$(cat "$STATE_DIR/lobster-claude")" "active"
+
+begin_test "output reports UPDATE COMPLETE"
+assert_contains "$(cat "$OUTPUT_LOG")" "UPDATE COMPLETE"
+
+cleanup_fixture
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed ==="
+if [ "$FAIL" -gt 0 ]; then
+    echo -e "${RED}$FAIL test(s) failed${NC}"
+    exit 1
+fi
+echo -e "${GREEN}All tests passed${NC}"
+exit 0


### PR DESCRIPTION
## Problem

`update-lobster.sh` is normally invoked via a Bash tool call from inside the live `lobster-claude` dispatcher session — that's how "do lobster update" gets triggered. That makes the script's own process tree a descendant of `lobster-claude.service`'s cgroup. `SERVICES_STOP` listed `lobster-claude` *first*, so `stop_services()`'s `systemctl stop lobster-claude` tore down that whole cgroup — including the running `update-lobster.sh` process itself — before `git_update()`, `update_dependencies()`, `update_systemd()`, or the `lobster-mcp-local`/`lobster-router` restart ever ran.

systemd's `Restart=on-failure` then silently brought `lobster-claude` back up on its own, which read as "the update finished and restarted things," while the repo was never actually pulled and `mcp-local`/`router` were never bounced. This is not hypothetical — it recurred in production on 2026-08-09 (see issue) after an earlier occurrence on 2026-08-08.

Closes #2179.

## Fix

Implements suggested-fix option 2 from the issue (reorder so `lobster-claude` is stopped/started last), restructured as a proper "self-last" flow, plus option 3 (post-update verification) as a belt-and-suspenders addition:

- `lobster-claude` is removed from `SERVICES_STOP`/`SERVICES_START` entirely. Only `lobster-mcp-local` and `lobster-router` — services that are *not* the cgroup this script runs in — are stopped, updated for, and restarted mid-flow.
- A new `restart_self_last()` bounces `lobster-claude` (`systemctl restart --no-block`, matching the script's existing non-blocking pattern) as the **literal last statement of `main()`**, after git update, dependency install, systemd template regen, CLI update, mcp-local/router restart, health checks, success notification, and lock cleanup have all already completed. If that call is what triggers this process's own death, the update has already actually happened.
- `health_checks()` now also verifies `git rev-parse HEAD` matches the commit `git_update()` merged to, so a partially-applied update can no longer silently read as success.
- The explicit `--rollback` CLI path threads the same "restart self last" behavior through `perform_rollback()` (via a new `restart_self` parameter), since a manual rollback also changes the checked-out commit. The three in-flow failure-rollback call sites (git merge failed / services failed to start / health checks failed) do **not** pass this — `lobster-claude` was never touched in those paths (it's only ever touched by `restart_self_last()`, which hasn't run yet), so restarting it there would be an unnecessary, unrelated bounce of a perfectly healthy service.
- `LOCK_FILE` is now overridable via `LOBSTER_UPDATE_LOCK_FILE` (default unchanged: `/tmp/lobster-update.lock`) purely for test isolation — no production behavior change.

**Functional patterns used:** the fix is primarily a control-flow reorder with named constants (`SERVICE_SELF`) replacing an implicit "index 0 is special" convention; `restart_self_last()` is a single-purpose, side-effect-isolated function; `perform_rollback()`'s new behavior is threaded through an explicit parameter rather than a global/hidden flag, keeping the function's effects visible at each call site.

## Flow change

```
BEFORE (buggy):                          AFTER (fixed):
stop lobster-claude   <- kills self!     stop mcp-local, router
stop mcp-local                           git update
stop router                              deps / systemd / CLI update
git update            <- never reached   start mcp-local, router
deps / systemd / CLI                     health checks (+ HEAD verify)
start router, mcp-local,                 success notification
  lobster-claude                         cleanup_lock
health checks                            restart_self_last()  <- lobster-claude,
success notification                                             LAST, may kill self here
```

Before: touching `lobster-claude` at step 1 could kill the whole update before anything meaningful ran, and there was no way to tell from the outside. After: `lobster-claude` is the only thing that can still be running old code partway through, and it's touched only once everything else is verifiably done.

**Out of scope:** no changes to `install.sh`, `scripts/upgrade.sh`, service `.template` files, or the health-check script. Suggested-fix option 1 (re-exec via `systemd-run --scope` to fully detach from the cgroup) was not implemented — option 2 avoids the added complexity of a self re-exec while still being fully correct, since it only requires care about *when* `lobster-claude` is touched, not *whether* the script is inside its cgroup.

## Tests run

- [x] `bash tests/test-update-lobster-self-restart-last.sh` (new) — 17/17 passed. This test reproduces the actual cgroup-kill dynamic in a hermetic fixture: a mocked `systemctl` sends `SIGTERM` then `SIGKILL` to the running `update-lobster.sh` process itself the moment it's asked to touch `lobster-claude` (exactly what a real cgroup teardown does), against a fake git origin/clone with a real commit to pull. Part A checks the `SERVICES_STOP`/`SERVICES_START`/`SERVICE_SELF` constants directly. Part B asserts that by the time `lobster-claude` is touched, the fake repo has already fast-forwarded to the target commit, `lobster-mcp-local`/`lobster-router` were already restarted (in that log order, before the `lobster-claude` call), the success notification was already sent, and the lock file was already cleaned up. Part C is a regression guard that the reordering didn't break the normal (non-self-kill) path.
- [x] `bash -n scripts/update-lobster.sh` — clean.
- [x] Falsifiability check: reverted `scripts/update-lobster.sh` to the `origin/main` version and reran the test — Part A fails immediately (`SERVICE_SELF: unbound variable`, since the constant doesn't exist pre-fix). To confirm Part B/C fail for the *causally correct* reason (not just the missing constant), I ran a scratch variant of the test against the original script with Part A's constants hardcoded to the pre-fix values instead of extracted: 7/17 failed, specifically — `stop lobster-claude --no-block` is the very first systemctl call (right after startup `is-active` probes), the fake repo's git HEAD never advances past the base commit, `lobster-mcp-local`/`lobster-router` are never started, and the only notification sent is `notify_starting` ("Lobster updating") — `notify_success` never fires. This reproduces the exact production symptom described in the issue. Restored the fix afterward and reran — 17/17 passed again.
- [ ] Real end-to-end run against actual systemd units on this host — not run. This script restarts `lobster-mcp-local`/`lobster-router`/`lobster-claude` for real; running it live would have been a genuine, disruptive production side effect on the very system I'm working from (this task itself runs inside a `lobster-claude` session), not a scoped/reversible test. The hermetic integration test above reproduces the actual failure mechanism (cgroup teardown killing the running process) faithfully enough that a real run wasn't necessary to prove the fix; see the falsifiability check above for the causal confirmation.

## Manual test

Covered by the integration test above, which *is* the manual/simulated verification: it actually runs the real `scripts/update-lobster.sh` script (not a mock of it) end-to-end via `bash`, against a real (fake, local) git repo with a real fast-forward merge, with only `systemctl`/`sudo`/`curl`/`claude` mocked out — and the mock `systemctl` genuinely sends real `SIGTERM`/`SIGKILL` signals to the real running script process, reproducing the actual kill dynamic rather than simulating it symbolically. No real Telegram messages were sent (curl is mocked) and no real systemd units were touched (systemctl/sudo are mocked) — this was a from-scratch fixture, not a scoped production call, so there was nothing to ask the user to confirm.

## Definition of Done
- [x] Unit/integration tests pass with proper mocking (no production hits — no real systemctl/sudo/curl calls)
- [x] Integration test run (see above) — this *is* the manual verification for this change, given the alternative (a real run) would have live-restarted the services this task itself depends on
- [x] User-visible outcome: N/A — this is an internal reliability fix for an admin-triggered script; no new user-facing output. The existing Telegram success/failure notifications (`notify_success`/`notify_failure`) are unchanged in content, only in *when* they can now be reliably assumed accurate.
- [x] Side-effect audit: no floods, no unscoped writes. The fixture only ever touches its own `mktemp -d` directory; the only host-shared path touched by the test is `/tmp/lobster-update.lock`'s *equivalent*, which is redirected via the new `LOBSTER_UPDATE_LOCK_FILE` override so the real production lock file is never touched by tests.
- [x] External service calls: all mocked in tests (systemctl, sudo, curl, claude); no manual run against production services was performed (see above)

## Known gaps

- No real end-to-end run against this host's actual systemd units (see above) — flagging per policy in case a maintainer wants that done separately in a maintenance window before merge, though I don't think it's necessary given the integration test's fidelity.
- I don't have `read:project` scope on this token, so I couldn't move this issue's Main Board status to "In Review" — flagging so it can be moved manually.