### PR TITLE
feat(hooks): soft-warn guard for DEFERRED task creation after commitment replies

### DIFF
--- a/hooks/deferred-commitment-guard.py
+++ b/hooks/deferred-commitment-guard.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+Soft-warn guard: flags a dispatcher deferral reply (e.g. "I'll check on that")
+that is not followed by the required `create_task(subject="DEFERRED: ...")`
+call, per the "Commitment Durability" contract in
+`.claude/sys.dispatcher.bootup.md`.
+
+## Why this exists
+
+That instruction has zero code-level enforcement today: nothing checks that
+a `create_task` call with a `DEFERRED:` subject actually follows a deferral
+reply. If the dispatcher forgets the follow-up call, the commitment is
+silently and permanently lost -- no trace, no alert. See GitHub issue #2199.
+
+## Design
+
+Single script, registered for two hook events (branches on
+`hook_event_name` in the stdin payload):
+
+1. **PostToolUse, matcher `mcp__lobster-inbox__send_reply`:** if the reply
+   text matches deferral language (see `_DEFERRAL_PATTERNS`) and this is the
+   dispatcher session, write a sentinel file
+   (`$LOBSTER_WORKSPACE/data/deferred-commitment-pending.json`) recording a
+   timestamp and a short snippet of the reply.
+
+2. **PostToolUse, matcher `mcp__lobster-inbox__create_task`:** if the task
+   subject starts with `DEFERRED:`, clear the sentinel -- the commitment was
+   captured as required.
+
+3. **PreToolUse, matcher `""` (all tools):** if the sentinel exists and the
+   *next* tool call is anything other than `create_task`, this means a
+   deferral reply was sent and the dispatcher moved on to something else
+   without creating the tracking task. Print a soft warning to stderr and
+   clear the sentinel (so the warning fires exactly once per miss, not on
+   every subsequent tool call). This never blocks (`exit(0)` always) --
+   deferral-language detection is a natural-language heuristic with a real
+   false-positive rate, so hard-blocking would risk deadlocking legitimate
+   dispatcher work.
+
+## Fail-open policy
+
+Any error reading/writing the sentinel file, parsing stdin, or determining
+session role results in `exit(0)` with no warning. This hook must never
+block or crash the dispatcher due to its own infrastructure failures.
+
+## Settings.json configuration
+
+Add to hooks -> PostToolUse:
+
+    {
+      "matcher": "mcp__lobster-inbox__send_reply|mcp__lobster-inbox__create_task",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 $HOME/lobster/hooks/deferred-commitment-guard.py",
+          "timeout": 5
+        }
+      ]
+    }
+
+Add to hooks -> PreToolUse:
+
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 $HOME/lobster/hooks/deferred-commitment-guard.py",
+          "timeout": 5
+        }
+      ]
+    }
+"""
+
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+# Make hooks/ importable regardless of cwd.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from session_role import is_dispatcher_session  # noqa: E402 -- after sys.path insertion
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_WORKSPACE = Path(os.environ.get("LOBSTER_WORKSPACE", Path.home() / "lobster-workspace"))
+SENTINEL_PATH = _WORKSPACE / "data" / "deferred-commitment-pending.json"
+
+SEND_REPLY_TOOL = "mcp__lobster-inbox__send_reply"
+CREATE_TASK_TOOL = "mcp__lobster-inbox__create_task"
+
+# Deferral language patterns -- deliberately conservative (favor missed
+# detections over false positives, since this hook only soft-warns anyway).
+_DEFERRAL_PATTERNS = [
+    r"\bi'?ll (check|look into|get back to you|dig into|follow up)\b",
+    r"\bi need to (check|look into|dig into)\b",
+    r"\bchecking (on|into) (that|this) now\b",
+    r"\blet me (check|look into|dig into) (that|this)\b",
+    r"\bi'?ll (have an? (answer|update) for you|circle back)\b",
+]
+_DEFERRAL_RE = re.compile("|".join(_DEFERRAL_PATTERNS), re.IGNORECASE)
+
+_SNIPPET_LEN = 200
+
+
+# ---------------------------------------------------------------------------
+# Sentinel helpers
+# ---------------------------------------------------------------------------
+
+def _write_sentinel(reply_text: str) -> None:
+    try:
+        SENTINEL_PATH.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "reply_snippet": reply_text[:_SNIPPET_LEN],
+        }
+        SENTINEL_PATH.write_text(json.dumps(payload))
+    except OSError:
+        pass  # fail open
+
+
+def _clear_sentinel() -> None:
+    try:
+        SENTINEL_PATH.unlink(missing_ok=True)
+    except OSError:
+        pass  # fail open
+
+
+def _read_sentinel() -> dict | None:
+    try:
+        if not SENTINEL_PATH.exists():
+            return None
+        return json.loads(SENTINEL_PATH.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Event handlers
+# ---------------------------------------------------------------------------
+
+def _handle_post_send_reply(data: dict) -> None:
+    if not is_dispatcher_session(data):
+        return
+    tool_input = data.get("tool_input", {})
+    text = str(tool_input.get("text", ""))
+    if _DEFERRAL_RE.search(text):
+        _write_sentinel(text)
+
+
+def _handle_post_create_task(data: dict) -> None:
+    tool_input = data.get("tool_input", {})
+    subject = str(tool_input.get("subject", ""))
+    if subject.strip().startswith("DEFERRED:"):
+        _clear_sentinel()
+
+
+def _handle_pre_tool(data: dict) -> None:
+    if data.get("agent_id"):
+        return  # subagent -- this guard only tracks dispatcher commitments
+    sentinel = _read_sentinel()
+    if sentinel is None:
+        return
+
+    tool_name = data.get("tool_name", "")
+    if tool_name == CREATE_TASK_TOOL:
+        # Give the upcoming create_task call a chance to be the DEFERRED:
+        # follow-up; _handle_post_create_task clears the sentinel if so.
+        return
+
+    # Any other next tool call means the required create_task call did not
+    # immediately follow the deferral reply. Warn once, then clear so this
+    # doesn't repeat on every subsequent tool call for the same miss.
+    snippet = sentinel.get("reply_snippet", "")
+    print(
+        "WARNING [deferred-commitment-guard]: the last reply looked like a "
+        f"deferral (\"{snippet}\") but no create_task(subject=\"DEFERRED: ...\") "
+        "call followed. If this was a real commitment, create the tracking "
+        "task now (see 'Commitment Durability' in sys.dispatcher.bootup.md).",
+        file=sys.stderr,
+    )
+    _clear_sentinel()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    event = data.get("hook_event_name", "")
+    tool_name = data.get("tool_name", "")
+
+    try:
+        if event == "PostToolUse" and tool_name == SEND_REPLY_TOOL:
+            _handle_post_send_reply(data)
+        elif event == "PostToolUse" and tool_name == CREATE_TASK_TOOL:
+            _handle_post_create_task(data)
+        elif event == "PreToolUse":
+            _handle_pre_tool(data)
+    except Exception:  # noqa: BLE001 -- never let this hook crash the session
+        pass
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_hooks/test_deferred_commitment_guard.py
+++ b/tests/unit/test_hooks/test_deferred_commitment_guard.py
@@ -1,0 +1,203 @@
+"""
+Unit tests for hooks/deferred-commitment-guard.py
+
+Tests cover:
+- PostToolUse on send_reply: deferral language -> sentinel written (dispatcher only)
+- PostToolUse on send_reply: non-deferral text -> no sentinel written
+- PostToolUse on send_reply: non-dispatcher session -> no sentinel written
+- PostToolUse on create_task: DEFERRED: subject -> sentinel cleared
+- PostToolUse on create_task: non-DEFERRED subject -> sentinel left alone
+- PreToolUse: no sentinel -> silent, exit 0
+- PreToolUse: sentinel + next tool is create_task -> silent, sentinel left for
+  the PostToolUse create_task handler to evaluate
+- PreToolUse: sentinel + next tool is something else -> warns once, clears sentinel,
+  exit 0 (never blocks)
+- PreToolUse: subagent (agent_id present) -> passes through untouched
+- Fail-open: malformed stdin JSON -> exit 0, no crash
+"""
+
+import importlib.util
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+HOOK_PATH = HOOKS_DIR / "deferred-commitment-guard.py"
+
+
+def _load_hook(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("LOBSTER_WORKSPACE", str(tmp_path))
+    sys.path.insert(0, str(HOOKS_DIR))
+    spec = importlib.util.spec_from_file_location("deferred_commitment_guard", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run_main(hook_mod, stdin_data: dict):
+    stdin_str = json.dumps(stdin_data)
+    captured_stderr = StringIO()
+    exit_code = None
+    with patch("sys.stdin", StringIO(stdin_str)), patch("sys.stderr", captured_stderr):
+        try:
+            hook_mod.main()
+        except SystemExit as e:
+            exit_code = e.code
+    return exit_code, captured_stderr.getvalue()
+
+
+def _sentinel_path(mod) -> Path:
+    return mod.SENTINEL_PATH
+
+
+class TestPostToolUseSendReply:
+    def test_deferral_language_writes_sentinel_for_dispatcher(self, monkeypatch, tmp_path):
+        mod = _load_hook(monkeypatch, tmp_path)
+        monkeypatch.setattr(mod, "is_dispatcher_session", lambda _data: True)
+
+        exit_code, _ = _run_main(mod, {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "mcp__lobster-inbox__send_reply",
+            "tool_input": {"text": "I'll check on that and get back to you."},
+        })
+
+        assert exit_code == 0
+        assert _sentinel_path(mod).exists()
+        payload = json.loads(_sentinel_path(mod).read_text())
+        assert "check on that" in payload["reply_snippet"]
+
+    def test_non_deferral_text_does_not_write_sentinel(self, monkeypatch, tmp_path):
+        mod = _load_hook(monkeypatch, tmp_path)
+        monkeypatch.setattr(mod, "is_dispatcher_session", lambda _data: True)
+
+        exit_code, _ = _run_main(mod, {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "mcp__lobster-inbox__send_reply",
+            "tool_input": {"text": "Here's the answer: it's 42."},
+        })
+
+        assert exit_code == 0
+        assert not _sentinel_path(mod).exists()
+
+    def test_non_dispatcher_session_does_not_write_sentinel(self, monkeypatch, tmp_path):
+        mod = _load_hook(monkeypatch, tmp_path)
+        monkeypatch.setattr(mod, "is_dispatcher_session", lambda _data: False)
+
+        exit_code, _ = _run_main(mod, {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "mcp__lobster-inbox__send_reply",
+            "tool_input": {"text": "I'll check on that."},
+        })
+
+        assert exit_code == 0
+        assert not _sentinel_path(mod).exists()
+
+
+class TestPostToolUseCreateTask:
+    def test_deferred_subject_clears_sentinel(self, monkeypatch, tmp_path):
+        mod = _load_hook(monkeypatch, tmp_path)
+        _sentinel_path(mod).parent.mkdir(parents=True, exist_ok=True)
+        _sentinel_path(mod).write_text(json.dumps({"ts": "x", "reply_snippet": "I'll check"}))
+
+        exit_code, _ = _run_main(mod, {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "mcp__lobster-inbox__create_task",
+            "tool_input": {"subject": "DEFERRED: what time is the meeting"},
+        })
+
+        assert exit_code == 0
+        assert not _sentinel_path(mod).exists()
+
+    def test_non_deferred_subject_leaves_sentinel(self, monkeypatch, tmp_path):
+        mod = _load_hook(monkeypatch, tmp_path)
+        _sentinel_path(mod).parent.mkdir(parents=True, exist_ok=True)
+        _sentinel_path(mod).write_text(json.dumps({"ts": "x", "reply_snippet": "I'll check"}))
+
+        exit_code, _ = _run_main(mod, {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "mcp__lobster-inbox__create_task",
+            "tool_input": {"subject": "Buy groceries"},
+        })
+
+        assert exit_code == 0
+        assert _sentinel_path(mod).exists()
+
+
+class TestPreToolUse:
+    def test_no_sentinel_silent(self, monkeypatch, tmp_path):
+        mod = _load_hook(monkeypatch, tmp_path)
+
+        exit_code, stderr = _run_main(mod, {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {},
+        })
+
+        assert exit_code == 0
+        assert stderr == ""
+
+    def test_sentinel_present_next_is_create_task_silent(self, monkeypatch, tmp_path):
+        mod = _load_hook(monkeypatch, tmp_path)
+        _sentinel_path(mod).parent.mkdir(parents=True, exist_ok=True)
+        _sentinel_path(mod).write_text(json.dumps({"ts": "x", "reply_snippet": "I'll check"}))
+
+        exit_code, stderr = _run_main(mod, {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "mcp__lobster-inbox__create_task",
+            "tool_input": {},
+        })
+
+        assert exit_code == 0
+        assert stderr == ""
+        # Left for the PostToolUse create_task handler to evaluate/clear.
+        assert _sentinel_path(mod).exists()
+
+    def test_sentinel_present_next_is_other_tool_warns_and_clears(self, monkeypatch, tmp_path):
+        mod = _load_hook(monkeypatch, tmp_path)
+        _sentinel_path(mod).parent.mkdir(parents=True, exist_ok=True)
+        _sentinel_path(mod).write_text(json.dumps({"ts": "x", "reply_snippet": "I'll check on that"}))
+
+        exit_code, stderr = _run_main(mod, {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "mcp__lobster-inbox__wait_for_messages",
+            "tool_input": {},
+        })
+
+        assert exit_code == 0  # never blocks
+        assert "deferred-commitment-guard" in stderr
+        assert "I'll check on that" in stderr
+        assert not _sentinel_path(mod).exists()
+
+    def test_subagent_passes_through_untouched(self, monkeypatch, tmp_path):
+        mod = _load_hook(monkeypatch, tmp_path)
+        _sentinel_path(mod).parent.mkdir(parents=True, exist_ok=True)
+        _sentinel_path(mod).write_text(json.dumps({"ts": "x", "reply_snippet": "I'll check"}))
+
+        exit_code, stderr = _run_main(mod, {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {},
+            "agent_id": "some-subagent-id",
+        })
+
+        assert exit_code == 0
+        assert stderr == ""
+        # Subagent tool calls don't consume/clear the dispatcher's sentinel.
+        assert _sentinel_path(mod).exists()
+
+
+class TestFailOpen:
+    def test_malformed_stdin_exits_zero(self, monkeypatch, tmp_path):
+        mod = _load_hook(monkeypatch, tmp_path)
+        captured_stderr = StringIO()
+        exit_code = None
+        with patch("sys.stdin", StringIO("not json")), patch("sys.stderr", captured_stderr):
+            try:
+                mod.main()
+            except SystemExit as e:
+                exit_code = e.code
+        assert exit_code == 0


### PR DESCRIPTION
## Summary
- Fixes footgun #2199: the "Commitment Durability" contract (`sys.dispatcher.bootup.md`, ~line 1360-1390) requires the dispatcher to call `create_task(subject="DEFERRED: ...")` immediately after any reply that defers a question. Nothing enforced this — a skipped follow-up silently and permanently lost the commitment.
- Adds `hooks/deferred-commitment-guard.py`: writes a sentinel when a dispatcher `send_reply` matches deferral language ("I'll check on that", "I'll get back to you on X", etc.), and soft-warns (never blocks — `exit(0)` always) if the very next tool call isn't `create_task`. Fails open on any error (missing sentinel dir, malformed stdin, etc.).
- Adds `tests/unit/test_hooks/test_deferred_commitment_guard.py` (10 tests) covering: deferral detection + sentinel write, non-deferral text (no-op), non-dispatcher sessions (no-op), sentinel clearing on a `DEFERRED:`-subject `create_task`, sentinel left alone for non-`DEFERRED:` tasks, the warn-once-then-clear PreToolUse path, subagent pass-through, and malformed-stdin fail-open.

## Not included in this PR (deliberate scope cut)
- **Hook registration** in `settings.json` / `install.sh` / `scripts/upgrade.sh`. This repo's convention (see `hooks/catchup-gate.py`, `hooks/secret-scanner.py`) is to register new hooks via `jq` patches in `install.sh` plus a numbered migration in `scripts/upgrade.sh` for existing installs. I deliberately left that out of this pass — it touches install-flow files beyond the "specific hook files" scope I was asked to stick to, and I'd rather have a human/dev decide when to wire it live rather than silently start warning in production without review. The hook is fully implemented and tested; wiring it up is a follow-up (either a small additional PR or a manual `jq` patch + upgrade.sh migration, same pattern as the two existing hooks referenced above).
- The design intentionally soft-warns only (never blocks), since deferral-language detection is a natural-language regex heuristic with a real false-positive rate — see the module docstring for the full rationale.

## Test plan
- [x] `uv run pytest tests/unit/test_hooks/test_deferred_commitment_guard.py -q` — 10 passed

🤖🦞 Generated with Claude Code