### PR TITLE
fix: retry Telegram photo downloads on transient network timeouts

### DIFF
--- a/src/bot/lobster_bot.py
+++ b/src/bot/lobster_bot.py
@@ -78,8 +78,14 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, ReplyParameters
+from telegram.error import TimedOut, NetworkError
 from telegram.ext import Application, CommandHandler, MessageHandler, CallbackQueryHandler, ChatMemberHandler, MessageReactionHandler, filters, ContextTypes
 from collections import deque
+
+# Retry policy for downloading files from Telegram (get_file + download_to_drive).
+# A single transient network hiccup should not drop a user's photo permanently.
+FILE_DOWNLOAD_MAX_ATTEMPTS = 3
+FILE_DOWNLOAD_BACKOFF_SECONDS = 1.0
 
 
 # URLs longer than this are copy-paste targets (e.g. OAuth flows).  Telegram
@@ -998,6 +1004,41 @@ async def handle_callback_query(update: Update, context: ContextTypes.DEFAULT_TY
     log.info(f"Wrote callback message to inbox: {msg_id}")
 
 
+async def _download_telegram_file_with_retry(
+    context: ContextTypes.DEFAULT_TYPE,
+    file_id: str,
+    dest_path: Path,
+    *,
+    max_attempts: int = FILE_DOWNLOAD_MAX_ATTEMPTS,
+    backoff_seconds: float = FILE_DOWNLOAD_BACKOFF_SECONDS,
+) -> None:
+    """Download a Telegram file (get_file + download_to_drive) with retry.
+
+    Retries on telegram.error.TimedOut / telegram.error.NetworkError, which are
+    the transient-failure classes for a getFile + download round trip (e.g. a
+    ReadTimeout under network jitter). Note NetworkError is python-telegram-bot's
+    base class for several non-transient errors too (e.g. BadRequest), so those
+    are retried as well; only exceptions outside the NetworkError/TimedOut
+    hierarchy (e.g. Forbidden) fail fast. Uses linear backoff between attempts.
+    Re-raises the last exception if all attempts are exhausted.
+    """
+    last_exc: Optional[Exception] = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            file = await context.bot.get_file(file_id)
+            await file.download_to_drive(dest_path)
+            return
+        except (TimedOut, NetworkError) as e:
+            last_exc = e
+            log.warning(
+                f"Telegram file download attempt {attempt}/{max_attempts} failed "
+                f"for file_id={file_id}: {e}"
+            )
+            if attempt < max_attempts:
+                await asyncio.sleep(backoff_seconds * attempt)
+    raise last_exc
+
+
 async def handle_photo_message(update: Update, context: ContextTypes.DEFAULT_TYPE, msg_id: str):
     """Handle photo messages: download and save to inbox with metadata."""
     user = update.effective_user
@@ -1014,10 +1055,9 @@ async def handle_photo_message(update: Update, context: ContextTypes.DEFAULT_TYP
         # Get the largest photo size
         photo = message.photo[-1]
 
-        # Download the photo
-        file = await context.bot.get_file(photo.file_id)
+        # Download the photo (with retry on transient network/timeout errors)
         image_path = IMAGES_DIR / f"{msg_id}.jpg"
-        await file.download_to_drive(image_path)
+        await _download_telegram_file_with_retry(context, photo.file_id, image_path)
         log.info(f"Downloaded photo to: {image_path}")
 
         caption = message.caption or ""
@@ -1087,13 +1127,16 @@ async def _handle_media_group_photo(update: Update, context: ContextTypes.DEFAUL
 
     try:
         photo = message.photo[-1]
-        file = await context.bot.get_file(photo.file_id)
         # Use msg_id (which is unique per photo update) as the filename
         image_path = IMAGES_DIR / f"{msg_id}.jpg"
-        await file.download_to_drive(image_path)
+        await _download_telegram_file_with_retry(context, photo.file_id, image_path)
         log.info(f"Downloaded media group photo to: {image_path}")
     except Exception as e:
         log.error(f"Error downloading media group photo: {e}", exc_info=True)
+        try:
+            await message.reply_text("❌ Failed to process a photo in this album.")
+        except Exception:
+            log.error("Failed to send media-group photo failure notice", exc_info=True)
         return
 
     if group_id not in _media_group_buffers:
@@ -2179,7 +2222,18 @@ async def run_bot():
     log.info("Watching outbox for replies...")
 
     # Create bot application
-    bot_app = Application.builder().token(BOT_TOKEN).write_timeout(30).build()
+    # connect_timeout/read_timeout are bumped from the python-telegram-bot
+    # default (5s) to 20s: too tight for a getFile + download round trip on
+    # photos/documents, and the source of issue #2252 (a ReadTimeout on
+    # get_file with no retry, causing total data loss for the message).
+    bot_app = (
+        Application.builder()
+        .token(BOT_TOKEN)
+        .connect_timeout(20)
+        .read_timeout(20)
+        .write_timeout(30)
+        .build()
+    )
 
     # Add handlers
     bot_app.add_handler(CommandHandler("start", start_command))

--- a/tests/unit/test_bot/test_photo_download_retry.py
+++ b/tests/unit/test_bot/test_photo_download_retry.py
@@ -1,0 +1,164 @@
+"""
+Unit tests for the Telegram photo-download retry helper (issue #2252).
+
+Covers `_download_telegram_file_with_retry`, the shared retry wrapper around
+`context.bot.get_file` + `file.download_to_drive` used by both
+`handle_photo_message` and `_handle_media_group_photo`.
+
+Tests cover:
+- Succeeds immediately with no retries when the first attempt works
+- Recovers after N transient (TimedOut/NetworkError) failures, within budget
+- Gives up and re-raises after exhausting all retry attempts
+- Does not retry on a non-network exception (fails fast)
+- `_handle_media_group_photo` sends a user-facing failure reply when retries
+  are exhausted (previously silent per issue #2252)
+"""
+
+import asyncio
+import importlib
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from telegram.error import Forbidden, NetworkError, TimedOut
+
+
+@pytest.fixture
+def bot_module(tmp_path, monkeypatch):
+    """Load lobster_bot with a patched environment and a fresh module state."""
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test_token")
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "123456")
+    monkeypatch.setenv("LOBSTER_MESSAGES", str(tmp_path / "messages"))
+    (tmp_path / "messages" / "inbox").mkdir(parents=True, exist_ok=True)
+
+    import src.bot.lobster_bot as module
+
+    importlib.reload(module)
+
+    # Keep retry backoff at zero so tests don't actually sleep.
+    monkeypatch.setattr(module, "FILE_DOWNLOAD_BACKOFF_SECONDS", 0.0)
+
+    yield module
+
+
+def _make_context(get_file_side_effects):
+    """Build a mock ContextTypes with context.bot.get_file() driven by a side_effect list.
+
+    Each entry in `get_file_side_effects` is either an Exception instance (raised)
+    or a MagicMock standing in for the returned `telegram.File` object.
+    """
+    context = MagicMock()
+    context.bot.get_file = AsyncMock(side_effect=get_file_side_effects)
+    return context
+
+
+def _make_file():
+    """A mock `telegram.File` with an awaitable download_to_drive()."""
+    f = MagicMock()
+    f.download_to_drive = AsyncMock(return_value=None)
+    return f
+
+
+class TestDownloadRetryHelper:
+    @pytest.mark.asyncio
+    async def test_succeeds_on_first_attempt_without_retry(self, bot_module, tmp_path):
+        good_file = _make_file()
+        context = _make_context([good_file])
+        dest = tmp_path / "photo.jpg"
+
+        await bot_module._download_telegram_file_with_retry(context, "file123", dest)
+
+        assert context.bot.get_file.await_count == 1
+        good_file.download_to_drive.assert_awaited_once_with(dest)
+
+    @pytest.mark.asyncio
+    async def test_recovers_after_transient_timeout_within_retry_budget(self, bot_module, tmp_path):
+        good_file = _make_file()
+        context = _make_context([TimedOut("simulated read timeout"), good_file])
+        dest = tmp_path / "photo.jpg"
+
+        await bot_module._download_telegram_file_with_retry(
+            context, "file123", dest, max_attempts=3
+        )
+
+        assert context.bot.get_file.await_count == 2
+        good_file.download_to_drive.assert_awaited_once_with(dest)
+
+    @pytest.mark.asyncio
+    async def test_recovers_from_network_error_on_final_attempt(self, bot_module, tmp_path):
+        good_file = _make_file()
+        context = _make_context(
+            [NetworkError("conn reset"), NetworkError("conn reset"), good_file]
+        )
+        dest = tmp_path / "photo.jpg"
+
+        await bot_module._download_telegram_file_with_retry(
+            context, "file123", dest, max_attempts=3
+        )
+
+        assert context.bot.get_file.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_raises_after_exhausting_all_retry_attempts(self, bot_module, tmp_path):
+        max_attempts = 3
+        context = _make_context(
+            [TimedOut("t1"), TimedOut("t2"), TimedOut("t3"), TimedOut("t4")]
+        )
+        dest = tmp_path / "photo.jpg"
+
+        with pytest.raises(TimedOut):
+            await bot_module._download_telegram_file_with_retry(
+                context, "file123", dest, max_attempts=max_attempts
+            )
+
+        assert context.bot.get_file.await_count == max_attempts
+
+    @pytest.mark.asyncio
+    async def test_non_network_exception_is_not_retried(self, bot_module, tmp_path):
+        # Forbidden (e.g. bot blocked/kicked) is a TelegramError but NOT a
+        # NetworkError/TimedOut subclass in python-telegram-bot, unlike
+        # BadRequest (which *is* a NetworkError subclass upstream and is
+        # therefore intentionally retried by this helper).
+        context = _make_context([Forbidden("bot was blocked by the user")])
+        dest = tmp_path / "photo.jpg"
+
+        with pytest.raises(Forbidden):
+            await bot_module._download_telegram_file_with_retry(context, "file123", dest)
+
+        # Fails fast: only one attempt, no retry loop for non-network errors.
+        assert context.bot.get_file.await_count == 1
+
+
+class TestMediaGroupPhotoFailureNotice:
+    @pytest.mark.asyncio
+    async def test_reports_failure_to_user_when_retries_exhausted(self, bot_module, tmp_path, monkeypatch):
+        """Regression test: _handle_media_group_photo used to silently drop a
+        photo from an album on download failure, with no user-facing error at
+        all. It should now notify the user."""
+
+        async def _always_fails(context, file_id, dest_path, **kwargs):
+            raise TimedOut("simulated exhausted retries")
+
+        monkeypatch.setattr(bot_module, "_download_telegram_file_with_retry", _always_fails)
+
+        update = MagicMock()
+        message = update.message
+        message.media_group_id = "group-1"
+        message.chat_id = 555
+        message.caption = None
+        message.photo = [MagicMock(file_id="file123")]
+        message.reply_text = AsyncMock(return_value=None)
+        update.effective_user.id = 1
+        update.effective_user.username = "tester"
+        update.effective_user.first_name = "Tester"
+
+        context = MagicMock()
+
+        await bot_module._handle_media_group_photo(update, context, "msg-1")
+
+        message.reply_text.assert_awaited_once()
+        (call_text,), _ = message.reply_text.call_args
+        assert "fail" in call_text.lower()
+
+        # The photo must not have been buffered into the media group after failure.
+        assert "group-1" not in bot_module._media_group_buffers


### PR DESCRIPTION
## Problem

A user-sent photo was lost entirely: no inbox entry was written, and the bot replied "❌ Failed to process photo." `handle_photo_message`'s `context.bot.get_file(photo.file_id)` call hit a `telegram.error.TimedOut` (an `httpx.ReadTimeout`) with no retry, and the failure propagated to a terminal user-facing error. Two contributing factors:

1. `Application.builder()` only set `write_timeout(30)`; `read_timeout`/`connect_timeout` were left at python-telegram-bot's 5s default — tight for a `getFile` + download round trip.
2. There was no retry on this transient failure class.

`_handle_media_group_photo` (the media-group/album path) has the identical unretried `get_file`/`download_to_drive` pattern, and is actually worse: on failure it just logs and returns, with **no user-facing error at all** — a dropped photo in an album was completely silent.

This has only reproduced once in production (checked `telegram-bot.log` + `logs/archive/`), so it's rare, but the failure mode is 100% data loss with no recovery path.

## What changed

- **Timeout headroom:** `Application.builder()` now sets `connect_timeout(20)` and `read_timeout(20)` alongside the existing `write_timeout(30)`, instead of leaving both at PTB's 5s default.
- **Shared retry helper:** added `_download_telegram_file_with_retry()` — a pure function wrapping `get_file` + `download_to_drive` in a 3-attempt retry loop with linear backoff, catching `telegram.error.TimedOut` / `telegram.error.NetworkError`. Both `handle_photo_message` and `_handle_media_group_photo` now call this single helper instead of each duplicating the unretried `get_file`/`download_to_drive` pair.
- **Media-group failure now surfaces to the user:** `_handle_media_group_photo` sends "❌ Failed to process a photo in this album." when retries are exhausted, instead of silently dropping the photo with only a log line.

Functional patterns: the retry helper is a small pure function (inputs → retry policy → result-or-raise, no shared mutable state beyond the two module-level constants `FILE_DOWNLOAD_MAX_ATTEMPTS`/`FILE_DOWNLOAD_BACKOFF_SECONDS`), and it's composed into both call sites rather than duplicated.

This is scoped as a minimal, targeted fix — timeout bump + retry wrapper — not a broader refactor of the photo-handling pipeline, matching how rarely this failure mode has actually occurred.

## Out of scope

No changes to `handle_document_message`, voice/audio handling, the media-group flush/buffer logic, or the inbox message schema. Only the `get_file`/`download_to_drive` call sites and the `Application.builder()` timeouts were touched.

## Flow: media-group failure path

```
Before:
  get_file/download fails -> log.error() -> return   (photo silently dropped, no album entry, no user notice)

After:
  get_file/download retried up to 3x (TimedOut/NetworkError only)
    -> succeeds: unchanged behavior, photo buffered into the album as before
    -> exhausts retries: log.error() -> reply_text("Failed to process a photo in this album.") -> return
```

The single-photo path (`handle_photo_message`) already had a user-facing failure reply; its `get_file`/`download_to_drive` call is now routed through the same retry helper, so it benefits from the same retry budget before that reply fires.

## Tests run

- [x] `uv run pytest tests/unit/test_bot/test_photo_download_retry.py -v` — 6 passed, 0 failed. Covers: succeeds without retry, recovers after N transient `TimedOut`/`NetworkError` failures within budget, raises after exhausting all attempts, does not retry (fails fast) on a non-`NetworkError` exception (`Forbidden`), and the media-group path now sends a user-facing failure reply on exhausted retries (regression test for the previously-silent drop).
- [x] `uv run pytest tests/unit/test_bot/` — 248 passed, 20 failed. All 20 failures are pre-existing and unrelated to this change: `ModuleNotFoundError: No module named 'slack_bolt'`/`'slack_sdk'` (optional dependency not installed in this environment) and one pre-existing `test_slack_router_config.py` assertion failure. No photo/message-handling test regressed.
- [x] `uv run python -c "import ast; ast.parse(open('src/bot/lobster_bot.py').read())"` — syntax check passes.

## Manual test

No live Telegram API call was made — this environment has no test bot token, and the failure mode (a real `ReadTimeout` from Telegram's servers) isn't reproducible on demand without one. Verification was done by unit-testing the retry helper in isolation with a mocked `context.bot.get_file` that raises `telegram.error.TimedOut`/`NetworkError` N times before succeeding (or exhausts retries), per the issue's own suggested test approach. No systemd/cron/DB changes are involved — this is a pure Python code change to an existing long-running bot process, picked up on next bot restart/deploy like any other code change to this file.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production Telegram calls in automated tests)
- [ ] Integration/manual test against live Telegram — not run; no test bot token available in this environment, and the original failure (`ReadTimeout`) is not reliably reproducible on demand. Recommend a maintainer either watches the next real occurrence resolve automatically, or does a manual photo-send test in production after merge if that reassurance is wanted before/after deploy.
- [x] User-visible outcome: the media-group failure message text change is Telegram-observable but not independently verified against a live chat (see above) — reasoning verified via unit test asserting `reply_text` is awaited with the expected text.
- [x] Side-effect audit: this only affects the failure path of photo downloads (retry + one new failure reply); no new writes to shared state, no risk of message floods (bounded to 3 attempts per photo), no change to successful-path behavior.
- [x] External service calls: `context.bot.get_file`/`download_to_drive` are mocked in all automated tests; no manual runs were made against the live Telegram API.

Closes #2252