### PR TITLE
fix(tests): stop test suite from polluting production logs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,32 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+# ---------------------------------------------------------------------------
+# Force LOBSTER_WORKSPACE to an isolated temp dir for the whole test session,
+# BEFORE any test module can import src.bot.lobster_bot.
+#
+# Root cause this fixes: src/bot/lobster_bot.py resolves LOG_DIR from
+# LOBSTER_WORKSPACE at *module import time* and immediately attaches a
+# RotatingFileHandler to the shared "lobster" logger pointing at
+# LOG_DIR/telegram-bot.log. The isolate_inbox_server_paths fixture below only
+# patches src.mcp.inbox_server's path globals -- it has no equivalent guard
+# for src.bot.lobster_bot. On a machine where LOBSTER_WORKSPACE is set in the
+# environment (e.g. this host, where the always-on Lobster process exports
+# it), running pytest in that same shell/session causes lobster_bot.py to
+# import with the *real* production LOBSTER_WORKSPACE, and any test that
+# imports or exercises lobster_bot (handle_audio_message, handle_photo_message,
+# etc.) writes synthetic pytest/MagicMock log lines straight into the
+# production ~/lobster-workspace/logs/telegram-bot.log.
+#
+# Overriding (not just defaulting) LOBSTER_WORKSPACE here, unconditionally,
+# before any src.* module is imported, ensures lobster_bot.py's module-level
+# LOG_DIR always resolves to a throwaway temp directory during tests. This
+# does not affect tests that explicitly monkeypatch LOBSTER_WORKSPACE for
+# subprocess envs (env=os.environ.copy()-style dicts) -- those are unaffected
+# since they build their own env mapping.
+# ---------------------------------------------------------------------------
+os.environ["LOBSTER_WORKSPACE"] = tempfile.mkdtemp(prefix="lobster-test-workspace-")
+
 # Add source and tests directories to path
 SRC_DIR = Path(__file__).parent.parent / "src"
 TESTS_DIR = Path(__file__).parent

--- a/tests/unit/test_hooks/test_pii_scan_guard.py
+++ b/tests/unit/test_hooks/test_pii_scan_guard.py
@@ -77,6 +77,38 @@ _CATEGORY_NETWORK_ERROR = _mod._CATEGORY_NETWORK_ERROR
 _CATEGORY_TIMEOUT = _mod._CATEGORY_TIMEOUT
 _CATEGORY_MALFORMED_RESPONSE = _mod._CATEGORY_MALFORMED_RESPONSE
 
+_real_default_failopen_log_path = _mod._default_failopen_log_path
+
+
+@pytest.fixture(autouse=True)
+def _isolate_failopen_log_default(tmp_path, monkeypatch):
+    """Guard against production log pollution from fail-open logging.
+
+    ``_default_failopen_log_path(env)`` falls back to
+    ``Path.home() / "lobster-workspace"`` whenever the ``env`` dict passed to
+    ``run()`` / ``log_failopen_event()`` has no ``LOBSTER_WORKSPACE`` key.
+    Most tests in this file build ad-hoc env dicts to exercise mode gating /
+    API-key precedence and don't set ``LOBSTER_WORKSPACE`` (and don't pass
+    ``failopen_log_path`` either), so without this guard every test that hits
+    a fail-open path (missing API key, timeout, malformed response, ...)
+    wrote synthetic JSONL records straight into the real production
+    ``~/lobster-workspace/logs/pii-scan-guard-failopen.jsonl``.
+
+    This wraps the real function rather than stubbing it out: when a test
+    explicitly supplies ``LOBSTER_WORKSPACE`` in ``env`` (as
+    ``test_default_log_path_resolves_under_lobster_workspace`` does, to
+    verify the real resolution logic), that real logic still runs unchanged.
+    Otherwise, writes are redirected to a per-test ``tmp_path`` so nothing
+    can escape the sandbox.
+    """
+
+    def _fake(env):
+        if "LOBSTER_WORKSPACE" in env:
+            return _real_default_failopen_log_path(env)
+        return tmp_path / "unset-workspace-logs" / _mod._FAILOPEN_LOG_FILENAME
+
+    monkeypatch.setattr(_mod, "_default_failopen_log_path", _fake)
+
 
 # ---------------------------------------------------------------------------
 # parse_pre_push_refs


### PR DESCRIPTION
## Summary
- `src/bot/lobster_bot.py` and `src/bot/slack_router.py` resolve their `RotatingFileHandler` log path from `$LOBSTER_WORKSPACE` at module import time. The autouse `isolate_inbox_server_paths` fixture in `tests/conftest.py` only patches `src.mcp.inbox_server`'s path globals, so on a host where `LOBSTER_WORKSPACE` is already set (e.g. an always-on Lobster deployment), any test importing these modules wrote MagicMock/pytest noise straight into the real `telegram-bot.log` / `slack-router.log`. Fixed by forcing `LOBSTER_WORKSPACE` to a fresh temp dir at the top of `tests/conftest.py`, before any `src.*` module can be imported.
- `hooks/pii-scan-guard.py`'s `log_failopen_event()` falls back to `Path.home()/"lobster-workspace"` when the `env` dict passed to `run()` has no `LOBSTER_WORKSPACE` key. Most tests in `test_pii_scan_guard.py` build ad-hoc env dicts and don't set it, so fail-open-path tests wrote synthetic JSONL records into the real `pii-scan-guard-failopen.jsonl`. Fixed with an autouse fixture that redirects the default log path to `tmp_path` unless a test explicitly supplies `LOBSTER_WORKSPACE`.

Found via an audit that traced ~20k lines of synthetic pytest/MagicMock content mixed into production logs on a live deployment back to these two gaps.

## Test plan
- [x] `uv run pytest tests/unit/` — 4341 passed, 22 failed (all pre-existing, identical failure set with/without this change, verified via `git stash`), 32 skipped
- [x] Confirmed `~/lobster-workspace/logs/telegram-bot.log`, `slack-router.log`, and `pii-scan-guard-failopen.jsonl` receive zero new lines when running the previously-polluting test files after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)