### PR TITLE
fix: obsidian MCP hang froze whole dispatcher, orphaned children, never verified writes

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -146,7 +146,7 @@ Never pass `hibernate_on_timeout=True` — feature removed in issue #1442; cause
 - Read images (the one documented carve-out — claim first with `mark_processing`)
 
 **What ALWAYS goes to a background subagent (`run_in_background=true`):**
-- ANY file read/write (except images)
+- ANY file read/write (except images) — this explicitly includes **every `mcp__obsidian__*` tool call** (`create-note`, `edit-note`, `read-note`, `search-vault`, `list-available-vaults`, `move-note`, `delete-note`, `add-tags`, `remove-tags`, `rename-tag`, `create-directory`). These are stdio MCP calls backed by `npx -y obsidian-mcp <vault-path>` with **no application-level timeout** — a hang blocks whatever thread made the call until the ~2h04m session-age SIGTERM kills the entire session (see issue #2119). Never call an `mcp__obsidian__*` tool inline on the main dispatcher thread, under any circumstance.
 - ANY git operation
 - ANY GitHub API call
 - ANY web fetch or research
@@ -160,7 +160,57 @@ Never pass `hibernate_on_timeout=True` — feature removed in issue #1442; cause
 Read("${LOBSTER_INSTALL_DIR:-~/lobster}/.claude/sys.dispatcher.bootup.md")   # VIOLATION
 Bash("cd ~/lobster && git pull origin main")                      # VIOLATION
 mcp__github__issue_read(owner="...", repo="...", ...)             # VIOLATION
+mcp__obsidian__list-available-vaults()                             # VIOLATION (issue #2119 — hung 2304s inline, froze the whole dispatcher loop)
 ```
+
+### Obsidian vault writes: delegate, then verify before claiming success (issue #2119)
+
+Mirror the link-capture delegation pattern used by `lobster-shop/obsidian-km/context/obsidian-km.md`
+for any Obsidian save request (a note, a redline, a meeting summary, anything the user asks you
+to "save to the vault" or "add to Obsidian"):
+
+```
+1. Acknowledge immediately, without promising a specific outcome yet:
+   send_reply(chat_id, "On it — saving that to the vault now.", message_id=message_id)
+
+2. Delegate the actual Obsidian tool calls to a background subagent:
+   Task(
+       prompt="""
+       ---
+       task_id: <task_id>
+       chat_id: <chat_id>
+       source: <source>
+       background: true
+       ---
+
+       Save this to the Obsidian vault: <content/details>.
+
+       Steps:
+       1. Call mcp__obsidian__create-note (or edit-note) to write the note.
+       2. MANDATORY — do not skip: call mcp__obsidian__search-vault (or
+          read-note on the exact path you just wrote) to confirm the note
+          actually exists in the vault. Never report success before this
+          read-back confirms the write landed — a stdio call that appears to
+          return can still have written nothing if the tool hung and was
+          later aborted by session recycling (issue #2119).
+       3. Only after the read-back confirms the note exists, call write_result
+          with a success message (include the vault path/link).
+          If the read-back fails or the note is missing, call write_result
+          with status="error" and say plainly that the save did not complete
+          — do not claim success.
+       """,
+       subagent_type="general-purpose",
+       run_in_background=true,
+   )
+
+3. mark_processed(message_id)
+4. Return to wait_for_messages() immediately — do not wait on the subagent.
+```
+
+**Never say "saving it now" and then call an `mcp__obsidian__*` tool in the same turn on the main
+thread.** The promise and the write must be separated by a background subagent boundary. If the
+subagent's call hangs, the dispatcher keeps processing other messages — it does not go silent for
+hours the way this incident did.
 
 **Code internals questions:** delegate to a subagent to read the actual code — never speculate from memory.
 

--- a/scripts/claude-persistent.sh
+++ b/scripts/claude-persistent.sh
@@ -388,10 +388,30 @@ kill_orphaned_mcp_processes() {
         # itself, but the service bounce still wiped in-memory session/lock state,
         # producing spurious session-lost-reminder / dispatcher-marked-dead
         # notifications with no actual dispatcher crash. See investigation for
-        # issues #2124 / #2142. The correct invocation takes the PID as a bare
-        # positional argument.
-        if systemctl status "$pid" >/dev/null 2>&1; then
-            log "CLEANUP: MCP PID $pid is a systemd-managed service — skipping"
+        # issues #2124 / #2142.
+        #
+        # #1551's fix ("pass the PID as a bare positional argument") replaced one
+        # bug with a subtler one (issue #2119): `systemctl status <pid>` does not
+        # ask "is this PID itself a systemd service" — it resolves the PID's
+        # cgroup to whichever unit owns that cgroup and reports THAT unit's
+        # status, exit 0, for *any* PID living anywhere inside it. Every process
+        # under lobster-claude.service's tmux session (the dispatcher, every MCP
+        # child it spawns, and any orphan reparented to PID 1 that still carries
+        # the same cgroup membership from when it was forked) resolves to
+        # lobster-claude.service and returns exit 0 — so this check has always
+        # treated every single MCP child, including hung/orphaned obsidian-mcp
+        # processes, as "systemd-managed" and skipped it. Confirmed empirically
+        # against live orphaned obsidian-mcp PIDs (PPID=1, one per session-age
+        # restart, accumulating indefinitely — see issue #2119).
+        #
+        # Fix: only the process that is actually the recorded MainPID of the
+        # protected unit should be skipped. Compare against MainPID directly
+        # instead of asking "does this PID's cgroup resolve to some unit".
+        local protected_service="${LOBSTER_MCP_SERVICE_NAME:-lobster-mcp.service}"
+        local protected_main_pid
+        protected_main_pid=$(systemctl show -p MainPID --value "$protected_service" 2>/dev/null || true)
+        if [[ -n "$protected_main_pid" && "$protected_main_pid" != "0" && "$pid" == "$protected_main_pid" ]]; then
+            log "CLEANUP: MCP PID $pid is the systemd-managed ${protected_service} MainPID — skipping"
             skipped=$((skipped + 1))
             continue
         fi
@@ -790,4 +810,10 @@ Claude persistent session initializing."
 trap 'log "Received SIGTERM, shutting down..."; write_state "stopped" "sigterm"; exit 0' SIGTERM
 trap 'log "Received SIGINT, shutting down..."; write_state "stopped" "sigint"; exit 0' SIGINT
 
-main "$@"
+# Only run main when executed directly. When sourced (e.g. by a test harness
+# exercising kill_orphaned_mcp_processes/kill_orphaned_claude_processes in
+# isolation), skip the auto-run so the caller controls exactly what runs.
+# No behavior change for the normal systemd/tmux launch path.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -125,6 +125,17 @@ DISPATCHER_HEARTBEAT_STALE_SECONDS=1200   # 20 min — covers compaction (~5m) +
 SESSION_AGE_LIMIT_SECONDS="${LOBSTER_SESSION_AGE_LIMIT_SECONDS:-7200}"
 DISPATCHER_SESSION_START_FILE="${LOBSTER_DISPATCHER_SESSION_START_FILE_OVERRIDE:-$WORKSPACE_DIR/data/dispatcher-session-start.ts}"
 
+# Orphaned stdio MCP process reaper (issue #2119). Backstop for stdio MCP
+# children (obsidian-mcp specifically, pattern is generic) that survive a
+# session-age restart despite check_session_age()'s kill_dispatcher_children
+# call -- e.g. a restart that took the crash path instead of the graceful
+# SIGTERM path, or any other route that reparents an MCP child to PID 1
+# without signalling it. Threshold is one restart cycle (SESSION_AGE_LIMIT_SECONDS,
+# 7200s = 2h) plus a margin so we never race a process that is still
+# mid-reparenting from a restart that is in progress right now.
+ORPHAN_MCP_REAP_AGE_SECONDS="${LOBSTER_ORPHAN_MCP_REAP_AGE_SECONDS:-8100}"   # 2h15m
+ORPHAN_MCP_REAP_PATTERN="${LOBSTER_ORPHAN_MCP_REAP_PATTERN:-obsidian-mcp}"
+
 # WFM-active signal (issue #1713 / #949): inbox_server.py writes this file with
 # a Unix epoch timestamp when wait_for_messages begins blocking and refreshes it
 # every WAIT_HEARTBEAT_INTERVAL (60s). When this file is fresh, the dispatcher is
@@ -1493,6 +1504,17 @@ check_session_age() {
         return 0
     fi
 
+    # Snapshot the dispatcher's direct children BEFORE sending SIGTERM (issue
+    # #2119). This must happen first: once the dispatcher (`claude`) receives
+    # SIGTERM and exits, its children (stdio MCP servers like `obsidian-mcp`)
+    # are reparented away from $dispatcher_pid immediately — querying `pgrep -P
+    # $dispatcher_pid` AFTER the SIGTERM is a race that can find zero children
+    # even though they existed a moment earlier, because the parent is already
+    # gone by the time the query runs. Capturing the list first and signalling
+    # those specific PIDs afterward removes the race entirely.
+    local mcp_child_pids
+    mcp_child_pids=$(pgrep -P "$dispatcher_pid" 2>/dev/null || true)
+
     # Notify BEFORE sending SIGTERM (issue #2075) so the message reaches the user
     # even if the session exits immediately once SIGTERM is delivered — if the
     # alert were sent after kill -TERM, a fast process death could drop it
@@ -1513,6 +1535,18 @@ check_session_age() {
     # restarts Claude. This is a graceful exit, not a crash.
     if kill -TERM "$dispatcher_pid" 2>/dev/null; then
         log_warn "Session age: SIGTERM sent to dispatcher PID $dispatcher_pid"
+
+        # Also signal the dispatcher's direct child processes we snapshotted
+        # above -- stdio MCP servers like `obsidian-mcp` (issue #2119).
+        # SIGTERM to $dispatcher_pid only reaches the `claude` process itself;
+        # it does NOT cascade to stdio MCP children it spawned, which are
+        # simply orphaned (reparented to PID 1) rather than killed.
+        # obsidian-mcp specifically has no application-level timeout and can
+        # be mid-hang at the moment of this restart, so leaving it running
+        # produces exactly the orphan leak this issue reports: one stray
+        # process per session-age restart, accumulating indefinitely.
+        kill_dispatcher_children $mcp_child_pids
+
         # Delete the start timestamp so a subsequent health check run (within the
         # next 4 minutes) does not send a second SIGTERM before the restart completes.
         rm -f "$DISPATCHER_SESSION_START_FILE" 2>/dev/null || true
@@ -1520,6 +1554,150 @@ check_session_age() {
     else
         log_warn "Session age: SIGTERM to PID $dispatcher_pid failed (process may have exited already)"
         return 0
+    fi
+}
+
+#===============================================================================
+# kill_dispatcher_children — signal direct child processes of the dispatcher
+# (issue #2119)
+#
+# Why not signal the dispatcher's whole process group instead (kill -TERM
+# -$pgid)? That was the initial fix proposal, but it does not hold up against
+# the live process tree. Verified on the production host:
+#
+#   $ ps -o pid,ppid,pgid,sid,comm -p "$dispatcher_pid"
+#       PID    PPID    PGID     SID COMMAND
+#   4183042 2901787 2901787 2901787 claude
+#
+# The dispatcher's PGID (2901787) is NOT its own PID (4183042) -- it shares
+# its process group with claude-persistent.sh (PID 2901787), the supervisor
+# script that detects the dispatcher's exit and relaunches it, which in turn
+# runs under the tmux session leader. `kill -TERM -$dispatcher_pid` would
+# target a process group that doesn't exist (no-op); using the *real* PGID
+# instead would SIGTERM the supervisor and the tmux pane along with it,
+# breaking the auto-restart mechanism this entire flow depends on.
+#
+# Enumerating direct children of $dispatcher_pid (ps --ppid / pgrep -P) is
+# the safe alternative: it reaches every MCP child the dispatcher spawned
+# (obsidian-mcp, inbox_server.py, etc.) without touching anything above the
+# dispatcher in the process tree. A fresh set of children is spawned by the
+# next Claude launch regardless, so killing all current children here is
+# safe -- none of them have a reason to outlive this session.
+#
+# Takes the child PIDs as arguments (already-enumerated by the caller) rather
+# than a parent PID to enumerate itself. This matters: the caller must
+# snapshot the children BEFORE sending SIGTERM to the dispatcher, because
+# once the dispatcher exits its children are reparented away immediately —
+# enumerating *after* the SIGTERM is a race that can observe zero children
+# even though they existed a moment earlier.
+#===============================================================================
+kill_dispatcher_children() {
+    local child_pids="$*"
+
+    if [[ -z "${child_pids// /}" ]]; then
+        log_info "Session age: no child processes to signal"
+        return 0
+    fi
+
+    log_warn "Session age: signalling dispatcher child process(es): $(echo "$child_pids" | tr '\n' ' ')"
+
+    local sigterm_pids=()
+    local cpid
+    for cpid in $child_pids; do
+        if kill -TERM "$cpid" 2>/dev/null; then
+            sigterm_pids+=("$cpid")
+        fi
+    done
+
+    if [[ ${#sigterm_pids[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    # Brief grace period, then SIGKILL any child that ignored SIGTERM (e.g. a
+    # stdio MCP server hung inside a blocking call with no signal handling
+    # path that actually exits). Only SIGKILL PIDs we sent SIGTERM to, to
+    # avoid hitting an unrelated process that reused the PID during the wait.
+    sleep 2
+    for cpid in "${sigterm_pids[@]}"; do
+        if kill -0 "$cpid" 2>/dev/null; then
+            log_warn "Session age: child PID $cpid still alive after SIGTERM — sending SIGKILL"
+            kill -KILL "$cpid" 2>/dev/null || true
+        fi
+    done
+}
+
+#===============================================================================
+# reap_orphaned_mcp_processes — cron backstop for orphaned stdio MCP servers
+# (issue #2119)
+#
+# check_session_age()'s kill_dispatcher_children() is the primary fix: it
+# signals stdio MCP children (obsidian-mcp) at the moment of a session-age
+# restart, before they can be orphaned. This function is the backstop for
+# every path that primary fix does not cover -- a dispatcher crash (OOM,
+# hard kill, CC's 7440s hard limit firing before the proactive restart),
+# a restart on an older/rolled-back build without kill_dispatcher_children,
+# or any other route that reparents an MCP child to PID 1 without signalling
+# it first.
+#
+# Runs every health-check-v3.sh cycle (cron, every 4 minutes -- see
+# `# LOBSTER-HEALTH` in crontab), independent of whether a restart is
+# happening right now. Only targets processes that are BOTH:
+#   1. Reparented to init (PPID=1) -- i.e. actually orphaned, not a live
+#      MCP child of the current dispatcher session
+#   2. Older than ORPHAN_MCP_REAP_AGE_SECONDS (default 8100s = 2h15m, i.e.
+#      one full session-age restart cycle plus a 15-minute margin) -- this
+#      avoids racing a process that is still mid-reparenting from a restart
+#      that is in progress right this moment
+#===============================================================================
+reap_orphaned_mcp_processes() {
+    local pattern="$ORPHAN_MCP_REAP_PATTERN"
+    local max_age="$ORPHAN_MCP_REAP_AGE_SECONDS"
+
+    local candidate_pids
+    candidate_pids=$(pgrep -f "$pattern" 2>/dev/null || true)
+
+    if [[ -z "$candidate_pids" ]]; then
+        return 0
+    fi
+
+    local reaped=0
+    local pid
+    for pid in $candidate_pids; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            continue
+        fi
+
+        local ppid
+        ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+        if [[ "$ppid" != "1" ]]; then
+            # Still has a live parent -- a legitimate MCP child of a current
+            # session, not an orphan. Leave it alone.
+            continue
+        fi
+
+        local etimes
+        etimes=$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d ' ')
+        if [[ -z "$etimes" || ! "$etimes" =~ ^[0-9]+$ ]]; then
+            continue
+        fi
+        if [[ "$etimes" -lt "$max_age" ]]; then
+            log_info "Orphan reaper: PID $pid matches '$pattern', PPID=1, but only ${etimes}s old (< ${max_age}s) — leaving it for now"
+            continue
+        fi
+
+        log_warn "Orphan reaper: killing orphaned MCP process PID $pid (matches '$pattern', PPID=1, age ${etimes}s >= ${max_age}s)"
+        if kill -TERM "$pid" 2>/dev/null; then
+            reaped=$((reaped + 1))
+            sleep 1
+            if kill -0 "$pid" 2>/dev/null; then
+                log_warn "Orphan reaper: PID $pid still alive after SIGTERM — sending SIGKILL"
+                kill -KILL "$pid" 2>/dev/null || true
+            fi
+        fi
+    done
+
+    if [[ $reaped -gt 0 ]]; then
+        log_warn "Orphan reaper: reaped $reaped orphaned MCP process(es) matching '$pattern'"
     fi
 }
 
@@ -1899,6 +2077,13 @@ main() {
         fi
     fi
 
+    # --- Orphaned stdio MCP process reaper (issue #2119) ---
+    # Cheap (pgrep + ps on a handful of PIDs at most) and safe to run every
+    # cycle regardless of lifecycle state or boot grace -- it only ever acts
+    # on processes that are already reparented to PID 1 and past the age
+    # threshold, never on anything belonging to the current session.
+    reap_orphaned_mcp_processes
+
     # --- Always check systemd services (includes router/bot) ---
     if ! check_services; then
         level="RED"
@@ -2240,4 +2425,12 @@ if [[ "${1:-}" == "--clear-black" ]]; then
     exit 0
 fi
 
-main "$@"
+# Only run main when executed directly (cron, manual invocation). When this
+# script is sourced (e.g. `source health-check-v3.sh` from a test harness, to
+# exercise individual functions like check_session_age/kill_dispatcher_children/
+# reap_orphaned_mcp_processes in isolation), skip the auto-run so the caller
+# controls exactly what runs. No behavior change for the normal cron path --
+# BASH_SOURCE[0] == $0 is true whenever the script is invoked directly.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tests/test-claude-persistent-orphan-mcp-cleanup.sh
+++ b/tests/test-claude-persistent-orphan-mcp-cleanup.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+#===============================================================================
+# Test Suite: claude-persistent.sh - kill_orphaned_mcp_processes() (issue #2119)
+#
+# Root cause under test: kill_orphaned_mcp_processes() is supposed to skip
+# systemd-managed MCP services (e.g. the real MCP HTTP server) and kill
+# everything else that looks orphaned. The guard it used, `systemctl status
+# "$pid"`, does NOT ask "is $pid itself a systemd service" -- it resolves
+# $pid's cgroup to whichever unit owns that cgroup and reports THAT unit's
+# status with exit 0, for ANY pid living anywhere inside it. Every process
+# under lobster-claude.service's tmux session (the dispatcher, every MCP
+# child it spawns -- including a hung/orphaned obsidian-mcp process, which
+# keeps its original cgroup membership even after being reparented to PID 1)
+# resolves to lobster-claude.service and returns exit 0. So the old guard
+# always treated every MCP child as "systemd-managed" and never killed it --
+# confirmed against real production orphan PIDs during investigation of this
+# issue (12 live orphaned obsidian-mcp processes, one per session-age
+# restart, accumulating indefinitely because this guard silently protected
+# every single one of them).
+#
+# The fix compares against the actual recorded MainPID of the protected
+# systemd unit (`systemctl show -p MainPID --value <service>`) instead of
+# the cgroup-membership test.
+#
+# This test suite runs INSIDE the real lobster-claude.service cgroup (this
+# is itself a subagent process under that service), so `systemctl status
+# $$` demonstrably returns exit 0 for this test's own PID -- the same
+# condition that made the old guard falsely "protect" every MCP child. This
+# is intentionally an integration-style test against the *real* systemctl
+# and the *real* lobster-mcp.service, not a mock: it proves the fix holds
+# under the actual production condition that caused the bug, not just a
+# synthetic double. No systemd unit is started, stopped, or otherwise
+# mutated -- only `systemctl status`/`show` (read-only) are used, and the
+# only processes signalled are throwaway `sleep`-based fakes spawned by this
+# test.
+#
+# Usage: bash tests/test-claude-persistent-orphan-mcp-cleanup.sh
+#===============================================================================
+
+set -u
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts"
+CLAUDE_PERSISTENT_SCRIPT="$SCRIPT_DIR/claude-persistent.sh"
+
+TEST_TMPDIR=$(mktemp -d /tmp/lobster-orphan-mcp-test-XXXXXX)
+cleanup() {
+    [[ -n "${fake_pid:-}" ]] && kill -9 "$fake_pid" 2>/dev/null
+    rm -rf "$TEST_TMPDIR"
+}
+trap cleanup EXIT
+
+begin_test() { TOTAL=$((TOTAL + 1)); test_name="$1"; }
+pass()  { PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC} $test_name"; }
+fail()  { FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC} $test_name: $1"; }
+
+# The pattern string is built from parts so this test file's own invocation
+# (`bash tests/test-claude-persistent-orphan-mcp-cleanup.sh ...`) never
+# contains the literal fake-binary marker string as a substring of its own
+# command line -- avoiding a pgrep -f self-match against the test runner.
+FAKE_MARKER="fake${TEST_TMPDIR##*-}obsidian_stub"
+
+#===============================================================================
+# Stub the minimal environment kill_orphaned_mcp_processes() needs.
+#===============================================================================
+LOG_FILE="$TEST_TMPDIR/claude-persistent.log"
+log() {
+    local msg="[$(date -Iseconds)] $1"
+    echo "$msg" >> "$LOG_FILE" 2>/dev/null
+}
+
+# Build a fake "obsidian-mcp"-shaped process whose command line contains
+# FAKE_MARKER instead of the real name, and patch the pgrep pattern the
+# extracted function uses to search for FAKE_MARKER instead of the literal
+# string "obsidian-mcp" -- this keeps the test fully isolated from any real
+# obsidian-mcp process that might legitimately be running on this host right
+# now (there are live ones on this production box; the test must not
+# interact with them in either direction).
+FAKE_BIN_DIR="$TEST_TMPDIR/bin"
+mkdir -p "$FAKE_BIN_DIR"
+FAKE_BIN="$FAKE_BIN_DIR/$FAKE_MARKER"
+cat > "$FAKE_BIN" <<'EOF'
+#!/bin/bash
+sleep 600
+EOF
+chmod +x "$FAKE_BIN"
+
+# Extract kill_orphaned_mcp_processes() from claude-persistent.sh, then:
+#  1. retarget its process-pattern search at FAKE_MARKER instead of the two
+#     hardcoded real patterns (inbox_server.py / obsidian-mcp), so this test
+#     only ever sees and signals its own fake process tree.
+#  2. neutralize the tmux-pane ownership check (force tmux_panes empty).
+#     This test's own process tree is a real descendant of the live
+#     production tmux session (this test runs inside a Task-spawned
+#     subagent, itself a descendant of the dispatcher's tmux pane) -- so
+#     without this, the ancestor-walk would correctly (by design) classify
+#     the fake process as a "current-session descendant" and skip it,
+#     which is a DIFFERENT code path than the systemctl guard this test
+#     targets. Forcing tmux_panes empty isolates the systemctl-guard fix
+#     under test from the (working, not-under-test) tmux ownership check.
+fn_body=$(sed -n '/^kill_orphaned_mcp_processes()/,/^}/p' "$CLAUDE_PERSISTENT_SCRIPT")
+if [[ -z "$fn_body" ]]; then
+    echo "FATAL: kill_orphaned_mcp_processes() not found in $CLAUDE_PERSISTENT_SCRIPT"
+    exit 1
+fi
+fn_body=$(echo "$fn_body" | sed \
+    -e 's/pgrep -f "src\/mcp\/inbox_server\\.py"/true/' \
+    -e "s/pgrep -f \"obsidian-mcp\"/pgrep -f \"$FAKE_MARKER\"/" \
+    -e "s/tmux_panes=\$(tmux -L lobster list-panes -a -F '#{pane_pid}' 2>\/dev\/null || true)/tmux_panes=\"\"/")
+eval "$fn_body"
+
+if ! declare -f kill_orphaned_mcp_processes | grep -q 'tmux_panes=""'; then
+    echo "FATAL: tmux_panes neutralization sed did not match -- refusing to run (would test against the live tmux session instead of an isolated fake)"
+    exit 1
+fi
+
+if ! declare -f kill_orphaned_mcp_processes > /dev/null 2>&1; then
+    echo "FATAL: kill_orphaned_mcp_processes() did not load"
+    exit 1
+fi
+
+echo ""
+echo "=== claude-persistent.sh: kill_orphaned_mcp_processes() Tests (issue #2119) ==="
+echo ""
+
+# Sanity: confirm this test process really does run inside a systemd-unit
+# cgroup, i.e. the exact condition that caused the original bug. If this
+# ever fails (e.g. running outside the Lobster production host), the rest
+# of this suite is still valid but is no longer proving the live-condition
+# claim in the header comment -- flag it rather than silently passing.
+begin_test "sanity_this_process_is_inside_a_systemd_cgroup"
+if systemctl status $$ >/dev/null 2>&1; then
+    pass
+else
+    fail "systemctl status \$\$ returned nonzero -- not running inside a systemd cgroup; the cgroup-membership bug this test targets cannot be demonstrated in this environment"
+fi
+
+# 1. A fake orphaned MCP process is killed by the FIXED guard, even though
+# `systemctl status` on its own PID returns exit 0 (same cgroup as this
+# test process -- the exact condition that made the OLD guard skip it).
+begin_test "fixed_guard_kills_orphan_despite_systemctl_status_returning_zero"
+"$FAKE_BIN" &
+fake_pid=$!
+sleep 0.3
+# Confirm the precondition: systemctl status on the fake PID returns 0,
+# reproducing the exact bug condition (cgroup-membership false positive).
+if ! systemctl status "$fake_pid" >/dev/null 2>&1; then
+    fail "precondition failed: systemctl status $fake_pid did not return 0 -- cannot demonstrate the bug in this environment"
+else
+    kill_orphaned_mcp_processes
+    sleep 3.5   # kill_orphaned_mcp_processes' own SIGTERM->3s grace->SIGKILL cycle
+    if kill -0 "$fake_pid" 2>/dev/null; then
+        fail "fake orphan PID $fake_pid is still alive -- the fixed guard did not kill it"
+        kill -9 "$fake_pid" 2>/dev/null
+    else
+        pass
+    fi
+fi
+unset fake_pid
+
+# 2. The real, unrelated lobster-mcp.service is never touched by this
+# function (its MainPID must still be alive and must not appear in any
+# SIGTERM/SIGKILL branch reachable by the fake-marker-only pattern used in
+# test 1). This is a read-only assertion -- we do not invoke
+# kill_orphaned_mcp_processes() with the real "obsidian-mcp"/"inbox_server.py"
+# patterns in this test suite (those live processes on this production host
+# are out of scope for testing; the hard constraint is not to touch them).
+begin_test "real_mcp_service_pid_still_alive_after_test"
+real_main_pid=$(systemctl show -p MainPID --value lobster-mcp.service 2>/dev/null || true)
+if [[ -n "$real_main_pid" && "$real_main_pid" != "0" ]] && kill -0 "$real_main_pid" 2>/dev/null; then
+    pass
+else
+    fail "lobster-mcp.service MainPID ($real_main_pid) is not alive -- this test suite must never affect it"
+fi
+
+#===============================================================================
+# Summary
+#===============================================================================
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $TOTAL total"
+if [[ $FAIL -eq 0 ]]; then
+    echo -e "${GREEN}All orphaned-MCP cleanup tests passed.${NC}"
+    exit 0
+else
+    echo -e "${RED}$FAIL test(s) failed.${NC}"
+    exit 1
+fi

--- a/tests/test-health-check-orphan-mcp-reaper.sh
+++ b/tests/test-health-check-orphan-mcp-reaper.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+#===============================================================================
+# Test Suite: Health Check v3 - reap_orphaned_mcp_processes() (issue #2119)
+#
+# Cron backstop for orphaned stdio MCP servers (obsidian-mcp specifically,
+# pattern is configurable) that survive a session-age restart despite
+# check_session_age()'s primary kill_dispatcher_children() fix -- e.g. a
+# dispatcher crash, an OOM kill, or CC's 7440s hard session limit firing
+# before the proactive restart gets a chance to signal children at all.
+#
+# Runs every health-check-v3.sh cron cycle (every 4 minutes). Only targets
+# processes that are BOTH:
+#   1. Reparented to init (PPID=1) -- actually orphaned, not a live MCP
+#      child of the current dispatcher session
+#   2. Older than the configured age threshold (production default 8100s =
+#      2h15m; overridden much lower here via LOBSTER_ORPHAN_MCP_REAP_AGE_SECONDS
+#      so the tests don't need to wait over two hours)
+#
+# Usage: bash tests/test-health-check-orphan-mcp-reaper.sh
+#===============================================================================
+
+set -u
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts"
+HEALTH_SCRIPT="$SCRIPT_DIR/health-check-v3.sh"
+
+TEST_TMPDIR=$(mktemp -d /tmp/lobster-orphan-reaper-test-XXXXXX)
+spawned_pids=()
+cleanup() {
+    local p
+    for p in "${spawned_pids[@]:-}"; do
+        [[ -n "$p" ]] && kill -9 "$p" 2>/dev/null
+    done
+    rm -rf "$TEST_TMPDIR"
+}
+trap cleanup EXIT
+
+begin_test() { TOTAL=$((TOTAL + 1)); test_name="$1"; }
+pass()  { PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC} $test_name"; }
+fail()  { FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC} $test_name: $1"; }
+
+#===============================================================================
+# Named constants (from the spec — never hardcode magic values in tests)
+#===============================================================================
+# A tiny threshold so the "old enough to reap" case doesn't require waiting
+# over two hours in a test. Kept distinct from the production default
+# (8100s) so it's obvious this is a test override, not the real value.
+TEST_REAP_AGE_SECONDS=2
+# A marker unlikely to ever collide with this test file's own invocation
+# command line (avoids a pgrep -f self-match against the test runner).
+FAKE_MARKER="reapfake${TEST_TMPDIR##*-}mcpstub"
+
+#===============================================================================
+# Stub the minimal environment reap_orphaned_mcp_processes() needs.
+#===============================================================================
+LOG_FILE="$TEST_TMPDIR/health-check.log"
+log()       { echo "[$(date -Iseconds)] [$1] $2" >> "$LOG_FILE" 2>/dev/null; }
+log_info()  { log INFO "$1"; }
+log_warn()  { log WARN "$1"; }
+log_error() { log ERROR "$1"; }
+
+ORPHAN_MCP_REAP_PATTERN="$FAKE_MARKER"
+ORPHAN_MCP_REAP_AGE_SECONDS="$TEST_REAP_AGE_SECONDS"
+
+# Load reap_orphaned_mcp_processes() from the health check script.
+eval "$(sed -n '/^reap_orphaned_mcp_processes()/,/^}/p' "$HEALTH_SCRIPT")" 2>/dev/null
+
+if ! declare -f reap_orphaned_mcp_processes > /dev/null 2>&1; then
+    echo "FATAL: reap_orphaned_mcp_processes() not found in $HEALTH_SCRIPT"
+    exit 1
+fi
+
+FAKE_BIN_DIR="$TEST_TMPDIR/bin"
+mkdir -p "$FAKE_BIN_DIR"
+FAKE_BIN="$FAKE_BIN_DIR/$FAKE_MARKER"
+cat > "$FAKE_BIN" <<'EOF'
+#!/bin/bash
+sleep 60
+EOF
+chmod +x "$FAKE_BIN"
+
+# NOTE: a "spawn a still-parented process" helper is deliberately NOT
+# implemented as a function called via command substitution
+# (pid=$(spawn_parented)) -- command substitution always runs in a subshell,
+# and that subshell exits immediately after backgrounding the fake process,
+# which orphans it right away (the same trick spawn_orphaned uses on
+# purpose below). A genuinely still-parented process must be backgrounded
+# directly in the top-level test script so its parent stays alive for the
+# duration of the test. See the "parented_process_never_reaped" test below.
+
+# Spawn a fake process and orphan it immediately (subshell backgrounds it
+# then exits, so init/nearest subreaper adopts it -- PPID becomes 1).
+spawn_orphaned() {
+    local pidfile="$TEST_TMPDIR/orphan_pid_$$_$RANDOM"
+    ( "$FAKE_BIN" >/dev/null 2>&1 & echo $! > "$pidfile" )
+    # Wait for the pidfile to appear before reading it.
+    for _ in $(seq 1 50); do
+        [[ -s "$pidfile" ]] && break
+        sleep 0.1
+    done
+    cat "$pidfile" 2>/dev/null
+    rm -f "$pidfile"
+}
+
+echo ""
+echo "=== Health Check Orphan MCP Reaper Tests (issue #2119) ==="
+echo ""
+
+# 1. A still-parented fake MCP process (PPID != 1) is left alone, regardless
+# of age -- it's a legitimate child of a live session, not an orphan.
+# Backgrounded directly in this top-level script (not via a function call
+# through command substitution) so its parent is this script's own PID and
+# stays alive for the duration of the test -- see the NOTE above.
+begin_test "parented_process_never_reaped"
+"$FAKE_BIN" >/dev/null 2>&1 &
+pid=$!
+spawned_pids+=("$pid")
+ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+if [[ "$ppid" == "1" ]]; then
+    fail "test setup failed: fake process was unexpectedly orphaned (PPID=1) immediately after backgrounding"
+else
+    sleep "$((TEST_REAP_AGE_SECONDS + 1))"
+    reap_orphaned_mcp_processes
+    if kill -0 "$pid" 2>/dev/null; then
+        pass
+    else
+        fail "parented (non-orphan, PPID=$ppid) fake process $pid was killed — reaper must only ever touch PPID=1 processes"
+    fi
+fi
+kill -9 "$pid" 2>/dev/null
+
+# 2. An orphaned fake MCP process (PPID=1) younger than the age threshold is
+# left alone -- avoids racing a process still mid-reparenting from a restart
+# in progress right now.
+begin_test "young_orphan_not_yet_reaped"
+pid=$(spawn_orphaned)
+if [[ -z "$pid" ]]; then
+    fail "test setup failed: never observed the fake orphan PID"
+else
+    spawned_pids+=("$pid")
+    ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    if [[ "$ppid" != "1" ]]; then
+        fail "test setup failed: fake process PPID=$ppid, expected 1 (orphaning trick did not work in this environment)"
+    else
+        # Act immediately, well under TEST_REAP_AGE_SECONDS.
+        reap_orphaned_mcp_processes
+        if kill -0 "$pid" 2>/dev/null; then
+            pass
+        else
+            fail "young orphan (age < ${TEST_REAP_AGE_SECONDS}s threshold) was reaped too early"
+        fi
+    fi
+fi
+kill -9 "$pid" 2>/dev/null || true
+
+# 3. An orphaned fake MCP process (PPID=1) older than the age threshold IS
+# reaped. This is the core positive case: it fails if reap_orphaned_mcp_processes()
+# is removed or its age/PPID gating is broken.
+begin_test "old_orphan_is_reaped"
+pid=$(spawn_orphaned)
+if [[ -z "$pid" ]]; then
+    fail "test setup failed: never observed the fake orphan PID"
+else
+    spawned_pids+=("$pid")
+    ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    if [[ "$ppid" != "1" ]]; then
+        fail "test setup failed: fake process PPID=$ppid, expected 1"
+    else
+        sleep "$((TEST_REAP_AGE_SECONDS + 1))"
+        reap_orphaned_mcp_processes
+        sleep 1.5   # reaper's own SIGTERM -> 1s grace -> SIGKILL cycle
+        if kill -0 "$pid" 2>/dev/null; then
+            fail "old orphan PID $pid (age >= ${TEST_REAP_AGE_SECONDS}s, PPID=1) is still alive — reaper did not kill it"
+        else
+            pass
+        fi
+    fi
+fi
+kill -9 "$pid" 2>/dev/null || true
+
+# 4. No matching processes at all -> no-op, no error.
+begin_test "noop_when_no_candidates"
+reap_orphaned_mcp_processes
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass
+else
+    fail "expected exit 0 with no candidate processes, got $rc"
+fi
+
+#===============================================================================
+# Summary
+#===============================================================================
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $TOTAL total"
+if [[ $FAIL -eq 0 ]]; then
+    echo -e "${GREEN}All orphan reaper tests passed.${NC}"
+    exit 0
+else
+    echo -e "${RED}$FAIL test(s) failed.${NC}"
+    exit 1
+fi

--- a/tests/test-health-check-session-age.sh
+++ b/tests/test-health-check-session-age.sh
@@ -87,12 +87,23 @@ DISPATCHER_SESSION_START_FILE="$TEST_DATA_DIR/$DISPATCHER_SESSION_START_FILENAME
 DISPATCHER_PID_FILE="$TEST_CONFIG_DIR/$DISPATCHER_PID_FILENAME"
 ALERT_DEDUP_DIR="$TEST_TMPDIR/alert-dedup"
 
-# Load check_session_age() from the health check script.
-# We extract just the function to avoid sourcing the entire ~2000-line file.
+# Load check_session_age() and kill_dispatcher_children() (issue #2119) from
+# the health check script. check_session_age() calls kill_dispatcher_children()
+# directly, so both must be extracted together or the call fails with
+# "command not found" inside the test (previously masked by `set -u` not being
+# fatal for undefined commands — the return code was unaffected, but the
+# child-killing behavior was silently never exercised).
+# We extract just these two functions to avoid sourcing the entire ~2000-line file.
 eval "$(sed -n '/^check_session_age()/,/^}/p' "$HEALTH_SCRIPT")" 2>/dev/null
+eval "$(sed -n '/^kill_dispatcher_children()/,/^}/p' "$HEALTH_SCRIPT")" 2>/dev/null
 
 if ! declare -f check_session_age > /dev/null 2>&1; then
     echo "FATAL: check_session_age() not found in $HEALTH_SCRIPT"
+    exit 1
+fi
+
+if ! declare -f kill_dispatcher_children > /dev/null 2>&1; then
+    echo "FATAL: kill_dispatcher_children() not found in $HEALTH_SCRIPT"
     exit 1
 fi
 
@@ -289,6 +300,101 @@ if [[ ! -f "$TELEGRAM_ALERTS_FILE" ]]; then
 else
     fail "Telegram alert was sent even though LOBSTER_DEBUG=false: $(cat "$TELEGRAM_ALERTS_FILE")"
 fi
+
+# 15. Session-age SIGTERM also kills a stdio MCP child of the dispatcher
+# (issue #2119). This is the "spawn a fake dispatcher + child process, trigger
+# the session-age kill path, show the child dies too" proof the issue asks
+# for: `sleep 600` stands in for the dispatcher (`claude`), and a second
+# `sleep 600` spawned as its child stands in for a hung stdio MCP server
+# (obsidian-mcp). Before this fix, check_session_age() only ever signalled
+# the dispatcher PID itself — the child was orphaned, never signalled, and
+# leaked indefinitely (confirmed in production: 12 live orphans, one per
+# session-age restart). This test fails if kill_dispatcher_children() is not
+# called from check_session_age() (i.e. if the fix in health-check-v3.sh is
+# reverted) because the child sleep process will still be alive after
+# check_session_age() returns.
+begin_test "session_age_sigterm_also_kills_dispatcher_child"
+reset_state
+# Fake dispatcher: a shell that spawns a child and then just sleeps, so the
+# child is a real child process of $target_pid (not of this test script).
+bash -c 'sleep 600 & child=$!; echo "$child" > "'"$TEST_TMPDIR"'/child.pid"; wait' &
+target_pid=$!
+# Wait for the child.pid file to appear (child has been spawned and is running).
+for _ in $(seq 1 50); do
+    [[ -f "$TEST_TMPDIR/child.pid" ]] && break
+    sleep 0.1
+done
+child_pid=$(cat "$TEST_TMPDIR/child.pid" 2>/dev/null || echo "")
+echo "$target_pid" > "$DISPATCHER_PID_FILE"
+past_start=$(( $(date +%s) - SESSION_AGE_LIMIT_SECONDS - 60 ))
+echo "$past_start" > "$DISPATCHER_SESSION_START_FILE"
+check_session_age
+rc=$?
+sleep 0.3
+# Capture aliveness BEFORE any manual cleanup — cleanup must not itself kill
+# the child, or the assertion below would pass unconditionally regardless of
+# whether kill_dispatcher_children() actually did its job.
+child_alive=false
+if [[ -n "$child_pid" ]] && kill -0 "$child_pid" 2>/dev/null; then
+    child_alive=true
+fi
+kill "$target_pid" "$child_pid" 2>/dev/null || true  # cleanup, captured above already
+if [[ -z "$child_pid" ]]; then
+    fail "test setup failed: never observed the fake MCP child PID"
+elif [[ "$rc" -eq 1 && "$child_alive" == "false" ]]; then
+    pass
+else
+    fail "expected exit 1 and child PID $child_pid dead; got rc=$rc, child_alive=$child_alive"
+fi
+rm -f "$TEST_TMPDIR/child.pid"
+
+# 16. kill_dispatcher_children() is a no-op (returns 0, no error) when called
+# with no PIDs at all — e.g. a dispatcher that never spawned any MCP
+# children yet. It takes the child PID list as arguments (pre-enumerated by
+# the caller, see the ordering note in health-check-v3.sh) rather than a
+# parent PID to enumerate itself, so "no children" here means an empty
+# argument list.
+begin_test "kill_dispatcher_children_noop_when_no_children"
+reset_state
+kill_dispatcher_children
+rc=$?
+assert_exit "$rc" 0
+
+# 17. Falsifiability check: with kill_dispatcher_children() replaced by a
+# true no-op stub (simulating the pre-fix behavior where check_session_age()
+# never touched the dispatcher's children at all), the fake MCP child must
+# survive the session-age SIGTERM. This directly demonstrates the bug this
+# fix closes, using the same harness as test 15.
+begin_test "pre_fix_behavior_would_leak_the_child"
+reset_state
+# Shadow kill_dispatcher_children with a no-op to simulate the reverted state.
+kill_dispatcher_children() { return 0; }
+bash -c 'sleep 600 & child=$!; echo "$child" > "'"$TEST_TMPDIR"'/child.pid"; wait' &
+target_pid=$!
+for _ in $(seq 1 50); do
+    [[ -f "$TEST_TMPDIR/child.pid" ]] && break
+    sleep 0.1
+done
+child_pid=$(cat "$TEST_TMPDIR/child.pid" 2>/dev/null || echo "")
+echo "$target_pid" > "$DISPATCHER_PID_FILE"
+past_start=$(( $(date +%s) - SESSION_AGE_LIMIT_SECONDS - 60 ))
+echo "$past_start" > "$DISPATCHER_SESSION_START_FILE"
+check_session_age
+rc=$?
+still_alive=false
+if [[ -n "$child_pid" ]] && kill -0 "$child_pid" 2>/dev/null; then
+    still_alive=true
+fi
+# Clean up real state now that the assertion has been captured.
+kill "$target_pid" "$child_pid" 2>/dev/null || true
+if [[ "$rc" -eq 1 && "$still_alive" == "true" ]]; then
+    pass
+else
+    fail "expected the no-op stub to reproduce the leak (child survives); rc=$rc still_alive=$still_alive"
+fi
+rm -f "$TEST_TMPDIR/child.pid"
+# Restore the real function extracted from health-check-v3.sh for any later tests.
+eval "$(sed -n '/^kill_dispatcher_children()/,/^}/p' "$HEALTH_SCRIPT")" 2>/dev/null
 
 #===============================================================================
 # Summary

--- a/tests/unit/test_hooks/test_obsidian_mcp_delegation_instructions.py
+++ b/tests/unit/test_hooks/test_obsidian_mcp_delegation_instructions.py
@@ -1,0 +1,133 @@
+"""
+Regression test: mcp__obsidian__* tool calls must be explicitly named as a
+background-delegation requirement in the dispatcher bootup instructions
+(issue #2119).
+
+Root cause recap: mcp__obsidian__* calls are backed by a stdio MCP server
+(`npx -y obsidian-mcp <vault-path>`) with no application-level timeout. A
+hung call (confirmed hangs of 2304s and 6462s in production) that runs
+inline on the main dispatcher thread freezes the *entire* dispatcher loop
+until the ~2h04m session-age SIGTERM kills the whole session — which is
+exactly what happened when Wallace told a user "saving it to the vault now"
+and then went silent for hours, because create-note/edit-note was never
+reached and the promise died with the killed session.
+
+This is a behavioral/instructional fix, not a runtime code fix — the
+dispatcher is an LLM reading these bootup instructions at session start.
+The "automated test that would fail if reverted" for this kind of change is
+a content assertion against the instruction file: it fails if the required
+guidance is missing, and passes once it is present. This does not prove the
+dispatcher will always obey the instruction (that would require behavioral
+observation over live traffic), but it does prove the instruction the
+dispatcher is supposed to obey is actually present and specific.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Path to the actual dispatcher bootup file (relative to the repo root).
+_REPO_ROOT = Path(__file__).parents[3]
+_DISPATCHER_BOOTUP = _REPO_ROOT / ".claude" / "sys.dispatcher.bootup.md"
+
+
+def _bootup_content() -> str:
+    assert _DISPATCHER_BOOTUP.exists(), (
+        f"sys.dispatcher.bootup.md not found at {_DISPATCHER_BOOTUP}"
+    )
+    return _DISPATCHER_BOOTUP.read_text()
+
+
+def test_obsidian_tools_named_under_background_delegation_rule() -> None:
+    """mcp__obsidian__* must be an explicit named example of the
+    'ANY file read/write' background-delegation rule, not left implicit."""
+    content = _bootup_content()
+    assert "ANY file read/write" in content, (
+        "The 'ANY file read/write' background-delegation rule is missing "
+        "from sys.dispatcher.bootup.md — cannot anchor the obsidian carve-out."
+    )
+    assert "mcp__obsidian__" in content, (
+        "sys.dispatcher.bootup.md does not name mcp__obsidian__* tools "
+        "anywhere. Issue #2119: obsidian MCP calls hang indefinitely "
+        "(stdio server, no app-level timeout) and must be an explicit "
+        "named example of the background-delegation rule, not left for "
+        "the dispatcher to infer from the generic 'file read/write' bullet."
+    )
+
+
+def test_obsidian_violation_example_present() -> None:
+    """The 'Violations that have occurred' list must include a concrete
+    mcp__obsidian__ example, mirroring the existing violation examples for
+    Read/Bash/mcp__github__ calls made inline on the dispatcher thread."""
+    content = _bootup_content()
+    assert "VIOLATION" in content, "Violations section missing entirely."
+    # The violation example must actually reference an obsidian tool call.
+    violation_section = content[content.index("Violations that have occurred") :]
+    assert "mcp__obsidian__" in violation_section, (
+        "The 'Violations that have occurred' section does not include an "
+        "mcp__obsidian__ example (issue #2119's incident: "
+        "mcp__obsidian__list-available-vaults called inline, hung 2304s, "
+        "froze the whole dispatcher loop)."
+    )
+
+
+def test_obsidian_write_requires_readback_before_success_claim() -> None:
+    """Item (d): a background subagent delegated an Obsidian write must
+    verify the write landed (read-back / search-vault) before calling
+    write_result with a success message. Success must never be claimed
+    before the write is confirmed — this is what silently produced
+    "said it saved something, went silent" in the original incident,
+    because create-note/edit-note was never even reached."""
+    content = _bootup_content()
+    assert "search-vault" in content or "read-note" in content, (
+        "No read-back verification step (search-vault / read-note) is "
+        "documented for Obsidian writes."
+    )
+    assert "before" in content.lower() and (
+        "report success" in content.lower()
+        or "claiming success" in content.lower()
+        or "before this read-back confirms" in content.lower()
+        or "before you report success" in content.lower()
+        or "never report success before" in content.lower()
+    ), (
+        "The instructions do not clearly state that read-back verification "
+        "must happen BEFORE reporting success on an Obsidian write."
+    )
+
+
+def test_obsidian_delegation_mirrors_link_capture_pattern() -> None:
+    """The obsidian delegation instructions should follow the same
+    acknowledge -> Task(background) -> write_result shape as the existing
+    link-capture pattern (lobster-shop/obsidian-km/context/obsidian-km.md),
+    so the dispatcher applies a pattern it has already seen elsewhere in
+    the codebase rather than inventing new behavior."""
+    content = _bootup_content()
+    obsidian_section_start = content.find("mcp__obsidian__")
+    assert obsidian_section_start != -1, "mcp__obsidian__ not mentioned at all."
+    # Look at the guidance following the first mention for the three-step shape.
+    tail = content[obsidian_section_start:]
+    assert "Task(" in tail, "No Task(...) delegation call shown near the obsidian guidance."
+    assert "run_in_background" in tail or "background: true" in tail, (
+        "The obsidian delegation guidance does not show background=true framing."
+    )
+    assert "write_result" in tail, (
+        "The obsidian delegation guidance does not mention write_result for "
+        "reporting back, unlike the rest of the delegation patterns in this file."
+    )
+
+
+def test_link_capture_pattern_still_exists_for_reference() -> None:
+    """Sanity check that the reference pattern this fix mirrors still exists
+    at the location the issue points to. If this moves, the mirrored
+    guidance above may drift out of sync with the canonical example."""
+    link_capture_doc = (
+        _REPO_ROOT / "lobster-shop" / "obsidian-km" / "context" / "obsidian-km.md"
+    )
+    assert link_capture_doc.exists(), (
+        f"Reference link-capture pattern doc not found at {link_capture_doc} "
+        "— the obsidian delegation guidance in sys.dispatcher.bootup.md was "
+        "written to mirror this pattern."
+    )
+    lc_content = link_capture_doc.read_text()
+    assert "run_in_background=True" in lc_content
+    assert "Task(" in lc_content


### PR DESCRIPTION
Closes #2119. Related follow-up (deferred, scoped separately): #2219.

## Problem

Wallace told a user "saving it to the Obsidian vault now... will send the link shortly," then went silent for hours. Nothing was ever written. Root cause, confirmed via two independent evidence passes (`~/.cache/claude-cli-nodejs/.../mcp-logs-obsidian/*.jsonl`, production `ps`/`systemctl` state):

1. **The obsidian tool call ran inline on the main dispatcher thread**, in violation of this codebase's own "ANY file read/write → background subagent" rule. `mcp__obsidian__*` calls are backed by a stdio MCP server (`obsidian-mcp`) with no application-level timeout. When the call hung (confirmed hangs of 2304s and 6462s), it froze the *entire* dispatcher loop, not just the one task — this is why the whole conversation went silent instead of Wallace being free to say "still working on it."
2. **The hang was only ever aborted by session-age recycling** (~2h04m SIGTERM), which meant the "I'll get back to you" promise died with the killed session — the new session has no memory of it.
3. **Orphaned process leak**: `health-check-v3.sh`'s session-age SIGTERM signals only the dispatcher's own PID, never its stdio MCP children. 12 orphaned `obsidian-mcp` processes were found live in production at investigation time, one per restart since Aug 11 06:00 — confirmed still present as of this PR (see Manual test below).
4. **No read-back verification**: even when a write *did* land, nothing confirmed it before reporting success — so a false "saved" claim and a genuinely-failed save were indistinguishable to the user.

## What changed

- **`.claude/sys.dispatcher.bootup.md`**: `mcp__obsidian__*` is now an explicit named example under the background-delegation rule (previously only the generic "file read/write" bullet existed, and it wasn't followed for this tool family). Adds a full delegation template — acknowledge → `Task(run_in_background=true)` → the subagent must call `search-vault`/`read-note` to confirm the write landed *before* calling `write_result` with a success message. This is instructional (LLM-followed) guidance, mirroring the existing link-capture pattern in `lobster-shop/obsidian-km/`, not a runtime code change — the "test that fails on revert" for this piece is a content assertion against the instruction file itself (see `tests/unit/test_hooks/test_obsidian_mcp_delegation_instructions.py`).
- **`scripts/health-check-v3.sh`**: `check_session_age()` now snapshots the dispatcher's direct child PIDs *before* sending SIGTERM (querying after is a race — children are reparented away the instant the parent process exits) and signals them too via a new `kill_dispatcher_children()` (SIGTERM, then SIGKILL after a grace period for anything still alive). Adds `reap_orphaned_mcp_processes()`, a backstop that runs every health-check cron cycle (independent of any restart happening right now) and reaps any `obsidian-mcp`-pattern process that's both reparented to init (`PPID=1`) and older than one restart cycle plus margin.
- **`scripts/claude-persistent.sh`**: fixes a second bug found while implementing the above. `kill_orphaned_mcp_processes()`'s "skip systemd-managed services" guard used `systemctl status $pid`, which doesn't ask "is this PID itself a service" — it resolves the PID's *cgroup* to whichever unit owns it and reports that unit's status. Every process under `lobster-claude.service`'s tmux session (dispatcher, every MCP child, every orphan that kept its original cgroup membership) resolved to `lobster-claude.service` and returned exit 0, so this guard has been silently protecting every single orphaned MCP child from cleanup since it was introduced. Now compares against the protected unit's actual `MainPID` (`systemctl show -p MainPID --value`) instead.
- **Syncthing `.stignore`** (`/home/lobster/LobsterDrop/.stignore`, not part of this repo but applied live as part of this fix — see Manual test): the vault's `.git/` was being synced by Syncthing with no ignore rule, producing 10 `index.sync-conflict-*` files from 2026-07-02 through 2026-08-11, some concurrent with the incident window. Excluded `.git` from sync on this device; git already has its own sync mechanism (push/pull) and doesn't need a second one racing it.

## Out of scope

Item 2 of the original fix plan — retiring the stdio `obsidian-mcp` server entirely in favor of the already-healthy `vault-api` HTTP service — is **not** in this PR. Investigated during this work: `vault-api` currently implements 4 of the 11 `mcp__obsidian__*` operations (no search, tags, delete, or move). A real migration is a multi-day scope with its own manual+automated verification needs, not a same-pass addition. Tracked as #2219, with the mitigations in this PR (background delegation + read-back verification + orphan cleanup) closing the actual user-facing failure mode in the meantime. This was an explicitly allowed deferral per the original issue triage comment.

No changes to `vault-api` itself, no changes to the obsidian-mcp npm package, no changes to any other health-check subsystem (service checks, WFM suppression, etc.) beyond the session-age block described above.

## Functional patterns

`kill_dispatcher_children()` and `reap_orphaned_mcp_processes()` take pre-enumerated PID lists / read live state independently rather than mutating shared globals, keeping "what to signal" separate from "how to signal it" and making each independently testable without needing a real dispatcher process. Both `health-check-v3.sh` and `claude-persistent.sh` gain a `BASH_SOURCE[0] == $0` guard around their `main()` call so test harnesses can `source` them and exercise individual functions in isolation, with zero behavior change on the real cron/systemd invocation path.

## Tests run

- [x] `bash tests/test-health-check-session-age.sh` — 17 passed, 0 failed (includes 3 new tests for issue #2119: child dies with the session, no-op on empty child list, and a reproduction of the pre-fix leak via a stubbed no-op)
- [x] `bash tests/test-health-check-orphan-mcp-reaper.sh` — 4 passed, 0 failed
- [x] `bash tests/test-claude-persistent-orphan-mcp-cleanup.sh` — 3 passed, 0 failed (runs against the real `systemctl`/cgroup condition that caused the bug, using only throwaway fake processes — no real MCP process is ever targeted)
- [x] `python3 -m pytest tests/unit/test_hooks/test_obsidian_mcp_delegation_instructions.py` — 5 passed, 0 failed
- [x] `bash -n scripts/health-check-v3.sh && bash -n scripts/claude-persistent.sh` — syntax OK

**Falsifiability**: reverted each implementation file (`git stash push -- <file>`) and re-ran its corresponding test suite. `health-check-v3.sh` revert → `FATAL: kill_dispatcher_children() not found` / `FATAL: reap_orphaned_mcp_processes() not found`. `claude-persistent.sh` revert → the orphan-cleanup test's fake orphan process is left running (systemd-cgroup guard bug reproduced, matching the exact production condition this fix targets). Restored and re-ran clean afterward — no test suite was left in a broken state.

## Manual test

- Confirmed the orphan leak is real and currently present in production, independent of this PR: `ps aux | grep obsidian-mcp` shows 12 processes, all `PPID=1`, matching the issue's original count.
- Confirmed the Syncthing fix live: added `.stignore` with `(?d).git`, triggered a rescan via the Syncthing REST API (`POST /rest/db/scan?folder=lobsterdrop`), and confirmed via `GET /rest/db/ignores?folder=lobsterdrop` that the pattern is active and expands to `(?d).git`, `(?d)**/.git`, `(?d).git/**`, `(?d)**/.git/**`. This only affects this device's local ignore rules — other Syncthing peers would need the same applied locally to fully close the loop, which is a config note rather than a code change.
- Did **not** yet restart the live `lobster-claude`/`lobster-mcp` services with this code — that's the next step post-merge (see plan below), done via the documented safe-restart pattern with an inbox warning first.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests — all fake processes match unique random markers, isolated from real `obsidian-mcp`/`inbox_server.py`)
- [x] Integration/manual test run — see Manual test above (live orphan count confirmed, Syncthing fix verified live via REST API)
- [ ] User-visible outcome verified — pending live deploy + post-restart verification (planned immediately after merge)
- [x] Side-effect audit complete: `.stignore` change only stops future sync of `.git` (no deletion, no history rewrite); orphan-reaper only ever targets processes already reparented to init and past an age threshold, never anything belonging to a live session; falsifiability testing confirmed zero impact on the real `lobster-mcp.service` MainPID or any live `obsidian-mcp` process
- [x] External service calls: none in automated tests; the one live API call made (Syncthing REST, localhost, read + scan-trigger only) was scoped to a single folder and is documented above