### PR TITLE
fix: cron entries invoking bare 'uv' fail with "uv: not found"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1800,7 +1800,7 @@ success "Nightly consolidation configured (runs at 03:02 nightly)"
 # summary to ~/messages/task-outputs/ (readable via check_task_outputs).
 chmod +x "$INSTALL_DIR/scheduled-tasks/export-logs.py" 2>/dev/null || true
 "$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-LOG-EXPORT" \
-    "0 3 * * * cd $INSTALL_DIR && uv run scheduled-tasks/export-logs.py # LOBSTER-LOG-EXPORT"
+    "0 3 * * * cd $INSTALL_DIR && $HOME/.local/bin/uv run scheduled-tasks/export-logs.py # LOBSTER-LOG-EXPORT"
 
 success "Log export configured (runs at 03:00 UTC daily)"
 
@@ -1815,7 +1815,7 @@ step "Setting up ghost detector cron..."
 # and marks ghost sessions as failed in agent_sessions.db. No LLM involved.
 # Offset 2 (vs the */3 anchor) to avoid lcm-aligned overlap at :00.
 "$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-GHOST-DETECTOR" \
-    "2-59/5 * * * * cd $HOME && uv run $INSTALL_DIR/scripts/agent-monitor.py --alert --mark-failed >> $HOME/lobster-workspace/logs/agent-monitor.log 2>&1 # LOBSTER-GHOST-DETECTOR"
+    "2-59/5 * * * * cd $HOME && $HOME/.local/bin/uv run $INSTALL_DIR/scripts/agent-monitor.py --alert --mark-failed >> $HOME/lobster-workspace/logs/agent-monitor.log 2>&1 # LOBSTER-GHOST-DETECTOR"
 
 success "Ghost detector configured (runs every 5 minutes)"
 
@@ -1833,7 +1833,7 @@ step "Setting up OOM monitor cron..."
 # Even offset is deliberate: it makes the */4+*/10 offset parities disagree
 # on the gcd(4,10)=2 sub-lattice, so */3+*/4+*/10 never triple-fires.
 "$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-OOM-CHECK" \
-    "8-59/10 * * * * cd $HOME && uv run $INSTALL_DIR/scripts/oom-monitor.py --since-minutes 10 >> $HOME/lobster-workspace/logs/oom-monitor.log 2>&1 # LOBSTER-OOM-CHECK"
+    "8-59/10 * * * * cd $HOME && $HOME/.local/bin/uv run $INSTALL_DIR/scripts/oom-monitor.py --since-minutes 10 >> $HOME/lobster-workspace/logs/oom-monitor.log 2>&1 # LOBSTER-OOM-CHECK"
 
 success "OOM monitor configured (runs every 10 minutes, active only when LOBSTER_DEBUG=true)"
 
@@ -1892,7 +1892,7 @@ step "Setting up inflight reminders cron..."
 # check-inflight-reminders.py runs every 3 minutes to detect stale subagent work
 # and drop reminder messages into the dispatcher inbox. No LLM involved.
 "$INSTALL_DIR/scripts/cron-manage.sh" add "# LOBSTER-INFLIGHT-REMINDERS" \
-    "*/3 * * * * uv run $INSTALL_DIR/scripts/check-inflight-reminders.py >> $HOME/lobster-workspace/logs/inflight-reminders.log 2>&1 # LOBSTER-INFLIGHT-REMINDERS"
+    "*/3 * * * * $HOME/.local/bin/uv run $INSTALL_DIR/scripts/check-inflight-reminders.py >> $HOME/lobster-workspace/logs/inflight-reminders.log 2>&1 # LOBSTER-INFLIGHT-REMINDERS"
 
 success "Inflight reminders configured (runs every 3 minutes)"
 

--- a/scripts/lib/migrations.sh
+++ b/scripts/lib/migrations.sh
@@ -1032,7 +1032,7 @@ else:
     local OOM_CHECK_MARKER="# LOBSTER-OOM-CHECK"
     if ! crontab -l 2>/dev/null | grep -q "$OOM_CHECK_MARKER"; then
         "$LOBSTER_DIR/scripts/cron-manage.sh" add "$OOM_CHECK_MARKER" \
-            "*/10 * * * * cd $HOME && uv run $LOBSTER_DIR/scripts/oom-monitor.py --since-minutes 10 >> $WORKSPACE_DIR/logs/oom-monitor.log 2>&1 $OOM_CHECK_MARKER"
+            "*/10 * * * * cd $HOME && $HOME/.local/bin/uv run $LOBSTER_DIR/scripts/oom-monitor.py --since-minutes 10 >> $WORKSPACE_DIR/logs/oom-monitor.log 2>&1 $OOM_CHECK_MARKER"
         substep "Added OOM monitor cron entry (oom-monitor.py --since-minutes 10, every 10 min)"
         migrated=$((migrated + 1))
     fi
@@ -2064,7 +2064,7 @@ print(f'prune-pr-worktrees: {result.status}')
         chmod +x "$INFLIGHT_SCRIPT" 2>/dev/null || true
         if ! crontab -l 2>/dev/null | grep -qF "$INFLIGHT_MARKER"; then
             "$LOBSTER_DIR/scripts/cron-manage.sh" add "$INFLIGHT_MARKER" \
-                "*/3 * * * * uv run $INFLIGHT_SCRIPT >> $HOME/lobster-workspace/logs/inflight-reminders.log 2>&1 $INFLIGHT_MARKER" 2>/dev/null && {
+                "*/3 * * * * $HOME/.local/bin/uv run $INFLIGHT_SCRIPT >> $HOME/lobster-workspace/logs/inflight-reminders.log 2>&1 $INFLIGHT_MARKER" 2>/dev/null && {
                 substep "Added LOBSTER-INFLIGHT-REMINDERS cron entry (check-inflight-reminders.py, every 3 min)"
                 migrated=$((migrated + 1))
             } || warn "Could not add LOBSTER-INFLIGHT-REMINDERS cron entry — check cron-manage.sh"
@@ -2405,6 +2405,94 @@ M88_PYEOF
         fi
     else
         substep "Migration 98: settings.json or jq not found — skipping"
+    fi
+
+    # Migration 99: Fix bare `uv` cron entries that fail with "uv: not found".
+    # cron runs jobs with a minimal PATH (typically /usr/bin:/bin) that does not
+    # include ~/.local/bin, where the official uv installer places the binary.
+    # Migrations 28 (LOG-EXPORT) and 52 (GHOST-DETECTOR) already used the
+    # absolute path, but Migrations 53 (OOM-CHECK) and 87 (INFLIGHT-REMINDERS)
+    # shipped with a bare `uv run ...` invocation. Installs that ran those
+    # migrations before this fix landed have a crontab entry that has been
+    # silently failing on every single invocation ("/bin/sh: 1: uv: not found"
+    # in the job's log). Re-write each entry unconditionally (not gated on
+    # "marker missing") so already-broken installs get repaired, not just new
+    # ones. Idempotent: re-running when entries are already correct is a no-op
+    # (the grep -qF check below skips the rewrite).
+    local UV_BIN="$HOME/.local/bin/uv"
+    if [ -x "$UV_BIN" ]; then
+        local _m99_fixed=0
+
+        # Repairs a single cron entry atomically: builds the replacement
+        # crontab (original entry swapped for the new line) in a temp file
+        # WITHOUT touching the live crontab, then writes it in one shot.
+        # If the build or the write fails at any point, the live crontab is
+        # never touched and the original entry is left intact — the caller
+        # must not log success or count the migration as applied in that case.
+        # This replaces the previous two-step remove-then-add approach, which
+        # could silently drop the entry entirely if the re-add write failed
+        # after the removal had already succeeded.
+        _m99_repair_entry() {
+            local marker="$1" new_line="$2" tmp
+            tmp=$(mktemp) || { warn "Migration 99: could not create temp file for $marker repair"; return 1; }
+            if ! crontab -l 2>/dev/null | grep -v -F "# $marker" > "$tmp"; then
+                # grep -v exits 1 if the entry wasn't found in a non-empty
+                # crontab; that's fine, $tmp still holds the filtered output.
+                :
+            fi
+            echo "$new_line" >> "$tmp"
+            if crontab "$tmp" 2>/dev/null; then
+                rm -f "$tmp"
+                return 0
+            else
+                rm -f "$tmp"
+                warn "Migration 99: failed to write repaired $marker cron entry — leaving existing (broken) entry in place, will retry next upgrade"
+                return 1
+            fi
+        }
+
+        # OOM-CHECK
+        if crontab -l 2>/dev/null | grep -F "# LOBSTER-OOM-CHECK" | grep -qv "$UV_BIN"; then
+            if _m99_repair_entry "LOBSTER-OOM-CHECK" "8-59/10 * * * * cd $HOME && $UV_BIN run $LOBSTER_DIR/scripts/oom-monitor.py --since-minutes 10 >> $WORKSPACE_DIR/logs/oom-monitor.log 2>&1 # LOBSTER-OOM-CHECK"; then
+                substep "Migration 99: repaired LOBSTER-OOM-CHECK cron entry to use $UV_BIN"
+                _m99_fixed=1
+            fi
+        fi
+
+        # INFLIGHT-REMINDERS
+        if crontab -l 2>/dev/null | grep -F "# LOBSTER-INFLIGHT-REMINDERS" | grep -qv "$UV_BIN"; then
+            if _m99_repair_entry "LOBSTER-INFLIGHT-REMINDERS" "*/3 * * * * $UV_BIN run $LOBSTER_DIR/scripts/check-inflight-reminders.py >> $WORKSPACE_DIR/logs/inflight-reminders.log 2>&1 # LOBSTER-INFLIGHT-REMINDERS"; then
+                substep "Migration 99: repaired LOBSTER-INFLIGHT-REMINDERS cron entry to use $UV_BIN"
+                _m99_fixed=1
+            fi
+        fi
+
+        # GHOST-DETECTOR and LOG-EXPORT already use the absolute path in their
+        # originating migrations (52 and 28), but repair them too in case an
+        # install's crontab was hand-edited back to a bare `uv` at some point.
+        if crontab -l 2>/dev/null | grep -F "# LOBSTER-GHOST-DETECTOR" | grep -qv "$UV_BIN"; then
+            if _m99_repair_entry "LOBSTER-GHOST-DETECTOR" "2-59/5 * * * * cd $HOME && $UV_BIN run $LOBSTER_DIR/scripts/agent-monitor.py --alert --mark-failed >> $WORKSPACE_DIR/logs/agent-monitor.log 2>&1 # LOBSTER-GHOST-DETECTOR"; then
+                substep "Migration 99: repaired LOBSTER-GHOST-DETECTOR cron entry to use $UV_BIN"
+                _m99_fixed=1
+            fi
+        fi
+
+        if crontab -l 2>/dev/null | grep -F "# LOBSTER-LOG-EXPORT" | grep -qv "$UV_BIN"; then
+            if _m99_repair_entry "LOBSTER-LOG-EXPORT" "0 3 * * * cd $LOBSTER_DIR && $UV_BIN run scheduled-tasks/export-logs.py # LOBSTER-LOG-EXPORT"; then
+                substep "Migration 99: repaired LOBSTER-LOG-EXPORT cron entry to use $UV_BIN"
+                _m99_fixed=1
+            fi
+        fi
+
+        unset -f _m99_repair_entry
+
+        if [ "$_m99_fixed" -eq 1 ]; then
+            migrated=$((migrated + 1))
+        else
+            substep "Migration 99: all uv-based cron entries already use absolute path — skipping"
+        fi
+    else
+        warn "Migration 99: uv not found at $UV_BIN — skipping cron entry repair"
     fi
 
     if [ "$migrated" -eq 0 ]; then


### PR DESCRIPTION
## Summary

Fixes #2189 — four generated cron entries invoke `uv run ...` without an absolute path. cron's minimal PATH (typically `/usr/bin:/bin`) does not include `~/.local/bin`, where the uv installer places the binary, so these jobs fail on every invocation with `/bin/sh: 1: uv: not found`.

- `install.sh`: `LOBSTER-LOG-EXPORT`, `LOBSTER-GHOST-DETECTOR`, `LOBSTER-OOM-CHECK`, `LOBSTER-INFLIGHT-REMINDERS` all switched to `$HOME/.local/bin/uv`.
- `scripts/upgrade.sh`: Migration 53 (OOM-CHECK) and Migration 87 (INFLIGHT-REMINDERS) fixed the same way — Migrations 28 (LOG-EXPORT) and 52 (GHOST-DETECTOR) already used the absolute path, so this closes the gap left by a partial regression of #1161/PR #1101.
- New **Migration 99** in `scripts/upgrade.sh`: repairs any existing install's crontab that already has the broken bare-`uv` entries (migrations 53/87 are gated on "marker not present," so fixing the source doesn't reach installs that already ran the buggy version). Rewrites each of the four entries in place if it doesn't already reference the absolute uv path; no-op / idempotent otherwise.

Confirmed on a live instance: `agent-monitor.py` and `check-inflight-reminders.py` had been failing on every single cron invocation since being set up (85+ / 141+ consecutive "uv: not found" log lines, zero prior successful runs).

## Test plan

- [x] `bash -n install.sh` and `bash -n scripts/upgrade.sh` — both parse cleanly.
- [x] Manually reproduced the bug and applied the equivalent fix live via `cron-manage.sh` on an affected instance; re-ran `agent-monitor.py` under a cron-like minimal PATH (`env -i PATH=/usr/bin:/bin`) — succeeds (exit 0, produces the real ghost report instead of "uv: not found").
- [x] Waited for the next real cron tick for both `LOBSTER-GHOST-DETECTOR` and `LOBSTER-INFLIGHT-REMINDERS` — both produced real log output (ghost report / stale-entry reminders) instead of "uv: not found".
- [x] Unit-tested the Migration 99 repair logic in isolation against a synthetic crontab with all four bare-`uv` entries: all four get rewritten to the absolute path in one pass, and a second pass is a confirmed no-op (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)