### PR TITLE
fix: exclude dispatcher's own session row even when agent_type is NULL

### DIFF
--- a/scripts/agent-monitor.py
+++ b/scripts/agent-monitor.py
@@ -103,7 +103,11 @@ from agents.pid_liveness import is_pid_alive  # noqa: E402
 # the dispatcher's row from this script's pipeline entirely — it never
 # reaches classify_agent(), so no PID-staleness race window can misclassify
 # it, regardless of restart timing.
-from utils.agent_types import DISPATCHER_EXCLUSION_SQL, is_dispatcher_agent_type  # noqa: E402
+from utils.agent_types import (  # noqa: E402
+    DISPATCHER_AGENT_ID as _DISPATCHER_AGENT_ID,
+    DISPATCHER_EXCLUSION_SQL,
+    is_dispatcher_agent_type,
+)
 
 # Age threshold for treating an unregistered output file as "active" (minutes)
 UNREGISTERED_ACTIVE_THRESHOLD_MINUTES = 30.0
@@ -111,7 +115,12 @@ UNREGISTERED_ACTIVE_THRESHOLD_MINUTES = 30.0
 # The static agent_id used when the dispatcher registers itself via session_start().
 # Matches the value used in the dispatcher bootup instructions:
 #   session_start(agent_id="lobster-dispatcher", agent_type="dispatcher", ...)
-_DISPATCHER_AGENT_ID = "lobster-dispatcher"
+#
+# Issue #2226: this is now imported from utils.agent_types as the single
+# source of truth (aliased to the pre-existing local name so every other
+# reference in this file — _is_dispatcher_agent(), mark_failed_all_ghosts(),
+# send_alert() — is unchanged) instead of being hand-copied here, closing the
+# same class of drift DISPATCHER_EXCLUSION_SQL already closed for the SQL side.
 
 
 @dataclass(frozen=True)

--- a/scripts/lib/agent_sessions.sh
+++ b/scripts/lib/agent_sessions.sh
@@ -9,23 +9,43 @@
 # (session_store.py x2, inbox_server.py x2) — the whole family of duplicates
 # had to be fixed four separate times (issue #781, PR #2099, PR #2103).
 #
-# Cross-reference: this constant MUST match DISPATCHER_AGENT_TYPE /
-# DISPATCHER_EXCLUSION_SQL in src/utils/agent_types.py. Bash and Python cannot
-# literally share one function, so if you change the excluded agent_type
-# value here, change it in src/utils/agent_types.py too (and vice versa).
+# Cross-reference: these constants MUST match DISPATCHER_AGENT_TYPE /
+# DISPATCHER_AGENT_ID / DISPATCHER_EXCLUSION_SQL in src/utils/agent_types.py.
+# Bash and Python cannot literally share one function, so if you change either
+# excluded value here, change it in src/utils/agent_types.py too (and vice
+# versa).
 #
 # Usage:
 #   source "$(dirname "$0")/lib/agent_sessions.sh"
 #   sqlite3 "$DB_PATH" \
 #     "SELECT COUNT(*) FROM agent_sessions WHERE status IN ('running','starting') AND $DISPATCHER_EXCLUSION_SQL"
+#
+# ## Belt-and-suspenders `id` fallback (issue #2226)
+#
+# `agent_type` is an optional parameter on the `session_start` MCP tool. A
+# dispatcher bootup call that omits it leaves the row's `agent_type` column
+# NULL, which COALESCE turns into '' — and '' != 'dispatcher' is TRUE, so the
+# row was NOT excluded, producing a permanent false-positive "[1 agents
+# pending]" self-check every 3 minutes with zero real subagents running
+# (issue #2226). The `id != '...'` clause below excludes the dispatcher's row
+# by its static agent_id (always 'lobster-dispatcher', per
+# .claude/sys.dispatcher.bootup.md's session_start bootup instructions) as a
+# second, independent signal — mirroring the belt-and-suspenders pattern
+# scripts/agent-monitor.py's `_is_dispatcher_agent()` already used.
 #===============================================================================
 
 # The agent_type value written when the dispatcher registers its own session.
 # Must match DISPATCHER_AGENT_TYPE in src/utils/agent_types.py.
 DISPATCHER_AGENT_TYPE="dispatcher"
 
+# The static agent_id the dispatcher always registers itself under. Must
+# match DISPATCHER_AGENT_ID in src/utils/agent_types.py.
+DISPATCHER_AGENT_ID="lobster-dispatcher"
+
 # SQL WHERE-clause fragment excluding dispatcher rows from a query over
 # agent_sessions. COALESCE guards against agent_type being NULL (legacy rows
-# predating the column, or subagents that never set it).
+# predating the column, or subagents that never set it). The `id !=` clause
+# is the belt-and-suspenders fallback (issue #2226): it excludes the
+# dispatcher's row by its static agent_id even when agent_type itself is NULL.
 # Must match DISPATCHER_EXCLUSION_SQL in src/utils/agent_types.py.
-DISPATCHER_EXCLUSION_SQL="COALESCE(agent_type, '') != '${DISPATCHER_AGENT_TYPE}'"
+DISPATCHER_EXCLUSION_SQL="(COALESCE(agent_type, '') != '${DISPATCHER_AGENT_TYPE}' AND id != '${DISPATCHER_AGENT_ID}')"

--- a/src/utils/agent_types.py
+++ b/src/utils/agent_types.py
@@ -15,6 +15,24 @@ agent_sessions.db directly via `sqlite3` rather than importing this module.
 Python and bash cannot literally share one function, so the two files carry
 matching comments pointing at each other — if one changes, the other must
 change too.
+
+## Belt-and-suspenders `id` fallback (issue #2226)
+
+`agent_type` is an optional parameter on the `session_start` MCP tool — a
+dispatcher bootup call that omits it (e.g. `session_start(agent_id=
+"lobster-dispatcher", description=..., chat_id=...)` with no `agent_type=
+"dispatcher"`) leaves the row's `agent_type` column NULL. `COALESCE(agent_type,
+'') != 'dispatcher'` then evaluates to `'' != 'dispatcher'` → TRUE, so the row
+is *not* excluded — it gets miscounted as a pending/dead subagent on every
+query. This exact failure mode produced a permanent false-positive
+`[1 agents pending]` self-check every 3 minutes (issue #2226).
+
+The fix mirrors the belt-and-suspenders pattern `scripts/agent-monitor.py`'s
+`_is_dispatcher_agent()` already used for its own call site (issue #2176):
+exclude by the static `agent_id` the dispatcher always registers under
+(`lobster-dispatcher`, per `.claude/sys.dispatcher.bootup.md`'s bootup
+instructions) in addition to `agent_type`, so a row is recognized as the
+dispatcher's own session even when `agent_type` failed to land.
 """
 
 from __future__ import annotations
@@ -25,14 +43,28 @@ from __future__ import annotations
 # DISPATCHER_AGENT_TYPE in scripts/lib/agent_sessions.sh.
 DISPATCHER_AGENT_TYPE = "dispatcher"
 
+# The static agent_id the dispatcher always registers itself under (see
+# .claude/sys.dispatcher.bootup.md's session_start(agent_id="lobster-dispatcher",
+# ...) bootup instruction, and scripts/agent-monitor.py's _DISPATCHER_AGENT_ID,
+# which now imports this constant rather than hand-copying the literal).
+# Belt-and-suspenders identifier for when agent_type itself is NULL (issue
+# #2226). Must match DISPATCHER_AGENT_ID in scripts/lib/agent_sessions.sh.
+DISPATCHER_AGENT_ID = "lobster-dispatcher"
+
 # SQL WHERE-clause fragment excluding dispatcher rows from a query over
 # agent_sessions. COALESCE guards against agent_type being NULL (legacy rows
 # predating the column, or subagents that never set it) — NULL != 'dispatcher'
 # is NULL (falsy) in SQL, so without COALESCE those rows would be silently
-# excluded from results that should include them.
+# excluded from results that should include them. The `id !=` clause is the
+# belt-and-suspenders fallback (issue #2226): it excludes the dispatcher's row
+# by its static agent_id even on the (otherwise unguarded) path where
+# agent_type itself landed NULL.
 #
 # Must match DISPATCHER_EXCLUSION_SQL in scripts/lib/agent_sessions.sh.
-DISPATCHER_EXCLUSION_SQL = f"COALESCE(agent_type, '') != '{DISPATCHER_AGENT_TYPE}'"
+DISPATCHER_EXCLUSION_SQL = (
+    f"(COALESCE(agent_type, '') != '{DISPATCHER_AGENT_TYPE}' "
+    f"AND id != '{DISPATCHER_AGENT_ID}')"
+)
 
 
 def is_dispatcher_agent_type(agent_type: str | None) -> bool:
@@ -49,8 +81,14 @@ def is_dispatcher_agent_type(agent_type: str | None) -> bool:
 def is_dispatcher_row(session: dict) -> bool:
     """Return True if a session dict represents the dispatcher's own session.
 
-    Convenience wrapper around is_dispatcher_agent_type() for callers holding
-    a full session dict (e.g. from get_active_sessions() or a row returned by
-    get_unnotified_completed()) rather than a bare agent_type string.
+    Checks agent_type first (the structural signal). Falls back to the static
+    agent_id ('lobster-dispatcher') so the row is still recognized as the
+    dispatcher's own session even if agent_type landed NULL — e.g. because the
+    dispatcher's own `session_start` bootup call omitted the optional
+    `agent_type` parameter (issue #2226). Mirrors the same agent_id fallback
+    `scripts/agent-monitor.py`'s `_is_dispatcher_agent()` already applies.
     """
-    return is_dispatcher_agent_type(session.get("agent_type"))
+    return (
+        is_dispatcher_agent_type(session.get("agent_type"))
+        or session.get("id") == DISPATCHER_AGENT_ID
+    )

--- a/tests/test-health-check-count-active-subagents.sh
+++ b/tests/test-health-check-count-active-subagents.sh
@@ -122,6 +122,25 @@ make_db "$MESSAGES_DIR/config/agent_sessions.db" \
 result=$(count_active_subagents)
 assert_eq "$result" "2"
 
+# -------------------------------------------------------------------
+# Test 5 (issue #2226): dispatcher row with agent_type=NULL → count is 0
+#
+# session_start()'s agent_type parameter is optional; when the dispatcher's
+# own bootup call omits it, this row shape (agent_type=NULL) is what actually
+# lands in production. Pre-#2226-fix, DISPATCHER_EXCLUSION_SQL's
+# COALESCE(agent_type, '') != 'dispatcher' evaluated to '' != 'dispatcher' →
+# TRUE for this row, so it was NOT excluded here either — same bug class as
+# periodic-self-check.sh's PENDING_COUNT, just via this call site instead.
+# -------------------------------------------------------------------
+begin_test "Dispatcher row (agent_type=NULL) → count is 0, not 1 (issue #2226)"
+MESSAGES_DIR="$TEST_TMPDIR/dispatcher-null-agent-type"
+mkdir -p "$MESSAGES_DIR/config"
+sqlite3 "$MESSAGES_DIR/config/agent_sessions.db" \
+    "CREATE TABLE agent_sessions (id TEXT, agent_type TEXT, status TEXT); \
+     INSERT INTO agent_sessions (id, agent_type, status) VALUES ('lobster-dispatcher', NULL, 'running');"
+result=$(count_active_subagents)
+assert_eq "$result" "0"
+
 #===============================================================================
 # Syntax check
 #===============================================================================

--- a/tests/test-periodic-self-check-dispatcher-null-agent-type.sh
+++ b/tests/test-periodic-self-check-dispatcher-null-agent-type.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+#===============================================================================
+# Test Suite: periodic-self-check.sh PENDING_COUNT — dispatcher row with NULL
+# agent_type (issue #2226)
+#
+# periodic-self-check.sh (cron, every 3 min) counts "pending" agents via:
+#   SELECT COUNT(*) FROM agent_sessions
+#   WHERE status IN ('running','starting') AND $DISPATCHER_EXCLUSION_SQL
+# (scripts/lib/agent_sessions.sh's DISPATCHER_EXCLUSION_SQL, sourced directly
+# by the script — this test exercises that exact query string, not a
+# reimplementation of it).
+#
+# The dispatcher registers its own row via session_start(agent_id=
+# "lobster-dispatcher", ...). agent_type is an OPTIONAL parameter on that
+# call — when the dispatcher's bootup turn omits it, the row's agent_type
+# column lands NULL. Pre-fix, DISPATCHER_EXCLUSION_SQL was just
+# `COALESCE(agent_type, '') != 'dispatcher'`, which evaluates to
+# `'' != 'dispatcher'` -> TRUE for a NULL row, so it was NOT excluded — every
+# 3-minute cron cycle counted it as 1 pending agent and injected a spurious
+# "status? (Self-check) [1 agents pending]" message, indefinitely, with zero
+# real subagents running. Confirmed live against the production DB in issue
+# #2226's bug report.
+#
+# Fix: DISPATCHER_EXCLUSION_SQL now also excludes by the dispatcher's static
+# agent_id ('lobster-dispatcher') as a second, independent signal — mirroring
+# the belt-and-suspenders pattern scripts/agent-monitor.py's
+# _is_dispatcher_agent() already used for its own call site (issue #2176).
+#
+# Cases covered:
+#   1. Dispatcher row, agent_type=NULL (the exact reported bug) -> count is 0
+#   2. Dispatcher row (agent_type=NULL) + one real pending subagent -> count is 1
+#   3. Dispatcher row, agent_type='dispatcher' (already-working case) -> count is 0
+#   4. No dispatcher row, one real pending subagent -> count is 1 (unaffected)
+#
+# Usage: bash tests/test-periodic-self-check-dispatcher-null-agent-type.sh
+#===============================================================================
+
+set -u
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TEST_TMPDIR=$(mktemp -d /tmp/lobster-periodic-self-check-null-agent-type-test-XXXXXX)
+cleanup() { rm -rf "$TEST_TMPDIR"; }
+trap cleanup EXIT
+
+begin_test() { TOTAL=$((TOTAL + 1)); test_name="$1"; }
+pass()  { PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC} $test_name"; }
+fail()  { FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC} $test_name: $1"; }
+
+assert_eq() {
+    local actual="$1" expected="$2"
+    if [[ "$actual" == "$expected" ]]; then pass; else fail "expected '$expected', got '$actual'"; fi
+}
+
+# Source the real shared fragment — the same single source of truth
+# periodic-self-check.sh itself sources. Not a hand-copied reimplementation.
+# shellcheck source=../scripts/lib/agent_sessions.sh
+source "$REPO_ROOT/scripts/lib/agent_sessions.sh"
+
+# Build an agent_sessions.db with the given rows.
+# Args: $1 = db path, remaining = "id|agent_type|status" triples.
+# agent_type of the literal string "NULL" is inserted as SQL NULL (unquoted).
+make_db() {
+    local db_path="$1"
+    shift
+    sqlite3 "$db_path" "CREATE TABLE agent_sessions (id TEXT PRIMARY KEY, agent_type TEXT, status TEXT);"
+    for row in "$@"; do
+        IFS='|' read -r id agent_type status <<< "$row"
+        if [[ "$agent_type" == "NULL" ]]; then
+            sqlite3 "$db_path" "INSERT INTO agent_sessions (id, agent_type, status) VALUES ('$id', NULL, '$status');"
+        else
+            sqlite3 "$db_path" "INSERT INTO agent_sessions (id, agent_type, status) VALUES ('$id', '$agent_type', '$status');"
+        fi
+    done
+}
+
+# Run the exact PENDING_COUNT query periodic-self-check.sh runs.
+pending_count() {
+    local db_path="$1"
+    sqlite3 "$db_path" \
+        "SELECT COUNT(*) FROM agent_sessions WHERE status IN ('running','starting') AND ${DISPATCHER_EXCLUSION_SQL}" \
+        2>/dev/null || echo "0"
+}
+
+echo "=== periodic-self-check.sh PENDING_COUNT — Dispatcher NULL agent_type Tests (issue #2226) ==="
+echo ""
+
+# -------------------------------------------------------------------
+# Test 1: The exact reported bug — dispatcher row, agent_type=NULL
+# -------------------------------------------------------------------
+begin_test "Dispatcher row (agent_type=NULL) -> count is 0, not 1"
+DB="$TEST_TMPDIR/null-agent-type.db"
+make_db "$DB" "lobster-dispatcher|NULL|running"
+result=$(pending_count "$DB")
+assert_eq "$result" "0"
+
+# -------------------------------------------------------------------
+# Test 2: Dispatcher row (agent_type=NULL) + one real pending subagent
+# -------------------------------------------------------------------
+begin_test "Dispatcher row (agent_type=NULL) + 1 real subagent -> count is 1"
+DB="$TEST_TMPDIR/null-agent-type-plus-one.db"
+make_db "$DB" \
+    "lobster-dispatcher|NULL|running" \
+    "real-subagent-001|subagent|running"
+result=$(pending_count "$DB")
+assert_eq "$result" "1"
+
+# -------------------------------------------------------------------
+# Test 3: Dispatcher row with agent_type correctly set (already-working
+# case) -> must remain excluded (no regression from the id fallback)
+# -------------------------------------------------------------------
+begin_test "Dispatcher row (agent_type='dispatcher') -> count is 0"
+DB="$TEST_TMPDIR/correct-agent-type.db"
+make_db "$DB" "lobster-dispatcher|dispatcher|running"
+result=$(pending_count "$DB")
+assert_eq "$result" "0"
+
+# -------------------------------------------------------------------
+# Test 4: No dispatcher row, one real pending subagent -> count is 1
+# -------------------------------------------------------------------
+begin_test "No dispatcher row, 1 real subagent -> count is 1 (unaffected)"
+DB="$TEST_TMPDIR/no-dispatcher-row.db"
+make_db "$DB" "real-subagent-001|subagent|running"
+result=$(pending_count "$DB")
+assert_eq "$result" "1"
+
+#===============================================================================
+# Syntax check
+#===============================================================================
+
+echo ""
+echo "=== Syntax Check ==="
+
+begin_test "periodic-self-check.sh passes bash -n syntax check"
+if bash -n "$REPO_ROOT/scripts/periodic-self-check.sh" 2>&1; then
+    pass
+else
+    fail "Syntax errors in periodic-self-check.sh"
+fi
+
+begin_test "scripts/lib/agent_sessions.sh passes bash -n syntax check"
+if bash -n "$REPO_ROOT/scripts/lib/agent_sessions.sh" 2>&1; then
+    pass
+else
+    fail "Syntax errors in scripts/lib/agent_sessions.sh"
+fi
+
+#===============================================================================
+# Summary
+#===============================================================================
+
+echo ""
+echo "=============================="
+echo "Results: $TOTAL tests"
+echo -e "  ${GREEN}PASS: $PASS${NC}"
+if [ "$FAIL" -gt 0 ]; then
+    echo -e "  ${RED}FAIL: $FAIL${NC}"
+fi
+echo "=============================="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+else
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi

--- a/tests/unit/test_agent_types.py
+++ b/tests/unit/test_agent_types.py
@@ -9,7 +9,10 @@ definition so a future accidental removal or inversion of the check is
 caught here first.
 """
 
+import sqlite3
+
 from src.utils.agent_types import (
+    DISPATCHER_AGENT_ID,
     DISPATCHER_AGENT_TYPE,
     DISPATCHER_EXCLUSION_SQL,
     is_dispatcher_agent_type,
@@ -60,3 +63,101 @@ def test_dispatcher_exclusion_sql_matches_constant():
     assert f"'{DISPATCHER_AGENT_TYPE}'" in DISPATCHER_EXCLUSION_SQL
     assert "COALESCE(agent_type, '')" in DISPATCHER_EXCLUSION_SQL
     assert "!=" in DISPATCHER_EXCLUSION_SQL
+
+
+# ---------------------------------------------------------------------------
+# Issue #2226: NULL agent_type on the dispatcher's own row (agent_id fallback)
+#
+# session_start()'s agent_type parameter is optional. When the dispatcher's
+# own bootup call omits it, the row's agent_type column lands NULL.
+# COALESCE(agent_type, '') != 'dispatcher' then evaluates to '' != 'dispatcher'
+# -> TRUE, so the row was NOT excluded pre-fix — it got counted as a pending
+# subagent by periodic-self-check.sh (and any other DISPATCHER_EXCLUSION_SQL
+# caller) on every query, forever, producing a permanent false-positive
+# "[1 agents pending]" self-check every 3 minutes with zero real subagents
+# running. These tests reproduce that exact row shape and confirm the id
+# fallback now excludes it.
+# ---------------------------------------------------------------------------
+
+def _dispatcher_row_with_null_agent_type() -> dict:
+    """The exact row shape reported in issue #2226's live reproduction."""
+    return {
+        "id": DISPATCHER_AGENT_ID,
+        "agent_type": None,
+        "status": "running",
+        "chat_id": "6645894734",
+        "description": "Lobster dispatcher main loop",
+    }
+
+
+def test_is_dispatcher_row_excludes_null_agent_type_via_id_fallback():
+    """The bug reproduction: is_dispatcher_row() must return True for the
+    dispatcher's row even when agent_type is NULL, via the id fallback."""
+    assert is_dispatcher_row(_dispatcher_row_with_null_agent_type()) is True
+
+
+def test_is_dispatcher_row_id_fallback_does_not_swallow_real_null_type_subagent():
+    """A real subagent with a NULL/missing agent_type (legacy row, or a
+    subagent type that was never set) must still NOT be treated as the
+    dispatcher — the id fallback only fires for the exact static agent_id."""
+    assert is_dispatcher_row({"id": "real-subagent-001", "agent_type": None}) is False
+
+
+def _make_agent_sessions_db(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE agent_sessions (
+            id TEXT PRIMARY KEY,
+            agent_type TEXT,
+            status TEXT NOT NULL DEFAULT 'running'
+        )
+        """
+    )
+
+
+def _pending_count(conn: sqlite3.Connection) -> int:
+    """Mirror periodic-self-check.sh's PENDING_COUNT query exactly."""
+    cursor = conn.execute(
+        f"""
+        SELECT COUNT(*) FROM agent_sessions
+        WHERE status IN ('running','starting') AND {DISPATCHER_EXCLUSION_SQL}
+        """
+    )
+    return cursor.fetchone()[0]
+
+
+def test_pending_count_sql_excludes_dispatcher_row_with_null_agent_type():
+    """Reproduces the false-positive count reported live in issue #2226
+    directly against the shared SQL fragment (not just the Python predicate),
+    since periodic-self-check.sh queries agent_sessions.db with this exact
+    fragment via raw sqlite3, bypassing is_dispatcher_row() entirely.
+
+    Pre-fix, this row (matching the live DB dump in the issue) would be
+    counted, producing PENDING_COUNT=1 with zero real subagents running.
+    """
+    conn = sqlite3.connect(":memory:")
+    _make_agent_sessions_db(conn)
+    conn.execute(
+        "INSERT INTO agent_sessions (id, agent_type, status) VALUES (?, NULL, 'running')",
+        (DISPATCHER_AGENT_ID,),
+    )
+    conn.commit()
+
+    assert _pending_count(conn) == 0
+
+
+def test_pending_count_sql_still_counts_real_subagent_alongside_null_dispatcher_row():
+    """The fix must not over-exclude: a real pending subagent must still be
+    counted even while the dispatcher's NULL-agent_type row is present."""
+    conn = sqlite3.connect(":memory:")
+    _make_agent_sessions_db(conn)
+    conn.execute(
+        "INSERT INTO agent_sessions (id, agent_type, status) VALUES (?, NULL, 'running')",
+        (DISPATCHER_AGENT_ID,),
+    )
+    conn.execute(
+        "INSERT INTO agent_sessions (id, agent_type, status) VALUES ('real-subagent-001', 'subagent', 'running')"
+    )
+    conn.commit()
+
+    assert _pending_count(conn) == 1

--- a/tests/unit/test_ghost_detector_dispatcher_exclusion.py
+++ b/tests/unit/test_ghost_detector_dispatcher_exclusion.py
@@ -193,6 +193,39 @@ class TestLoadRunningAgentsExcludesDispatcher:
 
         assert [r.agent_id for r in rows] == ["legacy-row"]
 
+    def test_dispatcher_row_with_null_agent_type_still_excluded(self, tmp_path: Path) -> None:
+        """Issue #2226: the dispatcher's own row must be excluded even when
+        agent_type is NULL (session_start()'s agent_type param is optional;
+        the dispatcher's bootup call can omit it).
+
+        Distinguishes from test_null_agent_type_row_still_included() above by
+        agent_id: 'legacy-row' (a real, non-dispatcher row with no agent_type
+        set) must still be returned, but 'lobster-dispatcher' with the same
+        NULL agent_type must not — the id fallback in DISPATCHER_EXCLUSION_SQL
+        is what tells them apart.
+        """
+        db_path = tmp_path / "agent_sessions.db"
+        _make_agent_sessions_db(db_path)
+
+        _insert_row(
+            db_path,
+            agent_id="lobster-dispatcher",
+            agent_type=None,
+            spawned_at=(NOW - timedelta(minutes=1)).isoformat(),
+            description="Lobster dispatcher main loop",
+        )
+        _insert_row(
+            db_path,
+            agent_id="real-subagent-001",
+            agent_type="subagent",
+            spawned_at=(NOW - timedelta(minutes=5)).isoformat(),
+            output_file="/tmp/real-subagent-001.output",
+        )
+
+        rows = gd.load_running_agents(db_path)
+
+        assert [r.agent_id for r in rows] == ["real-subagent-001"]
+
 
 class TestFullPipelineDispatcherRaceReproduction:
     """End-to-end reproduction of the restart race through the same sequence


### PR DESCRIPTION
## Problem

Since the dispatcher restarted at ~04:24 UTC on 2026-08-13, `periodic-self-check.sh` (cron, every 3 min) has been injecting `status? (Self-check) [1 agents pending]` into the inbox every single cycle, indefinitely, with zero real subagent work in flight — confirmed still firing live at the time this issue was filed.

`agent_type` is an *optional* parameter on the `session_start` MCP tool. When the dispatcher's own bootup `session_start(agent_id="lobster-dispatcher", ...)` call omits it, the row lands in `agent_sessions.db` with `agent_type=NULL`. `DISPATCHER_EXCLUSION_SQL`'s `COALESCE(agent_type, '') != 'dispatcher'` then evaluates to `'' != 'dispatcher'` → `TRUE`, so the row is **not** excluded, and gets counted as a pending agent on every 3-minute cycle.

This is the same "dispatcher's own row miscounted as a subagent" bug class documented in `docs/engineering-lessons-learned.md` ("Dispatcher-Exclusion Bug"), now confirmed as its **7th** occurrence (issue #781, PR #2099, PR #2103, PR #2152/issue #2176 ×2, and now this). `scripts/agent-monitor.py`'s `_is_dispatcher_agent()` had already closed this exact gap for its own call site via a belt-and-suspenders `agent_id` check (issue #2176) — but that fix lived only at that one call site.

## What changed

Applies the same belt-and-suspenders fallback **once, at the shared source of truth**, so every call site that already depends on it is protected simultaneously instead of patching `periodic-self-check.sh` alone and leaving the same gap open at the other five:

- `src/utils/agent_types.py` — adds `DISPATCHER_AGENT_ID = "lobster-dispatcher"`; `DISPATCHER_EXCLUSION_SQL` now also excludes `id = 'lobster-dispatcher'`; `is_dispatcher_row()` now falls back to the `id` check when `agent_type` is `None`
- `scripts/lib/agent_sessions.sh` — mirrors the same extension for the shell-side fragment (sourced directly by `periodic-self-check.sh` via raw `sqlite3`, bypassing the Python module entirely)
- `scripts/agent-monitor.py` — now imports `DISPATCHER_AGENT_ID` from `utils.agent_types` instead of hand-copying the literal `"lobster-dispatcher"`, removing one more duplicate definition of the same value

Because `DISPATCHER_EXCLUSION_SQL` / `is_dispatcher_row()` is the single shared definition consumed by `session_store.py` (x2), `inbox_server.py` (x2), `agent-monitor.py`, `health-check-v3.sh`, and `periodic-self-check.sh`, this one change closes the NULL-`agent_type` gap at all of them, not just the one that was reported firing live.

## Functional patterns

`is_dispatcher_row()` remains a pure predicate over an immutable session dict — no new mutation introduced. `DISPATCHER_EXCLUSION_SQL` stays a plain composed string constant (data, not control flow), so the belt-and-suspenders `id` clause is additive rather than a rewrite of the existing check. The `agent-monitor.py` change replaces a hand-copied constant with an import, reducing duplicate state rather than adding any.

## Out of scope

The issue also suggested (as an alternative, "ideally both") wiring `hooks/write-dispatcher-session-id.py` into `SessionStart` as defense-in-depth. While investigating I found `scripts/upgrade.sh`'s Migration 86 actively *removes* that hook from existing installs ("no longer needed... deleted entirely", issue #1908) while `install.sh` still wires it in on fresh installs — a pre-existing, unrelated contradiction in the repo's own hook-wiring logic, unconnected to the bug this PR fixes. Reconciling that is a separate investigation; the fix in this PR fully resolves the reported false-positive on its own, independent of that hook's wiring state.

No behavior change to anything else in `periodic-self-check.sh`, `health-check-v3.sh`, `session_store.py`, or `inbox_server.py` — only the shared exclusion predicate gained the `id` fallback.

## Tests run

- [x] `uv run pytest tests/unit/test_agent_types.py tests/unit/test_ghost_detector_dispatcher_exclusion.py tests/unit/test_mcp_server/test_ghost_session_fixes.py tests/unit/test_agent_monitor_pid_liveness.py` — 82 passed (new: 5 tests reproducing the NULL-`agent_type` false positive at the Python-predicate, raw-SQL-fragment, and `load_running_agents()` query-boundary levels, plus 1 negative case confirming a real subagent with `agent_type=None` is *not* swallowed by the `id` fallback)
- [x] `bash tests/test-periodic-self-check-dispatcher-null-agent-type.sh` — 6 passed (new file: sources the real shared shell fragment and runs periodic-self-check.sh's exact `PENDING_COUNT` query against a DB shaped like the live bug report, plus a regression case for the already-working `agent_type='dispatcher'` path and a syntax check)
- [x] `bash tests/test-health-check-count-active-subagents.sh` — 6 passed (added 1 case: `count_active_subagents()` — a second call site sharing the same fragment — also now excludes a NULL-`agent_type` dispatcher row)
- [x] `uv run pytest tests/unit/` (full suite) — 4379 passed, 45 failed, 32 skipped. All 45 failures are pre-existing and unrelated (migration/PII-scan/push-token-endpoint/context-monitor tests) — confirmed by running the same failing files against an unmodified `origin/main` checkout, which reproduces the identical 7 failures checked directly (`test_on_compact_write_claude_session_id.py`); the rest are the same class of environment-dependent tests untouched by this diff.
- [x] `uv run ruff check` on all touched Python files — 18 pre-existing style findings before and after this diff (byte-identical list except line-number shifts); zero new findings introduced.
- [x] `bash -n` syntax check on all touched/added shell files — clean.

**Falsifiability check:** stashed the three source changes (`src/utils/agent_types.py`, `scripts/lib/agent_sessions.sh`, `scripts/agent-monitor.py`) and reran the new tests — `test_agent_types.py` failed to import (`DISPATCHER_AGENT_ID` doesn't exist pre-fix), and `test-periodic-self-check-dispatcher-null-agent-type.sh` failed 2/6 with the exact wrong counts (`expected '0', got '1'`, `expected '1', got '2'`) — then restored the fix and reran everything clean.

## Manual test

This is a cron script (`periodic-self-check.sh`) that reads/writes real filesystem state (`agent_sessions.db`, the inbox directory), so automated tests alone aren't sufficient evidence — ran the actual script end-to-end, not just the extracted query:

1. Built a throwaway `agent_sessions.db` with the exact row shape from the live bug report (`id='lobster-dispatcher'`, `agent_type=NULL`, `status='running'`) in an isolated temp `LOBSTER_MESSAGES` dir, with `AGENT_TASKS_DIR` pointed at an empty directory to isolate the run from this instance's own real completed-task files.
2. **Pre-fix** (source changes stashed): ran `scripts/periodic-self-check.sh` against that DB for real — it wrote `{"text": "status? (Self-check) [1 agents pending]", ...}` into the temp inbox, reproducing the exact reported symptom byte-for-byte.
3. **Post-fix** (restored): ran the identical script against the identical DB — inbox stayed empty (0 files), confirming the fix closes the gap through the real script, not just the unit-tested fragment.
4. Note: `periodic-self-check.sh`'s rate-limit guard (`STATE_DIR="$LOBSTER_INSTALL_DIR/.state"`) is not overridable via `LOBSTER_MESSAGES`/`HOME` alone — I had to clear `$REPO/.state/last-self-check` between runs to avoid the 2-minute cooldown silently short-circuiting the second run. That state file is gitignored (`.state/` in `.gitignore`) and isn't part of this diff.

No Telegram-facing output changes — this is a pure bugfix to when a system-source inbox message gets injected, not to Telegram delivery itself. Nothing here required a live Telegram send to verify.

## Side-effect audit

- No floods, no unscoped writes: all test/manual-verification DB and inbox writes were confined to `mktemp -d` temp directories, cleaned up after each run.
- No production `agent_sessions.db` or inbox writes at any point — the manual test never touched the real `~/messages/` or `~/lobster-workspace/data/agent_sessions.db`.
- No external service calls in this change or its verification.

## Definition of Done

- [x] Unit tests pass with proper mocking (in-memory SQLite / `tmp_path` fixtures throughout — no production DB touched)
- [x] Manual/E2E test run — see above; real script, isolated temp state, both pre-fix and post-fix behavior directly observed
- [x] User-visible outcome: not directly applicable (no new Telegram-facing behavior) — the fix stops an existing false-positive system message from being generated in the first place; verified via the manual test's before/after inbox contents rather than a Telegram send
- [x] Side-effect audit complete: no floods, no unscoped writes, no unintended volume
- [x] External service calls: none in this PR

Closes #2226