### PR TITLE
fix(hooks): automate inflight-work.jsonl writes (running + done entries)

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -184,13 +184,14 @@ Never say "Noted." alone — it doesn't tell the user whether work is happening.
    # Atomically: moves message inbox/ → processing/ AND sends the ack.
    # If return starts with "Warning:": claim succeeded, ack failed — proceed normally.
 2. Generate a short task_id (e.g. "fix-pr-475", "upstream-check")
-3. Write in-flight entry (see "In-flight work tracking" below)
-4. Task(
+3. Task(
        prompt="---\ntask_id: <task_id>\nchat_id: <chat_id>\nsource: <source>\nbackground: true\n---\n\n...",
        subagent_type="..."
    )
-5. mark_processed(message_id)
-6. Return to wait_for_messages() IMMEDIATELY
+   # The inflight-work.jsonl "running" entry is written automatically by a
+   # PostToolUse hook (see "In-Flight Work Tracking" below) — no separate step needed.
+4. mark_processed(message_id)
+5. Return to wait_for_messages() IMMEDIATELY
 ```
 
 > **Background intent via prompt frontmatter:** Always include `background: true` in the YAML
@@ -200,14 +201,13 @@ Never say "Noted." alone — it doesn't tell the user whether work is happening.
 > (issue #1939). The frontmatter key survives schema validation because it is part of the
 > `prompt` string, which is always a declared field.
 
-Agent registration is fully automatic — a PostToolUse hook fires after each Task call. You do not need to call `register_agent`.
+Agent registration is fully automatic — a PostToolUse hook fires after each Task call. You do not need to call `register_agent`, and you do not need to write an inflight-work.jsonl entry either (see "In-Flight Work Tracking" below).
 
 **Alternative (no ack needed):**
 ```
 1. mark_processing(message_id)
-2. Write in-flight entry (see "In-flight work tracking" below)
-3. ... spawn subagent ...
-4. mark_processed(message_id)
+2. ... spawn subagent ...
+3. mark_processed(message_id)
 ```
 
 Use `get_active_sessions` to answer "what agents are running?" at any time — accurate even across restarts.
@@ -216,36 +216,16 @@ Use `get_active_sessions` to answer "what agents are running?" at any time — a
 
 ## In-Flight Work Tracking
 
-Before calling the Agent tool to spawn any background subagent, persist the entry **and the full prompt** by piping JSON to the helper script:
+**This is now fully automatic — no dispatcher action required.** Both the "running" and "done" entries in `inflight-work.jsonl` are written by hooks, not by you:
 
-```python
-Bash(
-    'echo \'' + json.dumps({
-        "task_id": task_id,
-        "type": "<task type>",
-        "description": "<brief description>",
-        "started_at": datetime.utcnow().isoformat() + "Z",
-        "chat_id": chat_id,
-        "subagent_type": subagent_type,  # the value passed to the Agent tool
-        "status": "running",
-        "prompt": prompt,  # full prompt text — will be written to a separate file
-    }).replace("'", "'\\''") + '\' | uv run ~/lobster/scripts/save-inflight-prompt.py'
-)
-```
+- **"running" entry**: written by the `auto-register-agent.py` PostToolUse hook, which fires on every real `Agent` tool call (same hook that already auto-registers `agent_sessions.db`). It extracts `task_id`/`chat_id`/`source` from the prompt's YAML frontmatter (same parsing `auto-register-agent.py` already did) and persists the full prompt via `scripts/save-inflight-prompt.py`'s write logic, exactly as the old manual instructions described — just no longer dependent on you remembering to run it.
+- **"done" entry**: written by the `require-write-result.py` SubagentStop hook, at the moment it confirms a subagent called `write_result` with a valid `chat_id` — the same reliable trigger point the old manual instructions used, but now firing deterministically instead of depending on your later processing of the `subagent_result` message.
 
-**Why a script instead of `echo '...' >> file`:** Prompts contain newlines and special characters that make shell escaping unreliable. `save-inflight-prompt.py` writes the prompt to `~/lobster-workspace/data/inflight-prompts/<task_id>.txt` and appends a JSONL entry to `inflight-work.jsonl` with a `prompt_file` path — never inline. The raw prompt must NOT appear in the JSONL file.
-
-This is a **synchronous write on the main thread** — it must complete before the Agent call. Do not spawn a subagent for this write.
-
-**Idempotency requirement:** Prompts passed to the Agent tool must be written to be stateless and idempotent. If the same prompt is launched 10 hours later, it should produce similar or better results — not worse. Prompts must not assume any ambient state (open editor windows, in-progress filesystem writes, specific partial outputs) that may have changed. This is the prerequisite for reliable auto-restart after session death.
-
-**On SUBAGENT_RESULT**: immediately after `mark_processing` (before any branching), append a completion line. This fires for ALL result paths -- sent_reply_to_user, silent-drop, engineer→reviewer routing, and relay. "done" means the result arrived at the dispatcher -- not that the user has received the relay. Use a Bash append for "done" entries (no prompt involved):
-
-```python
-Bash(f'echo \'{{"task_id": "{task_id}", "completed_at": "{completed_at}", "status": "done"}}\' >> ~/lobster-workspace/data/inflight-work.jsonl')
-```
+You do not need to call `save-inflight-prompt.py` or append a Bash `echo` line yourself for either entry. (Historical note: this section previously instructed the dispatcher to perform both writes manually; that approach was found to be unreliable in production — no new entries were written for over two months despite many subagent spawns — which is why it was automated via hooks instead.)
 
 The log is append-only. A task is "done" if any entry with the same `task_id` has `"status": "done"`. Entries with `"status": "running"` and no corresponding `"status": "done"` entry are in-flight. The full prompt for any in-flight entry is readable from its `prompt_file` path.
+
+**Idempotency requirement still applies to prompt authoring:** Prompts passed to the Agent tool must be written to be stateless and idempotent. If the same prompt is launched 10 hours later, it should produce similar or better results — not worse. Prompts must not assume any ambient state (open editor windows, in-progress filesystem writes, specific partial outputs) that may have changed. This is the prerequisite for reliable auto-restart after session death.
 
 ---
 
@@ -396,12 +376,10 @@ Background subagents call `write_result(task_id, chat_id, text, ...)`, which dro
 
 ```
 1. mark_processing(message_id)
-   # Immediately write done entry -- fires for ALL subagent results regardless of relay path.
-   # "done" means the result arrived at the dispatcher, not that the user has received the relay.
-   if msg.get("task_id"):
-       task_id = msg["task_id"]
-       completed_at = datetime.utcnow().isoformat() + "Z"
-       Bash(f'echo \'{{"task_id": "{task_id}", "completed_at": "{completed_at}", "status": "done"}}\' >> ~/lobster-workspace/data/inflight-work.jsonl')
+   # NOTE: the inflight-work.jsonl "done" entry is now written automatically by
+   # require-write-result.py's SubagentStop hook at the moment write_result was
+   # confirmed called with a valid chat_id -- no dispatcher action needed here
+   # (see "In-Flight Work Tracking" above). Do not add a manual append.
 
 2. if msg.get("sent_reply_to_user") == True:
        mark_processed(message_id)

--- a/hooks/auto-register-agent.py
+++ b/hooks/auto-register-agent.py
@@ -1,11 +1,26 @@
 #!/usr/bin/env python3
-"""PostToolUse hook: auto-register spawned agents into agent_sessions.db.
+"""PostToolUse hook: auto-register spawned agents into agent_sessions.db and
+inflight-work.jsonl.
 
 Fires after every Agent tool call. Extracts structured metadata from the
-agent prompt (YAML frontmatter or legacy "task_id is:" text), then inserts
-a 'running' row into agent_sessions.db so the spawned agent is immediately
-visible to the ghost detector and status queries. No intermediate 'starting'
-state is used — the agent IS running at the point this hook fires.
+agent prompt (YAML frontmatter or legacy "task_id is:" text), then:
+
+1. Inserts a 'running' row into agent_sessions.db so the spawned agent is
+   immediately visible to the ghost detector and status queries. No
+   intermediate 'starting' state is used — the agent IS running at the point
+   this hook fires.
+
+2. Writes a 'running' entry to inflight-work.jsonl (issue: automate-inflight-
+   work-writes), reusing scripts/save-inflight-prompt.py's actual write logic
+   (loaded dynamically — see `_load_save_inflight_prompt_module`) so the
+   JSONL schema and prompt-file-on-disk mechanism never diverge from that
+   script. This automates a step that was previously a manual dispatcher
+   instruction (see .claude/sys.dispatcher.bootup.md, "In-Flight Work
+   Tracking") and therefore depended on an LLM remembering to run it on every
+   single Agent call — confirmed unreliable in production (no new entries
+   written since 2026-05-31 despite many subsequent agent spawns). Skipped
+   when no task_id is present, since inflight-work.jsonl entries are keyed by
+   task_id.
 
 ## Frontmatter format (preferred)
 
@@ -42,6 +57,7 @@ Add this to ~/.claude/settings.json under "hooks" -> "PostToolUse":
     }
 """
 
+import importlib.util
 import json
 import os
 import re
@@ -321,6 +337,97 @@ def insert_agent_session(
 
 
 # ---------------------------------------------------------------------------
+# inflight-work.jsonl "running" entry (issue: automate-inflight-work-writes)
+# ---------------------------------------------------------------------------
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+_SAVE_INFLIGHT_PROMPT_SCRIPT = _SCRIPTS_DIR / "save-inflight-prompt.py"
+
+
+def _load_save_inflight_prompt_module():
+    """Dynamically import scripts/save-inflight-prompt.py.
+
+    The filename is hyphenated so it cannot be imported as a normal module --
+    load it via importlib.util the same way tests/unit/test_hooks/*.py already
+    load hyphenated hook files. Reusing the real module (rather than
+    reimplementing its I/O) guarantees the JSONL schema and prompt-file
+    mechanism never diverge from save-inflight-prompt.py.
+
+    Returns the loaded module, or None on any failure. Never raises.
+    """
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "save_inflight_prompt", _SAVE_INFLIGHT_PROMPT_SCRIPT
+        )
+        if spec is None or spec.loader is None:
+            return None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def write_inflight_running_entry(
+    *,
+    task_id: str | None,
+    chat_id: str | None,
+    source: str,
+    subagent_type: str | None,
+    description: str | None,
+    prompt: str,
+) -> None:
+    """Best-effort: write a 'running' entry to inflight-work.jsonl for this spawn.
+
+    Skipped entirely when task_id is None -- inflight-work.jsonl entries are
+    keyed by task_id (required by save-inflight-prompt.py's REQUIRED_FIELDS
+    and by the consumers in on-fresh-start.py / dispatcher-state-stop.py), so
+    a task_id-less spawn has nothing meaningful to record against.
+
+    Never raises -- failures are logged to hook-failures.log and swallowed,
+    mirroring insert_agent_session's failure policy so a bookkeeping problem
+    never blocks the Agent call.
+    """
+    if not task_id:
+        return
+
+    mod = _load_save_inflight_prompt_module()
+    if mod is None:
+        _log_failure(
+            f"could not load save-inflight-prompt module; "
+            f"skipped inflight-work running entry for task_id={task_id!r}"
+        )
+        return
+
+    try:
+        started_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        try:
+            chat_id_value: object = int(chat_id) if chat_id is not None else 0
+        except (TypeError, ValueError):
+            chat_id_value = chat_id
+
+        payload = {
+            "task_id": task_id,
+            "type": subagent_type or "subagent",
+            "description": description or "",
+            "started_at": started_at,
+            "chat_id": chat_id_value,
+            "subagent_type": subagent_type,
+            "status": "running",
+        }
+
+        prompt_file_path = mod.write_prompt_file(
+            mod.INFLIGHT_PROMPTS_DIR, task_id, prompt or ""
+        )
+        entry = mod.build_jsonl_entry(payload, prompt_file_path)
+        mod.append_jsonl_entry(mod.INFLIGHT_WORK_FILE, entry)
+    except Exception as exc:  # noqa: BLE001
+        _log_failure(
+            f"failed to write inflight-work running entry for task_id={task_id!r}: {exc}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -365,6 +472,15 @@ def main() -> None:
             output_file=output_file,
             input_summary=input_summary,
             dispatcher_pid=dispatcher_pid,
+        )
+
+        write_inflight_running_entry(
+            task_id=metadata["task_id"],
+            chat_id=metadata["chat_id"],
+            source=metadata["source"],
+            subagent_type=tool_input.get("subagent_type"),
+            description=tool_input.get("description"),
+            prompt=prompt,
         )
 
     except Exception as exc:  # noqa: BLE001

--- a/hooks/require-write-result.py
+++ b/hooks/require-write-result.py
@@ -10,6 +10,12 @@ When write_result was called, this hook also marks the session completed in
 agent_sessions.db synchronously — without relying on the unreliable server-side
 auto-unregister path in inbox_server.py.
 
+It also appends a "done" entry to inflight-work.jsonl for each task_id seen in
+a valid write_result call (see `_append_inflight_done_entry`), automating the
+bookkeeping step documented in .claude/sys.dispatcher.bootup.md's "In-Flight
+Work Tracking" section that previously depended on the dispatcher manually
+running a Bash append after every subagent_result message.
+
 ## Session ID strategy
 
 The SubagentStop hook receives a session_id that is CC's internal UUID for the
@@ -125,6 +131,50 @@ def _extract_write_result_task_ids(all_tool_use_items: list) -> list[str]:
                 seen.add(tid)
                 result.append(tid)
     return result
+
+
+# inflight-work.jsonl path -- override via env var for testability, matching
+# the convention used by scripts/save-inflight-prompt.py and on-fresh-start.py.
+INFLIGHT_WORK_FILE = Path(
+    os.environ.get(
+        "LOBSTER_INFLIGHT_WORK_FILE_OVERRIDE",
+        os.path.expanduser("~/lobster-workspace/data/inflight-work.jsonl"),
+    )
+)
+
+
+def _append_inflight_done_entry(task_id: str) -> None:
+    """Best-effort: append a 'done' entry to inflight-work.jsonl for task_id.
+
+    Automates the "done" bookkeeping write that was previously a manual
+    dispatcher step performed inline while handling subagent_result messages
+    (see .claude/sys.dispatcher.bootup.md, "In-Flight Work Tracking") --
+    confirmed unreliable in production (no new entries since 2026-05-31
+    despite many subsequent agent completions). This hook fires at the exact
+    moment write_result was confirmed called with a valid chat_id, which is
+    the same reliable trigger point the manual instructions described, but no
+    longer dependent on the dispatcher's own later processing of the
+    subagent_result message.
+
+    Idempotent by construction: inflight-work.jsonl is an append-only log and
+    consumers (on-fresh-start.py, dispatcher-state-stop.py) treat a task_id as
+    "done" if *any* entry has status == "done", so appending a duplicate
+    "done" line for the same task_id (e.g. hook re-fire) is harmless.
+
+    Never raises -- mirrors _mark_session_completed's best-effort failure
+    policy so a bookkeeping problem never blocks the subagent from exiting.
+    """
+    try:
+        entry = {
+            "task_id": task_id,
+            "completed_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "status": "done",
+        }
+        INFLIGHT_WORK_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with open(INFLIGHT_WORK_FILE, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:  # noqa: BLE001
+        pass  # Best-effort; never block exit
 
 
 def _mark_session_completed(id_or_task_id: str) -> None:
@@ -508,6 +558,15 @@ def main():
                 _mark_session_completed(tid)
             if session_id:
                 _mark_session_completed(session_id)
+
+            # Append inflight-work.jsonl "done" entries (issue: automate-
+            # inflight-work-writes). Only task_ids from write_result inputs
+            # are used here -- not session_id -- because inflight-work.jsonl
+            # "running" entries are keyed by the dispatcher's task_id (see
+            # auto-register-agent.py's write_inflight_running_entry), the same
+            # value a well-behaved subagent passes back to write_result.
+            for tid in write_result_task_ids:
+                _append_inflight_done_entry(tid)
 
             # Set notified_at on all rows so the reconciler never sees them as
             # unnotified and enqueues duplicate subagent_notification messages.

--- a/tests/unit/test_hooks/test_auto_register_agent.py
+++ b/tests/unit/test_hooks/test_auto_register_agent.py
@@ -589,3 +589,156 @@ class TestHookFailureSafety:
         assert log_path.exists(), "Expected failure to be logged"
         log_content = log_path.read_text()
         assert "auto-register-agent" in log_content
+
+
+# ---------------------------------------------------------------------------
+# inflight-work.jsonl "running" entry automation
+# (issue: automate-inflight-work-writes)
+# ---------------------------------------------------------------------------
+
+def _make_hook_input_with_tool_input(
+    tool_input: dict,
+    tool_response: object = None,
+    session_id: str = "sess-123",
+) -> dict:
+    return {
+        "hook_event_name": "PostToolUse",
+        "session_id": session_id,
+        "tool_name": "Agent",
+        "tool_input": tool_input,
+        "tool_response": tool_response,
+    }
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+class TestInflightRunningEntry:
+    """Automates the 'running' entry that was previously a manual dispatcher
+    Bash-piped-to-save-inflight-prompt.py step (see .claude/sys.dispatcher.bootup.md,
+    'In-Flight Work Tracking'). Confirmed unreliable in production: no new
+    inflight-work.jsonl entries were written since 2026-05-31 despite many
+    subsequent agent spawns.
+    """
+
+    def _inflight_work_file(self, tmp_path: Path) -> Path:
+        return tmp_path / "workspace" / "data" / "inflight-work.jsonl"
+
+    def _inflight_prompts_dir(self, tmp_path: Path) -> Path:
+        return tmp_path / "workspace" / "data" / "inflight-prompts"
+
+    def test_running_entry_written_on_real_agent_spawn(self, tmp_path):
+        """A real Agent call (agentId present) writes a 'running' entry with
+        the exact schema save-inflight-prompt.py produces -- prompt_file
+        reference, never the raw prompt inline."""
+        prompt = (
+            "---\ntask_id: t-inflight\nchat_id: 12345\nsource: telegram\n---\n"
+            "Do the thing."
+        )
+        hook_input = _make_hook_input_with_tool_input(
+            tool_input={
+                "prompt": prompt,
+                "subagent_type": "lobster-generalist",
+                "description": "Do the thing for the user",
+            },
+            tool_response={"agentId": "agent-inflight"},
+        )
+        exit_code, _, _ = _run_hook(hook_input, tmp_path)
+        assert exit_code == 0
+
+        entries = _read_jsonl(self._inflight_work_file(tmp_path))
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["task_id"] == "t-inflight"
+        assert entry["status"] == "running"
+        assert entry["chat_id"] == 12345
+        assert entry["subagent_type"] == "lobster-generalist"
+        assert entry["description"] == "Do the thing for the user"
+        assert "started_at" in entry
+        # Raw prompt must NEVER appear inline in the JSONL entry.
+        assert "prompt" not in entry
+        assert entry["prompt_file"] == str(
+            self._inflight_prompts_dir(tmp_path) / "t-inflight.txt"
+        )
+
+        # The full prompt is persisted to the referenced prompt_file.
+        prompt_file = Path(entry["prompt_file"])
+        assert prompt_file.exists()
+        assert prompt_file.read_text(encoding="utf-8") == prompt
+
+    def test_no_task_id_skips_inflight_write(self, tmp_path):
+        """A spawn with no task_id in the frontmatter writes no inflight entry
+        (agent_sessions.db registration still happens independently)."""
+        prompt = "No frontmatter here, just a prompt."
+        hook_input = _make_hook_input_with_tool_input(
+            tool_input={"prompt": prompt, "subagent_type": "lobster-generalist"},
+            tool_response={"agentId": "agent-no-task-id"},
+        )
+        exit_code, _, _ = _run_hook(hook_input, tmp_path)
+        assert exit_code == 0
+
+        assert not self._inflight_work_file(tmp_path).exists()
+        # agent_sessions.db registration is unaffected.
+        row = _get_row(tmp_path, "agent-no-task-id")
+        assert row is not None
+
+    def test_missing_agent_id_skips_inflight_write_too(self, tmp_path):
+        """No agentId in tool_response -- neither DB nor inflight-work.jsonl written."""
+        prompt = "---\ntask_id: t-noagentid\n---\nDo work."
+        hook_input = _make_hook_input_with_tool_input(
+            tool_input={"prompt": prompt},
+            tool_response={"result": "no agent id here"},
+        )
+        exit_code, _, _ = _run_hook(hook_input, tmp_path)
+        assert exit_code == 0
+        assert not self._inflight_work_file(tmp_path).exists()
+
+    def test_inflight_write_failure_does_not_block_hook(self, tmp_path):
+        """If save-inflight-prompt.py's module can't be loaded, the hook still
+        exits 0 and still registers the DB row -- inflight bookkeeping is
+        best-effort, never blocking."""
+        import os
+
+        prompt = "---\ntask_id: t-inflight-fail\n---\nDo work."
+        hook_input = _make_hook_input_with_tool_input(
+            tool_input={"prompt": prompt},
+            tool_response={"agentId": "agent-inflight-fail"},
+        )
+        # The hook is exec'd fresh each time (see _run_hook), so failure-safety
+        # is verified by pointing LOBSTER_WORKSPACE at a read-only directory
+        # that blocks the inflight-prompts/ mkdir inside write_prompt_file.
+        ro_workspace = tmp_path / "ro-workspace"
+        (ro_workspace / "data").mkdir(parents=True)
+        os.chmod(str(ro_workspace / "data"), 0o444)
+
+        stdout_cap = StringIO()
+        stderr_cap = StringIO()
+        exit_code = None
+        with (
+            patch("sys.stdin", StringIO(json.dumps(hook_input))),
+            patch("sys.stdout", stdout_cap),
+            patch("sys.stderr", stderr_cap),
+            patch.dict("os.environ", {
+                "LOBSTER_MESSAGES": str(tmp_path / "messages"),
+                "LOBSTER_WORKSPACE": str(ro_workspace),
+            }),
+        ):
+            try:
+                hook_globals = {"__name__": "__main__", "__file__": str(HOOK_PATH)}
+                exec(compile(HOOK_PATH.read_text(), str(HOOK_PATH), "exec"), hook_globals)
+            except SystemExit as e:
+                exit_code = e.code
+
+        os.chmod(str(ro_workspace / "data"), 0o755)  # restore for cleanup
+        assert exit_code == 0
+
+        # DB registration still succeeded despite inflight-work.jsonl failure.
+        row = _get_row(tmp_path, "agent-inflight-fail")
+        assert row is not None

--- a/tests/unit/test_hooks/test_require_write_result.py
+++ b/tests/unit/test_hooks/test_require_write_result.py
@@ -723,4 +723,121 @@ class TestFallbackAfterNFires:
         result = mod._extract_pre_hook_text(transcript, first_fire_ts=first_ts, n_turns=10)
 
         assert "early" in result
-        assert "late" not in result
+
+
+# ---------------------------------------------------------------------------
+# inflight-work.jsonl "done" entry automation
+# (issue: automate-inflight-work-writes)
+# ---------------------------------------------------------------------------
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+class TestInflightDoneEntry:
+    """Automates the 'done' entry that was previously a manual dispatcher Bash
+    append performed while handling subagent_result messages (see
+    .claude/sys.dispatcher.bootup.md, 'In-Flight Work Tracking'). Confirmed
+    unreliable in production: no new inflight-work.jsonl entries were written
+    since 2026-05-31 despite many subsequent subagent completions.
+    """
+
+    def _inflight_work_file(self, tmp_path: Path) -> Path:
+        return tmp_path / "lobster-workspace" / "data" / "inflight-work.jsonl"
+
+    def test_done_entry_written_on_successful_write_result(self, monkeypatch, tmp_path):
+        """A SubagentStop with a valid write_result(chat_id=..., task_id=...)
+        call appends a 'done' entry for that task_id."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        transcript_file = tmp_path / "agent-sub.jsonl"
+        messages = _make_transcript_with_write_result(chat_id=99999, task_id="t-done-1")
+        _write_jsonl_transcript(transcript_file, messages)
+
+        hook_input = _make_subagentstop_hook_input(str(transcript_file))
+        exit_code, _, stderr = _run_hook(mod, hook_input)
+
+        assert exit_code == 0, f"Expected exit 0, got {exit_code}. stderr={stderr}"
+
+        entries = _read_jsonl(self._inflight_work_file(tmp_path))
+        done_entries = [e for e in entries if e.get("task_id") == "t-done-1"]
+        assert len(done_entries) == 1
+        assert done_entries[0]["status"] == "done"
+        assert "completed_at" in done_entries[0]
+
+    def test_no_done_entry_when_chat_id_none(self, monkeypatch, tmp_path):
+        """write_result called with chat_id=None is invalid -- no done entry,
+        and the SubagentStop still blocks exit (exit 2)."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        transcript_file = tmp_path / "agent-sub.jsonl"
+        messages = _make_transcript_with_write_result(chat_id=None, task_id="t-nochat")
+        _write_jsonl_transcript(transcript_file, messages)
+
+        hook_input = _make_subagentstop_hook_input(str(transcript_file))
+        exit_code, _, _ = _run_hook(mod, hook_input)
+
+        assert exit_code == 2
+        entries = _read_jsonl(self._inflight_work_file(tmp_path))
+        assert not any(e.get("task_id") == "t-nochat" for e in entries)
+
+    def test_no_done_entry_when_write_result_not_called(self, monkeypatch, tmp_path):
+        """No write_result call at all -- no done entry written, no crash on
+        (absent) inflight-work.jsonl file."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        transcript_file = tmp_path / "agent-sub.jsonl"
+        _write_jsonl_transcript(transcript_file, _make_transcript_no_write_result())
+
+        hook_input = _make_subagentstop_hook_input(str(transcript_file))
+        exit_code, _, _ = _run_hook(mod, hook_input)
+
+        assert exit_code == 2
+        assert not self._inflight_work_file(tmp_path).exists()
+
+    def test_done_entry_respects_override_env_var(self, monkeypatch, tmp_path):
+        """LOBSTER_INFLIGHT_WORK_FILE_OVERRIDE redirects the done-entry write,
+        matching the convention used by scripts/save-inflight-prompt.py and
+        hooks/on-fresh-start.py."""
+        override_path = tmp_path / "custom" / "inflight-work.jsonl"
+        monkeypatch.setenv("LOBSTER_INFLIGHT_WORK_FILE_OVERRIDE", str(override_path))
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        transcript_file = tmp_path / "agent-sub.jsonl"
+        messages = _make_transcript_with_write_result(chat_id=1, task_id="t-override")
+        _write_jsonl_transcript(transcript_file, messages)
+
+        hook_input = _make_subagentstop_hook_input(str(transcript_file))
+        exit_code, _, _ = _run_hook(mod, hook_input)
+
+        assert exit_code == 0
+        entries = _read_jsonl(override_path)
+        assert any(e.get("task_id") == "t-override" and e.get("status") == "done" for e in entries)
+        # The default location must remain untouched.
+        assert not self._inflight_work_file(tmp_path).exists()
+
+    def test_multiple_write_result_task_ids_each_get_done_entry(self, monkeypatch, tmp_path):
+        """If the transcript contains multiple write_result calls with
+        distinct task_ids (unusual but possible), each gets a done entry."""
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        transcript_file = tmp_path / "agent-sub.jsonl"
+        messages = [
+            _make_jsonl_entry_with_write_result(chat_id=1, task_id="t-multi-a"),
+            _make_jsonl_entry_with_write_result(chat_id=1, task_id="t-multi-b"),
+        ]
+        _write_jsonl_transcript(transcript_file, messages)
+
+        hook_input = _make_subagentstop_hook_input(str(transcript_file))
+        exit_code, _, _ = _run_hook(mod, hook_input)
+
+        assert exit_code == 0
+        entries = _read_jsonl(self._inflight_work_file(tmp_path))
+        task_ids_done = {e["task_id"] for e in entries if e.get("status") == "done"}
+        assert {"t-multi-a", "t-multi-b"} <= task_ids_done


### PR DESCRIPTION
## Problem

`~/lobster-workspace/data/inflight-work.jsonl` is the only mechanism that lets a fresh dispatcher session detect and recover subagents orphaned by a dispatcher crash/restart — it's read by `hooks/on-fresh-start.py`'s `_compact_inflight_work()`, `.claude/agents/compact-catchup.md`'s "possibly lost subagents" section, and `hooks/dispatcher-state-stop.py`'s in-flight-agent handoff. Both entries in it ("running" before a spawn, "done" after a result) were written manually: the dispatcher's system prompt instructed it to pipe JSON to `scripts/save-inflight-prompt.py` before every `Agent` call, and to append a raw `Bash echo` line after every `subagent_result`.

Confirmed tonight via `tail`/`wc -l` that this had silently stopped happening since **2026-05-31**, despite the dispatcher spawning many subagents since. Nothing enforced the manual step — an LLM simply stopped doing it, with no error, no alert, and no way to notice short of manually inspecting the file. Restart-recovery coverage had been silently degrading for over two months.

This PR is prevention only. It does not touch the existing stuck `startup-catchup` entry from 2026-05-31 — that's #2194's job.

## What changed

Both writes now happen inside hooks instead of depending on the dispatcher remembering a manual step:

- **"running" entry** — `hooks/auto-register-agent.py`'s existing `PostToolUse` hook (which already auto-registers `agent_sessions.db` on every real `Agent` tool call) now also writes the inflight-work.jsonl "running" entry. It reuses `scripts/save-inflight-prompt.py`'s actual write functions (`write_prompt_file`, `build_jsonl_entry`, `append_jsonl_entry`), loaded dynamically via `importlib` — the same pattern this repo's own tests already use to import hyphenated hook files — so the JSONL schema and prompt-file-on-disk mechanism can never diverge from that script. Skipped entirely when no `task_id` is present in the prompt's frontmatter, since inflight-work.jsonl entries are keyed by `task_id`.
- **"done" entry** — `hooks/require-write-result.py`'s `SubagentStop` hook now appends the "done" entry at the exact moment it confirms `write_result` was called with a valid `chat_id` (the existing success branch that already marks the session completed in `agent_sessions.db`). This is the same trigger point the old manual instructions used, but it now fires deterministically instead of depending on the dispatcher's later processing of the `subagent_result` inbox message.
- `.claude/sys.dispatcher.bootup.md`'s "In-Flight Work Tracking" section (and the two other spots that told the dispatcher to do this manually) now say the writes are automatic, so future dispatcher sessions don't try to duplicate them.

### Before / after

```
BEFORE:
  Agent spawn ──(LLM must remember)──> Bash | save-inflight-prompt.py   [running entry]
  subagent_result ──(LLM must remember)──> Bash echo >> inflight-work.jsonl  [done entry]
  (confirmed: this stopped happening silently on 2026-05-31, no alarm)

AFTER:
  Agent spawn ──(PostToolUse hook, always fires)──> running entry written
  write_result succeeds w/ valid chat_id ──(SubagentStop hook, always fires)──> done entry written
  Dispatcher no longer performs either write itself.
```

No other part of the flow changes — `on-fresh-start.py`'s stale-entry compaction, `compact-catchup.md`'s lost-subagent detection, and `dispatcher-state-stop.py`'s handoff payload all consume the same schema as before (verified — see Tests run).

## Functional patterns

- Both new write paths are best-effort and side-effect-isolated: any failure is caught, logged to `hook-failures.log`, and swallowed — mirroring the existing `insert_agent_session` / `_mark_session_completed` failure policy — so a bookkeeping problem can never block an `Agent` spawn or a subagent's exit.
- `save-inflight-prompt.py`'s pure functions (`build_jsonl_entry`, `write_prompt_file`) are reused rather than reimplemented, keeping the JSONL-shape logic in exactly one place instead of forking it across two files.
- The "done" append (`_append_inflight_done_entry` in `require-write-result.py`) is a small, isolated I/O function with no branching logic mixed in — pure construction of the entry dict, then a single append.

## Out of scope

- Does not touch the existing stuck `startup-catchup` entry from 2026-05-31 (issue #2194's job — cleanup of an already-corrupted row, not prevention).
- Does not modify anything on the `fix/ghost-recovery-log-not-inbox` branch or PR #2193.
- Does not restart any live services.

Relates to #2194 (existing stuck-entry cleanup issue) — this PR is the prevention half; #2194 is the cleanup half.

## Tests run
- [x] `uv run pytest tests/unit/test_hooks/test_auto_register_agent.py tests/unit/test_hooks/test_require_write_result.py tests/unit/test_save_inflight_prompt.py tests/unit/test_hooks/test_compact_inflight_work.py tests/unit/test_hooks/test_dispatcher_state_stop.py -q` — 126 passed, 0 failed (includes new tests for both the "running" and "done" entry automation, plus regression coverage for `on-fresh-start.py`'s compaction and `dispatcher-state-stop.py`'s handoff payload against the new schema)
- [x] `uv run pytest tests/unit/ -q` — full suite: 4351 passed, 21 failed, 32 skipped. All 21 failures are pre-existing and unrelated (Slack poller precision, PII scan guard, push-token-endpoint enforcement, `on_compact_write_claude_session_id`, `test_script_inbox_sources`) — spot-checked two of them (`test_push_calendar_token_endpoint`, `test_slack_poller_oldest_precision`) directly against `main` and confirmed they fail there too (missing `LOBSTER_SLACK_BOT_TOKEN` env var in this environment, not caused by this change).
- [x] `python3 -m py_compile hooks/auto-register-agent.py hooks/require-write-result.py` — clean

## Manual test
N/A for a live end-to-end run (that would require actually spawning a real subagent through the live dispatcher, which I was told not to do — no service restarts). Instead verified schema compatibility directly:
- Manually constructed sample "running" and "done" entries matching exactly what the new code paths produce, and confirmed both `hooks/on-fresh-start.py::_compact_inflight_entries` and `hooks/dispatcher-state-stop.py::_read_in_flight_agents` parse them correctly (both only require `task_id` + `status`, plus `started_at`/`ts` for staleness on running entries — all present).
- Unit tests directly exercise the hook code paths end-to-end (stdin JSON in, JSONL file + prompt file on disk out) rather than mocking the write functions, so the on-disk artifacts are the real ones a live dispatcher/subagent pair would produce.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests — all file paths are tmp_path-scoped via `LOBSTER_WORKSPACE`/`HOME`/`LOBSTER_INFLIGHT_WORK_FILE_OVERRIDE` env overrides)
- [x] Integration/manual test run — see Manual test above (schema-compatibility verification substituted for a live spawn, per explicit no-restart constraint)
- [x] User-visible outcome — not applicable; this is internal dispatcher bookkeeping with no direct Telegram/UI surface
- [x] Side-effect audit: no floods, no unscoped writes (append-only to one file per write, guarded by try/except), no unintended volume
- [x] External service calls — none; this only touches local filesystem writes