### PR TITLE
fix: replace dead ADMIN_CHAT_ID_REDACTED literal with <ADMIN_CHAT_ID> token

### DIFF
--- a/.claude/sys.debug.dispatcher.bootup.md
+++ b/.claude/sys.debug.dispatcher.bootup.md
@@ -16,7 +16,7 @@ Task(
     prompt="""
 ---
 task_id: debug-branch-check
-chat_id: ADMIN_CHAT_ID_REDACTED
+chat_id: <ADMIN_CHAT_ID>
 source: system
 ---
 
@@ -25,7 +25,7 @@ Check the git branch of ~/lobster/ and report the result.
 Steps:
 1. Run: git -C ~/lobster branch --show-current
 2. If the branch is NOT 'local-dev':
-   - call send_reply(chat_id=ADMIN_CHAT_ID_REDACTED, text="BRANCH ALERT: ~/lobster/ is on '<branch>' — expected local-dev. Debug mode is active but the local-dev fixes are NOT running. Run: git -C ~/lobster checkout local-dev")
+   - call send_reply(chat_id=<ADMIN_CHAT_ID>, text="BRANCH ALERT: ~/lobster/ is on '<branch>' — expected local-dev. Debug mode is active but the local-dev fixes are NOT running. Run: git -C ~/lobster checkout local-dev")
 3. If the branch IS 'local-dev': no action needed (do not send a reply)
 4. call write_result(task_id='debug-branch-check', chat_id=0, source='system', text='Branch check complete. Branch: <branch>. Alert sent: <yes/no>.', status='success')
 """,
@@ -68,7 +68,7 @@ the subagent already sent the alert if the branch was wrong. Just
 ## Debug-Mode Alerting Policy
 
 When an invariant check fails in debug mode, **always alert the instance owner immediately**
-via `send_reply(chat_id=ADMIN_CHAT_ID_REDACTED, ...)`. Do not wait for the user to ask.
+via `send_reply(chat_id=<ADMIN_CHAT_ID>, ...)`. Do not wait for the user to ask.
 
 The branch invariant is critical: if `~/lobster/` is on `main` in debug mode,
 every fix from `local-dev` is absent and the system is silently degraded.

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -946,14 +946,14 @@ Route them directly to the owner's Telegram as a formatted notification:
 ```
 text = f"📨 From {msg['from']} via LobsterTalk:\n\n{msg['text']}"
 send_reply(
-    chat_id=ADMIN_CHAT_ID_REDACTED,  # ADMIN_CHAT_ID
+    chat_id=<ADMIN_CHAT_ID>,  # ADMIN_CHAT_ID
     source="telegram",
     text=text,
     reply_to_message_id=msg.get("telegram_message_id"),
 )
 ```
 
-The `from` field carries sender identity (e.g. `"AlbertLobster"`). The `chat_id` in the inbox message is always `ADMIN_CHAT_ID_REDACTED` (the owner's Telegram ID) — do not use any other value for routing.
+The `from` field carries sender identity (e.g. `"AlbertLobster"`). The `chat_id` in the inbox message is always `<ADMIN_CHAT_ID>` (the owner's Telegram ID) — do not use any other value for routing.
 
 ---
 


### PR DESCRIPTION
## Problem

A PII-redaction commit (`27620497`) blunt-replaced a real chat-ID literal with the dead string `ADMIN_CHAT_ID_REDACTED`, instead of the `<ADMIN_CHAT_ID>` template token used correctly everywhere else in the same files. This broke the debug-mode branch-invariant alerting path: `send_reply(chat_id="ADMIN_CHAT_ID_REDACTED", ...)` targets a non-existent chat_id and silently fails to deliver, defeating the entire purpose of the invariant check (added in #943 after a prior 10-hour production gap).

## Fix

Straight find/replace of the dead literal with the template token already used everywhere else in these two files, matching the surrounding convention (e.g. `sys.dispatcher.bootup.md` lines 27-42, which read `chat_id=<ADMIN_CHAT_ID>` and describe it as injected by `inject-bootup-context.py` at session start):

- `.claude/sys.debug.dispatcher.bootup.md` — 3 occurrences (branch-check subagent's `task_id`/`chat_id` frontmatter, the `send_reply` call inside its prompt, and the alerting-policy prose)
- `.claude/sys.dispatcher.bootup.md` — 2 occurrences (the bot-talk routing example's `send_reply` call, and the prose describing the inbox message's `chat_id` field)

No logic, structure, or unrelated content changed — this is a documentation/prompt-template correction only. `<ADMIN_CHAT_ID>` is resolved live from context at session start; it was never meant to be a literal string.

Closes #2168
Closes #2173

## Out of scope

Two other occurrences of the same dead string exist outside the files named in these issues (`docs/DEVELOPMENT.md:115` and `lobster-shop/email-autoresponder/context/reference.md:197`). Left untouched per the issue's explicit scope ("Do not touch anything else — this is a narrow find/replace, not a refactor"). Worth a follow-up issue if they represent the same bug.

## Tests run

This is a Markdown prompt-template fix with no executable code path — there is no test suite that exercises these files' prose. Verification performed instead:

- [x] `grep -rn "ADMIN_CHAT_ID_REDACTED" .claude/sys.debug.dispatcher.bootup.md .claude/sys.dispatcher.bootup.md` — zero matches after the fix
- [x] `git diff` reviewed line-by-line — confirms only the 5 targeted literal-token substitutions changed, no other content touched
- [x] Cross-checked replacement token against known-correct usages in the same files (`sys.dispatcher.bootup.md` lines 27-42) to confirm `<ADMIN_CHAT_ID>` is the right convention, not a different placeholder style

## Manual test

N/A — no systemd, cron, external service, file I/O, or DB schema changes. This PR only edits prompt-template Markdown consumed by future dispatcher sessions; there is no runtime behavior to exercise until a debug-mode dispatcher session actually starts and hits the branch-invariant-check path (which itself only fires when `~/lobster/` is off `local-dev` in debug mode).

## Definition of Done

- [x] N/A — no executable code or external service calls in this diff (see Tests run / Manual test above)