### PR TITLE
fix(fireflies-sync): invoke sync.py by file path, not -m module

### DIFF
--- a/scheduled-tasks/fireflies-sync.sh
+++ b/scheduled-tasks/fireflies-sync.sh
@@ -38,9 +38,18 @@ fi
 echo "[$(date -Iseconds)] fireflies-sync starting" | tee "$LOG_FILE"
 
 # Run the sync script
+#
+# Invoked by file path (not `-m integrations.fireflies.sync`) to mirror
+# granola-sync.sh. Module-mode invocation requires `integrations` to
+# already be importable from sys.path before the interpreter starts, which
+# depends on the editable install being wired up correctly. Running by
+# file path lets Python add the script's own directory to sys.path, and
+# sync.py's own `sys.path.insert(0, str(_SRC_DIR))` (pointing at src/) then
+# makes the `integrations.*` absolute imports resolve — the same pattern
+# granola/sync.py already relies on.
 cd "$LOBSTER_DIR"
 set +e
-OUTPUT=$(uv run python -m integrations.fireflies.sync 2>&1)
+OUTPUT=$(uv run python src/integrations/fireflies/sync.py 2>&1)
 EXIT_CODE=$?
 set -e
 


### PR DESCRIPTION
## Summary
- `fireflies-sync.sh` has failed on every run since Aug 9 (`ModuleNotFoundError: No module named 'integrations'`), stalling the Fireflies→Obsidian sync for 8 days.
- Root cause: the script invokes the sync entrypoint as `uv run python -m integrations.fireflies.sync` (module mode). Module-mode requires `integrations` to already be importable from `sys.path` before the interpreter loads the module — and it isn't, from the repo root (confirmed `uv run python -c "import integrations"` fails, as does the identical `-m` form for `integrations.granola.sync`).
- The sibling `granola-sync.sh` never hits this because it invokes its script **by file path** (`uv run python src/integrations/granola/sync.py`), which lets Python add the script's own directory to `sys.path` first. Both `granola/sync.py` and `fireflies/sync.py` already carry an internal `sys.path.insert(0, str(_SRC_DIR))` fallback pointing at `src/` for exactly this reason — but under `-m` invocation, the `ModuleNotFoundError` fires before that line ever executes.
- Fix: switch `fireflies-sync.sh` to file-path invocation, matching `granola-sync.sh`'s established pattern, so the existing fallback in `fireflies/sync.py` actually takes effect. No sys.path hack was added — the fallback was already there and already the codebase's pattern; this just lets it run.

## Test plan
- [x] Ran `scheduled-tasks/fireflies-sync.sh` directly on the production host — exit code 0, fetched 24 transcripts, wrote 16 new ones (the Aug 8–16 backlog), git-committed to the Obsidian vault (`fireflies: sync 16 transcripts [2026-08-16T15:27:36Z]`).
- [x] Re-ran via `systemctl start lobster-fireflies-sync.service` (the actual production invocation path) — `Result=success`, `ExecMainStatus=0`, correctly reported 0 new (idempotent re-run, all 15 already synced).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>