### PR TITLE
fix: Slack chat.update msg_too_long silently stranded replies as "..."

### DIFF
--- a/src/bot/slack_router.py
+++ b/src/bot/slack_router.py
@@ -723,15 +723,19 @@ def _send_with_typing_indicator(channel_id: str, text: str, thread_ts: str | Non
         log.info("Updated placeholder → real reply in %s: %s...", channel_id, text[:50])
         return True
     except SlackApiError as exc:
-        # The placeholder "..." is already visible in Slack.  Returning False
-        # would leave the outbox file in place and trigger a duplicate send.
-        # Log the failure and return True to consume the outbox file.
+        # The placeholder "..." is already visible in Slack, but the update
+        # failed to replace it (e.g. msg_too_long) — the real content never
+        # reached the channel. Falling back to a direct chat.postMessage,
+        # exactly as _update_placeholder does, so the reply is never silently
+        # lost behind a stuck "..." placeholder. This leaves the orphaned
+        # placeholder visible above the real message, which is preferable to
+        # dropping the content entirely.
         log.warning(
             "chat.update failed for placeholder ts=%s in %s: %s — "
-            "placeholder remains visible; not re-queuing to avoid duplicate",
+            "falling back to postMessage so the reply is not lost",
             placeholder_ts, channel_id, exc,
         )
-        return True
+        return _send_direct(channel_id, text, thread_ts)
 
 
 # Backward-compatible alias -- code that imports OutboxHandler directly still works.


### PR DESCRIPTION
## Summary
- `_send_with_typing_indicator` (the proactive-send path, used for background subagent Slack replies) posted a `...` placeholder then called `chat.update` with the real reply text. When `chat.update` failed — observed in production as `msg_too_long` for messages as short as ~4KB, well under `chat.postMessage`'s documented 40,000-char limit — the handler logged a warning and returned `True` without ever delivering the real content, leaving the bare `...` placeholder as the only thing visible in Slack while internal logs/session history recorded the send as successful.
- The inbound-placeholder path (`_update_placeholder`) already handled this correctly by falling back to `chat.postMessage` on `chat.update` failure. This PR brings `_send_with_typing_indicator` in line with that existing, correct behavior.

## Root cause (verified via production logs)
Two real incidents in `#wallace-jake` hit this bug:
- MSA IP-redline analysis, 2026-08-11 18:45 UTC (6416 chars) — Jake never received it; caused a confusing back-and-forth where Wallace incorrectly insisted it was "already delivered above."
- VMI research brief, 2026-08-12 16:39 UTC (4132 chars) — same failure, is what prompted this investigation.

`slack-router.log` shows the exact Slack API response for both: `{'ok': False, 'error': 'msg_too_long'}` on `chat.update`, followed by the old code path returning `True` and discarding the content.

## Fix
On `chat.update` `SlackApiError`, fall back to `_send_direct` (`chat.postMessage`) so the real content is always delivered, even if it leaves an orphaned `...` placeholder above it — same tradeoff already accepted by `_update_placeholder`.

## Test plan
- [x] Applied fix locally, restarted `lobster-slack-router.service`
- [x] Re-sent the missing VMI brief via `send_reply` to `C0B3S6RBFV5` — confirmed in `slack-router.log`: `chat.update` failed with `msg_too_long` again (same long message), then fell back to `chat.postMessage` and logged `Sent Slack reply to C0B3S6RBFV5` — delivered successfully this time.
- [ ] Existing unit tests in `tests/unit/test_bot/test_slack_typing_indicator.py` cover the happy path and the inbound-placeholder fallback; recommend adding a case for this proactive-path fallback specifically (not added here — flagging for follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)