### PR TITLE
fix(tests): stub crontab/sudo in test-migrations-lib.sh to stop real crontab writes

### DIFF
--- a/tests/test-migrations-lib.sh
+++ b/tests/test-migrations-lib.sh
@@ -212,6 +212,29 @@ exit 0
 EOF
 chmod +x "$FAKE_BIN_DIR/sudo"
 
+# Fake pidof stub (tests/test-migrations-lib.sh, issue #2246 follow-up) -
+# Migration 55 (systemd-timer-from-jobs.json) and a couple of other
+# migrations gate their body on `pidof systemd >/dev/null 2>&1` succeeding,
+# i.e. "are we actually running under systemd as PID 1". That's true on a
+# real Lobster host but false in this suite's Docker test container
+# (tests/docker/Dockerfile.test runs debian:bookworm-slim without systemd as
+# PID 1), so those migration branches - including the one this suite's
+# sudo-tee assertion below depends on - would otherwise be silently skipped
+# there, and the assertion would hard-fail even though the crontab/sudo
+# isolation itself works correctly. Stub `pidof` to always report systemd as
+# present so Migration 55 actually runs and gets exercised in every
+# environment this suite runs in, the same way `crontab`/`sudo` are stubbed
+# above rather than conditionally skipped.
+cat > "$FAKE_BIN_DIR/pidof" <<'EOF'
+#!/bin/bash
+# Fake pidof stub (tests/test-migrations-lib.sh, issue #2246 follow-up) -
+# always reports the queried process as running (exit 0), so
+# `pidof systemd >/dev/null 2>&1` succeeds regardless of whether this test
+# runs on a real systemd host or in a systemd-less container.
+exit 0
+EOF
+chmod +x "$FAKE_BIN_DIR/pidof"
+
 export PATH="$FAKE_BIN_DIR:$PATH"
 
 DRY_RUN=false

--- a/tests/test-migrations-lib.sh
+++ b/tests/test-migrations-lib.sh
@@ -12,6 +12,19 @@
 #      so a reimage-via-restore silently skipped every config.env migration.
 #   3. upgrade.sh still sources the shared lib and calls run_migrations().
 #
+# Also verifies (issue #2246): run_migrations() runs all ~99 migrations
+# unconditionally, and several of them shell out directly to the real
+# `crontab` binary and to `sudo` (systemctl, usermod, tee) - commands that
+# are NOT sandboxed by faking $LOBSTER_DIR/$WORKSPACE_DIR/etc, since
+# `crontab -l`/`crontab -` always read/write the real per-user system
+# crontab regardless of those variables. Running this test previously wrote
+# real entries (built from the fake temp path) into the actual system
+# crontab. This suite stubs `crontab` and `sudo` via a fake-bin directory
+# prepended to $PATH (catches both direct shell calls and the
+# subprocess.run(["sudo", ...]) calls made by the embedded Python migration
+# block) and asserts the real system crontab is byte-for-byte unchanged
+# after run_migrations() executes.
+#
 # Usage: bash tests/test-migrations-lib.sh
 #        (run from repo root or any directory)
 #===============================================================================
@@ -35,6 +48,17 @@ LIB="$REPO_ROOT/scripts/lib/migrations.sh"
 TEST_TMPDIR=$(mktemp -d /tmp/lobster-test-migrations-XXXXXX)
 cleanup() { rm -rf "$TEST_TMPDIR"; }
 trap cleanup EXIT
+
+# Resolve the real `crontab` binary's absolute path BEFORE any $PATH
+# stubbing happens below, and snapshot the real crontab's current contents.
+# After run_migrations() executes (with the fake-bin stub shadowing
+# `crontab` in $PATH), we re-snapshot via this same absolute path and
+# assert byte-for-byte equality - proving the stub, not the real binary,
+# absorbed every migration's crontab read/write (issue #2246).
+REAL_CRONTAB_BIN="$(command -v crontab || true)"
+if [ -n "$REAL_CRONTAB_BIN" ]; then
+    REAL_CRONTAB_BEFORE="$("$REAL_CRONTAB_BIN" -l 2>/dev/null || true)"
+fi
 
 pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo -e "  ${GREEN}PASS${NC} $1"; }
 fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo -e "  ${RED}FAIL${NC} $1"; echo -e "       ${YELLOW}$2${NC}"; }
@@ -93,6 +117,71 @@ step()    { :; }
 substep() { :; }
 log_to_file() { :; }
 
+# ---------------------------------------------------------------------------
+# Command isolation (issue #2246): several migrations shell out directly to
+# `crontab` and `sudo` (systemctl, usermod, tee) - real system binaries that
+# are NOT sandboxed by the fake $LOBSTER_DIR/$WORKSPACE_DIR/etc above. A
+# fake-bin directory prepended to $PATH intercepts these at the command
+# resolution boundary, so it catches both plain shell invocations in
+# migrations.sh AND the subprocess.run(["sudo", ...]) calls made by the
+# embedded Python migration block (a bash function override would only
+# catch the former).
+FAKE_BIN_DIR="$TEST_TMPDIR/fake-bin"
+FAKE_CRONTAB_STATE="$TEST_TMPDIR/fake-crontab-state"
+mkdir -p "$FAKE_BIN_DIR"
+: > "$FAKE_CRONTAB_STATE"
+
+cat > "$FAKE_BIN_DIR/crontab" <<EOF
+#!/bin/bash
+# Fake crontab stub (tests/test-migrations-lib.sh, issue #2246) - never
+# touches the real system crontab. Mimics the subset of \`crontab\` usage
+# migrations.sh relies on: \`crontab -l\`, \`crontab -\` (write stdin),
+# and \`crontab <file>\`.
+#
+# Several migrations chain \`crontab -l | grep ... | crontab -\` - bash
+# starts every pipeline stage concurrently, so the read-side (\`-l\`) and
+# write-side (\`-\`) invocations of this stub run at the same time. Writing
+# via a plain \`cat > "\$STATE"\` truncates the state file at open time,
+# racing the concurrent read-side's \`cat "\$STATE"\` and intermittently
+# handing it a truncated/empty file. Write to a temp file and \`mv\` it into
+# place instead (same technique the real crontab binary uses) so the state
+# file is always replaced atomically: a concurrent reader sees either the
+# complete old content or the complete new content, never a partial file.
+STATE="$FAKE_CRONTAB_STATE"
+case "\${1:-}" in
+    -l)
+        [ -s "\$STATE" ] && cat "\$STATE" || exit 1
+        ;;
+    -|"")
+        TMP="\$STATE.tmp.\$\$"
+        cat > "\$TMP" && mv "\$TMP" "\$STATE"
+        ;;
+    *)
+        [ -f "\$1" ] && cp "\$1" "\$STATE" || exit 1
+        ;;
+esac
+EOF
+chmod +x "$FAKE_BIN_DIR/crontab"
+
+cat > "$FAKE_BIN_DIR/sudo" <<'EOF'
+#!/bin/bash
+# Fake sudo stub (tests/test-migrations-lib.sh, issue #2246) - swallows all
+# privileged calls (systemctl, usermod, cp, tee, ldconfig, ...) so tests
+# never mutate the real host. `sudo -n true` (passwordless-sudo probe)
+# succeeds; `sudo tee ...` consumes stdin so pipelines don't block.
+if [ "${1:-}" = "-n" ] && [ "${2:-}" = "true" ]; then
+    exit 0
+fi
+if [ "${1:-}" = "tee" ]; then
+    cat >/dev/null
+    exit 0
+fi
+exit 0
+EOF
+chmod +x "$FAKE_BIN_DIR/sudo"
+
+export PATH="$FAKE_BIN_DIR:$PATH"
+
 DRY_RUN=false
 LOBSTER_DIR="$FAKE_LOBSTER_DIR"
 WORKSPACE_DIR="$FAKE_WORKSPACE_DIR"
@@ -113,6 +202,32 @@ assert_file_contains "Migration 96 applies CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=0 t
 run_migrations
 occurrences=$(grep -c "^CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=" "$CONFIG_FILE")
 assert_count "Migration 96 is idempotent (running twice does not duplicate the key)" "1" "$occurrences"
+
+#===============================================================================
+# Group 1b: crontab/sudo isolation (issue #2246)
+#===============================================================================
+echo ""
+echo "-- run_migrations() never touches the real system crontab --"
+
+# Sanity check: the crontab-writing migrations actually ran and exercised
+# the stub (proves this is a meaningful regression test, not a no-op because
+# the crontab code paths were skipped for some unrelated reason).
+assert_file_contains "Migration 28 (LOBSTER-LOG-EXPORT) wrote to the fake crontab stub" \
+    "$FAKE_CRONTAB_STATE" "LOBSTER-LOG-EXPORT"
+assert_file_contains "Migration 52 (LOBSTER-GHOST-DETECTOR) wrote to the fake crontab stub" \
+    "$FAKE_CRONTAB_STATE" "LOBSTER-GHOST-DETECTOR"
+
+if [ -n "$REAL_CRONTAB_BIN" ]; then
+    REAL_CRONTAB_AFTER="$("$REAL_CRONTAB_BIN" -l 2>/dev/null || true)"
+    if [ "$REAL_CRONTAB_BEFORE" = "$REAL_CRONTAB_AFTER" ]; then
+        pass "Real system crontab is byte-for-byte unchanged after run_migrations()"
+    else
+        fail "Real system crontab is byte-for-byte unchanged after run_migrations()" \
+            "real crontab changed during the test run - the crontab stub did not intercept every call"
+    fi
+else
+    pass "Real system crontab is byte-for-byte unchanged after run_migrations() (skipped: no crontab binary on this host)"
+fi
 
 #===============================================================================
 # Group 2: install.sh actually wires the runner in (the real bug fix)

--- a/tests/test-migrations-lib.sh
+++ b/tests/test-migrations-lib.sh
@@ -107,6 +107,27 @@ TELEGRAM_BOT_TOKEN=fake-token
 LOBSTER_ADMIN_CHAT_ID=12345
 EOF
 
+# Minimal jobs.json (issue #2246 follow-up): seeds a single enabled job with
+# an absolute `command` path and a `schedule`, matching the exact shape
+# Migration 55 (systemd-timer-from-jobs.json, scripts/lib/migrations.sh
+# ~line 1055) requires to actually run its migration branch rather than be
+# skipped because $WORKSPACE_DIR/scheduled-jobs/jobs.json doesn't exist. That
+# branch is the one embedding the Python subprocess.run(["sudo", "tee", ...])
+# call this suite's sudo stub needs to intercept and prove it caught.
+mkdir -p "$FAKE_WORKSPACE_DIR/scheduled-jobs"
+cat > "$FAKE_WORKSPACE_DIR/scheduled-jobs/jobs.json" <<'EOF'
+{
+  "jobs": {
+    "test-follow-up-job": {
+      "enabled": true,
+      "command": "/usr/local/bin/lobster-test-follow-up-job.sh",
+      "schedule": "*-*-* 04:00:00",
+      "description": "Fake job fixture for migration test (issue #2246 follow-up)"
+    }
+  }
+}
+EOF
+
 # Minimal logging/env contract required by scripts/lib/migrations.sh (see its
 # header docstring) - install.sh's own stubs, reused here 1:1.
 info()    { :; }
@@ -163,16 +184,27 @@ esac
 EOF
 chmod +x "$FAKE_BIN_DIR/crontab"
 
-cat > "$FAKE_BIN_DIR/sudo" <<'EOF'
+FAKE_SUDO_TEE_LOG="$TEST_TMPDIR/fake-sudo-tee-log"
+: > "$FAKE_SUDO_TEE_LOG"
+
+cat > "$FAKE_BIN_DIR/sudo" <<EOF
 #!/bin/bash
 # Fake sudo stub (tests/test-migrations-lib.sh, issue #2246) - swallows all
 # privileged calls (systemctl, usermod, cp, tee, ldconfig, ...) so tests
-# never mutate the real host. `sudo -n true` (passwordless-sudo probe)
-# succeeds; `sudo tee ...` consumes stdin so pipelines don't block.
-if [ "${1:-}" = "-n" ] && [ "${2:-}" = "true" ]; then
+# never mutate the real host. \`sudo -n true\` (passwordless-sudo probe)
+# succeeds; \`sudo tee ...\` consumes stdin so pipelines don't block.
+#
+# For \`tee\`, also record the target path into a log file (issue #2246
+# follow-up) - this is how the test proves the embedded Python migration's
+# subprocess.run(["sudo", "tee", ...]) call (Migration 55,
+# systemd-timer-from-jobs.json) was actually caught by this stub, the same
+# way the crontab stub's state file proves migrations 28/52 were caught.
+TEE_LOG="$FAKE_SUDO_TEE_LOG"
+if [ "\${1:-}" = "-n" ] && [ "\${2:-}" = "true" ]; then
     exit 0
 fi
-if [ "${1:-}" = "tee" ]; then
+if [ "\${1:-}" = "tee" ]; then
+    echo "\${2:-}" >> "\$TEE_LOG"
     cat >/dev/null
     exit 0
 fi
@@ -216,6 +248,8 @@ assert_file_contains "Migration 28 (LOBSTER-LOG-EXPORT) wrote to the fake cronta
     "$FAKE_CRONTAB_STATE" "LOBSTER-LOG-EXPORT"
 assert_file_contains "Migration 52 (LOBSTER-GHOST-DETECTOR) wrote to the fake crontab stub" \
     "$FAKE_CRONTAB_STATE" "LOBSTER-GHOST-DETECTOR"
+assert_file_contains "Migration 55 (systemd-timer-from-jobs.json) exercised the sudo tee stub" \
+    "$FAKE_SUDO_TEE_LOG" "/etc/systemd/system/lobster-test-follow-up-job.timer"
 
 if [ -n "$REAL_CRONTAB_BIN" ]; then
     REAL_CRONTAB_AFTER="$("$REAL_CRONTAB_BIN" -l 2>/dev/null || true)"


### PR DESCRIPTION
## Problem

`run_migrations()` (`scripts/lib/migrations.sh`) runs all ~99 migrations unconditionally in a single pass. `tests/test-migrations-lib.sh` (PR #2200) sandboxes this by faking `$LOBSTER_DIR`, `$WORKSPACE_DIR`, `$MESSAGES_DIR`, `$LOBSTER_CONFIG_DIR`, etc. as paths under a throwaway `mktemp -d` directory — but several migrations shell out directly to the real `crontab` binary (migration 28 `LOBSTER-LOG-EXPORT`, migration 52 `LOBSTER-GHOST-DETECTOR`, and others) and to `sudo` (`systemctl`, `usermod`, `tee`). None of those are sandboxed by faking the directory variables, because `crontab -l`/`crontab -` always read and write the real per-user system crontab regardless of what `$LOBSTER_DIR` points at.

Running `bash tests/test-migrations-lib.sh` on a real host therefore wrote real crontab entries built from the test's throwaway temp path (e.g. `cd /tmp/lobster-test-migrations-XXXXXX/lobster && ...`) into the live system crontab. This already happened once on the maintainer's host.

## Fix

`tests/test-migrations-lib.sh` now prepends a fake-bin directory to `$PATH` before sourcing `scripts/lib/migrations.sh`, containing stub `crontab` and `sudo` executables:

- **`crontab`** — mimics `crontab -l` / `crontab -` / `crontab <file>` against a local state file instead of the real spool. Writes go through a temp-file-then-`mv` (atomic replace), matching how the real `crontab` binary behaves — see "Race condition found" below for why this matters.
- **`sudo`** — swallows every privileged call (`systemctl`, `usermod`, `cp`, `tee`, `ldconfig`, ...) as a no-op. `sudo -n true` (the passwordless-sudo probe migration 46 uses to decide whether to attempt `usermod`) returns success; `sudo tee` consumes stdin so pipelines don't block.

Stubbing at the `$PATH` resolution boundary (real executables shadowing the real binaries) rather than as bash functions was a deliberate choice: one migration (~line 1083, systemd-timer migration from `jobs.json`) shells out via `subprocess.run(["sudo", "tee", ...])` from an embedded Python block. A bash function override only intercepts direct shell invocations in `migrations.sh` itself — it would not have caught that `subprocess.run` call. `$PATH`-shadowing catches both.

**Race condition found and fixed along the way:** several migrations chain `crontab -l | grep -v MARKER | crontab -`. Bash starts every pipeline stage concurrently, so the read-side (`-l`) and write-side (`-`) stub invocations run at the same time. An initial version of the stub wrote via `cat > "$STATE"`, which truncates the file at open time — racing the concurrent read-side's `cat "$STATE"` and intermittently handing it a truncated/empty file. This silently dropped previously-written crontab entries (e.g. migration 28's `LOBSTER-LOG-EXPORT` entry vanished by the time migration 52 ran) without failing the test, since each migration only checks for its own marker. Fixed by writing to a temp file and `mv`-ing it into place — same technique the real `crontab` binary uses — so a concurrent reader always sees either the complete old content or the complete new content, never a partial file.

## What's new in the test suite

A new assertion group, "run_migrations() never touches the real system crontab":
- Captures the real system crontab's content via the real `crontab` binary's resolved path *before* the `$PATH` stub is installed, and re-checks it *after* `run_migrations()` runs (through the same resolved path) — asserts byte-for-byte equality. This is a permanent regression guard: if any future migration is added that bypasses the stub, this assertion fails instead of silently mutating the real host.
- Asserts the crontab-writing migrations (28, 52) actually exercised the stub — i.e. the isolation test is not a no-op because the crontab code paths were skipped for an unrelated reason.

## Verified

- Rebuilt `tests/docker/Dockerfile.test` (clean Debian container with a real `cron`/`crontab` binary and `sudo`).
- Ran the **unpatched** (pre-fix, `origin/main`) `test-migrations-lib.sh` inside the container: `crontab -l` before = `no crontab for testuser`; after = 3 real entries written, including `LOBSTER-LOG-EXPORT` and `LOBSTER-GHOST-DETECTOR` pointing at the throwaway `/tmp/lobster-test-migrations-*` path — reproducing the exact bug.
- Ran the **patched** test in the same container. See "Follow-up" below for current pass counts (updated after a second commit fixed an environment-dependent regression the first follow-up commit introduced).
- Also ran patched test on the dev host directly: real crontab (`crontab -l | md5sum`) identical before/after the run.

Out of scope, noted for awareness: on this dev host (not in the clean Docker container), two "Migration 96" assertions can fail depending on host shell state — see "Follow-up" below, they are not caused by this PR's changes.

## Follow-up: Migration 55 coverage, and a fix for an environment-dependent regression it introduced

A follow-up commit (`ed528595`) seeded a minimal `jobs.json` fixture so Migration 55 (`systemd-timer-from-jobs.json`, the migration whose embedded Python does the `subprocess.run(["sudo", "tee", ...])` call this suite's `sudo` stub is specifically designed to catch) actually runs during the test, and added a hard assertion that its `sudo tee` call landed in the stub's log. This closed a real gap: without it, the suite's crontab/sudo isolation coverage never exercised the one migration that goes through Python `subprocess.run` rather than a direct shell call.

That assertion, however, hard-failed in `tests/docker/Dockerfile.test` — the same container this PR's own "Verified" section uses for its safety claims — because Migration 55 is additionally gated in `scripts/lib/migrations.sh` on `pidof systemd >/dev/null 2>&1` succeeding, and `debian:bookworm-slim` in that container never runs systemd as PID 1, so the migration's body (and the `sudo tee` call inside it) was silently skipped, and the new hard assertion failed even though the crontab/sudo isolation itself was working correctly.

Fixed by adding a `pidof` stub to the same fake-bin directory the suite already uses for `crontab`/`sudo` (rather than guarding the assertion into a conditional skip): `pidof` always exits 0, so `pidof systemd` reports success regardless of whether the test runs on a real systemd host or in a systemd-less container. This makes Migration 55 actually execute and get exercised for real in every environment the suite runs in, rather than only skip-passing in containers — the more robust of the two options, since a skip-pass would leave the container run with zero real coverage of the `subprocess.run(["sudo", "tee", ...])` path.

Two other `pidof systemd` call sites in `migrations.sh` (mcp-local service install, transcription service enable/start) are also covered by this stub, but neither's migration body executes in this test's fake `$LOBSTER_DIR`/`$WORKSPACE_DIR` fixtures — both are gated behind `-f` checks on service files that don't exist there — so stubbing `pidof` globally doesn't change their behavior in this suite.

Separately (not caused by the `pidof` stub — reproduces identically on `787dcf4c`, the commit before either follow-up change): the two "Migration 96" assertions read `${CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT:-}` from the *inherited* shell environment rather than only from the fake `config.env` fixture. When this test is run from inside a Lobster agent shell (which itself has `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=0` exported, per issue #2142), Migration 96 sees the var already set and skips writing it to the fixture file, failing the assertion. This is pre-existing host-state leakage unrelated to the crontab/sudo/pidof isolation work in this PR — confirmed reproducing on `787dcf4c` via `git stash` — and does not occur in the Docker container (no such var exported there) or in a dev-host shell without that var inherited. Left out of scope here; flagging for a possible separate follow-up to isolate `CONFIG_FILE`-only sourcing in that assertion.

## Considered but out of scope

Refactoring `run_migrations()` (currently one large sequential function with ~99 inline migration blocks) so tests could target a single migration by name, reducing blast radius further. This is a much larger refactor of the shared migration runner used by both `install.sh` and `upgrade.sh`; the command-stub fix here fully closes the actual crontab-leak on its own without touching `scripts/lib/migrations.sh` at all.

## Functional patterns

The stubs are pure state-machine scripts (read/write a single local file, no hidden global mutation beyond that file) and the new assertions are declarative (`assert_file_contains`, string equality) rather than imperative control flow — consistent with the existing test file's style. No changes to `scripts/lib/migrations.sh` itself; this is entirely test-harness isolation.

## Tests run
- [x] `bash tests/test-migrations-lib.sh` (dev host, run from inside a Lobster agent shell with `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=0` inherited) — 10/12 pass; the 2 failures are the pre-existing "Migration 96" host-state leakage described above (present unmodified on `787dcf4c`, unrelated to this commit); Migration 55 assertion passes; real crontab confirmed byte-identical before/after via `crontab -l | md5sum`
- [x] `bash tests/test-migrations-lib.sh` (dev host, `env -u CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT`, i.e. without that host-state leak) — 12/12 pass
- [x] `bash tests/test-migrations-lib.sh` inside `tests/docker/Dockerfile.test` container (clean `debian:bookworm-slim`, no systemd as PID 1, real `crontab`/`cron`/`sudo`) — 12/12 pass, including the Migration 55 `sudo tee` assertion (now genuinely exercised via the `pidof` stub, not skip-passed)
- [x] Unpatched `origin/main` version of the same test, same container — reproduces the bug (writes real crontab entries); confirms this test would have caught the original issue

## Manual test
Required (this PR touches file I/O affecting a real system's crontab). See "Verified" above — this *is* the manual/integration test: real `crontab -l` diffed before/after inside a throwaway Docker container, for both the unpatched (bug reproduced) and patched (bug fixed) versions of the test file, plus a same-check run on the dev host itself.

## Definition of Done
- [x] Unit tests pass (see Tests run)
- [x] Integration/manual test run — see Manual test
- [x] User-visible outcome: N/A (developer-facing test-harness fix, no user-visible behavior change)
- [x] Side-effect audit: verified via Docker crontab diff that no real crontab writes occur; `sudo` calls are no-ops in the stub so no real systemctl/usermod/tee side effects either
- [x] External service calls: N/A — this PR stubs local system binaries (`crontab`, `sudo`), no network/external services involved

Closes #2246.
