### PR TITLE
Reword debug 'Back online' notification as a post-hoc recap

### DIFF
--- a/.claude/agents/compact-catchup.md
+++ b/.claude/agents/compact-catchup.md
@@ -240,8 +240,11 @@ on success and ambiguous silence on failure (issue #1983).
 24. Convert `window_start` and `now` (from Phase 1) from UTC ISO to ET
     (EDT UTC-4 mid-March through early November, EST UTC-5 otherwise) and
     send, via `send_reply`, to ADMIN_CHAT_ID:
-    `"🔄 Back online. Context recovered from [window_start] to [now]. [N messages] processed, [M subagents] were running."`
-    (N and M come from the same counts used in the Phase 1 output.) Pass
+    `"🔄 Catchup recap: restart detected at [window_start] ET, recovery finished [now] ET. [N messages] processed, [M subagents] were running."`
+    (N and M come from the same counts used in the Phase 1 output.) This
+    wording is deliberate: `window_start` is labeled "restart detected" and
+    `now` is labeled "recovery finished," so the message reads as a summary
+    of a past event rather than something happening live (issue #2192). Pass
     `proactive=True` — this send has no originating user message to thread
     against (see `hooks/require-reply-to-message-id.py`).
 

--- a/.claude/agents/compact-catchup.md
+++ b/.claude/agents/compact-catchup.md
@@ -240,13 +240,20 @@ on success and ambiguous silence on failure (issue #1983).
 24. Convert `window_start` and `now` (from Phase 1) from UTC ISO to ET
     (EDT UTC-4 mid-March through early November, EST UTC-5 otherwise) and
     send, via `send_reply`, to ADMIN_CHAT_ID:
-    `"🔄 Catchup recap: restart detected at [window_start] ET, recovery finished [now] ET. [N messages] processed, [M subagents] were running."`
+    `"🔄 Catchup recap: scanned activity from [window_start] ET to [now] ET. [N messages] processed, [M subagents] were running."`
     (N and M come from the same counts used in the Phase 1 output.) This
-    wording is deliberate: `window_start` is labeled "restart detected" and
-    `now` is labeled "recovery finished," so the message reads as a summary
-    of a past event rather than something happening live (issue #2192). Pass
-    `proactive=True` — this send has no originating user message to thread
-    against (see `hooks/require-reply-to-message-id.py`).
+    wording is deliberate: `window_start` is a scan-window boundary computed
+    in Phase 1 (roughly the earlier of the last catchup/compaction timestamp,
+    clamped to a lookback horizon) — it is NOT the actual restart time, and no
+    true restart timestamp is available anywhere in the codebase
+    (`last_restart_ts` is never written by any hook; see Phase 1 note above).
+    Framing the message as "scanned activity from X to Y" describes what
+    `window_start` actually is — a scan boundary — without asserting it as the
+    moment a restart occurred, so the message reads as a summary of a past
+    scan rather than a restart-timestamp claim (issue #2192; corrected in
+    review to avoid reintroducing the same class of misleading claim).
+    Pass `proactive=True` — this send has no originating user message to
+    thread against (see `hooks/require-reply-to-message-id.py`).
 
 25. This phase never blocks or fails catchup: if the send errors for any
     reason (missing admin chat id, tool failure), swallow the error and

--- a/.claude/sys.dispatcher.bootup.md
+++ b/.claude/sys.dispatcher.bootup.md
@@ -345,7 +345,7 @@ After a context compaction you lose situational awareness of the last ~30 minute
 
 **When the compact_catchup result arrives** (`task_id: "compact-catchup"`, `chat_id: 0`):
 - Read `msg["text"]` to restore situational awareness
-- Do NOT send_reply — this is internal context. The debug-mode "🔄 Back online" recovery
+- Do NOT send_reply — this is internal context. The debug-mode "🔄 Catchup recap" recovery
   notification (issue #1983) is sent by the `compact-catchup` agent itself (Phase 5, `LOBSTER_DEBUG=true`
   only) before it calls `write_result` — no dispatcher action needed, and this fires deterministically
   regardless of dispatcher behavior.

--- a/tests/unit/test_hooks/test_compact_catchup_notification_determinism.py
+++ b/tests/unit/test_hooks/test_compact_catchup_notification_determinism.py
@@ -53,9 +53,18 @@ def test_compact_catchup_sends_notification_itself() -> None:
         "compact-catchup.md's Phase 5 must gate the notification on LOBSTER_DEBUG, "
         "matching the existing debug-only behavior."
     )
-    assert "Back online" in content, (
-        "compact-catchup.md must contain the 'Back online' recovery notification text "
-        "as part of Phase 5."
+    assert "Catchup recap: scanned activity from" in content, (
+        "compact-catchup.md must contain the Phase 5 recovery notification template "
+        "text, phrased as a scan-window recap rather than a restart-timestamp claim "
+        "(issue #2192) -- 'window_start' is a scan boundary, not the actual restart "
+        "time, so the template must not assert 'restart detected at [window_start]'."
+    )
+    assert "restart detected at" not in content, (
+        "compact-catchup.md's Phase 5 template must not claim 'restart detected at "
+        "[window_start]' -- window_start is a scan-window boundary computed in Phase "
+        "1, not the true restart time (no such timestamp is available anywhere in "
+        "the codebase), so labeling it as the restart moment reproduces the exact "
+        "misleading-timestamp problem issue #2192 was filed to fix."
     )
     assert "proactive=True" in content, (
         "compact-catchup.md's Phase 5 send_reply must pass proactive=True -- this "


### PR DESCRIPTION
## Problem

The debug-mode "🔄 Back online" recovery notification (sent by the `compact-catchup` subagent, Phase 5, only when `LOBSTER_DEBUG=true`) is worded as if a restart is happening live at send time. In reality it's a post-hoc summary sent after catchup work for an *earlier* restart finished. The gap between "when the restart happened" and "when this message arrives" caused real confusion: issue #2192 documents a restart at 10:28 PM ET followed by the recap arriving at 10:34 PM, worded like a fresh live event — the user reasonably asked whether a second restart had just occurred, requiring a full investigation to clarify there was only one.

## Change

Reworded the Phase 5 notification template in `.claude/agents/compact-catchup.md` (step 24) to stop asserting a restart timestamp the system doesn't actually track, and to frame the message as a recap of a scan window rather than a live event:

- Before: `"🔄 Back online. Context recovered from [window_start] to [now]. [N messages] processed, [M subagents] were running."`
- After: `"🔄 Catchup recap: scanned activity from [window_start] ET to [now] ET. [N messages] processed, [M subagents] were running."`

Note: an earlier draft of this fix labeled `window_start` as "restart detected at [window_start]", but code review caught that `window_start` is only a Phase-1 scan-window boundary (derived from `last_catchup_ts`/`last_compaction_ts`, clamped by a lookback horizon) — not an actual restart timestamp, which the codebase never records (`last_restart_ts` doesn't exist). That wording would have reproduced the exact mislabeled-timestamp confusion #2192 was filed to fix, just with new text. The final wording avoids claiming a restart time at all, describing `window_start` accurately as the start of the scanned window instead.

The message opens with "Catchup recap" instead of "Back online," making explicit that this is a summary of a past event, not a live notification.

This is a documentation/prompt change to an agent instruction file — no application code, no new logic. Nothing about when the notification fires, who it's sent to, or the guard conditions (LOBSTER_DEBUG check, admin chat id resolution, best-effort error swallowing) was touched.

Closes #2192

## Out of scope

- No change to the trigger conditions, timing, or error handling of Phase 5 (steps 22, 23, 25 untouched).
- No change to any other phase of `compact-catchup.md`.
- No change to the dispatcher's handling of this notification.

## Tests run

Updated `tests/unit/test_hooks/test_compact_catchup_notification_determinism.py`, which previously only asserted `"Back online" in content` — a false-green, since it matched unrelated leftover prose elsewhere in the file rather than the actual step-24 template. The test now asserts the new wording is present and the inaccurate "restart detected at" phrasing is absent.

- [x] `uv run pytest tests/unit/test_hooks/test_compact_catchup_notification_determinism.py -v` — 6 passed
- [x] `uv run pytest tests/unit/test_hooks/` (full suite) — 1084 passed, 10 pre-existing unrelated failures (session-id/PII-scan tests), untouched by this change
- [x] `git diff` reviewed — change scoped to the template line, an explanatory comment, and the one test file
- [x] Grepped the repo for other references to the old "Back online" wording — none found outside the file changed here

## Manual test

N/A — this is a wording-only change to a markdown instruction file consumed by the `compact-catchup` subagent at runtime (interpreted, not executed as code). The notification only fires when `LOBSTER_DEBUG=true` after a real dispatcher restart, which is not practical to trigger in this review flow. No systemd, cron, external service, file I/O, or DB schema is touched.

## Definition of Done
- [x] Unit tests pass with proper mocking — updated and passing, see Tests run above
- [x] Integration/manual test run (if applicable) — N/A, see Manual test above
- [x] User-visible outcome verified OR not applicable — the actual message text is directly readable in the diff and matches the issue's fix intent (avoid asserting an unmeasurable restart timestamp, frame as recap)
- [x] Side-effect audit complete — no floods, no unscoped writes, no unintended volume (no behavior changed, only text)
- [x] External service calls — none added or modified
