### PR TITLE
fix: self-heal hook-wiring drift and ack-before-spawn race (the 'disappearing agent problem')

### DIFF
--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -218,7 +218,7 @@ hours the way this incident did.
 
 ---
 
-## Delegation Pattern: claim_and_ack
+## Delegation Pattern: spawn-then-ack
 
 **Ack policy:**
 - **Send a brief ack** if the task will take >~4 seconds: "On it.", "Looking into this.", "Writing that up."
@@ -228,18 +228,29 @@ Note: The Telegram bot sends "📨 Message received. Processing..." automaticall
 
 Never say "Noted." alone — it doesn't tell the user whether work is happening. Use "On it — [what]" when kicking off background work. If just answering, reply directly with no preamble.
 
-**Preferred pattern (use `claim_and_ack` for long tasks):**
+**Preferred pattern — spawn first, ack only after the spawn is confirmed (issue #2249):**
+
+> **Why the ack comes AFTER the spawn, not before:** the ack tells the user work is happening.
+> If it is sent before the `Task()` call has actually completed, a dispatcher restart landing in
+> that window (compaction, health-check kill, OOM) produces exactly the "disappearing agent" bug:
+> the user was told an agent was spawned, and none of it ever happened — no registration, no
+> inflight entry, nothing. `claim_and_ack`'s combined claim+ack-send is still fine for tasks that
+> do their own work directly (no further spawn), but never fuse it with a `Task()` spawn.
+
 ```
-1. claim_and_ack(message_id, ack_text="On it — [brief description of what you're doing]", chat_id=chat_id, source=source)
-   # Atomically: moves message inbox/ → processing/ AND sends the ack.
-   # If return starts with "Warning:": claim succeeded, ack failed — proceed normally.
-2. Generate a short task_id (e.g. "fix-pr-475", "upstream-check")
-3. Task(
+1. mark_processing(message_id)
+   # Claim only — do NOT send the ack yet.
+2. Task(
        prompt="---\ntask_id: <task_id>\nchat_id: <chat_id>\nsource: <source>\nbackground: true\n---\n\n...",
        subagent_type="..."
    )
-   # The inflight-work.jsonl "running" entry is written automatically by a
-   # PostToolUse hook (see "In-Flight Work Tracking" below) — no separate step needed.
+   # The inflight-work.jsonl "running" entry and the agent_sessions.db row are
+   # written automatically by a PostToolUse hook the instant this call returns
+   # (see "In-Flight Work Tracking" below) — no separate step needed. This is
+   # also why the ack must come after this line: if the Task() call itself
+   # never fires (interrupted mid-generation), nothing gets acked either.
+3. send_reply(chat_id, "On it — [brief description of what you're doing]", source=source)
+   # Only now — after the spawn has actually happened — tell the user.
 4. mark_processed(message_id)
 5. Return to wait_for_messages() IMMEDIATELY
 ```

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -63,3 +63,30 @@ cat > "$MSG_FILE" << EOF
 EOF
 
 echo "[post-merge] Queued dependency upgrade reminder to Lobster inbox."
+
+# ---------------------------------------------------------------------------
+# Hook-wiring drift reconciliation (issue #2249 — "disappearing agent problem")
+#
+# Hooks added to install.sh's setup_claude_hooks() after an instance's initial
+# install previously never reached that instance: this git-pull upgrade path
+# only ever queued the reminder above (which just runs `uv pip install -e .`)
+# and never re-ran install.sh or any settings.json reconciliation. Confirmed
+# live: hooks/auto-register-agent.py sat completely unwired for an unknown
+# period as a direct result, causing spawned background agents to leave zero
+# trace anywhere the moment anything went wrong.
+#
+# reconcile-claude-hooks.py is a small, idempotent, self-contained script
+# (deliberately not a refactor of setup_claude_hooks()) that re-applies a
+# short list of CRITICAL hooks to settings.json if missing. Run it here, on
+# every git pull, so hook-wiring drift can never silently persist again.
+# Best-effort: never blocks the merge, never fails the hook.
+# ---------------------------------------------------------------------------
+LOBSTER_DIR="${LOBSTER_INSTALL_DIR:-$HOME/lobster}"
+RECONCILE_SCRIPT="$LOBSTER_DIR/scripts/reconcile-claude-hooks.py"
+if [ -f "$RECONCILE_SCRIPT" ]; then
+    if command -v uv >/dev/null 2>&1; then
+        uv run "$RECONCILE_SCRIPT" 2>&1 | sed 's/^/[post-merge] /' || true
+    else
+        python3 "$RECONCILE_SCRIPT" 2>&1 | sed 's/^/[post-merge] /' || true
+    fi
+fi

--- a/hooks/on-fresh-start.py
+++ b/hooks/on-fresh-start.py
@@ -98,6 +98,16 @@ import session_role  # noqa: E402 — path insert must precede this
 
 AGENT_MONITOR = Path(os.path.expanduser("~/lobster/scripts/agent-monitor.py"))
 
+# reconcile-claude-hooks.py self-heals drift between critical hooks this
+# codebase depends on (starting with auto-register-agent.py) and what is
+# actually wired into settings.json. Existing git-based installs upgrade via
+# `.githooks/post-merge`, which never re-runs install.sh's hook-wiring logic —
+# so a hook added after initial install can silently stay unwired forever.
+# Running this on every fresh dispatcher start closes that gap (issue #2249).
+RECONCILE_CLAUDE_HOOKS = Path(
+    os.path.expanduser("~/lobster/scripts/reconcile-claude-hooks.py")
+)
+
 # on-compact.py writes last_compaction_ts to this file on every compaction.
 COMPACTION_STATE_FILE = Path(
     os.environ.get(
@@ -635,6 +645,55 @@ def _mark_all_running_failed() -> None:
         )
 
 
+def _reconcile_claude_hooks() -> None:
+    """Run reconcile-claude-hooks.py via uv to self-heal hook-wiring drift.
+
+    Issue #2249: hooks added to install.sh's setup_claude_hooks() after an
+    instance's initial install never reach that instance, because the
+    git-pull upgrade path (.githooks/post-merge) never re-runs install.sh.
+    Running this reconciler on every fresh dispatcher start guarantees
+    critical hooks (starting with auto-register-agent.py) are re-wired
+    automatically, not just at install time.
+
+    Exit code 1 means "repaired something" — informational, not an error.
+    Exit code 2 means a fatal error (e.g. corrupt settings.json) — logged but
+    never raised, so it can't block the dispatcher from starting.
+    """
+    if not RECONCILE_CLAUDE_HOOKS.exists():
+        print(
+            f"[on-fresh-start] reconcile-claude-hooks not found at {RECONCILE_CLAUDE_HOOKS}; skipping",
+            file=sys.stderr,
+        )
+        return
+    try:
+        result = subprocess.run(
+            ["uv", "run", str(RECONCILE_CLAUDE_HOOKS)],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode == 1:
+            print(
+                f"[on-fresh-start] reconcile-claude-hooks repaired drift:\n{result.stderr.strip()}",
+                file=sys.stderr,
+            )
+        elif result.returncode == 2:
+            print(
+                f"[on-fresh-start] reconcile-claude-hooks fatal error (settings.json unchanged):\n{result.stderr.strip()}",
+                file=sys.stderr,
+            )
+    except subprocess.TimeoutExpired:
+        print(
+            "[on-fresh-start] reconcile-claude-hooks timed out after 15s",
+            file=sys.stderr,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[on-fresh-start] unexpected error running reconcile-claude-hooks: {exc}",
+            file=sys.stderr,
+        )
+
+
 def main() -> None:
     # Only fire for Lobster-managed sessions.
     if os.environ.get("LOBSTER_MAIN_SESSION", "") != "1":
@@ -666,6 +725,11 @@ def main() -> None:
     _compact_inflight_work()
 
     _mark_all_running_failed()
+
+    # Self-heal hook-wiring drift (issue #2249). Settings.json is only read by
+    # Claude Code at process start, so this belongs alongside the other
+    # fresh-restart-only checks above, not the compaction path.
+    _reconcile_claude_hooks()
 
     # Safety net for issue #909: if catchup state is stale (last_catchup_ts is
     # > 30 min old or absent), inject a compact-reminder into the inbox. This

--- a/scripts/reconcile-claude-hooks.py
+++ b/scripts/reconcile-claude-hooks.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""reconcile-claude-hooks.py — self-heal drift between the critical hooks this
+codebase depends on and what is actually wired into a running instance's
+~/.claude/settings.json.
+
+## Why this exists (issue #2249 — "disappearing agent problem")
+
+`hooks/auto-register-agent.py` is a PostToolUse hook that durably records
+every spawned background `Agent`/`Task` call into `agent_sessions.db` and
+`inflight-work.jsonl` — regardless of whether the dispatcher LLM remembers to
+do any manual bookkeeping. `install.sh`'s `setup_claude_hooks()` wires it in
+idempotently on a fresh install.
+
+But existing git-based installs upgrade via `.githooks/post-merge`, which
+only queues a "run `uv pip install -e .`" reminder after `git pull` — it never
+re-runs `install.sh` or any hook-reconciliation step. Any hook added to
+`install.sh` after an instance's initial install therefore never reaches that
+instance. This was confirmed live: `auto-register-agent.py` sat completely
+unwired on a running instance for an unknown period, so every background
+agent it spawned left zero trace anywhere the moment something went wrong
+(dispatcher restart, LLM skipping the manual fallback bookkeeping step) —
+the "disappearing agent" bug.
+
+This script is intentionally NOT a refactor of `install.sh`'s ~1600-line
+`setup_claude_hooks()` (too large and unrelated to touch safely here).
+Instead it is a small, independent, idempotent reconciler for a short list of
+CRITICAL hooks — ones whose absence causes silent, hard-to-detect failures
+rather than loud ones — that can run safely and repeatedly against an
+ALREADY-DEPLOYED `settings.json` on every dispatcher `SessionStart` and after
+every `git pull`, closing the drift gap for good (not just for this one hook
+— add future critical hooks to `_canonical_critical_hooks()`).
+
+## Usage
+
+    uv run scripts/reconcile-claude-hooks.py
+
+Exit codes:
+    0 — already in sync, nothing repaired
+    1 — one or more critical hooks were missing and have been repaired
+    2 — fatal error (invalid settings.json, write failure)
+
+## Environment overrides (for tests)
+
+    LOBSTER_CLAUDE_SETTINGS_OVERRIDE — override the settings.json path
+    LOBSTER_INSTALL_DIR              — override the lobster install dir (for hook command paths)
+    LOBSTER_WORKSPACE                — override the workspace dir (for the reconcile log)
+    LOBSTER_MESSAGES                 — override the messages dir (for the inbox alert)
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Paths (env-overridable for testability)
+# ---------------------------------------------------------------------------
+
+_HOME = Path(os.environ.get("HOME", str(Path.home())))
+
+INSTALL_DIR = Path(os.environ.get("LOBSTER_INSTALL_DIR", str(_HOME / "lobster")))
+
+SETTINGS_PATH = Path(
+    os.environ.get(
+        "LOBSTER_CLAUDE_SETTINGS_OVERRIDE",
+        str(_HOME / ".claude" / "settings.json"),
+    )
+)
+
+LOG_PATH = (
+    Path(os.environ.get("LOBSTER_WORKSPACE", str(_HOME / "lobster-workspace")))
+    / "logs"
+    / "hook-reconcile.log"
+)
+
+INBOX_DIR = Path(
+    os.environ.get("LOBSTER_MESSAGES", str(_HOME / "messages"))
+) / "inbox"
+
+
+# ---------------------------------------------------------------------------
+# Canonical critical hook manifest (pure data)
+# ---------------------------------------------------------------------------
+
+
+def _canonical_critical_hooks(install_dir: Path) -> list[dict]:
+    """Return the canonical list of critical hooks this codebase depends on.
+
+    Pure function of install_dir — no I/O. Intentionally a SMALL, high-value
+    subset, not a mirror of install.sh's full hook set: install.sh remains the
+    source of truth for fresh installs. Add an entry here only when its
+    absence causes a *silent* failure (no error, no trace) rather than a loud
+    one — that's the class of bug this script exists to close.
+    """
+    return [
+        {
+            "name": "auto-register-agent",
+            "event": "PostToolUse",
+            "command_match": "auto-register-agent",
+            "entry": {
+                "matcher": "Agent",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": f"python3 {install_dir}/hooks/auto-register-agent.py",
+                        "timeout": 10,
+                    }
+                ],
+            },
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Pure functions
+# ---------------------------------------------------------------------------
+
+
+def hook_present(settings: dict, event: str, command_match: str) -> bool:
+    """Return True if any hook entry for `event` has a command containing
+    `command_match`. Pure function — no I/O, does not mutate settings."""
+    for block in settings.get("hooks", {}).get(event, []) or []:
+        for h in block.get("hooks", []) or []:
+            if command_match in (h.get("command") or ""):
+                return True
+    return False
+
+
+def reconcile(settings: dict, canonical_hooks: list[dict]) -> tuple[dict, list[str]]:
+    """Return (new_settings, repaired_names).
+
+    For each canonical hook missing from `settings`, appends its entry to the
+    appropriate event list. Pure function — does not mutate the input dict;
+    returns a new dict. Existing hook entries (including unrelated ones) are
+    left untouched.
+    """
+    new_settings = copy.deepcopy(settings)
+    new_settings.setdefault("hooks", {})
+
+    repaired: list[str] = []
+    for hook in canonical_hooks:
+        event = hook["event"]
+        if hook_present(new_settings, event, hook["command_match"]):
+            continue
+        new_settings["hooks"].setdefault(event, [])
+        new_settings["hooks"][event].append(hook["entry"])
+        repaired.append(hook["name"])
+
+    return new_settings, repaired
+
+
+# ---------------------------------------------------------------------------
+# I/O functions (isolated side effects)
+# ---------------------------------------------------------------------------
+
+
+def load_settings(path: Path) -> dict:
+    """Load settings.json, or return a minimal scaffold if absent.
+
+    Raises json.JSONDecodeError if the file exists but is not valid JSON —
+    callers must not silently overwrite a corrupt file.
+    """
+    if not path.exists():
+        return {"hooks": {}}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_settings_atomic(path: Path, settings: dict) -> None:
+    """Write settings atomically: temp file in the same dir + rename."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent), prefix=".settings-", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(settings, f, indent=2)
+            f.write("\n")
+        os.replace(tmp_path, str(path))
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _log(message: str) -> None:
+    """Append a timestamped line to the reconcile log. Never raises."""
+    try:
+        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(timezone.utc).isoformat()
+        with LOG_PATH.open("a", encoding="utf-8") as f:
+            f.write(f"[{ts}] {message}\n")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def alert_inbox(repaired: list[str]) -> None:
+    """Write a system inbox message so the dispatcher can surface the repair.
+
+    Best-effort only — silently does nothing if the messages dir doesn't
+    exist (e.g. running in a test/container context) or on any write error.
+    """
+    try:
+        if not INBOX_DIR.parent.exists():
+            return
+        INBOX_DIR.mkdir(parents=True, exist_ok=True)
+        now = datetime.now(timezone.utc)
+        ts_ms = int(now.timestamp() * 1000)
+        msg_id = f"{ts_ms}_hook_reconcile"
+        message = {
+            "id": msg_id,
+            "source": "system",
+            "chat_id": 0,
+            "type": "system",
+            "text": (
+                "System notice: critical Claude Code hook(s) were missing from "
+                "~/.claude/settings.json and have been auto-repaired: "
+                f"{', '.join(repaired)}. Background agent spawns before this "
+                "repair may not have been reliably tracked — see issue #2249 "
+                "(the disappearing agent problem)."
+            ),
+            "timestamp": now.strftime("%Y-%m-%dT%H:%M:%S.%f"),
+        }
+        (INBOX_DIR / f"{msg_id}.json").write_text(
+            json.dumps(message, indent=2) + "\n", encoding="utf-8"
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    try:
+        settings = load_settings(SETTINGS_PATH)
+    except json.JSONDecodeError as exc:
+        msg = f"fatal: {SETTINGS_PATH} is not valid JSON: {exc}"
+        _log(msg)
+        print(f"[reconcile-claude-hooks] {msg}", file=sys.stderr)
+        return 2
+
+    canonical = _canonical_critical_hooks(INSTALL_DIR)
+    new_settings, repaired = reconcile(settings, canonical)
+
+    if not repaired:
+        return 0
+
+    try:
+        write_settings_atomic(SETTINGS_PATH, new_settings)
+    except Exception as exc:  # noqa: BLE001
+        msg = f"fatal: failed to write {SETTINGS_PATH}: {exc}"
+        _log(msg)
+        print(f"[reconcile-claude-hooks] {msg}", file=sys.stderr)
+        return 2
+
+    msg = f"repaired missing critical hooks: {repaired}"
+    _log(msg)
+    print(f"[reconcile-claude-hooks] {msg}", file=sys.stderr)
+    alert_inbox(repaired)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/smoke/test_post_merge_hook.py
+++ b/tests/smoke/test_post_merge_hook.py
@@ -7,6 +7,16 @@ Why these tests exist:
 - PM2: The hook must NOT write a second message if called again within the
   cooldown window (rate-limit correctness — the flood fix).
 - PM3: The hook MUST write a new message once the cooldown window has expired.
+- PM4/PM5 (issue #2249): the hook must also invoke reconcile-claude-hooks.py
+  on every run, so hook-wiring drift self-heals on every `git pull` instead
+  of silently persisting forever (the root cause of the "disappearing agent"
+  bug — hooks/auto-register-agent.py sat unwired for an unknown period
+  because this upgrade path never re-ran install.sh's hook-wiring logic).
+
+`_run_hook` always points `LOBSTER_INSTALL_DIR` at an isolated tmp_path by
+default (with no reconcile-claude-hooks.py present) so PM1–PM3 never touch
+the real repo or the real ~/.claude/settings.json. PM4/PM5 opt in to a real
+copy of the reconcile script under an isolated install dir explicitly.
 """
 
 from __future__ import annotations
@@ -21,6 +31,7 @@ from pathlib import Path
 import pytest
 
 HOOK_PATH = Path(__file__).parents[2] / ".githooks" / "post-merge"
+RECONCILE_SCRIPT_PATH = Path(__file__).parents[2] / "scripts" / "reconcile-claude-hooks.py"
 
 
 def _run_hook(
@@ -29,10 +40,19 @@ def _run_hook(
     cooldown: int = 600,
     now_ts: int | None = None,
     env_extra: dict | None = None,
+    install_dir: Path | None = None,
 ) -> subprocess.CompletedProcess:
-    """Run the post-merge hook with overridden paths and optional clock."""
+    """Run the post-merge hook with overridden paths and optional clock.
+
+    `install_dir` isolates the reconcile-claude-hooks.py lookup (issue #2249)
+    — defaults to a tmp dir with no such script present, so by default the
+    hook's reconcile step is a silent no-op and cannot touch real production
+    paths. Tests exercising the reconcile step pass an install_dir containing
+    a real copy of the script plus LOBSTER_CLAUDE_SETTINGS_OVERRIDE.
+    """
     env = os.environ.copy()
     env["LOBSTER_MESSAGES"] = str(inbox_dir.parent)
+    env["LOBSTER_INSTALL_DIR"] = str(install_dir) if install_dir else str(state_dir / "no-such-lobster-dir")
     # Allow overriding the rate-limit state dir via env (the hook reads
     # LOBSTER_MESSAGES to build STATE_DIR, so we set the parent).
     if env_extra:
@@ -131,4 +151,72 @@ def test_post_merge_writes_after_cooldown_expires(tmp_path: Path) -> None:
     )
     assert "Skipping" not in result.stdout, (
         f"Hook should not have skipped after expired cooldown; output: {result.stdout!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# PM4/PM5 (issue #2249) — post-merge self-heals hook-wiring drift
+# ---------------------------------------------------------------------------
+
+
+def _make_isolated_install_dir(tmp_path: Path) -> Path:
+    """Build a fake install dir containing a real copy of reconcile-claude-hooks.py."""
+    install_dir = tmp_path / "lobster"
+    (install_dir / "scripts").mkdir(parents=True)
+    (install_dir / "scripts" / "reconcile-claude-hooks.py").write_text(
+        RECONCILE_SCRIPT_PATH.read_text()
+    )
+    return install_dir
+
+
+def test_post_merge_repairs_missing_critical_hook(tmp_path: Path) -> None:
+    """PM4: post-merge must repair a missing critical hook in settings.json.
+
+    Reproduces the exact drift that caused issue #2249: a settings.json with
+    no auto-register-agent PostToolUse entry. After `git pull` fires this
+    hook, the hook must be wired in without any manual install.sh re-run.
+    """
+    inbox_dir = tmp_path / "inbox"
+    inbox_dir.mkdir(parents=True)
+    config_dir = tmp_path / "config"
+    install_dir = _make_isolated_install_dir(tmp_path)
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps({"hooks": {}}))
+
+    result = _run_hook(
+        inbox_dir,
+        config_dir,
+        install_dir=install_dir,
+        env_extra={"LOBSTER_CLAUDE_SETTINGS_OVERRIDE": str(settings_path)},
+    )
+    assert result.returncode == 0, f"post-merge itself must always exit 0: {result.stderr}"
+
+    new_settings = json.loads(settings_path.read_text())
+    commands = [
+        h.get("command", "")
+        for e in new_settings.get("hooks", {}).get("PostToolUse", [])
+        for h in e.get("hooks", [])
+    ]
+    assert any("auto-register-agent" in c for c in commands), (
+        f"Expected auto-register-agent hook to be wired in after post-merge, "
+        f"got PostToolUse commands: {commands}"
+    )
+
+
+def test_post_merge_noop_when_reconcile_script_absent(tmp_path: Path) -> None:
+    """PM5: when no reconcile script is present (e.g. pre-#2249 checkout),
+    post-merge must still succeed and must not create a settings.json."""
+    inbox_dir = tmp_path / "inbox"
+    inbox_dir.mkdir(parents=True)
+    config_dir = tmp_path / "config"
+    settings_path = tmp_path / "settings.json"  # deliberately never created
+
+    result = _run_hook(
+        inbox_dir,
+        config_dir,
+        env_extra={"LOBSTER_CLAUDE_SETTINGS_OVERRIDE": str(settings_path)},
+    )
+    assert result.returncode == 0
+    assert not settings_path.exists(), (
+        "post-merge must not touch settings.json when reconcile-claude-hooks.py is absent"
     )

--- a/tests/unit/test_hooks/test_on_fresh_start_reconcile_hooks.py
+++ b/tests/unit/test_hooks/test_on_fresh_start_reconcile_hooks.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for the `_reconcile_claude_hooks()` wiring added to
+hooks/on-fresh-start.py (issue #2249 — the "disappearing agent problem").
+
+## What this covers
+
+`_reconcile_claude_hooks()` must invoke `scripts/reconcile-claude-hooks.py`
+via `uv run` on every fresh dispatcher restart, so that hook-wiring drift
+between the repo's canonical critical-hook set and a running instance's
+`~/.claude/settings.json` self-heals automatically — closing the gap that let
+`hooks/auto-register-agent.py` sit unwired long enough for background agents
+to leave zero trace on spawn (issue #2249).
+
+Validates:
+- Skips cleanly (no crash) when the reconcile script is missing on disk
+- Invokes `uv run <path>` for the configured RECONCILE_CLAUDE_HOOKS path
+- Never raises on subprocess timeout or unexpected error (fail-open — must
+  never block dispatcher startup)
+- Exit codes 0/1/2 are all handled without raising
+"""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parents[3] / "hooks"
+_HOOK_PATH = _HOOKS_DIR / "on-fresh-start.py"
+
+
+def _make_session_role_stub():
+    import types
+
+    stub = types.ModuleType("session_role")
+    stub.is_dispatcher = lambda data: True
+    return stub
+
+
+def _load_module():
+    sys.modules.setdefault("session_role", _make_session_role_stub())
+    spec = importlib.util.spec_from_file_location("on_fresh_start_reconcile", _HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_module()
+
+
+class TestReconcileClaudeHooksWiring:
+    def test_skips_silently_when_script_missing(self, tmp_path: Path) -> None:
+        _mod.RECONCILE_CLAUDE_HOOKS = tmp_path / "does-not-exist.py"
+        with patch("subprocess.run") as mock_run:
+            _mod._reconcile_claude_hooks()
+        mock_run.assert_not_called()
+
+    def test_invokes_uv_run_with_configured_script_path(self, tmp_path: Path) -> None:
+        script = tmp_path / "reconcile-claude-hooks.py"
+        script.write_text("#!/usr/bin/env python3\n")
+        _mod.RECONCILE_CLAUDE_HOOKS = script
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
+            _mod._reconcile_claude_hooks()
+
+        mock_run.assert_called_once()
+        called_args = mock_run.call_args[0][0]
+        assert called_args == ["uv", "run", str(script)]
+
+    @pytest.mark.parametrize("exit_code", [0, 1, 2])
+    def test_never_raises_for_any_known_exit_code(self, tmp_path: Path, exit_code: int) -> None:
+        script = tmp_path / "reconcile-claude-hooks.py"
+        script.write_text("#!/usr/bin/env python3\n")
+        _mod.RECONCILE_CLAUDE_HOOKS = script
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=exit_code, stdout="", stderr="detail"
+            )
+            _mod._reconcile_claude_hooks()  # must not raise
+
+    def test_never_raises_on_timeout(self, tmp_path: Path) -> None:
+        script = tmp_path / "reconcile-claude-hooks.py"
+        script.write_text("#!/usr/bin/env python3\n")
+        _mod.RECONCILE_CLAUDE_HOOKS = script
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd="uv", timeout=15)
+            _mod._reconcile_claude_hooks()  # must not raise
+
+    def test_never_raises_on_unexpected_error(self, tmp_path: Path) -> None:
+        script = tmp_path / "reconcile-claude-hooks.py"
+        script.write_text("#!/usr/bin/env python3\n")
+        _mod.RECONCILE_CLAUDE_HOOKS = script
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = OSError("boom")
+            _mod._reconcile_claude_hooks()  # must not raise

--- a/tests/unit/test_reconcile_claude_hooks.py
+++ b/tests/unit/test_reconcile_claude_hooks.py
@@ -1,0 +1,301 @@
+"""
+Unit tests for scripts/reconcile-claude-hooks.py (issue #2249 — the
+"disappearing agent problem").
+
+## What this script must do
+
+`hooks/auto-register-agent.py` is the PostToolUse hook that durably records
+every spawned background agent into agent_sessions.db and inflight-work.jsonl.
+install.sh wires it into a fresh ~/.claude/settings.json idempotently, but
+existing git-based installs upgrade via `.githooks/post-merge`, which never
+re-runs install.sh's hook-wiring logic. Confirmed live: this hook sat
+completely unwired on a running instance, so spawned agents left zero trace
+the moment anything went wrong — the "disappearing agent" bug.
+
+`scripts/reconcile-claude-hooks.py` must:
+- Detect when a critical hook (starting with auto-register-agent) is missing
+  from settings.json's PostToolUse block
+- Repair it by appending the canonical hook entry, atomically, idempotently
+- Never duplicate an entry that is already present
+- Never touch or remove unrelated existing hooks/settings
+- Create a minimal settings.json scaffold if the file doesn't exist yet
+- Exit 0 when nothing needed repair, 1 when something was repaired,
+  2 on fatal error (e.g. invalid JSON)
+- Write an inbox system-message alert when it repairs something, so the
+  dispatcher can surface the drift to the user
+
+## Named constants (spec-derived, not magic literals)
+
+CRITICAL_HOOK_NAME = "auto-register-agent"
+CRITICAL_HOOK_EVENT = "PostToolUse"
+CRITICAL_HOOK_COMMAND_MATCH = "auto-register-agent"
+EXIT_NOOP = 0
+EXIT_REPAIRED = 1
+EXIT_FATAL = 2
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Named constants matching the spec / implementation
+# ---------------------------------------------------------------------------
+
+CRITICAL_HOOK_NAME = "auto-register-agent"
+CRITICAL_HOOK_EVENT = "PostToolUse"
+CRITICAL_HOOK_COMMAND_MATCH = "auto-register-agent"
+EXIT_NOOP = 0
+EXIT_REPAIRED = 1
+EXIT_FATAL = 2
+
+# ---------------------------------------------------------------------------
+# Path to the script under test / dynamic import of pure functions
+# ---------------------------------------------------------------------------
+
+_SCRIPT_PATH = Path(__file__).parents[2] / "scripts" / "reconcile-claude-hooks.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("reconcile_claude_hooks", _SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_module()
+hook_present = _mod.hook_present
+reconcile = _mod.reconcile
+
+
+def _run_script(settings_path: Path, install_dir: Path, messages_dir: Path) -> subprocess.CompletedProcess:
+    env = {
+        **os.environ,
+        "LOBSTER_CLAUDE_SETTINGS_OVERRIDE": str(settings_path),
+        "LOBSTER_INSTALL_DIR": str(install_dir),
+        "LOBSTER_WORKSPACE": str(settings_path.parent / "workspace"),
+        "LOBSTER_MESSAGES": str(messages_dir),
+    }
+    return subprocess.run(
+        ["uv", "run", str(_SCRIPT_PATH)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestHookPresent:
+    def test_absent_when_no_hooks_key(self) -> None:
+        assert hook_present({}, CRITICAL_HOOK_EVENT, CRITICAL_HOOK_COMMAND_MATCH) is False
+
+    def test_absent_when_event_missing(self) -> None:
+        settings = {"hooks": {"PreToolUse": []}}
+        assert hook_present(settings, CRITICAL_HOOK_EVENT, CRITICAL_HOOK_COMMAND_MATCH) is False
+
+    def test_absent_when_only_unrelated_hook_present(self) -> None:
+        settings = {
+            "hooks": {
+                CRITICAL_HOOK_EVENT: [
+                    {
+                        "matcher": "Agent",
+                        "hooks": [{"type": "command", "command": "python3 /x/hooks/context-monitor.py"}],
+                    }
+                ]
+            }
+        }
+        assert hook_present(settings, CRITICAL_HOOK_EVENT, CRITICAL_HOOK_COMMAND_MATCH) is False
+
+    def test_present_when_command_matches(self) -> None:
+        settings = {
+            "hooks": {
+                CRITICAL_HOOK_EVENT: [
+                    {
+                        "matcher": "Agent",
+                        "hooks": [{"type": "command", "command": "python3 /x/hooks/auto-register-agent.py"}],
+                    }
+                ]
+            }
+        }
+        assert hook_present(settings, CRITICAL_HOOK_EVENT, CRITICAL_HOOK_COMMAND_MATCH) is True
+
+
+class TestReconcile:
+    def test_repairs_missing_hook(self) -> None:
+        settings = {"hooks": {}}
+        canonical = _mod._canonical_critical_hooks(Path("/opt/lobster"))
+        new_settings, repaired = reconcile(settings, canonical)
+        assert repaired == [CRITICAL_HOOK_NAME]
+        assert hook_present(new_settings, CRITICAL_HOOK_EVENT, CRITICAL_HOOK_COMMAND_MATCH) is True
+
+    def test_noop_when_already_present(self) -> None:
+        canonical = _mod._canonical_critical_hooks(Path("/opt/lobster"))
+        settings = {"hooks": {CRITICAL_HOOK_EVENT: [canonical[0]["entry"]]}}
+        new_settings, repaired = reconcile(settings, canonical)
+        assert repaired == []
+        # Only one entry present — reconcile must not duplicate it.
+        entries = new_settings["hooks"][CRITICAL_HOOK_EVENT]
+        matching = [
+            e for e in entries
+            for h in e.get("hooks", [])
+            if CRITICAL_HOOK_COMMAND_MATCH in h.get("command", "")
+        ]
+        assert len(matching) == 1
+
+    def test_preserves_unrelated_existing_hooks(self) -> None:
+        settings = {
+            "hooks": {
+                "PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "foo.py"}]}],
+                CRITICAL_HOOK_EVENT: [
+                    {"matcher": "Bash", "hooks": [{"type": "command", "command": "context-monitor.py"}]}
+                ],
+            },
+            "env": {"LOBSTER_DEBUG": "true"},
+        }
+        canonical = _mod._canonical_critical_hooks(Path("/opt/lobster"))
+        new_settings, repaired = reconcile(settings, canonical)
+        assert repaired == [CRITICAL_HOOK_NAME]
+        # Unrelated hooks and top-level keys untouched.
+        assert new_settings["hooks"]["PreToolUse"] == settings["hooks"]["PreToolUse"]
+        assert new_settings["env"] == {"LOBSTER_DEBUG": "true"}
+        # Original PostToolUse entry (context-monitor) still present alongside the new one.
+        commands = [
+            h.get("command", "")
+            for e in new_settings["hooks"][CRITICAL_HOOK_EVENT]
+            for h in e.get("hooks", [])
+        ]
+        assert any("context-monitor" in c for c in commands)
+        assert any(CRITICAL_HOOK_COMMAND_MATCH in c for c in commands)
+
+    def test_does_not_mutate_input_settings(self) -> None:
+        settings = {"hooks": {}}
+        canonical = _mod._canonical_critical_hooks(Path("/opt/lobster"))
+        reconcile(settings, canonical)
+        assert settings == {"hooks": {}}, "reconcile() must not mutate its input"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end script tests (subprocess, real file I/O)
+# ---------------------------------------------------------------------------
+
+
+class TestScriptEndToEnd:
+    def test_repairs_missing_hook_in_settings_file(self, tmp_path: Path) -> None:
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text(json.dumps({"hooks": {}}))
+        install_dir = tmp_path / "lobster"
+        messages_dir = tmp_path / "messages"
+
+        result = _run_script(settings_path, install_dir, messages_dir)
+
+        assert result.returncode == EXIT_REPAIRED, f"stderr: {result.stderr}"
+        new_settings = json.loads(settings_path.read_text())
+        assert hook_present(new_settings, CRITICAL_HOOK_EVENT, CRITICAL_HOOK_COMMAND_MATCH) is True
+        # Command path must reference the given install dir.
+        commands = [
+            h.get("command", "")
+            for e in new_settings["hooks"][CRITICAL_HOOK_EVENT]
+            for h in e.get("hooks", [])
+        ]
+        assert any(str(install_dir) in c and "auto-register-agent.py" in c for c in commands)
+
+    def test_noop_exit_code_when_already_wired(self, tmp_path: Path) -> None:
+        settings_path = tmp_path / "settings.json"
+        install_dir = tmp_path / "lobster"
+        messages_dir = tmp_path / "messages"
+        canonical = _mod._canonical_critical_hooks(install_dir)
+        settings_path.write_text(
+            json.dumps({"hooks": {CRITICAL_HOOK_EVENT: [canonical[0]["entry"]]}})
+        )
+
+        result = _run_script(settings_path, install_dir, messages_dir)
+
+        assert result.returncode == EXIT_NOOP, f"stderr: {result.stderr}"
+
+    def test_running_twice_is_idempotent(self, tmp_path: Path) -> None:
+        """Running the script repeatedly must never produce duplicate hook entries."""
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text(json.dumps({"hooks": {}}))
+        install_dir = tmp_path / "lobster"
+        messages_dir = tmp_path / "messages"
+
+        first = _run_script(settings_path, install_dir, messages_dir)
+        second = _run_script(settings_path, install_dir, messages_dir)
+
+        assert first.returncode == EXIT_REPAIRED
+        assert second.returncode == EXIT_NOOP
+
+        final_settings = json.loads(settings_path.read_text())
+        commands = [
+            h.get("command", "")
+            for e in final_settings["hooks"][CRITICAL_HOOK_EVENT]
+            for h in e.get("hooks", [])
+            if CRITICAL_HOOK_COMMAND_MATCH in h.get("command", "")
+        ]
+        assert len(commands) == 1, f"Expected exactly one entry, got {len(commands)}: {commands}"
+
+    def test_fatal_exit_on_invalid_json(self, tmp_path: Path) -> None:
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text("{ not valid json ")
+        install_dir = tmp_path / "lobster"
+        messages_dir = tmp_path / "messages"
+
+        result = _run_script(settings_path, install_dir, messages_dir)
+
+        assert result.returncode == EXIT_FATAL, f"stderr: {result.stderr}"
+        # Must not have overwritten the corrupt file with something else.
+        assert settings_path.read_text() == "{ not valid json "
+
+    def test_creates_settings_scaffold_when_file_absent(self, tmp_path: Path) -> None:
+        settings_path = tmp_path / "does-not-exist" / "settings.json"
+        install_dir = tmp_path / "lobster"
+        messages_dir = tmp_path / "messages"
+
+        result = _run_script(settings_path, install_dir, messages_dir)
+
+        assert result.returncode == EXIT_REPAIRED, f"stderr: {result.stderr}"
+        assert settings_path.exists()
+        new_settings = json.loads(settings_path.read_text())
+        assert hook_present(new_settings, CRITICAL_HOOK_EVENT, CRITICAL_HOOK_COMMAND_MATCH) is True
+
+    def test_writes_inbox_alert_when_hook_repaired(self, tmp_path: Path) -> None:
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text(json.dumps({"hooks": {}}))
+        install_dir = tmp_path / "lobster"
+        messages_dir = tmp_path / "messages"
+        (messages_dir / "inbox").mkdir(parents=True, exist_ok=True)
+
+        _run_script(settings_path, install_dir, messages_dir)
+
+        inbox_files = list((messages_dir / "inbox").glob("*.json"))
+        assert len(inbox_files) == 1, "Expected exactly one inbox alert message"
+        alert = json.loads(inbox_files[0].read_text())
+        assert alert["source"] == "system"
+        assert "auto-register-agent" in alert["text"]
+        assert "2249" in alert["text"]
+
+    def test_no_inbox_alert_when_nothing_repaired(self, tmp_path: Path) -> None:
+        settings_path = tmp_path / "settings.json"
+        install_dir = tmp_path / "lobster"
+        messages_dir = tmp_path / "messages"
+        (messages_dir / "inbox").mkdir(parents=True, exist_ok=True)
+        canonical = _mod._canonical_critical_hooks(install_dir)
+        settings_path.write_text(
+            json.dumps({"hooks": {CRITICAL_HOOK_EVENT: [canonical[0]["entry"]]}})
+        )
+
+        _run_script(settings_path, install_dir, messages_dir)
+
+        inbox_files = list((messages_dir / "inbox").glob("*.json"))
+        assert inbox_files == []


### PR DESCRIPTION
## Problem

Twice in one evening (2026-08-22, ~00:03 and ~00:15 UTC) the dispatcher told the user a background agent had been spawned — and it hadn't. No error, no trace anywhere: not in `get_active_sessions()`, not in `agent_sessions.db`, not in `inflight-work.jsonl`, not in `inflight-prompts/`. The user was told work was happening that never happened. Full incident writeups and root-cause analysis are in #2249.

## Root cause (confirmed by direct inspection of the live instance, not assumed)

Two independent bugs compound to produce this exact failure signature:

**1. The registration hook was never wired in.** `hooks/auto-register-agent.py` is a `PostToolUse` hook meant to durably record every spawned `Agent`/`Task` call into `agent_sessions.db` and `inflight-work.jsonl`, regardless of whether the dispatcher LLM remembers any manual bookkeeping. `install.sh` wires it in idempotently on a fresh install. But this instance (and likely any git-based install) upgrades via `git pull` → `.githooks/post-merge`, which only ever queued a "run `uv pip install -e .`" reminder — it never re-ran `install.sh` or any hook-reconciliation step. Confirmed live via `cat ~/.claude/settings.json`: the hook was completely absent from `PostToolUse`. Any hook added to `install.sh` after an instance's initial install silently never reaches that instance.

**2. The documented delegation pattern sent the ack before the spawn was durable.** `.claude/sys.dispatcher.bootup.md`'s `claim_and_ack` pattern sent the user-facing ack in step 1, *before* the in-flight bookkeeping write and the actual `Task()` call in steps 2–4. A dispatcher restart landing in that window produces exactly Incident 1's signature — and its timeline is a near-exact reproduction: ack sent at 00:15:15 UTC, restart at 00:16:15 UTC.

Background subagents also run in-process as part of the single dispatcher `claude` OS process (per `src/agents/pid_liveness.py`'s documented finding) — a restart takes down anything that hasn't yet persisted its own state, which is why both bugs above are dangerous rather than merely theoretical.

## What changed

- **`scripts/reconcile-claude-hooks.py`** (new): a small, pure-function-based, idempotent reconciler for a short list of CRITICAL hooks (starting with `auto-register-agent`). Detects drift between the canonical hook set and a live `settings.json`, and self-heals it atomically. Deliberately *not* a refactor of `install.sh`'s ~1600-line `setup_claude_hooks()` — that stays the source of truth for fresh installs; this is the safety net for already-deployed instances.
- **`hooks/on-fresh-start.py`**: now runs the reconciler on every fresh dispatcher restart (fail-open — never blocks startup).
- **`.githooks/post-merge`**: now runs the reconciler on every `git pull`, so hook-wiring drift can no longer silently persist across upgrades — for this hook or any future one added to the canonical list.
- **`.claude/sys.dispatcher.bootup.md`**: delegation pattern reordered from ack → bookkeeping → spawn to claim → spawn → **then** ack. The ack is now sent only after the `Task()` call has actually completed, closing the race a restart could exploit.
- **Applied the same repair directly to the live `~/.claude/settings.json`** as an immediate operational fix (not part of this diff, but done alongside it — see Manual test below).

## Functional patterns

`reconcile-claude-hooks.py` is written as pure functions (`hook_present`, `reconcile`) with I/O isolated to the edges (`load_settings`, `write_settings_atomic`, `_log`, `alert_inbox`). `reconcile()` never mutates its input — it returns a new settings dict, matching the "treat data as immutable" principle. The canonical hook manifest (`_canonical_critical_hooks`) is plain data, not control flow, so extending the critical-hook list going forward is a one-line addition, not a code change.

## Before / after

```
BEFORE (per-hook wiring):
  install.sh runs once at install time → settings.json gets hook X
  ...months later...
  hook Y added to install.sh
  git pull → post-merge → "run pip install" reminder only
  settings.json still only has hook X — hook Y silently never arrives
  (this is exactly what happened to auto-register-agent.py)

AFTER:
  install.sh runs once at install time → settings.json gets hook X
  ...months later...
  hook Y added to install.sh AND to reconcile-claude-hooks.py's canonical list
  git pull → post-merge → pip reminder AND reconcile-claude-hooks.py
  settings.json gets hook Y automatically — no manual install.sh re-run needed
  (also self-heals on every dispatcher restart via on-fresh-start.py)
```

```
BEFORE (delegation pattern):
  claim_and_ack()  →  ack sent to user
       |
       |  <-- restart here = user told "on it", nothing ever spawned or recorded
       v
  write inflight entry, Task() spawn

AFTER:
  mark_processing()  →  Task() spawn (hook durably records it the instant it returns)
       |
       |  <-- restart here = no ack was ever sent; nothing false was promised
       v
  send_reply() (ack) — only now, after the spawn is already durable
```

Everything else about message handling, subagent lifecycle, and result routing is unchanged — this PR only touches the ack/spawn ordering and hook-wiring reconciliation.

## Tests run
- [x] `uv run pytest tests/unit/test_reconcile_claude_hooks.py` — 15 passed (pure functions + end-to-end subprocess tests: repair, idempotency, unrelated-hook preservation, corrupt-JSON handling, scaffold creation, inbox alerting)
- [x] `uv run pytest tests/unit/test_hooks/test_on_fresh_start_reconcile_hooks.py` — 7 passed (wiring into on-fresh-start.py: invocation, fail-open on missing script/timeout/error, all exit codes handled)
- [x] `uv run pytest tests/smoke/test_post_merge_hook.py` — 5 passed, including 2 new tests (PM4/PM5: post-merge repairs a missing critical hook end-to-end; no-ops safely when the reconcile script is absent)
- [x] `uv run pytest tests/unit/test_hooks/test_on_fresh_start_catchup.py` — 35 passed (regression check — untouched behavior still correct)
- [x] `uv run pytest tests/unit/test_hooks/test_auto_register_agent.py` — 39 passed (regression check — the hook itself, unmodified, still correct)
- [x] Falsifiability check on every new test file: neutered the implementation (reconcile() returning early with no repair; `_reconcile_claude_hooks()` returning before its subprocess call; post-merge's reconcile block gated behind `if false &&`), confirmed the corresponding tests failed (6/15, 1/7, 1/5 respectively), then restored the correct implementation and confirmed all tests passed again.

## Manual test
This touches file I/O (settings.json) and a git hook (`.githooks/post-merge`), so automated tests alone aren't sufficient evidence:
- Ran `reconcile-claude-hooks.py` directly against the **live** `~/.claude/settings.json` (backed up first to `/tmp/settings.json.bak.<ts>`). First run: exit 1, `auto-register-agent` hook added, confirmed via `jq`-equivalent Python check — settings.json still valid JSON, all pre-existing hooks (14+ PreToolUse/PostToolUse/Stop/SessionStart entries) untouched. Second run: exit 0, exactly one `auto-register-agent` entry present (no duplication) — idempotency confirmed on the real file, not just tmp_path fixtures.
- Confirmed the reconciler's inbox alert was written to `~/messages/inbox/` (a real system message the dispatcher will process on its next `wait_for_messages()` cycle).
- Directly invoked `hooks/auto-register-agent.py` (unmodified — proving the *previously unwired* hook itself was always correct) against an isolated temp `LOBSTER_MESSAGES`/`LOBSTER_WORKSPACE`, simulating a real `Task()` PostToolUse payload with `task_id: proof-2249-spawn`. Confirmed a row landed in `agent_sessions.db` (`status='running'`) and a matching entry landed in `inflight-work.jsonl` — the exact durable trace that was missing in both incidents — the instant the simulated tool call returned, before any ack could plausibly be sent under the corrected ordering.
- Note: the live dispatcher process itself won't pick up the newly-wired hook until its next natural restart (settings.json is read at Claude Code process start) — I did not force a restart of the live dispatcher as a side effect of this task. The fix is on disk and will take effect on the next restart, and will now stay in sync automatically going forward via both entry points added in this PR.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits in automated tests — `tmp_path` fixtures throughout, `LOBSTER_INSTALL_DIR`/`LOBSTER_CLAUDE_SETTINGS_OVERRIDE`/`LOBSTER_MESSAGES` env overrides isolate every test from the real settings.json)
- [x] Manual test run — see above; live settings.json repair was explicitly scoped (single file, backed up first, verified valid JSON + idempotent before/after)
- [x] User-visible outcome: not directly applicable to this PR (no new Telegram-facing behavior) — the fix restores the *accuracy* of an existing user-visible behavior (the ack), verified via the auto-register-agent.py end-to-end proof above
- [x] Side-effect audit: no floods, no unscoped writes — the only production write (repairing live settings.json) was explicitly scoped, backed up, and verified idempotent
- [x] External service calls: none in this PR

## Known gaps / out of scope
- While investigating, I found that `~/lobster-workspace/.claude` on this instance symlinks to `~/lobster-user-config/.claude` — a **stale, real copy** of the bootup docs from initial install (unchanged since install day), not a live symlink to the repo as `CLAUDE.md` currently documents ("editing files here is immediately live, no deploy needed"). This means the ack-ordering fix in `.claude/sys.dispatcher.bootup.md` in this PR won't reach the live dispatcher until that copy is refreshed — I patched the live copy directly as an operational action, but did not attempt to fix the underlying `.claude` sync mechanism here; it's a distinct, larger investigation (need to understand `apply_private_overlay`'s intended design) and is filed separately.
- Related issue #2231 (open) covers the same failure *class* on the completion side (dispatcher restart racing a subagent's own `"done"` write) — not duplicated here; this PR is the spawn-side counterpart.

Closes #2249