### PR TITLE
fix: session-age kill now reaches the full descendant tree, not just one hop (#2221)

### DIFF
--- a/scripts/health-check-v3.sh
+++ b/scripts/health-check-v3.sh
@@ -1426,6 +1426,58 @@ count_active_subagents() {
 }
 
 #===============================================================================
+# get_descendant_pids — recursively enumerate ALL descendants of a PID
+# (issue #2221)
+#
+# `pgrep -P $pid` only returns DIRECT children — one hop. Stdio MCP servers
+# spawned via `npx`/`npm exec` fork through an intermediate `sh -c` wrapper
+# before reaching the real worker process, so the process that actually needs
+# to be killed (e.g. the obsidian-mcp `node` process) can be two or three hops
+# below the dispatcher's direct child, not one. A single `pgrep -P` call never
+# reaches it.
+#
+# This does a breadth-first walk of the full descendant tree — pgrep -P on
+# each newly-discovered PID, repeated until no new descendants are found — so
+# every hop is captured regardless of depth, instead of assuming a fixed hop
+# count.
+#
+# $1 = root PID to walk descendants of (e.g. the dispatcher PID)
+# Prints one descendant PID per line to stdout (may print nothing if the PID
+# has no children). Never includes the root PID itself.
+#===============================================================================
+get_descendant_pids() {
+    local root_pid="$1"
+    local queue=("$root_pid")
+    local descendants=()
+    local visited=" "
+
+    while [[ ${#queue[@]} -gt 0 ]]; do
+        local current="${queue[0]}"
+        queue=("${queue[@]:1}")
+
+        # Defensive guard against a repeated PID in the walk (shouldn't happen
+        # with real process trees, but keeps this safe against pathological
+        # /proc states rather than looping forever).
+        if [[ "$visited" == *" $current "* ]]; then
+            continue
+        fi
+        visited="$visited$current "
+
+        local children
+        children=$(pgrep -P "$current" 2>/dev/null || true)
+        local child
+        for child in $children; do
+            descendants+=("$child")
+            queue+=("$child")
+        done
+    done
+
+    if [[ ${#descendants[@]} -gt 0 ]]; then
+        printf '%s\n' "${descendants[@]}"
+    fi
+}
+
+#===============================================================================
 # Session Age Check — proactive restart before the 7440s CC hard limit
 # (issue #2059)
 #
@@ -1504,16 +1556,29 @@ check_session_age() {
         return 0
     fi
 
-    # Snapshot the dispatcher's direct children BEFORE sending SIGTERM (issue
-    # #2119). This must happen first: once the dispatcher (`claude`) receives
-    # SIGTERM and exits, its children (stdio MCP servers like `obsidian-mcp`)
-    # are reparented away from $dispatcher_pid immediately — querying `pgrep -P
-    # $dispatcher_pid` AFTER the SIGTERM is a race that can find zero children
-    # even though they existed a moment earlier, because the parent is already
-    # gone by the time the query runs. Capturing the list first and signalling
-    # those specific PIDs afterward removes the race entirely.
+    # Snapshot the dispatcher's FULL descendant tree BEFORE sending SIGTERM
+    # (issue #2119, hardened for #2221). This must happen first: once the
+    # dispatcher (`claude`) receives SIGTERM and exits, its children (stdio
+    # MCP servers like `obsidian-mcp`) are reparented away from
+    # $dispatcher_pid immediately — querying the process tree AFTER the
+    # SIGTERM is a race that can find zero children even though they existed
+    # a moment earlier, because the parent is already gone by the time the
+    # query runs. Capturing the list first and signalling those specific PIDs
+    # afterward removes the race entirely.
+    #
+    # #2221: a single `pgrep -P $dispatcher_pid` only reaches ONE hop below
+    # the dispatcher. The real obsidian-mcp process tree is three hops deep
+    # (verified live via `ps -o pid,ppid,pgid,sid,comm`):
+    #   claude (dispatcher) -> npm exec obsidian-mcp -> sh -c obsidian-mcp -> node .../obsidian-mcp
+    # `npx`/`npm exec` forks (does not exec) into an intermediate `sh -c`,
+    # which forks (does not exec) into the real `node` worker -- the process
+    # that actually hangs. A one-hop `pgrep -P` only ever found the `npm exec`
+    # wrapper; its `sh`/`node` descendants were left running and reparented to
+    # PID 1 on every session-age restart, so this got caught by the cron
+    # backstop reaper instead of prevented at restart time. get_descendant_pids()
+    # walks the whole tree (all hops) so every descendant is captured.
     local mcp_child_pids
-    mcp_child_pids=$(pgrep -P "$dispatcher_pid" 2>/dev/null || true)
+    mcp_child_pids=$(get_descendant_pids "$dispatcher_pid")
 
     # Notify BEFORE sending SIGTERM (issue #2075) so the message reaches the user
     # even if the session exits immediately once SIGTERM is delivered — if the
@@ -1536,10 +1601,11 @@ check_session_age() {
     if kill -TERM "$dispatcher_pid" 2>/dev/null; then
         log_warn "Session age: SIGTERM sent to dispatcher PID $dispatcher_pid"
 
-        # Also signal the dispatcher's direct child processes we snapshotted
-        # above -- stdio MCP servers like `obsidian-mcp` (issue #2119).
+        # Also signal every descendant process we snapshotted above -- stdio
+        # MCP servers like `obsidian-mcp` (issue #2119), reached at every hop
+        # of the tree, not just the dispatcher's direct child (issue #2221).
         # SIGTERM to $dispatcher_pid only reaches the `claude` process itself;
-        # it does NOT cascade to stdio MCP children it spawned, which are
+        # it does NOT cascade to stdio MCP descendants it spawned, which are
         # simply orphaned (reparented to PID 1) rather than killed.
         # obsidian-mcp specifically has no application-level timeout and can
         # be mid-hang at the moment of this restart, so leaving it running
@@ -1558,12 +1624,13 @@ check_session_age() {
 }
 
 #===============================================================================
-# kill_dispatcher_children — signal direct child processes of the dispatcher
-# (issue #2119)
+# kill_dispatcher_children — signal descendant processes of the dispatcher
+# (issue #2119, hardened for #2221)
 #
 # Why not signal the dispatcher's whole process group instead (kill -TERM
 # -$pgid)? That was the initial fix proposal, but it does not hold up against
-# the live process tree. Verified on the production host:
+# the live process tree. Verified on the production host, both at #2119 fix
+# time and re-verified for #2221 (still holds -- same PGID sharing today):
 #
 #   $ ps -o pid,ppid,pgid,sid,comm -p "$dispatcher_pid"
 #       PID    PPID    PGID     SID COMMAND
@@ -1575,31 +1642,40 @@ check_session_age() {
 # runs under the tmux session leader. `kill -TERM -$dispatcher_pid` would
 # target a process group that doesn't exist (no-op); using the *real* PGID
 # instead would SIGTERM the supervisor and the tmux pane along with it,
-# breaking the auto-restart mechanism this entire flow depends on.
+# breaking the auto-restart mechanism this entire flow depends on. This also
+# rules out PGID as the fix for #2221: every obsidian-mcp descendant (the
+# `npm exec` wrapper, the `sh -c` it forks, and the `node` worker under that)
+# shares that same PGID with the supervisor, so group-signalling still is not
+# a safe way to isolate "the dispatcher's descendants" from "the supervisor
+# that must survive the restart."
 #
-# Enumerating direct children of $dispatcher_pid (ps --ppid / pgrep -P) is
-# the safe alternative: it reaches every MCP child the dispatcher spawned
-# (obsidian-mcp, inbox_server.py, etc.) without touching anything above the
-# dispatcher in the process tree. A fresh set of children is spawned by the
-# next Claude launch regardless, so killing all current children here is
-# safe -- none of them have a reason to outlive this session.
+# Enumerating the FULL descendant tree of $dispatcher_pid (get_descendant_pids,
+# a recursive walk -- see #2221) is the safe alternative: it reaches every MCP
+# descendant the dispatcher spawned at every hop (obsidian-mcp's `npm exec` ->
+# `sh -c` -> `node` chain, inbox_server.py, etc.) without touching anything
+# above the dispatcher in the process tree. A one-hop `pgrep -P` (the #2119
+# implementation) only found the immediate child (`npm exec`); it did not
+# reach the `sh`/`node` descendants underneath, which is exactly the gap
+# #2221 closes. A fresh set of children is spawned by the next Claude launch
+# regardless, so killing all current descendants here is safe -- none of them
+# have a reason to outlive this session.
 #
-# Takes the child PIDs as arguments (already-enumerated by the caller) rather
-# than a parent PID to enumerate itself. This matters: the caller must
-# snapshot the children BEFORE sending SIGTERM to the dispatcher, because
+# Takes the descendant PIDs as arguments (already-enumerated by the caller)
+# rather than a parent PID to enumerate itself. This matters: the caller must
+# snapshot the descendants BEFORE sending SIGTERM to the dispatcher, because
 # once the dispatcher exits its children are reparented away immediately —
-# enumerating *after* the SIGTERM is a race that can observe zero children
+# enumerating *after* the SIGTERM is a race that can observe zero descendants
 # even though they existed a moment earlier.
 #===============================================================================
 kill_dispatcher_children() {
     local child_pids="$*"
 
     if [[ -z "${child_pids// /}" ]]; then
-        log_info "Session age: no child processes to signal"
+        log_info "Session age: no descendant processes to signal"
         return 0
     fi
 
-    log_warn "Session age: signalling dispatcher child process(es): $(echo "$child_pids" | tr '\n' ' ')"
+    log_warn "Session age: signalling dispatcher descendant process(es): $(echo "$child_pids" | tr '\n' ' ')"
 
     local sigterm_pids=()
     local cpid

--- a/tests/test-health-check-session-age.sh
+++ b/tests/test-health-check-session-age.sh
@@ -87,15 +87,17 @@ DISPATCHER_SESSION_START_FILE="$TEST_DATA_DIR/$DISPATCHER_SESSION_START_FILENAME
 DISPATCHER_PID_FILE="$TEST_CONFIG_DIR/$DISPATCHER_PID_FILENAME"
 ALERT_DEDUP_DIR="$TEST_TMPDIR/alert-dedup"
 
-# Load check_session_age() and kill_dispatcher_children() (issue #2119) from
-# the health check script. check_session_age() calls kill_dispatcher_children()
-# directly, so both must be extracted together or the call fails with
-# "command not found" inside the test (previously masked by `set -u` not being
-# fatal for undefined commands — the return code was unaffected, but the
-# child-killing behavior was silently never exercised).
-# We extract just these two functions to avoid sourcing the entire ~2000-line file.
+# Load check_session_age(), kill_dispatcher_children() (issue #2119), and
+# get_descendant_pids() (issue #2221) from the health check script.
+# check_session_age() calls both of the other two directly, so all three must
+# be extracted together or the call fails with "command not found" inside the
+# test (previously masked by `set -u` not being fatal for undefined commands —
+# the return code was unaffected, but the child-killing behavior was silently
+# never exercised).
+# We extract just these three functions to avoid sourcing the entire ~2000-line file.
 eval "$(sed -n '/^check_session_age()/,/^}/p' "$HEALTH_SCRIPT")" 2>/dev/null
 eval "$(sed -n '/^kill_dispatcher_children()/,/^}/p' "$HEALTH_SCRIPT")" 2>/dev/null
+eval "$(sed -n '/^get_descendant_pids()/,/^}/p' "$HEALTH_SCRIPT")" 2>/dev/null
 
 if ! declare -f check_session_age > /dev/null 2>&1; then
     echo "FATAL: check_session_age() not found in $HEALTH_SCRIPT"
@@ -107,12 +109,94 @@ if ! declare -f kill_dispatcher_children > /dev/null 2>&1; then
     exit 1
 fi
 
+if ! declare -f get_descendant_pids > /dev/null 2>&1; then
+    echo "FATAL: get_descendant_pids() not found in $HEALTH_SCRIPT"
+    exit 1
+fi
+
 #===============================================================================
 # Helper: reset test state between tests
 #===============================================================================
 reset_state() {
     rm -f "$DISPATCHER_SESSION_START_FILE" "$DISPATCHER_PID_FILE"
     rm -f "$TELEGRAM_ALERTS_FILE"
+}
+
+#===============================================================================
+# Helper: build a fake THREE-HOP MCP descendant tree matching the REAL
+# production topology (issue #2221). Confirmed live via
+# `ps -o pid,ppid,pgid,sid,comm` against an actual running obsidian-mcp
+# instance:
+#
+#   claude (dispatcher)
+#    `- npm exec obsidian-mcp ...   (hop 1 -- dispatcher's DIRECT child;
+#                                     the ONLY pid a one-hop `pgrep -P
+#                                     $dispatcher_pid` -- the pre-#2221 code
+#                                     -- ever reached)
+#        `- sh -c obsidian-mcp ...  (hop 2 -- `npm exec`/`npx` forks, not
+#                                     execs, into this wrapper)
+#            `- node .../obsidian-mcp (hop 3 -- forked, not exec'd, from the
+#                                     `sh -c` above; this is the real worker
+#                                     process that actually hangs)
+#
+# The fake tree below uses plain shell/sleep processes instead of the real
+# npm/sh/node binaries, but the PARENT/CHILD SHAPE is the real one: three
+# hops below the dispatcher, not one. This is what test 15 (single-hop fake
+# child) above did NOT exercise -- see issue #2221's review of that gap.
+#===============================================================================
+fake_hop3_worker() {
+    # Hop 3: the real worker (`node .../obsidian-mcp`) -- a leaf process.
+    # `exec` replaces this shell with `sleep` so hop 3 is exactly one
+    # process, matching the real chain's depth (no extra hidden hop from
+    # forking sleep as a child instead of exec'ing into it).
+    exec sleep 600
+}
+
+fake_hop2_sh_wrapper() {
+    # Hop 2: `sh -c obsidian-mcp ...` -- forks hop 3 as its child.
+    local pid_dir="$1"
+    fake_hop3_worker &
+    echo "$!" > "$pid_dir/hop3.pid"
+    wait
+}
+
+fake_hop1_npm_exec() {
+    # Hop 1: `npm exec obsidian-mcp ...` -- the dispatcher's DIRECT child.
+    local pid_dir="$1"
+    fake_hop2_sh_wrapper "$pid_dir" &
+    echo "$!" > "$pid_dir/hop2.pid"
+    wait
+}
+
+fake_dispatcher_with_three_hop_mcp_tree() {
+    local pid_dir="$1"
+    fake_hop1_npm_exec "$pid_dir" &
+    echo "$!" > "$pid_dir/hop1.pid"
+    wait
+}
+
+# Spawns the fake dispatcher plus its 3-hop descendant chain in the
+# background, waits for all three hop pid files to appear, and echoes the
+# fake dispatcher's own PID (the one to write into DISPATCHER_PID_FILE).
+#
+# This function is called via command substitution ($(...)) by callers, which
+# forks a subshell whose stdout is the pipe being captured. Without an
+# explicit redirect, the backgrounded fake-tree processes inherit that same
+# pipe fd; since the leaf (`sleep 600`) never exits on its own, the pipe's
+# write end would stay open and $(...) would hang forever waiting for EOF
+# instead of returning as soon as the subshell's own `echo` finishes. Routing
+# the background job's stdio to /dev/null avoids that hang.
+spawn_fake_three_hop_tree() {
+    local pid_dir="$1"
+    rm -f "$pid_dir"/hop1.pid "$pid_dir"/hop2.pid "$pid_dir"/hop3.pid
+    bash -c "$(declare -f fake_hop3_worker fake_hop2_sh_wrapper fake_hop1_npm_exec fake_dispatcher_with_three_hop_mcp_tree); fake_dispatcher_with_three_hop_mcp_tree '$pid_dir'" > /dev/null 2>&1 < /dev/null &
+    local dispatcher_pid=$!
+    local waited=0
+    while [[ ! -f "$pid_dir/hop3.pid" && $waited -lt 50 ]]; do
+        sleep 0.1
+        waited=$((waited + 1))
+    done
+    echo "$dispatcher_pid"
 }
 
 #===============================================================================
@@ -395,6 +479,82 @@ fi
 rm -f "$TEST_TMPDIR/child.pid"
 # Restore the real function extracted from health-check-v3.sh for any later tests.
 eval "$(sed -n '/^kill_dispatcher_children()/,/^}/p' "$HEALTH_SCRIPT")" 2>/dev/null
+
+# 18. Session-age SIGTERM reaches ALL THREE hops of a real obsidian-mcp-shaped
+# descendant tree (issue #2221). Test 15/17 above only ever exercised a
+# one-hop fake child (`sleep 600` directly under the fake dispatcher), which
+# is exactly the simplified topology the #2221 review flagged as insufficient
+# -- it could never have caught a gap that only shows up two hops further
+# down. This test builds the real `npm exec -> sh -c -> node` shape (see the
+# fake_hop*/spawn_fake_three_hop_tree helpers above) and asserts every hop is
+# dead after check_session_age() fires, not just the dispatcher's direct
+# child.
+begin_test "session_age_sigterm_reaches_all_three_mcp_tree_hops"
+reset_state
+target_pid=$(spawn_fake_three_hop_tree "$TEST_TMPDIR")
+hop1_pid=$(cat "$TEST_TMPDIR/hop1.pid" 2>/dev/null || echo "")
+hop2_pid=$(cat "$TEST_TMPDIR/hop2.pid" 2>/dev/null || echo "")
+hop3_pid=$(cat "$TEST_TMPDIR/hop3.pid" 2>/dev/null || echo "")
+echo "$target_pid" > "$DISPATCHER_PID_FILE"
+past_start=$(( $(date +%s) - SESSION_AGE_LIMIT_SECONDS - 60 ))
+echo "$past_start" > "$DISPATCHER_SESSION_START_FILE"
+check_session_age
+rc=$?
+sleep 0.3
+# Capture aliveness BEFORE any manual cleanup, same discipline as test 15 --
+# cleanup must not be what kills these processes, or the assertion would pass
+# unconditionally regardless of whether the fix actually reached every hop.
+hop1_alive=false; hop2_alive=false; hop3_alive=false
+[[ -n "$hop1_pid" ]] && kill -0 "$hop1_pid" 2>/dev/null && hop1_alive=true
+[[ -n "$hop2_pid" ]] && kill -0 "$hop2_pid" 2>/dev/null && hop2_alive=true
+[[ -n "$hop3_pid" ]] && kill -0 "$hop3_pid" 2>/dev/null && hop3_alive=true
+kill "$target_pid" "$hop1_pid" "$hop2_pid" "$hop3_pid" 2>/dev/null || true
+if [[ -z "$hop1_pid" || -z "$hop2_pid" || -z "$hop3_pid" ]]; then
+    fail "test setup failed: never observed all three fake MCP tree PIDs (hop1=$hop1_pid hop2=$hop2_pid hop3=$hop3_pid)"
+elif [[ "$rc" -eq 1 && "$hop1_alive" == "false" && "$hop2_alive" == "false" && "$hop3_alive" == "false" ]]; then
+    pass
+else
+    fail "expected exit 1 and all three hops dead; got rc=$rc hop1_alive=$hop1_alive hop2_alive=$hop2_alive hop3_alive=$hop3_alive"
+fi
+rm -f "$TEST_TMPDIR"/hop1.pid "$TEST_TMPDIR"/hop2.pid "$TEST_TMPDIR"/hop3.pid
+
+# 19. Falsifiability check for #2221: with get_descendant_pids() shadowed by
+# the exact pre-#2221 one-hop implementation (`pgrep -P $dispatcher_pid`,
+# i.e. what check_session_age() called before this fix), hop 1 (the `npm
+# exec` wrapper, a direct child of the dispatcher) dies as before, but hop 2
+# and hop 3 -- the `sh -c` wrapper and the real `node` worker underneath it --
+# must survive, reproducing the exact orphan leak #2221 reports. This
+# directly demonstrates that test 18 above would have failed against the
+# pre-fix code, and passes only because get_descendant_pids() now walks the
+# full tree.
+begin_test "pre_2221_fix_one_hop_pgrep_would_leak_hop2_and_hop3"
+reset_state
+# Shadow get_descendant_pids with the pre-#2221 one-hop implementation to
+# simulate the reverted state.
+get_descendant_pids() { pgrep -P "$1" 2>/dev/null || true; }
+target_pid=$(spawn_fake_three_hop_tree "$TEST_TMPDIR")
+hop1_pid=$(cat "$TEST_TMPDIR/hop1.pid" 2>/dev/null || echo "")
+hop2_pid=$(cat "$TEST_TMPDIR/hop2.pid" 2>/dev/null || echo "")
+hop3_pid=$(cat "$TEST_TMPDIR/hop3.pid" 2>/dev/null || echo "")
+echo "$target_pid" > "$DISPATCHER_PID_FILE"
+past_start=$(( $(date +%s) - SESSION_AGE_LIMIT_SECONDS - 60 ))
+echo "$past_start" > "$DISPATCHER_SESSION_START_FILE"
+check_session_age
+rc=$?
+sleep 0.3
+hop1_alive=false; hop2_alive=false; hop3_alive=false
+[[ -n "$hop1_pid" ]] && kill -0 "$hop1_pid" 2>/dev/null && hop1_alive=true
+[[ -n "$hop2_pid" ]] && kill -0 "$hop2_pid" 2>/dev/null && hop2_alive=true
+[[ -n "$hop3_pid" ]] && kill -0 "$hop3_pid" 2>/dev/null && hop3_alive=true
+kill "$target_pid" "$hop1_pid" "$hop2_pid" "$hop3_pid" 2>/dev/null || true
+if [[ "$rc" -eq 1 && "$hop1_alive" == "false" && "$hop2_alive" == "true" && "$hop3_alive" == "true" ]]; then
+    pass
+else
+    fail "expected the pre-#2221 one-hop pgrep to reproduce the leak (hop1 dead, hop2+hop3 survive); rc=$rc hop1_alive=$hop1_alive hop2_alive=$hop2_alive hop3_alive=$hop3_alive"
+fi
+rm -f "$TEST_TMPDIR"/hop1.pid "$TEST_TMPDIR"/hop2.pid "$TEST_TMPDIR"/hop3.pid
+# Restore the real get_descendant_pids() extracted from health-check-v3.sh for any later tests.
+eval "$(sed -n '/^get_descendant_pids()/,/^}/p' "$HEALTH_SCRIPT")" 2>/dev/null
 
 #===============================================================================
 # Summary


### PR DESCRIPTION
## Problem

Follow-up hardening of #2119 / #2220 ("obsidian MCP hang froze whole dispatcher"). An independent post-merge review of #2220 found a real gap in that fix and filed it as #2221.

`check_session_age()` in `scripts/health-check-v3.sh` sends a graceful SIGTERM to the dispatcher before Claude Code's hard 7440s session limit hits, and is also supposed to signal any stdio MCP child processes (like `obsidian-mcp`) so they don't get orphaned in the process. The #2220 fix snapshotted `pgrep -P $dispatcher_pid` — **direct children only, one hop** — and signalled just those PIDs.

The real obsidian-mcp process tree is **three hops** deep, not one. Verified live against a running production instance:

```
$ pgrep -af obsidian-mcp
526420 npm exec obsidian-mcp /home/lobster/LobsterDrop/eloso-obsidian-vault
526451 sh -c obsidian-mcp /home/lobster/LobsterDrop/eloso-obsidian-vault
526452 node /home/lobster/.npm/_npx/.../obsidian-mcp ...

$ ps -o pid,ppid,pgid,sid,comm -p 526420,526451,526452
    PID    PPID    PGID     SID COMMAND
 526420  526386 2901787 2901787 npm exec obsidi
 526451  526420 2901787 2901787 sh
 526452  526451 2901787 2901787 node
```

`claude (dispatcher, 526386)` → `npm exec obsidian-mcp (526420, hop 1 — the only PID a one-hop `pgrep -P` ever reached)` → `sh -c obsidian-mcp (526451, hop 2)` → `node .../obsidian-mcp (526452, hop 3 — the actual worker that hangs)`.

`npx`/`npm exec` forks (does not exec) into an intermediate `sh -c`, which forks (does not exec) into the real `node` process. Killing the hop-1 wrapper never cascaded to hop 2/3 — they were still orphaned (reparented to PID 1) on every session-age restart, caught only by the separate cron backstop reaper instead of prevented at restart time as the #2220 code comments claimed.

## Fix

Adds `get_descendant_pids()` — a pure, side-effect-free breadth-first walk of `pgrep -P` that collects every descendant at every hop of the tree, not a fixed hop count. `check_session_age()` now snapshots `get_descendant_pids($dispatcher_pid)` instead of a single `pgrep -P` call, before sending SIGTERM (unchanged: snapshot-before-signal ordering, still needed to avoid the reparenting race). `kill_dispatcher_children()` itself is unchanged — it already just iterates over whatever PID list it's given.

Process-group kill (`kill -TERM -$pgid`) is still ruled out — re-verified live for this fix: every obsidian-mcp descendant (hops 1–3) shares the dispatcher's PGID with `claude-persistent.sh`, the supervisor that performs the restart. Group-signalling would kill the supervisor too.

**Functional patterns used:** `get_descendant_pids()` is a pure function — no globals read or mutated, output is entirely determined by its input PID and current process-table state, and it's trivially composable with `kill_dispatcher_children()` (which already took a PID list as a parameter rather than doing its own enumeration).

## Flow change

```
Before (#2220):                          After (this PR):
dispatcher --SIGTERM-->  X               dispatcher --SIGTERM--> X
  |                                        |
  `- npm exec (hop1) --SIGTERM--> X        `- npm exec (hop1) --SIGTERM--> X
       `- sh -c (hop2)  [ORPHANED]              `- sh -c (hop2)  --SIGTERM--> X
            `- node (hop3) [ORPHANED,               `- node (hop3) --SIGTERM--> X
               leaked until cron reaper]                (all hops reached directly,
                                                           no reliance on signal cascade)
```

## Tests run

- [x] `bash tests/test-health-check-session-age.sh` — 19 passed, 0 failed (17 pre-existing + 2 new)
- [x] All other `tests/test-health-check-*.sh` suites (boot-grace, count-active-subagents, dispatcher-heartbeat, dispatcher-pid-consistency, inbox-drain, orphan-mcp-reaper, pid-timing, thinking-heartbeat, wfm-active) — all pass, no regressions
- [x] `bash -n scripts/health-check-v3.sh` / `bash -n tests/test-health-check-session-age.sh` — syntax clean

**Falsifiability check (the gap this fix closes was found by review flagging a test that couldn't have caught it):**
- The old test only ever built a one-hop fake child (`sleep 600` directly under a fake dispatcher) — a topology that could never exercise a bug two hops further down.
- Added `session_age_sigterm_reaches_all_three_mcp_tree_hops`: builds a real three-hop fake tree (`npm exec`-analog → `sh -c`-analog → leaf worker, matching the live production shape above) and asserts all three PIDs are dead after `check_session_age()` fires.
- Added `pre_2221_fix_one_hop_pgrep_would_leak_hop2_and_hop3`: shadows `get_descendant_pids()` with the exact pre-#2221 one-hop `pgrep -P` implementation and confirms hop1 dies but hop2/hop3 survive — reproducing the leak this PR closes and proving the new test would have failed against the old code.
- Also reverted `scripts/health-check-v3.sh` wholesale to `origin/main` and reran the suite: it fails immediately (`FATAL: get_descendant_pids() not found`) since the pre-fix script has no such function. Restored the fix and reran — 19/19 pass again.

## Manual test

Required since this touches restart/process-management logic that runs against the live dispatcher process tree.

Built a standalone 3-hop fake tree outside the test harness (`npm exec`-analog → `sh -c`-analog → `sleep`-as-worker-analog), extracted the actual `get_descendant_pids()` / `kill_dispatcher_children()` functions from the fixed script, and ran them against it directly:

```
$ ps -o pid,ppid,comm -p 610909,610910,610911,610912
    PID    PPID COMMAND
 610909       1 bash        # fake dispatcher
 610910  610909 bash        # hop1 (npm exec analog)
 610911  610910 bash        # hop2 (sh -c analog)
 610912  610911 sleep       # hop3 (node worker analog, the deepest process)

$ pgrep -P 610909            # what the OLD one-hop pgrep -P found
610910

$ get_descendant_pids 610909  # what the FIX finds
610910
610911
610912

$ kill_dispatcher_children 610910 610911 610912
[WARN] Session age: signalling dispatcher descendant process(es): 610910 610911 610912

# aliveness after:
hop1 (PID 610910): dead
hop2 (PID 610911): dead
hop3(deepest worker) (PID 610912): dead
```

All three hops confirmed dead, including the deepest process — the one the pre-fix code left orphaned.

I did **not** touch the real production `obsidian-mcp` process tree (PIDs 526420/526451/526452 observed above) — only read it via `ps`/`pgrep` for the topology investigation. No live processes were killed or restarted as part of this work.

## Definition of Done

- [x] Unit tests pass (bash test harness, no mocking needed — this is process-management logic tested against real spawned processes)
- [x] Manual test run — see above, fake tree + real extracted functions
- [x] User-visible outcome: not applicable — this is an internal restart-hardening change with no user-facing output
- [x] Side-effect audit: no floods, no unscoped writes; the manual test used a disposable fake process tree in `/tmp`, cleaned up afterward; the live obsidian-mcp tree was only read, never signalled
- [ ] External service calls: N/A, no external services involved

## Out of scope

- Does not touch `reap_orphaned_mcp_processes()` (the cron backstop) — it remains the backstop for the separate failure modes it was built for (crash path, hard 7440s CC limit firing before the proactive restart, old/rolled-back builds). This PR only closes the specific one-hop gap in the proactive path.
- Does not change the PGID-based approach evaluation — re-confirmed live that group-signalling is still unsafe (same conclusion as #2220, now re-verified against the fuller 3-hop tree).
- **Not deployed.** This PR does not restart or deploy the live `lobster-claude` service. The current dispatcher process (the one that would be running this very check) is unaffected until this is merged and the service is restarted separately. See note below.

## Deployment note

**A live restart of `lobster-claude` is required to pick up this fix** — the currently-running health-check script still has the one-hop bug until this is deployed. I have not restarted anything. Please confirm before merge that a restart is scheduled/acceptable, since this script runs against the actual dispatcher process tree in production.

Closes #2221