### PR TITLE
fix(migrations): load systemd_jobs.py via importlib, avoid src/mcp package collision (fixes #2237, addresses #2239)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1865,11 +1865,28 @@ if command -v uv &>/dev/null && [ -f "$INSTALL_DIR/scripts/prune-pr-worktrees.py
     if systemctl is-enabled "lobster-prune-pr-worktrees.timer" &>/dev/null; then
         substep "prune-pr-worktrees systemd timer already enabled — skipping"
     else
+        # NOTE: We deliberately do NOT `import mcp.systemd_jobs` (or add
+        # src/mcp/__init__.py to make that importable). src/mcp/ shares its
+        # top-level name with the pip-installed `mcp` SDK; making it a real
+        # package makes it win import resolution ahead of the SDK everywhere
+        # `src/` is on sys.path (e.g. inbox_server.py), which crash-loops
+        # lobster-mcp-local (see issue #2239 / PR #2238 revert). Instead we
+        # load systemd_jobs.py directly by file path via importlib, which
+        # needs no package at all — same pattern used in Migration 83
+        # (scripts/lib/migrations.sh) and src/bisque/relay_server.py /
+        # src/bot/sms_router.py for the same collision on src/mcp/log_utils.py.
         uv run --project "$INSTALL_DIR" python -c "
-import asyncio, sys
-sys.path.insert(0, '$INSTALL_DIR/src')
-from mcp.systemd_jobs import create_job
-result = asyncio.run(create_job(
+import asyncio
+import importlib.util
+import sys
+
+spec = importlib.util.spec_from_file_location('lobster_mcp_systemd_jobs', '$INSTALL_DIR/src/mcp/systemd_jobs.py')
+systemd_jobs = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = systemd_jobs  # required: systemd_jobs.py uses @dataclass, which
+                                        # resolves its module via sys.modules at class-body eval time
+spec.loader.exec_module(systemd_jobs)
+
+result = asyncio.run(systemd_jobs.create_job(
     name='prune-pr-worktrees',
     schedule='*-*-* 03:00:00',
     command='$_PRUNE_CMD',

--- a/scripts/lib/migrations.sh
+++ b/scripts/lib/migrations.sh
@@ -1976,11 +1976,28 @@ CREATE TABLE IF NOT EXISTS dispatcher_lock (
         if systemctl is-enabled "$_m83_timer" &>/dev/null; then
             substep "prune-pr-worktrees systemd timer already enabled — skipping Migration 83"
         else
+            # NOTE: We deliberately do NOT `import mcp.systemd_jobs` (or add
+            # src/mcp/__init__.py to make that importable). src/mcp/ shares its
+            # top-level name with the pip-installed `mcp` SDK; making it a real
+            # package makes it win import resolution ahead of the SDK everywhere
+            # `src/` is on sys.path (e.g. inbox_server.py), which crash-loops
+            # lobster-mcp-local (see issue #2239 / PR #2238 revert). Instead we
+            # load systemd_jobs.py directly by file path via importlib, which
+            # needs no package at all — same pattern already used in
+            # src/bisque/relay_server.py and src/bot/sms_router.py for the same
+            # collision on src/mcp/log_utils.py.
             uv run --project "$LOBSTER_DIR" python -c "
-import asyncio, sys
-sys.path.insert(0, '$LOBSTER_DIR/src')
-from mcp.systemd_jobs import create_job
-result = asyncio.run(create_job(
+import asyncio
+import importlib.util
+import sys
+
+spec = importlib.util.spec_from_file_location('lobster_mcp_systemd_jobs', '$LOBSTER_DIR/src/mcp/systemd_jobs.py')
+systemd_jobs = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = systemd_jobs  # required: systemd_jobs.py uses @dataclass, which
+                                        # resolves its module via sys.modules at class-body eval time
+spec.loader.exec_module(systemd_jobs)
+
+result = asyncio.run(systemd_jobs.create_job(
     name='prune-pr-worktrees',
     schedule='*-*-* 03:00:00',
     command='$_m83_cmd',
@@ -1990,7 +2007,7 @@ print(f'prune-pr-worktrees: {result.status}')
 " 2>/dev/null && {
                 substep "Registered prune-pr-worktrees systemd timer (daily at 03:00 UTC)"
                 migrated=$((migrated + 1))
-            } || warn "Could not register prune-pr-worktrees — try: uv run python -c \"import asyncio; from src.mcp.systemd_jobs import create_job; ...\""
+            } || warn "Could not register prune-pr-worktrees — try: uv run python -c \"import asyncio, importlib.util, sys; spec = importlib.util.spec_from_file_location('lobster_mcp_systemd_jobs', '\$LOBSTER_DIR/src/mcp/systemd_jobs.py'); m = importlib.util.module_from_spec(spec); sys.modules[spec.name] = m; spec.loader.exec_module(m); ...\""
         fi
     else
         warn "prune-pr-worktrees.py not found at $_m83_script or uv unavailable — skipping Migration 83"


### PR DESCRIPTION
## Problem

Migration 83 (`scripts/lib/migrations.sh`, registers the `prune-pr-worktrees` scheduled job) did `import mcp.systemd_jobs` to reach `src/mcp/systemd_jobs.py`. Because `src/mcp/` has no `__init__.py`, it's an implicit namespace package, so the pip-installed `mcp` SDK wins that import — `ModuleNotFoundError: mcp.systemd_jobs`. Non-fatal (the migration loop continues), but the job never registers (#2237).

PR #2238 "fixed" this by adding `src/mcp/__init__.py`. That made `src/mcp` a *real* package, which then won import resolution ahead of the actual `mcp` SDK everywhere `src/` sits at the front of `sys.path` — notably `inbox_server.py`, which does `from mcp.server import Server`. That broke on every fresh process start and crash-looped `lobster-mcp-local.service` in production, taking down the Telegram/Slack bridge for ~5 minutes (#2239). #2238 was reverted (#2244) to restore service, which brings #2237 back.

## Fix

Same root cause both times: `src/mcp/` and the third-party `mcp` SDK share a top-level import name, and `src/` is on `sys.path` ahead of site-packages. Any fix that tries to make one or the other "win" the collision just breaks the other consumer. This PR removes the collision entirely instead of racing it:

Migration 83 now loads `src/mcp/systemd_jobs.py` directly by file path via `importlib.util.spec_from_file_location(...)` / `module_from_spec(...)`, so it never imports the `mcp` top-level name and never needs `src/mcp` to be a package. `src/mcp/__init__.py` is **not** reintroduced.

This is the same pattern already used elsewhere in this codebase for the identical collision: `src/bisque/relay_server.py` and `src/bot/sms_router.py` both load `src/mcp/log_utils.py` this way already. One addition beyond those two existing call sites: `systemd_jobs.py` defines `@dataclass(frozen=True)` classes, which resolve their own module via `sys.modules` at class-body evaluation time, so the loaded module must be registered in `sys.modules[spec.name]` *before* `exec_module()` runs (verified this is required — omitting it raises `AttributeError: 'NoneType' object has no attribute '__dict__'` from `dataclasses._is_type`). `log_utils.py` has no dataclasses, so the two existing call sites didn't need this and I didn't touch them.

## Functional patterns

The change is confined to a shell-embedded Python one-shot invocation; no application code changed. The loader itself is side-effect-free until `spec.loader.exec_module()` runs (module load is the only effect), and `create_job(...)` is called exactly as before — same arguments, same async invocation, same idempotency check (`systemctl is-enabled` gate) surrounding it. No behavior change to `create_job` itself or to any other migration.

## Out of scope

- Does not touch `src/mcp/__init__.py` (confirmed absent both before and after this change) or any `sys.path` setup in `inbox_server.py` — the exact area that caused the #2239 outage.
- Does not touch `src/bisque/relay_server.py` or `src/bot/sms_router.py` (existing importlib call sites are correct as-is for their use case, no dataclasses involved).
- No other migration in `scripts/lib/migrations.sh` is modified.

## Tests run

- [x] `bash -n scripts/lib/migrations.sh` — syntax OK
- [x] Standalone check: loaded `src/mcp/systemd_jobs.py` via the exact importlib pattern used in the migration (with `sys.modules` registration), confirmed `create_job` is present, is a coroutine function, and `JobInfo`'s dataclass fields resolve correctly (proves the `sys.modules` registration is both necessary and sufficient)
- [x] Confirmed `src/mcp/__init__.py` does not exist in this branch (`ls` fails as expected) and is not reintroduced by the diff
- [x] Regression check for the #2239 outage: with `src/` prepended to `sys.path` (mirroring `inbox_server.py`'s setup) and via `uv run` in this branch's venv, `from mcp.server import Server` succeeds and resolves to `.venv/lib/python3.12/site-packages/mcp/__init__.py` (the real SDK) — not shadowed
- [x] `bash tests/test-migrations-lib.sh` — 6/8 passed. The 2 failures (Migration 96 / `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT`) are pre-existing and unrelated: reproduced identically on `origin/main` before this change (missing `cron-manage.sh` in the test fixture's temp dir). Migration 83 is not covered by a dedicated test in this suite; verified via the standalone importlib check above instead.

## Manual test

N/A for a live install/upgrade run — this only affects a one-time migration path (`run_migrations()`, gated by `systemctl is-enabled lobster-prune-pr-worktrees.timer` so it no-ops if already applied) that isn't safe to trigger against the production install from this environment. Verified via the standalone importlib load test above instead, which exercises the exact code path embedded in the migration (module load + `sys.modules` registration + `create_job` symbol resolution). No Telegram/user-visible output involved.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits — importlib check ran against local files, no `systemctl` calls made)
- [x] Integration/manual test run — see Manual test above (full end-to-end migration run not performed; scoped to the specific fix)
- [x] Not applicable — no user-visible/Telegram output in this change
- [x] Side-effect audit: no floods, no unscoped writes; only effect is loading a Python module from a known local path, no writes to shared state beyond what `create_job` already did before this change
- [x] External service calls: none added; `systemctl`/timer registration behavior via `create_job` is unchanged from before this PR

Fixes #2237. Addresses #2239 (implements the "real fix" recommendation from that issue, without touching `src/mcp/__init__.py` or `sys.path`).