### PR TITLE
fix(health-check): restore graceful session-age restart in debug mode, without the debunked 2h forced recycle

### DIFF
--- a/scripts/claude-wrapper.exp
+++ b/scripts/claude-wrapper.exp
@@ -98,6 +98,32 @@ catch {
     close $fh
 }
 
+# Write the dispatcher.pid file, mirroring scripts/claude-persistent.sh
+# (which writes $MESSAGES_DIR/config/dispatcher.pid right before exec-ing
+# claude). health-check-v3.sh's check_session_age() reads this file to find
+# the PID to send a graceful SIGTERM to once the session passes
+# SESSION_AGE_LIMIT_SECONDS.
+#
+# Before this fix, claude-wrapper.exp never wrote dispatcher.pid, so the
+# graceful SESSION AGE LIMIT restart path could never find a PID while
+# running in debug mode (LOBSTER_DEBUG=true) — it silently logged
+# "no dispatcher.pid — cannot send SIGTERM" and took no action, every
+# 4-minute health-check tick, for as long as the session stayed over-age
+# (see issue #2196: 4,148 occurrences in health-check.log since 2026-06-07).
+#
+# Same LOBSTER_MESSAGES fallback as claude-persistent.sh/health-check-v3.sh
+# (MESSAGES_DIR="${LOBSTER_MESSAGES:-$HOME/messages}") — must stay in sync
+# with both so the writer and reader always agree on the path.
+set messages_dir [expr {[info exists ::env(LOBSTER_MESSAGES)] ? $::env(LOBSTER_MESSAGES) : "$::env(HOME)/messages"}]
+set dispatcher_pid_dir [file join $messages_dir "config"]
+set dispatcher_pid_file [file join $dispatcher_pid_dir "dispatcher.pid"]
+catch { file mkdir $dispatcher_pid_dir }
+catch {
+    set pid_fh [open $dispatcher_pid_file w]
+    puts $pid_fh [exp_pid]
+    close $pid_fh
+}
+
 # Wait for either the permissions dialog OR the ready prompt.
 #
 # The ❯ (U+276F) character appears in the prompt area surrounded by ANSI escape
@@ -152,3 +178,11 @@ send "\r"
 # Hand over terminal control — Claude runs indefinitely.
 # The expect process stays alive so the spawned claude process is not orphaned.
 interact
+
+# interact returns once the spawned claude process exits (or EOF). Clean up
+# dispatcher.pid now that the PID it names is gone — mirrors
+# claude-persistent.sh's `rm -f "$dispatcher_pid_file"` after its claude
+# process exits. Leaving a stale dispatcher.pid around risks a future,
+# unrelated process being assigned the same PID and incorrectly targeted by
+# health-check-v3.sh's check_session_age() SIGTERM.
+catch { file delete $dispatcher_pid_file }

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -115,14 +115,28 @@ HEARTBEAT_FILE="$WORKSPACE_DIR/logs/claude-heartbeat"   # legacy WFM-touch signa
 DISPATCHER_HEARTBEAT_FILE="${LOBSTER_DISPATCHER_HEARTBEAT_OVERRIDE:-$WORKSPACE_DIR/logs/dispatcher-heartbeat}"
 DISPATCHER_HEARTBEAT_STALE_SECONDS=1200   # 20 min — covers compaction (~5m) + catchup (~12m) + margin
 
-# Session age limit: CC enforces a hard 7440s session lifetime (issue #2059).
-# At this limit, CC kills the process without firing the Stop hook — no tombstone,
-# no compaction alert. We trigger a graceful SIGTERM at SESSION_AGE_LIMIT_SECONDS
-# (7200s = 2 min before hard limit) so the Stop hook fires cleanly.
+# Session age limit: proactive SIGTERM restart mechanism (issue #2059).
+#
+# DISABLED BY DEFAULT (issue #2196 / #2157). This mechanism was originally
+# justified by a claimed "CC enforces a hard 7440s session lifetime" — but
+# issue #2157 found that claim rested on only 2 data points, was never
+# confirmed against Anthropic docs, and had a more likely alternative
+# explanation (an unrelated heartbeat-staleness bug, since fixed by #2074).
+# The live dispatcher session has since run 90+ hours with zero problems,
+# directly contradicting the original 7440s premise. There is no remaining
+# evidence that Claude Code kills sessions on a wall-clock timer.
+#
+# The mechanism itself still works and is harmless once opted into: when
+# enabled, it sends a graceful SIGTERM to the dispatcher PID at
+# SESSION_AGE_LIMIT_SECONDS so the Stop hook fires cleanly (vs. an
+# uncontrolled kill from some other layer, e.g. a systemd bounce). Keep it
+# available as an opt-in operational precaution — e.g. an operator who wants
+# a periodic recycle for unrelated reasons (log rotation, memory hygiene) —
+# but do not force it on new/updated installs by default.
+#
 # Written by inject-bootup-context.py as a plain Unix epoch integer.
-# Set LOBSTER_SESSION_AGE_LIMIT_SECONDS=0 in config.env to disable this check
-# (safe if CC no longer enforces the 7440s hard limit in the installed version).
-SESSION_AGE_LIMIT_SECONDS="${LOBSTER_SESSION_AGE_LIMIT_SECONDS:-7200}"
+# Set LOBSTER_SESSION_AGE_LIMIT_SECONDS=<seconds> in config.env to opt in.
+SESSION_AGE_LIMIT_SECONDS="${LOBSTER_SESSION_AGE_LIMIT_SECONDS:-0}"
 DISPATCHER_SESSION_START_FILE="${LOBSTER_DISPATCHER_SESSION_START_FILE_OVERRIDE:-$WORKSPACE_DIR/data/dispatcher-session-start.ts}"
 
 # WFM-active signal (issue #1713 / #949): inbox_server.py writes this file with
@@ -164,7 +178,7 @@ WFM_ACTIVE_STALE_SECONDS=180   # 3x WAIT_HEARTBEAT_INTERVAL (60s) — absorbs on
 # tighter than the session lifetime a legitimate idle wait is allowed to reach.
 # See compute_wfm_suppression_max_seconds() below.
 WFM_SUPPRESSION_MARGIN_SECONDS=300      # 5 min: fire slightly before the session-age backstop would anyway
-WFM_SUPPRESSION_FALLBACK_SECONDS=21600  # 6h: used only when SESSION_AGE_LIMIT_SECONDS=0 (session-age check disabled)
+WFM_SUPPRESSION_FALLBACK_SECONDS=21600  # 6h: used when SESSION_AGE_LIMIT_SECONDS=0 (the default as of issue #2196 — session-age check disabled)
 
 # Pure function: derive the WFM-active suppression cap from the session-age
 # limit. No side effects, no globals read — everything comes in as an argument,
@@ -240,7 +254,9 @@ fi
 LOBSTER_ENV="${LOBSTER_ENV:-production}"
 
 # Read LOBSTER_SESSION_AGE_LIMIT_SECONDS from config.env (if not already in environment).
-# Set to 0 in config.env to disable the proactive session-age restart check.
+# Default is 0 (disabled — see the comment near the initial assignment above,
+# issue #2196 / #2157). Set a positive integer in config.env to opt in to the
+# proactive session-age restart.
 if [[ -z "${LOBSTER_SESSION_AGE_LIMIT_SECONDS:-}" && -f "$CONFIG_ENV" ]]; then
     _cfg_sal=$(grep '^LOBSTER_SESSION_AGE_LIMIT_SECONDS=' "$CONFIG_ENV" 2>/dev/null | cut -d'=' -f2- | tr -d '[:space:]"' || true)
     if [[ -n "$_cfg_sal" ]]; then
@@ -250,7 +266,7 @@ if [[ -z "${LOBSTER_SESSION_AGE_LIMIT_SECONDS:-}" && -f "$CONFIG_ENV" ]]; then
 fi
 # Re-apply SESSION_AGE_LIMIT_SECONDS now that config.env may have updated the env var.
 # The initial assignment at top of file used the env var before config.env was read.
-SESSION_AGE_LIMIT_SECONDS="${LOBSTER_SESSION_AGE_LIMIT_SECONDS:-7200}"
+SESSION_AGE_LIMIT_SECONDS="${LOBSTER_SESSION_AGE_LIMIT_SECONDS:-0}"
 
 # Read LOBSTER_WFM_SUPPRESSION_MAX_SECONDS from config.env (if not already in
 # environment) for operators who want an explicit override instead of the
@@ -1415,20 +1431,28 @@ count_active_subagents() {
 }
 
 #===============================================================================
-# Session Age Check — proactive restart before the 7440s CC hard limit
-# (issue #2059)
+# Session Age Check — opt-in proactive restart on a wall-clock timer
+# (issue #2059; disabled by default as of issue #2196 — see #2157)
 #
-# CC enforces a hard 7440-second (124-minute) session lifetime. When this limit
-# is hit, CC exits without firing the Stop hook — no tombstone, no compact-
-# catchup. To avoid this, we send SIGTERM to the dispatcher process at
-# SESSION_AGE_LIMIT_SECONDS (7200s = 2 min before the limit), which fires the
-# Stop hook cleanly.
+# Originally justified by a claimed hard 7440-second CC session lifetime.
+# That claim is debunked: issue #2157 found the original evidence (issue
+# #2059) rested on only 2 data points, was never confirmed against Anthropic
+# docs, and had a more likely alternative explanation (an unrelated
+# heartbeat-staleness bug, fixed by #2074). The live dispatcher session has
+# since run 90+ hours with zero problems, directly contradicting the
+# original premise. There is no remaining evidence CC kills sessions on a
+# wall-clock timer, so this is DISABLED BY DEFAULT (SESSION_AGE_LIMIT_SECONDS=0).
 #
-# Unlike do_restart() (which uses systemctl), this sends SIGTERM directly to the
-# claude process so the Stop hook fires. The claude-persistent.sh wrapper detects
-# the exit and restarts Claude automatically.
+# When enabled (LOBSTER_SESSION_AGE_LIMIT_SECONDS set to a positive value in
+# config.env), this sends SIGTERM to the dispatcher process once the session
+# reaches SESSION_AGE_LIMIT_SECONDS, so the Stop hook fires cleanly instead
+# of an uncontrolled kill from some other layer. Unlike do_restart() (which
+# uses systemctl), this sends SIGTERM directly to the claude process so the
+# Stop hook fires. The claude-persistent.sh wrapper detects the exit and
+# restarts Claude automatically.
 #
 # Suppressed when:
+#   - SESSION_AGE_LIMIT_SECONDS=0 (the default — check is disabled entirely)
 #   - DISPATCHER_SESSION_START_FILE is missing (old install, no session tracking)
 #   - Maintenance mode is active (flag is present — handled in main before this call)
 #   - Boot grace period is active (avoid killing a session that just started)

--- a/tests/test-health-check-session-age-default.sh
+++ b/tests/test-health-check-session-age-default.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+#===============================================================================
+# Test Suite: Health Check v3 - SESSION_AGE_LIMIT_SECONDS default (issue #2196)
+#
+# check_session_age() (tested separately in test-health-check-session-age.sh)
+# is only half the story: this suite tests the *config resolution* that feeds
+# SESSION_AGE_LIMIT_SECONDS into it.
+#
+# Background: PR #2197 fixed a real bug (claude-wrapper.exp never wrote
+# dispatcher.pid, so check_session_age() could never find a PID to SIGTERM in
+# debug-mode launches). But the restart this fix re-enables is gated by
+# SESSION_AGE_LIMIT_SECONDS, which used to default to 7200 (2h) — justified by
+# a claimed "CC enforces a hard 7440s session lifetime" that issue #2157 found
+# was never confirmed (2 data points, no Anthropic doc citation, a more likely
+# alternative explanation already fixed by #2074) and that a 90+ hour live
+# dispatcher session directly contradicts. Landing #2197's PID fix alongside
+# the old 7200s default would have silently reintroduced forced 2-hour
+# restarts for a debunked reason.
+#
+# Fix (issue #2196): SESSION_AGE_LIMIT_SECONDS now DEFAULTS TO 0 (disabled).
+# The mechanism remains available and functional (PID fix included) for an
+# operator who deliberately opts in via LOBSTER_SESSION_AGE_LIMIT_SECONDS.
+#
+# Tests:
+#   1. No env var, no config.env entry -> SESSION_AGE_LIMIT_SECONDS=0 (disabled)
+#   2. LOBSTER_SESSION_AGE_LIMIT_SECONDS env var set -> that value wins
+#   3. config.env sets LOBSTER_SESSION_AGE_LIMIT_SECONDS -> that value is read
+#   4. env var takes precedence over a conflicting config.env value
+#
+# Usage: bash tests/test-health-check-session-age-default.sh
+#===============================================================================
+
+set -u
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts"
+HEALTH_SCRIPT="$SCRIPT_DIR/health-check-v3.sh"
+
+TEST_TMPDIR=$(mktemp -d /tmp/lobster-session-age-default-test-XXXXXX)
+cleanup() { rm -rf "$TEST_TMPDIR"; }
+trap cleanup EXIT
+
+begin_test() { TOTAL=$((TOTAL + 1)); test_name="$1"; }
+pass()  { PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC} $test_name"; }
+fail()  { FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC} $test_name: $1"; }
+
+#===============================================================================
+# Named constant (from the spec — never hardcode magic values in tests)
+#===============================================================================
+EXPECTED_DEFAULT_SESSION_AGE_LIMIT_SECONDS=0   # issue #2196: disabled by default
+
+# Extract just the two config-resolution blocks for SESSION_AGE_LIMIT_SECONDS
+# from the real script (same "extract, don't reimplement" approach used by
+# test-health-check-session-age.sh), so this test exercises the actual
+# production logic rather than a hand-copied reimplementation of it.
+CONFIG_BLOCK=$(
+    sed -n '/^# Session age limit: proactive SIGTERM restart mechanism/,/^SESSION_AGE_LIMIT_SECONDS="\${LOBSTER_SESSION_AGE_LIMIT_SECONDS:-0}"$/p' "$HEALTH_SCRIPT"
+    sed -n '/^# Read LOBSTER_SESSION_AGE_LIMIT_SECONDS from config.env/,/^SESSION_AGE_LIMIT_SECONDS="\${LOBSTER_SESSION_AGE_LIMIT_SECONDS:-0}"$/p' "$HEALTH_SCRIPT"
+)
+
+if [[ -z "$CONFIG_BLOCK" ]]; then
+    echo "FATAL: could not extract SESSION_AGE_LIMIT_SECONDS config-resolution block from $HEALTH_SCRIPT"
+    echo "(anchors may be out of date — see test file header)"
+    exit 1
+fi
+
+# Run the extracted config-resolution block in a clean subshell with a
+# controlled environment, and print the resulting SESSION_AGE_LIMIT_SECONDS.
+resolve_session_age_limit() {
+    local config_env_path="$1"
+    shift
+    env -i \
+        HOME="$HOME" \
+        CONFIG_ENV="$config_env_path" \
+        "$@" \
+        bash -c "$CONFIG_BLOCK"$'\necho "$SESSION_AGE_LIMIT_SECONDS"'
+}
+
+NO_CONFIG_ENV="$TEST_TMPDIR/no-such-config.env"
+
+echo ""
+echo "=== Health Check SESSION_AGE_LIMIT_SECONDS Default Tests ==="
+echo ""
+
+# 1. No env var, no config.env -> default is 0 (disabled)
+begin_test "no_override_defaults_to_disabled"
+result=$(resolve_session_age_limit "$NO_CONFIG_ENV")
+if [[ "$result" -eq "$EXPECTED_DEFAULT_SESSION_AGE_LIMIT_SECONDS" ]]; then
+    pass
+else
+    fail "expected $EXPECTED_DEFAULT_SESSION_AGE_LIMIT_SECONDS, got '$result'"
+fi
+
+# 2. LOBSTER_SESSION_AGE_LIMIT_SECONDS env var set -> opt-in value wins
+begin_test "env_var_opts_in_to_explicit_value"
+result=$(resolve_session_age_limit "$NO_CONFIG_ENV" LOBSTER_SESSION_AGE_LIMIT_SECONDS=3600)
+if [[ "$result" -eq 3600 ]]; then
+    pass
+else
+    fail "expected 3600, got '$result'"
+fi
+
+# 3. config.env sets LOBSTER_SESSION_AGE_LIMIT_SECONDS -> value is read from file
+begin_test "config_env_opts_in_to_explicit_value"
+CONFIG_ENV_FILE="$TEST_TMPDIR/config.env"
+echo 'LOBSTER_SESSION_AGE_LIMIT_SECONDS=1800' > "$CONFIG_ENV_FILE"
+result=$(resolve_session_age_limit "$CONFIG_ENV_FILE")
+if [[ "$result" -eq 1800 ]]; then
+    pass
+else
+    fail "expected 1800, got '$result'"
+fi
+rm -f "$CONFIG_ENV_FILE"
+
+# 4. env var takes precedence over a conflicting config.env value
+begin_test "env_var_takes_precedence_over_config_env"
+CONFIG_ENV_FILE="$TEST_TMPDIR/config.env"
+echo 'LOBSTER_SESSION_AGE_LIMIT_SECONDS=1800' > "$CONFIG_ENV_FILE"
+result=$(resolve_session_age_limit "$CONFIG_ENV_FILE" LOBSTER_SESSION_AGE_LIMIT_SECONDS=9999)
+if [[ "$result" -eq 9999 ]]; then
+    pass
+else
+    fail "expected 9999, got '$result'"
+fi
+rm -f "$CONFIG_ENV_FILE"
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed ==="
+echo ""
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tests/unit/test_hooks/test_claude_wrapper_exp_dispatcher_pid.py
+++ b/tests/unit/test_hooks/test_claude_wrapper_exp_dispatcher_pid.py
@@ -1,0 +1,192 @@
+"""
+Tests verifying that claude-wrapper.exp (LOBSTER_DEBUG=true / debug-mode
+launcher) writes the dispatcher.pid file that health-check-v3.sh's
+check_session_age() depends on for the graceful SESSION AGE LIMIT restart.
+
+Root cause (fixed in this PR, issue #2196):
+  scripts/claude-persistent.sh (the default, non-debug launcher) writes
+  $MESSAGES_DIR/config/dispatcher.pid right before exec-ing claude, and
+  removes it on exit. scripts/claude-wrapper.exp (the LOBSTER_DEBUG=true
+  launcher) writes the analogous dispatcher-startup-flag file but never
+  wrote dispatcher.pid.
+
+  health-check-v3.sh's check_session_age() reads dispatcher.pid to find the
+  PID to send a graceful SIGTERM to once the session passes
+  SESSION_AGE_LIMIT_SECONDS. With no dispatcher.pid, it logs
+  "no dispatcher.pid — cannot send SIGTERM" and returns without acting —
+  every 4-minute health-check tick, for as long as debug mode is active and
+  the session is over-age. health-check.log shows this warning firing 4,148
+  times since 2026-06-07, essentially always alongside "Claude running
+  without persistent wrapper (debug mode — expected)" or the old-style-mode
+  variant of the same log line.
+
+  The fix mirrors claude-persistent.sh's pattern: write dispatcher.pid using
+  [exp_pid] (the correct expect built-in — see
+  test_claude_wrapper_exp_spawn_pid.py for why $spawn_pid must not be used)
+  immediately after spawn, and remove it when the wrapper exits.
+
+These tests use `expect -c` to exercise the Tcl/expect write pattern in
+isolation, plus static checks confirming the actual script contains the fix
+and derives the same path health-check-v3.sh reads from
+($MESSAGES_DIR/config/dispatcher.pid, where MESSAGES_DIR defaults to
+$HOME/messages exactly as claude-persistent.sh and health-check-v3.sh do).
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Path to claude-wrapper.exp — repo root is 3 levels above tests/unit/test_hooks/
+_REPO_ROOT = Path(__file__).parents[3]
+CLAUDE_WRAPPER_EXP = _REPO_ROOT / "scripts" / "claude-wrapper.exp"
+CLAUDE_PERSISTENT_SH = _REPO_ROOT / "scripts" / "claude-persistent.sh"
+HEALTH_CHECK_V3_SH = _REPO_ROOT / "scripts" / "health-check-v3.sh"
+
+# Guard: skip all tests if expect is not installed on this system.
+_EXPECT_AVAILABLE = shutil.which("expect") is not None
+
+
+@pytest.mark.skipif(not _EXPECT_AVAILABLE, reason="expect not installed")
+class TestExpPidWritesDispatcherPidFile:
+    """Regression tests confirming [exp_pid] can write a dispatcher.pid file."""
+
+    def test_exp_pid_writes_valid_integer_pid_to_dispatcher_pid_file(self, tmp_path):
+        """[exp_pid] writes a valid PID to a dispatcher.pid-shaped file.
+
+        Mirrors the already-fixed dispatcher-startup-flag write pattern
+        (test_claude_wrapper_exp_spawn_pid.py) applied to dispatcher.pid.
+        """
+        config_dir = tmp_path / "messages" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        pid_file = config_dir / "dispatcher.pid"
+        script = f"""
+spawn sh -c "sleep 0.1"
+catch {{
+    set fh [open {pid_file} w]
+    puts $fh [exp_pid]
+    close $fh
+}}
+"""
+        subprocess.run(
+            ["expect", "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert pid_file.exists(), "dispatcher.pid should exist after [exp_pid] write"
+        content = pid_file.read_text().strip()
+        assert content, "dispatcher.pid must not be empty when [exp_pid] is used"
+        assert content.isdigit(), (
+            f"dispatcher.pid must contain a valid integer PID, got: {content!r}"
+        )
+        pid = int(content)
+        assert 1 < pid < 4_194_304, f"PID {pid} is outside valid Linux range"
+
+
+class TestClaudeWrapperExpWritesDispatcherPid:
+    """Static checks: claude-wrapper.exp must write and clean up dispatcher.pid."""
+
+    def setup_method(self):
+        assert CLAUDE_WRAPPER_EXP.exists(), (
+            f"claude-wrapper.exp not found at {CLAUDE_WRAPPER_EXP}"
+        )
+        self.content = CLAUDE_WRAPPER_EXP.read_text()
+
+    def test_script_writes_dispatcher_pid_file(self):
+        """claude-wrapper.exp must write dispatcher.pid, not just the startup flag.
+
+        Without this, check_session_age() in health-check-v3.sh can never
+        find a PID to send the graceful SESSION AGE LIMIT SIGTERM to while
+        running in debug mode — the mechanism silently no-ops forever.
+        """
+        assert "dispatcher.pid" in self.content, (
+            "claude-wrapper.exp must write a file named dispatcher.pid "
+            "(mirroring scripts/claude-persistent.sh) so health-check-v3.sh's "
+            "check_session_age() can locate the dispatcher PID in debug mode."
+        )
+
+    def test_dispatcher_pid_write_uses_exp_pid_not_spawn_pid(self):
+        """The dispatcher.pid write must use [exp_pid], the same fix already
+        applied to the dispatcher-startup-flag write — $spawn_pid is not a
+        valid Tcl variable and silently writes an empty file (catch swallows
+        the error).
+        """
+        # Isolate the block that constructs/writes the dispatcher.pid path —
+        # anchor on the quoted literal ("dispatcher.pid") rather than the
+        # first textual mention of the word, since explanatory comments
+        # above the actual write code also legitimately say "dispatcher.pid".
+        match = re.search(r'"dispatcher\.pid"[\s\S]{0,1500}', self.content)
+        assert match, (
+            'could not locate a `"dispatcher.pid"` path-construction site to inspect '
+            "(expected something like [file join $dir \"dispatcher.pid\"])"
+        )
+        block = match.group(0)
+        assert "[exp_pid]" in block, (
+            "the dispatcher.pid write must use [exp_pid], not $spawn_pid "
+            "(which does not exist in Tcl/expect and would silently write "
+            "an empty file)."
+        )
+        assert "$spawn_pid" not in block, (
+            "the dispatcher.pid write must not use $spawn_pid — it is not a "
+            "valid Tcl variable and silently produces an empty file."
+        )
+
+    def test_dispatcher_pid_path_matches_health_check_and_persistent_sh(self):
+        """The path claude-wrapper.exp writes to must be the exact path
+        health-check-v3.sh reads from ($MESSAGES_DIR/config/dispatcher.pid,
+        MESSAGES_DIR defaulting to $HOME/messages) — the same path
+        claude-persistent.sh already uses.
+        """
+        assert HEALTH_CHECK_V3_SH.exists()
+        assert CLAUDE_PERSISTENT_SH.exists()
+        health_check_content = HEALTH_CHECK_V3_SH.read_text()
+        persistent_content = CLAUDE_PERSISTENT_SH.read_text()
+
+        # health-check-v3.sh's reader path
+        assert 'DISPATCHER_PID_FILE="$MESSAGES_DIR/config/dispatcher.pid"' in health_check_content
+        # claude-persistent.sh's writer path (already correct, used as the reference)
+        assert 'config/dispatcher.pid' in persistent_content
+
+        # claude-wrapper.exp must build the same relative path: config/dispatcher.pid
+        # under the messages directory (LOBSTER_MESSAGES, default $HOME/messages).
+        assert "config" in self.content and "dispatcher.pid" in self.content, (
+            "claude-wrapper.exp must write to <messages_dir>/config/dispatcher.pid, "
+            "matching health-check-v3.sh's DISPATCHER_PID_FILE and "
+            "claude-persistent.sh's dispatcher_pid_file."
+        )
+        # Must respect LOBSTER_MESSAGES like the other two scripts do, not hardcode
+        # a path that would silently diverge from a non-default install.
+        assert "LOBSTER_MESSAGES" in self.content, (
+            "claude-wrapper.exp must honour LOBSTER_MESSAGES (falling back to "
+            "$HOME/messages) when computing the dispatcher.pid path, exactly like "
+            "claude-persistent.sh (MESSAGES_DIR=\"${LOBSTER_MESSAGES:-$HOME/messages}\") "
+            "and health-check-v3.sh do — hardcoding $HOME/messages would silently "
+            "diverge on any install that overrides LOBSTER_MESSAGES."
+        )
+
+    def test_dispatcher_pid_cleaned_up_on_exit(self):
+        """claude-wrapper.exp should remove dispatcher.pid when the wrapper
+        exits, mirroring claude-persistent.sh's `rm -f "$dispatcher_pid_file"`
+        cleanup after Claude exits — otherwise a stale PID (later reused by an
+        unrelated process) could linger and be targeted incorrectly.
+        """
+        # Look for a cleanup statement referencing dispatcher.pid, e.g. a
+        # `file delete` call, positioned after the `interact` command (i.e.
+        # runs once the spawned claude process — and therefore `interact` —
+        # has exited).
+        interact_idx = self.content.find("interact")
+        assert interact_idx != -1, "claude-wrapper.exp must contain 'interact'"
+
+        # Accept either a delete after interact, or an exit-time trap/cleanup
+        # elsewhere in the file — the required property is that some code
+        # path removes dispatcher.pid once the spawned process is gone.
+        assert "file delete" in self.content and "dispatcher.pid" in self.content[interact_idx:] + self.content, (
+            "claude-wrapper.exp must clean up dispatcher.pid once the spawned "
+            "claude process (and therefore the wrapper) exits, mirroring "
+            "claude-persistent.sh's `rm -f \"$dispatcher_pid_file\"` on exit."
+        )


### PR DESCRIPTION
Closes #2196

## Problem

`health-check-v3.sh`'s `check_session_age()` sends a graceful `SIGTERM` to the dispatcher once a session passes `SESSION_AGE_LIMIT_SECONDS` (the proactive restart added in #2059 to beat CC's claimed hard 7440s session limit). It finds the target PID by reading `$MESSAGES_DIR/config/dispatcher.pid`.

That file is only ever written by `claude-persistent.sh` (the default, `LOBSTER_DEBUG=false` launcher), right before it execs `claude`. `claude-wrapper.exp` — the `LOBSTER_DEBUG=true` interactive/debug launcher — writes the analogous `dispatcher-startup-flag` but never wrote `dispatcher.pid`. So whenever the dispatcher was running in debug mode, `check_session_age()` could never find a PID: it logged `[WARN] Session age: no dispatcher.pid — cannot send SIGTERM` and took no action, on every 4-minute health-check tick, for as long as the session stayed over-age. The graceful restart mechanism was completely inert in that mode; the dispatcher only ever got restarted via harder backstops (the BLACK/circuit-breaker cap, a crash, or an unrelated systemd bounce).

## Evidence

`health-check.log` shows the `no dispatcher.pid` warning firing **4,148 times since 2026-06-07**. The very first occurrence already shows the co-occurring cause directly:

```
[2026-06-07T10:48:01-04:00] [WARN] SESSION AGE LIMIT: session is 7432s old (>= 7200s) — sending SIGTERM for graceful restart
[2026-06-07T10:48:01-04:00] [WARN] Session age: no dispatcher.pid — cannot send SIGTERM (systemctl restart fallback not used for this path)
[2026-06-07T10:48:02-04:00] [INFO] Claude running without persistent wrapper (debug mode — expected)
```

Most recently, a 2026-08-11 system audit (`~/lobster-user-config/agents/system-audit.context.md`) caught the same signature during a ~2-day window where `LOBSTER_DEBUG=true` had drifted on; the graceful path stayed dead the whole time until an unrelated `apt-get upgrade` cascade happened to bounce `lobster-claude.service`, which picked up the (by-then-reverted) `LOBSTER_DEBUG=false` on its next launch.

## Fix, part 1: `claude-wrapper.exp` writes `dispatcher.pid`

`claude-wrapper.exp` now writes `dispatcher.pid` right after `spawn claude ...`, using `[exp_pid]` — the same fix already applied to the `dispatcher-startup-flag` write (`$spawn_pid` is not a valid Tcl variable and silently produces an empty file). The path is derived from `LOBSTER_MESSAGES` with the same `$HOME/messages` fallback `claude-persistent.sh` and `health-check-v3.sh` already use. The file is removed once `interact` returns, mirroring `claude-persistent.sh`'s `rm -f` cleanup on exit.

No changes to `health-check-v3.sh`'s reader logic in this part — it closes the gap purely on the writer side.

## Fix, part 2: `SESSION_AGE_LIMIT_SECONDS` now defaults to disabled (0)

Fixing part 1 on its own would have reintroduced forced restarts every ~2 hours for every debug-mode session, on a justification that doesn't hold up.

`SESSION_AGE_LIMIT_SECONDS` (the threshold that gates the SIGTERM in `check_session_age()`) previously defaulted to `7200` (2h), justified by issue #2059's claim that "Claude Code enforces a hard 7440-second session lifetime." Issue #2157 investigated that claim and found:
- It rested on only 2 data points (sessions dying around 7433-7436s), with no raw logs and no citation to any Anthropic doc or changelog describing a wall-clock session-duration limit.
- The issue that originated the claim appears to have been authored by a prior Claude/Lobster session inferring a cause, not a human confirming one.
- No systemd unit has any `RuntimeMaxSec` or timeout near 7440s that would explain a hard kill.
- A more plausible, unruled-out alternative was active at the same time: `DISPATCHER_HEARTBEAT_STALE_SECONDS`'s health-check restart threshold was being actively patched for bugs one day before #2059 was filed, and later fixed properly in #2074 — a mechanism that kills the dispatcher via `systemctl restart` with no Stop hook, matching the originally observed symptoms.

Since then, the live dispatcher session (the one running this very conversation) has run **90+ hours with zero problems** — directly contradicting the original 7440s premise. There is no remaining evidence that Claude Code kills sessions on a wall-clock timer.

Given that, merging PID-fix part 1 as-is would have taken a currently-inert-and-harmless mechanism and made it start firing forced 2-hour restarts again, for a reason that's now known to be unfounded.

**Change:** `SESSION_AGE_LIMIT_SECONDS` now defaults to `0` (disabled) instead of `7200`. The mechanism itself is unchanged and still fully functional — including the part-1 PID fix, so it works correctly in both launch modes — but it no longer runs unless an operator explicitly opts in via `LOBSTER_SESSION_AGE_LIMIT_SECONDS=<seconds>` in `config.env` (this override mechanism already existed; only the *default* changed). This is a deliberate, minimal config-default change, not a removal of the mechanism — an operator who wants a periodic recycle for unrelated reasons (log rotation, memory hygiene, etc.) can still turn it on.

Comments in `check_session_age()` and around `SESSION_AGE_LIMIT_SECONDS` were reworded to stop asserting the debunked "hard 7440s limit" as fact and instead explain the disabled-by-default rationale, referencing #2157 and the 90+ hour counter-evidence. (`WFM_SUPPRESSION_MAX_SECONDS`, which derives from `SESSION_AGE_LIMIT_SECONDS`, already had a documented, tested fallback path for `SESSION_AGE_LIMIT_SECONDS=0` — see `compute_wfm_suppression_max_seconds()` — so this default flip does not require any change to that derivation, it just makes the existing fallback path (21600s/6h) the default one.)

This PR does not attempt the broader comment-accuracy sweep issue #2157 already tracks for other files (`inject-bootup-context.py`, test docstrings, etc.) — only the comments directly adjacent to the constant this PR changes were reworded.

## Functional patterns

Both parts are small, self-contained, side-effect-isolated changes. Part 1 mirrors an existing, already-correct sibling implementation (`claude-persistent.sh`) rather than introducing new logic shapes. Part 2 is a pure config-default change — `compute_wfm_suppression_max_seconds()` remains a pure function with no new branches; the new test (`test-health-check-session-age-default.sh`) exercises the actual production config-resolution code via `sed` extraction (same technique the pre-existing `test-health-check-session-age.sh` uses for `check_session_age()`) rather than reimplementing the logic under test.

## Out of scope

- No change to `check_session_age()`'s core logic, `DISPATCHER_PID_FILE` reader logic, or `do_restart()` — untouched.
- No change to `claude-persistent.sh` — it already wrote/cleaned up `dispatcher.pid` correctly.
- Does not address why `LOBSTER_DEBUG` drifted to `true` in the first place (separate, already-flagged config-drift issue).
- Does not perform issue #2157's full repo-wide comment-accuracy sweep — only comments directly touched by this diff were reworded.
- No migration entry added to `scripts/upgrade.sh` — this changes existing script/config-default behavior only (no new paths, config keys, cron entries, or service files), so a normal `lobster update` picks it up like any other source change. Existing installs that already have `LOBSTER_SESSION_AGE_LIMIT_SECONDS` set explicitly in `config.env` are unaffected either way.

## Tests run

- [x] New regression suite `tests/unit/test_hooks/test_claude_wrapper_exp_dispatcher_pid.py` — written first (TDD), confirmed failing against the pre-fix script, then passing after the fix: `uv run pytest tests/unit/test_hooks/test_claude_wrapper_exp_dispatcher_pid.py -v` — 5 passed.
- [x] Existing sibling suite `tests/unit/test_hooks/test_claude_wrapper_exp_spawn_pid.py` — 5 passed, no regression to the startup-flag write path.
- [x] Existing bash suite `tests/test-health-check-session-age.sh` (exercises `check_session_age()` in isolation, unaffected by the default-value change since it sets its own `SESSION_AGE_LIMIT_SECONDS` test constant): `bash tests/test-health-check-session-age.sh` — 14 passed, 0 failed.
- [x] Existing bash suite `tests/test-health-check-dispatcher-heartbeat.sh` (exercises `compute_wfm_suppression_max_seconds()`, including its explicit `SESSION_AGE_LIMIT_SECONDS=0` fallback path): `bash tests/test-health-check-dispatcher-heartbeat.sh` — 21 passed, 0 failed.
- [x] New bash suite `tests/test-health-check-session-age-default.sh` (exercises the actual config-resolution block that computes `SESSION_AGE_LIMIT_SECONDS` from env/config.env, extracted verbatim from the production script): `bash tests/test-health-check-session-age-default.sh` — 4 passed, 0 failed. Confirms: no override → 0 (disabled); env var opt-in respected; config.env opt-in respected; env var takes precedence over config.env.
- [x] `uv run pytest tests/unit/test_hooks/test_claude_wrapper_exp_dispatcher_pid.py tests/unit/test_hooks/test_dispatcher_session_start.py -q` — 13 passed.
- [x] Full `tests/unit/test_hooks/` directory (part 1's original run) — 1049 passed, 8 skipped, 11 failed; confirmed via `git stash` that the same 11 failures occur identically on unmodified `main` (pre-existing, unrelated to this PR).

## Manual test

Part 1 (`claude-wrapper.exp`): ran the actual script end-to-end against a stubbed `claude` binary with isolated `HOME`/`LOBSTER_MESSAGES`/`LOBSTER_WORKSPACE` pointed at a scratch tmp directory — no production paths touched. Observed `dispatcher.pid` created with the correct PID while the stub ran, and removed after it exited.

Part 2 (config default): no additional manual/live test — this is a pure default-value + comment change to already-tested shell logic, verified via the new and existing automated test suites above. No systemd/cron/external-service surface changed.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [x] Integration/manual test run (part 1) — see Manual test above
- [x] User-visible outcome: not applicable — internal launcher/health-check logic, no Telegram/UI-facing behavior change
- [x] Side-effect audit complete: no floods, no unscoped writes; part 2 only narrows when a SIGTERM restart fires (default now never, unless opted in) — strictly reduces disruptive side effects versus the pre-PR-#2197 state
- [x] External service calls: none added
