### PR TITLE
chore: prune stale test_*.json fixtures from ~/messages/failed/

### DIFF
--- a/scripts/cleanup-worktrees-audio.sh
+++ b/scripts/cleanup-worktrees-audio.sh
@@ -13,6 +13,16 @@
 #      AUDIO_RETENTION_DAYS. These files are transcribed and stored as text;
 #      the originals are only retained for debugging and can be safely deleted.
 #
+#   3. Stale synthetic test fixtures in ~/messages/failed/ — the unrecognized-
+#      source quarantine guard in src/mcp/inbox_server.py moves any inbox
+#      message with source="test" to failed/ as `test_<epoch>.json` (issue
+#      #2209). These accumulate indefinitely and drown out genuine quarantined
+#      messages in the same directory. Only files matching the exact
+#      `test_<digits>.json` pattern are removed, and only once older than
+#      FAILED_TEST_FIXTURE_RETENTION_DAYS — every other file in failed/
+#      (including real quarantined messages) is left untouched regardless of
+#      age or name.
+#
 # Usage:
 #   ~/lobster/scripts/cleanup-worktrees-audio.sh
 #
@@ -28,6 +38,9 @@ PROJECTS_DIR="${LOBSTER_PROJECTS:-$WORKSPACE_DIR/projects}"
 # AUDIO_DIR can be overridden directly (useful for tests); falls back to LOBSTER_MESSAGES/audio.
 AUDIO_DIR="${CLEANUP_AUDIO_DIR:-${LOBSTER_MESSAGES:-$HOME/messages}/audio}"
 AUDIO_RETENTION_DAYS="${CLEANUP_AUDIO_RETENTION_DAYS:-7}"
+# FAILED_DIR can be overridden directly (useful for tests); falls back to LOBSTER_MESSAGES/failed.
+FAILED_DIR="${CLEANUP_FAILED_DIR:-${LOBSTER_MESSAGES:-$HOME/messages}/failed}"
+FAILED_TEST_FIXTURE_RETENTION_DAYS="${CLEANUP_FAILED_TEST_FIXTURE_RETENTION_DAYS:-1}"
 
 timestamp() { date '+%Y-%m-%d %H:%M:%S'; }
 
@@ -115,6 +128,40 @@ prune_audio() {
 }
 
 #-------------------------------------------------------------------------------
+# 3. Prune stale synthetic test fixtures from ~/messages/failed/ (issue #2209)
+#    Only files matching the exact `test_<digits>.json` name are candidates;
+#    every other filename in failed/ (including real quarantined messages) is
+#    never touched by this step, regardless of age.
+#-------------------------------------------------------------------------------
+
+prune_failed_test_fixtures() {
+    if [ ! -d "$FAILED_DIR" ]; then
+        info "Failed-messages directory $FAILED_DIR does not exist — skipping"
+        return 0
+    fi
+
+    info "Removing test_<digits>.json fixtures older than ${FAILED_TEST_FIXTURE_RETENTION_DAYS} day(s) from $FAILED_DIR"
+
+    local deleted=0
+    while IFS= read -r -d '' filepath; do
+        rm -f "$filepath"
+        info "Deleted stale test fixture: $filepath"
+        deleted=$(( deleted + 1 ))
+    done < <(find "$FAILED_DIR" \
+        -maxdepth 1 \
+        -type f \
+        -regextype posix-extended -regex '.*/test_[0-9]+\.json' \
+        -mtime "+${FAILED_TEST_FIXTURE_RETENTION_DAYS}" \
+        -print0 2>/dev/null)
+
+    if [ "$deleted" -eq 0 ]; then
+        info "No stale test_<digits>.json fixtures found in $FAILED_DIR"
+    else
+        info "Deleted $deleted stale test fixture(s) from $FAILED_DIR"
+    fi
+}
+
+#-------------------------------------------------------------------------------
 # Main
 #-------------------------------------------------------------------------------
 
@@ -135,6 +182,7 @@ main() {
     prune_worktrees
     prune_pr_worktrees
     prune_audio
+    prune_failed_test_fixtures
     log "=== cleanup-worktrees-audio.sh complete ==="
 }
 

--- a/tests/smoke/test_cleanup_failed_test_fixtures.py
+++ b/tests/smoke/test_cleanup_failed_test_fixtures.py
@@ -1,0 +1,195 @@
+"""
+Smoke tests: scripts/cleanup-worktrees-audio.sh — test-fixture pruning in ~/messages/failed/
+
+Issue #2209: the unrecognized-source quarantine guard in
+src/mcp/inbox_server.py moves any inbox message with source="test" to
+~/messages/failed/ as `test_<epoch>.json` (see
+tests/unit/test_mcp_server/test_unrecognized_source_quarantine.py). These
+synthetic fixtures accumulate indefinitely and drown out genuine quarantined
+messages in the same directory. This adds a `prune_failed_test_fixtures` step
+to the existing daily cleanup cron job to remove them automatically, while
+never touching files that don't match the exact `test_<digits>.json` pattern.
+
+Behaviors verified:
+
+F1. `test_<digits>.json` files older than the retention window are deleted
+    from the failed/ directory.
+F2. `test_<digits>.json` files newer than the retention window are preserved
+    (avoids racing a write that's still in flight).
+F3. Files that do not match the `test_<digits>.json` pattern — including the
+    one known real quarantined message shape — are never deleted, regardless
+    of age.
+F4. Script does not fail if the failed/ directory is missing — it logs a
+    skip message and exits 0.
+F5. Script passes bash -n syntax check.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+CLEANUP_SCRIPT = Path(__file__).parents[2] / "scripts" / "cleanup-worktrees-audio.sh"
+
+# Retention period the tests exercise — must match the script default.
+FAILED_TEST_FIXTURE_RETENTION_DAYS = 1
+
+
+def run_script(env: dict | None = None, **kwargs) -> subprocess.CompletedProcess:
+    """Run the cleanup script with a fully isolated environment overlay.
+
+    We pass a minimal env rather than inheriting the full process env so that
+    paths like HOME, LOBSTER_MESSAGES, etc. don't bleed in from the test runner
+    and cause the script to operate on real directories.
+    """
+    base_env = os.environ.copy()
+    if env:
+        base_env.update(env)
+    return subprocess.run(
+        ["bash", str(CLEANUP_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=base_env,
+        **kwargs,
+    )
+
+
+def isolation_env(tmp_path: Path) -> dict:
+    """Return a minimal env dict that keeps the script confined to tmp_path."""
+    return {
+        "LOBSTER_INSTALL_DIR": str(tmp_path / "lobster-nonexistent"),
+        "LOBSTER_WORKSPACE": str(tmp_path / "workspace"),
+        "LOBSTER_PROJECTS": str(tmp_path / "projects"),
+        "LOBSTER_MESSAGES": str(tmp_path / "messages"),
+    }
+
+
+def make_old_file(path: Path, days_old: int = FAILED_TEST_FIXTURE_RETENTION_DAYS + 1) -> None:
+    """Create a file and backdate its mtime so it appears `days_old` days old."""
+    path.write_text("{}")
+    old_time = time.time() - (days_old * 86400)
+    os.utime(path, (old_time, old_time))
+
+
+def make_new_file(path: Path, days_old: float = 0) -> None:
+    """Create a file dated within the retention window (default: just created)."""
+    path.write_text("{}")
+    recent_time = time.time() - (days_old * 86400)
+    os.utime(path, (recent_time, recent_time))
+
+
+# ---------------------------------------------------------------------------
+# F5: Syntax check (run first — a broken script invalidates all other tests)
+# ---------------------------------------------------------------------------
+
+def test_script_has_no_syntax_errors():
+    """F5: bash -n must exit 0 — a syntax error silently breaks cron."""
+    result = subprocess.run(
+        ["bash", "-n", str(CLEANUP_SCRIPT)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Syntax error in cleanup script:\n{result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F1: Old test_<epoch>.json fixtures are deleted
+# ---------------------------------------------------------------------------
+
+def test_old_test_fixture_is_deleted(tmp_path):
+    """F1: A test_<digits>.json file older than the retention window is removed."""
+    failed_dir = tmp_path / "messages" / "failed"
+    failed_dir.mkdir(parents=True, exist_ok=True)
+
+    old_fixture = failed_dir / "test_1786476577.json"
+    make_old_file(old_fixture)
+    assert old_fixture.exists(), "Pre-condition: file must exist before running script"
+
+    env = isolation_env(tmp_path)
+    env["CLEANUP_FAILED_TEST_FIXTURE_RETENTION_DAYS"] = str(FAILED_TEST_FIXTURE_RETENTION_DAYS)
+
+    result = run_script(env=env)
+    assert result.returncode == 0, f"Script failed:\n{result.stderr}"
+    assert not old_fixture.exists(), "Old test_<digits>.json fixture should have been deleted"
+
+
+# ---------------------------------------------------------------------------
+# F2: Freshly-written test fixtures are preserved (retention window)
+# ---------------------------------------------------------------------------
+
+def test_recent_test_fixture_is_preserved(tmp_path):
+    """F2: A test_<digits>.json file within the retention window is not deleted."""
+    failed_dir = tmp_path / "messages" / "failed"
+    failed_dir.mkdir(parents=True, exist_ok=True)
+
+    recent_fixture = failed_dir / "test_1786769893.json"
+    make_new_file(recent_fixture)
+    assert recent_fixture.exists()
+
+    env = isolation_env(tmp_path)
+    env["CLEANUP_FAILED_TEST_FIXTURE_RETENTION_DAYS"] = str(FAILED_TEST_FIXTURE_RETENTION_DAYS)
+
+    result = run_script(env=env)
+    assert result.returncode == 0, f"Script failed:\n{result.stderr}"
+    assert recent_fixture.exists(), (
+        "Recent test fixture was incorrectly deleted (within retention window)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F3: Non-matching files (including real quarantined messages) are untouched
+# ---------------------------------------------------------------------------
+
+def test_non_matching_files_are_never_deleted(tmp_path):
+    """F3: Only the exact test_<digits>.json pattern is removed; everything else survives, even when old."""
+    failed_dir = tmp_path / "messages" / "failed"
+    failed_dir.mkdir(parents=True, exist_ok=True)
+
+    # Shaped like the one known real quarantined message in production.
+    real_quarantine = failed_dir / "daily-health-20260425-060005.json"
+    # Similar-looking but not an exact match for the test_<digits>.json pattern.
+    near_miss_prefix = failed_dir / "test_run_1786476577.json"
+    near_miss_suffix = failed_dir / "test_1786476577.json.bak"
+    near_miss_nondigit = failed_dir / "test_abc.json"
+
+    for f in (real_quarantine, near_miss_prefix, near_miss_suffix, near_miss_nondigit):
+        make_old_file(f)
+
+    env = isolation_env(tmp_path)
+    env["CLEANUP_FAILED_TEST_FIXTURE_RETENTION_DAYS"] = str(FAILED_TEST_FIXTURE_RETENTION_DAYS)
+
+    result = run_script(env=env)
+    assert result.returncode == 0, f"Script failed:\n{result.stderr}"
+    for f in (real_quarantine, near_miss_prefix, near_miss_suffix, near_miss_nondigit):
+        assert f.exists(), f"{f.name} should never be deleted by the test-fixture prune step"
+
+
+# ---------------------------------------------------------------------------
+# F4: Missing failed/ directory is handled gracefully
+# ---------------------------------------------------------------------------
+
+def test_missing_failed_directory_is_skipped(tmp_path):
+    """F4: Script exits 0 and logs a skip message when failed/ doesn't exist."""
+    # Point CLEANUP_FAILED_DIR at a path that definitely does not exist, rather
+    # than relying on LOBSTER_MESSAGES/failed (which the test suite's own
+    # autouse isolation fixture pre-creates under tmp_path for every test).
+    nonexistent_failed_dir = tmp_path / "definitely-absent" / "failed"
+    assert not nonexistent_failed_dir.exists(), "Pre-condition: dir must not exist"
+
+    env = isolation_env(tmp_path)
+    env["CLEANUP_FAILED_DIR"] = str(nonexistent_failed_dir)
+
+    result = run_script(env=env)
+    assert result.returncode == 0, (
+        f"Script should exit 0 even when failed/ dir is missing.\nstderr: {result.stderr}"
+    )
+    assert "failed" in result.stdout.lower() and "skipping" in result.stdout.lower(), (
+        f"Expected a 'skipping' message referencing the failed dir in stdout.\n"
+        f"Got stdout:\n{result.stdout}"
+    )


### PR DESCRIPTION
## Problem

`~/messages/failed/` had accumulated ~360 stale `test_<epoch>.json` files dating back to April 2026, drowning out the one real quarantined message in the directory. These come from `check_inbox`'s unrecognized-source quarantine guard in `src/mcp/inbox_server.py`: any inbox message with `source="test"` is quarantined there permanently (`_permanently_failed=True`), by design (issue #1735 / `tests/unit/test_mcp_server/test_unrecognized_source_quarantine.py`), but nothing ever prunes the resulting fixture files. Not itself a functional bug — the quarantine mechanism is working as designed — but it makes a genuinely failed/quarantined message impossible to spot among months of noise.

**Why not rely on PR #2198 (referenced in the issue)?** #2198 fixed pytest-suite log/JSONL pollution (`telegram-bot.log`, `slack-router.log`, `pii-scan-guard-failopen.jsonl`) by forcing `LOBSTER_WORKSPACE` isolation in `tests/conftest.py` before `src.*` modules import. It does not touch `~/messages/failed/` at all — the `test_*.json` fixtures here are quarantined *production* inbox messages with `source="test"`, not test-suite output leakage. Confirmed one of the two remaining fixture files (`test_1786769893.json`) was created ~3 minutes after #2198 merged, so #2198 does not prevent recurrence of this specific accumulation.

## What changed

Added a `prune_failed_test_fixtures` step to `scripts/cleanup-worktrees-audio.sh`, the existing daily (04:00 cron) housekeeping script that already prunes stale worktrees and old audio files. The new step:

- Only ever touches files matching the exact `test_<digits>.json` name (via `find -regextype posix-extended -regex '.*/test_[0-9]+\.json'`) — nothing else in `failed/`, including the one real quarantined message (`daily-health-*.json`), is a candidate regardless of age or name.
- Only removes files older than `FAILED_TEST_FIXTURE_RETENTION_DAYS` (default 1 day, overridable via `CLEANUP_FAILED_TEST_FIXTURE_RETENTION_DAYS`), giving a buffer against racing a write that might still be in flight.
- Is a no-op with a logged skip message if `failed/` doesn't exist, matching the existing `prune_audio` pattern in the same script.

This mirrors the structure and conventions already used by `prune_audio` in the same file (env-var-overridable dir/retention, `find -mtime`, info/warn logging).

## Functional patterns

- `prune_failed_test_fixtures` is a self-contained, side-effect-isolated step (mirrors `prune_audio`) — the filesystem scan (`find`) is pure with respect to script state, and the loop body performs the single side effect (`rm`) with no shared mutable state beyond a simple counter.
- No behavior change to existing steps (`prune_worktrees`, `prune_pr_worktrees`, `prune_audio`) — purely additive.

## Out of scope

- No change to the quarantine mechanism itself (`src/mcp/inbox_server.py`) — messages with `source="test"` will continue to be quarantined as designed; this PR only prunes the resulting files after the fact.
- No change to `tests/conftest.py` or PR #2198's log-isolation fix.
- This is not a multi-step flow / state-machine change — no before/after diagram needed; it's an additive cron housekeeping step.

## Live action taken on this host (not part of this diff)

Per issue #2209, `~/messages/failed/` is runtime data (`~/lobster-workspace/`, not in the repo). As a one-time cleanup on this host, I verified and deleted the 2 stale `test_<epoch>.json` fixtures present (`test_1786476577.json`, `test_1786769893.json` — both confirmed via content inspection to have `source: "test"` and `_permanently_failed: true`, matching the quarantine schema exactly) and left `daily-health-20260425-060005.json` (the one real, already self-resolved quarantined message) untouched. Only 2 files remained at cleanup time, not the ~360 described in the original audit finding — apparently already reduced by other activity since the issue was filed.

## Tests run

- [x] `bash -n scripts/cleanup-worktrees-audio.sh` — clean, no syntax errors
- [x] `uv run pytest tests/smoke/test_cleanup_failed_test_fixtures.py -v` — 5 passed (new tests: old fixture deleted, recent fixture preserved, non-matching filenames incl. real-quarantine shape never deleted, missing dir handled gracefully, syntax check)
- [x] `uv run pytest tests/smoke/test_cleanup_worktrees_audio.py -v` — 10 passed (pre-existing tests for the same script, unaffected)
- [x] `uv run pytest tests/smoke/ -q` — 76 passed (full smoke suite, no regressions)

## Manual test

Live one-time cleanup performed on this host — see "Live action taken on this host" above. Verified via `ls` and per-file JSON content inspection before deletion; confirmed remaining file count (1, the real quarantined message) via `ls` after deletion. No Telegram/user-visible output is involved in this change (it's a filesystem housekeeping cron step); N/A for user-visible-outcome verification.

## Definition of Done

- [x] Unit tests pass with proper mocking (no production hits in automated tests — all smoke tests use `tmp_path` isolation via env var overrides)
- [x] Manual test run — see `## Manual test` above (live, scoped, one-time deletion of exactly 2 verified files)
- [ ] User-visible outcome verified — not applicable, this is an internal cron housekeeping change with no Telegram/UI output
- [x] Side-effect audit complete: deletion is scoped to an exact filename regex, bounded by a retention window, and was manually verified file-by-file before the live deletion; no floods, no unscoped writes, no unintended volume

Closes #2209