### PR TITLE
fix(hooks): route content-less ghost-agent recoveries to a log, not inbox

### DIFF
--- a/hooks/require-write-result.py
+++ b/hooks/require-write-result.py
@@ -477,6 +477,61 @@ def main():
         if not transcript_path:
             # No path provided — can't verify; allow exit to avoid blocking.
             _exit_ok()
+
+        # --- Ghost fast-path (issue #2175) -----------------------------------
+        # Investigation on 2026-08-10 confirmed: every real Task-tool subagent
+        # gets an agent-<agent_id>.jsonl (and sibling .meta.json) file created
+        # under .claude/projects/<project>/<dispatcher-session-id>/subagents/
+        # at SPAWN time — before the subagent produces a single turn. Dozens of
+        # "phantom" SubagentStop fires were sampled (agent_ids with no row in
+        # agent_sessions.db, no register_agent call, no meta.json, and — this is
+        # the new finding — no transcript file on disk AT ALL, not merely an
+        # empty one). These ghosts cluster in tight ~20-40s bursts strictly
+        # during periods when a real session (dispatcher or subagent) is
+        # actively making tool calls, and go completely silent for hours during
+        # idle windows — ruling out a periodic cron/systemd timer (checked:
+        # crontab, systemd timers, nothing matches). This points to a Claude
+        # Code harness-internal mechanism (not a Lobster-side bug) that
+        # allocates an agent_id and fires SubagentStop for something that was
+        # never a real Agent/Task-tool spawn.
+        #
+        # Previously the hook would blindly retry-block (exit 2) up to
+        # MAX_HOOK_FIRES=5 times over ~2-3 minutes before giving up — for a
+        # session that structurally can never call write_result because it was
+        # never running Lobster's system prompt. Since a missing transcript
+        # file (FileNotFoundError, not just an empty/malformed one) is now a
+        # reliable, cheap, first-fire signal for "this is not a real Lobster
+        # subagent", short-circuit immediately: log once and exit clean instead
+        # of paying for 5 rounds of blocking retries per ghost.
+        if not os.path.exists(transcript_path):
+            try:
+                log_dir = Path(os.path.expanduser("~/lobster-workspace/logs"))
+                log_dir.mkdir(parents=True, exist_ok=True)
+                now = datetime.now(timezone.utc)
+                log_line = (
+                    f"[{now.isoformat()}] Ghost SubagentStop fast-path: "
+                    f"agent_transcript_path does not exist on disk (never a real "
+                    f"Task-tool spawn). agent_id={data.get('agent_id')!r} "
+                    f"session_id={data.get('session_id')!r} "
+                    f"transcript_path={transcript_path!r}\n"
+                )
+                with open(log_dir / "ghost-agent-recovery.log", "a") as f:
+                    f.write(log_line)
+                # Also append the full raw hook payload to a rolling debug log
+                # so a future investigation can inspect whatever additional
+                # fields CC sends for these ghosts (e.g. to finally confirm
+                # which internal CC mechanism produces them).
+                debug_path = log_dir / "ghost-agent-raw-input.jsonl"
+                with open(debug_path, "a") as f:
+                    f.write(json.dumps({"logged_at": now.isoformat(), "hook_input": data}) + "\n")
+            except Exception:
+                pass  # Best-effort diagnostics; never block exit
+            # Clean up any fire-count temp file that may exist for this key
+            # (defensive — normally none exists yet on the fast path).
+            key = _agent_key(data)
+            _cleanup_fire_state(_fire_count_path(key))
+            _exit_ok()
+
         transcript = _load_transcript_from_jsonl(transcript_path)
     else:
         # Stop hook: CC 2.1.76+ passes transcript_path (JSONL file), not inline.

--- a/hooks/require-write-result.py
+++ b/hooks/require-write-result.py
@@ -409,10 +409,28 @@ def _write_synthetic_inbox_message(
             f"Content recovered from transcript after {MAX_HOOK_FIRES} hook fires."
         )
 
-        if content:
-            text = f"{recovery_note}\n\nRecovered content:\n\n{content}"
-        else:
-            text = f"{recovery_note}\n\n(No recoverable transcript content found.)"
+        if not content:
+            # No recoverable content means there is nothing actionable for the
+            # dispatcher to relay or decide on. Writing this to inbox/ forces a
+            # full dispatcher turn (wait_for_messages wake + mark_processed) for
+            # zero information — this fires every ~3-4 min from the known
+            # phantom-hook issue (GitHub #2175), so route it to a log file
+            # instead of burning a dispatcher turn on an empty message.
+            try:
+                log_dir = Path(os.path.expanduser("~/lobster-workspace/logs"))
+                log_dir.mkdir(parents=True, exist_ok=True)
+                log_line = (
+                    f"[{now.isoformat()}] {recovery_note} "
+                    f"task_id_hint={task_id_hint!r} agent_id={data.get('agent_id')!r} "
+                    f"session_id={data.get('session_id')!r}\n"
+                )
+                with open(log_dir / "ghost-agent-recovery.log", "a") as f:
+                    f.write(log_line)
+            except Exception:
+                pass
+            return
+
+        text = f"{recovery_note}\n\nRecovered content:\n\n{content}"
 
         message = {
             "id": message_id,

--- a/tests/unit/test_hooks/test_require_write_result.py
+++ b/tests/unit/test_hooks/test_require_write_result.py
@@ -326,19 +326,26 @@ class TestSubagentStopHook:
         assert exit_code == 0, f"Expected exit 0 (safe fallback), got {exit_code}"
 
     def test_exits_0_when_jsonl_file_nonexistent(self, monkeypatch, tmp_path):
-        """SubagentStop: transcript file doesn't exist → allow exit (safe fallback)."""
+        """SubagentStop: transcript file doesn't exist → ghost fast-path, allow exit.
+
+        Issue #2175 root-cause update (2026-08-10): a completely absent
+        agent_transcript_path file (not merely empty/malformed) is a reliable
+        signal that this SubagentStop was never a real Task-tool subagent —
+        real subagents always get their agent-<id>.jsonl file created at spawn
+        time, before any turns are recorded. Phantom Claude-Code-internal
+        SubagentStop fires (see module docstring / ghost-agent-recovery.log)
+        point at a transcript path that was never created. Blocking these with
+        exit 2 for up to MAX_HOOK_FIRES retries wastes cycles on something that
+        can never call write_result, so the hook now short-circuits to a clean
+        exit 0 on first sight instead of retry-blocking.
+        """
         mod = _load_hook(monkeypatch, tmp_path)
 
         hook_input = _make_subagentstop_hook_input("/nonexistent/path/agent.jsonl")
-        # File doesn't exist, _load_transcript_from_jsonl returns []
-        # With empty transcript, no write_result found → would exit 2.
-        # But missing file is indistinguishable from an agent that didn't call write_result,
-        # so this test documents the actual behavior: exits 2.
         exit_code, stdout, stderr = _run_hook(mod, hook_input)
 
-        # An unreadable transcript means we can't verify — exit 2 (conservative)
-        # This is expected: the agent should have called write_result.
-        assert exit_code == 2
+        # Ghost fast-path: exit 0 immediately, no blocking retries.
+        assert exit_code == 0
 
     def test_blocking_message_goes_to_stderr(self, monkeypatch, tmp_path):
         """SubagentStop block messages must use stderr."""


### PR DESCRIPTION
## Summary
- Second commit adds the actual root-cause fix for #2175's phantom SubagentStop fires (first commit only stopped the content-less-recovery symptom from costing a dispatcher turn).
- **Root cause (evidence-backed):** captured a live ghost fire's raw hook payload. It carries the dispatcher's own `session_id`/`transcript_path` alongside a freshly-generated `agent_id` absent from Claude Code's internal `background_tasks` tracker. Every real Task-tool subagent gets its `agent-<id>.jsonl` transcript file created at spawn time, before any turns are recorded; every sampled ghost had no such file on disk at all, ever. Fires cluster in ~20-40s bursts only during active tool-calling and go silent for hours when idle — rules out any cron/systemd timer. This is a Claude Code harness-internal mechanism, not a Lobster-side bug; can't be fixed from this side, only mitigated.
- **Fix:** a missing `agent_transcript_path` file on `SubagentStop` now short-circuits to an immediate clean exit instead of falling through to the normal exit-2 retry-block path (previously up to `MAX_HOOK_FIRES`=5 blocking rounds, ~2-3 min, per ghost). Also logs the raw hook payload to `ghost-agent-raw-input.jsonl` for future forensics.
- Updated `test_exits_0_when_jsonl_file_nonexistent`, which previously documented the old blocking behavior as expected — now asserts the fast-path exit 0.

## Test plan
- [x] `uv run pytest tests/unit/test_hooks/test_require_write_result.py -q` — 25 passed
- [x] Verified live in production: a real ghost fire was caught and fast-pathed correctly, and `ghost-agent-recovery.log` is receiving entries as expected
- [ ] Monitor `ghost-agent-recovery.log` volume over the next day to confirm ghosts no longer cost blocking retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)