### PR TITLE
fix(cli): stop lobster test from silently dead-lettering to failed/

### DIFF
--- a/src/cli
+++ b/src/cli
@@ -351,7 +351,8 @@ cmd_test() {
     cat > "$msg_file" << EOF
 {
   "id": "$msg_id",
-  "source": "test",
+  "source": "system",
+  "type": "self_check",
   "chat_id": 0,
   "user_id": 0,
   "username": "test_user",

--- a/tests/unit/test_cli/test_commands.py
+++ b/tests/unit/test_cli/test_commands.py
@@ -230,6 +230,71 @@ class TestTestCommand:
         files = list(inbox.glob("test_*.json"))
         assert len(files) >= 0  # May not exist if HOME doesn't match
 
+    def test_message_uses_registered_source_and_self_check_type(
+        self, cli_path: Path, temp_messages_dir: Path
+    ):
+        """Regression test for issue #2201.
+
+        cmd_test previously wrote source="test", which is not (and never was)
+        a member of INBOX_MESSAGE_SOURCES (src/mcp/message_types.py). Since
+        PR #1736 (issue #1735) added source-quarantine, every `lobster test`
+        run was silently dead-lettered to failed/ despite the CLI printing a
+        "should process shortly" success message.
+
+        Fix: write source="system" (a registered source, matching the sibling
+        fix already applied to daily-health-check.sh) and type="self_check"
+        explicitly (self_check is a registered INBOX_SYSTEM_TYPES member and
+        is not in USER_FACING_TYPES, so a chat_id=0 message with this type
+        will not be mistaken for a user-facing message needing a reply).
+        """
+        inbox = temp_messages_dir / "inbox"
+        inbox.mkdir(parents=True, exist_ok=True)
+
+        env = os.environ.copy()
+        env["HOME"] = str(temp_messages_dir.parent)
+        env.pop("LOBSTER_MESSAGES", None)
+
+        result = subprocess.run(
+            ["bash", str(cli_path), "test"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0, f"lobster test failed: {result.stderr}"
+
+        files = list(inbox.glob("test_*.json"))
+        assert len(files) == 1, f"Expected exactly one test_*.json file, got {files}"
+
+        msg = json.loads(files[0].read_text())
+        assert msg["source"] == "system", (
+            f"cmd_test must write source='system' (registered in INBOX_MESSAGE_SOURCES), "
+            f"got source={msg.get('source')!r}"
+        )
+        assert msg["type"] == "self_check", (
+            f"cmd_test must write type='self_check' (registered in INBOX_SYSTEM_TYPES), "
+            f"got type={msg.get('type')!r}"
+        )
+
+        # Cross-check against the live taxonomy so this test breaks if the
+        # constants ever change underneath it.
+        import sys as _sys
+        mcp_dir = str(Path(__file__).parent.parent.parent.parent / "src" / "mcp")
+        if mcp_dir not in _sys.path:
+            _sys.path.insert(0, mcp_dir)
+        from message_types import INBOX_MESSAGE_SOURCES, INBOX_SYSTEM_TYPES, USER_FACING_TYPES
+
+        assert msg["source"] in INBOX_MESSAGE_SOURCES, (
+            f"cmd_test source {msg['source']!r} is not in INBOX_MESSAGE_SOURCES — "
+            "it would be quarantined to failed/ by the inbox server's source guard"
+        )
+        assert msg["type"] in INBOX_SYSTEM_TYPES, (
+            f"cmd_test type {msg['type']!r} is not in INBOX_SYSTEM_TYPES"
+        )
+        assert msg["type"] not in USER_FACING_TYPES, (
+            f"cmd_test type {msg['type']!r} must not be user-facing — "
+            "the message carries chat_id=0 and is not a real user conversation"
+        )
+
 
 class TestUnknownCommand:
     """Tests for unknown command handling."""

--- a/tests/unit/test_mcp_server/test_unrecognized_source_quarantine.py
+++ b/tests/unit/test_mcp_server/test_unrecognized_source_quarantine.py
@@ -285,6 +285,51 @@ class TestUnrecognizedSourceQuarantine:
             "bot-talk message must be returned by check_inbox"
         )
 
+    def test_cmd_test_message_shape_passes_quarantine_guard(
+        self, inbox_server_dirs: dict
+    ):
+        """Regression test for issue #2201: `lobster test` (cmd_test in src/cli)
+        message shape must not be quarantined.
+
+        Before the fix, cmd_test wrote source="test" — never a member of
+        INBOX_MESSAGE_SOURCES since PR #1736 (issue #1735) introduced this
+        quarantine guard — so every `lobster test` invocation was silently
+        dead-lettered to failed/ despite the CLI printing a success message.
+
+        This uses the exact message shape cmd_test now produces: source=system,
+        type=self_check, chat_id=0, user_id=0, username=test_user.
+        """
+        inbox_dir = inbox_server_dirs["inbox"]
+        failed_dir = inbox_server_dirs["failed"]
+
+        msg = {
+            "id": "test_1234567890",
+            "source": "system",
+            "type": "self_check",
+            "chat_id": 0,
+            "user_id": 0,
+            "username": "test_user",
+            "user_name": "Test",
+            "text": "This is a test message. Please acknowledge.",
+            "timestamp": _iso(_BASE_TS),
+        }
+        (inbox_dir / "test_1234567890.json").write_text(json.dumps(msg))
+
+        from src.mcp.inbox_server import handle_check_inbox
+
+        result = asyncio.run(handle_check_inbox({}))
+
+        # Must not be quarantined
+        assert list(failed_dir.glob("*.json")) == [], (
+            "cmd_test's message shape (source=system, type=self_check) must not "
+            "be quarantined — both are registered in message_types.py"
+        )
+        # Must be returned to the dispatcher
+        result_text = result[0].text
+        assert "test_1234567890" in result_text, (
+            "cmd_test's test message must be returned by check_inbox, not silently dropped"
+        )
+
     def test_quarantine_guard_runs_with_source_filter(
         self, inbox_server_dirs: dict
     ):


### PR DESCRIPTION
## Problem

`lobster test` (`cmd_test` in `src/cli`) writes a diagnostic message directly into the live inbox with `"source": "test"`. `"test"` has never been a member of `INBOX_MESSAGE_SOURCES` (`src/mcp/message_types.py`) since PR #1736 (issue #1735) added source-quarantine to prevent hot-loops. As a result, every `lobster test` invocation has been silently dead-lettered to `~/messages/failed/` — despite the CLI printing "If Claude is running, it should process this shortly." The command's own success message has been false since #1736 merged.

The sibling script, `scripts/daily-health-check.sh`, was fixed at the same time (switched to `source="system"`) but `cmd_test` was missed.

## Fix

`cmd_test` now writes `source="system"` and `type="self_check"` explicitly:
- `source="system"` mirrors the existing `daily-health-check.sh` fix and is a registered `INBOX_MESSAGE_SOURCES` member, so it passes the quarantine guard.
- `type="self_check"` is set explicitly rather than left to default (previously missing entirely, which defaults to `type="text"` on ingest). `text` is a member of `USER_FACING_TYPES` — pairing it with `source="system"`/`chat_id=0` was flagged in #2201 as an untested combination that could behave worse than the current quarantine (e.g. get treated as a user-facing message needing a reply against `chat_id=0`). `self_check` is already a registered `INBOX_SYSTEM_TYPES` member ("periodic health/reminder injection" — the closest existing match to a manual pipeline-liveness probe) and is *not* in `USER_FACING_TYPES`, so it quarantines/routes exactly like the already-proven `daily-health-check.sh` pattern.

Out of scope: registering `"test"` directly in `INBOX_MESSAGE_SOURCES` was considered (see #2201) and rejected — that's a change to the live MCP server's source of truth requiring a server restart, which per this repo's convention must go through `scripts/restart-mcp.sh`, sequenced by the dispatcher, not fired inline by this PR.

This PR does not restart or touch the live `lobster-mcp-local` service. No behavior changes outside of `cmd_test`'s message shape.

## Functional patterns

Pure data change — no control flow, no mutation of shared state. The fix narrows the message payload to a known-safe value; no new branching logic introduced.

## Tests run
- [x] `uv run pytest tests/unit/test_cli/test_commands.py` — 20 passed (includes new `test_message_uses_registered_source_and_self_check_type`, which asserts the emitted JSON has `source="system"`, `type="self_check"`, and cross-checks both against the live `INBOX_MESSAGE_SOURCES`/`INBOX_SYSTEM_TYPES`/`USER_FACING_TYPES` constants)
- [x] `uv run pytest tests/unit/test_mcp_server/test_unrecognized_source_quarantine.py` — 9 passed (includes new `test_cmd_test_message_shape_passes_quarantine_guard`, which feeds `handle_check_inbox` the exact message shape `cmd_test` now produces and asserts it is returned to the dispatcher, not quarantined to `failed/`)
- [x] `uv run pytest tests/unit/test_mcp_server/test_message_taxonomy.py tests/unit/test_script_inbox_sources.py` — 17 passed, 1 pre-existing failure (`test_daily_update_check_writes_system_source`), confirmed unrelated by stashing this PR's changes and re-running against unmodified `main` — same failure reproduces there
- [x] `uv run pytest tests/unit/` (full suite) — 4344 passed, 21 failed, 32 skipped. All 21 failures are in files this PR does not touch (Slack poller precision, Slack router config, on-compact hook session-id writer, PII scan guard, push-token endpoint tests, and the one pre-existing `daily-update-check.sh` guardrail failure above). Spot-checked a representative subset of the unrelated failures against unmodified `main` (stashed this PR's 3-file diff) — they reproduce identically, confirming pre-existing failures.

## Manual test
N/A — this is a pure inbox-message-shape change covered by unit tests exercising the exact code path (`handle_check_inbox`'s quarantine guard) that silently swallowed these messages in production. No systemd/cron/external-service/DB-schema surface touched. The fix requires the MCP server to pick up the change on its next natural restart; no restart performed as part of this PR (explicitly out of scope per the task).

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests)
- [ ] Integration/manual test — not applicable (no external service call; pure message-shape fix validated via unit tests against the real quarantine handler code path)
- [x] User-visible outcome verified — N/A, no direct user-facing output; verified via the inbox-server code path that was previously silently dropping these messages
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume — the change only affects `cmd_test`'s own single test-message payload
- [x] External service calls: N/A, no external service involved

Closes #2201