### PR TITLE
fix(scripts): correct stale systemd unit name in restart-mcp.sh

### DIFF
--- a/scripts/restart-mcp.sh
+++ b/scripts/restart-mcp.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# restart-mcp.sh — Safe wrapper for restarting the lobster-mcp-local service.
+# restart-mcp.sh — Safe wrapper for restarting the lobster-mcp service.
 #
-# USE THIS SCRIPT instead of calling `sudo systemctl restart lobster-mcp-local`
+# USE THIS SCRIPT instead of calling `sudo systemctl restart lobster-mcp`
 # directly.  Direct restarts invalidate the active MCP session immediately,
 # leaving the dispatcher blocked in wait_for_messages with a "Session not found"
 # error and no recovery guidance.
@@ -9,7 +9,7 @@
 # This script:
 #   1. Writes an mcp-restart warning message to ~/messages/inbox/
 #   2. Waits 2 seconds for the dispatcher to process it
-#   3. Runs `sudo systemctl restart lobster-mcp-local`
+#   3. Runs `sudo systemctl restart lobster-mcp`
 #
 # The inbox message tells the dispatcher the restart is intentional and that
 # it should re-orient after reconnecting.  Combined with Fix 1
@@ -42,7 +42,7 @@ cat > "${MSG_FILE}.tmp" <<EOF
   "source": "system",
   "type": "compact-reminder",
   "chat_id": 0,
-  "text": "MCP RESTART INCOMING — The lobster-mcp-local service is about to restart. Your MCP session will be invalidated. Re-orient after reconnecting: read sys.dispatcher.bootup.md and resume the main loop.",
+  "text": "MCP RESTART INCOMING — The lobster-mcp service is about to restart. Your MCP session will be invalidated. Re-orient after reconnecting: read sys.dispatcher.bootup.md and resume the main loop.",
   "timestamp": "${TIMESTAMP}"
 }
 EOF
@@ -55,6 +55,6 @@ if [[ "${NO_WAIT}" == "false" ]]; then
     sleep 2
 fi
 
-echo "[restart-mcp] Restarting lobster-mcp-local..."
-sudo systemctl restart lobster-mcp-local
+echo "[restart-mcp] Restarting lobster-mcp..."
+sudo systemctl restart lobster-mcp
 echo "[restart-mcp] Service restarted."


### PR DESCRIPTION
## Summary
- `scripts/restart-mcp.sh` referenced a systemd unit named `lobster-mcp-local`, which does not exist on the VPS. The actually-running unit is `lobster-mcp.service`.
- Updates comments and the two `systemctl` invocations to use the correct unit name (`lobster-mcp`).
- Found incidentally during BIS-729 (already resolved directly via the correct unit name; this just fixes the wrapper script so it works going forward).

## Test plan
- [x] `bash -n scripts/restart-mcp.sh` — syntax OK
- [x] `systemctl status lobster-mcp.service` — confirmed unit exists and is active
- [x] `systemctl status lobster-mcp-local` — confirmed "Unit lobster-mcp-local.service could not be found"
- Did not actually run the restart script (would restart a live MCP session).

Note: this fix is scoped narrowly to `scripts/restart-mcp.sh` only. There are other references to `lobster-mcp-local` across the repo (install.sh, upgrade.sh, the systemd service template, docs, CLAUDE.md) that are out of scope here — see follow-up note to Drew.