### PR TITLE
fix: harden repo root against accidental personal/instance data leaks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -18,6 +18,11 @@
 # configured in ~/lobster-user-config/blocked-commit-emails.txt (gitignored,
 # private). See the "Commit-Author Email Check" section below for details.
 #
+# Also warns (with a confirm-to-proceed prompt) when untracked files sitting
+# directly in the repo root match dump/export/backup/credential-shaped name
+# patterns, regardless of whether they are staged for this commit. See the
+# "Untracked Suspicious Root File Check" section below for details.
+#
 # Bypass: git commit --no-verify
 #===============================================================================
 
@@ -27,10 +32,11 @@ set -uo pipefail
 if [ -t 1 ]; then
     RED='\033[0;31m'
     GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
     BOLD='\033[1m'
     NC='\033[0m'
 else
-    RED='' GREEN='' BOLD='' NC=''
+    RED='' GREEN='' YELLOW='' BOLD='' NC=''
 fi
 
 BLOCKED=0
@@ -394,5 +400,121 @@ check_commit_author_email() {
 }
 
 check_commit_author_email || exit 1
+
+#===============================================================================
+# Untracked Suspicious Root File Check
+#
+# Flags untracked files sitting directly in the repo root that match
+# dump/export/backup/credential-shaped filename patterns — independent of
+# whatever happens to be staged for this particular commit.
+#
+# Motivated by the live_full_dump_now.json incident (2026-09): a 278KB raw
+# Google Slides API dump sat untracked and un-ignored in the repo root for
+# some time, one `git add -A` away from being committed. Every other check in
+# this hook only inspects STAGED files (git diff --cached) — a file nobody
+# has run `git add` on yet is invisible to all of them until the moment it
+# gets swept in, which is exactly the moment it's too late to warn before the
+# commit exists. This check inspects the repo root on every commit,
+# regardless of what's staged, so the warning fires long before that moment.
+#
+# `git ls-files --others --exclude-standard` already excludes anything
+# .gitignore matches — so only the residual-risk category reaches this check:
+# untracked AND not covered by any existing .gitignore rule. That is
+# precisely "a shape nobody has thought to ignore yet," which is what got
+# live_full_dump_now.json past every existing layer.
+#
+# Scope: repo root only (not recursive). Matches the incident, and keeps the
+# check's blast radius small — nested project/build/test directories
+# legitimately accumulate many untracked scratch files that would otherwise
+# produce constant noise.
+#
+# This does not hard-block the commit: the flagged file isn't part of what's
+# being committed, so blocking an unrelated commit over it would be
+# surprising. It warns and (interactively) requires explicit confirmation to
+# proceed — same UX precedent as the commit-author-email check above.
+#
+# Bypass: git commit --no-verify
+#===============================================================================
+
+# Glob patterns (case-insensitive match, see check function below) for
+# filenames that suggest a data dump, export, backup, or credential file —
+# the categories of accidental leak this hook exists to catch. Deliberately
+# broad; false positives here just mean answering one confirmation prompt.
+SUSPICIOUS_ROOT_PATTERNS=(
+    "*dump*"
+    "*export*"
+    "*backup*"
+    "*_bak"
+    "*-bak"
+    "*credential*"
+    "*secret*"
+    "*token*"
+    "*.pem"
+    "*.key"
+    "*snapshot*"
+)
+
+check_untracked_suspicious_root_files() {
+    local -a untracked_root_files=()
+    local f base_lc matched pattern
+
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        # Root-level only: no '/' anywhere in the path
+        case "$f" in
+            */*) continue ;;
+        esac
+        base_lc="$(echo "$f" | tr '[:upper:]' '[:lower:]')"
+        matched=0
+        for pattern in "${SUSPICIOUS_ROOT_PATTERNS[@]}"; do
+            case "$base_lc" in
+                $pattern) matched=1; break ;;
+            esac
+        done
+        [ "$matched" -eq 1 ] && untracked_root_files+=("$f")
+    done < <(git ls-files --others --exclude-standard 2>/dev/null || true)
+
+    [ "${#untracked_root_files[@]}" -eq 0 ] && return 0
+
+    echo ""
+    echo -e "${YELLOW}${BOLD}WARNING: suspicious untracked file(s) found in the repo root:${NC}"
+    for f in "${untracked_root_files[@]}"; do
+        echo -e "         ${BOLD}${f}${NC}"
+    done
+    echo "         These look like data dumps/exports/backups/credentials, which"
+    echo "         belong in \$LOBSTER_WORKSPACE, not the repo. They are not staged"
+    echo "         for THIS commit, but a future 'git add -A' would sweep them in."
+    echo ""
+
+    # Non-interactive (CI/scripted) commits: warn but never block — same
+    # /dev/tty-probe rationale as check_commit_author_email above (git always
+    # connects a hook's own stdin to /dev/null, so `[ -t 0 ]` can't be used
+    # here to detect interactivity).
+    if ! exec 3</dev/tty 2>/dev/null; then
+        echo "No controlling terminal available — proceeding with warning only (not blocking)."
+        echo ""
+        return 0
+    fi
+    exec 3<&-
+
+    read -r -p "Continue committing anyway? [y/N]: " _sus_response </dev/tty
+    _sus_response="${_sus_response:-N}"
+    if [[ "$_sus_response" =~ ^[Yy]([Ee][Ss])?$ ]]; then
+        echo ""
+        echo -e "${GREEN}Confirmed. Proceeding with commit.${NC}"
+        echo ""
+        return 0
+    else
+        echo ""
+        echo -e "${RED}Commit aborted.${NC} Move the file(s) above to \$LOBSTER_WORKSPACE, delete them,"
+        echo "or add a .gitignore rule if they are a legitimate tracked shape."
+        echo ""
+        echo "Emergency bypass: git commit --no-verify"
+        echo ""
+        return 1
+    fi
+}
+
+check_untracked_suspicious_root_files || exit 1
 
 exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,23 @@ lobster-shop/kissinger/context/reference.md
 
 # Stray backup files (should never be committed)
 *.bak
+
+# Ad-hoc data dumps / exports / scratch output. These should be written to
+# ~/lobster-workspace/, not the repo — see live_full_dump_now.json incident
+# (2026-09): a raw Google Slides API dump landed in the repo root via an
+# ad-hoc redirected command run with the wrong cwd, sat untracked and
+# un-ignored, and was one `git add -A` away from being committed. Scoped to
+# obvious dump/export/backup naming so legitimate tracked fixtures (e.g.
+# tests/**/*.json, package.json) are unaffected — no tracked file in this
+# repo currently matches any of these patterns (verified via `git ls-files`).
+*dump*.json
+*_dump
+*-dump
+*.dump
+*export*.json
+*_export
+*-export
+*_scratch*
+*-scratch*
+*_snapshot.json
+*-snapshot.json

--- a/scripts/install-pii-scan-hook.sh
+++ b/scripts/install-pii-scan-hook.sh
@@ -60,9 +60,26 @@ TARGET_REPO_ROOT="$(cd "$TARGET_DIR" && git rev-parse --show-toplevel 2>/dev/nul
     exit 1
 }
 
-GIT_HOOKS_DIR="$TARGET_REPO_ROOT/.git/hooks"
+# Resolve the hooks directory git will ACTUALLY consult for this repo, not
+# the default `.git/hooks` path. When `core.hooksPath` is configured (as it
+# is for SiderealPress/lobster itself, pointed at `.githooks`), git ignores
+# `.git/hooks` entirely — installing there would silently produce a hook
+# that never runs. `git rev-parse --git-path hooks` returns the correct,
+# hooksPath-aware directory (relative to the repo root, or absolute if
+# hooksPath was configured as an absolute path); falls back to `.git/hooks`
+# when no override is set, so this is a strict superset of the old behavior.
+GIT_HOOKS_DIR_RAW="$(git -C "$TARGET_REPO_ROOT" rev-parse --git-path hooks 2>/dev/null)" || {
+    echo "ERROR: could not resolve the git hooks directory for $TARGET_REPO_ROOT." >&2
+    exit 1
+}
+case "$GIT_HOOKS_DIR_RAW" in
+    /*) GIT_HOOKS_DIR="$GIT_HOOKS_DIR_RAW" ;;
+    *)  GIT_HOOKS_DIR="$TARGET_REPO_ROOT/$GIT_HOOKS_DIR_RAW" ;;
+esac
+
 if [[ ! -d "$GIT_HOOKS_DIR" ]]; then
-    echo "ERROR: $GIT_HOOKS_DIR does not exist (unusual repo layout — is this a worktree?)." >&2
+    echo "ERROR: $GIT_HOOKS_DIR does not exist (unusual repo layout — is this a worktree," >&2
+    echo "  or a core.hooksPath pointed at a directory that hasn't been created yet?)." >&2
     exit 1
 fi
 

--- a/tests/unit/test_install_pii_scan_hook.py
+++ b/tests/unit/test_install_pii_scan_hook.py
@@ -103,6 +103,29 @@ class TestInstallPiiScanHook:
         assert result.returncode != 0
         assert "not inside a git repository" in result.stderr
 
+    def test_installs_to_configured_hooks_path_not_dot_git_hooks(self, target_repo):
+        # Regression test for issue #2263: when a target repo configures
+        # core.hooksPath (as SiderealPress/lobster itself does, pointed at
+        # .githooks), git ignores .git/hooks entirely. Installing there
+        # produces a hook file that exists on disk but is never consulted by
+        # git — a silent no-op install. The installer must resolve and write
+        # to the actual configured hooks directory instead.
+        _run_git(["config", "core.hooksPath", ".githooks"], target_repo)
+        (target_repo / ".githooks").mkdir()
+
+        result = _install(target_repo)
+        assert result.returncode == 0, result.stderr
+
+        configured_hook = target_repo / ".githooks" / "pre-push"
+        assert configured_hook.is_file()
+        assert os.access(configured_hook, os.X_OK)
+        assert "installed-by: install-pii-scan-hook.sh" in configured_hook.read_text()
+
+        # Must NOT have also (or instead) landed in the now-irrelevant
+        # .git/hooks/pre-push — that would be the old, silently-broken path.
+        dead_path = target_repo / ".git" / "hooks" / "pre-push"
+        assert not dead_path.is_file()
+
     def test_installed_hook_actually_runs_pii_scan_guard_end_to_end(self, target_repo):
         # Prove the wiring works, not just that files were copied: invoke the
         # installed hook directly with a real pre-push-shaped stdin payload,

--- a/tests/unit/test_pre_commit_untracked_root_files.sh
+++ b/tests/unit/test_pre_commit_untracked_root_files.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+# =============================================================================
+# test_pre_commit_untracked_root_files.sh
+# Behavioral tests for the "Untracked Suspicious Root File Check" added to
+# .githooks/pre-commit (issue #2263, live_full_dump_now.json incident).
+#
+# These tests exercise the REAL hook file against REAL throwaway git repos —
+# not a synthetic re-implementation — by invoking `git commit` end-to-end with
+# core.hooksPath pointed at the repo's .githooks directory.
+#
+# Covers:
+#   1. No suspicious untracked file present        -> no-op, no warning
+#   2. Suspicious untracked file present (root),
+#      non-interactive commit                       -> warns; commit still
+#                                                        succeeds (CI policy)
+#   3. Suspicious untracked file present, INTERACTIVE
+#      (real pty via expect)                         -> confirmation prompt
+#                                                        actually gates the
+#                                                        commit ('n' aborts,
+#                                                        'y' proceeds)
+#   4. Suspicious file lives in a SUBDIRECTORY, not
+#      repo root                                     -> not flagged (scope is
+#                                                        root-level only)
+#   5. Suspicious-named file is TRACKED (already
+#      committed), not untracked                     -> not flagged (this
+#                                                        check only looks at
+#                                                        `git ls-files
+#                                                        --others`)
+#   6. Suspicious-named file is covered by a
+#      .gitignore rule                                -> not flagged (defense
+#                                                        in depth: gitignore
+#                                                        is the primary layer,
+#                                                        this check covers the
+#                                                        residual gap)
+#   7. Ordinary untracked file (no suspicious name)   -> not flagged
+#
+# Run: bash tests/unit/test_pre_commit_untracked_root_files.sh
+# Requires: bash, git, expect (for the interactive-prompt test)
+# =============================================================================
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK_SRC="$REPO_ROOT/.githooks/pre-commit"
+
+WARNING_MARKER="suspicious untracked file"
+
+ok()   { echo "  PASS: $1"; ((PASS++)) || true; }
+fail() { echo "  FAIL: $1"; ((FAIL++)) || true; }
+
+TMP_DIRS=()
+cleanup() {
+    for d in "${TMP_DIRS[@]:-}"; do
+        [ -n "$d" ] && rm -rf "$d"
+    done
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Helper: build a throwaway repo wired to the real .githooks/pre-commit hook.
+# An unset LOBSTER_USER_CONFIG_DIR pointed at an empty dir keeps the
+# commit-author-email check (which runs earlier in the same hook) a no-op so
+# it can't interfere with these tests.
+# ---------------------------------------------------------------------------
+make_repo() {
+    local repo_dir
+    repo_dir="$(mktemp -d /tmp/test_pre_commit_untracked_repo_XXXXXX)"
+    TMP_DIRS+=("$repo_dir")
+
+    git init -q "$repo_dir"
+    mkdir -p "$repo_dir/.githooks"
+    cp "$HOOK_SRC" "$repo_dir/.githooks/pre-commit"
+    chmod +x "$repo_dir/.githooks/pre-commit"
+
+    (
+        cd "$repo_dir" || exit 1
+        git config core.hooksPath .githooks
+        git config user.name "Test User"
+        git config user.email "clean-dev@example.com"
+    )
+
+    echo "$repo_dir"
+}
+
+empty_config_dir() {
+    local cfg_dir
+    cfg_dir="$(mktemp -d /tmp/test_pre_commit_untracked_cfg_XXXXXX)"
+    TMP_DIRS+=("$cfg_dir")
+    echo "$cfg_dir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: no suspicious untracked file -> no-op
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 1: no suspicious untracked file -> silent no-op ==="
+
+REPO1="$(make_repo)"
+CFG1="$(empty_config_dir)"
+
+(
+    cd "$REPO1" || exit 1
+    echo "hello" > file.txt
+    git add file.txt
+    LOBSTER_USER_CONFIG_DIR="$CFG1" git commit -m "test commit" < /dev/null > /tmp/test1_out.txt 2>&1
+)
+EXIT1=$?
+OUT1="$(cat /tmp/test1_out.txt)"
+rm -f /tmp/test1_out.txt
+
+if [ "$EXIT1" -eq 0 ] && ! echo "$OUT1" | grep -qi "$WARNING_MARKER"; then
+    ok "no suspicious untracked file -> commit succeeds with no warning"
+else
+    fail "expected clean commit with no warning; exit=$EXIT1 output='$OUT1'"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: suspicious untracked file in repo root, non-interactive -> warns,
+# commit still succeeds (CI/non-interactive policy: never hang, never block)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 2: live_full_dump_now.json-shaped untracked root file, non-interactive -> warns but does not block ==="
+
+REPO2="$(make_repo)"
+CFG2="$(empty_config_dir)"
+
+(
+    cd "$REPO2" || exit 1
+    echo '{"presentationId": "abc123fakeid", "slides": []}' > live_full_dump_now.json
+    echo "hello" > unrelated.txt
+    git add unrelated.txt
+    LOBSTER_USER_CONFIG_DIR="$CFG2" git commit -m "unrelated change" < /dev/null > /tmp/test2_out.txt 2>&1
+)
+EXIT2=$?
+OUT2="$(cat /tmp/test2_out.txt)"
+rm -f /tmp/test2_out.txt
+
+if [ "$EXIT2" -eq 0 ] && echo "$OUT2" | grep -qi "$WARNING_MARKER" && echo "$OUT2" | grep -q "live_full_dump_now.json"; then
+    ok "suspicious untracked root file (non-interactive) -> warning printed, commit not blocked"
+else
+    fail "expected warning + successful commit; exit=$EXIT2 output='$OUT2'"
+fi
+
+if (cd "$REPO2" && git log --oneline 2>/dev/null | grep -q "unrelated change"); then
+    ok "commit exists in history (non-interactive never blocks)"
+else
+    fail "commit should exist in history after non-interactive warning"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: suspicious untracked file, INTERACTIVE (real pty via expect) ->
+# confirmation prompt actually gates the commit
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 3: suspicious untracked root file, interactive pty -> confirmation prompt gates commit ==="
+
+if ! command -v expect >/dev/null 2>&1; then
+    echo "  SKIP: 'expect' not installed — cannot drive a real pty for this test"
+else
+    REPO3A="$(make_repo)"
+    CFG3="$(empty_config_dir)"
+    (
+        cd "$REPO3A" || exit 1
+        echo '{"presentationId": "abc123fakeid"}' > secret_export_dump.json
+        echo "hello" > unrelated.txt
+        git add unrelated.txt
+    )
+
+    # 3a: answer "n" (or default Enter) -> commit is ABORTED
+    EXPECT_SCRIPT_N=$(mktemp /tmp/test_pre_commit_untracked_expect_n_XXXXXX.exp)
+    TMP_DIRS+=("$EXPECT_SCRIPT_N")
+    cat > "$EXPECT_SCRIPT_N" << EOF
+set timeout 10
+spawn env LOBSTER_USER_CONFIG_DIR=$CFG3 git -C $REPO3A commit -m "test commit"
+expect "Continue committing anyway?"
+send "n\r"
+expect eof
+catch wait result
+exit [lindex \$result 3]
+EOF
+    OUT3A="$(expect "$EXPECT_SCRIPT_N" 2>&1)"
+    EXIT3A=$?
+
+    if [ "$EXIT3A" -ne 0 ] && echo "$OUT3A" | grep -qi "Commit aborted"; then
+        ok "interactive 'n' response aborts the commit"
+    else
+        fail "expected 'n' to abort commit; exit=$EXIT3A output='$OUT3A'"
+    fi
+
+    if (cd "$REPO3A" && git log --oneline 2>/dev/null | grep -q "test commit"); then
+        fail "commit should NOT exist in history after 'n' response"
+    else
+        ok "no commit was created in history after 'n' response"
+    fi
+
+    # 3b: answer "y" -> commit PROCEEDS
+    REPO3B="$(make_repo)"
+    (
+        cd "$REPO3B" || exit 1
+        echo '{"presentationId": "abc123fakeid"}' > secret_export_dump.json
+        echo "hello" > unrelated.txt
+        git add unrelated.txt
+    )
+
+    EXPECT_SCRIPT_Y=$(mktemp /tmp/test_pre_commit_untracked_expect_y_XXXXXX.exp)
+    TMP_DIRS+=("$EXPECT_SCRIPT_Y")
+    cat > "$EXPECT_SCRIPT_Y" << EOF
+set timeout 10
+spawn env LOBSTER_USER_CONFIG_DIR=$CFG3 git -C $REPO3B commit -m "test commit"
+expect "Continue committing anyway?"
+send "y\r"
+expect eof
+catch wait result
+exit [lindex \$result 3]
+EOF
+    OUT3B="$(expect "$EXPECT_SCRIPT_Y" 2>&1)"
+    EXIT3B=$?
+
+    if [ "$EXIT3B" -eq 0 ] && echo "$OUT3B" | grep -qi "Confirmed. Proceeding"; then
+        ok "interactive 'y' response proceeds with the commit"
+    else
+        fail "expected 'y' to proceed with commit; exit=$EXIT3B output='$OUT3B'"
+    fi
+
+    if (cd "$REPO3B" && git log --oneline 2>/dev/null | grep -q "test commit"); then
+        ok "commit exists in history after 'y' response"
+    else
+        fail "commit should exist in history after 'y' response"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: suspicious file lives in a subdirectory, not repo root -> not
+# flagged (this check is scoped to root-level files only)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 4: suspicious-named file in a subdirectory -> not flagged (root-only scope) ==="
+
+REPO4="$(make_repo)"
+CFG4="$(empty_config_dir)"
+
+(
+    cd "$REPO4" || exit 1
+    mkdir -p scratch
+    echo '{"presentationId": "abc123fakeid"}' > scratch/live_full_dump_now.json
+    echo "hello" > unrelated.txt
+    git add unrelated.txt
+    LOBSTER_USER_CONFIG_DIR="$CFG4" git commit -m "test commit" < /dev/null > /tmp/test4_out.txt 2>&1
+)
+EXIT4=$?
+OUT4="$(cat /tmp/test4_out.txt)"
+rm -f /tmp/test4_out.txt
+
+if [ "$EXIT4" -eq 0 ] && ! echo "$OUT4" | grep -qi "$WARNING_MARKER"; then
+    ok "suspicious file in subdirectory -> not flagged (root-only scope)"
+else
+    fail "expected no warning for a subdirectory file; exit=$EXIT4 output='$OUT4'"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: suspicious-named file is already TRACKED -> not flagged (this
+# check only looks at `git ls-files --others`, i.e. untracked files)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 5: suspicious-named file already tracked -> not flagged ==="
+
+REPO5="$(make_repo)"
+CFG5="$(empty_config_dir)"
+
+(
+    cd "$REPO5" || exit 1
+    echo '{"presentationId": "abc123fakeid"}' > data_export.json
+    git add data_export.json
+    git commit -q -m "add tracked export file" < /dev/null
+    echo "more" >> data_export.json
+    git add data_export.json
+    LOBSTER_USER_CONFIG_DIR="$CFG5" git commit -m "update tracked file" < /dev/null > /tmp/test5_out.txt 2>&1
+)
+EXIT5=$?
+OUT5="$(cat /tmp/test5_out.txt)"
+rm -f /tmp/test5_out.txt
+
+if [ "$EXIT5" -eq 0 ] && ! echo "$OUT5" | grep -qi "$WARNING_MARKER"; then
+    ok "already-tracked suspicious-named file -> not flagged"
+else
+    fail "expected no warning for a tracked file; exit=$EXIT5 output='$OUT5'"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: suspicious file covered by a .gitignore rule -> not flagged
+# (defense in depth: .gitignore is the primary layer; this check exists for
+# the residual gap of filename shapes nobody has thought to ignore yet)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 6: suspicious file already covered by .gitignore -> not flagged ==="
+
+REPO6="$(make_repo)"
+CFG6="$(empty_config_dir)"
+
+(
+    cd "$REPO6" || exit 1
+    printf '*dump*.json\n' > .gitignore
+    git add .gitignore
+    git commit -q -m "add gitignore rule" < /dev/null
+    echo '{"presentationId": "abc123fakeid"}' > live_full_dump_now.json
+    echo "hello" > unrelated.txt
+    git add unrelated.txt
+    LOBSTER_USER_CONFIG_DIR="$CFG6" git commit -m "test commit" < /dev/null > /tmp/test6_out.txt 2>&1
+)
+EXIT6=$?
+OUT6="$(cat /tmp/test6_out.txt)"
+rm -f /tmp/test6_out.txt
+
+if [ "$EXIT6" -eq 0 ] && ! echo "$OUT6" | grep -qi "$WARNING_MARKER"; then
+    ok "gitignore-covered suspicious file -> not flagged (primary layer handles it)"
+else
+    fail "expected no warning once .gitignore covers the file; exit=$EXIT6 output='$OUT6'"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: ordinary untracked file with no suspicious name -> not flagged
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 7: ordinary untracked file, no suspicious name -> not flagged ==="
+
+REPO7="$(make_repo)"
+CFG7="$(empty_config_dir)"
+
+(
+    cd "$REPO7" || exit 1
+    echo "just some notes" > scratch_notes.md
+    echo "hello" > unrelated.txt
+    git add unrelated.txt
+    LOBSTER_USER_CONFIG_DIR="$CFG7" git commit -m "test commit" < /dev/null > /tmp/test7_out.txt 2>&1
+)
+EXIT7=$?
+OUT7="$(cat /tmp/test7_out.txt)"
+rm -f /tmp/test7_out.txt
+
+if [ "$EXIT7" -eq 0 ] && ! echo "$OUT7" | grep -qi "$WARNING_MARKER"; then
+    ok "ordinary untracked file with no suspicious name -> not flagged"
+else
+    fail "expected no warning for an ordinary untracked file; exit=$EXIT7 output='$OUT7'"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Results: ${PASS} passed, ${FAIL} failed"
+echo ""
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Closes #2263

## Problem

A PII audit found `live_full_dump_now.json` (278KB, a raw Google Slides `presentations.get` API response with a real `presentationId`) sitting untracked in the repo root — not in `.gitignore`, one `git add -A` away from being committed. No script or code path in this repo produces a file with that name (grepped `src/`, `scripts/`, `hooks/`, `scheduled-tasks/` for "dump"/"presentationId"/"slides" — no hits); the best-available conclusion is an ad-hoc debug command run with `cwd=~/lobster` instead of `~/lobster-workspace/`. The file itself has already been deleted directly from `~/lobster/` (it was untracked, so there's no git history to worry about — nothing to do here in this PR).

More importantly: **none of the repo's existing leak defenses would have caught this before a commit happened.** `.githooks/pre-commit`'s `BLOCKED_PATTERNS`/`BLOCKED_EXTENSIONS` only recognize specific known paths and `.db`/`.jsonl` extensions. `.githooks/pre-push`'s regex scan operates on the diff of what's already been committed. Both only ever look at staged/committed content — nothing inspects the repo root for suspicious files that haven't been `git add`ed yet, which is exactly the state this file was in.

## What changed

**1. `.gitignore`** — a new section of dump/export/backup-shaped filename patterns (`*dump*.json`, `*_dump`, `*.dump`, `*export*.json`, `*_scratch*`, `*_snapshot.json`, etc.), scoped narrowly enough that no currently-tracked file in the repo matches any of them (verified via `git ls-files`).

**2. `.githooks/pre-commit`** — new "Untracked Suspicious Root File Check." On every `git commit`, it lists untracked files in the repo root (`git ls-files --others --exclude-standard`, so anything already covered by `.gitignore` is silently excluded — this is a backstop, not a replacement, for rule 1) and checks them against the same dump/export/backup/credential-shaped patterns. If one matches, it warns and (interactively) requires explicit confirmation to proceed — same UX precedent as the existing commit-author-email check in the same hook. Non-interactive/CI commits warn but never block. It does not touch what's staged for the current commit; it's a standing tripwire for "something suspicious is sitting in the repo root," independent of whatever this particular commit happens to be about.

**3. `scripts/install-pii-scan-hook.sh`** — found while auditing the existing PII-scanning mechanisms per the issue's request to "extend rather than duplicate." This script installs `hooks/pii-scan-guard.py` (the semantic/LLM-backed PII scanner mentioned in the issue) as `.git/hooks/pre-push` in a target repo. But `SiderealPress/lobster` (and any repo configuring `core.hooksPath`, which this repo does — pointed at `.githooks`) ignores `.git/hooks` entirely once that's set. An install into `.git/hooks/pre-push` would sit on disk, pass its own installer's checks, and simply never run. Fixed by resolving the actual hooks directory via `git rev-parse --git-path hooks`, which is hooksPath-aware and falls back to `.git/hooks` when no override exists — a strict superset of the old behavior, not a narrowing.

## Out of scope (deliberately)

- Git history rewrite — already assessed unnecessary (one low-severity historical leak, a test-fixture chat_id, already fixed in HEAD via PR #1313).
- Turning `hooks/pii-scan-guard.py` on for this repo (`LOBSTER_PII_SCAN_MODE`) — it remains `off` by default; this PR only fixes the install path so that a future decision to turn it on would actually take effect. Enabling it is a separate decision with its own cost/latency tradeoffs already documented in that hook's module docstring.
- Recursive scanning of untracked files outside the repo root — the incident was root-level, and keeping the new pre-commit check root-only avoids noise from the many legitimate untracked scratch files nested project/test directories accumulate.

## Functional patterns

All three changes are pure/declarative in shape: the new pre-commit check is a stateless scan-and-report function with no mutation of the files it inspects (it never rewrites or deletes anything, deliberately — same "never modifies files" principle the pre-push hook's own docstring states), and the `install-pii-scan-hook.sh` fix replaces a hardcoded path with the output of a single idempotent query (`git rev-parse --git-path hooks`) rather than adding branching state.

## No flow/state-machine changes

This is not a multi-step flow or state machine change — it adds one new independent check to an existing linear sequence of pre-commit checks (each of which already exits early/warns independently), and fixes a path-resolution bug in a standalone installer script. No diagram needed.

## Tests run

- [x] `bash tests/unit/test_pre_commit_untracked_root_files.sh` (new, 11 assertions) — all pass. Covers: no suspicious file (no-op), suspicious root file non-interactive (warns, doesn't block), suspicious root file interactive via real pty/`expect` (both `n`-aborts and `y`-proceeds paths), suspicious file in a subdirectory (correctly NOT flagged — root-only scope), suspicious-named file that's already tracked (correctly NOT flagged), suspicious file already covered by `.gitignore` (correctly NOT flagged — defense-in-depth layering confirmed), ordinary untracked file (not flagged).
- [x] `bash tests/unit/test_pre_commit_email_check.sh` (pre-existing, unmodified) — 9/9 pass, confirms the new check doesn't interfere with the existing email-blocklist check in the same hook file.
- [x] `bash tests/unit/test_pre_push_scan_diff_timeout.sh` and `test_pre_push_doc_secret_exemption.sh` (pre-existing, unmodified) — 8/8 and 7/7 pass, confirms `.githooks/pre-push` (untouched by this PR) still behaves correctly.
- [x] `uv run pytest tests/unit/test_install_pii_scan_hook.py` — 8/8 pass, including one new regression test (`test_installs_to_configured_hooks_path_not_dot_git_hooks`) that I verified FAILS against the pre-fix script (confirmed via `git stash` on just that file) and PASSES with the fix — proving the test is real, not a tautology.
- [x] `uv run pytest tests/unit/test_hooks/test_pii_scan_guard.py` — 118 passed, 1 skipped, 3 pre-existing failures unrelated to this change (they require `ANTHROPIC_API_KEY` to be set in the test environment; confirmed these 3 fail identically on a clean checkout of `origin/main` before any of my changes, via a throwaway clone).
- [ ] Full `uv run pytest tests/unit/` (whole-repo suite) — kicked off in background; still running at PR-open time (large repo, hundreds of unrelated tests). Not blocking: every file this PR touches has dedicated, directly-relevant test coverage above, all passing. Will report back if the full run surfaces anything unexpected.

## Manual test

Reproduced the actual incident end-to-end in a throwaway repo wired to the real (modified) `.githooks/pre-commit`:
1. Created `live_full_dump_now.json` with the same shape (`{"presentationId": ..., "slides": [...]}`) as an untracked file in repo root, staged an unrelated file, ran `git commit` non-interactively → warning printed naming the exact file, commit proceeded (CI policy).
2. Same setup, interactive session via `expect` → prompt appeared, answering `n` aborted the commit (verified no commit landed in `git log`), answering `y` proceeded (verified commit landed).
3. Added the new `.gitignore` rule to the same throwaway repo, recreated `live_full_dump_now.json` → `git ls-files --others --exclude-standard` no longer lists it, so the pre-commit check is silent (proves the two layers — gitignore primary, pre-commit backstop — compose correctly rather than fighting each other).
4. Confirmed `git push` from the real feature branch still runs the existing (untouched) `.githooks/pre-push` scanner cleanly against this diff (see push output: "Scan complete. No issues detected.").

This is a local git-hooks change with no systemd/cron/external-service/DB component, so the "Definition of Done" checklist items about external services / user-visible Telegram output are not applicable.

## Known gap noted, not fixed here

`hooks/pii-scan-guard.py` (the semantic/LLM PII scanner) has never actually been installed on this repo (`LOBSTER_PII_SCAN_MODE` unset, no `.git/hooks/pre-push` or `.githooks`-installed copy present) — it exists and is tested but is not currently part of this repo's active defenses. Fixing the install path (this PR) makes it *possible* to turn on correctly; deciding whether/when to turn it on is a separate call for the repo owner given its cost/latency tradeoffs.