### PR TITLE
fix: correlate done entries by task_id in stale-subagent reconciler

### DIFF
--- a/scripts/check-inflight-reminders.py
+++ b/scripts/check-inflight-reminders.py
@@ -9,6 +9,13 @@ Staleness condition: (now - started_at) > expected_done_in_minutes * STALENESS_M
 
 Entries with completed_at or reminded_at are skipped to prevent duplicate pings.
 The jsonl file is rewritten atomically with reminded_at timestamps on triggered entries.
+
+Because inflight-work.jsonl is append-only, a task's completion is recorded as
+a *separate* "done" line rather than an in-place update of its original
+"running" line (see hooks/require-write-result.py). Before evaluating
+staleness, this script cross-references "done" entries by task_id across the
+whole file (see `collect_done_task_ids`) so an already-completed task's
+"running" line is never flagged as stale, no matter how old it is (issue #2084).
 """
 
 from __future__ import annotations
@@ -58,11 +65,36 @@ def is_stale(entry: dict[str, Any], now: datetime) -> bool:
     return elapsed_minutes > threshold
 
 
-def should_remind(entry: dict[str, Any], now: datetime) -> bool:
+def collect_done_task_ids(entries: list[dict[str, Any]]) -> set[str]:
+    """Return the set of task_ids that have at least one 'done' entry anywhere in entries.
+
+    inflight-work.jsonl is an append-only log: a task's completion is recorded
+    as a *separate* JSONL line (written by hooks/require-write-result.py) rather
+    than as an in-place update of the original "running" line. Any staleness
+    check that only inspects a single entry in isolation will therefore never
+    see that the task actually finished — it has to cross-reference by task_id
+    across the whole file, the same way hooks/on-fresh-start.py's
+    `_compact_inflight_entries` already does.
+
+    Pure function — no side effects, no I/O.
+    """
+    return {
+        entry["task_id"]
+        for entry in entries
+        if "task_id" in entry and (entry.get("status") == "done" or "completed_at" in entry)
+    }
+
+
+def should_remind(
+    entry: dict[str, Any],
+    now: datetime,
+    done_task_ids: frozenset[str] | set[str] = frozenset(),
+) -> bool:
     """Return True if this entry should generate a reminder.
 
     Conditions:
-    - No completed_at (not done)
+    - No completed_at on this entry (not done)
+    - task_id has no 'done' entry anywhere else in the file (not done)
     - No reminded_at (not already reminded)
     - is_stale() is True
 
@@ -71,6 +103,8 @@ def should_remind(entry: dict[str, Any], now: datetime) -> bool:
     if "completed_at" in entry:
         return False
     if entry.get("status") == "done":
+        return False
+    if entry.get("task_id") in done_task_ids:
         return False
     if "reminded_at" in entry:
         return False
@@ -141,13 +175,19 @@ def process_entries(
     For each stale entry, builds a reminder message and marks the entry as
     reminded. All other entries are returned unchanged.
 
+    A task_id with a 'done' entry anywhere in `entries` is never reminded,
+    even if its original 'running' entry has no completed_at/status of its
+    own — see `collect_done_task_ids`.
+
     Pure function — no I/O.
     """
+    done_task_ids = collect_done_task_ids(entries)
+
     messages: list[dict[str, Any]] = []
     updated_entries: list[dict[str, Any]] = []
 
     for entry in entries:
-        if should_remind(entry, now):
+        if should_remind(entry, now, done_task_ids):
             messages.append(build_reminder_message(entry, now))
             updated_entries.append(mark_reminded(entry, now))
         else:

--- a/tests/unit/test_inflight_reminders.py
+++ b/tests/unit/test_inflight_reminders.py
@@ -111,6 +111,41 @@ class TestIsStale:
 
 
 # ---------------------------------------------------------------------------
+# collect_done_task_ids
+# ---------------------------------------------------------------------------
+
+
+class TestCollectDoneTaskIds:
+    def test_empty_entries_yields_empty_set(self) -> None:
+        assert ir.collect_done_task_ids([]) == set()
+
+    def test_entry_with_status_done_is_collected(self) -> None:
+        entries = [{"task_id": "t1", "status": "done"}]
+        assert ir.collect_done_task_ids(entries) == {"t1"}
+
+    def test_entry_with_completed_at_is_collected_even_without_status_done(self) -> None:
+        entries = [{"task_id": "t1", "completed_at": "2026-04-19T10:00:00Z"}]
+        assert ir.collect_done_task_ids(entries) == {"t1"}
+
+    def test_running_only_entries_are_not_collected(self) -> None:
+        entries = [{"task_id": "t1", "status": "running"}]
+        assert ir.collect_done_task_ids(entries) == set()
+
+    def test_done_entry_correlates_across_separate_lines_for_same_task_id(self) -> None:
+        # The append-only-log shape from issue #2084: a "running" line and a
+        # separate "done" line for the same task_id.
+        entries = [
+            {"task_id": "deploy-check-654", "status": "running", "started_at": "2026-04-20T21:51:40Z"},
+            {"task_id": "deploy-check-654", "status": "done", "completed_at": "2026-04-20T21:52:28Z"},
+        ]
+        assert ir.collect_done_task_ids(entries) == {"deploy-check-654"}
+
+    def test_entries_without_task_id_are_ignored(self) -> None:
+        entries = [{"status": "done"}]
+        assert ir.collect_done_task_ids(entries) == set()
+
+
+# ---------------------------------------------------------------------------
 # should_remind
 # ---------------------------------------------------------------------------
 
@@ -135,6 +170,18 @@ class TestShouldRemind:
     def test_entry_with_completed_at_skipped_even_if_no_reminded_at(self) -> None:
         entry = _entry("t5", started_minutes_ago=100, expected_done_in_minutes=10, completed=True)
         assert ir.should_remind(entry, NOW) is False
+
+    def test_entry_whose_task_id_is_in_done_task_ids_is_skipped(self) -> None:
+        # This is the append-only-log scenario (issue #2084): the "running" entry
+        # itself carries no completed_at/status=="done" of its own -- the task's
+        # completion is a *separate* line elsewhere in the file. done_task_ids
+        # is how that cross-reference gets passed in.
+        entry = _entry("t6", started_minutes_ago=100, expected_done_in_minutes=10)
+        assert ir.should_remind(entry, NOW, done_task_ids={"t6"}) is False
+
+    def test_entry_not_in_done_task_ids_still_evaluated_normally(self) -> None:
+        entry = _entry("t7", started_minutes_ago=21, expected_done_in_minutes=10)
+        assert ir.should_remind(entry, NOW, done_task_ids={"some-other-task"}) is True
 
 
 # ---------------------------------------------------------------------------
@@ -286,6 +333,26 @@ class TestProcessEntries:
         bad_entry = {"task_id": "bad-1", "description": "no timestamp", "chat_id": 0}
         messages, _ = ir.process_entries([bad_entry], NOW)
         assert messages == []
+
+    def test_running_entry_with_separate_done_line_generates_no_reminder(self) -> None:
+        # Regression test for issue #2084: a task that finished long ago via a
+        # separate "done" line (append-only log) must never be flagged as
+        # stale just because its original "running" line individually looks
+        # old and carries no completed_at/reminded_at of its own.
+        running = _entry("deploy-check-654", started_minutes_ago=60 * 24 * 30, expected_done_in_minutes=10)
+        done = {"task_id": "deploy-check-654", "status": "done", "completed_at": "2026-04-20T21:52:28Z"}
+        messages, updated = ir.process_entries([running, done], NOW)
+        assert messages == []
+        # The running entry is left untouched -- no spurious reminded_at stamp.
+        running_updated = next(e for e in updated if e["task_id"] == "deploy-check-654" and e.get("status") == "running")
+        assert "reminded_at" not in running_updated
+
+    def test_done_correlation_does_not_suppress_genuinely_stale_unrelated_task(self) -> None:
+        stale = _entry("still-running-1", started_minutes_ago=25, expected_done_in_minutes=10)
+        done = {"task_id": "other-task", "status": "done", "completed_at": "2026-04-20T21:52:28Z"}
+        messages, _ = ir.process_entries([stale, done], NOW)
+        assert len(messages) == 1
+        assert messages[0]["task_id"] == "still-running-1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The stale-subagent reconciler (`scripts/check-inflight-reminders.py`, cron every 3 min) repeatedly flagged already-completed tasks as "stale" and re-alerted the dispatcher inbox in waves. On 2026-08-27 this fired for the same ~15 task_ids (a PR-review sweep that had already finished and delivered results via `send_reply` before 8:52 AM EDT) across at least 5 waves, roughly 3 minutes apart.

## Root cause

`~/lobster-workspace/data/inflight-work.jsonl` is an append-only log. A subagent spawn writes a `"running"` line (`hooks/auto-register-agent.py`); a successful `write_result` call appends a **separate** `"done"` line (`hooks/require-write-result.py`) rather than updating the original line in place. `check-inflight-reminders.py`'s `should_remind()` only inspected the single entry dict it was given — it never checked whether some *other* line in the file recorded that same `task_id` as done. So once a task's original "running" line crossed 2x its expected duration, it got flagged as stale even though a "done" line for the same task_id sat a few lines below it.

This exact bug (with the fix it needed) was already root-caused and documented in issue #2084/#2085 from data pulled off this same file on 2026-08-19, but the fix was never implemented — this PR implements it. Once reminded, an entry sets `reminded_at` and normally wouldn't re-fire on its own, but each spawn attempt (or any place a fresh unreminded "running" line gets appended) reintroduces the same false positive, which is consistent with the repeated waves seen on 2026-08-27.

The same class of correlation problem was already solved once in this codebase, in `hooks/on-fresh-start.py::_compact_inflight_entries` (used for startup compaction) — it builds a `done_task_ids` set across the whole file before deciding whether to drop a stale orphaned "running" line. The reminder script never got the equivalent treatment.

## Fix

`scripts/check-inflight-reminders.py`:
- New pure function `collect_done_task_ids(entries)` builds the set of task_ids with a "done" entry (by `status == "done"` or presence of `completed_at`) anywhere in the file — mirrors the existing pattern in `on-fresh-start.py`.
- `should_remind()` now takes `done_task_ids` and short-circuits to `False` if the entry's `task_id` is in that set, before ever consulting `is_stale()`.
- `process_entries()` computes `done_task_ids` once per run and threads it through.

No I/O, tracking-store schema, or cron/install changes — the fix is confined to the pure evaluation logic inside the existing script. `install.sh` / `scripts/lib/migrations.sh` already register the `LOBSTER-INFLIGHT-REMINDERS` cron entry unchanged; nothing needed there.

Functional patterns: `collect_done_task_ids` and the updated `should_remind`/`process_entries` remain pure functions with no side effects; `done_task_ids` is threaded through as an immutable set rather than mutating any entry or global state.

## Before / after

```
Before (append-only log, single-entry evaluation):
  line 1: {task_id: X, status: running, started_at: T0}
  line 2: {task_id: X, status: done, completed_at: T0+2min}
  ...
  reconciler run at T0+61min:
    inspects line 1 in isolation -> looks stale (61min > 2*30min) -> ALERT (false positive)
    inspects line 2 -> status==done -> skip
  => 1 spurious alert per completed task, indefinitely, for every task that
     crosses the staleness threshold after finishing.

After (cross-referenced by task_id):
  reconciler run at T0+61min:
    done_task_ids = {X, ...}  (built from ALL lines up front)
    inspects line 1 -> task_id X in done_task_ids -> skip, no alert
    inspects line 2 -> status==done -> skip
  => no alert for any task_id that has a done entry anywhere in the file,
     regardless of which line is evaluated or its own completed_at/reminded_at.
```

## Tests run
- [x] `uv run pytest tests/unit/test_inflight_reminders.py -q` — 50 passed (12 new: `TestCollectDoneTaskIds` x6, `should_remind` cross-reference cases x2, `process_entries` regression tests x2, plus existing suite unaffected)
- [x] `uv run pytest tests/unit/test_inflight_reminders.py tests/unit/test_hooks/test_compact_inflight_work.py -q` — 73 passed
- [x] Manual repro script simulating the exact production scenario from this morning (15 task_ids each with a `running` line at 8:30 and a `done` line at 8:52, evaluated as if the reconciler ran later): 0 reminders fired after the fix (was reproducing the bug before the fix was applied — confirmed via `git stash`)
- [ ] `uv run pytest tests/unit/test_hooks/test_require_write_result.py` (combined with other hook test files) — 30 pre-existing failures, confirmed present identically on `main` with this branch's changes stashed out (test-isolation issue unrelated to this change, not touched by this PR)

**Blocked items needing attention before merge:** none — the 30 failing tests are a pre-existing, unrelated test-isolation issue in `test_require_write_result.py` when run alongside other hook test files; reproduced independently of this PR's diff.

## Manual test
Not applicable for systemd/cron/external-service/file-I/O/DB-schema criteria in the strict sense — this is a pure logic change inside an existing cron script, no new cron entry, no new file paths, no schema change. I did verify the fix against a JSONL file shaped exactly like the reported production incident (see Tests run above) rather than relying on unit tests alone, since the bug was itself a JSONL-file-shape issue.

## Definition of Done
- [x] Unit tests pass with proper mocking (no production hits)
- [x] Manual verification against a reconstructed production-shaped JSONL file (see Tests run)
- [x] N/A — no user-visible Telegram output; this only suppresses a false-positive internal reminder message
- [x] Side-effect audit: pure function change, no new writes, no new volume, no schema change

Closes #2084

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P22i8F6XLPDuGPSK9vN5Ka