### PR TITLE
feat(lobster-shop): add paperclip board-operator skill scaffold

### DIFF
--- a/lobster-shop/INDEX.md
+++ b/lobster-shop/INDEX.md
@@ -19,6 +19,7 @@ Browse available skills for your Lobster assistant. Install any skill with one c
 | [Buy Things](./buy-things/) | Purchase items via Telegram — search products, confirm with you, and complete checkout using Camofox browser automation | Tool | Available |
 | [Lobster Dev](./lobster-dev/) | Lobster development context — staging Docker setup, active dev patterns, and known dev environment quirks. Activate when developing or debugging Lobster itself. | Context | Available |
 | [Skill Builder](./skill-builder/) | Guides Lobster users through creating custom skills — scaffolds the correct file layout, explains the two-location model (repo vs instance), and wires MCP tool registration. | Workflow | Available |
+| [Paperclip](./paperclip/) | Board-operator integration for Eloso's Paperclip control plane — read agent state, manage heartbeats/issues/routines via the Paperclip API, never runs as an in-Paperclip agent itself | Integration | In Dev |
 
 ## Templates
 

--- a/lobster-shop/paperclip/skill.toml
+++ b/lobster-shop/paperclip/skill.toml
@@ -1,0 +1,42 @@
+[skill]
+name = "paperclip"
+version = "1.0.0"
+description = "Interact with the Paperclip control plane API to manage tasks, coordinate with other agents, and follow company governance. Use when you need to check assignments, update task status, delegate work, post comments, set up or manage routines (recurring scheduled tasks), or call any Paperclip API endpoint. Do NOT use for the actual domain work itself (writing code, research, etc.) — only for Paperclip coordination."
+author = "Lobster"
+category = "integration"
+
+[activation]
+mode = "triggered"
+triggers = ["/paperclip", "/eloso", "/agents"]
+context_patterns = [
+    "when user asks about Eloso agents",
+    "when user asks about Paperclip",
+    "when user asks about the CEO or CMO agent",
+    "when user wants to run outbound or prospect sourcing",
+    "when user asks about ELO tickets or issues",
+    "when user asks to enable or disable heartbeats",
+    "when user asks about agent runs or logs",
+    "when user wants to create a routine or scheduled task",
+    "when user asks what the agents are working on",
+    "when user mentions something seems broken with agents",
+]
+
+[layering]
+priority = 60
+merge_strategy = "append"
+
+[provides]
+mcp_tools = []
+bot_commands = ["/paperclip", "/eloso", "/agents"]
+
+[compatibility]
+enhances = []
+conflicts = []
+
+[dependencies]
+pip = []
+npm = []
+system = ["curl"]
+api_keys = []
+
+[dependencies.runtime]

--- a/scheduled-tasks/fireflies-sync.sh
+++ b/scheduled-tasks/fireflies-sync.sh
@@ -38,18 +38,9 @@ fi
 echo "[$(date -Iseconds)] fireflies-sync starting" | tee "$LOG_FILE"
 
 # Run the sync script
-#
-# Invoked by file path (not `-m integrations.fireflies.sync`) to mirror
-# granola-sync.sh. Module-mode invocation requires `integrations` to
-# already be importable from sys.path before the interpreter starts, which
-# depends on the editable install being wired up correctly. Running by
-# file path lets Python add the script's own directory to sys.path, and
-# sync.py's own `sys.path.insert(0, str(_SRC_DIR))` (pointing at src/) then
-# makes the `integrations.*` absolute imports resolve — the same pattern
-# granola/sync.py already relies on.
 cd "$LOBSTER_DIR"
 set +e
-OUTPUT=$(uv run python src/integrations/fireflies/sync.py 2>&1)
+OUTPUT=$(uv run python -m integrations.fireflies.sync 2>&1)
 EXIT_CODE=$?
 set -e
 

--- a/scheduled-tasks/fireflies-sync.sh
+++ b/scheduled-tasks/fireflies-sync.sh
@@ -38,9 +38,18 @@ fi
 echo "[$(date -Iseconds)] fireflies-sync starting" | tee "$LOG_FILE"
 
 # Run the sync script
+#
+# Invoked by file path (not `-m integrations.fireflies.sync`) to mirror
+# granola-sync.sh. Module-mode invocation requires `integrations` to
+# already be importable from sys.path before the interpreter starts, which
+# depends on the editable install being wired up correctly. Running by
+# file path lets Python add the script's own directory to sys.path, and
+# sync.py's own `sys.path.insert(0, str(_SRC_DIR))` (pointing at src/) then
+# makes the `integrations.*` absolute imports resolve — the same pattern
+# granola/sync.py already relies on.
 cd "$LOBSTER_DIR"
 set +e
-OUTPUT=$(uv run python -m integrations.fireflies.sync 2>&1)
+OUTPUT=$(uv run python src/integrations/fireflies/sync.py 2>&1)
 EXIT_CODE=$?
 set -e
 


### PR DESCRIPTION
## Summary
- Adds the `paperclip` skill manifest (`skill.toml`) — Lobster acting as board operator for Eloso's Paperclip instance (read state, manage heartbeats/issues via curl, never run as an in-Paperclip agent).
- **Correction from the original PR description:** it previously claimed this PR also adds `behavior/system.md` and `context/eloso-reference.md`. It doesn't, and it can't — both paths are explicitly gitignored (`.gitignore` lines 87-88), added by the #2116 PII/instance-data remediation, which classified them as instance-specific/business data (real Eloso company/agent/issue UUIDs) that belongs in the private skill overlay at `~/lobster-user-config/skills/paperclip/`, not the public repo. `skill.toml` is genuinely everything that belongs here for this skill.
- This directory was found sitting untracked and un-branched in the production `~/lobster` checkout during a local-branch cleanup pass — it was never committed anywhere, so I can't confirm from git history whether it's finished or how current the hardcoded IDs (company/agent/issue UUIDs) still are. (That's now moot for this repo, since those files don't belong here — see above.)
- Opening as a PR rather than committing to main directly so Drew can confirm this is current/complete before it's live via skill loading.

## Follow-up review fixes (this commit)
1. Registered the skill in `lobster-shop/INDEX.md` (marked **In Dev** — the skill currently has no `behavior/` content, so it will activate on its triggers but inject nothing until the overlay files below exist).
2. Reverted an unrelated change to `scheduled-tasks/fireflies-sync.sh` that had been accidentally carried into this branch — confirmed via `gh pr diff 2233` it's the exact same fix already shipped in PR #2233. This branch now only touches paperclip-scaffold files.
3. Checked for a `list_decisions()`-style architectural decision mechanism before making the gitignore-vs-force-add call above: none exists in this repo. There's only `memory/canonical-templates/pending-decisions.md` (a markdown template, not a queryable tool/API) — no `list_decisions()` or equivalent MCP tool. Noting this per standing rule 86.

## What's still needed before this skill actually does anything
Someone with the real values needs to create these files at `~/lobster-user-config/skills/paperclip/` (the private overlay `src/mcp/skill_manager.py` merges in by skill name, overriding the repo version):
- `behavior/system.md` — the board-operator behavior instructions (what to do on `/paperclip`, `/eloso`, `/agents`)
- `context/eloso-reference.md` — the Paperclip base URL, auth mechanism, and company/agent/issue UUIDs

Until those exist, activating this skill will surface no injected behavior/context (the triggers/bot-commands are registered, but there's nothing to inject).

## Test plan
- [ ] Drew confirms the hardcoded company/agent/issue IDs that will go into the *private* `context/eloso-reference.md` overlay are still accurate
- [ ] Drew (or whoever has the original scaffold) fills in `~/lobster-user-config/skills/paperclip/behavior/system.md` and `context/eloso-reference.md`
- [ ] Once populated: verify `/paperclip`, `/eloso`, `/agents` trigger correctly and inject the expected behavior/context

🤖 Generated with [Claude Code](https://claude.com/claude-code)
